### PR TITLE
haskell-language-server: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1416,16 +1416,12 @@ self: super: {
     lsp-test = dontCheck self.lsp-test;
     fourmolu = self.fourmolu_0_3_0_0;
   });
-  # 2021-01-20
-  # apply-refact 0.9.0.0 get's a build error with hls-hlint-plugin 0.8.0
-  # https://github.com/haskell/haskell-language-server/issues/1240
-  apply-refact = super.apply-refact_0_8_2_1;
 
   fourmolu = dontCheck super.fourmolu;
 
   # 1. test requires internet
   # 2. dependency shake-bench hasn't been published yet so we also need unmarkBroken and doDistribute
-  ghcide = doDistribute (unmarkBroken (dontCheck (super.ghcide_0_7_0_0.override { lsp-test = dontCheck self.lsp-test; })));
+  ghcide = doDistribute (unmarkBroken (dontCheck (super.ghcide.override { lsp-test = dontCheck self.lsp-test; })));
   refinery = doDistribute super.refinery_0_3_0_0;
   data-tree-print = doJailbreak super.data-tree-print;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -1037,8 +1037,8 @@ default-package-overrides:
   - haskell-gi-overloading ==1.0
   - haskell-import-graph ==1.0.4
   - haskell-lexer ==1.1
-  - haskell-lsp ==0.22.0.0
-  - haskell-lsp-types ==0.22.0.0
+  - haskell-lsp ==0.23.0.0
+  - haskell-lsp-types ==0.23.0.0
   - haskell-names ==0.9.9
   - haskell-src ==1.0.3.1
   - haskell-src-exts ==1.23.1
@@ -1453,7 +1453,7 @@ default-package-overrides:
   - loop ==0.3.0
   - lrucache ==1.2.0.1
   - lrucaching ==0.3.3
-  - lsp-test ==0.11.0.5
+  - lsp-test ==0.11.0.7
   - lucid ==2.9.12
   - lucid-cdn ==0.2.2.0
   - lucid-extras ==0.2.2
@@ -2707,8 +2707,6 @@ extra-packages:
   - dependent-map == 0.2.4.0            # required by Hasura 1.3.1, 2020-08-20
   - dependent-sum == 0.4                # required by Hasura 1.3.1, 2020-08-20
   - network == 2.6.3.1                  # required by pkgs/games/hedgewars/default.nix, 2020-11-15
-  - ghcide == 0.7.0.0                   # Needed for hls 0.8.0
-  - apply-refact == 0.8.2.1             # Needed for hls 0.8.0
 
 package-maintainers:
   peti:

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -27,6 +27,8 @@ self: super: {
   hls-retrie-plugin = self.callPackage ../tools/haskell/haskell-language-server/hls-retrie-plugin.nix { };
   hls-class-plugin = self.callPackage ../tools/haskell/haskell-language-server/hls-class-plugin.nix { };
   hls-eval-plugin = self.callPackage ../tools/haskell/haskell-language-server/hls-eval-plugin.nix { };
+  ghcide = self.callPackage ../tools/haskell/haskell-language-server/ghcide.nix { };
+  hls-plugin-api = self.callPackage ../tools/haskell/haskell-language-server/hls-plugin-api.nix { };
 
   nix-output-monitor = self.callPackage ../../tools/nix/nix-output-monitor { };
 

--- a/pkgs/development/tools/haskell/haskell-language-server/default.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/default.nix
@@ -1,24 +1,24 @@
 { mkDerivation, aeson, base, binary, blaze-markup, brittany
 , bytestring, containers, data-default, deepseq, directory, extra
-, fetchgit, filepath, floskell, fourmolu, ghc, ghc-boot-th
+, fetchgit, filepath, floskell, fourmolu, fuzzy, ghc, ghc-boot-th
 , ghc-paths, ghcide, gitrev, hashable, haskell-lsp, hie-bios
 , hls-class-plugin, hls-eval-plugin, hls-explicit-imports-plugin
-, hls-hlint-plugin, hls-plugin-api, hls-retrie-plugin
-, hls-tactics-plugin, hslogger, hspec, hspec-core
-, hspec-expectations, lens, lsp-test, mtl, optparse-applicative
-, optparse-simple, ormolu, process, regex-tdfa, safe-exceptions
-, shake, lib, stm, stylish-haskell, tasty, tasty-ant-xml
-, tasty-expected-failure, tasty-golden, tasty-hunit, tasty-rerun
-, temporary, text, transformers, unordered-containers, with-utf8
-, yaml
+, hls-haddock-comments-plugin, hls-hlint-plugin, hls-plugin-api
+, hls-retrie-plugin, hls-splice-plugin, hls-tactics-plugin
+, hslogger, hspec, hspec-core, hspec-expectations, lens, lib
+, lsp-test, mtl, optparse-applicative, optparse-simple, ormolu
+, process, regex-tdfa, safe-exceptions, shake, stm, stylish-haskell
+, tasty, tasty-ant-xml, tasty-expected-failure, tasty-golden
+, tasty-hunit, tasty-rerun, temporary, text, transformers
+, unordered-containers, with-utf8, yaml
 }:
 mkDerivation {
   pname = "haskell-language-server";
-  version = "0.8.0.0";
+  version = "0.9.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588";
-    rev = "eb58f13f7b8e4f9bc771af30ff9fd82dc4309ff5";
+    sha256 = "18g0d7zac9xwywmp57dcrjnvms70f2mawviswskix78cv0iv4sk5";
+    rev = "46d2a3dc7ef49ba57b2706022af1801149ab3f2b";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -30,17 +30,18 @@ mkDerivation {
   ];
   executableHaskellDepends = [
     aeson base binary brittany bytestring containers deepseq directory
-    extra filepath floskell fourmolu ghc ghc-boot-th ghc-paths ghcide
-    gitrev hashable haskell-lsp hie-bios hls-class-plugin
-    hls-eval-plugin hls-explicit-imports-plugin hls-hlint-plugin
-    hls-plugin-api hls-retrie-plugin hls-tactics-plugin hslogger lens
-    mtl optparse-applicative optparse-simple ormolu process regex-tdfa
-    safe-exceptions shake stylish-haskell temporary text transformers
-    unordered-containers with-utf8
+    extra filepath floskell fourmolu fuzzy ghc ghc-boot-th ghc-paths
+    ghcide gitrev hashable haskell-lsp hie-bios hls-class-plugin
+    hls-eval-plugin hls-explicit-imports-plugin
+    hls-haddock-comments-plugin hls-hlint-plugin hls-plugin-api
+    hls-retrie-plugin hls-splice-plugin hls-tactics-plugin hslogger
+    lens mtl optparse-applicative optparse-simple ormolu process
+    regex-tdfa safe-exceptions shake stylish-haskell temporary text
+    transformers unordered-containers with-utf8
   ];
   testHaskellDepends = [
     aeson base blaze-markup bytestring containers data-default
-    directory extra filepath haskell-lsp hie-bios hls-plugin-api
+    directory extra filepath ghcide haskell-lsp hie-bios hls-plugin-api
     hslogger hspec hspec-core hspec-expectations lens lsp-test process
     stm tasty tasty-ant-xml tasty-expected-failure tasty-golden
     tasty-hunit tasty-rerun temporary text transformers

--- a/pkgs/development/tools/haskell/haskell-language-server/ghcide.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/ghcide.nix
@@ -1,0 +1,65 @@
+{ mkDerivation, aeson, array, async, base, base16-bytestring
+, binary, bytestring, case-insensitive, containers, cryptohash-sha1
+, data-default, deepseq, directory, dlist, extra, fetchgit
+, filepath, fingertree, fuzzy, ghc, ghc-boot, ghc-boot-th
+, ghc-check, ghc-exactprint, ghc-paths, ghc-typelits-knownnat
+, gitrev, Glob, haddock-library, hashable, haskell-lsp
+, haskell-lsp-types, heapsize, hie-bios, hie-compat, hls-plugin-api
+, hp2pretty, hslogger, implicit-hie-cradle, lens, lib, lsp-test
+, mtl, network-uri, opentelemetry, optparse-applicative, parallel
+, prettyprinter, prettyprinter-ansi-terminal, process, QuickCheck
+, quickcheck-instances, record-dot-preprocessor, record-hasfield
+, regex-tdfa, retrie, rope-utf16-splay, safe, safe-exceptions
+, shake, sorted-list, stm, syb, tasty
+, tasty-expected-failure, tasty-hunit, tasty-quickcheck
+, tasty-rerun, text, time, transformers, unix, unordered-containers
+, utf8-string, vector, yaml
+}:
+mkDerivation {
+  pname = "ghcide";
+  version = "0.7.2.0";
+  src = fetchgit {
+    url = "https://github.com/haskell/haskell-language-server.git";
+    sha256 = "18g0d7zac9xwywmp57dcrjnvms70f2mawviswskix78cv0iv4sk5";
+    rev = "46d2a3dc7ef49ba57b2706022af1801149ab3f2b";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/ghcide; echo source root reset to $sourceRoot";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson array async base base16-bytestring binary bytestring
+    case-insensitive containers cryptohash-sha1 data-default deepseq
+    directory dlist extra filepath fingertree fuzzy ghc ghc-boot
+    ghc-boot-th ghc-check ghc-exactprint ghc-paths Glob haddock-library
+    hashable haskell-lsp haskell-lsp-types heapsize hie-bios hie-compat
+    hls-plugin-api hslogger implicit-hie-cradle lens mtl network-uri
+    opentelemetry parallel prettyprinter prettyprinter-ansi-terminal
+    regex-tdfa retrie rope-utf16-splay safe safe-exceptions shake
+    sorted-list stm syb text time transformers unix
+    unordered-containers utf8-string vector
+  ];
+  executableHaskellDepends = [
+    aeson base bytestring containers data-default directory extra
+    filepath gitrev hashable haskell-lsp haskell-lsp-types heapsize
+    hie-bios hls-plugin-api lens lsp-test optparse-applicative process
+    safe-exceptions shake text unordered-containers
+  ];
+  testHaskellDepends = [
+    aeson base binary bytestring containers data-default directory
+    extra filepath ghc ghc-typelits-knownnat haddock-library
+    haskell-lsp haskell-lsp-types hls-plugin-api lens lsp-test
+    network-uri optparse-applicative process QuickCheck
+    quickcheck-instances record-dot-preprocessor record-hasfield
+    rope-utf16-splay safe safe-exceptions shake tasty
+    tasty-expected-failure tasty-hunit tasty-quickcheck tasty-rerun
+    text
+  ];
+  benchmarkHaskellDepends = [
+    aeson base directory filepath shake text yaml
+  ];
+  benchmarkToolDepends = [ hp2pretty ];
+  homepage = "https://github.com/haskell/ghcide#readme";
+  description = "The core of an IDE";
+  license = lib.licenses.asl20;
+}

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-class-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-class-plugin.nix
@@ -1,14 +1,14 @@
 { mkDerivation, aeson, base, containers, fetchgit, ghc
-, ghc-exactprint, ghcide, haskell-lsp, hls-plugin-api, lens, shake
-, lib, text, transformers, unordered-containers
+, ghc-exactprint, ghcide, haskell-lsp, hls-plugin-api, lens, lib
+, shake, text, transformers, unordered-containers
 }:
 mkDerivation {
   pname = "hls-class-plugin";
-  version = "0.1.0.0";
+  version = "0.1.0.1";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588";
-    rev = "eb58f13f7b8e4f9bc771af30ff9fd82dc4309ff5";
+    sha256 = "18g0d7zac9xwywmp57dcrjnvms70f2mawviswskix78cv0iv4sk5";
+    rev = "46d2a3dc7ef49ba57b2706022af1801149ab3f2b";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/plugins/hls-class-plugin; echo source root reset to $sourceRoot";
@@ -16,6 +16,7 @@ mkDerivation {
     aeson base containers ghc ghc-exactprint ghcide haskell-lsp
     hls-plugin-api lens shake text transformers unordered-containers
   ];
-  description = "Explicit imports plugin for Haskell Language Server";
+  homepage = "https://github.com/haskell/haskell-language-server#readme";
+  description = "Class/instance management plugin for Haskell Language Server";
   license = lib.licenses.asl20;
 }

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-eval-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-eval-plugin.nix
@@ -1,17 +1,16 @@
 { mkDerivation, aeson, base, containers, deepseq, Diff, directory
 , extra, fetchgit, filepath, ghc, ghc-boot-th, ghc-paths, ghcide
-, hashable, haskell-lsp, haskell-lsp-types, hls-plugin-api
+, hashable, haskell-lsp, haskell-lsp-types, hls-plugin-api, lib
 , parser-combinators, pretty-simple, QuickCheck, safe-exceptions
-, shake, lib, temporary, text, time, transformers
-, unordered-containers
+, shake, temporary, text, time, transformers, unordered-containers
 }:
 mkDerivation {
   pname = "hls-eval-plugin";
-  version = "0.1.0.0";
+  version = "0.1.0.1";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588";
-    rev = "eb58f13f7b8e4f9bc771af30ff9fd82dc4309ff5";
+    sha256 = "18g0d7zac9xwywmp57dcrjnvms70f2mawviswskix78cv0iv4sk5";
+    rev = "46d2a3dc7ef49ba57b2706022af1801149ab3f2b";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/plugins/hls-eval-plugin; echo source root reset to $sourceRoot";

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-explicit-imports-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-explicit-imports-plugin.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, base, containers, deepseq, fetchgit, ghc
-, ghcide, haskell-lsp-types, hls-plugin-api, shake, lib, text
+, ghcide, haskell-lsp-types, hls-plugin-api, lib, shake, text
 , unordered-containers
 }:
 mkDerivation {
@@ -7,8 +7,8 @@ mkDerivation {
   version = "0.1.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588";
-    rev = "eb58f13f7b8e4f9bc771af30ff9fd82dc4309ff5";
+    sha256 = "18g0d7zac9xwywmp57dcrjnvms70f2mawviswskix78cv0iv4sk5";
+    rev = "46d2a3dc7ef49ba57b2706022af1801149ab3f2b";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/plugins/hls-explicit-imports-plugin; echo source root reset to $sourceRoot";

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-hlint-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-hlint-plugin.nix
@@ -1,25 +1,26 @@
 { mkDerivation, aeson, apply-refact, base, binary, bytestring
 , containers, data-default, deepseq, Diff, directory, extra
-, fetchgit, filepath, ghc, ghc-lib, ghc-lib-parser-ex, ghcide
-, hashable, haskell-lsp, hlint, hls-plugin-api, hslogger, lens
-, regex-tdfa, shake, lib, temporary, text, transformers
-, unordered-containers
+, fetchgit, filepath, ghc, ghc-exactprint, ghc-lib
+, ghc-lib-parser-ex, ghcide, hashable, haskell-lsp, hlint
+, hls-plugin-api, hslogger, lens, lib, regex-tdfa, shake, temporary
+, text, transformers, unordered-containers
 }:
 mkDerivation {
   pname = "hls-hlint-plugin";
   version = "0.1.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588";
-    rev = "eb58f13f7b8e4f9bc771af30ff9fd82dc4309ff5";
+    sha256 = "18g0d7zac9xwywmp57dcrjnvms70f2mawviswskix78cv0iv4sk5";
+    rev = "46d2a3dc7ef49ba57b2706022af1801149ab3f2b";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/plugins/hls-hlint-plugin; echo source root reset to $sourceRoot";
   libraryHaskellDepends = [
     aeson apply-refact base binary bytestring containers data-default
-    deepseq Diff directory extra filepath ghc ghc-lib ghc-lib-parser-ex
-    ghcide hashable haskell-lsp hlint hls-plugin-api hslogger lens
-    regex-tdfa shake temporary text transformers unordered-containers
+    deepseq Diff directory extra filepath ghc ghc-exactprint ghc-lib
+    ghc-lib-parser-ex ghcide hashable haskell-lsp hlint hls-plugin-api
+    hslogger lens regex-tdfa shake temporary text transformers
+    unordered-containers
   ];
   description = "Hlint integration plugin with Haskell Language Server";
   license = lib.licenses.asl20;

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-plugin-api.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-plugin-api.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, aeson, base, containers, data-default, Diff
+, fetchgit, hashable, haskell-lsp, hslogger, lens, lib, process
+, regex-tdfa, shake, text, unix, unordered-containers
+}:
+mkDerivation {
+  pname = "hls-plugin-api";
+  version = "0.6.0.0";
+  src = fetchgit {
+    url = "https://github.com/haskell/haskell-language-server.git";
+    sha256 = "0i17ssfmcgh6z1b8q7cy3x46xi81x5z82ngik86h8d5cb6w98lsn";
+    rev = "9c40dcff1b989b14e05b5aebe96f3da78c6ea25c";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/hls-plugin-api; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    aeson base containers data-default Diff hashable haskell-lsp
+    hslogger lens process regex-tdfa shake text unix
+    unordered-containers
+  ];
+  homepage = "https://github.com/haskell/haskell-language-server/hls-plugin-api";
+  description = "Haskell Language Server API for plugin communication";
+  license = lib.licenses.asl20;
+}

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-retrie-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-retrie-plugin.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, base, containers, deepseq, directory, extra
 , fetchgit, ghc, ghcide, hashable, haskell-lsp, haskell-lsp-types
-, hls-plugin-api, retrie, safe-exceptions, shake, lib, text
+, hls-plugin-api, lib, retrie, safe-exceptions, shake, text
 , transformers, unordered-containers
 }:
 mkDerivation {
@@ -8,8 +8,8 @@ mkDerivation {
   version = "0.1.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588";
-    rev = "eb58f13f7b8e4f9bc771af30ff9fd82dc4309ff5";
+    sha256 = "18g0d7zac9xwywmp57dcrjnvms70f2mawviswskix78cv0iv4sk5";
+    rev = "46d2a3dc7ef49ba57b2706022af1801149ab3f2b";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/plugins/hls-retrie-plugin; echo source root reset to $sourceRoot";

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-tactics-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-tactics-plugin.nix
@@ -2,7 +2,7 @@
 , directory, extra, fetchgit, filepath, fingertree, generic-lens
 , ghc, ghc-boot-th, ghc-exactprint, ghc-source-gen, ghcide
 , haskell-lsp, hie-bios, hls-plugin-api, hspec, hspec-discover
-, lens, mtl, QuickCheck, refinery, retrie, shake, lib, syb, text
+, lens, lib, mtl, QuickCheck, refinery, retrie, shake, syb, text
 , transformers
 }:
 mkDerivation {
@@ -10,11 +10,11 @@ mkDerivation {
   version = "0.5.1.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588";
-    rev = "eb58f13f7b8e4f9bc771af30ff9fd82dc4309ff5";
+    sha256 = "18g0d7zac9xwywmp57dcrjnvms70f2mawviswskix78cv0iv4sk5";
+    rev = "46d2a3dc7ef49ba57b2706022af1801149ab3f2b";
     fetchSubmodules = true;
   };
-  postUnpack = "sourceRoot+=/plugins/tactics; echo source root reset to $sourceRoot";
+  postUnpack = "sourceRoot+=/plugins/hls-tactics-plugin; echo source root reset to $sourceRoot";
   libraryHaskellDepends = [
     aeson base containers deepseq directory extra filepath fingertree
     generic-lens ghc ghc-boot-th ghc-exactprint ghc-source-gen ghcide
@@ -27,6 +27,5 @@ mkDerivation {
   ];
   testToolDepends = [ hspec-discover ];
   description = "Tactics plugin for Haskell Language Server";
-  license = "unknown";
-  hydraPlatforms = lib.platforms.none;
+  license = lib.licenses.asl20;
 }

--- a/pkgs/development/tools/haskell/haskell-language-server/update.sh
+++ b/pkgs/development/tools/haskell/haskell-language-server/update.sh
@@ -42,8 +42,9 @@ hls_new_version=$hls_latest_release
 echo "Updating haskell-language-server from old version $hls_old_version to new version $hls_new_version."
 echo "Running cabal2nix and outputting to ${hls_derivation_file}..."
 cabal2nix --revision "$hls_new_version" "https://github.com/haskell/haskell-language-server.git" > "$hls_derivation_file"
-cabal2nix --revision "$hls_new_version" --subpath plugins/tactics "https://github.com/haskell/haskell-language-server.git" > "${script_dir}/hls-tactics-plugin.nix"
-for plugin in "hls-hlint-plugin" "hls-explicit-imports-plugin" "hls-retrie-plugin" "hls-class-plugin" "hls-eval-plugin"; do
+cabal2nix --revision "$hls_new_version" --subpath ghcide "https://github.com/haskell/haskell-language-server.git" > "${script_dir}/ghcide.nix"
+cabal2nix --revision "$hls_new_version" --subpath hls-plugin-api "https://github.com/haskell/haskell-language-server.git" > "${script_dir}/hls-plugin-api.nix"
+for plugin in "hls-hlint-plugin" "hls-explicit-imports-plugin" "hls-retrie-plugin" "hls-class-plugin" "hls-eval-plugin" "hls-tactics-plugin"; do
    cabal2nix --revision "$hls_new_version" --subpath plugins/$plugin "https://github.com/haskell/haskell-language-server.git" > "${script_dir}/$plugin.nix"
 done
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
