### PR TITLE
fwupd: 1.5.3 → 1.5.5

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,5 +1,5 @@
 diff --git a/data/meson.build b/data/meson.build
-index 14454458..12a798c0 100644
+index 50154569..f8058a8e 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -17,7 +17,7 @@ endif
@@ -73,10 +73,10 @@ index 826a3c1d..b78db663 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index a6fb55dd..aedb7530 100644
+index b075ca89..8d504d3c 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -183,6 +183,12 @@ endif
+@@ -194,6 +194,12 @@ endif
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
  
@@ -90,7 +90,7 @@ index a6fb55dd..aedb7530 100644
  gio = dependency('gio-2.0', version : '>= 2.45.8')
  giounix = dependency('gio-unix-2.0', version : '>= 2.45.8', required: false)
 diff --git a/meson_options.txt b/meson_options.txt
-index 0a0e2853..198ae930 100644
+index bc76c0ab..8a67d012 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -1,3 +1,4 @@
@@ -98,19 +98,6 @@ index 0a0e2853..198ae930 100644
  option('build', type : 'combo', choices : ['all', 'standalone', 'library'], value : 'all', description : 'build type')
  option('agent', type : 'boolean', value : true, description : 'enable the fwupd agent')
  option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
-diff --git a/plugins/ata/meson.build b/plugins/ata/meson.build
-index f32b97fe..679ccc7b 100644
---- a/plugins/ata/meson.build
-+++ b/plugins/ata/meson.build
-@@ -7,7 +7,7 @@ install_data([
- )
- 
- install_data(['ata.conf'],
--  install_dir:  join_paths(sysconfdir, 'fwupd')
-+  install_dir:  join_paths(sysconfdir_install, 'fwupd')
- )
- 
- shared_module('fu_plugin_ata',
 diff --git a/plugins/dell-esrt/meson.build b/plugins/dell-esrt/meson.build
 index ed4eee70..76dbdb1d 100644
 --- a/plugins/dell-esrt/meson.build
@@ -123,10 +110,10 @@ index ed4eee70..76dbdb1d 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/plugins/redfish/meson.build b/plugins/redfish/meson.build
-index 92762791..08bb37ea 100644
+index 205d1394..3223f404 100644
 --- a/plugins/redfish/meson.build
 +++ b/plugins/redfish/meson.build
-@@ -26,7 +26,7 @@ shared_module('fu_plugin_redfish',
+@@ -27,7 +27,7 @@ shared_module('fu_plugin_redfish',
  )
  
  install_data(['redfish.conf'],
@@ -148,14 +135,14 @@ index 6b2368fb..2bd06fed 100644
  )
  # we use functions from 2.52 in the tests
  if get_option('tests') and umockdev.found() and gio.version().version_compare('>= 2.52')
-diff --git a/plugins/uefi/meson.build b/plugins/uefi/meson.build
-index 2d1b2d22..c4217a72 100644
---- a/plugins/uefi/meson.build
-+++ b/plugins/uefi/meson.build
+diff --git a/plugins/uefi-capsule/meson.build b/plugins/uefi-capsule/meson.build
+index 0b793a07..ebd3e5ea 100644
+--- a/plugins/uefi-capsule/meson.build
++++ b/plugins/uefi-capsule/meson.build
 @@ -97,7 +97,7 @@ if get_option('man')
  endif
  
- install_data(['uefi.conf'],
+ install_data(['uefi_capsule.conf'],
 -  install_dir:  join_paths(sysconfdir, 'fwupd')
 +  install_dir:  join_paths(sysconfdir_install, 'fwupd')
  )

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -30,6 +30,7 @@
 , docbook-xsl-nons
 , ninja
 , gcab
+, gnutls
 , python3
 , wrapGAppsHook
 , json-glib
@@ -87,7 +88,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
-    version = "1.5.3";
+    version = "1.5.5";
 
     # libfwupd goes to lib
     # daemon, plug-ins and libfwupdplugin go to out
@@ -96,7 +97,7 @@ let
 
     src = fetchurl {
       url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      sha256 = "005y5wicmm6f2v8i9m3axx7ivgj3z8mbqps4v9m71bsqmq298j86";
+      sha256 = "0c2m9qz1g7zxqc6w90w9hksf8y9hvlh0vyvx06q01x893j5hzxh6";
     };
 
     patches = [
@@ -129,6 +130,7 @@ let
       shared-mime-info
       valgrind
       gcab
+      gnutls
       docbook_xml_dtd_43
       docbook-xsl-nons
       help2man
@@ -274,7 +276,6 @@ let
 
     passthru = {
       filesInstalledToEtc = [
-        "fwupd/ata.conf"
         "fwupd/daemon.conf"
         "fwupd/redfish.conf"
         "fwupd/remotes.d/lvfs-testing.conf"
@@ -283,7 +284,7 @@ let
         "fwupd/remotes.d/vendor-directory.conf"
         "fwupd/thunderbolt.conf"
         "fwupd/upower.conf"
-        "fwupd/uefi.conf"
+        "fwupd/uefi_capsule.conf"
         "pki/fwupd/GPG-KEY-Hughski-Limited"
         "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
         "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://blogs.gnome.org/hughsie/2021/01/11/fwupd-1-5-5/


﻿- https://github.com/fwupd/fwupd/releases/tag/1.5.4
- https://github.com/fwupd/fwupd/releases/tag/1.5.5



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
