### PR TITLE
[20.09] net-snmp: 5.8 -> 5.9

### DIFF
--- a/pkgs/servers/monitoring/net-snmp/0002-autoconf-version.patch
+++ b/pkgs/servers/monitoring/net-snmp/0002-autoconf-version.patch
@@ -1,7 +1,0 @@
-diff --git a/dist/autoconf-version b/dist/autoconf-version
-index 264f2ce..5e1b8b0 100644
---- a/dist/autoconf-version
-+++ b/dist/autoconf-version
-@@ -1 +1 @@
--2.68
-+2.69

--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -2,11 +2,12 @@
 , file, openssl, perl, perlPackages, unzip, nettools, ncurses }:
 
 stdenv.mkDerivation rec {
-  name = "net-snmp-5.8";
+  pname = "net-snmp";
+  version = "5.9";
 
   src = fetchurl {
-    url = "mirror://sourceforge/net-snmp/${name}.tar.gz";
-    sha256 = "1pvajzj9gmj56dmwix0ywmkmy2pglh6nny646hkm7ghfhh03bz5j";
+    url = "mirror://sourceforge/net-snmp/${pname}-${version}.tar.gz";
+    sha256 = "0wb0vyafpspw3mcifkjjmf17r1r80kjvslycscb8nvaxz1k3lc04";
   };
 
   patches =
@@ -17,7 +18,6 @@ stdenv.mkDerivation rec {
   in [
     (fetchAlpinePatch "fix-includes.patch" "0zpkbb6k366qpq4dax5wknwprhwnhighcp402mlm7950d39zfa3m")
     (fetchAlpinePatch "netsnmp-swinst-crash.patch" "0gh164wy6zfiwiszh58fsvr25k0ns14r3099664qykgpmickkqid")
-    ./0002-autoconf-version.patch
   ];
 
   outputs = [ "bin" "out" "dev" "lib" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2019-20892.

(cherry picked from commit e95b84e6a19d42cd8632933d1cf88cfd43f96ab0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
