### PR TITLE
tmux-mem-cpu-load: init at 3.4.0

### DIFF
--- a/pkgs/tools/misc/tmux-mem-cpu-load/default.nix
+++ b/pkgs/tools/misc/tmux-mem-cpu-load/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit, cmake }:
+
+stdenv.mkDerivation {
+  pname = "tmux-mem-cpu-load";
+  version = "v3.4.0";
+
+  src = fetchgit {
+    url = https://github.com/thewtex/tmux-mem-cpu-load.git;
+    rev = "54fdf3c68c13f7a5fd1a1e998d801d0a24dd910a";
+    sha256 = "1ybj513l4953jhayrzb47dlh4yv9bkvs0q1lfvky17v9fdkxgn2j";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [];
+
+  meta = with stdenv.lib; {
+    description = "CPU, RAM, and load monitor for use with tmux";
+    homepage = https://github.com/thewtex/tmux-mem-cpu-load;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ thomasjm ];
+    platforms = with platforms; linux ++ darwin ++ freebsd ++ openbsd ++ netbsd;
+  };
+}

--- a/pkgs/tools/misc/tmux-mem-cpu-load/default.nix
+++ b/pkgs/tools/misc/tmux-mem-cpu-load/default.nix
@@ -1,24 +1,23 @@
-{ stdenv, fetchgit, cmake }:
+{ stdenv, lib, fetchFromGitHub, cmake }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "tmux-mem-cpu-load";
-  version = "v3.4.0";
+  version = "3.4.0";
 
-  src = fetchgit {
-    url = https://github.com/thewtex/tmux-mem-cpu-load.git;
-    rev = "54fdf3c68c13f7a5fd1a1e998d801d0a24dd910a";
+  src = fetchFromGitHub {
+    owner = "thewtex";
+    repo = "tmux-mem-cpu-load";
+    rev = "v${version}";
     sha256 = "1ybj513l4953jhayrzb47dlh4yv9bkvs0q1lfvky17v9fdkxgn2j";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "CPU, RAM, and load monitor for use with tmux";
     homepage = https://github.com/thewtex/tmux-mem-cpu-load;
     license = licenses.asl20;
     maintainers = with maintainers; [ thomasjm ];
-    platforms = with platforms; linux ++ darwin ++ freebsd ++ openbsd ++ netbsd;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8327,6 +8327,8 @@ in
 
   tmuxinator = callPackage ../tools/misc/tmuxinator { };
 
+  tmux-mem-cpu-load = callPackage ../tools/misc/tmux-mem-cpu-load { };
+
   tmux-xpanes = callPackage ../tools/misc/tmux-xpanes { };
 
   tmuxPlugins = recurseIntoAttrs (callPackage ../misc/tmux-plugins { });


### PR DESCRIPTION

###### Motivation for this change

Init `tmux-mem-cpu-load`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions (Ubuntu 20.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [N/A] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
