### PR TITLE
masscan: 1.3.1 -> 1.3.2

### DIFF
--- a/pkgs/tools/security/masscan/default.nix
+++ b/pkgs/tools/security/masscan/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "masscan";
-  version = "1.3.1";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "robertdavidgraham";
     repo = "masscan";
     rev = version;
-    sha256 = "sha256-gH0zOf2kl6cqws1nB3QPtaAjpvNAgbawXRx77bqJTIc=";
+    sha256 = "sha256-mnGC/moQANloR5ODwRjzJzBa55OEZ9QU+9WpAHxQE/g=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/masscan/default.nix
+++ b/pkgs/tools/security/masscan/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, libpcap }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, installShellFiles
+, makeWrapper
+, libpcap
+}:
 
 stdenv.mkDerivation rec {
   pname = "masscan";
@@ -11,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-mnGC/moQANloR5ODwRjzJzBa55OEZ9QU+9WpAHxQE/g=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   makeFlags = [ "PREFIX=$(out)" "GITVER=${version}" "CC=cc" ];
 
@@ -20,13 +26,13 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    mkdir -p $out/share/man/man8
+    installManPage doc/masscan.8
+
     mkdir -p $out/share/{doc,licenses}/masscan
     mkdir -p $out/etc/masscan
 
     cp data/exclude.conf $out/etc/masscan
     cp -t $out/share/doc/masscan doc/algorithm.js doc/howto-afl.md doc/bot.html
-    cp doc/masscan.8 $out/share/man/man8/masscan.8
     cp LICENSE $out/share/licenses/masscan/LICENSE
 
     wrapProgram $out/bin/masscan --prefix LD_LIBRARY_PATH : "${libpcap}/lib"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.3.2

Change log: https://github.com/robertdavidgraham/masscan/releases/tag/1.3.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
