### PR TITLE
flatpak: 1.8.2 → 1.10.1

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -1,12 +1,8 @@
 { lib, stdenv
 , fetchurl
-, fetchpatch
-, autoconf
-, automake
-, libtool
+, autoreconfHook
 , docbook_xml_dtd_412
-, docbook_xml_dtd_42
-, docbook_xml_dtd_43
+, docbook_xml_dtd_45
 , docbook-xsl-nons
 , which
 , libxml2
@@ -49,7 +45,7 @@
 , xorg
 , valgrind
 , glib-networking
-, wrapGAppsHook
+, wrapGAppsNoGuiHook
 , dconf
 , gsettings-desktop-schemas
 , librsvg
@@ -57,14 +53,14 @@
 
 stdenv.mkDerivation rec {
   pname = "flatpak";
-  version = "1.8.2";
+  version = "1.10.1";
 
   # TODO: split out lib once we figure out what to do with triggerdir
   outputs = [ "out" "dev" "man" "doc" "devdoc" "installedTests" ];
 
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "eSZiXffCKCpe4aizwxevU9QKZjsbxrGKLch0fiZQhbA=";
+    sha256 = "1dywvfpmszvp2wy5hvpzy8z6gz2gzmi9p302njp52p9vpx14ydf1";
   };
 
   patches = [
@@ -104,24 +100,15 @@ stdenv.mkDerivation rec {
 
     # But we want the GDK_PIXBUF_MODULE_FILE from the wrapper affect the icon validator.
     ./validate-icon-pixbuf.patch
-
-    # Fix `flatpak/test-oci-registry@{user,system}.wrap.test` installed tests.
-    # https://github.com/flatpak/flatpak/pull/3762
-    (fetchpatch {
-      url = "https://github.com/flatpak/flatpak/commit/c1447dadecd50f384b6d11dac18b014245267d00.patch";
-      sha256 = "UAA/wGr8/aMbx5MV+8Ilro2kgKkx2QOn88lDUjCgeDA=";
-    })
   ];
 
   nativeBuildInputs = [
-    autoconf
-    automake
-    libtool
+    autoreconfHook
     libxml2
-    # TODO: replace with docbook_xml_dtd_45 https://github.com/flatpak/flatpak/pull/3760
+    # Remove 4.1.2 again once the following is merged
+    # https://github.com/flatpak/flatpak/pull/4102
     docbook_xml_dtd_412
-    docbook_xml_dtd_42
-    docbook_xml_dtd_43
+    docbook_xml_dtd_45
     docbook-xsl-nons
     which
     gobject-introspection
@@ -132,7 +119,7 @@ stdenv.mkDerivation rec {
     xmlto
     appstream-glib
     yacc
-    wrapGAppsHook
+    wrapGAppsNoGuiHook
   ];
 
   buildInputs = [
@@ -147,7 +134,7 @@ stdenv.mkDerivation rec {
     libseccomp
     libsoup
     lzma
-    # zstd # TODO: broken paths in .pc file
+    zstd
     polkit
     python3
     systemd
@@ -199,16 +186,6 @@ stdenv.mkDerivation rec {
     PATH=${lib.makeBinPath [vsc-py]}:$PATH patchShebangs --build variant-schema-compiler/variant-schema-compiler
   '';
 
-  preConfigure = ''
-    # TODO: remove the condition once autogen.sh is shipped in the tarball
-    # https://github.com/flatpak/flatpak/pull/3761
-    if [[ -f autogen.sh ]]; then
-        NOCONFIGURE=1 ./autogen.sh
-    else
-        autoreconf --install --force --verbose
-    fi
-  '';
-
   passthru = {
     tests = {
       installedTests = nixosTests.installed-tests.flatpak;
@@ -218,7 +195,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Linux application sandboxing and distribution framework";
     homepage = "https://flatpak.org/";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

**Security advisories:**
- https://github.com/flatpak/flatpak/security/advisories/GHSA-4ppf-fxf6-vxg2

﻿Changes:
- https://github.com/flatpak/flatpak/releases/tag/1.9.1
- https://github.com/flatpak/flatpak/releases/tag/1.9.2
- https://github.com/flatpak/flatpak/releases/tag/1.8.4
- https://github.com/flatpak/flatpak/releases/tag/1.9.3
- https://github.com/flatpak/flatpak/releases/tag/1.8.5
- https://github.com/flatpak/flatpak/releases/tag/1.10.0
- https://github.com/flatpak/flatpak/releases/tag/1.10.1

Also:
- Clarify license.
- Re-enable zstd compression (seems to be fixed now).
- Stop introducing GTK to scope through wrapGAppsHook.
- Clean up the DTDs and build tools we managed to fix upstream.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
