### PR TITLE
pythonPackages.python-levenshtein: 0.12.0 -> 0.12.1

### DIFF
--- a/pkgs/development/python-modules/python-levenshtein/default.nix
+++ b/pkgs/development/python-modules/python-levenshtein/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "python-Levenshtein";
-  version = "0.12.0";
+  version = "0.12.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1c9ybqcja31nghfcc8xxbbz9h60s9qi12b9hr4jyl69xbvg12fh3";
+    sha256 = "0489zzjlfgzpc7vggs7s7db13pld2nlnw7iwgdz1f386i0x2fkjm";
   };
 
   # No tests included in archive


### PR DESCRIPTION
###### Motivation for this change

This fixes a potential segfault on 32bit machines when the input string
causes some 32 bit size calculations (on size_t) to overflow.

See https://github.com/ztane/python-Levenshtein/issues/62 for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`