### PR TITLE
waybox: init at unstable-2020-05-01

### DIFF
--- a/pkgs/applications/window-managers/waybox/default.nix
+++ b/pkgs/applications/window-managers/waybox/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, meson
+, ninja
+, libxkbcommon
+, wayland
+, wayland-protocols
+, wlroots
+, pixman
+, udev
+, libGL
+}:
+
+stdenv.mkDerivation rec {
+  pname = "waybox";
+  version = "unstable-2020-05-01";
+
+  src = fetchFromGitHub {
+    owner = "wizbright";
+    repo = pname;
+    rev = "93811898f0eea3035145f593938d49d5af759b46";
+    sha256 = "IOdKOqAQD87Rs3td8NVEgMnRF6kQSuQ64UVqeVqMBSM=";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [
+    libxkbcommon
+    wayland
+    wayland-protocols
+    wlroots
+    pixman
+    udev
+    libGL
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/wizbright/waybox";
+    description = "An openbox clone on Wayland";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22767,6 +22767,8 @@ in
 
   i3-wk-switch = callPackage ../applications/window-managers/i3/wk-switch.nix { };
 
+  waybox = callPackage ../applications/window-managers/waybox { };
+
   windowchef = callPackage ../applications/window-managers/windowchef/default.nix { };
 
   wmfocus = callPackage ../applications/window-managers/i3/wmfocus.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
