### PR TITLE
rt{audio,midi}: refactor

### DIFF
--- a/pkgs/development/libraries/audio/rtaudio/default.nix
+++ b/pkgs/development/libraries/audio/rtaudio/default.nix
@@ -1,4 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, libjack2,  alsaLib, pulseaudio, rtmidi }:
+{ stdenv
+, lib
+, config
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, alsaSupport ? stdenv.hostPlatform.isLinux
+, alsaLib
+, pulseaudioSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux
+, libpulseaudio
+, jackSupport ? true
+, jack
+, coreaudioSupport ? stdenv.hostPlatform.isDarwin
+, CoreAudio
+}:
 
 stdenv.mkDerivation rec {
   version = "5.1.0";
@@ -11,22 +26,40 @@ stdenv.mkDerivation rec {
     sha256 = "1pglnjz907ajlhnlnig3p0sx7hdkpggr8ss7b3wzf1lykzgv9l52";
   };
 
-  patches = [ ./rtaudio-pkgconfig.patch ];
+  patches = [
+    # Fixes missing headers & install location
+    # Drop with version > 5.1.0
+    (fetchpatch {
+      name = "RtAudio-Adjust-CMake-public-header-installs-to-match-autotools.patch";
+      url = "https://github.com/thestk/rtaudio/commit/4273cf7572b8f51b5996cf6b42e3699cc6b165da.patch";
+      sha256 = "1p0idll0xsfk3jwjg83jkxkaf20gk0wqa7l982ni389rn6i4n26p";
+    })
+  ];
 
-  enableParallelBuilding = true;
-
-  buildInputs = [ autoconf automake libtool libjack2 alsaLib pulseaudio rtmidi ];
-
-  preConfigure = ''
-    ./autogen.sh --no-configure
-    ./configure
+  postPatch = ''
+    substituteInPlace rtaudio.pc.in \
+      --replace 'Requires:' 'Requires.private:'
   '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = lib.optional alsaSupport alsaLib
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional jackSupport jack
+    ++ lib.optional coreaudioSupport CoreAudio;
+
+  cmakeFlags = [
+    "-DRTAUDIO_API_ALSA=${if alsaSupport then "ON" else "OFF"}"
+    "-DRTAUDIO_API_PULSE=${if pulseaudioSupport then "ON" else "OFF"}"
+    "-DRTAUDIO_API_JACK=${if jackSupport then "ON" else "OFF"}"
+    "-DRTAUDIO_API_CORE=${if coreaudioSupport then "ON" else "OFF"}"
+  ];
 
   meta = with lib; {
     description = "A set of C++ classes that provide a cross platform API for realtime audio input/output";
-    homepage =  "http://www.music.mcgill.ca/~gary/rtaudio/";
+    homepage = "https://www.music.mcgill.ca/~gary/rtaudio/";
     license = licenses.mit;
-    maintainers = [ maintainers.magnetophon ];
+    maintainers = with maintainers; [ magnetophon ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/rtaudio/rtaudio-pkgconfig.patch
+++ b/pkgs/development/libraries/audio/rtaudio/rtaudio-pkgconfig.patch
@@ -1,5 +1,0 @@
---- a/rtaudio.pc.in
-+++ b/rtaudio.pc.in
-@@ -9 +9 @@ Version: @PACKAGE_VERSION@
--Requires: @req@ 
-+Requires.private: @req@ 

--- a/pkgs/development/libraries/audio/rtmidi/default.nix
+++ b/pkgs/development/libraries/audio/rtmidi/default.nix
@@ -1,4 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, libjack2, alsaLib, pkg-config }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, alsaSupport ? stdenv.hostPlatform.isLinux
+, alsaLib
+, jackSupport ? true
+, jack
+, coremidiSupport ? stdenv.hostPlatform.isDarwin
+, CoreMIDI
+, CoreAudio
+, CoreServices
+}:
 
 stdenv.mkDerivation rec {
   version = "4.0.0";
@@ -11,21 +25,45 @@ stdenv.mkDerivation rec {
     sha256 = "1g31p6a96djlbk9jh5r4pjly3x76lhccva9hrw6xzdma8dsjzgyq";
   };
 
-  enableParallelBuilding = true;
+  patches = [
+    # PR #230, fix CMake problems
+    (fetchpatch {
+      name = "RtMidi-Fix-JACK_HAS_PORT_RENAME-define.patch";
+      url = "https://github.com/thestk/rtmidi/pull/230/commits/768a30a61b60240b66cc2d43bc27a544ff9f1622.patch";
+      sha256 = "1sym4f7nb2qyyxfhi1l0xsm2hfh6gddn81y36qvfq4mcs33vvid0";
+    })
+    (fetchpatch {
+      name = "RtMidi-Add-prefix-define-for-pkgconfig.patch";
+      url = "https://github.com/thestk/rtmidi/pull/230/commits/7a32e23e3f6cb43c0d2d58443ce205d438e76f44.patch";
+      sha256 = "06im8mb05wah6bnkadw2gpkhmilxb8p84pxqr50b205cchpq304w";
+    })
+  ];
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ autoconf automake libtool libjack2 alsaLib ];
-
-  preConfigure = ''
-    ./autogen.sh --no-configure
-    ./configure
+  postPatch = ''
+    substituteInPlace rtmidi.pc.in \
+      --replace 'Requires:' 'Requires.private:'
+    substituteInPlace CMakeLists.txt \
+      --replace 'PUBLIC_HEADER RtMidi.h' 'PUBLIC_HEADER "RtMidi.h;rtmidi_c.h"' \
+      --replace 'PUBLIC_HEADER DESTINATION $''\{CMAKE_INSTALL_INCLUDEDIR}' 'PUBLIC_HEADER DESTINATION $''\{CMAKE_INSTALL_INCLUDEDIR}/rtmidi'
   '';
 
-  meta = {
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = lib.optional alsaSupport alsaLib
+    ++ lib.optional jackSupport jack
+    ++ lib.optionals coremidiSupport [ CoreMIDI CoreAudio CoreServices ];
+
+  cmakeFlags = [
+    "-DRTMIDI_API_ALSA=${if alsaSupport then "ON" else "OFF"}"
+    "-DRTMIDI_API_JACK=${if jackSupport then "ON" else "OFF"}"
+    "-DRTMIDI_API_CORE=${if coremidiSupport then "ON" else "OFF"}"
+  ];
+
+  meta = with lib; {
     description = "A set of C++ classes that provide a cross platform API for realtime MIDI input/output";
-    homepage =  "http://www.music.mcgill.ca/~gary/rtmidi/";
-    license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.magnetophon ];
-    platforms = with lib.platforms; linux ++ darwin;
+    homepage = "https://www.music.mcgill.ca/~gary/rtmidi/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7277,7 +7277,10 @@ in
 
   rocket = libsForQt5.callPackage ../tools/graphics/rocket { };
 
-  rtaudio = callPackage ../development/libraries/audio/rtaudio { };
+  rtaudio = callPackage ../development/libraries/audio/rtaudio {
+    jack = libjack2;
+    inherit (darwin.apple_sdk.frameworks) CoreAudio;
+  };
 
   rtmidi = callPackage ../development/libraries/audio/rtmidi {
     jack = libjack2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7279,7 +7279,10 @@ in
 
   rtaudio = callPackage ../development/libraries/audio/rtaudio { };
 
-  rtmidi = callPackage ../development/libraries/audio/rtmidi { };
+  rtmidi = callPackage ../development/libraries/audio/rtmidi {
+    jack = libjack2;
+    inherit (darwin.apple_sdk.frameworks) CoreMIDI CoreAudio CoreServices;
+  };
 
   openmpi = callPackage ../development/libraries/openmpi { };
 


### PR DESCRIPTION
###### Motivation for this change
- Nixpkgs-fmt'd
- switched both to CMake
- using `xyzSupport` pattern & explicit CMake variables for audio APIs
- moved RtAudio's patch into postPatch, way too simple of a fix to really need an in-tree patch file imo
- fixed RtMidi's pkg-config file similar to RtAudio's previously

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
