### PR TITLE
nixos/thinkfan: rewrite for 1.2 update

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -466,6 +466,19 @@ self: super:
      ALSA OSS emulation (<varname>sound.enableOSSEmulation</varname>) is now disabled by default.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      Thinkfan as been updated to <literal>1.2.x</literal>, which comes with a
+      new YAML based configuration format. For this reason, several NixOS options
+      of the thinkfan module have been changed to non-backward compatible types.
+      In addition, a new <xref linkend="opt-services.thinkfan.settings"/> option has
+      been added.
+    </para>
+    <para>
+      Please read the <link xlink:href="https://github.com/vmatare/thinkfan#readme">
+      thinkfan documentation</link> before updating.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -20,9 +20,24 @@ stdenv.mkDerivation rec {
     sha256 = "18vgm5w5pjnpipa34j4x87q10695w2jnqwvc2f027afy7mnzw7kz";
   };
 
+  postPatch = ''
+    # fix hardcoded install path
+    substituteInPlace CMakeLists.txt --replace /etc $out/etc
+
+    # fix command paths in unit files
+    for unit in rcscripts/systemd/*; do
+      substituteInPlace "$unit" \
+        --replace /bin/kill ${procps}/bin/kill \
+        --replace /usr/bin/pkill ${procps}/bin/pkill \
+        --replace /usr/bin/sleep ${coreutils}/bin/sleep
+    done
+  '';
+
   cmakeFlags = [
     "-DCMAKE_INSTALL_DOCDIR=share/doc/${pname}"
     "-DUSE_NVML=OFF"
+    # force install unit files
+    "-DSYSTEMD_FOUND=ON"
   ] ++ lib.optional smartSupport "-DUSE_ATASMART=ON";
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.gpl3Plus;
     homepage = "https://github.com/vmatare/thinkfan";
-    maintainers = with lib.maintainers; [ domenkozar ];
+    maintainers = with lib.maintainers; [ domenkozar rnhmjoj ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -1,5 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libyamlcpp, pkg-config
-, smartSupport ? false, libatasmart }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, libyamlcpp
+, pkg-config
+, procps
+, coreutils
+, smartSupport ? false, libatasmart
+}:
 
 stdenv.mkDerivation rec {
   pname = "thinkfan";
@@ -21,27 +29,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libyamlcpp ] ++ lib.optional smartSupport libatasmart;
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 {.,$out/bin}/thinkfan
-
-    cd "$NIX_BUILD_TOP"; cd "$sourceRoot" # attempt to be a bit robust
-    install -Dm644 {.,$out/share/doc/thinkfan}/README.md
-    cp -R examples $out/share/doc/thinkfan
-    install -Dm644 {src,$out/share/man/man1}/thinkfan.1
-
-    runHook postInstall
-  '';
-
-  meta = with lib; {
-    description  = "A minimalist fan control program";
-    longDescription = "A minimalist fan control program. Originally designed
-specifically for IBM/Lenovo Thinkpads, it now supports any kind of system via
-the sysfs hwmon interface (/sys/class/hwmon).";
-    license = licenses.gpl3;
+  meta = {
+    description = "A simple, lightweight fan control program";
+    longDescription = ''
+      Thinkfan is a minimalist fan control program. Originally designed
+      specifically for IBM/Lenovo Thinkpads, it now supports any kind of
+      system via the sysfs hwmon interface (/sys/class/hwmon).
+    '';
+    license = lib.licenses.gpl3Plus;
     homepage = "https://github.com/vmatare/thinkfan";
-    maintainers = with maintainers; [ domenkozar ];
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ domenkozar ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

nixos/thinkfan: rewrite for 1.2 update

Thinkfan underwent some major changes and the config file
is now based on YAML. This commit contains a number of changes:

- rewrite the module to output the new format;
- add a `settings` option, following RFC 0042[1];
- add fancy type-checking for the most critical options
- use upstream systemd units (which fix the resume issue)

[1]: https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested `services.thinkfan.enable` on my machine with NixOS 20.09
- [x] Built NixOS manual
- [x] Tested compilation of all pkgs that depend on this change (thinkfan)
- [x] Tested execution of all binary files
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc: @domenkozar (are you still using thinkfan?)