### PR TITLE
iotools: Init at 1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3043,6 +3043,12 @@
     githubId = 9959940;
     name = "Andreas Fehn";
   };
+  felixsinger = {
+    email = "felixsinger@posteo.net";
+    github = "felixsinger";
+    githubId = 628359;
+    name = "Felix Singer";
+  };
   felschr = {
     email = "dev@felschr.com";
     github = "felschr";

--- a/pkgs/tools/misc/iotools/default.nix
+++ b/pkgs/tools/misc/iotools/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "iotools";
+  version = "unstable-2017-12-11";
+
+  src = fetchFromGitHub {
+    owner = "adurbin";
+    repo = pname;
+    rev = "18949fdc4dedb1da3f51ee83a582b112fb9f2c71";
+    sha256 = "0vymnah44d5bzsjhfmxkcrlrikkp0db22k7a1s8bknz7glk9fldn";
+  };
+
+  makeFlags = [ "DEBUG=0" "STATIC=0" ];
+
+  installPhase = ''
+    install -Dm755 iotools -t $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Set of simple command line tools which allow access to
+      hardware device registers";
+    longDescription = ''
+      Provides a set of simple command line tools which allow access to
+      hardware device registers. Supported register interfaces include PCI,
+      IO, memory mapped IO, SMBus, CPUID, and MSR. Also included are some
+      utilities which allow for simple arithmetic, logical, and other
+      operations.
+    '';
+    homepage = "https://github.com/adurbin/iotools";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ felixsinger ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2440,6 +2440,8 @@ in
 
   interlock = callPackage ../servers/interlock {};
 
+  iotools = callPackage ../tools/misc/iotools { };
+
   jellyfin = callPackage ../servers/jellyfin { };
 
   jellyfin_10_5 = callPackage ../servers/jellyfin/10.5.x.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Provides a set of simple command line tools which allow access to hardware device registers. Supported register interfaces include PCI, IO, memory mapped IO, SMBus, CPUID, and MSR. Also included are some utilities which allow for simple arithmetic, logical, and other operations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
