### PR TITLE
libkeyfinder: 2.1 -> 2.2.4

### DIFF
--- a/pkgs/development/libraries/libkeyfinder/default.nix
+++ b/pkgs/development/libraries/libkeyfinder/default.nix
@@ -1,37 +1,32 @@
-{ lib, stdenv, fetchFromGitHub, fftw, qtbase, qmake }:
+{ lib, stdenv, fetchFromGitHub, cmake, fftw, catch2 }:
 
 stdenv.mkDerivation rec {
   pname = "libkeyfinder";
-  version = "2.1";
+  version = "2.2.4";
 
   src = fetchFromGitHub {
-    sha256 = "07kc0cl6kirgmpdgkgmp6r3yvyf7b1w569z01g8rfl1cig80qdc7";
+    owner = "mixxxdj";
+    repo = "libkeyfinder";
     rev = "v${version}";
-    repo = "libKeyFinder";
-    owner = "ibsh";
+    sha256 = "005qq81xfzi1iifvpgkqpizxcrfisafq2r0cjp4fxqh1ih7bfimv";
   };
 
-  nativeBuildInputs = [ qmake ];
-  buildInputs = [ fftw qtbase ];
-
-  postPatch = ''
-    substituteInPlace LibKeyFinder.pro \
-      --replace "/usr/local" "$out" \
-      --replace "-stdlib=libc++" ""
+  # needed for linking libkeyfinder.so into keyfinder-tests executable
+  preBuild = ''
+    export LD_LIBRARY_PATH=$(pwd)
   '';
 
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake ];
 
-  postInstall = ''
-    mkdir -p $out/include/keyfinder
-    install -m644 *.h $out/include/keyfinder
-    mkdir -p $out/lib
-    cp -a lib*.so* $out/lib
-  '';
+  buildInputs = [ fftw ];
+
+  checkInputs = [ catch2 ];
+
+  doCheck = true;
 
   meta = with lib; {
     description = "Musical key detection for digital audio (C++ library)";
-    homepage = "http://www.ibrahimshaath.co.uk/keyfinder/";
+    homepage = "https://mixxxdj.github.io/libkeyfinder/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15108,6 +15108,8 @@ in
 
   libkate = callPackage ../development/libraries/libkate { };
 
+  libkeyfinder = callPackage ../development/libraries/libkeyfinder { };
+
   libkml = callPackage ../development/libraries/libkml { };
 
   libksba = callPackage ../development/libraries/libksba { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23023,7 +23023,7 @@ in
 
   keyfinder = libsForQt5.callPackage ../applications/audio/keyfinder { };
 
-  keyfinder-cli = libsForQt5.callPackage ../applications/audio/keyfinder-cli { };
+  keyfinder-cli = callPackage ../applications/audio/keyfinder-cli { };
 
   kgraphviewer = libsForQt5.callPackage ../applications/graphics/kgraphviewer { };
 

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -95,8 +95,6 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeApplications // qt5 // 
 
   libdbusmenu = callPackage ../development/libraries/libdbusmenu-qt/qt-5.5.nix { };
 
-  libkeyfinder = callPackage ../development/libraries/libkeyfinder { };
-
   libktorrent = callPackage ../development/libraries/libktorrent { };
 
   liblastfm = callPackage ../development/libraries/liblastfm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
###### Motivation for this change
https://github.com/ibsh/libKeyFinder#this-repository-is-now-maintained-by-the-mixxx-dj-software-team-please-send-new-pull-requests-and-bug-reports-there

Can someone with knowledge of CMake explain why I see
```
running tests
check flags: SHELL=/nix/store/cwnwyy82wrq53820z6yg7869z8dl5s7g-bash-4.4-p23/bin/bash VERBOSE=y test
Running tests...
/nix/store/mzbylj1zprn18m7h2nsf6vmfafkvz54r-cmake-3.19.3/bin/ctest --force-new-ctest-process
Test project /build/source/build
No tests were found!!!
```
See https://github.com/mixxxdj/libkeyfinder/tree/v2.2.4#testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
