### PR TITLE
ocamlPackages.ppx_deriving_cmdliner: init at 0.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildDunePackage
+, fetchFromGitHub
+, alcotest
+, cmdliner
+, ppx_deriving
+, ppxlib
+}:
+
+buildDunePackage rec {
+  pname = "ppx_deriving_cmdliner";
+  version = "0.6.0";
+
+  minimumOCamlVersion = "4.08";
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "hammerlab";
+    repo = "ppx_deriving_cmdliner";
+    rev = "v${version}";
+    sha256 = "19l32y2wv64d1c7fvln07dg3bkf7wf5inzjxlff7lbabskdbbras";
+  };
+
+  propagatedBuildInputs = [
+    cmdliner
+    ppx_deriving
+    ppxlib
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+  ];
+
+  meta = with lib; {
+    description = "Ppx_deriving plugin for generating command line interfaces from types for OCaml";
+    inherit (src.meta) homepage;
+    license = licenses.asl20;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1076,6 +1076,8 @@ let
 
     ppx_deriving_yojson = callPackage ../development/ocaml-modules/ppx_deriving_yojson {};
 
+    ppx_deriving_cmdliner = callPackage ../development/ocaml-modules/ppx_deriving_cmdliner {};
+
     ppx_gen_rec = callPackage ../development/ocaml-modules/ppx_gen_rec {};
 
     ppx_import = callPackage ../development/ocaml-modules/ppx_import (


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [ppx_deriving_cmdliner](https://github.com/hammerlab/ppx_deriving_cmdliner), a `ppx_deriving` plugin that generates a `Cmdliner` `Term` for a given type for OCaml.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
