### PR TITLE
python3Packages.sqlalchemy: 1.3.20 -> 1.3.23

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -2,6 +2,7 @@
 , mock
 , pysqlite
 , pytestCheckHook
+, pytest_xdist
 }:
 
 buildPythonPackage rec {
@@ -15,8 +16,11 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
+    pytest_xdist
     mock
   ] ++ lib.optional (!isPy3k) pysqlite;
+
+  pytestFlagsArray = [ "-n auto" ];
 
   postInstall = ''
     sed -e 's:--max-worker-restart=5::g' -i setup.cfg

--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "SQLAlchemy";
-  version = "1.3.20";
+  version = "1.3.23";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d2f25c7f410338d31666d7ddedfa67570900e248b940d186b48461bd4e5569a1";
+    sha256 = "12wi4vxjsx4ra76phks9drhc2yc9xz25458kgijnyrkq4mkk7jkg";
   };
 
   checkInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream releases
https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_1_3_21
https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_1_3_22
https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_1_3_23

The tests took their sweet time, so while they were running I added xdist to parallelize them.

```
# before
=============== 10312 passed, 1211 skipped in 665.06s (0:11:05) ================
# after
=============== 10312 passed, 1211 skipped in 259.32s (0:04:19) ================
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
