### PR TITLE
octant: refactor

### DIFF
--- a/pkgs/applications/networking/cluster/octant/update.sh
+++ b/pkgs/applications/networking/cluster/octant/update.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused gawk nix-prefetch
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_DRV="$ROOT/default.nix"
+if [ ! -f "$NIX_DRV" ]; then
+  echo "ERROR: cannot find default.nix in $ROOT"
+  exit 1
+fi
+
+fetch_arch() {
+  VER="$1"; ARCH="$2"
+  URL="https://github.com/vmware-tanzu/octant/releases/download/v${VER}/octant_${VER}_${ARCH}.tar.gz"
+  nix-prefetch "{ stdenv, fetchzip }:
+stdenv.mkDerivation rec {
+  pname = \"octant\"; version = \"${VER}\";
+  src = fetchzip { url = \"$URL\"; };
+}
+"
+}
+
+replace_sha() {
+  sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_DRV"
+}
+
+OCTANT_VER=$(curl -Ls -w "%{url_effective}" -o /dev/null https://github.com/vmware-tanzu/octant/releases/latest | awk -F'/' '{print $NF}' | sed 's/v//')
+
+OCTANT_LINUX_X64_SHA256=$(fetch_arch "$OCTANT_VER" "Linux-64bit")
+OCTANT_DARWIN_X64_SHA256=$(fetch_arch "$OCTANT_VER" "Linux-arm64")
+OCTANT_LINUX_AARCH64_SHA256=$(fetch_arch "$OCTANT_VER" "macOS-64bit")
+
+sed -i "s/version = \".*\"/version = \"$OCTANT_VER\"/" "$NIX_DRV"
+
+replace_sha "x86_64-linux" "$OCTANT_LINUX_X64_SHA256"
+replace_sha "x86_64-darwin" "$OCTANT_LINUX_AARCH64_SHA256"
+replace_sha "aarch64-linux" "$OCTANT_DARWIN_X64_SHA256"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add update script
Refactor to be more similar to recent boundary package (#111151)
Resolves "treewide: Remove doBuild = false" for octant (#111646)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
