### PR TITLE
Haskell generic args builder modifier backport

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -285,38 +285,151 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     #
     #     bash$ nix-shell --run "cabal new-build all"
     #     bash$ nix-shell --run "python"
-    shellFor = { packages, withHoogle ? false, ... } @ args:
+    shellFor =
+      { # Packages to create this development shell for.  These are usually
+        # your local packages.
+        packages
+      , # Whether or not to generate a Hoogle database for all the
+        # dependencies.
+        withHoogle ? false
+      , # Whether or not to include benchmark dependencies of your local
+        # packages.  You should set this to true if you have benchmarks defined
+        # in your local packages that you want to be able to run with cabal benchmark
+        doBenchmark ? false
+      , genericBuilderArgsModifier ? (args: args)
+      , ...
+      } @ args:
       let
-        combinedPackageFor = packages:
-          let
-            selected = packages self;
+        # A list of the packages we want to build a development shell for.
+        # This is a list of Haskell package derivations.
+        selected = packages self;
 
-            pname = if pkgs.lib.length selected == 1
-              then (pkgs.lib.head selected).name
-              else "packages";
+        # This is a list of attribute sets, where each attribute set
+        # corresponds to the build inputs of one of the packages input to shellFor.
+        #
+        # Each attribute has keys like buildDepends, executableHaskellDepends,
+        # testPkgconfigDepends, etc.  The values for the keys of the attribute
+        # set are lists of dependencies.
+        #
+        # Example:
+        #   cabalDepsForSelected
+        #   => [
+        #        # This may be the attribute set corresponding to the `backend`
+        #        # package in the example above.
+        #        { buildDepends = [ gcc ... ];
+        #          libraryHaskellDepends = [ lens conduit ... ];
+        #          ...
+        #        }
+        #        # This may be the attribute set corresponding to the `common`
+        #        # package in the example above.
+        #        { testHaskellDepends = [ tasty hspec ... ];
+        #          libraryHaskellDepends = [ lens aeson ];
+        #          benchmarkHaskellDepends = [ criterion ... ];
+        #          ...
+        #        }
+        #        ...
+        #      ]
+        cabalDepsForSelected = map (p: p.getCabalDeps) selected;
 
-            # If `packages = [ a b ]` and `a` depends on `b`, don't build `b`,
-            # because cabal will end up ignoring that built version, assuming
-            # new-style commands.
-            combinedPackages = pkgs.lib.filter
-              (input: pkgs.lib.all (p: input.outPath or null != p.outPath) selected);
+        # A predicate that takes a derivation as input, and tests whether it is
+        # the same as any of the `selected` packages.
+        #
+        # Returns true if the input derivation is not in the list of `selected`
+        # packages.
+        #
+        # isNotSelected :: Derivation -> Bool
+        #
+        # Example:
+        #
+        #   isNotSelected common [ frontend backend common ]
+        #   => false
+        #
+        #   isNotSelected lens [ frontend backend common ]
+        #   => true
+        isNotSelected = input: pkgs.lib.all (p: input.outPath or null != p.outPath) selected;
 
-            # Returns an attrset containing a combined list packages' inputs for each
-            # stage of the build process
-            packageInputs = pkgs.lib.zipAttrsWith
-              (_: pkgs.lib.concatMap combinedPackages)
-              (map (p: p.getCabalDeps) selected);
+        # A function that takes a list of list of derivations, filters out all
+        # the `selected` packages from each list, and concats the results.
+        #
+        #   zipperCombinedPkgs :: [[Derivation]] -> [Derivation]
+        #
+        # Example:
+        #   zipperCombinedPkgs [ [ lens conduit ] [ aeson frontend ] ]
+        #   => [ lens conduit aeson ]
+        #
+        # Note: The reason this isn't just the function `pkgs.lib.concat` is
+        # that we need to be careful to remove dependencies that are in the
+        # `selected` packages.
+        #
+        # For instance, in the above example, if `common` is a dependency of
+        # `backend`, then zipperCombinedPkgs needs to be careful to filter out
+        # `common`, because cabal will end up ignoring that built version,
+        # assuming new-style commands.
+        zipperCombinedPkgs = vals:
+          pkgs.lib.concatMap
+            (drvList: pkgs.lib.filter isNotSelected drvList)
+            vals;
 
-            genericBuilderArgs = {
-              inherit pname;
-              version = "0";
-              license = null;
-            } // packageInputs;
+        # Zip `cabalDepsForSelected` into a single attribute list, combining
+        # the derivations in all the individual attributes.
+        #
+        # Example:
+        #   packageInputs
+        #   => # Assuming the value of cabalDepsForSelected is the same as
+        #      # the example in cabalDepsForSelected:
+        #      { buildDepends = [ gcc ... ];
+        #        libraryHaskellDepends = [ lens conduit aeson ... ];
+        #        testHaskellDepends = [ tasty hspec ... ];
+        #        benchmarkHaskellDepends = [ criterion ... ];
+        #        ...
+        #      }
+        #
+        # See the Note in `zipperCombinedPkgs` for what gets filtered out from
+        # each of these dependency lists.
+        packageInputs =
+          pkgs.lib.zipAttrsWith (_name: zipperCombinedPkgs) cabalDepsForSelected;
 
-          in self.mkDerivation genericBuilderArgs;
+        # A attribute set to pass to `haskellPackages.mkDerivation`.
+        #
+        # The important thing to note here is that all the fields from
+        # packageInputs are set correctly.
+        genericBuilderArgs = {
+          pname =
+            if pkgs.lib.length selected == 1
+            then (pkgs.lib.head selected).name
+            else "packages";
+          version = "0";
+          license = null;
+        }
+        // packageInputs
+        // pkgs.lib.optionalAttrs doBenchmark {
+          # `doBenchmark` needs to explicitly be set here because haskellPackages.mkDerivation defaults it to `false`.  If the user wants benchmark dependencies included in their development shell, it has to be explicitly enabled here.
+          doBenchmark = true;
+        };
 
-        mkDerivationArgs = builtins.removeAttrs args [ "packages" "withHoogle" ];
-      in ((combinedPackageFor packages).envFunc { inherit withHoogle; }).overrideAttrs (old: mkDerivationArgs // {
+        # This is a pseudo Haskell package derivation that contains all the
+        # dependencies for the packages in `selected`.
+        #
+        # This is a derivation created with `haskellPackages.mkDerivation`.
+        #
+        # pkgWithCombinedDeps :: HaskellDerivation
+        pkgWithCombinedDeps = self.mkDerivation (genericBuilderArgsModifier genericBuilderArgs);
+
+        # The derivation returned from `envFunc` for `pkgWithCombinedDeps`.
+        #
+        # This is a derivation that can be run with `nix-shell`.  It provides a
+        # GHC with a package database with all the dependencies of our
+        # `selected` packages.
+        #
+        # This is a derivation created with `stdenv.mkDerivation` (not
+        # `haskellPackages.mkDerivation`).
+        #
+        # pkgWithCombinedDepsDevDrv :: Derivation
+        pkgWithCombinedDepsDevDrv = pkgWithCombinedDeps.envFunc { inherit withHoogle; };
+
+        mkDerivationArgs = builtins.removeAttrs args [ "genericBuilderArgsModifier" "packages" "withHoogle" "doBenchmark" ];
+
+      in pkgWithCombinedDepsDevDrv.overrideAttrs (old: mkDerivationArgs // {
         nativeBuildInputs = old.nativeBuildInputs ++ mkDerivationArgs.nativeBuildInputs or [];
         buildInputs = old.buildInputs ++ mkDerivationArgs.buildInputs or [];
       });

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -296,6 +296,36 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
         # packages.  You should set this to true if you have benchmarks defined
         # in your local packages that you want to be able to run with cabal benchmark
         doBenchmark ? false
+        # An optional function that can modify the generic builder arguments
+        # for the fake package that shellFor uses to construct its environment.
+        #
+        # Example:
+        #   let
+        #     # elided...
+        #     haskellPkgs = pkgs.haskell.packages.ghc884.override (hpArgs: {
+        #       overrides = pkgs.lib.composeExtensions (hpArgs.overrides or (_: _: { })) (
+        #         _hfinal: hprev: {
+        #           mkDerivation = args: hprev.mkDerivation ({
+        #             doCheck = false;
+        #             doBenchmark = false;
+        #             doHoogle = true;
+        #             doHaddock = true;
+        #             enableLibraryProfiling = false;
+        #             enableExecutableProfiling = false;
+        #           } // args);
+        #         }
+        #       );
+        #     });
+        #   in
+        #   hpkgs.shellFor {
+        #     packages = p: [ p.foo ];
+        #     genericBuilderArgsModifier = args: args // { doCheck = true; doBenchmark = true };
+        #   }
+        #
+        # This will disable tests and benchmarks for everything in "haskellPkgs"
+        # (which will invalidate the binary cache), and then re-enable them
+        # for the "shellFor" environment (ensuring that any test/benchmark
+        # dependencies for "foo" will be available within the nix-shell).
       , genericBuilderArgsModifier ? (args: args)
       , ...
       } @ args:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#109059 introduced "generic builder arguments modifier" functionality to the nixpkgs Haskell builder, which allows users to make modifications to the whole package set being used within `shellFor` when compiling dependencies and then again when compiling the "dummy" package that's used to create the final shell.

The intended use-case is to support users who want to disable test suites, benchmarks, haddocks, etc. for the Haskell dependencies, but re-enable them for the packages within the final shell.

This can be useful when developing a complex local package with lots of overrides; building the package set can be prohibitively complex when having to override lots of test dependency breakage, but one would still want to run the test/benchmark suite of the _local_ package (and thus have Nix pull down all of _its_ dependencies into the shell).

###### Things done

Cherry picked 335f1fb25f2f784e496dc4e5560cea7e3414a7a8 and 95d0e6c1b8adca3a03c5e79fc1dba84b5c1f68d6 from the main branch onto the `release-20.09` branch. It _seems_ like there were some other changes that got mixed in from previous commits, so let me know if I should go back and rework this PR (e.g. maybe try to find those older commits and cherry-pick them first).

cc @cdepillabout @expipiplus1 since you helped me out with the initial work and seem to have the most working familiarity with this stuff of the active contributors.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
