### PR TITLE
home-assistant dependencies

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -144,7 +144,9 @@ let
 
               postPatch = let
                 ignoreVersionConstraints = [
+                  "emoji"
                   "sentry-sdk"
+                  "watchdog"
                 ];
               in
                 ''

--- a/pkgs/development/python-modules/brother/default.nix
+++ b/pkgs/development/python-modules/brother/default.nix
@@ -4,15 +4,23 @@
 
 buildPythonPackage rec {
   pname = "brother";
-  version = "0.1.18";
+  version = "0.2.0";
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = pname;
     rev = version;
-    sha256 = "14fiwhgcgymgqsl9kcfb0597rcjxvdknhwbakpdf0xp2ph6cj266";
+    sha256 = "0d984apw73kzd6bid65bqhp26gvvgqjni56nqr0gnb2sv7mknnm8";
   };
+
+  # pytest-error-for-skips is not packaged
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace " --error-for-skips" ""
+    substituteInPlace setup.py \
+      --replace "\"pytest-error-for-skips\"" ""
+  '';
 
   propagatedBuildInputs = [
     pysnmp

--- a/pkgs/development/python-modules/bt-proximity/default.nix
+++ b/pkgs/development/python-modules/bt-proximity/default.nix
@@ -3,7 +3,7 @@
 
 buildPythonPackage {
   pname = "bt-proximity";
-  version = "0.0.20180217";
+  version = "0.2";
 
   # pypi only has a pre-compiled wheel and no sources
   src = fetchFromGitHub {
@@ -17,6 +17,8 @@ buildPythonPackage {
 
   # there are no tests
   doCheck = false;
+
+  pythonImportsCheck = [ "bt_proximity" ];
 
   meta = with lib; {
     description = "Bluetooth Proximity Detection using Python";

--- a/pkgs/development/python-modules/emoji/default.nix
+++ b/pkgs/development/python-modules/emoji/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "emoji";
-  version = "0.6.0";
+  version = "1.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e42da4f8d648f8ef10691bc246f682a1ec6b18373abfd9be10ec0b398823bd11";
+    sha256 = "18siknldyqvxvjf0nv18m0a1c26ahkg7vmhkij1qayanb0h46vs9";
   };
 
   checkInputs = [ nose ];

--- a/pkgs/development/python-modules/fixerio/default.nix
+++ b/pkgs/development/python-modules/fixerio/default.nix
@@ -4,22 +4,19 @@
 , requests
 , pytestCheckHook
 , httpretty
+, responses
 }:
 
 buildPythonPackage rec {
   pname = "fixerio";
-  version = "0.1.1";
+  version = "1.0.0-alpha";
 
   src = fetchFromGitHub {
     owner = "amatellanes";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1k9ss5jc7sbpkjd2774vbmvljny0wm2lrc8155ha8yk2048jsaxk";
+    sha256 = "009h1mys175xdyznn5bl980vly40544s4ph1zcgqwg2i2ic93gvb";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py --replace "requests==2.10.0" "requests"
-  '';
 
   propagatedBuildInputs = [
     requests
@@ -28,6 +25,17 @@ buildPythonPackage rec {
   checkInputs = [
     httpretty
     pytestCheckHook
+    responses
+  ];
+
+  disabledTests = [
+    # tests require network access
+    "test_returns_historical_rates_for_symbols_passed_if_both"
+    "test_returns_historical_rates_for_symbols_passed_in_constructor"
+    "test_returns_historical_rates_for_symbols_passed_in_method"
+    "test_returns_latest_rates_for_symbols_passed_in_constructor"
+    "test_returns_latest_rates_for_symbols_passed_in_method"
+    "test_returns_latest_rates_for_symbols_passed_in_method_if_both"
   ];
 
   pythonImportsCheck = [ "fixerio" ];

--- a/pkgs/development/python-modules/influxdb-client/default.nix
+++ b/pkgs/development/python-modules/influxdb-client/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "influxdb-client";
-  version = "1.13.0";
+  version = "1.14.0";
 
   disabled = pythonOlder "3.6"; # requires python version >=3.6
 
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "influxdata";
     repo = "influxdb-client-python";
     rev = "v${version}";
-    sha256 = "0g7jhjnag8jx8zbjh6xlqds42alpj87a4dpqc37xqa4ir55m3c2q";
+    sha256 = "1qq727gwz5migr3xlqxj57qxv1y52g7xpkdgggz2wz739w5czffd";
   };
 
   # makes test not reproducible

--- a/pkgs/development/python-modules/libsoundtouch/default.nix
+++ b/pkgs/development/python-modules/libsoundtouch/default.nix
@@ -1,30 +1,40 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchFromGitHub
-
-, lib
-, pythonOlder
+, enum-compat
 , requests
-, enum34
+, websocket_client
+, zeroconf
+, pytestCheckHook
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname   = "libsoundtouch";
-  version = "0.4.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
-    owner  = "CharlesBlonde";
-    repo   = "libsoundtouch";
-    rev    = "875074b7a23734021974345b3dc297918e453aa2";
-    sha256 = "1psd556j4x77hjxahxxgdgnq2mcd769whvnf0gmwf3jy2svfkqlg";
+    owner = "CharlesBlonde";
+    repo = "libsoundtouch";
+    rev = version;
+    sha256 = "1wl2w5xfdkrv0qzsz084z2k6sycfyq62mqqgciycha3dywf2fvva";
   };
 
-  postPatch = lib.optionalString (! (pythonOlder "3.4")) ''
-    substituteInPlace setup.py --replace "'enum34>=1.1.6'" ""
-  '';
+  propagatedBuildInputs = [
+    requests
+    enum-compat
+    websocket_client
+    zeroconf
+  ];
 
-  propagatedBuildInputs = [ requests enum34 ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  doCheck = false;
+  disabledTests = [
+    # mock data order mismatch
+    "test_select_content_item"
+    "test_snapshot_restore"
+  ];
 
   meta = with lib; {
     description = "Bose Soundtouch Python library";

--- a/pkgs/development/python-modules/mpd2/default.nix
+++ b/pkgs/development/python-modules/mpd2/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "python-mpd2";
-  version = "3.0.3";
+  version = "3.0.4";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ikvn2qv6cnbjscpbk6hhsqg34h832mxgg6hp1mf4d8d6nwdx4sn";
+    sha256 = "1r8saq1460yfa0sxfrvxqs2r453wz2xchlc9gzbpqznr49786rvs";
   };
 
   buildInputs = [ mock ];

--- a/pkgs/development/python-modules/pysonos/default.nix
+++ b/pkgs/development/python-modules/pysonos/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , isPy3k
 , xmltodict
 , requests
@@ -9,17 +9,21 @@
 # Test dependencies
 , pytest, pylint, flake8, graphviz
 , mock, sphinx, sphinx_rtd_theme
+, requests-mock
 }:
 
 buildPythonPackage rec {
   pname = "pysonos";
-  version = "0.0.37";
+  version = "0.0.40";
 
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "43a046c1c6086500fb0f4be1094ca963f5b0f555a04b692832b2b88ab741824e";
+  # pypi package is missing test fixtures
+  src = fetchFromGitHub {
+    owner = "amelchio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0a0c7jwv39nbvpdcx32sd8kjmj4nyrd7k0yxhpmxdnx4zr4vvzqg";
   };
 
   propagatedBuildInputs = [ xmltodict requests ifaddr ];
@@ -27,6 +31,7 @@ buildPythonPackage rec {
   checkInputs = [
     pytest pylint flake8 graphviz
     mock sphinx sphinx_rtd_theme
+    requests-mock
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/pywilight/default.nix
+++ b/pkgs/development/python-modules/pywilight/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "pywilight";
-  version = "0.0.65";
+  version = "0.0.68";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1bldhg81lal9mbf55ky3gj2ndlplr0vfjp1bamd0mz5d9icas8nf";
+    sha256 = "1s1xyw5hkfr4rlni1p9z4941pp1740fsg4a3b23a618hv2p1i4ww";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/xknx/default.nix
+++ b/pkgs/development/python-modules/xknx/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "xknx";
-  version = "0.16.1";
+  version = "0.16.2";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "XKNX";
     repo = pname;
     rev = version;
-    sha256 = "0nma0fq67p9c90b6s5v7n4s6j94sdiwqf8rk1k2vfc6nxxn1jfll";
+    sha256 = "14cx54ia38ifz7c750i8jxcmnybzwh03ds6hinlwhx8hd2cx9knj";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.51";
+  version = "0.0.53";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zha-device-handlers";
     rev = version;
-    sha256 = "14v01kclf096ax88cd6ckfs8gcffqissli9vpr0wfzli08afmbi9";
+    sha256 = "16n99r7bjd3lnxn72lfnxg44n7mkv196vdhkw2sf1nq1an4ks1nc";
   };
 
   propagatedBuildInputs = [ aiohttp zigpy ];

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.30.0";
+  version = "0.32.0";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy";
     rev = version;
-    sha256 = "14qyxm7bj62fsvxfp6x3r1ygjlv7q3jjvq6gzj30na78x1fqr9g1";
+    sha256 = "18grqx1fzh539ccar0865shgd2mnfni65rjj787cq5j5p5rn0yc7";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

More home-assistant dep updates

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
