### PR TITLE
pinball: init at 0.3.20201218

### DIFF
--- a/pkgs/games/pinball/default.nix
+++ b/pkgs/games/pinball/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchurl, autoreconfHook, pkg-config
+, libglvnd, SDL, SDL_image, SDL_mixer, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pinball";
+  version = "0.3.20201218";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/pinball/pinball-${version}.tar.gz";
+    sha256 = "0vacypp3ksq1hs6hxpypx7nrfkprbl4ksfywcncckwrh4qcir631";
+  };
+
+  postPatch = ''
+    sed -i 's/^AUTOMAKE_OPTIONS = gnu$/AUTOMAKE_OPTIONS = foreign/' Makefile.am
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ libglvnd SDL SDL_image SDL_mixer xorg.libSM ];
+  strictDeps = true;
+
+  configureFlags = [
+    "--with-sdl-prefix=${lib.getDev SDL}"
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-I${lib.getDev SDL_image}/include/SDL"
+    "-I${lib.getDev SDL_mixer}/include/SDL"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://purl.org/rzr/pinball";
+    description = "Emilia Pinball simulator";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ qyliss ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26853,6 +26853,11 @@ in
     boost = boost166;
   };
 
+  pinball = callPackage ../games/pinball {
+    autoreconfHook = with buildPackages;
+      autoreconfHook.override { automake = automake115x; };
+  };
+
   pingus = callPackage ../games/pingus {};
 
   pioneer = callPackage ../games/pioneer { };


### PR DESCRIPTION
I chose "pinball" over "emilia-pinball", because the former seems to
be much more widely used in distributions.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
