### PR TITLE
openslp: add patch for CVE-2019-5544

### DIFF
--- a/pkgs/development/libraries/openslp/CVE-2019-5544.patch
+++ b/pkgs/development/libraries/openslp/CVE-2019-5544.patch
@@ -1,0 +1,165 @@
+diff -ur openslp-2.0.0.orig/common/slp_buffer.c openslp-2.0.0/common/slp_buffer.c
+--- openslp-2.0.0.orig/common/slp_buffer.c	2012-12-10 15:31:53.000000000 -0800
++++ openslp-2.0.0/common/slp_buffer.c	2019-11-26 21:54:20.000000000 -0800
+@@ -30,6 +30,13 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *-------------------------------------------------------------------------*/
+ 
++/* Copyright (c) 2019 VMware, Inc.
++ * SPDX-License-Identifier: BSD-3-Clause
++ * This file is provided under the BSD-3-Clause license.
++ * See COPYING file for more details and other copyrights
++ * that may apply.
++ */
++
+ /** Functions for managing SLP message buffers.
+  *
+  * This file provides a higher level abstraction over malloc and free that
+@@ -153,4 +160,20 @@
+    xfree(buf);
+ }
+ 
++/** Report remaining free buffer size in bytes.
++ *
++ * Check if buffer is allocated and if so return bytes left in a
++ * @c SLPBuffer object.
++ *
++ * @param[in] buf The SLPBuffer to be freed.
++ */
++size_t
++RemainingBufferSpace(SLPBuffer buf)
++{
++   if (buf->allocated == 0) {
++      return 0;
++   }
++   return buf->end - buf->curpos;
++}
++
+ /*=========================================================================*/
+diff -ur openslp-2.0.0.orig/common/slp_buffer.h openslp-2.0.0/common/slp_buffer.h
+--- openslp-2.0.0.orig/common/slp_buffer.h	2012-11-28 09:07:04.000000000 -0800
++++ openslp-2.0.0/common/slp_buffer.h	2019-11-26 21:54:32.000000000 -0800
+@@ -30,6 +30,13 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *-------------------------------------------------------------------------*/
+ 
++/* Copyright (c) 2019 VMware, Inc.
++ * SPDX-License-Identifier: BSD-3-Clause
++ * This file is provided under the BSD-3-Clause license.
++ * See COPYING file for more details and other copyrights
++ * that may apply.
++ */
++
+ /** Header file that defines SLP message buffer management routines.
+  *
+  * Includes structures, constants and functions that used to handle memory 
+@@ -78,6 +85,8 @@
+ 
+ SLPBuffer SLPBufferListAdd(SLPBuffer * list, SLPBuffer buf);
+ 
++size_t RemainingBufferSpace(SLPBuffer buf);
++
+ /*! @} */
+ 
+ #endif /* SLP_BUFFER_H_INCLUDED */
+diff -ur openslp-2.0.0.orig/slpd/slpd_process.c openslp-2.0.0/slpd/slpd_process.c
+--- openslp-2.0.0.orig/slpd/slpd_process.c	2012-12-12 09:38:54.000000000 -0800
++++ openslp-2.0.0/slpd/slpd_process.c	2019-11-26 21:55:10.000000000 -0800
+@@ -30,6 +30,13 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *-------------------------------------------------------------------------*/
+ 
++/* Copyright (c) 2019 VMware, Inc.
++ * SPDX-License-Identifier: BSD-3-Clause
++ * This file is provided under the BSD-3-Clause license.
++ * See COPYING file for more details and other copyrights
++ * that may apply.
++ */
++
+ /** Processes incoming SLP messages.
+  *
+  * @file       slpd_process.c
+@@ -514,13 +521,27 @@
+    {
+       for (i = 0; i < db->urlcount; i++)
+       {
+-         /* urlentry is the url from the db result */
+          urlentry = db->urlarray[i];
++         if (urlentry->opaque != NULL) {
++            const int64_t newsize = size + urlentry->opaquelen;
++            if (urlentry->opaquelen <= 0 || newsize > INT_MAX)
++            {
++               SLPDLog("Invalid opaquelen %d or sizeo of opaque url is too big, size=%d\n",
++                       urlentry->opaquelen, size);
++               errorcode = SLP_ERROR_PARSE_ERROR;
++               goto FINISHED;
++            }
++            size +=  urlentry->opaquelen;
++         }
++         else
++         {
++            /* urlentry is the url from the db result */
++            size += urlentry->urllen + 6; /*  1 byte for reserved  */
++                                          /*  2 bytes for lifetime */
++                                          /*  2 bytes for urllen   */
++                                          /*  1 byte for authcount */
++          }
+ 
+-         size += urlentry->urllen + 6; /*  1 byte for reserved  */
+-                                       /*  2 bytes for lifetime */
+-                                       /*  2 bytes for urllen   */
+-                                       /*  1 byte for authcount */
+ #ifdef ENABLE_SLPv2_SECURITY
+          /* make room to include the authblock that was asked for */
+          if (G_SlpdProperty.securityEnabled
+@@ -594,7 +615,7 @@
+          urlentry = db->urlarray[i];
+ 
+ #ifdef ENABLE_SLPv1
+-         if (urlentry->opaque == 0)
++         if (urlentry->opaque == NULL)
+          {
+             /* url-entry reserved */
+             *result->curpos++ = 0;
+@@ -606,8 +627,18 @@
+             PutUINT16(&result->curpos, urlentry->urllen);
+ 
+             /* url-entry url */
+-            memcpy(result->curpos, urlentry->url, urlentry->urllen);
+-            result->curpos += urlentry->urllen;
++            if (RemainingBufferSpace(result) >= urlentry->urllen)
++            {
++               memcpy(result->curpos, urlentry->url, urlentry->urllen);
++               result->curpos = result->curpos + urlentry->urllen;
++            }
++            else
++            {
++                SLPDLog("Url too big (ask: %d have %" PRId64 "), failing request\n",
++                        urlentry->opaquelen, (int64_t) RemainingBufferSpace(result));
++                errorcode = SLP_ERROR_PARSE_ERROR;
++                goto FINISHED;
++            }
+ 
+             /* url-entry auths */
+             *result->curpos++ = 0;
+@@ -621,8 +652,18 @@
+ 
+             /* TRICKY: Fix up the lifetime. */
+             TO_UINT16(urlentry->opaque + 1, urlentry->lifetime);
+-            memcpy(result->curpos, urlentry->opaque, urlentry->opaquelen);
+-            result->curpos += urlentry->opaquelen;
++            if (RemainingBufferSpace(result) >= urlentry->opaquelen)
++            {
++               memcpy(result->curpos, urlentry->opaque, urlentry->opaquelen);
++               result->curpos = result->curpos + urlentry->opaquelen;
++             }
++             else
++             {
++               SLPDLog("Opaque Url too big (ask: %d have %" PRId64 "), failing request\n",
++                       urlentry->opaquelen, (int64_t) RemainingBufferSpace(result));
++               errorcode = SLP_ERROR_PARSE_ERROR;
++               goto FINISHED;
++             }
+          }
+       }
+    }

--- a/pkgs/development/libraries/openslp/default.nix
+++ b/pkgs/development/libraries/openslp/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
       sha256 = "0zp61axx93b7nrbsyhn2x4dnw7n9y6g4rys21hyqxk4khrnc2yr9";
     })
     ./CVE-2016-4912.patch
+    ./CVE-2019-5544.patch
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/76014

I obtained the patch from https://www.openwall.com/lists/oss-security/2019/12/06/1.

Does someone know of a patch for [CVE-2020-3992](https://nvd.nist.gov/vuln/detail/CVE-2020-3992)?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
