### PR TITLE
python3Packages.numpy: 1.19.4 -> 1.20.1

### DIFF
--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage rec {
   pname = "joblib";
-  version = "0.17.0";
-  disabled = pythonOlder "3.6";
+  version = "1.0.0";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9e284edd6be6b71883a63c9b7f124738a3c16195513ad940eae7e3438de885d5";
+    sha256 = "092bnvr724cfvka8267z687bf086fvm7i1hwslkyrzf1g836dn3s";
   };
 
   checkInputs = [ sphinx numpydoc pytestCheckHook ];

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -4,15 +4,15 @@
 , buildPythonPackage
 , gfortran
 , hypothesis
-, pytest_5
+, pytest
 , blas
 , lapack
 , writeTextFile
 , isPyPy
 , cython
 , setuptoolsBuildHook
-, fetchpatch
- }:
+, pythonOlder
+}:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
 
@@ -40,30 +40,25 @@ let
   };
 in buildPythonPackage rec {
   pname = "numpy";
-  version = "1.19.4";
+  version = "1.20.1";
   format = "pyproject.toml";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512";
+    sha256 = "02m6sms6wb4flfg8y4h0msan4y7w7qgfqxhdk21lcabhm2339iiv";
   };
 
-  nativeBuildInputs = [ gfortran cython setuptoolsBuildHook ];
-  buildInputs = [ blas lapack ];
-
-  patches = [
-    # For compatibility with newer pytest
-    (fetchpatch {
-      url = "https://github.com/numpy/numpy/commit/ba315034759fbf91c61bb55390edc86e7b2627f3.patch";
-      sha256 = "F2P5q61CyhqsZfwkLmxb7A9YdE+43FXLbQkSjop2rVY=";
-    })
-  ] ++ lib.optionals python.hasDistutilsCxxPatch [
+  patches = lib.optionals python.hasDistutilsCxxPatch [
     # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
     # Patching of numpy.distutils is needed to prevent it from undoing the
     # patch to distutils.
     ./numpy-distutils-C++.patch
   ];
+
+  nativeBuildInputs = [ gfortran cython setuptoolsBuildHook ];
+  buildInputs = [ blas lapack ];
 
   # we default openblas to build with 64 threads
   # if a machine has more than 64 threads, it will segfault
@@ -83,7 +78,7 @@ in buildPythonPackage rec {
   doCheck = !isPyPy; # numpy 1.16+ hits a bug in pypy's ctypes, using either numpy or pypy HEAD fixes this (https://github.com/numpy/numpy/issues/13807)
 
   checkInputs = [
-    pytest_5 # pytest 6 will error: "module is already imported: hypothesis"
+    pytest
     hypothesis
   ];
 

--- a/pkgs/development/python-modules/scikitlearn/default.nix
+++ b/pkgs/development/python-modules/scikitlearn/default.nix
@@ -3,24 +3,37 @@
 , buildPythonPackage
 , fetchPypi
 , fetchpatch
-, gfortran, glibcLocales
-, numpy, scipy, pytest, pillow
+, gfortran
+, glibcLocales
+, numpy
+, scipy
+, pytest
+, pillow
 , cython
 , joblib
 , llvmPackages
 , threadpoolctl
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "scikit-learn";
   version = "0.24.1";
-  # UnboundLocalError: local variable 'message' referenced before assignment
-  disabled = stdenv.isi686;  # https://github.com/scikit-learn/scikit-learn/issues/5534
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "oDNKGALmTWVgIsO/q1anP71r9LEpg0PzaIryFRgQu98=";
   };
+
+  patches = [
+    # This patch fixes compatibility with numpy 1.20. It was merged before 0.24.1 was released,
+    # but for some reason was not included in the 0.24.1 release tarball.
+    (fetchpatch {
+      url = "https://github.com/scikit-learn/scikit-learn/commit/e7ef22c3ba2334cb3b476e95d7c083cf6b48ce56.patch";
+      sha256 = "174554k1pbf92bj7wgq0xjj16bkib32ailyhwavdxaknh4bd9nmv";
+    })
+  ];
 
   buildInputs = [
     pillow


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://numpy.org/devdocs/release/1.20.0-notes.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

-----------

Based on https://github.com/joblib/joblib/pull/1136 (and my testing), there's an incompatibility between numpy 1.20 and joblib <= 1.0, so I've also bumped joblib in this PR as well.

I did not rebuild everything since there are quite a lot of downstream packages that depend on `numpy`, but I did to a random selection of 62 packages:
```
NIXPKGS_ALLOW_BROKEN=1 nix build -f .  python39Packages.pyrr python39Packages.pysptk python39Packages.pysqueezebox python39Packages.pysrim python39Packages.pyssim python39Packages.pystray python39Packages.pytesseract python39Packages.pytest-aiohttp python39Packages.pytest-arraydiff python39Packages.pytest-black python39Packages.pytest-doctestplus python39Packages.pytest-filter-subpackage python39Packages.pytest-httpbin python39Packages.pytest-mpl python39Packages.pytest-randomly python39Packages.pytest-sanic python39Packages.pytest-vcr python39Packages.python-engineio python39Packages.python-miio python39Packages.python-mystrom python39Packages.python-opendata-transport python39Packages.python-socketio python39Packages.pytools python39Packages.pytorch python39Packages.pytorch-lightning python39Packages.pytorch-metric-learning python39Packages.pyuavcan python39Packages.pywbem python39Packages.pyworld python39Packages.pyxeoma python39Packages.py_stringmatching python39Packages.qdldl python39Packages.qimage2ndarray python39Packages.qrcode python39Packages.quantities python39Packages.rainbowstream python39Packages.rasterio python39Packages.regenmaschine python39Packages.regional python39Packages.reikna python39Packages.reportlab python39Packages.resampy python39Packages.ripser python39Packages.rising python39Packages.roboschool python39Packages.rtmixer python39Packages.s3fs python39Packages.sasmodels python39Packages.scapy python39Packages.scikit-fmm python39Packages.scikit-optimize python39Packages.scikit-tda python39Packages.scipy python39Packages.scrapy-deltafetch python39Packages.scrapy-fake-useragent python39Packages.scrapy-splash python39Packages.scs python39Packages.seabreeze python39Packages.seekpath python39Packages.seqdiag python39Packages.shapely python39Packages.sharedmem --keep-going
```

The failures are:
 - python39Packages.rainbowstream: Also broken currently on hydra staging.
 - python39Packages.fixtures. Also broken on currently on hydra staging.
 - python39Packages.sasmodels: Also broken currently on hydra staging.
 - python39Packages.scikitlearn: Not sure why. I think these are new failures not on staging though.
 
 This is the scikit-learn failure: https://gist.github.com/rmcgibbo/21392d1c75d2c0809533bc3a97dce4ba
