### PR TITLE
[20.09] pythonPackages.pillow: add patches for CVE-2020-35653, CVE-2020-35654, CVE-2020-35655

### DIFF
--- a/pkgs/development/python-modules/pillow/7.2.0-CVE-2020-35653.patch
+++ b/pkgs/development/python-modules/pillow/7.2.0-CVE-2020-35653.patch
@@ -1,0 +1,75 @@
+Modified version of https://github.com/python-pillow/Pillow/commit/3757b8c7485f9d804f4a96772384543b4fe59121
+--- a/Tests/test_image.py
++++ b/Tests/test_image.py
+@@ -775,26 +775,29 @@
+         with pytest.warns(DeprecationWarning):
+             assert test_module.PILLOW_VERSION > "7.0.0"
+ 
+-    def test_overrun(self):
+-        """ For overrun completeness, test as:
+-        valgrind pytest -qq Tests/test_image.py::TestImage::test_overrun | grep decode.c
+-        """
+-        for file in [
++    @pytest.mark.parametrize("path", [
+             "fli_overrun.bin",
+             "sgi_overrun.bin",
+             "sgi_overrun_expandrow.bin",
+             "sgi_overrun_expandrow2.bin",
+             "pcx_overrun.bin",
+             "pcx_overrun2.bin",
++            "ossfuzz-4836216264589312.pcx",
+             "01r_00.pcx",
+-        ]:
+-            with Image.open(os.path.join("Tests/images", file)) as im:
+-                try:
+-                    im.load()
+-                    assert False
+-                except OSError as e:
+-                    assert str(e) == "buffer overrun when reading image file"
++        ])
++    def test_overrun(self, path):
++        """For overrun completeness, test as:
++        valgrind pytest -qq Tests/test_image.py::TestImage::test_overrun | grep decode.c
++        """
++        with Image.open(os.path.join("Tests/images", path)) as im:
++            try:
++                im.load()
++                assert False
++            except OSError as e:
++                assert (str(e) == "buffer overrun when reading image file" or
++                        "image file is truncated" in str(e))
+ 
++    def test_fli_overrun2(self):
+         with Image.open("Tests/images/fli_overrun2.bin") as im:
+             try:
+                 im.seek(1)
+--- a/src/PIL/PcxImagePlugin.py
++++ b/src/PIL/PcxImagePlugin.py
+@@ -66,13 +66,13 @@
+         version = i8(s[1])
+         bits = i8(s[3])
+         planes = i8(s[65])
+-        stride = i16(s, 66)
++        ignored_stride = i16(s, 66)
+         logger.debug(
+             "PCX version %s, bits %s, planes %s, stride %s",
+             version,
+             bits,
+             planes,
+-            stride,
++            ignored_stride,
+         )
+ 
+         self.info["dpi"] = i16(s, 12), i16(s, 14)
+@@ -110,6 +110,11 @@
+         self.mode = mode
+         self._size = bbox[2] - bbox[0], bbox[3] - bbox[1]
+ 
++        # don't trust the passed in stride. Calculate for ourselves.
++        # CVE-2020-35655
++        stride = (self._size[0] * bits + 7) // 8
++        stride += stride % 2
++
+         bbox = (0, 0) + self.size
+         logger.debug("size: %sx%s", *self.size)
+ 

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPyPy
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, fetchurl, isPyPy
 , olefile
 , freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
 , openjpeg, libimagequant
@@ -17,11 +17,80 @@ buildPythonPackage rec {
     sha256 = "97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626";
   };
 
+  patches = [
+    ./7.2.0-CVE-2020-35653.patch
+    (fetchpatch {
+      name = "CVE-2020-35654.prerequisite-1.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/21533e4deba80290bbc46f1a9e660196f75be45f.patch";
+      sha256 = "19i7svxqlcz02ffcx1n1r6brf4m2iqm3k0zq3wd8k1pj2zw9gkhi";
+    })
+    (fetchpatch {
+      name = "CVE-2020-35654.prerequisite-2.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/26bf1c352489c9e847ff770cd752e97fda5b82cb.patch";
+      sha256 = "0h4ch8in2ljz3qgah7k8nwzby1kg02p0fbkg8zzvmmkms051v0im";
+    })
+    (fetchpatch {
+      name = "CVE-2020-35654.part-1.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/eb8c1206d6b170d4e798a00db7432e023853da5c.patch";
+      sha256 = "0cw1hp9irzhgh52s9g5mb6j6cry5gz2n5al4sy1sl5k998h76qaq";
+    })
+    (fetchpatch {
+      name = "CVE-2020-35654.part-2.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/45a62e91b1f72e79989a7919af97b062dc8dfaf4.patch";
+      sha256 = "1kk4jrbz1h74pa5racxc1skp0rgwb00b8ybfyb7v7wmc34f1lm8f";
+    })
+    (fetchpatch {
+      name = "CVE-2020-35655.part-1.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/7e95c63fa7f503f185d3d9eb16b9cee1e54d1e46.patch";
+      sha256 = "15zjkiwcmnv70vy1cfwrvzkfjmgclw4fzvina4rjd8xqap9na5fr";
+    })
+    (fetchpatch {
+      name = "CVE-2020-35655.part-2.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/9a2c9f722f78773e608d44710873437baf3f17d1.patch";
+      sha256 = "15dhzd3i8xwx2iaff2qp6z3h0b2yrzcmqi6x7ngld96805gf7v2q";
+    })
+  ];
+
+  # patching mechanism doesn't work with binary files, but the commits contain
+  # example images needed for the accompanying tests, so invent our own mechanism
+  # to put these in place
+  injectMissingBinFiles = stdenv.lib.concatMapStrings ({commit, sha256, path}: let
+      src = fetchurl {
+        inherit sha256;
+        url = "https://github.com/python-pillow/Pillow/raw/${commit}/${path}";
+      };
+      dest = path;
+    in ''
+      cp ${src} ${dest}
+    ''
+  ) [
+    { # needed by CVE-2020-35653.patch
+      commit = "2f409261eb1228e166868f8f0b5da5cda52e55bf";
+      sha256 = "1gf7zn0qv0i8qvr22sm9azchwizb9aa4xxipy6x5lh7kgb974g0f";
+      path = "Tests/images/ossfuzz-4836216264589312.pcx";
+    }
+    { # needed by CVE-2020-35654.part-1.patch
+      commit = "eb8c1206d6b170d4e798a00db7432e023853da5c";
+      sha256 = "0v7jg2xdqzyq3rq6jq0ipsy335sw557symv5jrcz9rdfgkbafh92";
+      path = "Tests/images/crash-2020-10-test.tif";
+    }
+    { # needed by CVE-2020-35655.part-1.patch
+      commit = "7e95c63fa7f503f185d3d9eb16b9cee1e54d1e46";
+      sha256 = "0jkzwnv11c1h3hy0ri6kqvcjj800armzrvwc9724ivnm2id8qi8z";
+      path = "Tests/images/crash-6b7f2244da6d0ae297ee0754a424213444e92778.sgi";
+    }
+    { # needed by CVE-2020-35655.part-1.patch
+      commit = "7e95c63fa7f503f185d3d9eb16b9cee1e54d1e46";
+      sha256 = "0is0r49pbaxy8mgp5fdlx9hm7zdp64ij38hzgnjj9pzxxdrcw3qk";
+      path = "Tests/images/ossfuzz-5730089102868480.sgi";
+    }
+  ];
+
   # Disable imagefont tests, because they don't work well with infinality:
   # https://github.com/python-pillow/Pillow/issues/1259
   postPatch = ''
     rm Tests/test_imagefont.py
-  '';
+  '' + injectMissingBinFiles;
 
   # Disable darwin tests which require executables: `iconutil` and `screencapture`
   disabledTests = stdenv.lib.optionals stdenv.isDarwin [ "test_save" "test_grab" "test_grabclipboard" ];


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2020-35653
https://nvd.nist.gov/vuln/detail/CVE-2020-35654
https://nvd.nist.gov/vuln/detail/CVE-2020-35655

Patches for the fix only apply if two prerequisite tiff-related patches are added first, but the result passes all its tests including the new ones covering the vulnerability, so I'm pretty confident the result is functioning correctly

Not done a full rebuild because ... massive. Will pick some key packages for ofborg.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
