### PR TITLE
pythonPackages.markdown2: 2.3.6 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -1,14 +1,22 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchFromGitHub, python, pygments }:
 
 buildPythonPackage rec {
   pname = "markdown2";
-  version = "2.3.6";
+  version = "2.4.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "08a124043aa0ad36ba2136239547d5011a2b770278abb11a5609611e0040ea05";
+  # PyPI does not contain tests, so using GitHub instead.
+  src = fetchFromGitHub {
+    owner = "trentm";
+    repo = "python-markdown2";
+    rev = version;
+    sha256 = "sha256:03qmf087phpj0h9hx111k4r5pkm48dhb61mqhp1v75gd09k0z79z";
   };
+
+  checkInputs = [ pygments ];
+
+  checkPhase = ''
+    ${python.interpreter} ./test/test.py
+  '';
 
   meta = with lib; {
     description = "A fast and complete Python implementation of Markdown";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`pythonPackages.markdown2` is out of date. [According to PyPI](https://pypi.org/project/markdown2/#history) `2.3.6` is from September 2018. `2.4.0` is from January 2012.

Here is the changelog: https://github.com/trentm/python-markdown2/blob/master/CHANGES.md

~~NB: The new version has dropped support for Python 2. Not sure if that's a problem. Let me know if you'd like to see anything changed.~~ Nevermind this, I mixed up two sets of release notes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
