### PR TITLE
open-isns: 0.100 -> 0.101

### DIFF
--- a/pkgs/os-specific/linux/open-isns/default.nix
+++ b/pkgs/os-specific/linux/open-isns/default.nix
@@ -1,28 +1,15 @@
-{ lib, stdenv, openssl, fetchFromGitHub, fetchpatch }:
+{ lib, stdenv, openssl, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "open-isns";
-  version = "0.100";
+  version = "0.101";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo = "open-isns";
     rev = "v${version}";
-    sha256 = "0d0dz965azsisvfl5wpp1b7m0q0fmaz5r7x5dfybkry551sbcydr";
+    sha256 = "1g7kp1j2f8afsach6sbl4k05ybz1yz2s8yg073bv4gnv48gyxb2p";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "deprecated-sighold-sigrelease";
-      url = "https://github.com/open-iscsi/open-isns/commit/e7dac76ce61039fefa58985c955afccb60dabe87.patch";
-      sha256 = "15v106xn3ns7z4nlpby7kkm55rm9qncsmy2iqc4ifli0h67g34id";
-    })
-    (fetchpatch {
-      name = "warn_unused_result";
-      url = "https://github.com/open-iscsi/open-isns/commit/4c39cb09735a494099fba0474d25ff26800de952.patch";
-      sha256 = "1jlydrh9rgkky698jv0mp2wbbizn90q5wjbay086l0h6iqp8ibc3";
-    })
-  ];
 
   propagatedBuildInputs = [ openssl ];
   outputs = [ "out" "lib" ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
 Out of tree test used: https://github.com/markuskowa/nix-system/blob/master/tests/isns.nix
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
