### PR TITLE
wolfssl: 4.5.0 -> 4.6.0

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -2,20 +2,32 @@
 
 stdenv.mkDerivation rec {
   pname = "wolfssl";
-  version = "4.5.0";
+  version = "4.6.0";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
     rev = "v${version}-stable";
-    sha256 = "138ppnwkqkfi7nnqpd0b93dqaph72ma65m9286bz2qzlis1x8r0v";
+    sha256 = "0hk3bnzznxj047gwxdxw2v3w6jqq47996m7g72iwj6c2ai9g6h4m";
   };
 
-  configureFlags = [ "--enable-all" ];
+  # almost same as Debian but for now using --enable-all instead of --enable-distro to ensure options.h gets installed
+  configureFlags = [ "--enable-all --enable-pkcs11 --enable-tls13 --enable-base64encode" ];
 
   outputs = [ "out" "dev" "doc" "lib" ];
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  postPatch = ''
+     # fix recursive cycle:
+     # build flags (including location of header files) are exposed in the
+     # public API of wolfssl, causing lib to depend on dev
+     substituteInPlace configure.ac \
+       --replace '#define LIBWOLFSSL_CONFIGURE_ARGS \"$ac_configure_args\"' ' '
+     substituteInPlace configure.ac \
+       --replace '#define LIBWOLFSSL_GLOBAL_CFLAGS \"$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS\"' ' '
+  '';
+
 
   postInstall = ''
      # fix recursive cycle:


### PR DESCRIPTION
Hi,






<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I maintain `wolfssl` in Debian. This change will help mitigate CVE-2020-36177.

The configuration parameters were adopted from Debian and may track the ABI for the advertised shared object version more closely.

###### Things done

This configuration builds with `nix-build -A wolfssl` in a fresh `chroot` with Debian unstable. I tested nothing else.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
