### PR TITLE
glfw: hardwire path to libGL.so.1 the intended way

### DIFF
--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -22,11 +22,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ libX11 libXrandr libXinerama libXcursor libXi libXext ]
     ++ lib.optionals stdenv.isDarwin [ Cocoa Kernel ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
-
-  preConfigure  = lib.optional (!stdenv.isDarwin) ''
-    substituteInPlace src/glx_context.c --replace "libGL.so.1" "${lib.getLib libGL}/lib/libGL.so.1"
-  '';
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+  ] ++ lib.optional (!stdenv.isDarwin) [
+    "-DCMAKE_C_FLAGS=-D_GLFW_GLX_LIBRARY='\"${lib.getLib libGL}/lib/libGL.so.1\"'"
+  ];
 
   meta = with lib; {
     description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time";


### PR DESCRIPTION
###### Motivation for this change
GLFW provides a better way to specify the path to libGL than to patch the source code.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Two packages that depend on GLFW fail to build but they also fail to build without this PR.