### PR TITLE
surface-control: init at 0.3.1-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9940,6 +9940,12 @@
     githubId = 6016963;
     name = "Patrick Winter";
   };
+  winterqt = {
+    email = "nixos@winter.cafe";
+    github = "winterqt";
+    githubId = 78392041;
+    name = "Winter";
+  };
   wishfort36 = {
     email = "42300264+wishfort36@users.noreply.github.com";
     github = "wishfort36";

--- a/pkgs/applications/misc/surface-control/default.nix
+++ b/pkgs/applications/misc/surface-control/default.nix
@@ -1,0 +1,37 @@
+{ lib, rustPlatform, fetchFromGitHub, installShellFiles, coreutils }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "surface-control";
+  version = "0.3.1-1";
+
+  src = fetchFromGitHub {
+    owner = "linux-surface";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0wclzlix0a2naxbdg3wym7yw19p2wqpcjmkf7gn8cs00shrmzjld";
+  };
+
+  cargoSha256 = "0vi26v9mvx298kx6k5g7h8dnn7r208an9knadc23vxcrrxjr6pn5";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion \
+      $releaseDir/build/surface-*/out/surface.{bash,fish} \
+      --zsh $releaseDir/build/surface-*/out/_surface
+    install -Dm 0444 -t $out/etc/udev/rules.d \
+      etc/udev/40-surface-control.rules
+    substituteInPlace $out/etc/udev/rules.d/40-surface-control.rules \
+      --replace "/usr/bin/chmod" "${coreutils}/bin/chmod" \
+      --replace "/usr/bin/chown" "${coreutils}/bin/chown"
+  '';
+
+  meta = with lib; {
+    description =
+      "Control various aspects of Microsoft Surface devices on Linux from the Command-Line";
+    homepage = "https://github.com/linux-surface/surface-control";
+    license = licenses.mit;
+    maintainers = with maintainers; [ winterqt ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7973,6 +7973,8 @@ in
 
   stubby = callPackage ../tools/networking/stubby { };
 
+  surface-control = callPackage ../applications/misc/surface-control { };
+
   syntex = callPackage ../tools/graphics/syntex {};
 
   sl = callPackage ../tools/misc/sl { stdenv = gccStdenv; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds [surface-control](https://github.com/linux-surface/surface-control), a command line tool to control various aspects of the Microsoft Surface line of devices from the command line. This is added with the intent of adding this package to the `nixos-hardware` configuration for these devices. (see https://github.com/NixOS/nixos-hardware/pull/227)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
