### PR TITLE
signumone-ks: removing libav_0_8

### DIFF
--- a/pkgs/applications/misc/signumone-ks/default.nix
+++ b/pkgs/applications/misc/signumone-ks/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, dpkg, autoPatchelfHook, makeWrapper,
-  atk, ffmpeg, gdk-pixbuf, glibc, gtk3, libav_0_8, libXtst }:
+  atk, ffmpeg, gdk-pixbuf, gtk3, libXtst }:
 
 stdenv.mkDerivation rec {
   pname = "signumone-ks";
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    atk glibc gdk-pixbuf stdenv.cc.cc ffmpeg
-    libav_0_8 gtk3 libXtst
+    atk gdk-pixbuf ffmpeg
+    gtk3 libXtst
   ];
 
   libPath = lib.makeLibraryPath buildInputs;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Based on #111330.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
