### PR TITLE
Readd "Apple IST CA 2" to certificates

### DIFF
--- a/nixos/modules/security/ca.nix
+++ b/nixos/modules/security/ca.nix
@@ -79,7 +79,46 @@ in
 
   config = {
 
-    security.pki.certificateFiles = [ "${cacertPackage}/etc/ssl/certs/ca-bundle.crt" ];
+    security.pki.certificateFiles = [
+      "${cacertPackage}/etc/ssl/certs/ca-bundle.crt"
+
+      # GeoTrust Global CA is removed from NSS in version 3.60.
+      # Unfortunately, some Apple hosts (api.push.apple.com &
+      # store.storeimages.cdn-apple.com) still use certificates signed
+      # by this root. To avoid, breaking these, Apple IST CA 2
+      # intermediate certificate is enabled here. You can inspect this
+      # CA at https://crt.sh/?caid=1597.
+      (builtins.toFile "Apple_IST_CA_2.crt" ''
+         Apple IST CA 2
+         -----BEGIN CERTIFICATE-----
+         MIIEnjCCA4agAwIBAgIQBVLH7/7sKSup8Th7B6+SnzANBgkqhkiG9w0BAQsFADBa
+         MQswCQYDVQQGEwJJRTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJl
+         clRydXN0MSIwIAYDVQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTE4
+         MTIxMjEyMDAwMFoXDTI1MDUwNzEyMDAwMFowYjEcMBoGA1UEAxMTQXBwbGUgSVNU
+         IENBIDIgLSBHMTEgMB4GA1UECxMXQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxEzAR
+         BgNVBAoTCkFwcGxlIEluYy4xCzAJBgNVBAYTAlVTMIIBIjANBgkqhkiG9w0BAQEF
+         AAOCAQ8AMIIBCgKCAQEA0JOhHUdDIBayC2vrw9W06MeYzfPev+hN6eM2gAf8RRtq
+         fEWGrlbTpAl/YQ1rXX5Sa320yDnE9Gc694POGW+GL35FfkccZ1LKlQVd4jZRhcDU
+         Z4A1bxXdPv0d0v2PNFDY7HYqvuPT2uT9yOsoApYRlxdhHOnEWTtC3DLRCR3aptFD
+         hv9esryMz2bbAYsCrpRI8ziP/eoyqAjshpdRlCQ+SUmWU+h5oUCB6QW7k5VR/OP9
+         fBFL954IsxVJFQf50Tegm0sy9rXE3GrR/Art9uDFKaCoi3H+DZK8/lRwGAptx+0M
+         +8ktBsOMhfzLhlzWNo4Siwl/+xkaONXwlDB6D6aM8wIDAQABo4IBVjCCAVIwHQYD
+         VR0OBBYEFNh6lER8kHCQFp7dF5wBRAOG1iopMB8GA1UdIwQYMBaAFOWdWTCCR1jM
+         rPoIVDaGezq1BE3wMA4GA1UdDwEB/wQEAwIBhjAdBgNVHSUEFjAUBggrBgEFBQcD
+         AQYIKwYBBQUHAwIwEgYDVR0TAQH/BAgwBgEB/wIBADA0BggrBgEFBQcBAQQoMCYw
+         JAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTA6BgNVHR8EMzAx
+         MC+gLaArhilodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vT21uaXJvb3QyMDI1LmNy
+         bDBbBgNVHSAEVDBSMAwGCiqGSIb3Y2QFCwQwCAYGZ4EMAQICMDgGCmCGSAGG/WwA
+         AgQwKjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzAN
+         BgkqhkiG9w0BAQsFAAOCAQEAWgDobaZ4Dq8zSOdyWvCa+Tad60OIwE9qkz2o33KF
+         CcAM/CvxXrcXTTYo9VJHninE+G9SguIdukkDDAOHMT8WvsqomydMXknQJVbREOAX
+         KUKgS5q0/9ou9N1FjJvkhPGFzAbuLnSJtLomfJPxHW4h3l6bdliQodVQXd3xUbXR
+         qTKNUbF9bIh4601+KhyZL0u0B/eTppf/1O5S+qFAyRADr1lvfIeNHZv11iyf4u7e
+         uLBsXjyT3vPwxrihpAwB5pu/DhJWh4iv70Q7pcvAaRRfiJgMj3A0fFgvqvGbW9jm
+         t04+Cr/PjpWeMFt3KKj3DRh4jJKjJUGt+JxdGGJ4tCGyCw==
+         -----END CERTIFICATE-----
+      '')
+    ];
 
     # NixOS canonical location + Debian/Ubuntu/Arch/Gentoo compatibility.
     environment.etc."ssl/certs/ca-certificates.crt".source = caCertificates;


### PR DESCRIPTION
Starting in version 3.60, NSS (Mozilla's SSL library) removes trust for the GeoTrust Global CA root certificate. This was a root certificate managed by Symtantec that is being [gradually phased out](https://wiki.mozilla.org/CA/Additional_Trust_Changes#Symantec).

Unfortunately, some intermediate certificates in use still rely on GeoTrust Global CA. Specifically, [Apple IST CA 2 intermediate certificate](https://crt.sh/?caid=1597)  is still in use by Apple and used for:

- api.push.apple.com
- api.sandbox.push.apple.com
- browserbench.org
- foundationdb.org
- store.storeimages.cdn-apple.com

and [potentially others](https://crt.sh/?Identity=%25&iCAID=1597&exclude=expired).

This adds trust to the Apple intermediate certificate to avoid this issue. Mozilla whitelists this manually via the [b5cf82d47ef9823f9aa78f123186c52e8879ea84b0f822c91d83e04279b78fd5](https://crt.sh/?spkisha256=b5cf82d47ef9823f9aa78f123186c52e8879ea84b0f822c91d83e04279b78fd5) fingerprint, but only for the Firefox web browser.

Interestingly, Apple IST CA 2 is also signed by the valid Baltimore CyberTrust Root, in addition to GeoTrust Global CA. But, the above hosts return only the GeoTrust Global one.

This can be removed once Apple fixes its services. Even if this isn't merged, it's good to have this available for visibility. You can apply it in your NixOS configuration by adding this to your configuration.nix:

```nix
security.pki.certificateFiles = [
  (builtins.toFile "Apple_IST_CA_2.crt" ''
     Apple IST CA 2
     -----BEGIN CERTIFICATE-----
     MIIEnjCCA4agAwIBAgIQBVLH7/7sKSup8Th7B6+SnzANBgkqhkiG9w0BAQsFADBa
     MQswCQYDVQQGEwJJRTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJl
     clRydXN0MSIwIAYDVQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTE4
     MTIxMjEyMDAwMFoXDTI1MDUwNzEyMDAwMFowYjEcMBoGA1UEAxMTQXBwbGUgSVNU
     IENBIDIgLSBHMTEgMB4GA1UECxMXQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxEzAR
     BgNVBAoTCkFwcGxlIEluYy4xCzAJBgNVBAYTAlVTMIIBIjANBgkqhkiG9w0BAQEF
     AAOCAQ8AMIIBCgKCAQEA0JOhHUdDIBayC2vrw9W06MeYzfPev+hN6eM2gAf8RRtq
     fEWGrlbTpAl/YQ1rXX5Sa320yDnE9Gc694POGW+GL35FfkccZ1LKlQVd4jZRhcDU
     Z4A1bxXdPv0d0v2PNFDY7HYqvuPT2uT9yOsoApYRlxdhHOnEWTtC3DLRCR3aptFD
     hv9esryMz2bbAYsCrpRI8ziP/eoyqAjshpdRlCQ+SUmWU+h5oUCB6QW7k5VR/OP9
     fBFL954IsxVJFQf50Tegm0sy9rXE3GrR/Art9uDFKaCoi3H+DZK8/lRwGAptx+0M
     +8ktBsOMhfzLhlzWNo4Siwl/+xkaONXwlDB6D6aM8wIDAQABo4IBVjCCAVIwHQYD
     VR0OBBYEFNh6lER8kHCQFp7dF5wBRAOG1iopMB8GA1UdIwQYMBaAFOWdWTCCR1jM
     rPoIVDaGezq1BE3wMA4GA1UdDwEB/wQEAwIBhjAdBgNVHSUEFjAUBggrBgEFBQcD
     AQYIKwYBBQUHAwIwEgYDVR0TAQH/BAgwBgEB/wIBADA0BggrBgEFBQcBAQQoMCYw
     JAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTA6BgNVHR8EMzAx
     MC+gLaArhilodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vT21uaXJvb3QyMDI1LmNy
     bDBbBgNVHSAEVDBSMAwGCiqGSIb3Y2QFCwQwCAYGZ4EMAQICMDgGCmCGSAGG/WwA
     AgQwKjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzAN
     BgkqhkiG9w0BAQsFAAOCAQEAWgDobaZ4Dq8zSOdyWvCa+Tad60OIwE9qkz2o33KF
     CcAM/CvxXrcXTTYo9VJHninE+G9SguIdukkDDAOHMT8WvsqomydMXknQJVbREOAX
     KUKgS5q0/9ou9N1FjJvkhPGFzAbuLnSJtLomfJPxHW4h3l6bdliQodVQXd3xUbXR
     qTKNUbF9bIh4601+KhyZL0u0B/eTppf/1O5S+qFAyRADr1lvfIeNHZv11iyf4u7e
     uLBsXjyT3vPwxrihpAwB5pu/DhJWh4iv70Q7pcvAaRRfiJgMj3A0fFgvqvGbW9jm
     t04+Cr/PjpWeMFt3KKj3DRh4jJKjJUGt+JxdGGJ4tCGyCw==
     -----END CERTIFICATE-----
  '')
];
```

Related discussions:

- https://bbs.archlinux.org/viewtopic.php?id=262737
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962596
