### PR TITLE
U-Boot: Adds Orange Pi 3 build

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -80,6 +80,12 @@ in {
     filesToInstall = ["build/${platform}/release/bl31.bin"];
   };
 
+  armTrustedFirmwareAllwinnerH6 = buildArmTrustedFirmware rec {
+    platform = "sun50i_h6";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = ["build/${platform}/release/bl31.bin"];
+  };
+
   armTrustedFirmwareQemu = buildArmTrustedFirmware rec {
     platform = "qemu";
     extraMeta.platforms = ["aarch64-linux"];

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -11,6 +11,7 @@
 , swig
 , meson-tools
 , armTrustedFirmwareAllwinner
+, armTrustedFirmwareAllwinnerH6
 , armTrustedFirmwareRK3328
 , armTrustedFirmwareRK3399
 , armTrustedFirmwareS905
@@ -239,6 +240,13 @@ in {
   ubootOrangePiPc = buildUBoot {
     defconfig = "orangepi_pc_defconfig";
     extraMeta.platforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+  };
+
+  ubootOrangePi3 = buildUBoot {
+    defconfig = "orangepi_3_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    BL31 = "${armTrustedFirmwareAllwinnerH6}/bl31.bin";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18596,6 +18596,7 @@ in
     buildArmTrustedFirmware
     armTrustedFirmwareTools
     armTrustedFirmwareAllwinner
+    armTrustedFirmwareAllwinnerH6
     armTrustedFirmwareQemu
     armTrustedFirmwareRK3328
     armTrustedFirmwareRK3399
@@ -19933,6 +19934,7 @@ in
     ubootOdroidC2
     ubootOdroidXU3
     ubootOrangePiPc
+    ubootOrangePi3
     ubootOrangePiZeroPlus2H5
     ubootPcduino3Nano
     ubootPine64


### PR DESCRIPTION
### **This PR will function when U-Boot have released [`v2021.04` where Orange Pi 3 support has been upstreamed](https://github.com/u-boot/u-boot/commit/c81877a919d2ae214650b4f10b862dd62f0284a7):**

###### Motivation for this change

Getting NixOS bootable on the Orange Pi 3 along with Wiki documentation.

This adds a new attrname (attribute name) called `armTrustedFirmwareAllwinnerH6` that is necessary to make ATF (Arm Trusted Firmware) function on this board. This new attrname sets `platform = "sun50i_h6"` unlike `armTrustedFirmwareAllwinner` which sets only `sun50i_a64`. This ignores [this section of the U-Boot README from Sunxi](https://github.com/u-boot/u-boot/blob/e72a6be4fc071930016903638e1e493ab5d3be8a/board/sunxi/README.sunxi64#L54-L56) and assumes that `sun50i_a64` is the only value required for Sunxi boards: 

> The platform target "sun50i_a64" covers all boards with either an Allwinner
A64 or H5 SoC (since they are very similar). For boards with an Allwinner H6
SoC use "sun50i_h6".

https://github.com/NixOS/nixpkgs/blob/0cbb80e7f162fac25fdd173d38136068ed6856bb/pkgs/misc/arm-trusted-firmware/default.nix#L77-L80

It may be a good idea to change `armTrustedFirmwareAllwinner` to something like `armTrustedFirmwareAllwinnerA64` based on this.

@samueldr suggests the following in IRC:

```
<samueldr> one way I'd like to redesign the trusted firmware derivation may be to either make it an attrset or a function, both serving to ask "configuration xx_yy of ATF please"
<samueldr> so `buildArmTrustedFirmware "sun50i_a64"` or `buildArmTrustedFirmware.sun50i_a64`
<samueldr> uh
<samueldr> or `armTrustedFirmware.sun50i_a64`
<samueldr> the idea being to use exactly the config names
<samueldr> hm, not sure it's worth it
<samueldr> might just want to rename the existing attributes, it's already setup like u-boot is
<samueldr> so instead of S905, Gxbb... instead of Allwinner Sun50iA64 and Sun50iH6
<samueldr> that would more closely mirror the u-boot setup, where the attrnames come from the defconfig built
```

### If you want to boot on the Orange Pi Zero using this PR.
```
# Clone my repository and checkout my changes branch
git clone https://github.com/MatthewCroughan/nixpkgs.git
git checkout add-ubootOrangePi3

# Cross compile U-Boot
nix-build -I ./ -v -A pkgsCross.aarch64-multiplatform.ubootOrangePi3

# Flash the NixOS Installer image for 
# for aarch64 You can get it from here:
# https://hydra.nixos.org/job/nixos/release-20.09/nixos.sd_image.aarch64-linux
dd if=<aarch64-installer-image> of=/dev/mmcblkX

# Flash U-Boot over top the NixOS Installer image
dd if=u-boot-sunxi-with-spl.bin of=/dev/mmcblkX bs=1024 seek=8
```

The board should now boot into the NixOS installer image, this can be verified over serial.
Since this board has little ram, you may need to use a swapfile in order to install NixOS with `nixos-install`.

```
fallocate -l 2G /swapfile
chmod 600 /swapfile
mkswap /swapfile
swapon /swapfile
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
