### PR TITLE
[20.09] libvirt: add patch for CVE-2020-25637

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -33,6 +33,28 @@ in stdenv.mkDerivation rec {
         fetchSubmodules = true;
       };
 
+  patches = [
+    # Patches for CVE-2020-25637
+    (fetchpatch {
+      name = "libvirt-CVE-2020-25637-p1";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=955029bd0ad7ef96000f529ac38204a8f4a96401";
+      sha256 = "1diblx24spzyak4d94nmydfdyppc6zmw5qzja151llzwxic9a05k";
+    })
+    (fetchpatch {
+      name = "libvirt-CVE-2020-25637-p2";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=50864dcda191eb35732dbd80fb6ca251a6bba923";
+      sha256 = "1gz21hjaf02yqrx7ziyqsxcrrrf2fcw1h8py1rqkqbfcg146yn3y";
+    })
+    (fetchpatch {
+      name = "libvirt-CVE-2020-25637-p3";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=e4116eaa44cb366b59f7fe98f4b88d04c04970ad";
+      sha256 = "1m0408hnsyb8b7r88g2ykbfd0dc4971yndy07x7wkpzgayk1igjr";
+    })
+    # Part of the CVE-2020-25637 patches, but checked in to fix a merge conflict
+    # Modified from https://libvirt.org/git/?p=libvirt.git;a=commitdiff;h=a63b48c5ecef077bf0f909a85f453a605600cf05
+    ./patches/0001-qemu-agent-set-ifname-to-NULL-after-freeing.patch
+  ];
+
   nativeBuildInputs = [ makeWrapper pkgconfig docutils ] ++ optionals (!buildFromTarball) [ autoreconfHook ];
   buildInputs = [
     libxml2 gnutls perl python2 readline gettext libtasn1 libgcrypt yajl

--- a/pkgs/development/libraries/libvirt/patches/0001-qemu-agent-set-ifname-to-NULL-after-freeing.patch
+++ b/pkgs/development/libraries/libvirt/patches/0001-qemu-agent-set-ifname-to-NULL-after-freeing.patch
@@ -1,0 +1,34 @@
+From 88002560d48ae7b778c6be5b8daa21ea443e52e1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A1n=20Tomko?= <jtomko@redhat.com>
+Date: Fri, 18 Sep 2020 17:56:37 +0200
+Subject: [PATCH 4/4] qemu: agent: set ifname to NULL after freeing
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CVE-2020-25637
+
+Signed-off-by: Ján Tomko <jtomko@redhat.com>
+Reported-by: Ilja Van Sprundel <ivansprundel@ioactive.com>
+Fixes: 0977b8aa071de550e1a013d35e2c72615e65d520
+Reviewed-by: Mauro Matteo Cascella <mcascell@redhat.com>
+Reviewed-by: Jiri Denemark <jdenemar@redhat.com>
+---
+ src/qemu/qemu_agent.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/qemu/qemu_agent.c b/src/qemu/qemu_agent.c
+index d7fcc869c6..31d3268d42 100644
+--- a/src/qemu/qemu_agent.c
++++ b/src/qemu/qemu_agent.c
+@@ -2166,6 +2166,7 @@ qemuAgentGetInterfaces(qemuAgentPtr agent,
+ 
+         /* Has to be freed for each interface. */
+         virStringListFree(ifname);
++        ifname = NULL;
+ 
+         /* as well as IP address which - moreover -
+          * can be presented multiple times */
+-- 
+2.30.0
+


### PR DESCRIPTION
###### Motivation for this change

Backport a CVE fix, see https://github.com/NixOS/nixpkgs/issues/100308

This applies all 4 patches referenced in https://bugzilla.redhat.com/show_bug.cgi?id=1881037#c8, all of which also reference the CVE in their commit description.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note: I didn't test the execution of all binaries because libvirt gives you quite a few, but I verified `virsh` could connect to my libvirtd and list resources etc, so at least some of them run :)