### PR TITLE
python3Packages.androidtv: 0.0.50 -> 0.0.57

### DIFF
--- a/pkgs/development/python-modules/androidtv/default.nix
+++ b/pkgs/development/python-modules/androidtv/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "androidtv";
-  version = "0.0.50";
+  version = "0.0.57";
 
   # pypi does not contain tests, using github sources instead
   src = fetchFromGitHub {
     owner = "JeffLIrion";
     repo = "python-androidtv";
     rev = "v${version}";
-    sha256 = "1iqw40szwgzvhv3fbnx2wwfnw0d3clcwk9vsq1xsn30fjil2vl7b";
+    sha256 = "sha256-xOLMUf72VHeBzbMnhJGOnUIKkflnY4rV9NS/P1aYLJc=";
   };
 
   propagatedBuildInputs = [ adb-shell pure-python-adb ]

--- a/pkgs/development/python-modules/androidtv/default.nix
+++ b/pkgs/development/python-modules/androidtv/default.nix
@@ -1,5 +1,14 @@
-{ aiofiles, adb-shell, buildPythonPackage, fetchFromGitHub, isPy3k, lib, mock
-, pure-python-adb, python }:
+{ lib
+, adb-shell
+, aiofiles
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, mock
+, pure-python-adb
+, pytestCheckHook
+, python
+}:
 
 buildPythonPackage rec {
   pname = "androidtv";
@@ -16,14 +25,16 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ adb-shell pure-python-adb ]
     ++ lib.optionals (isPy3k) [ aiofiles ];
 
-  checkInputs = [ mock ];
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests -t .
-  '';
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "androidtv" ];
 
   meta = with lib; {
     description =
-      "Communicate with an Android TV or Fire TV device via ADB over a network.";
+      "Communicate with an Android TV or Fire TV device via ADB over a network";
     homepage = "https://github.com/JeffLIrion/python-androidtv/";
     license = licenses.mit;
     maintainers = with maintainers; [ jamiemagee ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.0.57

Commit log: https://github.com/JeffLIrion/python-androidtv/commits/master

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
