### PR TITLE
patroni: 1.6.5 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/pysyncobj/default.nix
+++ b/pkgs/development/python-modules/pysyncobj/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "pysyncobj";
+  version = "0.3.7";
+
+  src = fetchFromGitHub {
+    owner = "bakwc";
+    repo = "PySyncObj";
+    rev = version;
+    sha256 = "0i7gjapaggkfvys4rgd4krpmh6mxwpzv30ngiwb6ddgp8jx0nzxk";
+  };
+
+  # Tests require network features
+  doCheck = false;
+  pythonImportsCheck = [ "pysyncobj" ];
+
+  meta = with lib; {
+    description = "Python library for replicating your class";
+    homepage = "https://github.com/bakwc/PySyncObj";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/sql/patroni/default.nix
+++ b/pkgs/servers/sql/patroni/default.nix
@@ -1,14 +1,17 @@
-{ lib, pythonPackages, fetchFromGitHub }:
+{ lib
+, pythonPackages
+, fetchFromGitHub
+}:
 
 pythonPackages.buildPythonApplication rec {
   pname = "patroni";
-  version = "1.6.5";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "zalando";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0iw0ra9fya4bf1vkjq3w5kij4x46yinb90v015pi9c6qfpancfdj";
+    sha256 = "sha256-IlRltJrEMrRiwVVMYQywb0MqwEoL8MX3do2GlHXjuPc=";
   };
 
   # cdiff renamed to ydiff; remove when patroni source reflects this.
@@ -28,6 +31,7 @@ pythonPackages.buildPythonApplication rec {
     prettytable
     psutil
     psycopg2
+    pysyncobj
     python-dateutil
     python-etcd
     pyyaml
@@ -40,12 +44,14 @@ pythonPackages.buildPythonApplication rec {
     flake8
     mock
     pytestCheckHook
-    pytestcov
+    pytest-cov
     requests
   ];
 
   # Fix tests by preventing them from writing to /homeless-shelter.
   preCheck = "export HOME=$(mktemp -d)";
+
+  pythonImportsCheck = [ "patroni" ];
 
   meta = with lib; {
     homepage = "https://patroni.readthedocs.io/en/latest/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5989,6 +5989,8 @@ in {
 
   pysychonaut = callPackage ../development/python-modules/pysychonaut { };
 
+  pysyncobj = callPackage ../development/python-modules/pysyncobj { };
+
   pytabix = callPackage ../development/python-modules/pytabix { };
 
   pytado = callPackage ../development/python-modules/pytado { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.1

Change log: https://github.com/zalando/patroni/blob/master/docs/releases.rst#version-201

Should fix the build issue detected in #111717.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
