### PR TITLE
jetbrains.mps: fix license

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -336,7 +336,7 @@ in
     name = "mps-${version}";
     version = "2020.3"; /* updated by script */
     description = "Create your own domain-specific language";
-    license = lib.licenses.unfree;
+    license = lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/mps/2020.3/MPS-${version}.tar.gz";
       sha256 = "0dr1z2sxarz1xif4swxx28hpzsyjd86m0c3xdaw5lmpqwqlzvc5h"; /* updated by script */


### PR DESCRIPTION
###### Motivation for this change

Jetbrains MPS is licensed under the Apache 2.0 license and all third-party
libraries use proper open source licenses as well, so I see no reason why MPS
would be marked as unfree.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
