### PR TITLE
python3Packages.shamir-mnemonic: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/mnemonic/default.nix
+++ b/pkgs/development/python-modules/mnemonic/default.nix
@@ -1,20 +1,28 @@
-{ lib, fetchPypi, buildPythonPackage, pbkdf2 }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "mnemonic";
   version = "0.19";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "4e37eb02b2cbd56a0079cabe58a6da93e60e3e4d6e757a586d9f23d96abea931";
+  src = fetchFromGitHub {
+    owner = "trezor";
+    repo = "python-${pname}";
+    rev = "v${version}";
+    sha256 = "0rs3szdikkgypiwn43ad3lwh7zvpccw39j5ggkziq6v7pnw3isaq";
   };
 
-  propagatedBuildInputs = [ pbkdf2 ];
+  checkInputs = [ pytestCheckHook ];
 
-  meta = {
-    description = "Implementation of Bitcoin BIP-0039";
+  pythonImportsCheck = [ "mnemonic" ];
+
+  meta = with lib; {
+    description = "Reference implementation of BIP-0039";
     homepage = "https://github.com/trezor/python-mnemonic";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ np ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ np prusnak ];
   };
 }

--- a/pkgs/development/python-modules/shamir-mnemonic/default.nix
+++ b/pkgs/development/python-modules/shamir-mnemonic/default.nix
@@ -1,22 +1,40 @@
-{ lib, fetchPypi, buildPythonPackage, isPy3k, click, colorama }:
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchFromGitHub
+, attrs
+, click
+, colorama
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "shamir-mnemonic";
-  version = "0.1.0";
+  version = "0.2.0";
 
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1cc08d276e05b13cd32bd3b0c5d1cb6c30254e0086e0f6857ec106d4cceff121";
+  src = fetchFromGitHub {
+    owner = "trezor";
+    repo = "python-${pname}";
+    rev = "v${version}";
+    sha256 = "0lkkbl50n8g5z44x7rk1ly6ld0vlassahwagm8b15bvxfi0q9yqb";
   };
 
-  propagatedBuildInputs = [ click colorama ];
+  propagatedBuildInputs = [
+    attrs
+    click
+    colorama
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "shamir_mnemonic" ];
 
   meta = with lib; {
     description = "Reference implementation of SLIP-0039";
     homepage = "https://github.com/trezor/python-shamir-mnemonic";
     license = licenses.mit;
-    maintainers = with maintainers; [ _1000101 ];
+    maintainers = with maintainers; [ _1000101 prusnak ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- version update
- included also smaller cleanup of the cousin mnemonic package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
