### PR TITLE
calcurse: include oauth2client package

### DIFF
--- a/pkgs/applications/misc/calcurse/default.nix
+++ b/pkgs/applications/misc/calcurse/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     patchShebangs .
-    buildPythonPath ${python3Packages.httplib2}
+    buildPythonPath "${python3Packages.httplib2} ${python3Packages.oauth2client}"
     patchPythonScript $out/bin/calcurse-caldav
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The `oauth2client` is required for the `calcurse-caldav` program to
e.g. connect to Google Calendar with OAuth2

With this change I successfully connected to my Google Calendar using OAuth2

###### Things done
Added `oauth2client` to the dependencies.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
