### PR TITLE
sfeed: 0.9.20 -> 0.9.21

### DIFF
--- a/pkgs/tools/misc/sfeed/default.nix
+++ b/pkgs/tools/misc/sfeed/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "sfeed";
-  version = "0.9.20";
+  version = "0.9.21";
 
   src = fetchgit {
     url = "git://git.codemadness.org/sfeed";
     rev = version;
-    sha256 = "17bs31wns71fx7s06rdzqkghkgv86r9d9i3814rznyzi9484c7aq";
+    sha256 = "010wasp6hcnwbf0d3gaxmjpkvr85zyv2xxz2pnkwxyk2bbr1h6q8";
   };
 
   installPhase = ''


### PR DESCRIPTION
I'm forwarding this patch that I received via email:

```
commit dc69fc793abf8e3b081599d3b9fb0db10ec3a3f0
Author: Matthias Beyer <mail@beyermatthias.de>
Date:   Mon Feb 1 15:22:55 2021 +0100

    sfeed: 0.9.20 -> 0.9.21

    Signed-off-by: Matthias Beyer <mail@beyermatthias.de>
    Message-Id: <20210201142257.517-1-mail@beyermatthias.de>
```

You can find the submission in the [archive](https://lists.sr.ht/~andir/nixpkgs-dev/%3C20210201142257.517-1-mail%40beyermatthias.de%3E).