### PR TITLE
smenu: 0.9.16 -> 0.9.17

### DIFF
--- a/pkgs/tools/misc/smenu/default.nix
+++ b/pkgs/tools/misc/smenu/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, ncurses }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.16";
+  version = "0.9.17";
   pname = "smenu";
 
   src = fetchFromGitHub {
     owner  = "p-gen";
     repo   = "smenu";
     rev    = "v${version}";
-    sha256 = "1vlsrc071fznqnz67jbhrc4pcfwzc737lwd9jxpnidn0i08py5p2";
+    sha256 = "1p8y1fgrfb7jxmv5ycvvnqaz7ghdi50paisgzk71169fqwp1crfa";
   };
 
   buildInputs = [ ncurses ];


### PR DESCRIPTION
I'm forwarding this patch that I received via email:

```
commit 18a962418485146805a9e1eee74093ed6133c79e
Author: Matthias Beyer <mail@beyermatthias.de>
Date:   Mon Feb 1 15:22:56 2021 +0100

    smenu: 0.9.16 -> 0.9.17

    Signed-off-by: Matthias Beyer <mail@beyermatthias.de>
    Message-Id: <20210201142257.517-2-mail@beyermatthias.de>
```

You can find the submission in the [archive](https://lists.sr.ht/~andir/nixpkgs-dev/%3C20210201142257.517-2-mail%40beyermatthias.de%3E).