### PR TITLE
taskwarrior-tui: 0.9.5 -> 0.9.6

### DIFF
--- a/pkgs/applications/misc/taskwarrior-tui/default.nix
+++ b/pkgs/applications/misc/taskwarrior-tui/default.nix
@@ -5,19 +5,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "taskwarrior-tui";
-  version = "0.9.5";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
     owner = "kdheepak";
     repo = "taskwarrior-tui";
     rev = "v${version}";
-    sha256 = "1348ypjphm5f46civbrcxbbahwwl2j47z1hg8ndq1cg2bh5wb8kg";
+    sha256 = "1w8x3qfw7p4q8srdbamqlrz5nsilyd0dy87jp7kq2n7yxsrbyh4x";
   };
 
   # Because there's a test that requires terminal access
   doCheck = false;
 
-  cargoSha256 = "11zpy3whzir9mlbvf0jyscqwj9z44a6s5i1bc2cnxyciqy9b57md";
+  cargoSha256 = "0b69qyb74r9may6n61i5a5nzwhxpaij6y40bq6kh8rzdwy0awwx7";
 
   meta = with lib; {
     description = "A terminal user interface for taskwarrior ";


### PR DESCRIPTION
I'm forwarding this patch that I received via email:

```
commit c585670615275f661e9081818997f1d41d794bdf
Author: Matthias Beyer <mail@beyermatthias.de>
Date:   Mon Feb 1 15:22:57 2021 +0100

    taskwarrior-tui: 0.9.5 -> 0.9.6

    Signed-off-by: Matthias Beyer <mail@beyermatthias.de>
    Message-Id: <20210201142257.517-3-mail@beyermatthias.de>
```

You can find the submission in the [archive](https://lists.sr.ht/~andir/nixpkgs-dev/%3C20210201142257.517-3-mail%40beyermatthias.de%3E).