### PR TITLE
ankisyncd: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/servers/ankisyncd/default.nix
+++ b/pkgs/servers/ankisyncd/default.nix
@@ -6,12 +6,12 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "ankisyncd";
-  version = "2.1.0";
+  version = "2.2.0";
   src = fetchFromGitHub {
-    owner = "tsudoko";
+    owner = "ankicommunity";
     repo = "anki-sync-server";
     rev = version;
-    sha256 = "6a140afa94fdb1725fed716918875e3d2ad0092cb955136e381c9d826cc4927c";
+    sha256 = "196xhd6vzp1ncr3ahz0bv0gp1ap2s37j8v48dwmvaywzayakqdab";
   };
   format = "other";
 
@@ -60,8 +60,8 @@ python3.pkgs.buildPythonApplication rec {
   meta = with lib; {
     description = "Self-hosted Anki sync server";
     maintainers = with maintainers; [ matt-snider ];
-    homepage = "https://github.com/tsudoko/anki-sync-server";
-    license = licenses.agpl3;
+    homepage = "https://github.com/ankicommunity/anki-sync-server";
+    license = licenses.agpl3Only;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently ankisyncd uses the [tsudoko/anki-sync-server repository](https://github.com/tsudoko/anki-sync-server) which does not appear to maintained. The repository [ankicommunity/anki-sync-server](https://github.com/ankicommunity/anki-sync-server/) is actively maintained. In [this comment](https://github.com/ankicommunity/anki-sync-server/issues/33#issuecomment-711421178) the maintainer goes over the history of the repo and its connection to the original from dsnopek, and the fork from tsudoku.

See #107526

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
