### PR TITLE
home-assistant: list outdated libs in parse-requirements.py

### DIFF
--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ mypy attrs ])
+#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ mypy attrs packaging rich ])
 #
 # This script downloads Home Assistant's source tarball.
 # Inside the homeassistant/components directory, each integration has an associated manifest.json,
@@ -26,6 +26,9 @@ import tempfile
 from io import BytesIO
 from typing import Dict, Optional, Set, Any
 from urllib.request import urlopen
+from packaging import version as Version
+from rich.console import Console
+from rich.table import Table
 
 COMPONENT_PREFIX = "homeassistant.components"
 PKG_SET = "python3Packages"
@@ -142,12 +145,20 @@ def name_to_attr_path(req: str, packages: Dict[str, Dict[str, str]]) -> Optional
         return None
 
 
+def get_pkg_version(package: str, packages: Dict[str, Dict[str, str]]) -> Optional[str]:
+    pkg = packages.get(f"{PKG_SET}.{package}", None)
+    if not pkg:
+        return None
+    return pkg["version"]
+
+
 def main() -> None:
     packages = dump_packages()
     version = get_version()
     print("Generating component-packages.nix for version {}".format(version))
     components = parse_components(version=version)
     build_inputs = {}
+    outdated = {}
     for component in sorted(components.keys()):
         attr_paths = []
         missing_reqs = []
@@ -156,8 +167,14 @@ def main() -> None:
             # Some requirements are specified by url, e.g. https://example.org/foobar#xyz==1.0.0
             # Therefore, if there's a "#" in the line, only take the part after it
             req = req[req.find("#") + 1 :]
-            name = req.split("==")[0]
+            name, required_version = req.split("==", maxsplit=1)
             attr_path = name_to_attr_path(name, packages)
+            if our_version := get_pkg_version(name, packages):
+                if Version.parse(our_version) < Version.parse(required_version):
+                    outdated[name] = {
+                      'wanted': required_version,
+                      'current': our_version
+                    }
             if attr_path is not None:
                 # Add attribute path without "python3Packages." prefix
                 attr_paths.append(attr_path[len(PKG_SET + ".") :])
@@ -188,6 +205,17 @@ def main() -> None:
             f.write("\n")
         f.write("  };\n")
         f.write("}\n")
+
+    if outdated:
+        table = Table(title="Outdated dependencies")
+        table.add_column("Package")
+        table.add_column("Current")
+        table.add_column("Wanted")
+        for package, version in sorted(outdated.items()):
+            table.add_row(package, version['current'], version['wanted'])
+
+        console = Console()
+        console.print(table)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

More closely watch for outdated dependencies  used in the home-assistant ecosystem.

Before #111661 it would print this at the end of `./parse-requirements.py` run:

```
Outdated packages:
 - bt_proximity 0.0.20180217 < 0.2
 - brother 0.1.18 < 0.1.20
 - plexapi 4.1.2 < 4.2.0
 - plexauth 0.0.5 < 0.0.6
 - py-cpuinfo 5.0.0 < 7.0.0
 - fixerio 0.1.1 < 1.0.0a0
 - linode-api 4.1.8b1 < 4.1.9b1
 - libsoundtouch 0.4.0 < 0.8
 - python-telegram-bot 13.0 < 13.1
 - holidays 0.10.3 < 0.10.4
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
