### PR TITLE
vokoscreenNG: 3.0.5 -> 3.0.8

### DIFF
--- a/pkgs/applications/video/vokoscreen-ng/default.nix
+++ b/pkgs/applications/video/vokoscreen-ng/default.nix
@@ -1,12 +1,12 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
-, fetchpatch
 , pkg-config
 , qmake
 , qttools
 , gstreamer
 , libX11
+, pulseaudio
 , qtbase
 , qtmultimedia
 , qtx11extras
@@ -19,21 +19,19 @@
 mkDerivation rec {
 
   pname = "vokoscreen-ng";
-  version = "3.0.5";
+  version = "3.0.8";
 
   src = fetchFromGitHub {
     owner = "vkohaupt";
     repo = "vokoscreenNG";
     rev = version;
-    sha256 = "1spyqw8h8bkc1prdb9aixiw5h3hk3gp2p0nj934bnwq04kmfp660";
+    sha256 = "1302663hyp2xxhaavhfky24a2p9gz23i3rykmrc6c1n23h24snri";
   };
 
   patches = [
-    # Better linux integration
-    (fetchpatch {
-      url = "https://github.com/vkohaupt/vokoscreenNG/commit/0a3784095ecca582f7eb09551ceb34c309d83637.patch";
-      sha256 = "1iibimv8xfxxfk44kkbrkay37ibdndjvs9g53mxr8x8vrsp917bz";
-    })
+    # Adaptation of previously used https://github.com/City-busz/vokoscreenNG/commit/0a3784095ecca582f7eb09551ceb34c309d83637 patch
+    # used for 3.0.5 but incompatible at least since 3.0.8. The issue is addressed here https://github.com/vkohaupt/vokoscreenNG/issues/139
+    ./linux-support-installation-target.patch
   ];
 
   qmakeFlags = [ "src/vokoscreenNG.pro" ];
@@ -42,6 +40,7 @@ mkDerivation rec {
   buildInputs = [
     gstreamer
     libX11
+    pulseaudio
     qtbase
     qtmultimedia
     qtx11extras

--- a/pkgs/applications/video/vokoscreen-ng/linux-support-installation-target.patch
+++ b/pkgs/applications/video/vokoscreen-ng/linux-support-installation-target.patch
@@ -1,0 +1,40 @@
+Seulement dans b: patch.patch
+Seulement dans b: ..rej
+diff --color -ur a/src/vokoscreenNG.pro b/src/vokoscreenNG.pro
+--- a/src/vokoscreenNG.pro	2021-02-03 15:00:57.377401016 +0100
++++ b/src/vokoscreenNG.pro	2021-02-03 15:09:18.141905863 +0100
+@@ -160,7 +160,32 @@
+ # systrayAlternative
+ include(systrayAlternative/systrayAlternative.pri)
+ 
++unix:!macx {
++  isEmpty(PREFIX) {
++    PREFIX = /usr/local
++  }
++  isEmpty(BINDIR) {
++    BINDIR = $$PREFIX/bin
++  }
++  isEmpty(DATADIR) {
++    DATADIR = $$PREFIX/share
++  }
++
++  target.path = $$BINDIR
++
++  icon.files = applications/vokoscreenNG.png
++  icon.path = $$DATADIR/icons/hicolor/256x256/apps/
++
++  desktop.files = applications/vokoscreenNG.desktop
++  desktop.path = $$DATADIR/applications/
++
++  appdata.files = applications/vokoscreenNG.appdata.xml
++  appdata.path = $$DATADIR/metainfo/
++
++  INSTALLS += target icon desktop appdata
++}
+ # ciscoOpenh264
+ win32:include(ciscoOpenh264/ciscoOpenh264.pri)
+ 
+-unix:include(wayland/wayland.pri)
+\ Pas de fin de ligne à la fin du fichier
++unix:include(wayland/wayland.pri)
++


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
