### PR TITLE
python3Packages.javaobj-py3: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/development/python-modules/javaobj-py3/default.nix
+++ b/pkgs/development/python-modules/javaobj-py3/default.nix
@@ -2,27 +2,30 @@
 , fetchPypi
 , isPy27
 , lib
+, numpy
 }:
 
 buildPythonPackage rec {
   pname = "javaobj-py3";
-  version = "0.4.1";
+  version = "0.4.2";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "419ff99543469e68149f875abb0db5251cecd350c03d2bfb4c94a5796f1cbc14";
+    sha256 = "sha256-7Tsf/P058WVynLU1h8ygKrC/pMMyyDepLV/+au9cgBA=";
   };
+
+  propagatedBuildInputs = [ numpy ];
 
   # Tests assume network connectivity
   doCheck = false;
 
-  meta = {
+  pythonImportsCheck = [ "javaobj" ];
+
+  meta = with lib; {
     description = "Module for serializing and de-serializing Java objects";
     homepage = "https://github.com/tcalmant/python-javaobj";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      kamadorueda
-    ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kamadorueda ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.4.2

Change log: https://github.com/tcalmant/python-javaobj/releases/tag/0.4.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
