### PR TITLE
licensor: "Fix" integration test for 2021

### DIFF
--- a/pkgs/tools/misc/licensor/default.nix
+++ b/pkgs/tools/misc/licensor/default.nix
@@ -1,22 +1,17 @@
-{ lib, rustPlatform, fetchFromGitHub, fetchpatch }:
+{ lib, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
   pname = "licensor";
-  version = "2.1.0";
+  version = "unstable-2021-02-03";
 
   src = fetchFromGitHub {
     owner = "raftario";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0zr8hcq7crmhrdhwcclc0nap68wvg5kqn5l93ha0vn9xgjy8z11p";
+    rev = "1897882a708ec6ed65a9569ae0e07d6ea576c652";
+    sha256 = "0x0lkfrj7jka0p6nx6i9syz0bnzya5z9np9cw09zm1c9njv9mm32";
   };
 
-  patches = [ (fetchpatch {
-    url = "https://github.com/raftario/licensor/commit/77ae1ea6d9b6de999ee7590d9dbd3c8465d70bb6.patch";
-    sha256 = "0kfyg06wa2v7swm7hs9kkazjg34mircd4nm4qmljyzjh2yh8icg3";
-  })];
-
-  cargoSha256 = "1z2r8nfizifj8sk1ghppyqk5r65sgmbk47fiq95pnwpadm5drvqa";
+  cargoSha256 = "1yix40351yasg7mjmz7qwvwh1dq292dv47gy2a3bwkzhcn6whyjf";
 
   meta = with lib; {
     description = "Write licenses to stdout";


### PR DESCRIPTION
###### Motivation for this change
The `license_and_name` test depends on the year, thus failing and causing the build to fail.

###### Things done
* Use `unstable-2021-02-03` instead of `2.1.0` + patches

Use the patch from https://github.com/raftario/licensor/pull/28 that "fixes" the `license_and_name` test by bumping the year from 2020 to 2021, until the test implementation can be properly addressed

###### Security Updates
This also includes a security update from https://github.com/raftario/licensor/pull/8

Instead of adding 2 more patches (one for the test fix, one for the security update), using the latest commit from master seems to make the most sense for now