### PR TITLE
pinentry-mac: name -> pname

### DIFF
--- a/pkgs/tools/security/pinentry/mac.nix
+++ b/pkgs/tools/security/pinentry/mac.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, fetchFromGitHub, xcbuildHook, libiconv, ncurses, Cocoa }:
 
 stdenv.mkDerivation {
-  name = "pinentry-mac-0.9.4";
+  pname = "pinentry-mac";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "matthewbauer";


### PR DESCRIPTION
###### Motivation for this change
According to the manual, this is preferred for packages in Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).