### PR TITLE
home-assistant: 2021.1.5 -> 2021.2.0

### DIFF
--- a/pkgs/development/python-modules/asyncio_mqtt/default.nix
+++ b/pkgs/development/python-modules/asyncio_mqtt/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, async_generator
+, paho-mqtt
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "asyncio_mqtt";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hwfgww1ywhjvkpnvafbk2hxlqkrngfdz0sx5amzw68srzazvl6g";
+  };
+
+  propagatedBuildInputs = [
+    paho-mqtt
+  ] ++ lib.optional (pythonOlder "3.7") async_generator;
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "asyncio_mqtt" ];
+
+  meta = with lib; {
+    description = "Idomatic asyncio wrapper around paho-mqtt";
+    homepage = "https://github.com/sbtinstruments/asyncio-mqtt";
+    license = licenses.bsd3;
+    changelog = "https://github.com/sbtinstruments/asyncio-mqtt/blob/master/CHANGELOG.md";
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/convertdate/default.nix
+++ b/pkgs/development/python-modules/convertdate/default.nix
@@ -1,18 +1,31 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pymeeus, pytz }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pymeeus
+, pytz
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "convertdate";
-  version = "2.2.1";
+  version = "2.3.0";
 
   # Tests are not available in the PyPI tarball so use GitHub instead.
   src = fetchFromGitHub {
     owner = "fitnr";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1xgi7x9b9kxm0q51bqnmwdm5lp8vwhx5yk4d1b23r37spz9dbhw5";
+    sha256 = "17j188zlp46zmq8qyy4z4f9v25l3zibkwzj8wp4fxqgimjnfj2nr";
   };
 
-  propagatedBuildInputs = [ pymeeus pytz ];
+  propagatedBuildInputs = [
+    pymeeus
+    pytz
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/fitnr/convertdate";

--- a/pkgs/development/python-modules/hijri-converter/default.nix
+++ b/pkgs/development/python-modules/hijri-converter/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "hijri-converter";
+  version = "2.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08gv6ypn2zd0i8yrv24m448xkic492qrgxj349slp1achhg9p7ln";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Accurate Hijri-Gregorian date converter based on the Umm al-Qura calendar";
+    homepage = "https://github.com/dralshehri/hijri-converter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/holidays/default.nix
+++ b/pkgs/development/python-modules/holidays/default.nix
@@ -3,25 +3,46 @@
 , fetchPypi
 , convertdate
 , dateutil
+, hijri-converter
 , korean-lunar-calendar
 , six
+, python
+, flake8
 }:
 
 buildPythonPackage rec {
   pname = "holidays";
-  version = "0.10.3";
+  version = "0.10.5.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "839281f2b1ae7ac576da7951472482f6e714818296853107ea861fa60f5013cc";
+    sha256 = "0g4hqbb94cwxlcwsjzrzxzlann1ks2r4mgnfzqz74a2rg1nih5zd";
   };
+
+  postPatch = ''
+    # ignore too long line issues
+    # https://github.com/dr-prodigy/python-holidays/issues/423
+    substituteInPlace tests.py \
+      --replace "flake8.get_style_guide(ignore=[" "flake8.get_style_guide(ignore=['E501', "
+  '';
+
 
   propagatedBuildInputs = [
     convertdate
     dateutil
+    hijri-converter
     korean-lunar-calendar
     six
   ];
+
+  checkInputs = [
+    flake8
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest
+  '';
+
   pythonImportsCheck = [ "holidays" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/plexauth/default.nix
+++ b/pkgs/development/python-modules/plexauth/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "plexauth";
-  version = "0.0.5";
+  version = "0.0.6";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "jjlawren";
     repo = "python-plexauth";
     rev = "v${version}";
-    sha256 = "1wbrn22iywl4ccz64r3w3f17k0r7vi2cqkqd2mrdkx5xqhscn9hz";
+    sha256 = "1wy6syz3cgfw28zvigh2br4jabg8rzpi5l0bhfb6vjjc7aam13ag";
   };
 
   propagatedBuildInputs = [ aiohttp ];

--- a/pkgs/development/python-modules/python-openzwave-mqtt/default.nix
+++ b/pkgs/development/python-modules/python-openzwave-mqtt/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, asyncio-mqtt
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "python-openzwave-mqtt";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "cgarwood";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0zqx00dacs59y4gjr4swrn46c7hrp8a1167bcl270333284m8mqm";
+  };
+
+  propagatedBuildInputs = [
+    asyncio-mqtt
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python wrapper for OpenZWave's MQTT daemon";
+    homepage = "https://github.com/cgarwood/python-openzwave-mqtt";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/python-tado/default.nix
+++ b/pkgs/development/python-modules/python-tado/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "python-tado";
-  version = "0.9.0";
+  version = "0.11.0";
 
   disabled = pythonOlder "3.5";
 
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "wmalgadey";
     repo = "PyTado";
     rev = version;
-    sha256 = "0cr5sxdvjgdrrlhl32rs8pwyay8liyi6prm37y66dn00b41cb5l3";
+    sha256 = "0fw4f9gqnhxwpxyb34qi8bl5pmzz13h4x3mdk903hhjyccanqncr";
   };
 
   propagatedBuildInputs = [ requests ];

--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -29,11 +29,11 @@
 
 buildPythonPackage rec {
   pname = "sentry-sdk";
-  version = "0.19.4";
+  version = "0.19.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1052f0ed084e532f66cb3e4ba617960d820152aee8b93fc6c05bd53861768c1c";
+    sha256 = "0grba3rpgg20sqhrh8mxcjwmwgbwrybrxymavh7xsad59570jykk";
   };
 
   checkInputs = [ blinker botocore chalice django flask tornado bottle rq falcon sqlalchemy werkzeug trytond

--- a/pkgs/development/python-modules/volkszaehler/default.nix
+++ b/pkgs/development/python-modules/volkszaehler/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "volkszaehler";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "087gw1k3f81lm859r0j65cjia8c2dcy4cx8c7s3mb5msb1csdh0x";
+    sha256 = "13zhxq08wn5y9yn6xbazfl0gxxysmirwpc26wcnr6jk2va1kpc4l";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.1.5";
+  version = "2021.2.0";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];
@@ -16,6 +16,7 @@
     "agent_dvr" = ps: with ps; [ agent-py ];
     "air_quality" = ps: with ps; [ ];
     "airly" = ps: with ps; [ airly ];
+    "airnow" = ps: with ps; [ ]; # missing inputs: pyairnow
     "airvisual" = ps: with ps; [ pyairvisual ];
     "aladdin_connect" = ps: with ps; [ ]; # missing inputs: aladdin_connect
     "alarm_control_panel" = ps: with ps; [ ];
@@ -107,7 +108,7 @@
     "calendar" = ps: with ps; [ aiohttp-cors ];
     "camera" = ps: with ps; [ aiohttp-cors ];
     "canary" = ps: with ps; [ ha-ffmpeg ]; # missing inputs: py-canary
-    "cast" = ps: with ps; [ aiohttp-cors hass-nabucasa mutagen plexapi plexauth plexwebsocket PyChromecast pysonos zeroconf ];
+    "cast" = ps: with ps; [ aiohttp-cors hass-nabucasa mutagen plexapi plexauth plexwebsocket PyChromecast zeroconf ];
     "cert_expiry" = ps: with ps; [ ];
     "channels" = ps: with ps; [ ]; # missing inputs: pychannels
     "circuit" = ps: with ps; [ ]; # missing inputs: circuit-webhook
@@ -153,7 +154,7 @@
     "deconz" = ps: with ps; [ ]; # missing inputs: pydeconz
     "decora" = ps: with ps; [ bluepy ]; # missing inputs: decora
     "decora_wifi" = ps: with ps; [ ]; # missing inputs: decora_wifi
-    "default_config" = ps: with ps; [ pynacl aiohttp-cors defusedxml distro emoji hass-nabucasa netdisco pillow sqlalchemy zeroconf ];
+    "default_config" = ps: with ps; [ pynacl aiohttp-cors defusedxml distro emoji hass-nabucasa netdisco pillow scapy sqlalchemy zeroconf ];
     "delijn" = ps: with ps; [ ]; # missing inputs: pydelijn
     "deluge" = ps: with ps; [ deluge-client ];
     "demo" = ps: with ps; [ aiohttp-cors ];
@@ -166,6 +167,7 @@
     "device_tracker" = ps: with ps; [ ];
     "devolo_home_control" = ps: with ps; [ aiohttp-cors devolo-home-control-api zeroconf ];
     "dexcom" = ps: with ps; [ pydexcom ];
+    "dhcp" = ps: with ps; [ scapy ];
     "dht" = ps: with ps; [ ]; # missing inputs: Adafruit-DHT
     "dialogflow" = ps: with ps; [ aiohttp-cors ];
     "digital_ocean" = ps: with ps; [ digital-ocean ];
@@ -242,7 +244,7 @@
     "familyhub" = ps: with ps; [ ]; # missing inputs: python-family-hub-local
     "fan" = ps: with ps; [ ];
     "fastdotcom" = ps: with ps; [ ]; # missing inputs: fastdotcom
-    "feedreader" = ps: with ps; [ ]; # missing inputs: feedparser-homeassistant
+    "feedreader" = ps: with ps; [ feedparser ];
     "ffmpeg" = ps: with ps; [ ha-ffmpeg ];
     "ffmpeg_motion" = ps: with ps; [ ha-ffmpeg ];
     "ffmpeg_noise" = ps: with ps; [ ha-ffmpeg ];
@@ -364,6 +366,7 @@
     "huawei_lte" = ps: with ps; [ getmac stringcase url-normalize ]; # missing inputs: huawei-lte-api
     "huawei_router" = ps: with ps; [ ];
     "hue" = ps: with ps; [ aiohue ];
+    "huisbaasje" = ps: with ps; [ ]; # missing inputs: huisbaasje-client
     "humidifier" = ps: with ps; [ ];
     "hunterdouglas_powerview" = ps: with ps; [ ]; # missing inputs: aiopvapi
     "hvv_departures" = ps: with ps; [ ]; # missing inputs: pygti
@@ -460,7 +463,7 @@
     "luftdaten" = ps: with ps; [ luftdaten ];
     "lupusec" = ps: with ps; [ ]; # missing inputs: lupupy
     "lutron" = ps: with ps; [ pylutron ];
-    "lutron_caseta" = ps: with ps; [ ]; # missing inputs: pylutron-caseta
+    "lutron_caseta" = ps: with ps; [ ]; # missing inputs: aiolip pylutron-caseta
     "lw12wifi" = ps: with ps; [ ]; # missing inputs: lw12
     "lyft" = ps: with ps; [ ]; # missing inputs: lyft_rides
     "magicseaweed" = ps: with ps; [ ]; # missing inputs: magicseaweed
@@ -573,6 +576,7 @@
     "ombi" = ps: with ps; [ ]; # missing inputs: pyombi
     "omnilogic" = ps: with ps; [ ]; # missing inputs: omnilogic
     "onboarding" = ps: with ps; [ aiohttp-cors pillow ];
+    "ondilo_ico" = ps: with ps; [ aiohttp-cors ]; # missing inputs: ondilo
     "onewire" = ps: with ps; [ ]; # missing inputs: pi1wire pyownet
     "onkyo" = ps: with ps; [ onkyo-eiscp ];
     "onvif" = ps: with ps; [ ha-ffmpeg zeep ]; # missing inputs: WSDiscovery onvif-zeep-async
@@ -599,7 +603,7 @@
     "otp" = ps: with ps; [ pyotp ];
     "ovo_energy" = ps: with ps; [ ]; # missing inputs: ovoenergy
     "owntracks" = ps: with ps; [ pynacl aiohttp-cors hass-nabucasa paho-mqtt ];
-    "ozw" = ps: with ps; [ aiohttp-cors paho-mqtt ]; # missing inputs: python-openzwave-mqtt[mqtt-client]
+    "ozw" = ps: with ps; [ aiohttp-cors homeassistant-pyozw paho-mqtt pydispatcher python-openzwave-mqtt ];
     "panasonic_bluray" = ps: with ps; [ ]; # missing inputs: panacotta
     "panasonic_viera" = ps: with ps; [ ]; # missing inputs: panasonic_viera
     "pandora" = ps: with ps; [ pexpect ];
@@ -620,7 +624,7 @@
     "pjlink" = ps: with ps; [ ]; # missing inputs: pypjlink2
     "plaato" = ps: with ps; [ aiohttp-cors ];
     "plant" = ps: with ps; [ sqlalchemy ];
-    "plex" = ps: with ps; [ aiohttp-cors plexapi plexauth plexwebsocket pysonos ];
+    "plex" = ps: with ps; [ aiohttp-cors plexapi plexauth plexwebsocket ];
     "plugwise" = ps: with ps; [ plugwise ];
     "plum_lightpad" = ps: with ps; [ ]; # missing inputs: plumlightpad
     "pocketcasts" = ps: with ps; [ ]; # missing inputs: pycketcasts
@@ -636,7 +640,6 @@
     "proxmoxve" = ps: with ps; [ ]; # missing inputs: proxmoxer
     "proxy" = ps: with ps; [ pillow ];
     "ps4" = ps: with ps; [ ]; # missing inputs: pyps4-2ndscreen
-    "ptvsd" = ps: with ps; [ ]; # missing inputs: ptvsd
     "pulseaudio_loopback" = ps: with ps; [ pulsectl ];
     "push" = ps: with ps; [ aiohttp-cors ];
     "pushbullet" = ps: with ps; [ pushbullet ];
@@ -764,7 +767,7 @@
     "somfy_mylink" = ps: with ps; [ ]; # missing inputs: somfy-mylink-synergy
     "sonarr" = ps: with ps; [ ]; # missing inputs: sonarr
     "songpal" = ps: with ps; [ ]; # missing inputs: python-songpal
-    "sonos" = ps: with ps; [ pysonos ];
+    "sonos" = ps: with ps; [ aiohttp-cors plexapi plexauth plexwebsocket pysonos ];
     "sony_projector" = ps: with ps; [ ]; # missing inputs: pysdcp
     "soundtouch" = ps: with ps; [ aiohttp-cors libsoundtouch zeroconf ];
     "spaceapi" = ps: with ps; [ aiohttp-cors ];
@@ -970,6 +973,7 @@
     "zodiac" = ps: with ps; [ ];
     "zone" = ps: with ps; [ ];
     "zoneminder" = ps: with ps; [ zm-py ];
-    "zwave" = ps: with ps; [ homeassistant-pyozw pydispatcher ];
+    "zwave" = ps: with ps; [ aiohttp-cors homeassistant-pyozw paho-mqtt pydispatcher python-openzwave-mqtt ];
+    "zwave_js" = ps: with ps; [ aiohttp-cors ]; # missing inputs: zwave-js-server-python
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -57,7 +57,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.1.5";
+  hassVersion = "2021.2.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -76,7 +76,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "sha256-xi5rHZlhwgEHll3TFlRu7D963tdcQNMmWcoXVjEFLXo=";
+    sha256 = "116aq683wy7sxdbxr43li90irpfbsz0dv8w0r1fghcjpwlj7ihwa";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling
@@ -84,12 +84,13 @@ in with py.pkgs; buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "aiohttp==3.7.1" "aiohttp>=3.6.3" \
       --replace "attrs==19.3.0" "attrs>=19.3.0" \
       --replace "bcrypt==3.1.7" "bcrypt>=3.1.7" \
       --replace "cryptography==3.2" "cryptography" \
       --replace "pip>=8.0.3,<20.3" "pip" \
-      --replace "requests==2.25.0" "requests>=2.24.0" \
+      --replace "pytz>=2020.5" "pytz>=2020.4" \
+      --replace "pyyaml==5.4.1" "pyyaml" \
+      --replace "requests==2.25.1" "requests>=2.25.0" \
       --replace "ruamel.yaml==0.15.100" "ruamel.yaml>=0.15.100"
     substituteInPlace tests/test_config.py --replace '"/usr"' '"/build/media"'
   '';
@@ -99,10 +100,10 @@ in with py.pkgs; buildPythonApplication rec {
     aiohttp astral async-timeout attrs bcrypt certifi ciso8601 httpx jinja2
     pyjwt cryptography pip python-slugify pytz pyyaml requests ruamel_yaml
     setuptools voluptuous voluptuous-serialize yarl
-    # From default_config. frontend, http, image, mobile_app and recorder components as well as
-    # the auth.mfa_modules.totp module
-    aiohttp-cors defusedxml distro emoji hass-frontend pynacl pillow pyotp
-    pyqrcode sqlalchemy
+    # From default_config. dhcp, frontend, http, image, mobile_app and
+    # recorder components as well as the auth.mfa_modules.totp module
+    aiohttp-cors aiohue defusedxml distro emoji hass-frontend pynacl pillow pyotp
+    pyqrcode scapy sqlalchemy python-openzwave-mqtt
   ] ++ componentBuildInputs ++ extraBuildInputs;
 
   # upstream only tests on Linux, so do we.
@@ -114,13 +115,16 @@ in with py.pkgs; buildPythonApplication rec {
 
   # We cannot test all components, since they'd introduce lots of dependencies, some of which are unpackaged,
   # but we should test very common stuff, like what's in `default_config`.
+  # https://github.com/home-assistant/core/commits/dev/homeassistant/components/default_config/manifest.json
   componentTests = [
     "api"
     "automation"
     "config"
     "configurator"
+    "counter"
     "default_config"
     "demo"
+    "dhcp"
     "discovery"
     "frontend"
     "group"
@@ -145,6 +149,8 @@ in with py.pkgs; buildPythonApplication rec {
     "system_health"
     "system_log"
     "tag"
+    "timer"
+    "webhook"
     "websocket_api"
     "zeroconf"
     "zone"
@@ -156,31 +162,25 @@ in with py.pkgs; buildPythonApplication rec {
     "--ignore tests/components"
     # prone to race conditions due to parallel file access
     "--ignore tests/test_config.py"
-    # tries to import unpackaged dependencies
-    "--ignore tests/test_loader.py"
     # pyotp since v2.4.0 complains about the short mock keys, hass pins v2.3.0
     "--ignore tests/auth/mfa_modules/test_notify.py"
     "tests"
   ] ++ map (component: "tests/components/" + component) componentTests;
 
   disabledTests = [
-    # AssertionError: merge_log_err.call_count != 0
-    "test_merge"
-    # ModuleNotFoundError: No module named 'pyqwikswitch'
-    "test_merge_id_schema"
     # AssertionError: assert 'unknown' == 'not_home'
     "test_device_tracker_not_home"
-    # Racy https://github.com/home-assistant/core/issues/41425
-    "test_cached_event_message"
-    # ValueError: count must be a positive integer (got 0)
-    "test_media_view"
-    # AssertionError: len(events) == 1
-    "test_error_posted_as_event"
     # keyring.errors.NoKeyringError: No recommended backend was available.
     "test_secrets_from_unrelated_fails"
     "test_secrets_credstash"
+    # AssertionError: Expected 'start' to have been called once. Called 0 times.
+    "test_setup_and_stop"
+    # AssertionError: assert {} == {'test': <ANY...ckage': <ANY>}
+    "test_get_custom_components_internal"
+    # assert 0 == 1 where 0 = len([])
+    "test_error_posted_as_event"
     # RuntimeError: Event loop is closed
-    "test_remove_older_logs"
+    "test_info_endpoint_register_callback_timeout"
   ];
 
   preCheck = ''

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20201229.1";
+  version = "20210127.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-3JMWugAiVDq/NBgX8ft2Bchim2g493jy7wZvvXrX+Ws=";
+    sha256 = "sha256-N+n1DI1oZ/j+GydH+Du21zTNA6leW4YBri7cAMvAac4=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -484,6 +484,8 @@ in {
 
   asyncio-dgram = callPackage ../development/python-modules/asyncio-dgram { };
 
+  asyncio-mqtt = callPackage ../development/python-modules/asyncio_mqtt { };
+
   asyncio-throttle = callPackage ../development/python-modules/asyncio-throttle { };
 
   asyncpg = callPackage ../development/python-modules/asyncpg { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4898,6 +4898,8 @@ in {
 
   python-openems = callPackage ../development/python-modules/python-openems { };
 
+  python-openzwave-mqtt = callPackage ../development/python-modules/python-openzwave-mqtt { };
+
   python-tado = callPackage ../development/python-modules/python-tado { };
 
   pkutils = callPackage ../development/python-modules/pkutils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2928,6 +2928,8 @@ in {
 
   hieroglyph = callPackage ../development/python-modules/hieroglyph { };
 
+  hijri-converter = callPackage ../development/python-modules/hijri-converter { };
+
   hiredis = callPackage ../development/python-modules/hiredis { };
 
   hiro = callPackage ../development/python-modules/hiro { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release.
https://www.home-assistant.io/blog/2021/02/03/release-20212/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
           Outdated dependencies           
┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ Package             ┃ Current ┃ Wanted  ┃
┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
│ holidays            │ 0.10.3  │ 0.10.4  │
│ linode-api          │ 4.1.8b1 │ 4.1.9b1 │
│ pillow              │ 8.0.1   │ 8.1.0   │
│ plexapi             │ 4.1.2   │ 4.3.1   │
│ plexauth            │ 0.0.5   │ 0.0.6   │
│ py-cpuinfo          │ 5.0.0   │ 7.0.0   │
│ python-tado         │ 0.9.0   │ 0.10.0  │
│ python-telegram-bot │ 13.0    │ 13.1    │
│ sentry-sdk          │ 0.19.4  │ 0.19.5  │
│ sqlalchemy          │ 1.3.20  │ 1.3.22  │
│ volkszaehler        │ 0.2.0   │ 0.2.1   │
└─────────────────────┴─────────┴─────────┘
```