### PR TITLE
systemd: 247.2 -> 247.3

### DIFF
--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -93,17 +93,7 @@ in
             (if i.useDHCP != null then i.useDHCP else false));
           address = forEach (interfaceIps i)
             (ip: "${ip.address}/${toString ip.prefixLength}");
-          # IPv6PrivacyExtensions=kernel seems to be broken with networkd.
-          # Instead of using IPv6PrivacyExtensions=kernel, configure it according to the value of
-          # `tempAddress`:
-          networkConfig.IPv6PrivacyExtensions = {
-            # generate temporary addresses and use them by default
-            "default" = true;
-            # generate temporary addresses but keep using the standard EUI-64 ones by default
-            "enabled" = "prefer-public";
-            # completely disable temporary addresses
-            "disabled" = false;
-          }.${i.tempAddress};
+          networkConfig.IPv6PrivacyExtensions = "kernel";
           linkConfig = optionalAttrs (i.macAddress != null) {
             MACAddress = i.macAddress;
           } // optionalAttrs (i.mtu != null) {

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,3 +1,5 @@
+# NOTE: Make sure to (re-)format this file on changes with `nixpkgs-fmt`!
+
 { stdenv
 , lib
 , fetchFromGitHub

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -111,7 +111,7 @@ assert withCryptsetup ->
 let
   wantCurl = withRemote || withImportd;
 
-  version = "247.2";
+  version = "247.3";
 in
 stdenv.mkDerivation {
   inherit version pname;
@@ -122,7 +122,7 @@ stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "091pwrvxz3gcf80shlp28d6l4gvjzc6pb61v4mwxmk9d71qaq7ry";
+    sha256 = "0zn0b74iwz3vxabqsk4yydwpgky3c5z4dl83wxbs1qi5d2dnbqa7";
   };
 
   # If these need to be regenerated, `git am path/to/00*.patch` them into a

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -160,83 +160,87 @@ stdenv.mkDerivation {
       --replace \
       "find_program('objcopy'" \
       "find_program('${stdenv.cc.bintools.targetPrefix}objcopy'"
-  '' + (let
+  '' + (
+    let
+      # The folllowing dlopen patches ensure that all the features that are
+      # implemented via dlopen(3) are available (or explicitly deactivated) by
+      # pointing dlopen to the absolute store path instead of relying on the
+      # linkers runtime lookup code.
+      #
+      # All of the dlopen calls have to be handled. When new ones are introduced
+      # by upstream (or one of our patches) they must be explicitly declared,
+      # otherwise the build will fail.
+      #
+      # As of systemd version 247 we've seen a few errors like `libpcre2.… not
+      # found` when using e.g. --grep with journalctl. Those errors should
+      # become less unexpected now.
+      #
+      # There are generally two classes of dlopen(3) calls. Those that we want to
+      # support and those that should be deactivated / unsupported. This change
+      # enforces that we handle all dlopen calls explicitly. Meaning: There is
+      # not a single dlopen call in the source code tree that we did not
+      # explicitly handle.
+      #
+      # In order to do this we introduced a list of attributes that maps from
+      # shared object name to the package that contains them. The package can be
+      # null meaning the reference should be nuked and the shared object will
+      # never be loadable during runtime (because it points at an invalid store
+      # path location).
+      #
+      # To get a list of dynamically loaded libraries issue something like
+      # `grep -ri 'dlopen("lib' $src` and update the below list.
+      dlopenLibs = [
+        # We did never provide support for libxkbcommon & qrencode
+        { name = "libxkbcommon.so.0"; pkg = null; }
+        { name = "libqrencode.so.4"; pkg = null; }
 
-    # The folllowing dlopen patches ensure that all the features that are
-    # implemented via dlopen(3) are available (or explicitly deactivated) by
-    # pointing dlopen to the absolute store path instead of relying on the
-    # linkers runtime lookup code.
-    #
-    # All of the dlopen calls have to be handled. When new ones are introduced
-    # by upstream (or one of our patches) they must be explicitly declared,
-    # otherwise the build will fail.
-    #
-    # As of systemd version 247 we've seen a few errors like `libpcre2.… not
-    # found` when using e.g. --grep with journalctl. Those errors should
-    # become less unexpected now.
-    #
-    # There are generally two classes of dlopen(3) calls. Those that we want to
-    # support and those that should be deactivated / unsupported. This change
-    # enforces that we handle all dlopen calls explicitly. Meaning: There is
-    # not a single dlopen call in the source code tree that we did not
-    # explicitly handle.
-    #
-    # In order to do this we introduced a list of attributes that maps from
-    # shared object name to the package that contains them. The package can be
-    # null meaning the reference should be nuked and the shared object will
-    # never be loadable during runtime (because it points at an invalid store
-    # path location).
-    #
-    # To get a list of dynamically loaded libraries issue something like
-    # `grep -ri 'dlopen("lib' $src` and update the below list.
-    dlopenLibs = [
-      # We did never provide support for libxkbcommon & qrencode
-      { name = "libxkbcommon.so.0"; pkg = null; }
-      { name = "libqrencode.so.4"; pkg = null; }
+        # We did not provide libpwquality before so it is safe to disable it for
+        # now.
+        { name = "libpwquality.so.1"; pkg = null; }
 
-      # We did not provide libpwquality before so it is safe to disable it for
-      # now.
-      { name = "libpwquality.so.1"; pkg = null; }
+        # Only include cryptsetup if it is enabled. We might not be able to
+        # provide it during "bootstrap" in e.g. the minimal systemd build as
+        # cryptsetup has udev (aka systemd) in it's dependencies.
+        { name = "libcryptsetup.so.12"; pkg = if withCryptsetup then cryptsetup else null; }
 
-      # Only include cryptsetup if it is enabled. We might not be able to
-      # provide it during "bootstrap" in e.g. the minimal systemd build as
-      # cryptsetup has udev (aka systemd) in it's dependencies.
-      { name = "libcryptsetup.so.12"; pkg = if withCryptsetup then cryptsetup else null; }
+        # We are using libidn2 so we only provide that and ignore the others.
+        # Systemd does this decision during configure time and uses ifdef's to
+        # enable specific branches. We can safely ignore (nuke) the libidn "v1"
+        # libraries.
+        { name = "libidn2.so.0"; pkg = libidn2; }
+        { name = "libidn.so.12"; pkg = null; }
+        { name = "libidn.so.11"; pkg = null; }
 
-      # We are using libidn2 so we only provide that and ignore the others.
-      # Systemd does this decision during configure time and uses ifdef's to
-      # enable specific branches. We can safely ignore (nuke) the libidn "v1"
-      # libraries.
-      { name = "libidn2.so.0"; pkg = libidn2; }
-      { name = "libidn.so.12"; pkg = null; }
-      { name = "libidn.so.11"; pkg = null; }
+        # journalctl --grep requires libpcre so lets provide it
+        { name = "libpcre2-8.so.0"; pkg = pcre2; }
+      ];
 
-      # journalctl --grep requires libpcre so lets provide it
-      { name = "libpcre2-8.so.0"; pkg = pcre2; }
-    ];
-
-    patchDlOpen = dl: let
-      library = "${lib.makeLibraryPath [dl.pkg]}/${dl.name}";
-    in if dl.pkg == null then ''
-      # remove the dependency on the library by replacing it with an invalid path
-      for file in $(grep -lr 'dlopen("${dl.name}"' src); do
-        echo "patching dlopen(\"${dl.name}\", …) in $file to an invalid store path ("/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-not-implemented/${dl.name}")…"
-        substituteInPlace "$file" --replace 'dlopen("${dl.name}"' 'dlopen("/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-not-implemented/${dl.name}"'
-      done
-    '' else ''
-      # ensure that the library we provide actually exists
-      if ! [ -e ${library} ]; then
-        echo 'The shared library `${library}` does not exist but was given as subtitute for `${dl.name}`'
-        exit 1
-      fi
-      # make the path to the dependency explicit
-      for file in $(grep -lr 'dlopen("${dl.name}"' src); do
-        echo "patching dlopen(\"${dl.name}\", …) in $file to ${library}…"
-        substituteInPlace "$file" --replace 'dlopen("${dl.name}"' 'dlopen("${library}"'
-      done
-    '';
-  in # patch all the dlopen calls to contain absolute paths to the libraries
-  lib.concatMapStringsSep "\n" patchDlOpen dlopenLibs)
+      patchDlOpen = dl:
+        let
+          library = "${lib.makeLibraryPath [ dl.pkg ]}/${dl.name}";
+        in
+        if dl.pkg == null then ''
+          # remove the dependency on the library by replacing it with an invalid path
+          for file in $(grep -lr 'dlopen("${dl.name}"' src); do
+            echo "patching dlopen(\"${dl.name}\", …) in $file to an invalid store path ("/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-not-implemented/${dl.name}")…"
+            substituteInPlace "$file" --replace 'dlopen("${dl.name}"' 'dlopen("/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-not-implemented/${dl.name}"'
+          done
+        '' else ''
+          # ensure that the library we provide actually exists
+          if ! [ -e ${library} ]; then
+            echo 'The shared library `${library}` does not exist but was given as subtitute for `${dl.name}`'
+            exit 1
+          fi
+          # make the path to the dependency explicit
+          for file in $(grep -lr 'dlopen("${dl.name}"' src); do
+            echo "patching dlopen(\"${dl.name}\", …) in $file to ${library}…"
+            substituteInPlace "$file" --replace 'dlopen("${dl.name}"' 'dlopen("${library}"'
+          done
+        '';
+    in
+    # patch all the dlopen calls to contain absolute paths to the libraries
+    lib.concatMapStringsSep "\n" patchDlOpen dlopenLibs
+  )
   # finally ensure that there are no left-over dlopen calls that we didn't handle
   + ''
     if grep -qr 'dlopen("[^/]' src; then


### PR DESCRIPTION
###### Motivation for this change
Sync with latest upstream stable release.

Fixes:
```551dd873b0 test: fix fd_is_mount_point() check
1cb171695a sd-device: make TAGS= property prefixed and suffixed with ":"
0e0a165d72 sd-device: keep escaped strings in DEVLINK= property
ca3b974a55 sd-device: use set_strjoin()
041fe7dfee set: introduce set_strjoin()
fc398137fc tools: make update-dbus-docs compatible with Python 3.6
539e67159c man: fix small issue in AllowedMemoryNodes description
eb6910c8ab man: make it clear how systemd calculate the DefaultTasksMax.
ab9f7e1a51 resolved: use reference counting for DnsQueryCandidate objects
91ba2eac4b resolved: minor cleanups
fd76ba69a1 tools: make update-dbus-docs compatible with Python 3.7
c6d30eb104 network: drop wrong flag for neighbor entry
b3465837dd sysusers: flush nscd's caches whenever /etc/{passwd,group} are modified
b7e0ac754e tree-wide: ignore messages with too long control data
a054fe9c89 systemctl: warn when importing environment variables with control characters
288b980fe5 Allow control characters in environment variable values
57bc92bf08 systemctl: print a warning when trying to import a nonexistent variable
64317106ae resolved: fix use-after-free with queries hitting the cache
c97c62ed3d man: clarify what network scopes are
490b9ae9dd rpm: expose $systemd_util_dir also as rpm macro
c77f5629d7 systemctl-edit: Add missing ret_dropin_paths argument in retry path
71630f1187 systemctl-edit: fix abort in find_paths_to_edit()
e12b4112a8 import: mangle untarred OS images after pull-tar, too
d60de7d137 dhcp6: refuse zero length vendor class
a455e20118 dhcp6: refuse zero length dhcp user class
ead71a1a95 network: refuse zero length dhcp user class
5dbb9342a1 dhcp: length of each user class field must be positive
dc9ab43854 journal: send journald logs to kmsg again
f3997dd056 timedate: actually reset system time with new timezone
fc4eae72f8 wifi-util: do not ignore wifi iftype when SSID is not set
3885103672 wifi-util: cleanup header inclusion
b81e441b61 docs: `mesonconf` is not a valid command, `meson configure` is
95ee2c6b48 bpf: do not use structured initialization for bpf_attr
3dcf950663 test-xattr-util: don't insist that /usr supports xattrs
94bb28590b bpf: zero bpf_attr before initialization
6db2ae6618 shell-completion: fix systemctl set/unset/import-environment
d0a124c0af man: improve description of environment block creation
a2f0da2de0 stat-util: don't try to open path on path_is_temporary_fs()
7c63e5ed58 systemctl: have is-enabled return success for aliases when calling into pid1 too
d0b76f0738 man: fix path reference to unit file
1f39070e40 docs: fix the link to boot loader specification
b7db0461a6 network: fix possible memory leak
310fd03e07 resolve: field size in dns resource record may be zero
9401ed294d siphash: introduce siphash24_compress_safe()
5cb414f8c5 fuzzers: set maximum length for several fuzzers
efa8f49344 shared/dns: fix dlopen_idn return code check
4032a13588 man/systemd-nspawn: document hashing machine name for uid base
5dd2b56443 udev: fix memleak
cefb123e8a journal-importer: ignore invalid field at one more place
a580023f1d man/localtime: document default timezone
14475e0e79 man/systemd.netdev: clarify the wireguard AllowedIPs= setting
2a76d510d9 logs-show: refuse data which contain invalid fields
2c53886b4f journal: refuse data which contain invalid fields
b7f69284f1 journal: move journal_field_valid() to journal_file.c
b7171ae4bd test: use modern qemu numa arguments
36bc4a18fd bus-util: improve logging when we can't connect to the bus
a1b1ef65a4 sd-bus: make credential acquisition more graceful
a62421591e sd-bus: 'ret' parameter to sd_bus_query_sender_creds() is not optional, check for it
242fc1d261 network: fix IPv6PrivacyExtensions=kernel handling
2ba904a2e5 network: fix typo
a22eef68c0 dissect: fix root hash signature autodiscovery
6fa5ec5a41 cryptsetup: add support for workqueue options
4275f1c95e test-login: skip consistency checks when logind is not active
```

Also, `nixpkgs-fmt` the changes introduced in 494ed4d6ee6f3d3b25a0b5d45f3f9e8dd1c45ccf.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
