### PR TITLE
agate: init at 2.3.0

### DIFF
--- a/pkgs/servers/gemini/agate/default.nix
+++ b/pkgs/servers/gemini/agate/default.nix
@@ -14,8 +14,8 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-ey/fUHkPoWjWlLjh1WNpwMKOkdQKgFYcLwQdx2RQ3CI=";
 
   meta = with lib; {
-    homepage = "gemini://gem.limpet.net/agate";
-    changelog = "gemini://gem.limpet.net/agate";
+    homepage = "https://proxy.vulpes.one/gemini/gem.limpet.net/agate";
+    changelog = "https://proxy.vulpes.one/gemini/gem.limpet.net/agate";
     description = "Very simple server for the Gemini hypertext protocol";
     longDescription = ''
       Agate is a server for the Gemini network protocol, built with the Rust

--- a/pkgs/servers/gemini/agate/default.nix
+++ b/pkgs/servers/gemini/agate/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchFromGitHub, rustPlatform, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "agate";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "mbrubeck";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-rwoEZnxh0x+xaggJuoeSjE1ctF43ChW5awcDJyoWioA=";
+  };
+
+  cargoSha256 = "sha256-ey/fUHkPoWjWlLjh1WNpwMKOkdQKgFYcLwQdx2RQ3CI=";
+
+  meta = with lib; {
+    homepage = "gemini://gem.limpet.net/agate";
+    changelog = "gemini://gem.limpet.net/agate";
+    description = "Very simple server for the Gemini hypertext protocol";
+    longDescription = ''
+      Agate is a server for the Gemini network protocol, built with the Rust
+      programming language. Agate has very few features, and can only serve
+      static files. It uses async I/O, and should be quite efficient even when
+      running on low-end hardware and serving many concurrent requests.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -701,6 +701,8 @@ in
 
   afpfs-ng = callPackage ../tools/filesystems/afpfs-ng { };
 
+  agate = callPackage ../servers/gemini/agate { };
+
   agda-pkg = callPackage ../development/tools/agda-pkg { };
 
   agrep = callPackage ../tools/text/agrep { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add agate

Homepage uses gemini, there is a package where the homepage is a gopher link (https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/networking/gopher/sacc/default.nix#L26)
Changelog is also on the gemini page

![agate](https://user-images.githubusercontent.com/9866621/106793552-841ee980-664f-11eb-9cc1-e0f7a6843474.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
