### PR TITLE
patroni: disable

### DIFF
--- a/pkgs/servers/sql/patroni/default.nix
+++ b/pkgs/servers/sql/patroni/default.nix
@@ -53,5 +53,6 @@ pythonPackages.buildPythonApplication rec {
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = teams.deshaw.members;
+    broken = true; # tests time out
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This package has been failing for many months now
```
$ hydra-check patroni
Build Status for nixpkgs.patroni.x86_64-linux on unstable
✖ (Timed out) patroni-1.6.5 from 2021-02-02 - https://hydra.nixos.org/build/136240715

Last Builds:
✖ (Timed out) patroni-1.6.5 from 2021-01-30 - https://hydra.nixos.org/build/135912396
✖ (Timed out) patroni-1.6.5 from 2021-01-24 - https://hydra.nixos.org/build/135615903
✖ (Cancelled) patroni-1.6.5 from 2021-01-22 - https://hydra.nixos.org/build/135435184
✖ (Timed out) patroni-1.6.5 from 2021-01-18 - https://hydra.nixos.org/build/135223171
✖ (Timed out) patroni-1.6.5 from 2021-01-15 - https://hydra.nixos.org/build/135086945
✖ (Timed out) patroni-1.6.5 from 2021-01-14 - https://hydra.nixos.org/build/135080123
✖ (Timed out) patroni-1.6.5 from 2021-01-13 - https://hydra.nixos.org/build/135020305
✖ (Timed out) patroni-1.6.5 from 2021-01-11 - https://hydra.nixos.org/build/134727321
✖ (Timed out) patroni-1.6.5 from 2021-01-09 - https://hydra.nixos.org/build/134702211
```

cc @limeytexan 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
