### PR TITLE
ocamlPackages.ssl: 0.5.9 -> 0.5.10

### DIFF
--- a/pkgs/development/ocaml-modules/lwt_ssl/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_ssl/default.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   version = "1.1.3";
 
   minimumOCamlVersion = "4.02";
+  useDune2 = true;
 
   src = fetchzip {
     url = "https://github.com/aantron/${pname}/archive/${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/ssl/default.nix
+++ b/pkgs/development/ocaml-modules/ssl/default.nix
@@ -1,17 +1,20 @@
-{ lib, buildDunePackage, fetchFromGitHub, pkg-config, openssl }:
+{ lib, buildDunePackage, fetchFromGitHub, pkg-config, openssl
+, dune-configurator }:
 
 buildDunePackage rec {
   pname = "ssl";
-  version = "0.5.9";
+  version = "0.5.10";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-ssl";
-    rev = version;
-    sha256 = "04h02rvzrwp886n5hsx84rnc9b150iggy38g5v1x1rwz3pkdnmf0";
+    rev = "v${version}";
+    sha256 = "1rszqiqayh67xlwd5411k8vib47x9kapdr037z1majd2c14z3kcb";
   };
 
+  useDune2 = true;
   nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [openssl];
 
   meta = {
@@ -20,6 +23,7 @@ buildDunePackage rec {
     license = "LGPL+link exception";
     maintainers = [
       lib.maintainers.maggesi
+      lib.maintainers.anmonteiro
     ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/savonet/ocaml-ssl/releases/tag/v0.5.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
