### PR TITLE
[20.09] libqb: 0.17.2 -> 2.0.2

### DIFF
--- a/pkgs/development/libraries/libqb/default.nix
+++ b/pkgs/development/libraries/libqb/default.nix
@@ -1,19 +1,24 @@
-{ stdenv, fetchurl, pkgconfig }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libxml2 }:
 
 stdenv.mkDerivation rec {
-  name = "libqb-0.17.2";
+  pname = "libqb";
+  version = "2.0.2";
 
-  src = fetchurl {
-    url = "https://fedorahosted.org/releases/q/u/quarterback/${name}.tar.xz";
-    sha256 = "1zpl45p3n6dn1jgbsrrmccrmv2mvp8aqmnl0qxfjf7ymkrj9qhcs";
+  src = fetchFromGitHub {
+    owner = "ClusterLabs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1gpfcz84igqncky09hdibxmzapzl37y8914avgq89rsizynj1wsm";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  buildInputs = [ libxml2 ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/clusterlabs/libqb";
     description = "A library providing high performance logging, tracing, ipc, and poll";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2019-12779.

(cherry picked from commit 68889745cb52f4854adb87140489191f14848b7a)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
