### PR TITLE
osmium-tool: add meta.changelog

### DIFF
--- a/pkgs/applications/misc/osmium-tool/default.nix
+++ b/pkgs/applications/misc/osmium-tool/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Multipurpose command line tool for working with OpenStreetMap data based on the Osmium library";
     homepage = "https://osmcode.org/osmium-tool/";
+    changelog = "https://github.com/osmcode/osmium-tool/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ gpl3Plus mit bsd3 ];
     maintainers = with maintainers; [ das-g ];
   };


### PR DESCRIPTION
###### Motivation for this change

At https://github.com/NixOS/nixpkgs/pull/111799#issue-567100629 r-ryantm wrote
> meta.changelog for osmium-tool is: ""

so I looked up [7.1. Standard meta-attributes](https://nixos.org/manual/nixpkgs/stable/#sec-standard-meta-attributes) in the Nixpkgs manual.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
