### PR TITLE
ryujinx: 1.0.6448 -> 1.0.6498

### DIFF
--- a/pkgs/misc/emulators/ryujinx/default.nix
+++ b/pkgs/misc/emulators/ryujinx/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, makeWrapper, makeDesktopItem, linkFarmFromDrvs
-, dotnet-sdk_5, dotnetPackages, dotnetCorePackages
+, dotnet-sdk_5, dotnetPackages, dotnetCorePackages, cacert
 , SDL2, libX11, ffmpeg, openal, libsoundio
 , gtk3, gobject-introspection, gdk-pixbuf, wrapGAppsHook
 }:
@@ -15,16 +15,16 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "ryujinx";
-  version = "1.0.6448"; # Versioning is based off of the official appveyor builds: https://ci.appveyor.com/project/gdkchan/ryujinx
+  version = "1.0.6498"; # Versioning is based off of the official appveyor builds: https://ci.appveyor.com/project/gdkchan/ryujinx
 
   src = fetchFromGitHub {
     owner = "Ryujinx";
     repo = "Ryujinx";
-    rev = "9eb0ab05c6e820e113b3c61cbacd9b085b2819c4";
-    sha256 = "168nm7p6lqswmsya6gf3296ligyjabqmbrdzginkcviii643yslz";
+    rev = "67033ed8e05eb70860ac6af2b83deab0256c11eb";
+    sha256 = "1lg0cybbrf0x3jl10jwdwcg1zyhxsqfdnwnsvdm1lah75xg15ymw";
   };
 
-  nativeBuildInputs = [ dotnet-sdk_5 dotnetPackages.Nuget makeWrapper wrapGAppsHook gobject-introspection gdk-pixbuf ];
+  nativeBuildInputs = [ dotnet-sdk_5 dotnetPackages.Nuget cacert makeWrapper wrapGAppsHook gobject-introspection gdk-pixbuf ];
 
   nugetDeps = linkFarmFromDrvs "${pname}-nuget-deps" (import ./deps.nix {
     fetchNuGet = { name, version, sha256 }: fetchurl {

--- a/pkgs/misc/emulators/ryujinx/fetch-deps.sh
+++ b/pkgs/misc/emulators/ryujinx/fetch-deps.sh
@@ -36,6 +36,3 @@ while read pkg_spec; do
 EOF
 done < <(find ./nuget_tmp.packages -name '*.nuspec' | sort)
 echo "]" >>"$deps_file"
-
-popd
-rm -r "$src"


### PR DESCRIPTION

###### Motivation for this change
Fixes a bunch of compilation warnings introduced with the switch to net5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
