### PR TITLE
python3Packages.solax: init at 0.2.5

### DIFF
--- a/pkgs/development/python-modules/pytest-httpserver/default.nix
+++ b/pkgs/development/python-modules/pytest-httpserver/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, pytest-asyncio
+, pytest-cov
+, pytestCheckHook
+, requests
+, werkzeug
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-httpserver";
+  version = "0.3.6";
+
+  src = fetchPypi {
+    pname = "pytest_httpserver";
+    inherit version;
+    sha256 = "1wdhbzv6x2v4qsqwgsc5660c4lxplh9b61vfj1zqhbhs36y96vl9";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "remove-pytest-runner.patch";
+      url = "https://github.com/csernazs/pytest-httpserver/commit/c9752018bc2f13d141dd52c92df75c19ea388836.patch";
+      sha256 = "0b76ywzl2gwddbqqlb662mfv5j42l88l5hffm7jbxzvqbz94mx3k";
+    })
+  ];
+
+  propagatedBuildInputs = [ werkzeug ];
+
+  checkInputs = [
+    pytest-cov
+    pytestCheckHook
+    requests
+  ];
+
+  pythonImportsCheck = [ "pytest_httpserver" ];
+
+  meta = with lib; {
+    description = "HTTP server for pytest to test HTTP clients";
+    homepage = "https://www.github.com/csernazs/pytest-httpserver";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/solax/default.nix
+++ b/pkgs/development/python-modules/solax/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchPypi
+, pytest-asyncio
+, pytest-cov
+, pytest-httpserver
+, pytestCheckHook
+, setuptools-scm
+, voluptuous
+}:
+
+buildPythonPackage rec {
+  pname = "solax";
+  version = "0.2.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0h7q6y2cdkj9dqxw0k7pgz7a7vbpq1qw50pmy9rajphhv2600cbc";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [ aiohttp voluptuous ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-cov
+    pytest-httpserver
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "solax" ];
+
+  meta = with lib; {
+    description = "Python wrapper for the Solax Inverter API";
+    homepage = "https://github.com/squishykid/solax";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -758,7 +758,7 @@
     "solaredge" = ps: with ps; [ stringcase ]; # missing inputs: solaredge
     "solaredge_local" = ps: with ps; [ ]; # missing inputs: solaredge-local
     "solarlog" = ps: with ps; [ ]; # missing inputs: sunwatcher
-    "solax" = ps: with ps; [ ]; # missing inputs: solax
+    "solax" = ps: with ps; [ solax ];
     "soma" = ps: with ps; [ pysoma ];
     "somfy" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pymfy
     "somfy_mylink" = ps: with ps; [ ]; # missing inputs: somfy-mylink-synergy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6095,6 +6095,8 @@ in {
 
   pytest-httpbin = callPackage ../development/python-modules/pytest-httpbin { };
 
+  pytest-httpserver = callPackage ../development/python-modules/pytest-httpserver { };
+
   pytest-instafail = callPackage ../development/python-modules/pytest-instafail { };
 
   pytest-isort = callPackage ../development/python-modules/pytest-isort { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7264,6 +7264,8 @@ in {
 
   softlayer = callPackage ../development/python-modules/softlayer { };
 
+  solax = callPackage ../development/python-modules/solax { };
+
   solo-python = disabledIf (!pythonAtLeast "3.6") (callPackage ../development/python-modules/solo-python { });
 
   somajo = callPackage ../development/python-modules/somajo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python wrapper for the Solax Inverter API.

https://github.com/squishykid/solax

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
