### PR TITLE
goimapnotify: patch sh with /bin/sh

### DIFF
--- a/pkgs/tools/networking/goimapnotify/default.nix
+++ b/pkgs/tools/networking/goimapnotify/default.nix
@@ -1,4 +1,4 @@
-{ buildGoPackage, fetchFromGitLab, lib }:
+{ buildGoPackage, fetchFromGitLab, lib, runtimeShell }:
 
 buildGoPackage rec {
   pname = "goimapnotify";
@@ -12,6 +12,10 @@ buildGoPackage rec {
     rev = version;
     sha256 = "1d42gd3m2rkvy985d181dbcm5i3f7xsg2z8z6s4bpvw24pfnzs42";
   };
+
+  postPatch = ''
+    substituteInPlace command.go --replace '"sh"' '"${runtimeShell}"'
+  '';
 
   goDeps = ./deps.nix;
 


### PR DESCRIPTION
sh is not on PATH in some environments (see #111688).

###### Motivation for this change

`goimapnotify` was failing to start, reporting `"sh": executable file not found in $PATH` (#111688).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
