### PR TITLE
python3.pkgs.osmpythontools: 0.2.8 -> 0.2.9

### DIFF
--- a/pkgs/development/python-modules/osmpythontools/default.nix
+++ b/pkgs/development/python-modules/osmpythontools/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , beautifulsoup4
 , geojson
 , lxml
@@ -15,10 +15,11 @@ buildPythonPackage rec {
   pname = "osmpythontools";
   version = "0.2.8";
 
-  src = fetchPypi {
-    pname = "OSMPythonTools";
-    inherit version;
-    sha256 = "8a33adbd266127e342d12da755075fae08f398032a6f0909b5e86bef13960a85";
+  src = fetchFromGitHub {
+    owner = "mocnik-science";
+    repo = "osm-python-tools";
+    rev = "v${version}";
+    sha256 = "1hkc18zcw1fqx8zk3z18xpas87vkcpgsch5cavqda4aihl51vmy2";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/osmpythontools/default.nix
+++ b/pkgs/development/python-modules/osmpythontools/default.nix
@@ -13,14 +13,16 @@
 
 buildPythonPackage rec {
   pname = "osmpythontools";
-  version = "0.2.8";
+  version = "0.2.9";
 
   src = fetchFromGitHub {
     owner = "mocnik-science";
     repo = "osm-python-tools";
     rev = "v${version}";
-    sha256 = "1hkc18zcw1fqx8zk3z18xpas87vkcpgsch5cavqda4aihl51vmy2";
+    sha256 = "1qpj03fgn8rmrg9a9vk7bw32k9hdy15g5p2q3a6q52ykpb78jdz5";
   };
+
+  patches = [ ./remove-test-only-dependencies.patch ];
 
   propagatedBuildInputs = [
     beautifulsoup4
@@ -33,7 +35,7 @@ buildPythonPackage rec {
     xarray
   ];
 
-  # no tests included
+  # tests touch network
   doCheck = false;
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/osmpythontools/remove-test-only-dependencies.patch
+++ b/pkgs/development/python-modules/osmpythontools/remove-test-only-dependencies.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 801d081..6d93128 100644
+--- a/setup.py
++++ b/setup.py
+@@ -19,8 +19,6 @@ setup(
+         'matplotlib',
+         'numpy',
+         'pandas',
+-        'pytest',
+-        'pytest-sugar',
+         'ujson',
+         'xarray',
+     ],


### PR DESCRIPTION
###### Motivation for this change

- upstream release 0.2.9 ([GitHub](https://github.com/mocnik-science/osm-python-tools/releases/tag/v0.2.9), [PyPI](https://pypi.org/project/OSMPythonTools/0.2.9/))
- GitHub repo now has tags for releases (as requested at mocnik-science/osm-python-tools#25)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix run nixpkgs.nixpkgs-review
-c nixpkgs-review pr 111847 --post-result`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (there are no executable files, as this is a library)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
