### PR TITLE
sile: 0.10.13 -> 0.10.14

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -30,6 +30,7 @@ let
     luarepl
     luasec
     luasocket
+    luautf8
     penlight
     stdlib
     vstruct
@@ -38,11 +39,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.10.13";
+  version = "0.10.14";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "19k4r7wfszml4dac8cm1hx9rb1im3psigcidz8bdm9j9jzpd01yj";
+    sha256 = "100f6iangpiwlv8k55d134w856r0xwsgw90s1rkkmqa5syziwni5";
   };
 
   configureFlags = [


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/sile-typesetter/sile/releases/tag/v0.10.14


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
