### PR TITLE
clojure-lsp: migrate to GraalVM

### DIFF
--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -1,66 +1,59 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, graalvm11-ce, babashka }:
+{ lib, stdenv, callPackage, fetchFromGitHub, leiningen, openjdk11
+, graalvm11-ce, babashka }:
 
-stdenv.mkDerivation rec {
+let
   pname = "clojure-lsp";
   version = "2021.02.14-19.46.47";
+  leiningen11 = leiningen.override ({ jdk = openjdk11; });
 
-  src = fetchurl {
-    url = "https://github.com/clojure-lsp/clojure-lsp/releases/download/${version}/${pname}.jar";
-    sha256 = "sha256-fLwubRwWa1fu37bdkaCr2uZK79z37wqPLToOb5BlegY=";
-  };
-
-  # For tests
-  ghSrc = fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "1ydf8bgwvjp77wyhjqwzn7crpn5hxmq701czlkhpm5ablnxcwhn7";
+    sha256 = "sha256-Zj7/8RcuxCy2xdd+5jeOb1GTsQsX0EVW32k32fA6uf4=";
   };
 
-  dontUnpack = true;
+  repository = callPackage ./repository.nix {
+    inherit src pname version;
+    leiningen = leiningen11;
+  };
+in stdenv.mkDerivation rec {
+  inherit src pname version;
 
-  buildInputs = [ graalvm11-ce ];
+  postPatch = ''
+    # Hack to set maven cache in another directory since MAVEN_OPTS doesn't work
+    substituteInPlace project.clj \
+      --replace ":main" ":local-repo \"${repository}\" :main"
+  '';
+
+  GRAALVM_HOME = graalvm11-ce;
+
+  buildInputs = [ graalvm11-ce leiningen11 repository ];
 
   buildPhase = with lib; ''
-    args=("-jar" "${src}"
-          "-H:Name=clojure-lsp"
-          ${optionalString stdenv.isDarwin ''"-H:-CheckToolchain"''}
-          "-J-Dclojure.compiler.direct-linking=true"
-          "-J-Dclojure.spec.skip-macros=true"
-          "-H:+ReportExceptionStackTraces"
-          "--enable-url-protocols=jar"
-          # TODO: Enable in GraalVM 21.0.0
-          # "-H:+InlineBeforeAnalysis"
-          "-H:Log=registerResource:"
-          "--verbose"
-          "-H:IncludeResources=\"CLOJURE_LSP_VERSION|db/.*|static/.*|templates/.*|.*.yml|.*.xml|.*/org/sqlite/.*|org/sqlite/.*|.*.properties\""
-          "-H:ConfigurationFileDirectories=graalvm"
-          "--initialize-at-build-time"
-          "--report-unsupported-elements-at-runtime"
-          "--no-server"
-          "--no-fallback"
-          "--native-image-info"
-          "--allow-incomplete-classpath"
-          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.sampled.spi.AudioFileReader"
-          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.midi.spi.MidiFileReader"
-          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.sampled.spi.MixerProvider"
-          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.sampled.spi.FormatConversionProvider"
-          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.sampled.spi.AudioFileWriter"
-          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.midi.spi.MidiDeviceProvider"
-          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.midi.spi.SoundbankReader"
-          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.midi.spi.MidiFileWriter"
-          "-J-Xmx4g")
+    runHook preBuild
 
-    native-image "''${args[@]}"
+    export LEIN_HOME="$(mktemp -d)"
+    bash ./graalvm/native-unix-compile.sh
+
+    runHook postBuild
   '';
 
   installPhase = ''
-    install -Dm755 clojure-lsp $out/bin/clojure-lsp
+    runHook preInstall
+
+    install -Dm755 ./clojure-lsp $out/bin/clojure-lsp
+
+    runHook postInstall
   '';
 
   doCheck = true;
   checkPhase = ''
-    ${babashka}/bin/bb ${ghSrc}/integration-test/run-all.clj ./clojure-lsp
+    runHook preCheck
+
+    ${babashka}/bin/bb ./integration-test/run-all.clj ./clojure-lsp
+
+    runHook postCheck
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/clojure-lsp/repository.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/repository.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, src, pname, version, leiningen }:
+
+stdenv.mkDerivation {
+  inherit src;
+
+  name = "${pname}-${version}-repository";
+  buildInputs = [ leiningen ];
+
+  postPatch = ''
+    # Hack to set maven cache in another directory since MAVEN_OPTS doesn't work
+    substituteInPlace project.clj \
+      --replace ":main" ":local-repo \"$out\" :main"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export LEIN_HOME="$(mktemp -d)"
+    lein with-profiles +native-image deps
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    find $out -type f \
+      -name \*.lastUpdated -or \
+      -name resolver-status.properties -or \
+      -name _remote.repositories \
+      -delete
+
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "sha256-aWZPsJF32ENyYNZCHf5amxVF9pb+5M73JqG/OITZlak=";
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

clojure-lsp now supports GraalVM builds that makes the binary faster to start and also seems to reduce memory usage.

Also bump version, to ensure we are using the latest fixes for GraalVM builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
