### PR TITLE
python3Packages.shapely: fix build with geos 3.9.0

### DIFF
--- a/pkgs/development/python-modules/shapely/default.nix
+++ b/pkgs/development/python-modules/shapely/default.nix
@@ -1,17 +1,25 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, substituteAll, pythonOlder
-, geos, pytest, cython
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, substituteAll
+, pythonOlder
+, geos
+, pytest
+, cython
 , numpy
+, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "Shapely";
   version = "1.7.1";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "0adiz4jwmwxk7k1awqifb1a9bj5x4nx4gglb5dz9liam21674h8n";
   };
-  disabled = pythonOlder "3.5";
 
   nativeBuildInputs = [
     geos # for geos-config
@@ -26,6 +34,18 @@ buildPythonPackage rec {
   GEOS_LIBRARY_PATH = "${geos}/lib/libgeos_c${stdenv.hostPlatform.extensions.sharedLibrary}";
 
   patches = [
+    # Fix with geos 3.9. This patch will be part of the next release after 1.7.1
+    (fetchpatch {
+      url = "https://github.com/Toblerity/Shapely/commit/77879a954d24d1596f986d16ba3eff5e13861164.patch";
+      sha256 = "1w7ngjqbpf9vnvrfg4nyv34kckim9a60gvx20h6skc79xwihd4m5";
+      excludes = [
+        "tests/test_create_inconsistent_dimensionality.py"
+        "appveyor.yml"
+        ".travis.yml"
+      ];
+    })
+
+    # Patch to search form GOES .so/.dylib files in a Nix-aware way
     (substituteAll {
       src = ./library-paths.patch;
       libgeos_c = GEOS_LIBRARY_PATH;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
While testing #111671, I noticed that python3Packages.shapely was failing on staging. This pulls in an upstream patch to add compatibility with geos 3.9.0, which is on staging right now, but not yet on master.

I'm not sure if this PR should be targeted at staging or master though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
