### PR TITLE
libreoffice-fresh: 7.0.4.2 -> 7.1.0.3 & libreoffice-still: 6.3.5.2 -> 7.0.4.2

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -58,17 +58,12 @@ in (mkDrv rec {
 
   outputs = [ "out" "dev" ];
 
-  # For some reason librdf_redland sometimes refers to rasqal.h instead
-  # of rasqal/rasqal.h
   NIX_CFLAGS_COMPILE = [
-    "-I${librdf_rasqal}/include/rasqal"
-  ] ++ lib.optionals stdenv.isx86_64 [ "-mno-fma" "-mno-avx" ]
-  # https://bugs.documentfoundation.org/show_bug.cgi?id=78174#c10
-  ++ [ "-fno-visibility-inlines-hidden" ];
-
-  patches = [
-    ./xdg-open-brief.patch
+    "-I${librdf_rasqal}/include/rasqal" # librdf_redland refers to rasqal.h instead of rasqal/rasqal.h
+    "-fno-visibility-inlines-hidden" # https://bugs.documentfoundation.org/show_bug.cgi?id=78174#c10
   ];
+
+  patches = [ ./xdg-open-brief.patch ];
 
   tarballPath = "external/tarballs";
 
@@ -378,7 +373,7 @@ in (mkDrv rec {
     "--enable-kf5"
     "--enable-qt5"
     "--enable-gtk3-kde5"
-  ] ++ lib.optional (lib.versionOlder version "6.4") "--disable-gtk"; # disables GTK2, GTK3 is still there
+  ];
 
   checkPhase = ''
     make unitcheck

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, lib, pam, python3, libxslt, perl, ArchiveZip, gettext
+{ stdenv, fetchurl, fetchpatch, lib, pam, python3, libxslt, perl, ArchiveZip, box2d, gettext
 , IOCompress, zlib, libjpeg, expat, freetype, libwpd
 , libxml2, db, curl, fontconfig, libsndfile, neon
 , bison, flex, zip, unzip, gtk3, libmspack, getopt, file, cairo, which
@@ -391,7 +391,7 @@ in (mkDrv rec {
     ++ lib.optional kdeIntegration wrapQtAppsHook;
 
   buildInputs = with xorg;
-    [ ant ArchiveZip boost cairo clucene_core
+    [ ant ArchiveZip boost box2d cairo clucene_core
       IOCompress cppunit cups curl db dbus-glib expat file flex fontconfig
       freetype getopt gperf gtk3
       hunspell icu jdk lcms libcdr libexttextcat unixODBC libjpeg

--- a/pkgs/applications/office/libreoffice/src-fresh/download.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/download.nix
@@ -35,6 +35,13 @@
     md5name = "35e06a3bd7cd8f66be822c7d64e80c2b6051a181e9e897006917cb8e7988a543-boost_1_71_0.tar.xz";
   }
   {
+    name = "box2d-2.3.1.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/box2d-2.3.1.tar.gz";
+    sha256 = "58ffc8475a8650aadc351345aef696937747b40501ab78d72c197c5ff5b3035c";
+    md5 = "";
+    md5name = "58ffc8475a8650aadc351345aef696937747b40501ab78d72c197c5ff5b3035c-box2d-2.3.1.tar.gz";
+  }
+  {
     name = "breakpad.zip";
     url = "https://dev-www.libreoffice.org/src/breakpad.zip";
     sha256 = "7060149be16a8789b0ccf596bdeaf63115f03f520acb508f72a14686fb311cb9";
@@ -329,11 +336,11 @@
     md5name = "c5e167c042afd2d7ad642ace6b643863baeb33880781983563e1ab68a30d3e95-glm-0.9.9.7.zip";
   }
   {
-    name = "gpgme-1.9.0.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/gpgme-1.9.0.tar.bz2";
-    sha256 = "1b29fedb8bfad775e70eafac5b0590621683b2d9869db994568e6401f4034ceb";
+    name = "gpgme-1.13.1.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/gpgme-1.13.1.tar.bz2";
+    sha256 = "c4e30b227682374c23cddc7fdb9324a99694d907e79242a25a4deeedb393be46";
     md5 = "";
-    md5name = "1b29fedb8bfad775e70eafac5b0590621683b2d9869db994568e6401f4034ceb-gpgme-1.9.0.tar.bz2";
+    md5name = "c4e30b227682374c23cddc7fdb9324a99694d907e79242a25a4deeedb393be46-gpgme-1.13.1.tar.bz2";
   }
   {
     name = "graphite2-minimal-1.3.14.tgz";
@@ -371,18 +378,18 @@
     md5name = "5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
   }
   {
-    name = "icu4c-67_1-src.tgz";
-    url = "https://dev-www.libreoffice.org/src/icu4c-67_1-src.tgz";
-    sha256 = "94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc";
+    name = "icu4c-68_1-src.tgz";
+    url = "https://dev-www.libreoffice.org/src/icu4c-68_1-src.tgz";
+    sha256 = "a9f2e3d8b4434b8e53878b4308bd1e6ee51c9c7042e2b1a376abefb6fbb29f2d";
     md5 = "";
-    md5name = "94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc-icu4c-67_1-src.tgz";
+    md5name = "a9f2e3d8b4434b8e53878b4308bd1e6ee51c9c7042e2b1a376abefb6fbb29f2d-icu4c-68_1-src.tgz";
   }
   {
-    name = "icu4c-67_1-data.zip";
-    url = "https://dev-www.libreoffice.org/src/icu4c-67_1-data.zip";
-    sha256 = "7c16a59cc8c06128b7ecc1dc4fc056b36b17349312829b17408b9e67b05c4a7e";
+    name = "icu4c-68_1-data.zip";
+    url = "https://dev-www.libreoffice.org/src/icu4c-68_1-data.zip";
+    sha256 = "03ea8b4694155620548c8c0ba20444f1e7db246cc79e3b9c4fc7a960b160d510";
     md5 = "";
-    md5name = "7c16a59cc8c06128b7ecc1dc4fc056b36b17349312829b17408b9e67b05c4a7e-icu4c-67_1-data.zip";
+    md5name = "03ea8b4694155620548c8c0ba20444f1e7db246cc79e3b9c4fc7a960b160d510-icu4c-68_1-data.zip";
   }
   {
     name = "flow-engine-0.9.4.zip";
@@ -483,18 +490,18 @@
     md5name = "b63e6340a02ff1cacfeadb2c42286161-JLanguageTool-1.7.0.tar.bz2";
   }
   {
-    name = "lcms2-2.9.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/lcms2-2.9.tar.gz";
-    sha256 = "48c6fdf98396fa245ed86e622028caf49b96fa22f3e5734f853f806fbc8e7d20";
+    name = "lcms2-2.11.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/lcms2-2.11.tar.gz";
+    sha256 = "dc49b9c8e4d7cdff376040571a722902b682a795bf92985a85b48854c270772e";
     md5 = "";
-    md5name = "48c6fdf98396fa245ed86e622028caf49b96fa22f3e5734f853f806fbc8e7d20-lcms2-2.9.tar.gz";
+    md5name = "dc49b9c8e4d7cdff376040571a722902b682a795bf92985a85b48854c270772e-lcms2-2.11.tar.gz";
   }
   {
-    name = "libassuan-2.5.1.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/libassuan-2.5.1.tar.bz2";
-    sha256 = "47f96c37b4f2aac289f0bc1bacfa8bd8b4b209a488d3d15e2229cb6cc9b26449";
+    name = "libassuan-2.5.3.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/libassuan-2.5.3.tar.bz2";
+    sha256 = "91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702";
     md5 = "";
-    md5name = "47f96c37b4f2aac289f0bc1bacfa8bd8b4b209a488d3d15e2229cb6cc9b26449-libassuan-2.5.1.tar.bz2";
+    md5name = "91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702-libassuan-2.5.3.tar.bz2";
   }
   {
     name = "libatomic_ops-7.6.8.tar.gz";
@@ -525,11 +532,11 @@
     md5name = "72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056-libffi-3.3.tar.gz";
   }
   {
-    name = "libgpg-error-1.27.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/libgpg-error-1.27.tar.bz2";
-    sha256 = "4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2";
+    name = "libgpg-error-1.37.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/libgpg-error-1.37.tar.bz2";
+    sha256 = "b32d6ff72a73cf79797f7f2d039e95e9c6f92f0c1450215410840ab62aea9763";
     md5 = "";
-    md5name = "4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2-libgpg-error-1.27.tar.bz2";
+    md5name = "b32d6ff72a73cf79797f7f2d039e95e9c6f92f0c1450215410840ab62aea9763-libgpg-error-1.37.tar.bz2";
   }
   {
     name = "liblangtag-0.6.2.tar.bz2";
@@ -595,11 +602,11 @@
     md5name = "431434d3926f4bcce2e5c97240609983f60d7ff50df5a72083934759bb863f7b-mariadb-connector-c-3.1.8-src.tar.gz";
   }
   {
-    name = "mdds-1.6.0.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/mdds-1.6.0.tar.bz2";
-    sha256 = "f1585c9cbd12f83a6d43d395ac1ab6a9d9d5d77f062c7b5f704e24ed72dae07d";
+    name = "mdds-1.7.0.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/mdds-1.7.0.tar.bz2";
+    sha256 = "a66a2a8293a3abc6cd9baff7c236156e2666935cbfb69a15d64d38141638fecf";
     md5 = "";
-    md5name = "f1585c9cbd12f83a6d43d395ac1ab6a9d9d5d77f062c7b5f704e24ed72dae07d-mdds-1.6.0.tar.bz2";
+    md5name = "a66a2a8293a3abc6cd9baff7c236156e2666935cbfb69a15d64d38141638fecf-mdds-1.7.0.tar.bz2";
   }
   {
     name = "mDNSResponder-878.200.35.tar.gz";
@@ -616,11 +623,11 @@
     md5name = "ef36c1a1aabb2ba3b0bedaaafe717bf4480be2ba8de6f3894be5fd3702b013ba-libmspub-0.1.4.tar.xz";
   }
   {
-    name = "libmwaw-0.3.16.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libmwaw-0.3.16.tar.xz";
-    sha256 = "0c639edba5297bde5575193bf5b5f2f469956beaff5c0206d91ce9df6bde1868";
+    name = "libmwaw-0.3.17.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libmwaw-0.3.17.tar.xz";
+    sha256 = "8e1537eb1de1b4714f4bf0a20478f342c5d71a65bf99307a694b1e9e30bb911c";
     md5 = "";
-    md5name = "0c639edba5297bde5575193bf5b5f2f469956beaff5c0206d91ce9df6bde1868-libmwaw-0.3.16.tar.xz";
+    md5name = "8e1537eb1de1b4714f4bf0a20478f342c5d71a65bf99307a694b1e9e30bb911c-libmwaw-0.3.17.tar.xz";
   }
   {
     name = "mythes-1.2.4.tar.gz";
@@ -630,11 +637,11 @@
     md5name = "a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
   }
   {
-    name = "neon-0.30.2.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/neon-0.30.2.tar.gz";
-    sha256 = "db0bd8cdec329b48f53a6f00199c92d5ba40b0f015b153718d1b15d3d967fbca";
+    name = "neon-0.31.1.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/neon-0.31.1.tar.gz";
+    sha256 = "c9dfcee723050df37ce18ba449d7707b78e7ab8230f3a4c59d9112e17dc2718d";
     md5 = "";
-    md5name = "db0bd8cdec329b48f53a6f00199c92d5ba40b0f015b153718d1b15d3d967fbca-neon-0.30.2.tar.gz";
+    md5name = "c9dfcee723050df37ce18ba449d7707b78e7ab8230f3a4c59d9112e17dc2718d-neon-0.31.1.tar.gz";
   }
   {
     name = "nss-3.55-with-nspr-4.27.tar.gz";
@@ -672,18 +679,18 @@
     md5name = "cdd6cffdebcd95161a73305ec13fc7a78e9707b46ca9f84fb897cd5626df3824-openldap-2.4.45.tgz";
   }
   {
-    name = "openssl-1.0.2t.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/openssl-1.0.2t.tar.gz";
-    sha256 = "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc";
+    name = "openssl-1.1.1i.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/openssl-1.1.1i.tar.gz";
+    sha256 = "e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242";
     md5 = "";
-    md5name = "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc-openssl-1.0.2t.tar.gz";
+    md5name = "e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242-openssl-1.1.1i.tar.gz";
   }
   {
-    name = "liborcus-0.15.4.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/liborcus-0.15.4.tar.bz2";
-    sha256 = "cfb2aa60825f2a78589ed030c07f46a1ee16ef8a2d1bf2279192fbc1ae5a5f61";
+    name = "liborcus-0.16.1.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/liborcus-0.16.1.tar.bz2";
+    sha256 = "c700d1325f744104d9fca0d5a019434901e9d51a16eedfb05792f90a298587a4";
     md5 = "";
-    md5name = "cfb2aa60825f2a78589ed030c07f46a1ee16ef8a2d1bf2279192fbc1ae5a5f61-liborcus-0.15.4.tar.bz2";
+    md5name = "c700d1325f744104d9fca0d5a019434901e9d51a16eedfb05792f90a298587a4-liborcus-0.16.1.tar.bz2";
   }
   {
     name = "owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
@@ -721,11 +728,11 @@
     md5name = "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca-libpng-1.6.37.tar.xz";
   }
   {
-    name = "poppler-0.82.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/poppler-0.82.0.tar.xz";
-    sha256 = "234f8e573ea57fb6a008e7c1e56bfae1af5d1adf0e65f47555e1ae103874e4df";
+    name = "poppler-21.01.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/poppler-21.01.0.tar.xz";
+    sha256 = "016dde34e5f868ea98a32ca99b643325a9682281500942b7113f4ec88d20e2f3";
     md5 = "";
-    md5name = "234f8e573ea57fb6a008e7c1e56bfae1af5d1adf0e65f47555e1ae103874e4df-poppler-0.82.0.tar.xz";
+    md5name = "016dde34e5f868ea98a32ca99b643325a9682281500942b7113f4ec88d20e2f3-poppler-21.01.0.tar.xz";
   }
   {
     name = "postgresql-9.2.24.tar.bz2";
@@ -735,11 +742,11 @@
     md5name = "a754c02f7051c2f21e52f8669a421b50485afcde9a581674d6106326b189d126-postgresql-9.2.24.tar.bz2";
   }
   {
-    name = "Python-3.7.7.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/Python-3.7.7.tar.xz";
-    sha256 = "06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136";
+    name = "Python-3.8.4.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/Python-3.8.4.tar.xz";
+    sha256 = "5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37";
     md5 = "";
-    md5name = "06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136-Python-3.7.7.tar.xz";
+    md5name = "5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37-Python-3.8.4.tar.xz";
   }
   {
     name = "QR-Code-generator-1.4.0.tar.gz";
@@ -798,11 +805,11 @@
     md5name = "6988d394b62c3494635b6f0760bc3079f9a0cd380baf0f6b075af1eb9fa5e700-serf-1.2.1.tar.bz2";
   }
   {
-    name = "skia-m85-e684c6daef6bfb774a325a069eda1f76ca6ac26c.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/skia-m85-e684c6daef6bfb774a325a069eda1f76ca6ac26c.tar.xz";
-    sha256 = "3294877fa2b61b220d98a0f7bfc11325429b13edd2cf455444c703ee3a14d760";
+    name = "skia-m88-59bafeeaa7de9eb753e3778c414e01dcf013dcd8.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/skia-m88-59bafeeaa7de9eb753e3778c414e01dcf013dcd8.tar.xz";
+    sha256 = "f293656a15342a53bb407b932fc907c6894178a162f09728bd383e24d84b1301";
     md5 = "";
-    md5name = "3294877fa2b61b220d98a0f7bfc11325429b13edd2cf455444c703ee3a14d760-skia-m85-e684c6daef6bfb774a325a069eda1f76ca6ac26c.tar.xz";
+    md5name = "f293656a15342a53bb407b932fc907c6894178a162f09728bd383e24d84b1301-skia-m88-59bafeeaa7de9eb753e3778c414e01dcf013dcd8.tar.xz";
   }
   {
     name = "libstaroffice-0.0.7.tar.xz";
@@ -854,11 +861,11 @@
     md5name = "99b3f7f8832385748582ab8130fbb9e5607bd5179bebf9751ac1d51a53099d1c-libwpg-0.3.3.tar.xz";
   }
   {
-    name = "libwps-0.4.11.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libwps-0.4.11.tar.xz";
-    sha256 = "a8fdaabc28654a975fa78c81873ac503ba18f0d1cdbb942f470a21d29284b4d1";
+    name = "libwps-0.4.12.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libwps-0.4.12.tar.xz";
+    sha256 = "e21afb52a06d03b774c5a8c72679687ab64891b91ce0c3bdf2d3e97231534edb";
     md5 = "";
-    md5name = "a8fdaabc28654a975fa78c81873ac503ba18f0d1cdbb942f470a21d29284b4d1-libwps-0.4.11.tar.xz";
+    md5name = "e21afb52a06d03b774c5a8c72679687ab64891b91ce0c3bdf2d3e97231534edb-libwps-0.4.12.tar.xz";
   }
   {
     name = "xsltml_2.1.2.zip";

--- a/pkgs/applications/office/libreoffice/src-fresh/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/primary.nix
@@ -7,9 +7,9 @@ rec {
   };
 
   major = "7";
-  minor = "0";
-  patch = "4";
-  tweak = "2";
+  minor = "1";
+  patch = "0";
+  tweak = "3";
 
   subdir = "${major}.${minor}.${patch}";
 
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "1g9akxvm7fh6lnprnc3g184qdy8gbinhb4rb60gjpw82ip6d5acz";
+    sha256 = "1rpk90g1g8m70nrj4lwkg50aiild73d29yjlgyrgg8wx6hzq7l4y";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    sha256 = "1v3kpk56fm783d5wihx41jqidpclizkfxrg4n0pq95d79hdiljsl";
+    sha256 = "0m6cxyrxig8akv9183xdn6ialmjddicn676149nm506yc5y0szmi";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    sha256 = "1np9f799ww12kggl5az6piv5fi9rf737il5a5r47r4wl2li56qqb";
+    sha256 = "1kvsi28n8x3gxpiszxh84x05aw23i3z4id63pgw2s7mfclby52k9";
   };
 }

--- a/pkgs/applications/office/libreoffice/src-still/download.nix
+++ b/pkgs/applications/office/libreoffice/src-still/download.nix
@@ -1,854 +1,882 @@
 [
   {
     name = "libabw-0.1.3.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libabw-0.1.3.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libabw-0.1.3.tar.xz";
     sha256 = "e763a9dc21c3d2667402d66e202e3f8ef4db51b34b79ef41f56cacb86dcd6eed";
     md5 = "";
     md5name = "e763a9dc21c3d2667402d66e202e3f8ef4db51b34b79ef41f56cacb86dcd6eed-libabw-0.1.3.tar.xz";
   }
   {
     name = "commons-logging-1.2-src.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/commons-logging-1.2-src.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/commons-logging-1.2-src.tar.gz";
     sha256 = "49665da5a60d033e6dff40fe0a7f9173e886ae859ce6096c1afe34c48b677c81";
     md5 = "";
     md5name = "49665da5a60d033e6dff40fe0a7f9173e886ae859ce6096c1afe34c48b677c81-commons-logging-1.2-src.tar.gz";
   }
   {
     name = "apr-1.5.2.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/apr-1.5.2.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/apr-1.5.2.tar.gz";
     sha256 = "1af06e1720a58851d90694a984af18355b65bb0d047be03ec7d659c746d6dbdb";
     md5 = "";
     md5name = "1af06e1720a58851d90694a984af18355b65bb0d047be03ec7d659c746d6dbdb-apr-1.5.2.tar.gz";
   }
   {
     name = "apr-util-1.5.4.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/apr-util-1.5.4.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/apr-util-1.5.4.tar.gz";
     sha256 = "976a12a59bc286d634a21d7be0841cc74289ea9077aa1af46be19d1a6e844c19";
     md5 = "";
     md5name = "976a12a59bc286d634a21d7be0841cc74289ea9077aa1af46be19d1a6e844c19-apr-util-1.5.4.tar.gz";
   }
   {
-    name = "boost_1_69_0.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/boost_1_69_0.tar.bz2";
-    sha256 = "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406";
+    name = "boost_1_71_0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/boost_1_71_0.tar.xz";
+    sha256 = "35e06a3bd7cd8f66be822c7d64e80c2b6051a181e9e897006917cb8e7988a543";
     md5 = "";
-    md5name = "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406-boost_1_69_0.tar.bz2";
+    md5name = "35e06a3bd7cd8f66be822c7d64e80c2b6051a181e9e897006917cb8e7988a543-boost_1_71_0.tar.xz";
   }
   {
     name = "breakpad.zip";
-    url = "http://dev-www.libreoffice.org/src/breakpad.zip";
+    url = "https://dev-www.libreoffice.org/src/breakpad.zip";
     sha256 = "7060149be16a8789b0ccf596bdeaf63115f03f520acb508f72a14686fb311cb9";
     md5 = "";
     md5name = "7060149be16a8789b0ccf596bdeaf63115f03f520acb508f72a14686fb311cb9-breakpad.zip";
   }
   {
     name = "bsh-2.0b6-src.zip";
-    url = "http://dev-www.libreoffice.org/src/beeca87be45ec87d241ddd0e1bad80c1-bsh-2.0b6-src.zip";
+    url = "https://dev-www.libreoffice.org/src/beeca87be45ec87d241ddd0e1bad80c1-bsh-2.0b6-src.zip";
     sha256 = "9e93c73e23aff644b17dfff656444474c14150e7f3b38b19635e622235e01c96";
     md5 = "beeca87be45ec87d241ddd0e1bad80c1";
     md5name = "beeca87be45ec87d241ddd0e1bad80c1-bsh-2.0b6-src.zip";
   }
   {
     name = "bzip2-1.0.6.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/00b516f4704d4a7cb50a1d97e6e8e15b-bzip2-1.0.6.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/00b516f4704d4a7cb50a1d97e6e8e15b-bzip2-1.0.6.tar.gz";
     sha256 = "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd";
     md5 = "00b516f4704d4a7cb50a1d97e6e8e15b";
     md5name = "00b516f4704d4a7cb50a1d97e6e8e15b-bzip2-1.0.6.tar.gz";
   }
   {
     name = "cairo-1.16.0.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/cairo-1.16.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/cairo-1.16.0.tar.xz";
     sha256 = "5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331";
     md5 = "";
     md5name = "5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331-cairo-1.16.0.tar.xz";
   }
   {
-    name = "libcdr-0.1.5.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libcdr-0.1.5.tar.xz";
-    sha256 = "6ace5c499a8be34ad871e825442ce388614ae2d8675c4381756a7319429e3a48";
+    name = "libcdr-0.1.6.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libcdr-0.1.6.tar.xz";
+    sha256 = "01cd00b04a030977e544433c2d127c997205332cd9b8e35ec0ee17110da7f861";
     md5 = "";
-    md5name = "6ace5c499a8be34ad871e825442ce388614ae2d8675c4381756a7319429e3a48-libcdr-0.1.5.tar.xz";
+    md5name = "01cd00b04a030977e544433c2d127c997205332cd9b8e35ec0ee17110da7f861-libcdr-0.1.6.tar.xz";
   }
   {
     name = "clucene-core-2.3.3.4.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz";
     sha256 = "ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab";
     md5 = "48d647fbd8ef8889e5a7f422c1bfda94";
     md5name = "48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz";
   }
   {
+    name = "dtoa-20180411.tgz";
+    url = "https://dev-www.libreoffice.org/src/dtoa-20180411.tgz";
+    sha256 = "0082d0684f7db6f62361b76c4b7faba19e0c7ce5cb8e36c4b65fea8281e711b4";
+    md5 = "";
+    md5name = "0082d0684f7db6f62361b76c4b7faba19e0c7ce5cb8e36c4b65fea8281e711b4-dtoa-20180411.tgz";
+  }
+  {
     name = "libcmis-0.5.2.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libcmis-0.5.2.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libcmis-0.5.2.tar.xz";
     sha256 = "d7b18d9602190e10d437f8a964a32e983afd57e2db316a07d87477a79f5000a2";
     md5 = "";
     md5name = "d7b18d9602190e10d437f8a964a32e983afd57e2db316a07d87477a79f5000a2-libcmis-0.5.2.tar.xz";
   }
   {
     name = "CoinMP-1.7.6.tgz";
-    url = "http://dev-www.libreoffice.org/src/CoinMP-1.7.6.tgz";
+    url = "https://dev-www.libreoffice.org/src/CoinMP-1.7.6.tgz";
     sha256 = "86c798780b9e1f5921fe4efe651a93cb420623b45aa1fdff57af8c37f116113f";
     md5 = "";
     md5name = "86c798780b9e1f5921fe4efe651a93cb420623b45aa1fdff57af8c37f116113f-CoinMP-1.7.6.tgz";
   }
   {
-    name = "cppunit-1.14.0.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/cppunit-1.14.0.tar.gz";
-    sha256 = "3d569869d27b48860210c758c4f313082103a5e58219a7669b52bfd29d674780";
+    name = "cppunit-1.15.1.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/cppunit-1.15.1.tar.gz";
+    sha256 = "89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7";
     md5 = "";
-    md5name = "3d569869d27b48860210c758c4f313082103a5e58219a7669b52bfd29d674780-cppunit-1.14.0.tar.gz";
+    md5name = "89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7-cppunit-1.15.1.tar.gz";
   }
   {
     name = "converttexttonumber-1-5-0.oxt";
-    url = "http://dev-www.libreoffice.org/src/1f467e5bb703f12cbbb09d5cf67ecf4a-converttexttonumber-1-5-0.oxt";
+    url = "https://dev-www.libreoffice.org/src/1f467e5bb703f12cbbb09d5cf67ecf4a-converttexttonumber-1-5-0.oxt";
     sha256 = "71b238efd2734be9800af07566daea8d6685aeed28db5eb5fa0e6453f4d85de3";
     md5 = "1f467e5bb703f12cbbb09d5cf67ecf4a";
     md5name = "1f467e5bb703f12cbbb09d5cf67ecf4a-converttexttonumber-1-5-0.oxt";
   }
   {
-    name = "curl-7.65.0.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/curl-7.65.0.tar.xz";
-    sha256 = "7766d263929404f693905b5e5222aa0f2bdf8c66ab4b8758f0c0820a42b966cd";
+    name = "curl-7.71.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/curl-7.71.0.tar.xz";
+    sha256 = "cdf18794393d8bead915312708a9e5d819c6e9919de14b20d5c8e7987abd9772";
     md5 = "";
-    md5name = "7766d263929404f693905b5e5222aa0f2bdf8c66ab4b8758f0c0820a42b966cd-curl-7.65.0.tar.xz";
+    md5name = "cdf18794393d8bead915312708a9e5d819c6e9919de14b20d5c8e7987abd9772-curl-7.71.0.tar.xz";
   }
   {
     name = "libe-book-0.1.3.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libe-book-0.1.3.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libe-book-0.1.3.tar.xz";
     sha256 = "7e8d8ff34f27831aca3bc6f9cc532c2f90d2057c778963b884ff3d1e34dfe1f9";
     md5 = "";
     md5name = "7e8d8ff34f27831aca3bc6f9cc532c2f90d2057c778963b884ff3d1e34dfe1f9-libe-book-0.1.3.tar.xz";
   }
   {
     name = "libepoxy-1.5.3.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libepoxy-1.5.3.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libepoxy-1.5.3.tar.xz";
     sha256 = "002958c5528321edd53440235d3c44e71b5b1e09b9177e8daf677450b6c4433d";
     md5 = "";
     md5name = "002958c5528321edd53440235d3c44e71b5b1e09b9177e8daf677450b6c4433d-libepoxy-1.5.3.tar.xz";
   }
   {
     name = "epm-3.7.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/3ade8cfe7e59ca8e65052644fed9fca4-epm-3.7.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/3ade8cfe7e59ca8e65052644fed9fca4-epm-3.7.tar.gz";
     sha256 = "b3fc4c5445de6c9a801504a3ea3efb2d4ea9d5a622c9427e716736e7713ddb91";
     md5 = "3ade8cfe7e59ca8e65052644fed9fca4";
     md5name = "3ade8cfe7e59ca8e65052644fed9fca4-epm-3.7.tar.gz";
   }
   {
     name = "libepubgen-0.1.1.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libepubgen-0.1.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libepubgen-0.1.1.tar.xz";
     sha256 = "03e084b994cbeffc8c3dd13303b2cb805f44d8f2c3b79f7690d7e3fc7f6215ad";
     md5 = "";
     md5name = "03e084b994cbeffc8c3dd13303b2cb805f44d8f2c3b79f7690d7e3fc7f6215ad-libepubgen-0.1.1.tar.xz";
   }
   {
     name = "libetonyek-0.1.9.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libetonyek-0.1.9.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libetonyek-0.1.9.tar.xz";
     sha256 = "e61677e8799ce6e55b25afc11aa5339113f6a49cff031f336e32fa58635b1a4a";
     md5 = "";
     md5name = "e61677e8799ce6e55b25afc11aa5339113f6a49cff031f336e32fa58635b1a4a-libetonyek-0.1.9.tar.xz";
   }
   {
     name = "expat-2.2.8.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/expat-2.2.8.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/expat-2.2.8.tar.bz2";
     sha256 = "9a130948b05a82da34e4171d5f5ae5d321d9630277af02c8fa51e431f6475102";
     md5 = "";
     md5name = "9a130948b05a82da34e4171d5f5ae5d321d9630277af02c8fa51e431f6475102-expat-2.2.8.tar.bz2";
   }
   {
     name = "Firebird-3.0.0.32483-0.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/Firebird-3.0.0.32483-0.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/Firebird-3.0.0.32483-0.tar.bz2";
     sha256 = "6994be3555e23226630c587444be19d309b25b0fcf1f87df3b4e3f88943e5860";
     md5 = "";
     md5name = "6994be3555e23226630c587444be19d309b25b0fcf1f87df3b4e3f88943e5860-Firebird-3.0.0.32483-0.tar.bz2";
   }
   {
-    name = "fontconfig-2.12.6.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/fontconfig-2.12.6.tar.bz2";
-    sha256 = "cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017";
+    name = "fontconfig-2.13.91.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/fontconfig-2.13.91.tar.gz";
+    sha256 = "19e5b1bc9d013a52063a44e1307629711f0bfef35b9aca16f9c793971e2eb1e5";
     md5 = "";
-    md5name = "cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017-fontconfig-2.12.6.tar.bz2";
+    md5name = "19e5b1bc9d013a52063a44e1307629711f0bfef35b9aca16f9c793971e2eb1e5-fontconfig-2.13.91.tar.gz";
   }
   {
     name = "crosextrafonts-20130214.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/368f114c078f94214a308a74c7e991bc-crosextrafonts-20130214.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/368f114c078f94214a308a74c7e991bc-crosextrafonts-20130214.tar.gz";
     sha256 = "c48d1c2fd613c9c06c959c34da7b8388059e2408d2bb19845dc3ed35f76e4d09";
     md5 = "368f114c078f94214a308a74c7e991bc";
     md5name = "368f114c078f94214a308a74c7e991bc-crosextrafonts-20130214.tar.gz";
   }
   {
     name = "crosextrafonts-carlito-20130920.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/c74b7223abe75949b4af367942d96c7a-crosextrafonts-carlito-20130920.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/c74b7223abe75949b4af367942d96c7a-crosextrafonts-carlito-20130920.tar.gz";
     sha256 = "4bd12b6cbc321c1cf16da76e2c585c925ce956a08067ae6f6c64eff6ccfdaf5a";
     md5 = "c74b7223abe75949b4af367942d96c7a";
     md5name = "c74b7223abe75949b4af367942d96c7a-crosextrafonts-carlito-20130920.tar.gz";
   }
   {
     name = "dejavu-fonts-ttf-2.37.zip";
-    url = "http://dev-www.libreoffice.org/src/33e1e61fab06a547851ed308b4ffef42-dejavu-fonts-ttf-2.37.zip";
+    url = "https://dev-www.libreoffice.org/src/33e1e61fab06a547851ed308b4ffef42-dejavu-fonts-ttf-2.37.zip";
     sha256 = "7576310b219e04159d35ff61dd4a4ec4cdba4f35c00e002a136f00e96a908b0a";
     md5 = "33e1e61fab06a547851ed308b4ffef42";
     md5name = "33e1e61fab06a547851ed308b4ffef42-dejavu-fonts-ttf-2.37.zip";
   }
   {
     name = "GentiumBasic_1102.zip";
-    url = "http://dev-www.libreoffice.org/src/1725634df4bb3dcb1b2c91a6175f8789-GentiumBasic_1102.zip";
+    url = "https://dev-www.libreoffice.org/src/1725634df4bb3dcb1b2c91a6175f8789-GentiumBasic_1102.zip";
     sha256 = "2f1a2c5491d7305dffd3520c6375d2f3e14931ee35c6d8ae1e8f098bf1a7b3cc";
     md5 = "1725634df4bb3dcb1b2c91a6175f8789";
     md5name = "1725634df4bb3dcb1b2c91a6175f8789-GentiumBasic_1102.zip";
   }
   {
     name = "liberation-narrow-fonts-ttf-1.07.6.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/liberation-narrow-fonts-ttf-1.07.6.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/liberation-narrow-fonts-ttf-1.07.6.tar.gz";
     sha256 = "8879d89b5ff7b506c9fc28efc31a5c0b954bbe9333e66e5283d27d20a8519ea3";
     md5 = "";
     md5name = "8879d89b5ff7b506c9fc28efc31a5c0b954bbe9333e66e5283d27d20a8519ea3-liberation-narrow-fonts-ttf-1.07.6.tar.gz";
   }
   {
     name = "liberation-fonts-ttf-2.00.4.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/liberation-fonts-ttf-2.00.4.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/liberation-fonts-ttf-2.00.4.tar.gz";
     sha256 = "c40e95fc5e0ecb73d4be565ae2afc1114e2bc7dc5253e00ee92d8fd6cc4adf45";
     md5 = "";
     md5name = "c40e95fc5e0ecb73d4be565ae2afc1114e2bc7dc5253e00ee92d8fd6cc4adf45-liberation-fonts-ttf-2.00.4.tar.gz";
   }
   {
     name = "LinLibertineG-20120116.zip";
-    url = "http://dev-www.libreoffice.org/src/e7a384790b13c29113e22e596ade9687-LinLibertineG-20120116.zip";
+    url = "https://dev-www.libreoffice.org/src/e7a384790b13c29113e22e596ade9687-LinLibertineG-20120116.zip";
     sha256 = "54adcb2bc8cac0927a647fbd9362f45eff48130ce6e2379dc3867643019e08c5";
     md5 = "e7a384790b13c29113e22e596ade9687";
     md5name = "e7a384790b13c29113e22e596ade9687-LinLibertineG-20120116.zip";
   }
   {
     name = "source-code-pro-2.030R-ro-1.050R-it.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/907d6e99f241876695c19ff3db0b8923-source-code-pro-2.030R-ro-1.050R-it.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/907d6e99f241876695c19ff3db0b8923-source-code-pro-2.030R-ro-1.050R-it.tar.gz";
     sha256 = "09466dce87653333f189acd8358c60c6736dcd95f042dee0b644bdcf65b6ae2f";
     md5 = "907d6e99f241876695c19ff3db0b8923";
     md5name = "907d6e99f241876695c19ff3db0b8923-source-code-pro-2.030R-ro-1.050R-it.tar.gz";
   }
   {
     name = "source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
     sha256 = "e7bc9a1fec787a529e49f5a26b93dcdcf41506449dfc70f92cdef6d17eb6fb61";
     md5 = "edc4d741888bc0d38e32dbaa17149596";
     md5name = "edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
   }
   {
     name = "source-serif-pro-3.000R.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/source-serif-pro-3.000R.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/source-serif-pro-3.000R.tar.gz";
     sha256 = "826a2b784d5cdb4c2bbc7830eb62871528360a61a52689c102a101623f1928e3";
     md5 = "";
     md5name = "826a2b784d5cdb4c2bbc7830eb62871528360a61a52689c102a101623f1928e3-source-serif-pro-3.000R.tar.gz";
   }
   {
     name = "EmojiOneColor-SVGinOT-1.3.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/EmojiOneColor-SVGinOT-1.3.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/EmojiOneColor-SVGinOT-1.3.tar.gz";
     sha256 = "d1a08f7c10589f22740231017694af0a7a270760c8dec33d8d1c038e2be0a0c7";
     md5 = "";
     md5name = "d1a08f7c10589f22740231017694af0a7a270760c8dec33d8d1c038e2be0a0c7-EmojiOneColor-SVGinOT-1.3.tar.gz";
   }
   {
     name = "noto-fonts-20171024.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/noto-fonts-20171024.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/noto-fonts-20171024.tar.gz";
     sha256 = "29acc15a4c4d6b51201ba5d60f303dfbc2e5acbfdb70413c9ae1ed34fa259994";
     md5 = "";
     md5name = "29acc15a4c4d6b51201ba5d60f303dfbc2e5acbfdb70413c9ae1ed34fa259994-noto-fonts-20171024.tar.gz";
   }
   {
     name = "culmus-0.131.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/culmus-0.131.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/culmus-0.131.tar.gz";
     sha256 = "dcf112cfcccb76328dcfc095f4d7c7f4d2f7e48d0eed5e78b100d1d77ce2ed1b";
     md5 = "";
     md5name = "dcf112cfcccb76328dcfc095f4d7c7f4d2f7e48d0eed5e78b100d1d77ce2ed1b-culmus-0.131.tar.gz";
   }
   {
     name = "libre-hebrew-1.0.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/libre-hebrew-1.0.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libre-hebrew-1.0.tar.gz";
     sha256 = "f596257c1db706ce35795b18d7f66a4db99d427725f20e9384914b534142579a";
     md5 = "";
     md5name = "f596257c1db706ce35795b18d7f66a4db99d427725f20e9384914b534142579a-libre-hebrew-1.0.tar.gz";
   }
   {
     name = "alef-1.001.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/alef-1.001.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/alef-1.001.tar.gz";
     sha256 = "b98b67602a2c8880a1770f0b9e37c190f29a7e2ade5616784f0b89fbdb75bf52";
     md5 = "";
     md5name = "b98b67602a2c8880a1770f0b9e37c190f29a7e2ade5616784f0b89fbdb75bf52-alef-1.001.tar.gz";
   }
   {
     name = "Amiri-0.111.zip";
-    url = "http://dev-www.libreoffice.org/src/Amiri-0.111.zip";
+    url = "https://dev-www.libreoffice.org/src/Amiri-0.111.zip";
     sha256 = "1fbfccced6348b5db2c1c21d5b319cd488e14d055702fa817a0f6cb83d882166";
     md5 = "";
     md5name = "1fbfccced6348b5db2c1c21d5b319cd488e14d055702fa817a0f6cb83d882166-Amiri-0.111.zip";
   }
   {
     name = "ttf-kacst_2.01+mry.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/ttf-kacst_2.01+mry.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/ttf-kacst_2.01+mry.tar.gz";
     sha256 = "dca00f5e655f2f217a766faa73a81f542c5c204aa3a47017c3c2be0b31d00a56";
     md5 = "";
     md5name = "dca00f5e655f2f217a766faa73a81f542c5c204aa3a47017c3c2be0b31d00a56-ttf-kacst_2.01+mry.tar.gz";
   }
   {
     name = "ReemKufi-0.7.zip";
-    url = "http://dev-www.libreoffice.org/src/ReemKufi-0.7.zip";
+    url = "https://dev-www.libreoffice.org/src/ReemKufi-0.7.zip";
     sha256 = "f60c6508d209ce4236d2d7324256c2ffddd480be7e3d6023770b93dc391a605f";
     md5 = "";
     md5name = "f60c6508d209ce4236d2d7324256c2ffddd480be7e3d6023770b93dc391a605f-ReemKufi-0.7.zip";
   }
   {
     name = "Scheherazade-2.100.zip";
-    url = "http://dev-www.libreoffice.org/src/Scheherazade-2.100.zip";
+    url = "https://dev-www.libreoffice.org/src/Scheherazade-2.100.zip";
     sha256 = "251c8817ceb87d9b661ce1d5b49e732a0116add10abc046be4b8ba5196e149b5";
     md5 = "";
     md5name = "251c8817ceb87d9b661ce1d5b49e732a0116add10abc046be4b8ba5196e149b5-Scheherazade-2.100.zip";
   }
   {
     name = "libfreehand-0.1.2.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libfreehand-0.1.2.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libfreehand-0.1.2.tar.xz";
     sha256 = "0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac";
     md5 = "";
     md5name = "0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac-libfreehand-0.1.2.tar.xz";
   }
   {
     name = "freetype-2.9.1.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/freetype-2.9.1.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/freetype-2.9.1.tar.bz2";
     sha256 = "db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d";
     md5 = "";
     md5name = "db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d-freetype-2.9.1.tar.bz2";
   }
   {
-    name = "glm-0.9.4.6-libreoffice.zip";
-    url = "http://dev-www.libreoffice.org/src/bae83fa5dc7f081768daace6e199adc3-glm-0.9.4.6-libreoffice.zip";
-    sha256 = "d0312c360efe04dd048b3311fe375ff36f1993b4c2e3cb58c81062990532904a";
-    md5 = "bae83fa5dc7f081768daace6e199adc3";
-    md5name = "bae83fa5dc7f081768daace6e199adc3-glm-0.9.4.6-libreoffice.zip";
+    name = "glm-0.9.9.7.zip";
+    url = "https://dev-www.libreoffice.org/src/glm-0.9.9.7.zip";
+    sha256 = "c5e167c042afd2d7ad642ace6b643863baeb33880781983563e1ab68a30d3e95";
+    md5 = "";
+    md5name = "c5e167c042afd2d7ad642ace6b643863baeb33880781983563e1ab68a30d3e95-glm-0.9.9.7.zip";
   }
   {
     name = "gpgme-1.9.0.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/gpgme-1.9.0.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/gpgme-1.9.0.tar.bz2";
     sha256 = "1b29fedb8bfad775e70eafac5b0590621683b2d9869db994568e6401f4034ceb";
     md5 = "";
     md5name = "1b29fedb8bfad775e70eafac5b0590621683b2d9869db994568e6401f4034ceb-gpgme-1.9.0.tar.bz2";
   }
   {
-    name = "graphite2-minimal-1.3.13.tgz";
-    url = "http://dev-www.libreoffice.org/src/graphite2-minimal-1.3.13.tgz";
-    sha256 = "d47d387161db7f7ebade1920aa7cbdc797e79772597d8b55e80b58d1071bcc36";
+    name = "graphite2-minimal-1.3.14.tgz";
+    url = "https://dev-www.libreoffice.org/src/graphite2-minimal-1.3.14.tgz";
+    sha256 = "b8e892d8627c41888ff121e921455b9e2d26836978f2359173d19825da62b8fc";
     md5 = "";
-    md5name = "d47d387161db7f7ebade1920aa7cbdc797e79772597d8b55e80b58d1071bcc36-graphite2-minimal-1.3.13.tgz";
+    md5name = "b8e892d8627c41888ff121e921455b9e2d26836978f2359173d19825da62b8fc-graphite2-minimal-1.3.14.tgz";
   }
   {
-    name = "harfbuzz-2.3.1.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/harfbuzz-2.3.1.tar.bz2";
-    sha256 = "f205699d5b91374008d6f8e36c59e419ae2d9a7bb8c5d9f34041b9a5abcae468";
+    name = "harfbuzz-2.6.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/harfbuzz-2.6.0.tar.xz";
+    sha256 = "9cf7d117548265f95ca884e2f4c9fafaf4e17d45a67b11107147b79eed76c966";
     md5 = "";
-    md5name = "f205699d5b91374008d6f8e36c59e419ae2d9a7bb8c5d9f34041b9a5abcae468-harfbuzz-2.3.1.tar.bz2";
+    md5name = "9cf7d117548265f95ca884e2f4c9fafaf4e17d45a67b11107147b79eed76c966-harfbuzz-2.6.0.tar.xz";
   }
   {
     name = "hsqldb_1_8_0.zip";
-    url = "http://dev-www.libreoffice.org/src/17410483b5b5f267aa18b7e00b65e6e0-hsqldb_1_8_0.zip";
+    url = "https://dev-www.libreoffice.org/src/17410483b5b5f267aa18b7e00b65e6e0-hsqldb_1_8_0.zip";
     sha256 = "d30b13f4ba2e3b6a2d4f020c0dee0a9fb9fc6fbcc2d561f36b78da4bf3802370";
     md5 = "17410483b5b5f267aa18b7e00b65e6e0";
     md5name = "17410483b5b5f267aa18b7e00b65e6e0-hsqldb_1_8_0.zip";
   }
   {
     name = "hunspell-1.7.0.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/hunspell-1.7.0.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/hunspell-1.7.0.tar.gz";
     sha256 = "57be4e03ae9dd62c3471f667a0d81a14513e314d4d92081292b90435944ff951";
     md5 = "";
     md5name = "57be4e03ae9dd62c3471f667a0d81a14513e314d4d92081292b90435944ff951-hunspell-1.7.0.tar.gz";
   }
   {
     name = "hyphen-2.8.8.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
     sha256 = "304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705";
     md5 = "5ade6ae2a99bc1e9e57031ca88d36dad";
     md5name = "5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
   }
   {
-    name = "icu4c-63_1-src.tgz";
-    url = "http://dev-www.libreoffice.org/src/icu4c-63_1-src.tgz";
-    sha256 = "05c490b69454fce5860b7e8e2821231674af0a11d7ef2febea9a32512998cb9d";
+    name = "icu4c-67_1-src.tgz";
+    url = "https://dev-www.libreoffice.org/src/icu4c-67_1-src.tgz";
+    sha256 = "94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc";
     md5 = "";
-    md5name = "05c490b69454fce5860b7e8e2821231674af0a11d7ef2febea9a32512998cb9d-icu4c-63_1-src.tgz";
+    md5name = "94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc-icu4c-67_1-src.tgz";
   }
   {
-    name = "icu4c-63_1-data.zip";
-    url = "http://dev-www.libreoffice.org/src/icu4c-63_1-data.zip";
-    sha256 = "9bef2bf28ec4fdc86a3bd88d7ac4d509fef6dfbe9c6798299e55b9d4343e960c";
+    name = "icu4c-67_1-data.zip";
+    url = "https://dev-www.libreoffice.org/src/icu4c-67_1-data.zip";
+    sha256 = "7c16a59cc8c06128b7ecc1dc4fc056b36b17349312829b17408b9e67b05c4a7e";
     md5 = "";
-    md5name = "9bef2bf28ec4fdc86a3bd88d7ac4d509fef6dfbe9c6798299e55b9d4343e960c-icu4c-63_1-data.zip";
+    md5name = "7c16a59cc8c06128b7ecc1dc4fc056b36b17349312829b17408b9e67b05c4a7e-icu4c-67_1-data.zip";
   }
   {
     name = "flow-engine-0.9.4.zip";
-    url = "http://dev-www.libreoffice.org/src/ba2930200c9f019c2d93a8c88c651a0f-flow-engine-0.9.4.zip";
+    url = "https://dev-www.libreoffice.org/src/ba2930200c9f019c2d93a8c88c651a0f-flow-engine-0.9.4.zip";
     sha256 = "233f66e8d25c5dd971716d4200203a612a407649686ef3b52075d04b4c9df0dd";
     md5 = "ba2930200c9f019c2d93a8c88c651a0f";
     md5name = "ba2930200c9f019c2d93a8c88c651a0f-flow-engine-0.9.4.zip";
   }
   {
     name = "flute-1.1.6.zip";
-    url = "http://dev-www.libreoffice.org/src/d8bd5eed178db6e2b18eeed243f85aa8-flute-1.1.6.zip";
+    url = "https://dev-www.libreoffice.org/src/d8bd5eed178db6e2b18eeed243f85aa8-flute-1.1.6.zip";
     sha256 = "1b5b24f7bc543c0362b667692f78db8bab4ed6dafc6172f104d0bd3757d8a133";
     md5 = "d8bd5eed178db6e2b18eeed243f85aa8";
     md5name = "d8bd5eed178db6e2b18eeed243f85aa8-flute-1.1.6.zip";
   }
   {
     name = "libbase-1.1.6.zip";
-    url = "http://dev-www.libreoffice.org/src/eeb2c7ddf0d302fba4bfc6e97eac9624-libbase-1.1.6.zip";
+    url = "https://dev-www.libreoffice.org/src/eeb2c7ddf0d302fba4bfc6e97eac9624-libbase-1.1.6.zip";
     sha256 = "75c80359c9ce343c20aab8a36a45cb3b9ee7c61cf92c13ae45399d854423a9ba";
     md5 = "eeb2c7ddf0d302fba4bfc6e97eac9624";
     md5name = "eeb2c7ddf0d302fba4bfc6e97eac9624-libbase-1.1.6.zip";
   }
   {
     name = "libfonts-1.1.6.zip";
-    url = "http://dev-www.libreoffice.org/src/3bdf40c0d199af31923e900d082ca2dd-libfonts-1.1.6.zip";
+    url = "https://dev-www.libreoffice.org/src/3bdf40c0d199af31923e900d082ca2dd-libfonts-1.1.6.zip";
     sha256 = "e0531091787c0f16c83965fdcbc49162c059d7f0c64669e7f119699321549743";
     md5 = "3bdf40c0d199af31923e900d082ca2dd";
     md5name = "3bdf40c0d199af31923e900d082ca2dd-libfonts-1.1.6.zip";
   }
   {
     name = "libformula-1.1.7.zip";
-    url = "http://dev-www.libreoffice.org/src/3404ab6b1792ae5f16bbd603bd1e1d03-libformula-1.1.7.zip";
+    url = "https://dev-www.libreoffice.org/src/3404ab6b1792ae5f16bbd603bd1e1d03-libformula-1.1.7.zip";
     sha256 = "5826d1551bf599b85742545f6e01a0079b93c1b2c8434bf409eddb3a29e4726b";
     md5 = "3404ab6b1792ae5f16bbd603bd1e1d03";
     md5name = "3404ab6b1792ae5f16bbd603bd1e1d03-libformula-1.1.7.zip";
   }
   {
     name = "liblayout-0.2.10.zip";
-    url = "http://dev-www.libreoffice.org/src/db60e4fde8dd6d6807523deb71ee34dc-liblayout-0.2.10.zip";
+    url = "https://dev-www.libreoffice.org/src/db60e4fde8dd6d6807523deb71ee34dc-liblayout-0.2.10.zip";
     sha256 = "e1fb87f3f7b980d33414473279615c4644027e013012d156efa538bc2b031772";
     md5 = "db60e4fde8dd6d6807523deb71ee34dc";
     md5name = "db60e4fde8dd6d6807523deb71ee34dc-liblayout-0.2.10.zip";
   }
   {
     name = "libloader-1.1.6.zip";
-    url = "http://dev-www.libreoffice.org/src/97b2d4dba862397f446b217e2b623e71-libloader-1.1.6.zip";
+    url = "https://dev-www.libreoffice.org/src/97b2d4dba862397f446b217e2b623e71-libloader-1.1.6.zip";
     sha256 = "3d853b19b1d94a6efa69e7af90f7f2b09ecf302913bee3da796c15ecfebcfac8";
     md5 = "97b2d4dba862397f446b217e2b623e71";
     md5name = "97b2d4dba862397f446b217e2b623e71-libloader-1.1.6.zip";
   }
   {
     name = "librepository-1.1.6.zip";
-    url = "http://dev-www.libreoffice.org/src/8ce2fcd72becf06c41f7201d15373ed9-librepository-1.1.6.zip";
+    url = "https://dev-www.libreoffice.org/src/8ce2fcd72becf06c41f7201d15373ed9-librepository-1.1.6.zip";
     sha256 = "abe2c57ac12ba45d83563b02e240fa95d973376de2f720aab8fe11f2e621c095";
     md5 = "8ce2fcd72becf06c41f7201d15373ed9";
     md5name = "8ce2fcd72becf06c41f7201d15373ed9-librepository-1.1.6.zip";
   }
   {
     name = "libserializer-1.1.6.zip";
-    url = "http://dev-www.libreoffice.org/src/f94d9870737518e3b597f9265f4e9803-libserializer-1.1.6.zip";
+    url = "https://dev-www.libreoffice.org/src/f94d9870737518e3b597f9265f4e9803-libserializer-1.1.6.zip";
     sha256 = "05640a1f6805b2b2d7e2cb9c50db9a5cb084e3c52ab1a71ce015239b4a1d4343";
     md5 = "f94d9870737518e3b597f9265f4e9803";
     md5name = "f94d9870737518e3b597f9265f4e9803-libserializer-1.1.6.zip";
   }
   {
     name = "libxml-1.1.7.zip";
-    url = "http://dev-www.libreoffice.org/src/ace6ab49184e329db254e454a010f56d-libxml-1.1.7.zip";
+    url = "https://dev-www.libreoffice.org/src/ace6ab49184e329db254e454a010f56d-libxml-1.1.7.zip";
     sha256 = "7d2797fe9f79a77009721e3f14fa4a1dec17a6d706bdc93f85f1f01d124fab66";
     md5 = "ace6ab49184e329db254e454a010f56d";
     md5name = "ace6ab49184e329db254e454a010f56d-libxml-1.1.7.zip";
   }
   {
     name = "sacjava-1.3.zip";
-    url = "http://dev-www.libreoffice.org/src/39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip";
+    url = "https://dev-www.libreoffice.org/src/39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip";
     sha256 = "085f2112c51fa8c1783fac12fbd452650596415121348393bb51f0f7e85a9045";
     md5 = "39bb3fcea1514f1369fcfc87542390fd";
     md5name = "39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip";
   }
   {
     name = "libjpeg-turbo-1.5.3.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/libjpeg-turbo-1.5.3.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libjpeg-turbo-1.5.3.tar.gz";
     sha256 = "b24890e2bb46e12e72a79f7e965f409f4e16466d00e1dd15d93d73ee6b592523";
     md5 = "";
     md5name = "b24890e2bb46e12e72a79f7e965f409f4e16466d00e1dd15d93d73ee6b592523-libjpeg-turbo-1.5.3.tar.gz";
   }
   {
-    name = "language-subtag-registry-2019-09-16.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/language-subtag-registry-2019-09-16.tar.bz2";
-    sha256 = "07b66bc0f2786fde55f6bbcbcb4a455a846eb8e2351c8ce3d0a219a73693736a";
+    name = "language-subtag-registry-2020-09-29.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/language-subtag-registry-2020-09-29.tar.bz2";
+    sha256 = "cbe9fca811a37056560aab73e9fc9d3522b46b6785cb02db165f521bf42c230f";
     md5 = "";
-    md5name = "07b66bc0f2786fde55f6bbcbcb4a455a846eb8e2351c8ce3d0a219a73693736a-language-subtag-registry-2019-09-16.tar.bz2";
+    md5name = "cbe9fca811a37056560aab73e9fc9d3522b46b6785cb02db165f521bf42c230f-language-subtag-registry-2020-09-29.tar.bz2";
   }
   {
     name = "JLanguageTool-1.7.0.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/b63e6340a02ff1cacfeadb2c42286161-JLanguageTool-1.7.0.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/b63e6340a02ff1cacfeadb2c42286161-JLanguageTool-1.7.0.tar.bz2";
     sha256 = "48c87e41636783bba438b65fd895821e369ed139e1465fac654323ad93c5a82d";
     md5 = "b63e6340a02ff1cacfeadb2c42286161";
     md5name = "b63e6340a02ff1cacfeadb2c42286161-JLanguageTool-1.7.0.tar.bz2";
   }
   {
     name = "lcms2-2.9.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/lcms2-2.9.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/lcms2-2.9.tar.gz";
     sha256 = "48c6fdf98396fa245ed86e622028caf49b96fa22f3e5734f853f806fbc8e7d20";
     md5 = "";
     md5name = "48c6fdf98396fa245ed86e622028caf49b96fa22f3e5734f853f806fbc8e7d20-lcms2-2.9.tar.gz";
   }
   {
     name = "libassuan-2.5.1.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/libassuan-2.5.1.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/libassuan-2.5.1.tar.bz2";
     sha256 = "47f96c37b4f2aac289f0bc1bacfa8bd8b4b209a488d3d15e2229cb6cc9b26449";
     md5 = "";
     md5name = "47f96c37b4f2aac289f0bc1bacfa8bd8b4b209a488d3d15e2229cb6cc9b26449-libassuan-2.5.1.tar.bz2";
   }
   {
     name = "libatomic_ops-7.6.8.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/libatomic_ops-7.6.8.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libatomic_ops-7.6.8.tar.gz";
     sha256 = "1d6a279edf81767e74d2ad2c9fce09459bc65f12c6525a40b0cb3e53c089f665";
     md5 = "";
     md5name = "1d6a279edf81767e74d2ad2c9fce09459bc65f12c6525a40b0cb3e53c089f665-libatomic_ops-7.6.8.tar.gz";
   }
   {
     name = "libeot-0.01.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/libeot-0.01.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/libeot-0.01.tar.bz2";
     sha256 = "cf5091fa8e7dcdbe667335eb90a2cfdd0a3fe8f8c7c8d1ece44d9d055736a06a";
     md5 = "";
     md5name = "cf5091fa8e7dcdbe667335eb90a2cfdd0a3fe8f8c7c8d1ece44d9d055736a06a-libeot-0.01.tar.bz2";
   }
   {
     name = "libexttextcat-3.4.5.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libexttextcat-3.4.5.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libexttextcat-3.4.5.tar.xz";
     sha256 = "13fdbc9d4c489a4d0519e51933a1aa21fe3fb9eb7da191b87f7a63e82797dac8";
     md5 = "";
     md5name = "13fdbc9d4c489a4d0519e51933a1aa21fe3fb9eb7da191b87f7a63e82797dac8-libexttextcat-3.4.5.tar.xz";
   }
   {
+    name = "libffi-3.3.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libffi-3.3.tar.gz";
+    sha256 = "72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056";
+    md5 = "";
+    md5name = "72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056-libffi-3.3.tar.gz";
+  }
+  {
     name = "libgpg-error-1.27.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/libgpg-error-1.27.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/libgpg-error-1.27.tar.bz2";
     sha256 = "4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2";
     md5 = "";
     md5name = "4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2-libgpg-error-1.27.tar.bz2";
   }
   {
     name = "liblangtag-0.6.2.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/liblangtag-0.6.2.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/liblangtag-0.6.2.tar.bz2";
     sha256 = "d6242790324f1432fb0a6fae71b6851f520b2c5a87675497cf8ea14c2924d52e";
     md5 = "";
     md5name = "d6242790324f1432fb0a6fae71b6851f520b2c5a87675497cf8ea14c2924d52e-liblangtag-0.6.2.tar.bz2";
   }
   {
-    name = "libnumbertext-1.0.5.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libnumbertext-1.0.5.tar.xz";
-    sha256 = "e1c9086b4cecb6b25f180316f30740dfabe6a4dbaf70dddc34276fc839e4f4f7";
+    name = "libnumbertext-1.0.6.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libnumbertext-1.0.6.tar.xz";
+    sha256 = "739f220b34bf7cb731c09de2921771d644d37dfd276c45564401e5759f10ae57";
     md5 = "";
-    md5name = "e1c9086b4cecb6b25f180316f30740dfabe6a4dbaf70dddc34276fc839e4f4f7-libnumbertext-1.0.5.tar.xz";
+    md5name = "739f220b34bf7cb731c09de2921771d644d37dfd276c45564401e5759f10ae57-libnumbertext-1.0.6.tar.xz";
   }
   {
     name = "ltm-1.0.zip";
-    url = "http://dev-www.libreoffice.org/src/ltm-1.0.zip";
+    url = "https://dev-www.libreoffice.org/src/ltm-1.0.zip";
     sha256 = "083daa92d8ee6f4af96a6143b12d7fc8fe1a547e14f862304f7281f8f7347483";
     md5 = "";
     md5name = "083daa92d8ee6f4af96a6143b12d7fc8fe1a547e14f862304f7281f8f7347483-ltm-1.0.zip";
   }
   {
-    name = "xmlsec1-1.2.28.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/xmlsec1-1.2.28.tar.gz";
-    sha256 = "13eec4811ea30e3f0e16a734d1dbf7f9d246a71d540b48d143a07b489f6222d4";
+    name = "xmlsec1-1.2.30.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/xmlsec1-1.2.30.tar.gz";
+    sha256 = "2d84360b03042178def1d9ff538acacaed2b3a27411db7b2874f1612ed71abc8";
     md5 = "";
-    md5name = "13eec4811ea30e3f0e16a734d1dbf7f9d246a71d540b48d143a07b489f6222d4-xmlsec1-1.2.28.tar.gz";
+    md5name = "2d84360b03042178def1d9ff538acacaed2b3a27411db7b2874f1612ed71abc8-xmlsec1-1.2.30.tar.gz";
   }
   {
     name = "libxml2-2.9.10.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/libxml2-2.9.10.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libxml2-2.9.10.tar.gz";
     sha256 = "aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f";
     md5 = "";
     md5name = "aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f-libxml2-2.9.10.tar.gz";
   }
   {
     name = "libxslt-1.1.34.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/libxslt-1.1.34.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libxslt-1.1.34.tar.gz";
     sha256 = "98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f";
     md5 = "";
     md5name = "98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f-libxslt-1.1.34.tar.gz";
   }
   {
     name = "lp_solve_5.5.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/26b3e95ddf3d9c077c480ea45874b3b8-lp_solve_5.5.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/26b3e95ddf3d9c077c480ea45874b3b8-lp_solve_5.5.tar.gz";
     sha256 = "171816288f14215c69e730f7a4f1c325739873e21f946ff83884b350574e6695";
     md5 = "26b3e95ddf3d9c077c480ea45874b3b8";
     md5name = "26b3e95ddf3d9c077c480ea45874b3b8-lp_solve_5.5.tar.gz";
   }
   {
     name = "lxml-4.1.1.tgz";
-    url = "http://dev-www.libreoffice.org/src/lxml-4.1.1.tgz";
+    url = "https://dev-www.libreoffice.org/src/lxml-4.1.1.tgz";
     sha256 = "940caef1ec7c78e0c34b0f6b94fe42d0f2022915ffc78643d28538a5cfd0f40e";
     md5 = "";
     md5name = "940caef1ec7c78e0c34b0f6b94fe42d0f2022915ffc78643d28538a5cfd0f40e-lxml-4.1.1.tgz";
   }
   {
-    name = "mariadb_client-2.0.0-src.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/a233181e03d3c307668b4c722d881661-mariadb_client-2.0.0-src.tar.gz";
-    sha256 = "fd2f751dea049c1907735eb236aeace1d811d6a8218118b00bbaa9b84dc5cd60";
-    md5 = "a233181e03d3c307668b4c722d881661";
-    md5name = "a233181e03d3c307668b4c722d881661-mariadb_client-2.0.0-src.tar.gz";
+    name = "mariadb-connector-c-3.1.8-src.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/mariadb-connector-c-3.1.8-src.tar.gz";
+    sha256 = "431434d3926f4bcce2e5c97240609983f60d7ff50df5a72083934759bb863f7b";
+    md5 = "";
+    md5name = "431434d3926f4bcce2e5c97240609983f60d7ff50df5a72083934759bb863f7b-mariadb-connector-c-3.1.8-src.tar.gz";
   }
   {
-    name = "mdds-1.4.3.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/mdds-1.4.3.tar.bz2";
-    sha256 = "25ce3d5af9f6609e1de05bb22b2316e57b74a72a5b686fbb2da199da72349c81";
+    name = "mdds-1.6.0.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/mdds-1.6.0.tar.bz2";
+    sha256 = "f1585c9cbd12f83a6d43d395ac1ab6a9d9d5d77f062c7b5f704e24ed72dae07d";
     md5 = "";
-    md5name = "25ce3d5af9f6609e1de05bb22b2316e57b74a72a5b686fbb2da199da72349c81-mdds-1.4.3.tar.bz2";
+    md5name = "f1585c9cbd12f83a6d43d395ac1ab6a9d9d5d77f062c7b5f704e24ed72dae07d-mdds-1.6.0.tar.bz2";
   }
   {
     name = "mDNSResponder-878.200.35.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/mDNSResponder-878.200.35.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/mDNSResponder-878.200.35.tar.gz";
     sha256 = "e777b4d7dbf5eb1552cb80090ad1ede319067ab6e45e3990d68aabf6e8b3f5a0";
     md5 = "";
     md5name = "e777b4d7dbf5eb1552cb80090ad1ede319067ab6e45e3990d68aabf6e8b3f5a0-mDNSResponder-878.200.35.tar.gz";
   }
   {
     name = "libmspub-0.1.4.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libmspub-0.1.4.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libmspub-0.1.4.tar.xz";
     sha256 = "ef36c1a1aabb2ba3b0bedaaafe717bf4480be2ba8de6f3894be5fd3702b013ba";
     md5 = "";
     md5name = "ef36c1a1aabb2ba3b0bedaaafe717bf4480be2ba8de6f3894be5fd3702b013ba-libmspub-0.1.4.tar.xz";
   }
   {
-    name = "libmwaw-0.3.15.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libmwaw-0.3.15.tar.xz";
-    sha256 = "0440bb09f05e3419423d8dfa36ee847056ebfd837f9cbc091fdb5b057daab0b1";
+    name = "libmwaw-0.3.16.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libmwaw-0.3.16.tar.xz";
+    sha256 = "0c639edba5297bde5575193bf5b5f2f469956beaff5c0206d91ce9df6bde1868";
     md5 = "";
-    md5name = "0440bb09f05e3419423d8dfa36ee847056ebfd837f9cbc091fdb5b057daab0b1-libmwaw-0.3.15.tar.xz";
+    md5name = "0c639edba5297bde5575193bf5b5f2f469956beaff5c0206d91ce9df6bde1868-libmwaw-0.3.16.tar.xz";
   }
   {
     name = "mythes-1.2.4.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
     sha256 = "1e81f395d8c851c3e4e75b568e20fa2fa549354e75ab397f9de4b0e0790a305f";
     md5 = "a8c2c5b8f09e7ede322d5c602ff6a4b6";
     md5name = "a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
   }
   {
     name = "neon-0.30.2.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/neon-0.30.2.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/neon-0.30.2.tar.gz";
     sha256 = "db0bd8cdec329b48f53a6f00199c92d5ba40b0f015b153718d1b15d3d967fbca";
     md5 = "";
     md5name = "db0bd8cdec329b48f53a6f00199c92d5ba40b0f015b153718d1b15d3d967fbca-neon-0.30.2.tar.gz";
   }
   {
-    name = "nss-3.47.1-with-nspr-4.23.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/nss-3.47.1-with-nspr-4.23.tar.gz";
-    sha256 = "07d4276168f59bb3038c7826dabb5fbfbab8336ddf65e4e6e43bce89ada78c64";
+    name = "nss-3.55-with-nspr-4.27.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/nss-3.55-with-nspr-4.27.tar.gz";
+    sha256 = "ec6032d78663c6ef90b4b83eb552dedf721d2bce208cec3bf527b8f637db7e45";
     md5 = "";
-    md5name = "07d4276168f59bb3038c7826dabb5fbfbab8336ddf65e4e6e43bce89ada78c64-nss-3.47.1-with-nspr-4.23.tar.gz";
+    md5name = "ec6032d78663c6ef90b4b83eb552dedf721d2bce208cec3bf527b8f637db7e45-nss-3.55-with-nspr-4.27.tar.gz";
   }
   {
     name = "libodfgen-0.1.6.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/libodfgen-0.1.6.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/libodfgen-0.1.6.tar.bz2";
     sha256 = "2c7b21892f84a4c67546f84611eccdad6259875c971e98ddb027da66ea0ac9c2";
     md5 = "";
     md5name = "2c7b21892f84a4c67546f84611eccdad6259875c971e98ddb027da66ea0ac9c2-libodfgen-0.1.6.tar.bz2";
   }
   {
-    name = "odfvalidator-1.2.0-incubating-SNAPSHOT-jar-with-dependencies-971c54fd38a968f5860014b44301872706f9e540.jar";
-    url = "http://dev-www.libreoffice.org/src/../extern/odfvalidator-1.2.0-incubating-SNAPSHOT-jar-with-dependencies-971c54fd38a968f5860014b44301872706f9e540.jar";
-    sha256 = "984f2a479df79e27e7b01a5815ac53ae64e07746b882262d8a64566494515504";
+    name = "odfvalidator-0.9.0-RC2-SNAPSHOT-jar-with-dependencies-2726ab578664434a545f8379a01a9faffac0ae73.jar";
+    url = "https://dev-www.libreoffice.org/src/../extern/odfvalidator-0.9.0-RC2-SNAPSHOT-jar-with-dependencies-2726ab578664434a545f8379a01a9faffac0ae73.jar";
+    sha256 = "d55495ab3a86544650587de2a72180ddf8bfc6376d14ddfa923992dbc86a06e0";
     md5 = "";
-    md5name = "984f2a479df79e27e7b01a5815ac53ae64e07746b882262d8a64566494515504-odfvalidator-1.2.0-incubating-SNAPSHOT-jar-with-dependencies-971c54fd38a968f5860014b44301872706f9e540.jar";
+    md5name = "d55495ab3a86544650587de2a72180ddf8bfc6376d14ddfa923992dbc86a06e0-odfvalidator-0.9.0-RC2-SNAPSHOT-jar-with-dependencies-2726ab578664434a545f8379a01a9faffac0ae73.jar";
   }
   {
     name = "officeotron-0.7.4-master.jar";
-    url = "http://dev-www.libreoffice.org/src/../extern/8249374c274932a21846fa7629c2aa9b-officeotron-0.7.4-master.jar";
+    url = "https://dev-www.libreoffice.org/src/../extern/8249374c274932a21846fa7629c2aa9b-officeotron-0.7.4-master.jar";
     sha256 = "f2443f27561af52324eee03a1892d9f569adc8db9e7bca55614898bc2a13a770";
     md5 = "8249374c274932a21846fa7629c2aa9b";
     md5name = "8249374c274932a21846fa7629c2aa9b-officeotron-0.7.4-master.jar";
   }
   {
     name = "openldap-2.4.45.tgz";
-    url = "http://dev-www.libreoffice.org/src/openldap-2.4.45.tgz";
+    url = "https://dev-www.libreoffice.org/src/openldap-2.4.45.tgz";
     sha256 = "cdd6cffdebcd95161a73305ec13fc7a78e9707b46ca9f84fb897cd5626df3824";
     md5 = "";
     md5name = "cdd6cffdebcd95161a73305ec13fc7a78e9707b46ca9f84fb897cd5626df3824-openldap-2.4.45.tgz";
   }
   {
     name = "openssl-1.0.2t.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/openssl-1.0.2t.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/openssl-1.0.2t.tar.gz";
     sha256 = "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc";
     md5 = "";
     md5name = "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc-openssl-1.0.2t.tar.gz";
   }
   {
-    name = "liborcus-0.14.1.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/liborcus-0.14.1.tar.gz";
-    sha256 = "3f48cfbc21ad74787218284939c04d42cb836c73bc393f27f538b668e4d78a5f";
+    name = "liborcus-0.15.4.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/liborcus-0.15.4.tar.bz2";
+    sha256 = "cfb2aa60825f2a78589ed030c07f46a1ee16ef8a2d1bf2279192fbc1ae5a5f61";
     md5 = "";
-    md5name = "3f48cfbc21ad74787218284939c04d42cb836c73bc393f27f538b668e4d78a5f-liborcus-0.14.1.tar.gz";
+    md5name = "cfb2aa60825f2a78589ed030c07f46a1ee16ef8a2d1bf2279192fbc1ae5a5f61-liborcus-0.15.4.tar.bz2";
   }
   {
     name = "owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
     sha256 = "b18b3e3ef7fae6a79b62f2bb43cc47a5346b6330f6a383dc4be34439aca5e9fb";
     md5 = "";
     md5name = "b18b3e3ef7fae6a79b62f2bb43cc47a5346b6330f6a383dc4be34439aca5e9fb-owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
   }
   {
     name = "libpagemaker-0.0.4.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libpagemaker-0.0.4.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libpagemaker-0.0.4.tar.xz";
     sha256 = "66adacd705a7d19895e08eac46d1e851332adf2e736c566bef1164e7a442519d";
     md5 = "";
     md5name = "66adacd705a7d19895e08eac46d1e851332adf2e736c566bef1164e7a442519d-libpagemaker-0.0.4.tar.xz";
   }
   {
-    name = "pdfium-3794.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/pdfium-3794.tar.bz2";
-    sha256 = "e3faddcf741336c64ca2e6f72b23e9e60979969b2cf67c878c9a5bc38328cfc4";
+    name = "pdfium-4306.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/pdfium-4306.tar.bz2";
+    sha256 = "eca406d47ac7e2a84dcc86f93c08f96e591d409589e881477fa75e488e4851d8";
     md5 = "";
-    md5name = "e3faddcf741336c64ca2e6f72b23e9e60979969b2cf67c878c9a5bc38328cfc4-pdfium-3794.tar.bz2";
+    md5name = "eca406d47ac7e2a84dcc86f93c08f96e591d409589e881477fa75e488e4851d8-pdfium-4306.tar.bz2";
   }
   {
     name = "pixman-0.34.0.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/e80ebae4da01e77f68744319f01d52a3-pixman-0.34.0.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/e80ebae4da01e77f68744319f01d52a3-pixman-0.34.0.tar.gz";
     sha256 = "21b6b249b51c6800dc9553b65106e1e37d0e25df942c90531d4c3997aa20a88e";
     md5 = "e80ebae4da01e77f68744319f01d52a3";
     md5name = "e80ebae4da01e77f68744319f01d52a3-pixman-0.34.0.tar.gz";
   }
   {
     name = "libpng-1.6.37.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libpng-1.6.37.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libpng-1.6.37.tar.xz";
     sha256 = "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca";
     md5 = "";
     md5name = "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca-libpng-1.6.37.tar.xz";
   }
   {
     name = "poppler-0.82.0.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/poppler-0.82.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/poppler-0.82.0.tar.xz";
     sha256 = "234f8e573ea57fb6a008e7c1e56bfae1af5d1adf0e65f47555e1ae103874e4df";
     md5 = "";
     md5name = "234f8e573ea57fb6a008e7c1e56bfae1af5d1adf0e65f47555e1ae103874e4df-poppler-0.82.0.tar.xz";
   }
   {
     name = "postgresql-9.2.24.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/postgresql-9.2.24.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/postgresql-9.2.24.tar.bz2";
     sha256 = "a754c02f7051c2f21e52f8669a421b50485afcde9a581674d6106326b189d126";
     md5 = "";
     md5name = "a754c02f7051c2f21e52f8669a421b50485afcde9a581674d6106326b189d126-postgresql-9.2.24.tar.bz2";
   }
   {
-    name = "Python-3.5.9.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/Python-3.5.9.tar.xz";
-    sha256 = "c24a37c63a67f53bdd09c5f287b5cff8e8b98f857bf348c577d454d3f74db049";
+    name = "Python-3.7.7.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/Python-3.7.7.tar.xz";
+    sha256 = "06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136";
     md5 = "";
-    md5name = "c24a37c63a67f53bdd09c5f287b5cff8e8b98f857bf348c577d454d3f74db049-Python-3.5.9.tar.xz";
+    md5name = "06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136-Python-3.7.7.tar.xz";
+  }
+  {
+    name = "QR-Code-generator-1.4.0.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/QR-Code-generator-1.4.0.tar.gz";
+    sha256 = "fcdf9fd69fde07ae4dca2351d84271a9de8093002f733b77c70f52f1630f6e4a";
+    md5 = "";
+    md5name = "fcdf9fd69fde07ae4dca2351d84271a9de8093002f733b77c70f52f1630f6e4a-QR-Code-generator-1.4.0.tar.gz";
   }
   {
     name = "libqxp-0.0.2.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libqxp-0.0.2.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libqxp-0.0.2.tar.xz";
     sha256 = "e137b6b110120a52c98edd02ebdc4095ee08d0d5295a94316a981750095a945c";
     md5 = "";
     md5name = "e137b6b110120a52c98edd02ebdc4095ee08d0d5295a94316a981750095a945c-libqxp-0.0.2.tar.xz";
   }
   {
     name = "raptor2-2.0.15.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/a39f6c07ddb20d7dd2ff1f95fa21e2cd-raptor2-2.0.15.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/a39f6c07ddb20d7dd2ff1f95fa21e2cd-raptor2-2.0.15.tar.gz";
     sha256 = "ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed";
     md5 = "a39f6c07ddb20d7dd2ff1f95fa21e2cd";
     md5name = "a39f6c07ddb20d7dd2ff1f95fa21e2cd-raptor2-2.0.15.tar.gz";
   }
   {
     name = "rasqal-0.9.33.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/1f5def51ca0026cd192958ef07228b52-rasqal-0.9.33.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/1f5def51ca0026cd192958ef07228b52-rasqal-0.9.33.tar.gz";
     sha256 = "6924c9ac6570bd241a9669f83b467c728a322470bf34f4b2da4f69492ccfd97c";
     md5 = "1f5def51ca0026cd192958ef07228b52";
     md5name = "1f5def51ca0026cd192958ef07228b52-rasqal-0.9.33.tar.gz";
   }
   {
     name = "redland-1.0.17.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/e5be03eda13ef68aabab6e42aa67715e-redland-1.0.17.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/e5be03eda13ef68aabab6e42aa67715e-redland-1.0.17.tar.gz";
     sha256 = "de1847f7b59021c16bdc72abb4d8e2d9187cd6124d69156f3326dd34ee043681";
     md5 = "e5be03eda13ef68aabab6e42aa67715e";
     md5name = "e5be03eda13ef68aabab6e42aa67715e-redland-1.0.17.tar.gz";
   }
   {
     name = "librevenge-0.0.4.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/librevenge-0.0.4.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/librevenge-0.0.4.tar.bz2";
     sha256 = "c51601cd08320b75702812c64aae0653409164da7825fd0f451ac2c5dbe77cbf";
     md5 = "";
     md5name = "c51601cd08320b75702812c64aae0653409164da7825fd0f451ac2c5dbe77cbf-librevenge-0.0.4.tar.bz2";
   }
   {
     name = "rhino1_5R5.zip";
-    url = "http://dev-www.libreoffice.org/src/798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip";
+    url = "https://dev-www.libreoffice.org/src/798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip";
     sha256 = "1fb458d6aab06932693cc8a9b6e4e70944ee1ff052fa63606e3131df34e21753";
     md5 = "798b2ffdc8bcfe7bca2cf92b62caf685";
     md5name = "798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip";
   }
   {
     name = "serf-1.2.1.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/serf-1.2.1.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/serf-1.2.1.tar.bz2";
     sha256 = "6988d394b62c3494635b6f0760bc3079f9a0cd380baf0f6b075af1eb9fa5e700";
     md5 = "";
     md5name = "6988d394b62c3494635b6f0760bc3079f9a0cd380baf0f6b075af1eb9fa5e700-serf-1.2.1.tar.bz2";
   }
   {
-    name = "libstaroffice-0.0.6.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libstaroffice-0.0.6.tar.xz";
-    sha256 = "6b00e1ed8194e6072be4441025d1b888e39365727ed5b23e0e8c92c4009d1ec4";
+    name = "skia-m85-e684c6daef6bfb774a325a069eda1f76ca6ac26c.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/skia-m85-e684c6daef6bfb774a325a069eda1f76ca6ac26c.tar.xz";
+    sha256 = "3294877fa2b61b220d98a0f7bfc11325429b13edd2cf455444c703ee3a14d760";
     md5 = "";
-    md5name = "6b00e1ed8194e6072be4441025d1b888e39365727ed5b23e0e8c92c4009d1ec4-libstaroffice-0.0.6.tar.xz";
+    md5name = "3294877fa2b61b220d98a0f7bfc11325429b13edd2cf455444c703ee3a14d760-skia-m85-e684c6daef6bfb774a325a069eda1f76ca6ac26c.tar.xz";
+  }
+  {
+    name = "libstaroffice-0.0.7.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libstaroffice-0.0.7.tar.xz";
+    sha256 = "f94fb0ad8216f97127bedef163a45886b43c62deac5e5b0f5e628e234220c8db";
+    md5 = "";
+    md5name = "f94fb0ad8216f97127bedef163a45886b43c62deac5e5b0f5e628e234220c8db-libstaroffice-0.0.7.tar.xz";
   }
   {
     name = "swingExSrc.zip";
-    url = "http://dev-www.libreoffice.org/src/35c94d2df8893241173de1d16b6034c0-swingExSrc.zip";
+    url = "https://dev-www.libreoffice.org/src/35c94d2df8893241173de1d16b6034c0-swingExSrc.zip";
     sha256 = "64585ac36a81291a58269ec5347e7e3e2e8596dbacb9221015c208191333c6e1";
     md5 = "35c94d2df8893241173de1d16b6034c0";
     md5name = "35c94d2df8893241173de1d16b6034c0-swingExSrc.zip";
   }
   {
     name = "twaindsm_2.4.1.orig.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/twaindsm_2.4.1.orig.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/twaindsm_2.4.1.orig.tar.gz";
     sha256 = "82c818be771f242388457aa8c807e4b52aa84dc22b21c6c56184a6b4cbb085e6";
     md5 = "";
     md5name = "82c818be771f242388457aa8c807e4b52aa84dc22b21c6c56184a6b4cbb085e6-twaindsm_2.4.1.orig.tar.gz";
   }
   {
     name = "ucpp-1.3.2.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz";
     sha256 = "983941d31ee8d366085cadf28db75eb1f5cb03ba1e5853b98f12f7f51c63b776";
     md5 = "0168229624cfac409e766913506961a8";
     md5name = "0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz";
   }
   {
     name = "libvisio-0.1.7.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libvisio-0.1.7.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libvisio-0.1.7.tar.xz";
     sha256 = "8faf8df870cb27b09a787a1959d6c646faa44d0d8ab151883df408b7166bea4c";
     md5 = "";
     md5name = "8faf8df870cb27b09a787a1959d6c646faa44d0d8ab151883df408b7166bea4c-libvisio-0.1.7.tar.xz";
   }
   {
     name = "libwpd-0.10.3.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libwpd-0.10.3.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libwpd-0.10.3.tar.xz";
     sha256 = "2465b0b662fdc5d4e3bebcdc9a79027713fb629ca2bff04a3c9251fdec42dd09";
     md5 = "";
     md5name = "2465b0b662fdc5d4e3bebcdc9a79027713fb629ca2bff04a3c9251fdec42dd09-libwpd-0.10.3.tar.xz";
   }
   {
     name = "libwpg-0.3.3.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libwpg-0.3.3.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libwpg-0.3.3.tar.xz";
     sha256 = "99b3f7f8832385748582ab8130fbb9e5607bd5179bebf9751ac1d51a53099d1c";
     md5 = "";
     md5name = "99b3f7f8832385748582ab8130fbb9e5607bd5179bebf9751ac1d51a53099d1c-libwpg-0.3.3.tar.xz";
   }
   {
-    name = "libwps-0.4.10.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libwps-0.4.10.tar.xz";
-    sha256 = "1421e034286a9f96d3168a1c54ea570ee7aa008ca07b89de005ad5ce49fb29ca";
+    name = "libwps-0.4.11.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libwps-0.4.11.tar.xz";
+    sha256 = "a8fdaabc28654a975fa78c81873ac503ba18f0d1cdbb942f470a21d29284b4d1";
     md5 = "";
-    md5name = "1421e034286a9f96d3168a1c54ea570ee7aa008ca07b89de005ad5ce49fb29ca-libwps-0.4.10.tar.xz";
+    md5name = "a8fdaabc28654a975fa78c81873ac503ba18f0d1cdbb942f470a21d29284b4d1-libwps-0.4.11.tar.xz";
   }
   {
     name = "xsltml_2.1.2.zip";
-    url = "http://dev-www.libreoffice.org/src/a7983f859eafb2677d7ff386a023bc40-xsltml_2.1.2.zip";
+    url = "https://dev-www.libreoffice.org/src/a7983f859eafb2677d7ff386a023bc40-xsltml_2.1.2.zip";
     sha256 = "75823776fb51a9c526af904f1503a7afaaab900fba83eda64f8a41073724c870";
     md5 = "a7983f859eafb2677d7ff386a023bc40";
     md5name = "a7983f859eafb2677d7ff386a023bc40-xsltml_2.1.2.zip";
   }
   {
     name = "zlib-1.2.11.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/zlib-1.2.11.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/zlib-1.2.11.tar.xz";
     sha256 = "4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066";
     md5 = "";
     md5name = "4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066-zlib-1.2.11.tar.xz";
   }
   {
     name = "libzmf-0.0.2.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libzmf-0.0.2.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libzmf-0.0.2.tar.xz";
     sha256 = "27051a30cb057fdb5d5de65a1f165c7153dc76e27fe62251cbb86639eb2caf22";
     md5 = "";
     md5name = "27051a30cb057fdb5d5de65a1f165c7153dc76e27fe62251cbb86639eb2caf22-libzmf-0.0.2.tar.xz";

--- a/pkgs/applications/office/libreoffice/src-still/override.nix
+++ b/pkgs/applications/office/libreoffice/src-still/override.nix
@@ -1,19 +1,10 @@
-{ lib, kdeIntegration, fetchpatch, ... }:
+{ lib, kdeIntegration, ... }:
 attrs:
 {
-  patches = attrs.patches or [ ] ++ [
-    (fetchpatch {
-      url = "https://git.pld-linux.org/gitweb.cgi?p=packages/libreoffice.git;a=blob_plain;f=poppler-0.86.patch;h=76b8356d5f22ef537a83b0f9b0debab591f152fe;hb=a2737a61353e305a9ee69640fb20d4582c218008";
-      name = "poppler-0.86.patch";
-      sha256 = "0q6k4l8imgp8ailcv0qx5l83afyw44hah24fi7gjrm9xgv5sbb8j";
-    })
-  ];
   postConfigure = attrs.postConfigure + ''
-    sed -e '/CPPUNIT_TEST(Import_Export_Import);/d' -i './sw/qa/extras/inc/swmodeltestbase.hxx'
+    sed -e '/CPPUNIT_TEST(Import_Export_Import);/d' -i './sw/qa/inc/swmodeltestbase.hxx'
   '';
-  configureFlags = lib.remove "--without-system-qrcodegen"
-  (attrs.configureFlags ++ [
-    (lib.enableFeature kdeIntegration "kde5")
-  ]);
-  meta = attrs.meta // { description = "Comprehensive, professional-quality productivity suite (Still/Stable release)"; };
+  configureFlags = attrs.configureFlags ++ [
+    (lib.enableFeature kdeIntegration "kf5")
+  ];
 }

--- a/pkgs/applications/office/libreoffice/src-still/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-still/primary.nix
@@ -6,9 +6,9 @@ rec {
     inherit sha256;
   };
 
-  major = "6";
-  minor = "3";
-  patch = "5";
+  major = "7";
+  minor = "0";
+  patch = "4";
   tweak = "2";
 
   subdir = "${major}.${minor}.${patch}";
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "0jnayv1i0iq1gpf3q3z9nfq6jid77d0c76675lkqb3gi07f63nzz";
+    sha256 = "1g9akxvm7fh6lnprnc3g184qdy8gbinhb4rb60gjpw82ip6d5acz";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    sha256 = "01g09bbn1ixrsfj4l0x6x8p06dz9hnlrhnr3f3xb42drmi9ipvjv";
+    sha256 = "1v3kpk56fm783d5wihx41jqidpclizkfxrg4n0pq95d79hdiljsl";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    sha256 = "1p38wlclv6cbjpkkq7n2mjpxy84pxi4vxc9s5kjp4dm63zzxafd6";
+    sha256 = "1np9f799ww12kggl5az6piv5fi9rf737il5a5r47r4wl2li56qqb";
   };
 }

--- a/pkgs/development/libraries/neon/default.nix
+++ b/pkgs/development/libraries/neon/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libxml2, pkg-config, perl
+{ lib, stdenv, fetchurl, libxml2, pkg-config
 , compressionSupport ? true, zlib ? null
 , sslSupport ? true, openssl ? null
 , static ? stdenv.hostPlatform.isStatic
@@ -14,12 +14,12 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "0.31.0";
+  version = "0.31.2";
   pname = "neon";
 
   src = fetchurl {
-    url = "http://www.webdav.org/neon/${pname}-${version}.tar.gz";
-    sha256 = "19dx4rsqrck9jl59y4ad9jf115hzh6pz1hcl2dnlfc84hc86ymc0";
+    url = "https://notroj.github.io/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "0y46dbhiblcvg8k41bdydr3fivghwk73z040ki5825d24ynf67ng";
   };
 
   patches = optionals stdenv.isDarwin [ ./0.29.6-darwin-fix-configure.patch ];
@@ -37,12 +37,10 @@ stdenv.mkDerivation rec {
 
   passthru = {inherit compressionSupport sslSupport;};
 
-  checkInputs = [ perl ];
-  doCheck = false; # fails, needs the net
-
   meta = with lib; {
     description = "An HTTP and WebDAV client library";
-    homepage = "http://www.webdav.org/neon/";
+    homepage = "https://notroj.github.io/neon/";
+    changelog = "https://github.com/notroj/${pname}/blob/${version}/NEWS";
     platforms = platforms.unix;
     license = licenses.lgpl2;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23230,10 +23230,7 @@ in
   libreoffice-still = lowPrio (callPackage ../applications/office/libreoffice/wrapper.nix {
     libreoffice = callPackage ../applications/office/libreoffice
       (libreoffice-args // {
-        stdenv = gcc9Stdenv; # Fails in multiple ways with gcc10
-        icu = icu64;
         variant = "still";
-        jdk = jdk8;
       });
   });
   libreoffice-still-unwrapped = libreoffice-still.libreoffice;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23212,11 +23212,10 @@ in
   };
 
   libreoffice-qt = lowPrio (callPackage ../applications/office/libreoffice/wrapper.nix {
-    libreoffice = libsForQt514.callPackage ../applications/office/libreoffice
+    libreoffice = libsForQt5.callPackage ../applications/office/libreoffice
       (libreoffice-args // {
         kdeIntegration = true;
         variant = "fresh";
-        jdk = jdk11;
       });
   });
 
@@ -23224,7 +23223,6 @@ in
     libreoffice = callPackage ../applications/office/libreoffice
       (libreoffice-args // {
         variant = "fresh";
-        jdk = jdk11;
       });
   });
   libreoffice-fresh-unwrapped = libreoffice-fresh.libreoffice;


### PR DESCRIPTION
Merge after https://github.com/NixOS/nixpkgs/pull/111877.

###### Motivation for this change
https://wiki.documentfoundation.org/ReleaseNotes/7.1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).