### PR TITLE
licenses: mark issl 'free' for inclusion in channels

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -460,7 +460,8 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
   issl = {
     fullName = "Intel Simplified Software License";
     url = "https://software.intel.com/en-us/license/intel-simplified-software-license";
-    free = false;
+    # Note: we currently consider these "free" for inclusion in the
+    # channel.
   };
 
   lgpl2Only = spdx {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The ISSL license is currently only used for Intel MKL. Motivation
to permit this license in Hydra builds:
    
- Improves performance for many numerical and machine learning libraries.
- The license allows redistribution:
  https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html#inpage-nav-3
- MKL is distributed by many other package repositories, such as
  Debian, Ubuntu, and Anaconda.

Also see discussion starting at: https://discourse.nixos.org/t/comparing-nix-and-conda/11366/8

cc @bhipple 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
