### PR TITLE
[20.09] wpa_supplicant: fix for security advisory 2020-2

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -19,6 +19,12 @@ stdenv.mkDerivation rec {
       url = "https://w1.fi/security/2019-7/0001-AP-Silently-ignore-management-frame-from-unexpected-.patch";
       sha256 = "15xjyy7crb557wxpx898b5lnyblxghlij0xby5lmj9hpwwss34dz";
     })
+    # P2P: Fix copying of secondary device types for P2P group client (https://w1.fi/security/2020-2/)
+    (fetchurl {
+      name = "CVE-2021-0326.patch";
+      url = "https://w1.fi/security/2020-2/0001-P2P-Fix-copying-of-secondary-device-types-for-P2P-gr.patch";
+      sha256 = "19f4hx0p547mdx8y8arb3vclwyy4w9c8a6a40ryj7q33730mrmn4";
+    })
   ];
 
   # TODO: Patch epoll so that the dbus actually responds


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport #111833 

A vulnerability was discovered in how wpa_supplicant processing P2P
(Wi-Fi Direct) group information from active group owners. The actual
parsing of that information validates field lengths appropriately, but
processing of the parsed information misses a length check when storing
a copy of the secondary device types. This can result in writing
attacker controlled data into the peer entry after the area assigned for
the secondary device type. The overflow can result in corrupting
pointers for heap allocations. This can result in an attacker within
radio range of the device running P2P discovery being able to cause
unexpected behavior, including termination of the wpa_supplicant process
and potentially arbitrary code execution.

https://w1.fi/security/2020-2/wpa_supplicant-p2p-group-info-processing-vulnerability.txt

Fixes: CVE-2021-0326
(cherry picked from commit 95164dc11b6dff87868e4d9bbfb565a90c783772)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
