### PR TITLE
isync: 1.3.4 -> 1.4.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -666,6 +666,12 @@ self: super:
      <varname>services.restic</varname> now uses a dedicated cache directory for every backup defined in <varname>services.restic.backups</varname>. The old global cache directory, <literal>/root/.cache/restic</literal>, is now unused and can be removed to free up disk space.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <literal>isync</literal>: The <literal>isync</literal> compatibility wrapper was removed and the Master/Slave
+     terminology has been deprecated and should be replaced with Far/Near in the configuration file.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/pkgs/tools/networking/isync/default.nix
+++ b/pkgs/tools/networking/isync/default.nix
@@ -1,18 +1,20 @@
 { lib, stdenv, fetchurl, pkg-config, perl
-, openssl, db, zlib, cyrus_sasl
+, openssl, db, cyrus_sasl, zlib
+, Security
 }:
 
 stdenv.mkDerivation rec {
   pname = "isync";
-  version = "1.3.4";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/isync/${pname}-${version}.tar.gz";
-    sha256 = "0w9fqz1qsdm1zfpv9jp5v2dav6pyigf1n6x7asxi0fg58sf49sz8";
+    sha256 = "0pkqvsdmi85xrhzzc7mz87vdvvvp01lf8akhfdnmsdlks8zbzy44";
   };
 
   nativeBuildInputs = [ pkg-config perl ];
-  buildInputs = [ openssl db cyrus_sasl zlib ];
+  buildInputs = [ openssl db cyrus_sasl zlib ]
+    ++ lib.optionals stdenv.isDarwin [ Security ];
 
   meta = with lib; {
     homepage = "http://isync.sourceforge.net/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5327,7 +5327,9 @@ in
 
   ispike = callPackage ../development/libraries/science/robotics/ispike { };
 
-  isync = callPackage ../tools/networking/isync { };
+  isync = callPackage ../tools/networking/isync {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   itm-tools = callPackage ../development/tools/misc/itm-tools { };
 


### PR DESCRIPTION
The Master/Slave configuration keywords where deprecated and should be
replaced with Far/Near. All users should update their configuration file
accordingly. It's a trivial change and the old Master/Slave keywords
will still work for now but result in the following message:
Notice: Master/Slave are deprecated; use Far/Near instead.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Not sure if we should also add a NixOS release notes entry for this or not (because existing configurations still work, there's a notice, and there could be only few isync users).

cc @KarlJoad (FYI): At some point https://github.com/nix-community/home-manager/blob/7e5fee4268f53be8758598b7634dff8b3ad8a22b/modules/programs/mbsync.nix should be updated accordingly. I guess the ideal time would be after the next stable NixOS release (so that all users have isync 1.4.x).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
