### PR TITLE
fscryptctl-experimental: 2017-10-23 -> 0.1.0

### DIFF
--- a/pkgs/os-specific/linux/fscryptctl/default.nix
+++ b/pkgs/os-specific/linux/fscryptctl/default.nix
@@ -3,24 +3,35 @@
 # Don't use this for anything important yet!
 
 stdenv.mkDerivation rec {
-  pname = "fscryptctl-unstable";
-  version = "2017-10-23";
+  pname = "fscryptctl";
+  version = "0.1.0";
 
   goPackagePath = "github.com/google/fscrypt";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "fscryptctl";
-    rev = "142326810eb19d6794793db6d24d0775a15aa8e5";
+    rev = "v${version}";
     sha256 = "1853hlpklisbqnkb7a921dsf0vp2nr2im26zpmrs592cnpsvk3hb";
   };
 
   makeFlags = [ "DESTDIR=$(out)/bin" ];
 
   meta = with lib; {
-    description = ''
-      A low-level tool that handles raw keys and manages policies for Linux
-      filesystem encryption
+    description = "Small C tool for Linux filesystem encryption";
+    longDescription = ''
+      fscryptctl is a low-level tool written in C that handles raw keys and
+      manages policies for Linux filesystem encryption, specifically the
+      "fscrypt" kernel interface which is supported by the ext4, f2fs, and
+      UBIFS filesystems.
+      fscryptctl is mainly intended for embedded systems which can't use the
+      full-featured fscrypt tool, or for testing or experimenting with the
+      kernel interface to Linux filesystem encryption. fscryptctl does not
+      handle key generation, key stretching, key wrapping, or PAM integration.
+      Most users should use the fscrypt tool instead, which supports these
+      features and generally is much easier to use.
+      As fscryptctl is intended for advanced users, you should read the kernel
+      documentation for filesystem encryption before using fscryptctl.
     '';
     inherit (src.meta) homepage;
     license = licenses.asl20;


### PR DESCRIPTION
Version 0.1.0 is based on the last commit that included support for V1
encryption policies. Version 1.0 is about to be released and will
include a PR which removes V1 policy support and adds V2 policy support.

When version 1.0 is released we'll likely package it as fscryptctl and
mark fscryptctl-experimental as broken (referring to fscryptctl).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
