### PR TITLE
python3Packages.aresponses: 2.1.2 -> 2.1.4

### DIFF
--- a/pkgs/development/python-modules/aresponses/default.nix
+++ b/pkgs/development/python-modules/aresponses/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "aresponses";
-  version = "2.1.2";
+  version = "2.1.4";
 
   disabled = !isPy3k;
 
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "CircleUp";
     repo = pname;
     rev = version;
-    sha256 = "007wrk4wdy97a81imgzxd6sm5dly9v7abmxh9fyfi0vp1p7s75bw";
+    sha256 = "sha256-crMiMZ2IDuYDFt8Bixg3NRhlUa2tqmfzd7ZeHM+2Iu4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyipp/default.nix
+++ b/pkgs/development/python-modules/pyipp/default.nix
@@ -6,7 +6,7 @@
 , fetchFromGitHub
 , pytest-asyncio
 , pytestCheckHook
-, pytestcov
+, pytest-cov
 , yarl
 }:
 
@@ -30,22 +30,8 @@ buildPythonPackage rec {
   checkInputs = [
     aresponses
     pytest-asyncio
-    pytestcov
+    pytest-cov
     pytestCheckHook
-  ];
-
-  # Some tests are failing due to encoding issues
-  # https://github.com/ctalkington/python-ipp/issues/121
-  disabledTests = [
-    "test_internal_session"
-    "test_request_port"
-    "est_http_error426"
-    "test_unexpected_response"
-    "test_printer"
-    "test_raw"
-    "test_ipp_request"
-    "test_request_tls"
-    "test_ipp_error_0x0503"
   ];
 
   pythonImportsCheck = [ "pyipp" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.4.

Change log: https://github.com/aresponses/aresponses#214

This fixes the [tests failures](https://github.com/NixOS/nixpkgs/pull/109427) of `python-ipp`. Thus now all tests are now enabled again. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
