### PR TITLE
weechatScripts.multiline: init at 0.6.3

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -1,7 +1,11 @@
-{ callPackage, luaPackages, python3Packages }:
+{ callPackage, luaPackages, perlPackages, python3Packages }:
 
 {
   colorize_nicks = callPackage ./colorize_nicks { };
+
+  multiline = callPackage ./multiline {
+    inherit (perlPackages) PodParser;
+  };
 
   weechat-matrix-bridge = callPackage ./weechat-matrix-bridge {
     inherit (luaPackages) cjson luaffi;

--- a/pkgs/applications/networking/irc/weechat/scripts/multiline/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/multiline/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchurl, substituteAll, PodParser }:
+
+stdenv.mkDerivation {
+  pname = "multiline";
+  version = "0.6.3";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/weechat/scripts/945315bed4bc2beaf1e47f9b946ffe8f638f77fe/perl/multiline.pl";
+    sha256 = "1smialb21ny7brhij4sbw46xvsmrdv6ig2da0ip63ga2afngwsy4";
+  };
+
+  dontUnpack = true;
+  prePatch = ''
+    cp $src multiline.pl
+  '';
+
+  patches = [
+    # The script requires a special Perl environment.
+    (substituteAll {
+      src = ./libpath.patch;
+      env = PodParser;
+    })
+  ];
+
+  passthru.scripts = [ "multiline.pl" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D multiline.pl $out/share/multiline.pl
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Multi-line edit box";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/applications/networking/irc/weechat/scripts/multiline/libpath.patch
+++ b/pkgs/applications/networking/irc/weechat/scripts/multiline/libpath.patch
@@ -1,0 +1,9 @@
+diff --git a/multiline.pl b/multiline.pl
+index 54474d4..42fbef8 100644
+--- a/multiline.pl
++++ b/multiline.pl
+@@ -1,3 +1,4 @@
++use lib '@env@/lib/perl5/site_perl';
+ use strict; use warnings;
+ $INC{'Encode/ConfigLocal.pm'}=1;
+ require Encode;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This pull requests introduces a new package for WeeChat's [multiline.pl](https://weechat.org/scripts/source/multiline.pl.html/) script.

One can test these changes with the following "short" one liner:
`nix-shell -I nixpkgs=/path/to/nixpkgs -p '(weechat.override { configure = {...}: { scripts = [ weechatScripts.multiline ]; };})' --run weechat`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
