### PR TITLE
palemoon: 28.17.0 -> 29.0.0, switch to gtk3

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -6,7 +6,7 @@
 , libGLU, libGL, perl, python2, libpulseaudio
 , unzip, xorg, wget, which, yasm, zip, zlib
 
-, withGTK3 ? false, gtk3
+, withGTK3 ? true, gtk3
 }:
 
 let
@@ -16,14 +16,14 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "28.17.0";
+  version = "29.0.0";
 
   src = fetchFromGitHub {
     githubBase = "repo.palemoon.org";
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "0478xn5skpls91hkraykc308hppdc8vj9xbgvlm5wkv0y4dp7h5x";
+    sha256 = "1v870kxbl7b0kazd6krjiarvbjwmv13hgwkzpi054i9cf8z7pyiv";
     fetchSubmodules = true;
   };
 
@@ -119,6 +119,9 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     ./mach install
 
+    # Fix missing icon due to wrong WMClass
+    substituteInPlace ./palemoon/branding/official/palemoon.desktop \
+      --replace 'StartupWMClass="pale moon"' 'StartupWMClass=Pale moon'
     desktop-file-install --dir=$out/share/applications \
       ./palemoon/branding/official/palemoon.desktop
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24108,8 +24108,8 @@ in
   osmo = callPackage ../applications/office/osmo { };
 
   palemoon = callPackage ../applications/networking/browsers/palemoon {
-    # https://www.palemoon.org/sourcecode.shtml
-    stdenv = gcc7Stdenv;
+    # https://developer.palemoon.org/build/linux/
+    stdenv = gcc8Stdenv;
   };
 
   webbrowser = callPackage ../applications/networking/browsers/webbrowser {};


### PR DESCRIPTION
###### Motivation for this change
https://www.palemoon.org/releasenotes.shtml

New release.

> - Fixed a memory safety issue related to XUL trees (CVE-2021-23962).
> - Implemented several defense-in-depth measures to improve stability and future security.
> - Unified XUL Platform Mozilla Security Patch Summary: 1 fixed, 6 DiD, 1 already implemented, 1 deferred to the next release, 24 not applicable.

Moved to a GTK3 build now that it's officially supported.

> We now offer official GTK3 builds for Linux alongside the GTK2 builds.

Fixed wrong StartupWMClass setting in the (also currently) shipped desktop file causing a missing app icon under Pantheon. (don't know about other DE/WMs, just happened to try Pantheon once)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
