### PR TITLE
home-assistant: improve checkInputs package selection

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -96,22 +96,43 @@ in with py.pkgs; buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = [
-    # From setup.py
-    aiohttp astral async-timeout attrs bcrypt certifi ciso8601 httpx jinja2
-    pyjwt cryptography pip python-slugify pytz pyyaml requests ruamel_yaml
-    setuptools voluptuous voluptuous-serialize yarl
-    # From default_config. dhcp, frontend, http, image, mobile_app and
-    # recorder components as well as the auth.mfa_modules.totp module
-    aiohttp-cors aiohue defusedxml distro emoji hass-frontend pynacl pillow pyotp
-    pyqrcode scapy sqlalchemy python-openzwave-mqtt
+    # Only packages required in setup.py + hass-frontend
+    aiohttp
+    astral
+    async-timeout
+    attrs
+    bcrypt
+    certifi
+    ciso8601
+    cryptography
+    hass-frontend
+    httpx
+    jinja2
+    pip
+    pyjwt
+    python-slugify
+    pytz
+    pyyaml
+    requests
+    ruamel_yaml
+    voluptuous
+    voluptuous-serialize
+    yarl
   ] ++ componentBuildInputs ++ extraBuildInputs;
 
   # upstream only tests on Linux, so do we.
   doCheck = stdenv.isLinux;
 
   checkInputs = [
-    asynctest pytestCheckHook pytest-aiohttp pytest_xdist requests-mock hass-nabucasa netdisco pydispatcher
-  ];
+    # test infrastructure
+    asynctest
+    pytest-aiohttp
+    pytest-xdist
+    pytestCheckHook
+    requests-mock
+    # component dependencies
+    pyotp
+  ] ++ lib.concatMap (component: getPackages component py.pkgs) componentTests;
 
   # We cannot test all components, since they'd introduce lots of dependencies, some of which are unpackaged,
   # but we should test very common stuff, like what's in `default_config`.
@@ -131,6 +152,7 @@ in with py.pkgs; buildPythonApplication rec {
     "history"
     "homeassistant"
     "http"
+    "hue"
     "input_boolean"
     "input_datetime"
     "input_text"
@@ -154,6 +176,7 @@ in with py.pkgs; buildPythonApplication rec {
     "websocket_api"
     "zeroconf"
     "zone"
+    "zwave"
   ];
 
   pytestFlagsArray = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

and migrate unnecessary packages out of propagatedBuildInputs. This
shrinks the whole package by ~65%.

```
/nix/store/wdhqcxhp45p287zknw3r0cv7pxgp6r14-homeassistant-2021.2.0	 696.7M
/nix/store/1v20wdqfn4v1nf3v2jmlkx89q18n8fzx-homeassistant-2021.2.0	 250.8M
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
