### PR TITLE
lagrange: 1.1.0 → 1.1.1

### DIFF
--- a/pkgs/applications/networking/browsers/lagrange/default.nix
+++ b/pkgs/applications/networking/browsers/lagrange/default.nix
@@ -1,9 +1,11 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, nix-update-script
 , cmake
 , pkg-config
 , libunistring
+, mpg123
 , openssl
 , pcre
 , SDL2
@@ -12,19 +14,19 @@
 
 stdenv.mkDerivation rec {
   pname = "lagrange";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "skyjake";
     repo = "lagrange";
     rev = "v${version}";
-    sha256 = "04bp5k1byjbzwnmcx4b7sw68pr2jrj4c21z76jq311hyrmanj6fi";
+    sha256 = "0c7w4a19cwx3bkmbhc9c1wx0zmqd3a1grrj4ffifdic95wdihv7x";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ libunistring openssl pcre SDL2 ]
+  buildInputs = [ libunistring mpg123 openssl pcre SDL2 ]
     ++ lib.optional stdenv.isDarwin AppKit;
 
   hardeningDisable = lib.optional (!stdenv.cc.isClang) "format";
@@ -33,6 +35,12 @@ stdenv.mkDerivation rec {
     mkdir -p $out/Applications
     mv Lagrange.app $out/Applications
   '' else null;
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
 
   meta = with lib; {
     description = "A Beautiful Gemini Client";


### PR DESCRIPTION
###### Motivation for this change
* [changelog](https://github.com/skyjake/lagrange/releases/tag/v1.1.1)
* added `mpg123` input for MPEG audio support
* added `passthru.updateScript`

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
