### PR TITLE
nixos/cri-o: add OCI seccomp bpf hook support

### DIFF
--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -103,7 +103,10 @@ in
       cgroup_manager = "systemd"
       log_level = "${cfg.logLevel}"
       pinns_path = "${cfg.package}/bin/pinns"
-      hooks_dir = []
+      hooks_dir = [
+      ${lib.optionalString config.virtualisation.containers.ociSeccompBpfHook.enable
+        ''"${config.boot.kernelPackages.oci-seccomp-bpf-hook}",''}
+      ]
 
       ${optionalString (cfg.runtime != null) ''
       default_runtime = "${cfg.runtime}"


### PR DESCRIPTION
###### Motivation for this change
We now set the hooks dir correctly if the OCI hook is enabled. CRI-O
supports this specific hook from v1.20.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/podman 