### PR TITLE
python3Packages.uarray: 0.6.0 -> 0.8.2

### DIFF
--- a/pkgs/development/python-modules/uarray/default.nix
+++ b/pkgs/development/python-modules/uarray/default.nix
@@ -1,33 +1,43 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , fetchpatch
 , matchpy
 , numpy
 , astunparse
 , typing-extensions
-, black
-, pytest
+, pytestCheckHook
 , pytestcov
-, numba
-, nbval
-, python
-, isPy37
 }:
 
 buildPythonPackage rec {
   pname = "uarray";
-  version = "0.6.0";
+  version = "0.8.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "fa63ae7034833a99bc1628d3cd5501d4d00f2e6437b6cbe73f710dcf212a6bea";
+  src = fetchFromGitHub {
+    owner = "Quansight-Labs";
+    repo = pname;
+    rev = version;
+    sha256 = "1x2jp7w2wmn2awyv05xs0frpq0fa0rprwcxyg72wgiss0bnzxnhm";
   };
 
-  doCheck = false; # currently has circular dependency module import, remove when bumping to >0.5.1
-  checkInputs = [ pytest nbval pytestcov numba ];
-  propagatedBuildInputs = [ matchpy numpy astunparse typing-extensions black ];
+  patches = [(
+    # Fixes a compile error with newer versions of GCC -- should be included
+    # in the next release after 0.8.2
+    fetchpatch {
+      url = "https://github.com/Quansight-Labs/uarray/commit/a2012fc7bb94b3773eb402c6fe1ba1a894ea3d18.patch";
+      sha256 = "1qqh407qg5dz6x766mya2bxrk0ffw5h17k478f5kcs53g4dyfc3s";
+    }
+  )];
 
+  checkInputs = [ pytestCheckHook pytestcov ];
+  propagatedBuildInputs = [ matchpy numpy astunparse typing-extensions ];
+
+  # Tests must be run from outside the source directory
+  preCheck = ''
+    cd $TMP
+  '';
+  pytestFlagsArray = ["--pyargs" "uarray"];
   pythonImportsCheck = [ "uarray" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`python3Packages.uarray` has been [broken on hydra](https://hydra.nixos.org/build/135917908) for a little while. This fixes it and re-enables tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

----------------------------

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>python37Packages.uarray</li>
    <li>python38Packages.uarray</li>
    <li>python39Packages.uarray</li>
  </ul>
</details>