### PR TITLE
swagger-codegen3: init at 3.0.25

### DIFF
--- a/pkgs/tools/networking/swagger-codegen/default.nix
+++ b/pkgs/tools/networking/swagger-codegen/default.nix
@@ -15,12 +15,12 @@ stdenv.mkDerivation rec {
     sha256 = "04wl5k8k1ziqz7k5w0g7i6zdfn41pbh3k0m8vq434k1886inf8yn";
   };
 
-  phases = [ "installPhase" ];
+  dontUnpack = true;
 
   installPhase = ''
-    install -D "$src" "$out/share/java/${jarfilename}"
+    install -D $src $out/share/java/${jarfilename}
 
-    makeWrapper ${jre}/bin/java $out/bin/swagger-codegen \
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
       --add-flags "-jar $out/share/java/${jarfilename}"
   '';
 

--- a/pkgs/tools/networking/swagger-codegen3/default.nix
+++ b/pkgs/tools/networking/swagger-codegen3/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  version = "3.0.25";
+  pname = "swagger-codegen";
+
+  jarfilename = "${pname}-cli-${version}.jar";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  src = fetchurl {
+    url = "https://repo1.maven.org/maven2/io/swagger/codegen/v3/${pname}-cli/${version}/${jarfilename}";
+    sha256 = "1rdz45kmmg60fs7ddnla1xq30nah6s6rd18fqbjbjxng8r92brnd";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    install -D $src $out/share/java/${jarfilename}
+
+    makeWrapper ${jre}/bin/java $out/bin/${pname}3 \
+      --add-flags "-jar $out/share/java/${jarfilename}"
+  '';
+
+  meta = with lib; {
+    description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
+    homepage = "https://github.com/swagger-api/swagger-codegen/tree/3.0.0";
+    license = licenses.asl20;
+    maintainers = [ maintainers._1000101 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8558,6 +8558,8 @@ in
 
   swagger-codegen = callPackage ../tools/networking/swagger-codegen { };
 
+  swagger-codegen3 = callPackage ../tools/networking/swagger-codegen3 { };
+
   swapview = callPackage ../os-specific/linux/swapview/default.nix { };
 
   swec = callPackage ../tools/networking/swec { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
