### PR TITLE
[A rather critical bugfix] fetchzip: fix `extraPostFetch` concatenation

### DIFF
--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -45,16 +45,17 @@
     '' else ''
       mv "$unpackDir" "$out"
     '')
-    + extraPostFetch
-    # Remove write permissions for files unpacked with write bits set
-    # Fixes https://github.com/NixOS/nixpkgs/issues/38649
-    #
-    # However, we should (for the moment) retain write permission on the directory
-    # itself, to avoid tickling https://github.com/NixOS/nix/issues/4295 in
-    # single-user Nix installations. This is because in sandbox mode we'll try to
-    # move the path, and if we don't have write permissions on the directory,
-    # then we can't update the ".." entry.
     + ''
+      ${extraPostFetch}
+
+      # Remove write permissions for files unpacked with write bits set
+      # Fixes https://github.com/NixOS/nixpkgs/issues/38649
+      #
+      # However, we should (for the moment) retain write permission on the directory
+      # itself, to avoid tickling https://github.com/NixOS/nix/issues/4295 in
+      # single-user Nix installations. This is because in sandbox mode we'll try to
+      # move the path, and if we don't have write permissions on the directory,
+      # then we can't update the ".." entry.
       chmod -R a-w "$out"
       chmod u+w "$out"
     '';

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -47,17 +47,11 @@
     '')
     + ''
       ${extraPostFetch}
-
-      # Remove write permissions for files unpacked with write bits set
-      # Fixes https://github.com/NixOS/nixpkgs/issues/38649
-      #
-      # However, we should (for the moment) retain write permission on the directory
-      # itself, to avoid tickling https://github.com/NixOS/nix/issues/4295 in
-      # single-user Nix installations. This is because in sandbox mode we'll try to
-      # move the path, and if we don't have write permissions on the directory,
-      # then we can't update the ".." entry.
-      chmod -R a-w "$out"
-      chmod u+w "$out"
+    ''
+    # Remove non-owner write permissions
+    # Fixes https://github.com/NixOS/nixpkgs/issues/38649
+    + ''
+      chmod 755 "$out"
     '';
 } // removeAttrs args [ "stripRoot" "extraPostFetch" ])).overrideAttrs (x: {
   # Hackety-hack: we actually need unzip hooks, too


### PR DESCRIPTION
4a5c49363a58e711c2016b9ebb6f642e3c9c1be5 added some more commands after
`extraPostFetch` but concatenated them without a separating newline.

Which means, that since that commit

  fetchzip { ..., extraPostFetch = ''rm -f "$out"/some-file''; }

now actually runs the following shell command

  rm -f "$out"/some-file"chmod -R a-w "$out"

thus deleting "$out". Which is very unfortunate.

Especially since this actually happens on master for all `fetchFromBitbucket`
derivations. But since the results are fixed-output users bulding with hydra
cache enabled are not hitting this for not recently updated derivations yet.

Closes #108887, which does the same thing -- I found it after I made this one -- and, IMHO, is a bit uglier, so I'm PRing this one.

Merge either one ASAP.

/cc @vcunat @grahamc @dbueno @SuperSandro2000 @metadark @bhipple