### PR TITLE
spotify-spicified: init

### DIFF
--- a/pkgs/applications/audio/spotify-spicified/README.md
+++ b/pkgs/applications/audio/spotify-spicified/README.md
@@ -1,0 +1,87 @@
+# Using Spotify-Spicified / Spicetify-cli's Nix API
+
+Spicetify-cli is a tool which edits the files from Spotify, to extend it's functionality or to theme the application. To achive this with nixpkgs, you can use Spotify-Spicified. For more information on Spicetify-cli and it's features, please refer to it's GitHub repository and wiki. https://github.com/khanhas/spicetify-cli
+
+## Basic usage
+
+When installing the package, you will keep the default Spotify experience.
+
+```nix
+{ pkgs, ... }:
+
+{
+  environment.systemPackages = [
+    pkgs.spotify-spicified
+  ];
+}
+```
+
+If you for example want to change the theme of Spotify, you can override the theme attribute.
+
+```nix
+{ pkgs, ... }:
+
+{
+  environment.systemPackages = [
+    (pkgs.spotify-spicified.override { theme = "SpicetifyDefault"; })
+  ];
+}
+```
+
+## Options
+
+The following attributes are available for changing
+| Attribute                  | Type    | Containing                                                                                                                                                                             | Default Value | Example value                               | Documentation (spicetify-cli wiki)                                           |                                                                                                      |
+|----------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|---------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| theme                      | string  | the name of the chosen theme. All community themes from [morpheusthewhite/spicetify-themes](https://github.com/morpheusthewhite/spicetify-themes) are available by default                                            | `""`          | `"Dribbblish"`                              | [Customization](https://github.com/khanhas/spicetify-cli/wiki/Customization) |                                                                                                      |
+| colorScheme                | string  | an alternative color scheme of the chosen theme                                                                                                                                        | `""`          | `"horizon"`                                 | [Customization](https://github.com/khanhas/spicetify-cli/wiki/Customization) |                                                                                                      |
+| thirdParyThemes            | set     | a set of third-party themes to be made available to be set                                                                                                                             | `{}`          | [third-party example](#third-party-example) | [Customization](https://github.com/khanhas/spicetify-cli/wiki/Customization) |                                                                                                      |
+| thirdParyExtensions        | set     | a set of third-party extensions to be made available to be set. After adding them here, they still need to be enabled with `enabledExtensions`                                         | `{}`          | [third-party example](#third-party-example) | [Extensions](https://github.com/khanhas/spicetify-cli/wiki/Extensions)       |                                                                                                      |
+| thirdParyCustomApps        | set     | a set of third-party apps to be made available to be set. After adding them here, they still need to be enabled with `enabledCustomApps`                                               | `{}`          | [third-party example](#third-party-example) | [Custom Apps](https://github.com/khanhas/spicetify-cli/wiki/Custom-Apps)     |                                                                                                      |
+| enabledExtensions          | array   | which extensions are enabled                                                                                                                                                           | `[]`          | `[ "reddit" ]`                              | [Extensions](https://github.com/khanhas/spicetify-cli/wiki/Extensions)       |                                                                                                      |
+| enabledCustomApps          | array   | which custom apps are enabled                                                                                                                                                          | `[]`          | `[ "newRelease.js" ]`                       | [Custom Apps](https://github.com/khanhas/spicetify-cli/wiki/Custom-Apps)     |                                                                                                      |
+| spotifyLaunchFlags         | string  | Command-line flags used when launching/restarting Spotify. Separate each flag with "\                                                                                                  | ".            | `""`                                        | `"`--show-console`"`                                                         | [Spotify Commandline Flags](https://github.com/khanhas/spicetify-cli/wiki/Spotify-Commandline-Flags) |
+| injectCss                  | boolean | Whether custom css from user.css in theme folder is applied. This is enabled by default when using Dribbblish as a theme                                                               | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| replaceColors              | boolean | Whether custom colors is applied. This is enabled by default when using Dribbblish as a theme                                                                                          | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| overwriteAssets            | boolean | Whether assets can be overwritten. This is enabled by default when using Dribbblish as a theme                                                                                         | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| disableSentry              | boolean | Prevents Sentry and Amazon Qualaroo to send console log/error/warning to Spotify developers. Enable if you don't want to catch their attention when developing extension or app.       | `true`        | `false`                                     |                                                                              |                                                                                                      |
+| disableUiLogging           | boolean | Various elements logs every user clicks, scrolls. Enable to stop logging and improve user experience.                                                                                  | `true`        | `false`                                     |                                                                              |                                                                                                      |
+| removeRtlRule              | boolean | To support Arabic and other Right-To-Left language, Spotify added a lot of CSS rules that are obsoleted to Left-To-Right users. Enable to remove all of them and improve render speed. | `true`        | `false`                                     |                                                                              |                                                                                                      |
+| exposeApis                 | boolean | Leaks some Spotify's API, functions, objects to Spicetify global object that are useful for making extensions to extend Spotify functionality.                                         | `true`        | `false`                                     |                                                                              |                                                                                                      |
+| disableUpgradeCheck        | boolean | Prevent Spotify checking new version and visually notifying user.                                                                                                                      | `true`        | `false`                                     |                                                                              |                                                                                                      |
+| fastUserSwitching          | boolean | Enable/Disable ability to quickly change account. Open it in profile menu.                                                                                                             | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| visualizationHighFramerate | boolean | Force Visualization in Lyrics app to render in 60fps.                                                                                                                                  | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| radio                      | boolean | Enable/Disable Radio page. Access it in left sidebar.                                                                                                                                  | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| songPage                   | boolean | Enable/Disable ability to click at song name in player bar will access that song page (instead of its album page) to discover playlists it appearing on.                               | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| experimentalFeatures       | boolean | Enable/Disable ability access to Experimental Features of Spotify. Open it in profile menu (top right corner).                                                                         | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| home                       | boolean | Enable/Disable Home page. Access it in left sidebar.                                                                                                                                   | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| lyricAlwaysShow            | boolean | Force Lyrics button to show all the time in player bar. Useful for who want to watch visualization page.                                                                               | `false`       | `true`                                      |                                                                              |                                                                                                      |
+| lyricForceNoSync           | boolean | Force displaying all of lyrics.                                                                                                                                                        | `false`       | `true`                                      |                                                                              |                                                                                                      |
+
+
+## Third-party example
+
+To use third-party components like themes, extensions and plugins, you need to provide a set with those assets. After registering them to be found, you still need to enable them.
+
+```nix
+{ pkgs, ... }:
+
+let
+  av = pkgs.fetchFromGitHub {
+    owner = "amanharwara";
+    repo = "spicetify-autoVolume";
+    rev = "d7f7962724b567a8409ef2898602f2c57abddf5a";
+    sha256 = "1pnya2j336f847h3vgiprdys4pl0i61ivbii1wyb7yx3wscq7ass";
+  };
+in
+{
+  environment.systemPackages = [
+    (pkgs.spotify-spicified.override {
+      enabledExtensions = [ "autoVolume.js" ];
+      thirdParyExtensions = {
+        "autoVolume.js" = "${av}/autoVolume.js";
+      };
+    })
+  ];
+}
+```

--- a/pkgs/applications/audio/spotify-spicified/default.nix
+++ b/pkgs/applications/audio/spotify-spicified/default.nix
@@ -1,0 +1,118 @@
+{ lib
+, spotify-unwrapped
+, spicetify-cli
+, spicetify-themes
+
+  # Spicetify settings
+, theme ? ""
+, colorScheme ? ""
+, thirdParyThemes ? {}
+, thirdParyExtensions ? {}
+, thirdParyCustomApps ? {}
+, enabledExtensions ? []
+, enabledCustomApps ? []
+, spotifyLaunchFlags ? ""
+, injectCss ? false
+, replaceColors ? false
+, overwriteAssets ? false
+, disableSentry ? true
+, disableUiLogging ? true
+, removeRtlRule ? true
+, exposeApis ? true
+, disableUpgradeCheck ? true
+, fastUserSwitching ? false
+, visualizationHighFramerate ? false
+, radio ? false
+, songPage ? false
+, experimentalFeatures ? false
+, home ? false
+, lyricAlwaysShow ? false
+, lyricForceNoSync ? false
+}:
+
+with lib;
+
+let
+  # Helper functions
+  pipeConcat = lists.foldr (a: b: a + "|" + b) "";
+  lineBreakConcat = foldr (a: b: a + "\n" + b) "";
+  boolToString = x: if x then "1" else "0";
+  makeLnCommands = type:
+    (attrsets.mapAttrsToList (name: path: "ln -sf ${path} ./${type}/${name}"));
+
+  # Setup spicetify
+  spicetify = "SPICETIFY_CONFIG=. ${spicetify-cli}/bin/spicetify-cli";
+
+  # Dribblish is a theme which needs a couple extra settings
+  isDribblish = theme == "Dribbblish";
+
+  extraCommands = (optionalString isDribblish ''
+    cp ./Themes/Dribbblish/dribbblish.js ./Extensions
+  '') + (lineBreakConcat (makeLnCommands "Themes" thirdParyThemes))
+    + (lineBreakConcat (makeLnCommands "Extensions" thirdParyExtensions))
+    + (lineBreakConcat (makeLnCommands "CustomApps" thirdParyCustomApps));
+
+  customAppsFixupCommands =
+    lineBreakConcat (makeLnCommands "Apps" thirdParyCustomApps);
+
+  injectCssOrDribblish = boolToString (isDribblish || injectCss);
+  replaceColorsOrDribblish = boolToString (isDribblish || replaceColors);
+  overwriteAssetsOrDribblish = boolToString (isDribblish || overwriteAssets);
+
+  extensionString = pipeConcat
+    ((optionals isDribblish [ "dribbblish.js" ]) ++ enabledExtensions);
+  customAppsString = pipeConcat enabledCustomApps;
+in spotify-unwrapped.overrideAttrs (oldAttrs: rec {
+  name = "spotify-spicified-${spotify-unwrapped.version}";
+
+  postInstall = ''
+    touch $out/prefs
+    mkdir Themes Extensions CustomApps
+
+    find ${spicetify-themes} -maxdepth 1 -type d -exec ln -s {} Themes \;
+    ${extraCommands}
+
+    ${spicetify} config \
+      spotify_path "$out/share/spotify" \
+      prefs_path "$out/prefs" \
+      ${optionalString (theme != "") ''current_theme "${theme}"''} \
+      ${optionalString (colorScheme != "") ''color_scheme "${colorScheme}"''} \
+      ${
+        optionalString (extensionString != "")
+        ''extensions "${extensionString}"''
+      } \
+      ${
+        optionalString (customAppsString != "")
+        ''custom_apps "${customAppsString}"''
+      } \
+      ${
+        optionalString (spotifyLaunchFlags != "")
+        ''spotify_launch_flags "${spotifyLaunchFlags}"''
+      } \
+      inject_css ${injectCssOrDribblish} \
+      replace_colors ${replaceColorsOrDribblish} \
+      overwrite_assets ${overwriteAssetsOrDribblish} \
+      disable_sentry ${boolToString disableSentry} \
+      disable_ui_logging ${boolToString disableUiLogging} \
+      remove_rtl_rule ${boolToString removeRtlRule} \
+      expose_apis ${boolToString exposeApis} \
+      disable_upgrade_check ${boolToString disableUpgradeCheck} \
+      fastUser_switching ${boolToString fastUserSwitching} \
+      visualization_high_framerate ${boolToString visualizationHighFramerate} \
+      radio ${boolToString radio} \
+      song_page ${boolToString songPage} \
+      experimental_features ${boolToString experimentalFeatures} \
+      home ${boolToString home} \
+      lyric_always_show ${boolToString lyricAlwaysShow} \
+      lyric_force_no_sync ${boolToString lyricForceNoSync}
+
+    ${spicetify} backup apply
+
+    cd $out/share/spotify
+    ${customAppsFixupCommands}
+  '';
+
+  meta = spotify-unwrapped.meta // {
+    priority = (spotify-unwrapped.meta.priority or 0) - 1;
+  };
+})

--- a/pkgs/applications/misc/spicetify-cli/default.nix
+++ b/pkgs/applications/misc/spicetify-cli/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   # used at runtime, but not installed by default
   postInstall = ''
-    cp -r ${src}/jsHelper $out/bin/jsHelper
+    cp -r ${src}/jsHelper ${src}/Themes ${src}/Extensions ${src}/CustomApps ${src}/globals.d.ts $out/bin
   '';
 
   doInstallCheck = true;

--- a/pkgs/applications/misc/spicetify-themes/default.nix
+++ b/pkgs/applications/misc/spicetify-themes/default.nix
@@ -1,0 +1,9 @@
+{ fetchFromGitHub }:
+
+fetchFromGitHub {
+  owner = "morpheusthewhite";
+  repo = "spicetify-themes";
+  rev = "589af4005016571e57675d154016ad016cff6a1e";
+  sha256 = "P9tt4oUeIuE7Usgutaob1gfON8cFe9hzK7gVuz9Wc20=";
+  fetchSubmodules = true;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24867,6 +24867,10 @@ in
 
   spotify = callPackage ../applications/audio/spotify/wrapper.nix { };
 
+  spotify-spicified = callPackage ../applications/audio/spotify-spicified { };
+
+  spicetify-themes = callPackage ../applications/misc/spicetify-themes { };
+
   libspotify = callPackage ../development/libraries/libspotify (config.libspotify or {});
 
   sourcetrail = libsForQt5.callPackage ../development/tools/sourcetrail {


### PR DESCRIPTION
###### Motivation for this change
A little while back, spicetify-cli has been added to nixpkgs. However, Spicetify is build to edit the Spotify files, to theme/extend the application. To make this work with the immutable nature of nix, I made derivation in which the user can pass their config to the package. I personally used this for a while already in a personal repo (https://github.com/pietdevries94/spicetify-nix).

I also added the spicetify-themes package, to provide the most popular themes. I also noticed that the spicetify-cli package is missing some folders, as seen at the AUR (https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=spicetify-cli#n27)

I'm not entirely sure what the correct way forward is, but I thought it was most productive to make this PR, so I don't put in any more effort into the wrong direction.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
