### PR TITLE
nixos-install: add --no-local-copy option

### DIFF
--- a/nixos/doc/manual/man-nixos-install.xml
+++ b/nixos/doc/manual/man-nixos-install.xml
@@ -81,6 +81,12 @@
    </arg>
 
    <arg>
+    <arg choice='plain'>
+     <option>--no-local-copy</option>
+    </arg>
+   </arg>
+
+   <arg>
     <group choice='req'>
     <arg choice='plain'>
      <option>--max-jobs</option>
@@ -293,6 +299,17 @@
      <para>
       Set the Nix configuration option <replaceable>name</replaceable> to
       <replaceable>value</replaceable>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--no-local-copy</option>
+    </term>
+    <listitem>
+     <para>
+      Does <emphasis>not</emphasis> add the installation medium's store as an extra
+      substituter during installation.
      </para>
     </listitem>
    </varlistentry>

--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -64,6 +64,9 @@ while [ "$#" -gt 0 ]; do
         --no-bootloader)
             noBootLoader=1
             ;;
+        --no-local-copy)
+            noLocalCopy=1
+            ;;
         --show-trace|--impure|--keep-going)
             extraBuildFlags+=("$i")
             ;;
@@ -140,7 +143,11 @@ trap 'rm -rf $tmpdir' EXIT
 # store temporary files on target filesystem by default
 export TMPDIR=${TMPDIR:-$tmpdir}
 
-sub="auto?trusted=1"
+if [[ -z "$noLocalCopy" ]]; then
+  sub="auto?trusted=1"
+else
+  sub=""
+fi
 
 # Build the system configuration in the target filesystem.
 if [[ -z $system ]]; then


### PR DESCRIPTION
###### Motivation for this change
Fixes #111947

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I tried it in a virtual machine and it seems to work.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
