### PR TITLE
tootle: 0.2.0 -> 1.0

### DIFF
--- a/pkgs/applications/misc/tootle/default.nix
+++ b/pkgs/applications/misc/tootle/default.nix
@@ -16,17 +16,18 @@
 , json-glib
 , glib
 , glib-networking
+, libhandy
 }:
 
 stdenv.mkDerivation rec {
   pname = "tootle";
-  version = "0.2.0";
+  version = "1.0";
 
   src = fetchFromGitHub {
     owner = "bleakgrey";
     repo = pname;
     rev = version;
-    sha256 = "1z3wyx316nns6gi7vlvcfmalhvxncmvcmmlgclbv6b6hwl5x2ysi";
+    sha256 = "NRM7GiJA8c5z9AvXpGXtMl4ZaYN2GauEIbjBmoY4pdo=";
   };
 
   nativeBuildInputs = [
@@ -47,15 +48,7 @@ stdenv.mkDerivation rec {
     json-glib
     libgee
     pantheon.granite
-  ];
-
-  patches = [
-    # Fix build with Vala 0.46
-    # https://github.com/bleakgrey/tootle/pull/164
-    (fetchpatch {
-      url = "https://github.com/worldofpeace/tootle/commit/0a88bdad6d969ead1e4058b1a19675c9d6857b16.patch";
-      sha256 = "0xyx00pgswnhxxbsxngsm6khvlbfcl6ic5wv5n64x7klk8rzh6cm";
-    })
+    libhandy
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix  #111900

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

```
❯ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"                                                                                                                                      
this path will be fetched (0.04 MiB download, 0.15 MiB unpacked):
  /nix/store/3fl8iy9www8kx2yzdsqng0qbajza0z4q-nixpkgs-review-2.5.0
copying path '/nix/store/3fl8iy9www8kx2yzdsqng0qbajza0z4q-nixpkgs-review-2.5.0' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   9889ae01be5..837b4d86baf  master     -> refs/nixpkgs-review/0
$ git worktree add /home/thiago/.cache/nixpkgs-review/rev-837b4d86baf835f561f8b6ae29e7436b3e214f08-dirty/nixpkgs 837b4d86baf835f561f8b6ae29e7436b3e214f08
Preparing worktree (detached HEAD 837b4d86baf)
HEAD is now at 837b4d86baf dhallPackages.Prelude: v20.0.0 -> v20.1.0
$ nix-env -f /home/thiago/.cache/nixpkgs-review/rev-837b4d86baf835f561f8b6ae29e7436b3e214f08-dirty/nixpkgs -qaP --xml --out-path --show-trace
Applying `nixpkgs` diff...
$ nix-env -f /home/thiago/.cache/nixpkgs-review/rev-837b4d86baf835f561f8b6ae29e7436b3e214f08-dirty/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package updated:
tootle (0.2.0 → 1.0)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/thiago/.cache/nixpkgs-review/rev-837b4d86baf835f561f8b6ae29e7436b3e214f08-dirty/build.nix
1 package built:
tootle
```

- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
