### PR TITLE
e2tools: 0.0.16 -> 0.1.0

### DIFF
--- a/pkgs/tools/filesystems/e2tools/default.nix
+++ b/pkgs/tools/filesystems/e2tools/default.nix
@@ -1,21 +1,23 @@
-{ lib, stdenv, fetchurl, pkg-config, e2fsprogs }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, e2fsprogs }:
 
 stdenv.mkDerivation rec {
   pname = "e2tools";
-  version = "0.0.16";
+  version = "0.1.0";
 
-  src = fetchurl {
-    url = "http://home.earthlink.net/~k_sheff/sw/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "16wlc54abqz06dpipjdkw58bncpkxlj5f55lkzy07k3cg0bqwg2f";
+src = fetchFromGitHub {
+    owner = "e2tools";
+    repo = "e2tools";
+    rev = "6ee7c2d9015dce7b90c3388096602e307e3bd790";
+    sha256 = "0nlqynrhj6ww7bnfhhfcx6bawii8iyvhgp6vz60zbnpgd68ifcx7";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ e2fsprogs ];
 
   enableParallelBuilding = true;
 
   meta = {
-    homepage = "http://home.earthlink.net/~k_sheff/sw/e2tools/";
+    homepage = "https://e2tools.github.io/";
     description = "Utilities to read/write/manipulate files in an ext2/ext3 filesystem";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/tools/filesystems/e2tools/default.nix
+++ b/pkgs/tools/filesystems/e2tools/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "e2tools";
   version = "0.1.0";
 
-src = fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "e2tools";
     repo = "e2tools";
     rev = "6ee7c2d9015dce7b90c3388096602e307e3bd790";


### PR DESCRIPTION
repository moved to GitHub, website changed as well

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New version, old website is no longer online and development has moved to GitHub

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
