### PR TITLE
ncompress: 4.2.4.5 -> 4.2.4.6

### DIFF
--- a/pkgs/tools/compression/ncompress/default.nix
+++ b/pkgs/tools/compression/ncompress/default.nix
@@ -1,7 +1,7 @@
 {lib, stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "ncompress-4.2.4.5";
+  name = "ncompress-4.2.4.6";
 
   builder = ./builder.sh;
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/project/ncompress/${name}.tar.gz";
-    sha256 = "0fwhfijnzggqpbmln82zq7zp6sra7p9arfakswicwi7qsp6vnxgm";
+    sha256 = "0sw3c7h80v9pagfqfx16ws9w2y3yrajrdk54bgiwdm0b0q06lyzv";
   };
 
   meta = {

--- a/pkgs/tools/compression/ncompress/makefile.patch
+++ b/pkgs/tools/compression/ncompress/makefile.patch
@@ -1,25 +1,6 @@
 diff -Naur ncompress-4.2.4.2.orig/Makefile.def ncompress-4.2.4.2/Makefile.def
 --- ncompress-4.2.4.2.orig/Makefile.def	2007-09-06 22:28:42.000000000 -0500
 +++ ncompress-4.2.4.2/Makefile.def	2009-08-18 12:30:53.000000000 -0500
-@@ -3,14 +3,16 @@
- # C complier
- #CC=cc
- 
-+PREFIX=/usr/local
-+
- # Install prefix
- DESTDIR=
- 
- # Install directory for binarys
--BINDIR=/usr/local/bin
-+BINDIR=$(PREFIX)/bin
- 
- # Install directory for manual
--MANDIR=/usr/local/man/man1
-+MANDIR=$(PREFIX)/man/man1
- 
- # compiler options:
- # options is a collection of:
 @@ -31,7 +33,7 @@
  #	-DDEF_ERRNO=1				Define error (not defined in errno.h).
  #	-DMAXSEG_64K=1 -BITS=16		Support segment processsor like 80286.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update ncompress from 4.2.4.5 to 4.2.4.6. Rework patch to make sure that it works with the latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
