### PR TITLE
vimacs: don't assume vimPackage has a version attribute

### DIFF
--- a/pkgs/applications/editors/vim/vimacs.nix
+++ b/pkgs/applications/editors/vim/vimacs.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vimacs";
-  version = vimPackage.version;
+  version = lib.getVersion vimPackage;
   vimPackage = if useMacvim then macvim else vim_configurable;
 
   buildInputs = [ vimPackage vimPlugins.vimacs ];


### PR DESCRIPTION
###### Motivation for this change
`vimPackage` may not have a version attribute if it was specified using a full name instead, such as with a `buildEnv` call. This can happen right now on Darwin when `vimPackage` is `macvim.configure {…}`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested by running `nix-env -qaA -f . vimacs` with and without this change, where I have an overlay that sets `macvim` to `super.macvim.configure`. Without this change nix-env throws an error about a missing 'version' attribute. With this change it prints the expected name-version combo.
