### PR TITLE
pythpn3Packages.slixmpp: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "slixmpp";
-  version = "1.6.0";
+  version = "1.7.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0jamly1jv31ragpv8yn52av1m48iwl4i7f9knb67vmk8c22rjdwa";
+    sha256 = "sha256-fy7sRKS7ih4JmjOW/noL8qJ1xWVpQLbBbObHnMwT3Bc=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -1,4 +1,15 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k, substituteAll, aiodns, pyasn1, pyasn1-modules, aiohttp, gnupg, nose }:
+{ lib
+, buildPythonPackage
+, aiodns
+, aiohttp
+, fetchPypi
+, gnupg
+, isPy3k
+, pyasn1
+, pyasn1-modules
+, pytestCheckHook
+, substituteAll
+}:
 
 buildPythonPackage rec {
   pname = "slixmpp";
@@ -18,17 +29,24 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [ aiodns pyasn1 pyasn1-modules aiohttp ];
+  propagatedBuildInputs = [
+    aiodns
+    aiohttp
+    pyasn1
+    pyasn1-modules
+  ];
 
-  checkInputs = [ nose ];
+  checkInputs = [ pytestCheckHook ];
 
-  checkPhase = ''
-    nosetests --where=tests --exclude=live -i slixtest.py
-  '';
+  # Exclude live tests
+  disabledTestFiles = [ "tests/live_test.py" ];
 
-  meta = {
+  pythonImportsCheck = [ "slixmpp" ];
+
+  meta = with lib; {
     description = "Elegant Python library for XMPP";
-    license = lib.licenses.mit;
-    homepage = "https://dev.louiz.org/projects/slixmpp";
+    homepage = "https://slixmpp.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.7.0

Commit log: https://lab.louiz.org/poezio/slixmpp/-/compare/slix-1.6.0...slix-1.7.0

Also, switch to `pytestCheckHook`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
