### PR TITLE
python3Packages.slackclient: 2.5.0 -> 2.9.3, python3Packages.slack-sdk: init at 3.3.0

### DIFF
--- a/pkgs/applications/networking/errbot/default.nix
+++ b/pkgs/applications/networking/errbot/default.nix
@@ -1,75 +1,90 @@
-{ lib, fetchFromGitHub, python, glibcLocales }:
+{ lib
+, ansi
+, buildPythonApplication
+, colorlog
+, daemonize
+, deepmerge
+, dulwich
+, fetchFromGitHub
+, flask
+, glibcLocales
+, hypchat
+, irc
+, jinja2
+, markdown
+, mock
+, pyasn1
+, pyasn1-modules
+, pygments
+, pygments-markdown-lexer
+, pyopenssl
+, pytestCheckHook
+, requests
+, slackclient
+, sleekxmpp
+, telegram
+, webtest
+}:
 
-let
-  py = python.override {
-    packageOverrides = self: super: {
-      # errbot requires markdown<3, and is not compatible with it either.
-      markdown = super.markdown.overridePythonAttrs (oldAttrs: rec {
-        version = "2.6.11";
-        src = super.fetchPypi {
-          pname = "Markdown";
-          inherit version;
-          sha256 = "108g80ryzykh8bj0i7jfp71510wrcixdi771lf2asyghgyf8cmm8";
-        };
-      });
-
-      # errbot requires slackclient 1.x, see https://github.com/errbotio/errbot/pull/1367
-      # latest 1.x release would be 1.3.2, but it requires an older websocket_client than the one in nixpkgs
-      # so let's just vendor the known-working version until they've migrated to 2.x.
-      slackclient = super.slackclient.overridePythonAttrs (oldAttrs: rec {
-        version = "1.2.1";
-        pname = "slackclient";
-        src = fetchFromGitHub {
-          owner  = "slackapi";
-          repo   = "python-slackclient";
-          rev    = version;
-          sha256 = "073fwf6fm2sqdp5ms3vm1v3ljh0pldi69k048404rp6iy3cfwkp0";
-        };
-
-        propagatedBuildInputs = with self; [ websocket_client requests six ];
-
-        checkInputs = with self; [ pytest codecov coverage mock pytestcov pytest-mock responses flake8 ];
-        # test_server.py fails because it needs connection (I think);
-        checkPhase = ''
-          py.test --cov-report= --cov=slackclient tests --ignore=tests/test_server.py
-        '';
-      });
-    };
-  };
-
-in
-py.pkgs.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "errbot";
-  version = "6.1.1";
+  version = "6.1.7";
 
   src = fetchFromGitHub {
     owner = "errbotio";
     repo = "errbot";
     rev = version;
-    sha256 = "1s4dl1za5imwsv6j3y7m47dy91hmqd5n221kkqm9ni4mpzgpffz0";
+    sha256 = "02h44qd3d91zy657hyqsw3gskgxg31848pw6zpb8dhd1x84z5y77";
   };
 
   LC_ALL = "en_US.utf8";
 
   buildInputs = [ glibcLocales ];
-  propagatedBuildInputs = with py.pkgs; [
-    webtest requests jinja2 flask dulwich
-    pyopenssl colorlog markdown ansi pygments
-    daemonize pygments-markdown-lexer telegram irc slackclient
-    sleekxmpp pyasn1 pyasn1-modules hypchat
+
+  propagatedBuildInputs = [
+    ansi
+    colorlog
+    daemonize
+    deepmerge
+    dulwich
+    flask
+    hypchat
+    irc
+    jinja2
+    markdown
+    pyasn1
+    pyasn1-modules
+    pygments
+    pygments-markdown-lexer
+    pyopenssl
+    requests
+    slackclient
+    sleekxmpp
+    telegram
+    webtest
   ];
 
-  checkInputs = with py.pkgs; [ mock pytest ];
-  # avoid tests that do network calls
-  checkPhase = ''
-    pytest tests -k 'not backup and not broken_plugin and not plugin_cycle'
-  '';
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  # Slack backend test has an import issue
+  pytestFlagsArray = [ "--ignore=tests/backend_tests/slack_test.py" ];
+
+  disabledTests = [
+    "backup"
+    "broken_plugin"
+    "plugin_cycle"
+  ];
+
+  pythonImportsCheck = [ "errbot" ];
 
   meta = with lib; {
     description = "Chatbot designed to be simple to extend with plugins written in Python";
     homepage = "http://errbot.io/";
     maintainers = with maintainers; [ fpletz globin ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     # flaky on darwin, "RuntimeError: can't start new thread"
   };

--- a/pkgs/development/python-modules/slack-sdk/default.nix
+++ b/pkgs/development/python-modules/slack-sdk/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, aiodns
+, aiohttp
+, boto3
+, buildPythonPackage
+, codecov
+, databases
+, fetchFromGitHub
+, flake8
+, flask-sockets
+, isPy3k
+, psutil
+, pytest-asyncio
+, pytest-cov
+, pytestCheckHook
+, pytestrunner
+, sqlalchemy
+, websocket_client
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "slack-sdk";
+  version = "3.3.0";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "slackapi";
+    repo = "python-slack-sdk";
+    rev = "v${version}";
+    sha256 = "0nr1avxycvjnvg1n8r09xi4sc5h6i4b64pzfgq14l55dgi5sv1rx";
+  };
+
+  propagatedBuildInputs = [
+    aiodns
+    aiohttp
+    boto3
+    sqlalchemy
+    websocket_client
+    websockets
+  ];
+
+  checkInputs = [
+    codecov
+    databases
+    flake8
+    flask-sockets
+    psutil
+    pytest-asyncio
+    pytest-cov
+    pytestCheckHook
+    pytestrunner
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # Exclude tests that requires network features
+  pytestFlagsArray = [ "--ignore=integration_tests" ];
+  disabledTests = [
+    "test_start_raises_an_error_if_rtm_ws_url_is_not_returned"
+    "test_org_installation"
+  ];
+
+  pythonImportsCheck = [ "slack_sdk" ];
+
+  meta = with lib; {
+    description = "Slack Developer Kit for Python";
+    homepage = "https://slack.dev/python-slack-sdk/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/slackclient/default.nix
+++ b/pkgs/development/python-modules/slackclient/default.nix
@@ -1,15 +1,15 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
 , aiohttp
-, black
+, buildPythonPackage
 , codecov
+, fetchFromGitHub
 , flake8
 , isPy3k
 , mock
+, psutil
+, pytest-cov
 , pytest-mock
 , pytestCheckHook
-, pytestcov
 , pytestrunner
 , requests
 , responses
@@ -19,15 +19,15 @@
 
 buildPythonPackage rec {
   pname = "python-slackclient";
-  version = "2.5.0";
+  version = "2.9.3";
 
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
-    owner  = "slackapi";
-    repo   = pname;
-    rev    = version;
-    sha256 = "1ngj1mivbln19546195k400w9yaw69g0w6is7c75rqwyxr8wgzsk";
+    owner = "slackapi";
+    repo = "python-slack-sdk";
+    rev = "v${version}";
+    sha256 = "1rfb7izgddv28ag37gdnv3sd8z2zysrxs7ad8x20x690zshpaq16";
   };
 
   propagatedBuildInputs = [
@@ -38,16 +38,20 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    black
     codecov
     flake8
     mock
+    psutil
+    pytest-cov
     pytest-mock
     pytestCheckHook
-    pytestcov
     pytestrunner
     responses
   ];
+
+  # Exclude tests that requires network features
+  pytestFlagsArray = [ "--ignore=integration_tests" ];
+  disabledTests = [ "test_start_raises_an_error_if_rtm_ws_url_is_not_returned" ];
 
   pythonImportsCheck = [ "slack" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21834,9 +21834,7 @@ in
 
   eq10q = callPackage ../applications/audio/eq10q { };
 
-  errbot = callPackage ../applications/networking/errbot {
-    python = python3;
-  };
+  errbot = python3Packages.callPackage ../applications/networking/errbot { };
 
   espeak-classic = callPackage ../applications/audio/espeak { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7220,6 +7220,8 @@ in {
 
   skorch = callPackage ../development/python-modules/skorch { };
 
+  slack-sdk = callPackage ../development/python-modules/slack-sdk { };
+
   slackclient = callPackage ../development/python-modules/slackclient { };
 
   sleekxmpp = callPackage ../development/python-modules/sleekxmpp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Update `slackclient` to latest upstream release 2.9.3. This is the last release of `slackclient`.
- The client was renamed to [`slack_sdk`](https://github.com/slackapi/python-slack-sdk). 
- Update of `errbot` to 6.1.7 (https://github.com/errbotio/errbot/blob/master/CHANGES.rst#v617-2020-12-18) to fix the build issue

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
