### PR TITLE
bazel: add execlog parser

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -62,6 +62,7 @@ let
       srcs.rules_cc
       srcs.rules_java
       srcs.rules_proto
+      srcs.com_google_protobuf
       ]);
 
   distDir = runCommand "bazel-deps" {} ''
@@ -527,6 +528,13 @@ stdenv.mkDerivation rec {
         --output=./bazel_src/output/bazel-complete.bash \
         --prepend=./bazel_src/scripts/bazel-complete-header.bash \
         --prepend=./bazel_src/scripts/bazel-complete-template.bash
+
+    # need to change directory for bazel to find the workspace
+    cd ./bazel_src
+    # build execlog tooling
+    export HOME=$(mktemp -d)
+    ./output/bazel build  src/tools/execlog:parser_deploy.jar
+    cd -
   '';
 
   installPhase = ''
@@ -537,7 +545,15 @@ stdenv.mkDerivation rec {
     # The binary _must_ exist with this naming if your project contains a .bazelversion
     # file.
     cp ./bazel_src/scripts/packages/bazel.sh $out/bin/bazel
+
+    mkdir $out/share
+    cp ./bazel_src/bazel-bin/src/tools/execlog/parser_deploy.jar $out/share/parser_deploy.jar
     mv ./bazel_src/output/bazel $out/bin/bazel-${version}-${system}-${arch}
+    cat <<EOF > $out/bin/bazel-execlog
+    #!${runtimeShell} -e
+    ${runJdk}/bin/java -jar $out/share/parser_deploy.jar \$@
+    EOF
+    chmod +x $out/bin/bazel-execlog
 
     # shell completion files
     installShellCompletion --bash \

--- a/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
@@ -560,6 +560,13 @@ stdenv.mkDerivation rec {
     ${python3}/bin/python3 ./bazel_src/scripts/generate_fish_completion.py \
         --bazel=./bazel_src/output/bazel \
         --output=./bazel_src/output/bazel-complete.fish
+
+    # need to change directory for bazel to find the workspace
+    cd ./bazel_src
+    # build execlog tooling
+    export HOME=$(mktemp -d)
+    ./output/bazel build  src/tools/execlog:parser_deploy.jar
+    cd -
   '';
 
   installPhase = ''
@@ -571,6 +578,14 @@ stdenv.mkDerivation rec {
     # file.
     cp ./bazel_src/scripts/packages/bazel.sh $out/bin/bazel
     mv ./bazel_src/output/bazel $out/bin/bazel-${version}-${system}-${arch}
+
+    mkdir $out/share
+    cp ./bazel_src/bazel-bin/src/tools/execlog/parser_deploy.jar $out/share/parser_deploy.jar
+    cat <<EOF > $out/bin/bazel-execlog
+    #!${runtimeShell} -e
+    ${runJdk}/bin/java -jar $out/share/parser_deploy.jar \$@
+    EOF
+    chmod +x $out/bin/bazel-execlog
 
     # shell completion files
     installShellCompletion --bash \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://docs.bazel.build/versions/master/remote-execution-caching-debug.html advises to build the execlog parser to troubleshoot bazel cache issues. I would like to add it to our bazel packaging. So far fails with 

```
Analyzing: 2 targets (28 packages loaded, 323 targets configured)
    currently loading: src/main/protobuf
    Fetching @com_google_protobuf; fetching
WARNING: Download from https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException Unknown host: mirror.bazel.build
Analyzing: 2 targets (28 packages loaded, 323 targets configured)
    currently loading: src/main/protobuf
WARNING: Download from https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException Unknown host: github.com
Analyzing: 2 targets (28 packages loaded, 323 targets configured)
    currently loading: src/main/protobuf
ERROR: An error occurred during the fetch of repository 'com_google_protobuf':
   Traceback (most recent call last):
        File "/build/bazel_src/tools/build_defs/repo/http.bzl", line 111, column 45, in _http_archive_impl
                download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz, https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz] to /build/tmp.Yby7S1DIZl/.cache/bazel/_bazel_nixbld/96c321f6d4067432c019ff2725c18acb/external/com_google_protobuf/temp12648161410897702521/v3.13.0.tar.gz: Unknown host: github.com
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
