### PR TITLE
kmsxx: 2020-08-04 -> 2020-12-18

### DIFF
--- a/pkgs/development/libraries/kmsxx/default.nix
+++ b/pkgs/development/libraries/kmsxx/default.nix
@@ -1,22 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libdrm
-, withPython ? false, python }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, fmt
+, pkg-config
+, libdrm
+, libevdev
+, withPython ? false
+, python
+, pybind11
+, ninja
+, git
+, cmake
+}:
 
 stdenv.mkDerivation {
   pname = "kmsxx";
-  version = "2020-08-04";
+  version = "2020-12-18";
 
   src = fetchFromGitHub {
     owner = "tomba";
     repo = "kmsxx";
     fetchSubmodules = true;
-    rev = "38bee3092f2d477f1baebfcae464f888d3d04bbe";
-    sha256 = "0xz4m9bk0naawxwpx5cy1j3cm6c8c9m5y551csk88y88x1g0z0xh";
+    rev = "b12aab5d4bb45e77934d9838576a817bc8defe4b";
+    sha256 = "0wni7iymf8mj6vymr092l9zq4b73lbm99ad45i5ihcl9y3y4rk2x";
   };
 
-  cmakeFlags = lib.optional (!withPython) "-DKMSXX_ENABLE_PYTHON=OFF";
+  mesonFlags = lib.optional (!withPython) "-Dpykms=disabled";
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ libdrm python ];
+  # meson uses CMake to find pybind11, it can't seem to find pybind11 otherwise
+  nativeBuildInputs = [ meson ninja pkg-config pybind11 git cmake ];
+  buildInputs = [ libdrm fmt libevdev python  ];
 
   meta = with lib; {
     description = "C++11 library, utilities and python bindings for Linux kernel mode setting";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3504,9 +3504,9 @@ in {
 
   kmapper = callPackage ../development/python-modules/kmapper { };
 
-  kmsxx = toPythonModule ((callPackage ../development/libraries/kmsxx {
-    inherit (pkgs.kmsxx) stdenv;
-    inherit (pkgs) pkg-config;
+  kmsxx = toPythonModule ((pkgs.callPackage ../development/libraries/kmsxx {
+    inherit python;
+    inherit (python.pkgs) pybind11;
     withPython = true;
   }).overrideAttrs (oldAttrs: { name = "${python.libPrefix}-${pkgs.kmsxx.name}"; }));
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This build was [broken on hydra](https://nix-cache.s3.amazonaws.com/log/3yc28q0m896xbs4mvv5g3dc7v99hinnr-python3.7-kmsxx-2020-08-04.drv), probably because of a gcc upgrade (?).

I updated to the latest version to pull in fixes for gcc, which switched the build system from cmake -> meson, so that's the cause of most of the churn.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

------------------------

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>kmsxx</li>
    <li>python37Packages.kmsxx</li>
    <li>python38Packages.kmsxx</li>
    <li>python39Packages.kmsxx</li>
  </ul>
</details>
