### PR TITLE
fish: Add fishEnvPreInit option

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -16,11 +16,21 @@
 , ncurses
 , python3
 , cmake
+, fishPlugins
 
 , runCommand
 , writeText
 , nixosTests
 , useOperatingSystemEtc ? true
+  # An optional string containing Fish code that initializes the environment.
+  # This is run at the very beginning of initialization. If it sets $NIX_PROFILES
+  # then Fish will use that to configure its function, completion, and conf.d paths.
+  # For example:
+  #   fishEnvPreInit = "source /etc/fish/my-env-preinit.fish";
+  # It can also be a function that takes one argument, which is a function that
+  # takes a path to a bash file and converts it to fish. For example:
+  #   fishEnvPreInit = source: source "${nix}/etc/profile.d/nix-daemon.sh";
+, fishEnvPreInit ? null
 }:
 let
   etcConfigAppendix = writeText "config.fish.appendix" ''
@@ -62,8 +72,12 @@ let
     #   2. Before the shell is initialized, so that config snippets can find the commands they use on the PATH
     builtin status --is-login
     or test -z "$__fish_nixos_env_preinit_sourced" -a -z "$ETC_PROFILE_SOURCED" -a -z "$ETC_ZSHENV_SOURCED"
+    ${if fishEnvPreInit != null then ''
+    and begin
+    ${lib.removeSuffix "\n" (if lib.isFunction fishEnvPreInit then fishEnvPreInit sourceWithFenv else fishEnvPreInit)}
+    end'' else ''
     and test -f /etc/fish/nixos-env-preinit.fish
-    and source /etc/fish/nixos-env-preinit.fish
+    and source /etc/fish/nixos-env-preinit.fish''}
     and set -gx __fish_nixos_env_preinit_sourced 1
 
     test -n "$NIX_PROFILES"
@@ -92,6 +106,22 @@ let
         $__nix_profile_paths"/etc/fish/conf.d" \
         $__nix_profile_paths"/share/fish/vendor_conf.d"
     end
+  '';
+
+  # This is wrapped in begin/end in case the user wants to apply redirections.
+  # This does mean the basic usage of sourcing a single file will produce
+  # `begin; begin; …; end; end` but that's ok.
+  sourceWithFenv = path: ''
+    begin # fenv
+      # This happens before $__fish_datadir/config.fish sets fish_function_path, so it is currently
+      # unset. We set it and then completely erase it, leaving its configuration to $__fish_datadir/config.fish
+      set fish_function_path ${fishPlugins.foreign-env}/share/fish/vendor_functions.d $__fish_datadir/functions
+      fenv source ${lib.escapeShellArg path}
+      set -l fenv_status $status
+      # clear fish_function_path so that it will be correctly set when we return to $__fish_datadir/config.fish
+      set -e fish_function_path
+      test $fenv_status -eq 0
+    end # fenv
   '';
 
   fish = stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change
This new option allows for replacing the sourcing of `/etc/fish/nixos-env-preinit.fish` with another file, optionally passing it through `fenv`. The idea here is that non-NixOS users can do something like

```nix
fish.override {
  fishEnvPreInit = sourceBash: sourceBash "${nix}/etc/profile.d/nix-daemon.sh";
}
```

and this will set up their shell environment for Nix just as though they were running NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The default build is identical before and after this change, it only affects anything if you override fish.
