### PR TITLE
microplane: 0.0.25 -> 0.0.26

### DIFF
--- a/pkgs/tools/misc/microplane/default.nix
+++ b/pkgs/tools/misc/microplane/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "microplane";
-  version = "0.0.25";
+  version = "0.0.26";
 
   src = fetchFromGitHub {
     owner = "Clever";
     repo = "microplane";
     rev = "v${version}";
-    sha256 = "0vynkv3d70q8d079kgdmwbavyyrjssqnd223dl1rikyy7sd5sli8";
+    sha256 = "0dba8cz13ljcsfibcwycd9vb759fzlllh2bv31vgbs2pjgcinzvm";
   };
 
   goPackagePath = "github.com/Clever/microplane";

--- a/pkgs/tools/misc/microplane/deps.nix
+++ b/pkgs/tools/misc/microplane/deps.nix
@@ -194,8 +194,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sync";
-      rev =  "6e8e738ad208923de99951fe0b48239bfd864f28";
-      sha256 = "1avk27pszd5l5df6ff7j78wgla46ir1hhy2jwfl9a3c0ys602yx9";
+      rev =  "09787c993a3ab68e3d1f5c9b2394ab9433f391be";
+      sha256 = "1nv4mwi9njkkyc7lwmxrjr8ggfh2cf1c67a9bq85dnss81vpj61y";
     };
   }
   {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
New version released:
https://github.com/Clever/microplane/releases/tag/v0.0.26

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
