### PR TITLE
ocamlPackages.ppx_deriving_protobuf: 2.7 → 3.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
@@ -1,28 +1,24 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, cppo, ppx_tools, ppx_deriving
-, ppxfind }:
-
-if lib.versionAtLeast ocaml.version "4.11"
-then throw "ppx_deriving_protobuf is not available for OCaml ${ocaml.version}"
-else
+{ lib, fetchurl, buildDunePackage, cppo, ppx_deriving
+, ppxlib
+}:
 
 buildDunePackage rec {
   pname = "ppx_deriving_protobuf";
-  version = "2.7";
+  version = "3.0.0";
 
-  src = fetchFromGitHub {
-    owner = "ocaml-ppx";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0aq4f3gbkhhai0c8i5mcw2kpqy8l610f4dknwkrxh0nsizwbwryn";
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-ppx/ppx_deriving_protobuf/releases/download/v${version}/ppx_deriving_protobuf-v${version}.tbz";
+    sha256 = "1dc1vxnkd0cnrgac5v3zbaj2lq1d2w8118mp1cmsdxylp06yz1sj";
   };
 
-  buildInputs = [ cppo ppx_tools ppxfind ppx_deriving ];
+  buildInputs = [ cppo ppxlib ppx_deriving ];
 
   meta = with lib; {
     homepage = "https://github.com/ocaml-ppx/ppx_deriving_protobuf";
     description = "A Protocol Buffers codec generator for OCaml";
     license = licenses.mit;
     maintainers = [ maintainers.vyorkin ];
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This package is currently broken.
cc maintainer @vyorkin

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
