### PR TITLE
haskellPackages.readline: fix Setup.hs to work with Cabal 3

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1490,6 +1490,11 @@ self: super: {
   gi-gtk-hs = assert super.gi-gtk-hs.version == "0.3.8.1"; self.gi-gtk-hs_0_3_9;
   gi-xlib = assert super.gi-xlib.version == "2.0.8"; self.gi-xlib_2_0_9;
 
+  # Readline uses Distribution.Simple from Cabal 2, in a way that is not
+  # compatible with Cabal 3
+  readline = unmarkBroken (
+    appendPatch super.readline ./patches/readline-fix-for-cabal-3.patch);
+
   # INSERT NEW OVERRIDES ABOVE THIS LINE
 
 } // (let

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1491,9 +1491,10 @@ self: super: {
   gi-xlib = assert super.gi-xlib.version == "2.0.8"; self.gi-xlib_2_0_9;
 
   # Readline uses Distribution.Simple from Cabal 2, in a way that is not
-  # compatible with Cabal 3
-  readline = unmarkBroken (
-    appendPatch super.readline ./patches/readline-fix-for-cabal-3.patch);
+  # compatible with Cabal 3.  There does not appear to be an upstream
+  # repo that we can pull this patch from, so we unfortunately have to
+  # carry it in nixpkgs.
+  readline = appendPatch super.readline ./patches/readline-fix-for-cabal-3.patch;
 
   # INSERT NEW OVERRIDES ABOVE THIS LINE
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9053,7 +9053,6 @@ broken-packages:
   - read-bounded
   - read-ctags
   - read-io
-  - readline
   - readline-statevar
   - readme-lhs
   - readpyc

--- a/pkgs/development/haskell-modules/patches/readline-fix-for-cabal-3.patch
+++ b/pkgs/development/haskell-modules/patches/readline-fix-for-cabal-3.patch
@@ -1,0 +1,8 @@
+--- a/Setup.hs	2021-02-04 14:01:09.557970245 +0100
++++ b/Setup.hs	2021-02-04 14:07:45.047443753 +0100
+@@ -3,4 +3,4 @@
+ import           Distribution.Simple
+ 
+ main :: IO ()
+-main = defaultMainWithHooks defaultUserHooks
++main = defaultMainWithHooks autoconfUserHooks


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix Haskell's readline package, which is marked as broken in the latest release.

###### Things done

Patched the Setup.hs file, to use Cabal 3's API, which is backwards incompatible with Cabal 2.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
