### PR TITLE
Darwin platform versions

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -112,6 +112,15 @@ rec {
         aarch64 = "arm64";
       }.${final.parsed.cpu.name} or final.parsed.cpu.name;
 
+      darwinPlatform =
+        if final.isMacOS then "macos"
+        else if final.isiOS then "ios"
+        else null;
+      # The canonical name for this attribute is darwinSdkVersion, but some
+      # platforms define the old name "sdkVer".
+      darwinSdkVersion = final.sdkVer or "10.12";
+      darwinMinVersion = final.darwinSdkVersion;
+
       emulator = pkgs: let
         qemu-user = pkgs.qemu.override {
           smartcardSupport = false;

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -120,6 +120,10 @@ rec {
       # platforms define the old name "sdkVer".
       darwinSdkVersion = final.sdkVer or "10.12";
       darwinMinVersion = final.darwinSdkVersion;
+      darwinMinVersionVariable =
+        if final.isMacOS then "MACOSX_DEPLOYMENT_TARGET"
+        else if final.isiOS then "IPHONEOS_DEPLOYMENT_TARGET"
+        else null;
 
       emulator = pkgs: let
         qemu-user = pkgs.qemu.override {

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -219,6 +219,7 @@ rec {
     sdkVer = "14.3";
     xcodeVer = "12.3";
     xcodePlatform = "iPhoneSimulator";
+    darwinPlatform = "ios-simulator";
     useiOSPrebuilt = true;
   };
 
@@ -228,6 +229,7 @@ rec {
     sdkVer = "14.3";
     xcodeVer = "12.3";
     xcodePlatform = "iPhoneSimulator";
+    darwinPlatform = "ios-simulator";
     useiOSPrebuilt = true;
   };
 

--- a/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
+++ b/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
@@ -21,6 +21,15 @@ havePlatformVersionFlag=
 haveDarwinSDKVersion=
 haveDarwinPlatformVersion=
 
+# Roles will set by add-flags.sh, but add-flags.sh can be skipped when the
+# cc-wrapper has added the linker flags. Both the cc-wrapper and the binutils
+# wrapper mangle the same variable (MACOSX_DEPLOYMENT_TARGET), so if roles are
+# empty due to being run through the cc-wrapper then the mangle here is a no-op
+# and we still do the right thing.
+#
+# To be robust, make sure we always have the correct set of roles.
+accumulateRoles
+
 mangleVarSingle @darwinMinVersionVariable@ ${role_suffixes[@]+"${role_suffixes[@]}"}
 
 n=0

--- a/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
+++ b/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
@@ -1,0 +1,70 @@
+# Unconditionally adding in platform version flags will result in warnings that
+# will be treated as errors by some packages. Add any missing flags here.
+
+# There are two things to be configured: the "platform version" (oldest
+# supported version of macos, ios, etc), and the "sdk version".
+#
+# The modern way of configuring these is to use:
+#    -platform_version $platform $platform_version $sdk_version"
+#
+# The old way is still supported, and uses flags like:
+#    -${platform}_version_min $platform_version
+#    -sdk_version $sdk_version
+#
+# If both styles are specified ld will combine them. If multiple versions are
+# specified for the same platform, ld will emit an error.
+#
+# The following adds flags for whichever properties have not already been
+# provided.
+
+havePlatformVersionFlag=
+haveDarwinSDKVersion=
+haveDarwinPlatformVersion=
+
+n=0
+nParams=${#params[@]}
+while (( n < nParams )); do
+    p=${params[n]}
+    case "$p" in
+        # the current platform
+        -@darwinPlatform@_version_min)
+            haveDarwinPlatformVersion=1
+            ;;
+
+        # legacy aliases
+        -macosx_version_min|-iphoneos_version_min|-iosmac_version_min|-uikitformac_version_min)
+            haveDarwinPlatformVersion=1
+            ;;
+
+        -sdk_version)
+            haveDarwinSDKVersion=1
+            ;;
+
+        -platform_version)
+            havePlatformVersionFlag=1
+
+            # If clang can't determine the sdk version it will pass 0.0.0. This
+            # has runtime effects so we override this to use the known sdk
+            # version.
+            if [ "${params[n+3]-}" = 0.0.0 ]; then
+                params[n+3]=@darwinSdkVersion@
+            fi
+            ;;
+    esac
+    n=$((n + 1))
+done
+
+# If the caller has set -platform_version, trust they're doing the right thing.
+# This will be the typical case for clang in nixpkgs.
+if [ ! "$havePlatformVersionFlag" ]; then
+    if [ ! "$haveDarwinSDKVersion" ] && [ ! "$haveDarwinPlatformVersion" ]; then
+        # Nothing provided. Use the modern "-platform_version" to set both.
+        extraBefore+=(-platform_version @darwinPlatform@ @darwinMinVersion@ @darwinSdkVersion@)
+    elif [ ! "$haveDarwinSDKVersion" ]; then
+        # Add missing sdk version
+        extraBefore+=(-sdk_version @darwinSdkVersion@)
+    elif [ ! "$haveDarwinPlatformVersion" ]; then
+        # Add missing platform version
+        extraBefore+=(-@darwinPlatform@_version_min @darwinMinVersion@)
+    fi
+fi

--- a/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
+++ b/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
@@ -21,7 +21,7 @@ havePlatformVersionFlag=
 haveDarwinSDKVersion=
 haveDarwinPlatformVersion=
 
-mangleVarSingle MACOSX_DEPLOYMENT_TARGET ${role_suffixes[@]+"${role_suffixes[@]}"}
+mangleVarSingle @darwinMinVersionVariable@ ${role_suffixes[@]+"${role_suffixes[@]}"}
 
 n=0
 nParams=${#params[@]}
@@ -61,12 +61,12 @@ done
 if [ ! "$havePlatformVersionFlag" ]; then
     if [ ! "$haveDarwinSDKVersion" ] && [ ! "$haveDarwinPlatformVersion" ]; then
         # Nothing provided. Use the modern "-platform_version" to set both.
-        extraBefore+=(-platform_version @darwinPlatform@ "${MACOSX_DEPLOYMENT_TARGET_@suffixSalt@:-@darwinMinVersion@}" @darwinSdkVersion@)
+        extraBefore+=(-platform_version @darwinPlatform@ "${@darwinMinVersionVariable@_@suffixSalt@:-@darwinMinVersion@}" @darwinSdkVersion@)
     elif [ ! "$haveDarwinSDKVersion" ]; then
         # Add missing sdk version
         extraBefore+=(-sdk_version @darwinSdkVersion@)
     elif [ ! "$haveDarwinPlatformVersion" ]; then
         # Add missing platform version
-        extraBefore+=(-@darwinPlatform@_version_min "${MACOSX_DEPLOYMENT_TARGET_@suffixSalt@:-@darwinMinVersion@}")
+        extraBefore+=(-@darwinPlatform@_version_min "${@darwinMinVersionVariable@_@suffixSalt@:-@darwinMinVersion@}")
     fi
 fi

--- a/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
+++ b/pkgs/build-support/bintools-wrapper/add-darwin-ldflags-before.sh
@@ -21,6 +21,8 @@ havePlatformVersionFlag=
 haveDarwinSDKVersion=
 haveDarwinPlatformVersion=
 
+mangleVarSingle MACOSX_DEPLOYMENT_TARGET ${role_suffixes[@]+"${role_suffixes[@]}"}
+
 n=0
 nParams=${#params[@]}
 while (( n < nParams )); do
@@ -59,12 +61,12 @@ done
 if [ ! "$havePlatformVersionFlag" ]; then
     if [ ! "$haveDarwinSDKVersion" ] && [ ! "$haveDarwinPlatformVersion" ]; then
         # Nothing provided. Use the modern "-platform_version" to set both.
-        extraBefore+=(-platform_version @darwinPlatform@ @darwinMinVersion@ @darwinSdkVersion@)
+        extraBefore+=(-platform_version @darwinPlatform@ "${MACOSX_DEPLOYMENT_TARGET_@suffixSalt@:-@darwinMinVersion@}" @darwinSdkVersion@)
     elif [ ! "$haveDarwinSDKVersion" ]; then
         # Add missing sdk version
         extraBefore+=(-sdk_version @darwinSdkVersion@)
     elif [ ! "$haveDarwinPlatformVersion" ]; then
         # Add missing platform version
-        extraBefore+=(-@darwinPlatform@_version_min @darwinMinVersion@)
+        extraBefore+=(-@darwinPlatform@_version_min "${MACOSX_DEPLOYMENT_TARGET_@suffixSalt@:-@darwinMinVersion@}")
     fi
 fi

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -252,11 +252,6 @@ stdenv.mkDerivation {
       fi
     '')
 
-    # Ensure consistent LC_VERSION_MIN_MACOSX and remove LC_UUID.
-    + optionalString stdenv.targetPlatform.isMacOS ''
-      echo "-sdk_version 10.12 -no_uuid" >> $out/nix-support/libc-ldflags-before
-    ''
-
     ##
     ## User env support
     ##
@@ -310,6 +305,13 @@ stdenv.mkDerivation {
       echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/libc-ldflags
     ''
 
+    ###
+    ### Remove LC_UUID
+    ###
+    + optionalString (stdenv.targetPlatform.isDarwin && !(stdenv.cc.bintools.bintools.isGNU or false)) ''
+      echo "-no_uuid" >> $out/nix-support/libc-ldflags-before
+    ''
+
     + ''
       for flags in "$out/nix-support"/*flags*; do
         substituteInPlace "$flags" --replace $'\n' ' '
@@ -319,6 +321,20 @@ stdenv.mkDerivation {
       substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
     ''
+
+    ###
+    ### Ensure consistent LC_VERSION_MIN_MACOSX
+    ###
+    + optionalString stdenv.targetPlatform.isDarwin (
+      let
+        inherit (stdenv.targetPlatform) darwinMinVersion darwinPlatform darwinSdkVersion;
+      in ''
+        export darwinPlatform=${darwinPlatform}
+        export darwinMinVersion=${darwinMinVersion}
+        export darwinSdkVersion=${darwinSdkVersion}
+        substituteAll ${./add-darwin-ldflags-before.sh} $out/nix-support/add-local-ldflags-before.sh
+      ''
+    )
 
     ##
     ## Extra custom steps

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -327,11 +327,14 @@ stdenv.mkDerivation {
     ###
     + optionalString stdenv.targetPlatform.isDarwin (
       let
-        inherit (stdenv.targetPlatform) darwinMinVersion darwinPlatform darwinSdkVersion;
+        inherit (stdenv.targetPlatform)
+          darwinPlatform darwinSdkVersion
+          darwinMinVersion darwinMinVersionVariable;
       in ''
         export darwinPlatform=${darwinPlatform}
         export darwinMinVersion=${darwinMinVersion}
         export darwinSdkVersion=${darwinSdkVersion}
+        export darwinMinVersionVariable=${darwinMinVersionVariable}
         substituteAll ${./add-darwin-ldflags-before.sh} $out/nix-support/add-local-ldflags-before.sh
       ''
     )

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -78,6 +78,14 @@ fi
 
 extraAfter+=($NIX_LDFLAGS_AFTER_@suffixSalt@)
 
+# These flags *must not* be pulled up to -Wl, flags, so they can't go in
+# add-flags.sh. They must always be set, so must not be disabled by
+# NIX_LDFLAGS_SET.
+if [ -e @out@/nix-support/add-local-ldflags-before.sh ]; then
+    source @out@/nix-support/add-local-ldflags-before.sh
+fi
+
+
 # Specify the target emulation if nothing is passed in ("-m" overrides this
 # environment variable). Ensures we never blindly fallback on targeting the host
 # platform.

--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -65,5 +65,13 @@ if [ -e @out@/nix-support/cc-cflags-before ]; then
     NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@="$(< @out@/nix-support/cc-cflags-before) $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@"
 fi
 
+# Only add darwin min version flag if a default darwin min version is set,
+# which is a signal that we're targetting darwin.
+if [ "@darwinMinVersion@" ]; then
+    mangleVarSingle MACOSX_DEPLOYMENT_TARGET ${role_suffixes[@]+"${role_suffixes[@]}"}
+
+    NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@="-m@darwinPlatformForCC@-version-min=${MACOSX_DEPLOYMENT_TARGET_@suffixSalt@:-@darwinMinVersion@} $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@"
+fi
+
 # That way forked processes will not extend these environment variables again.
 export NIX_CC_WRAPPER_FLAGS_SET_@suffixSalt@=1

--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -68,9 +68,9 @@ fi
 # Only add darwin min version flag if a default darwin min version is set,
 # which is a signal that we're targetting darwin.
 if [ "@darwinMinVersion@" ]; then
-    mangleVarSingle MACOSX_DEPLOYMENT_TARGET ${role_suffixes[@]+"${role_suffixes[@]}"}
+    mangleVarSingle @darwinMinVersionVariable@ ${role_suffixes[@]+"${role_suffixes[@]}"}
 
-    NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@="-m@darwinPlatformForCC@-version-min=${MACOSX_DEPLOYMENT_TARGET_@suffixSalt@:-@darwinMinVersion@} $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@"
+    NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@="-m@darwinPlatformForCC@-version-min=${@darwinMinVersionVariable@_@suffixSalt@:-@darwinMinVersion@} $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@"
 fi
 
 # That way forked processes will not extend these environment variables again.

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -487,6 +487,7 @@ stdenv.mkDerivation {
 
     + optionalString stdenv.targetPlatform.isDarwin ''
       echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/cc-cflags
+      echo "-m${targetPlatform.darwinPlatform}-version-min=${targetPlatform.darwinMinVersion}" >> $out/nix-support/cc-cflags-before
     ''
 
     ##

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -485,10 +485,15 @@ stdenv.mkDerivation {
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
     ''
 
-    + optionalString stdenv.targetPlatform.isDarwin ''
-      echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/cc-cflags
-      echo "-m${targetPlatform.darwinPlatform}-version-min=${targetPlatform.darwinMinVersion}" >> $out/nix-support/cc-cflags-before
-    ''
+    + optionalString stdenv.targetPlatform.isDarwin (
+      let darwinPlatformForCC =
+        if (targetPlatform.darwinPlatform == "macos" && isGNU) then "macosx"
+        else targetPlatform.darwinPlatform;
+      in ''
+        echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/cc-cflags
+        echo "-m${darwinPlatformForCC}-version-min=${targetPlatform.darwinMinVersion}" >> $out/nix-support/cc-cflags-before
+      ''
+    )
 
     ##
     ## Extra custom steps

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -109,6 +109,9 @@ let
   darwinMinVersion = optionalString stdenv.targetPlatform.isDarwin (
     stdenv.targetPlatform.darwinMinVersion
   );
+
+  darwinMinVersionVariable = optionalString stdenv.targetPlatform.isDarwin
+    stdenv.targetPlatform.darwinMinVersionVariable;
 in
 
 # Ensure bintools matches
@@ -131,7 +134,7 @@ stdenv.mkDerivation {
   gnugrep_bin = if nativeTools then "" else gnugrep;
 
   inherit targetPrefix suffixSalt;
-  inherit darwinPlatformForCC darwinMinVersion;
+  inherit darwinPlatformForCC darwinMinVersion darwinMinVersionVariable;
 
   outputs = [ "out" ] ++ optionals propagateDoc [ "man" "info" ];
 

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -143,6 +143,7 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit targetPrefix;
+    isGNU = true;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/luarocks/darwin-3.1.3.patch
+++ b/pkgs/development/tools/misc/luarocks/darwin-3.1.3.patch
@@ -7,7 +7,7 @@ index c5af5a2..1949fdc 100644
        defaults.arch = "macosx-"..target_cpu
        defaults.variables.LIBFLAG = "-bundle -undefined dynamic_lookup -all_load"
 -      local version = util.popen_read("sw_vers -productVersion")
-+      local version = os.getenv("MACOSX_DEPLOYMENT_TARGET") or "10.12"
++      local version = os.getenv("MACOSX_DEPLOYMENT_TARGET") or "@darwinMinVersion@"
        version = tonumber(version and version:match("^[^.]+%.([^.]+)")) or 3
        if version >= 10 then
           version = 8

--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
   };
 
   patches = [ ./darwin-3.1.3.patch ];
+
+  postPatch = lib.optionalString stdenv.targetPlatform.isDarwin ''
+    substituteInPlace src/luarocks/core/cfg.lua --subst-var-by 'darwinMinVersion' '${stdenv.targetPlatform.darwinMinVersion}'
+  '';
+
   preConfigure = ''
     lua -e "" || {
         luajit -e "" && {

--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -3,7 +3,7 @@
 , runtimeShell, callPackage
 , xcodePlatform ? stdenv.targetPlatform.xcodePlatform or "MacOSX"
 , xcodeVer ? stdenv.targetPlatform.xcodeVer or "9.4.1"
-, sdkVer ? stdenv.targetPlatform.sdkVer or "10.12" }:
+, sdkVer ? stdenv.targetPlatform.darwinSdkVersion or "10.12" }:
 
 let
 

--- a/pkgs/os-specific/darwin/xcode/sdk-pkgs.nix
+++ b/pkgs/os-specific/darwin/xcode/sdk-pkgs.nix
@@ -29,11 +29,6 @@ rec {
   binutils = wrapBintoolsWith {
     libc = targetIosSdkPkgs.libraries;
     bintools = binutils-unwrapped;
-    extraBuildCommands = lib.optionalString (sdk.platform == "iPhoneSimulator") ''
-      echo "-platform_version ios-sim ${minSdkVersion} ${sdk.version}" >> $out/nix-support/libc-ldflags
-    '' + lib.optionalString (sdk.platform == "iPhoneOS") ''
-      echo "-platform_version ios ${minSdkVersion} ${sdk.version}" >> $out/nix-support/libc-ldflags
-    '';
   };
 
   clang = (wrapCCWith {
@@ -46,10 +41,6 @@ rec {
       mv cc-cflags.tmp $out/nix-support/cc-cflags
       echo "-target ${targetPlatform.config}" >> $out/nix-support/cc-cflags
       echo "-isystem ${sdk}/usr/include${lib.optionalString (lib.versionAtLeast "10" sdk.version) " -isystem ${sdk}/usr/include/c++/4.2.1/ -stdlib=libstdc++"}" >> $out/nix-support/cc-cflags
-    '' + lib.optionalString (sdk.platform == "iPhoneSimulator") ''
-      echo "-mios-simulator-version-min=${minSdkVersion}" >> $out/nix-support/cc-cflags
-    '' + lib.optionalString (sdk.platform == "iPhoneOS") ''
-      echo "-miphoneos-version-min=${minSdkVersion}" >> $out/nix-support/cc-cflags
     '';
   }) // {
     inherit sdk;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1,7 +1,5 @@
 { lib
 , localSystem, crossSystem, config, overlays, crossOverlays ? []
-# Minimum required macOS version, used both for compatibility as well as reproducability.
-, macosVersionMin ? "10.12"
 # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
 , bootstrapFiles ? let
   fetch = { file, sha256, executable ? true }: import <nix/fetchurl.nix> {
@@ -35,8 +33,6 @@ in rec {
     export NIX_ENFORCE_PURITY=''${NIX_ENFORCE_PURITY-1}
     export NIX_IGNORE_LD_THROUGH_GCC=1
     unset SDKROOT
-
-    export MACOSX_DEPLOYMENT_TARGET=${macosVersionMin}
 
     # Workaround for https://openradar.appspot.com/22671534 on 10.11.
     export gl_cv_func_getcwd_abort_bug=no
@@ -147,9 +143,6 @@ in rec {
         __stdenvImpureHostDeps = commonImpureHostDeps;
         __extraImpureHostDeps = commonImpureHostDeps;
 
-        extraAttrs = {
-          inherit macosVersionMin;
-        };
         overrides  = self: super: (overrides self super) // {
           inherit ccNoLibcxx;
           fetchurl = thisStdenv.fetchurlBoot;
@@ -523,7 +516,7 @@ in rec {
     extraAttrs = {
       libc = pkgs.darwin.Libsystem;
       shellPackage = pkgs.bash;
-      inherit macosVersionMin bootstrapTools;
+      inherit bootstrapTools;
     };
 
     allowedRequisites = (with pkgs; [

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -106,6 +106,8 @@ let
       '' + lib.optionalString (hostPlatform.isDarwin || (hostPlatform.parsed.kernel.execFormat != lib.systems.parse.execFormats.elf && hostPlatform.parsed.kernel.execFormat != lib.systems.parse.execFormats.macho)) ''
         export NIX_DONT_SET_RPATH=1
         export NIX_NO_SELF_RPATH=1
+      '' + lib.optionalString (hostPlatform.isDarwin && hostPlatform.isMacOS) ''
+        export MACOSX_DEPLOYMENT_TARGET=${hostPlatform.darwinMinVersion}
       ''
       # TODO this should be uncommented, but it causes stupid mass rebuilds. I
       # think the best solution would just be to fixup linux RPATHs so we don't


### PR DESCRIPTION
###### Motivation for this change

Implement the reproducibility of #77632, without the warnings that were introduced by cctools (https://github.com/NixOS/nixpkgs/pull/93596#issuecomment-695186910), with support for cross compilation by moving sdk versions and deployment targets out of the darwin stdenv and onto `targetPlatform`.

Effectively reverts: #110140 by @holymonson. When working on `aarch64-darwin` the SDK version provided (and embedded in `LC_BUILD_VERSION`) controls some kind of compatibility layer, see [gist](https://gist.github.com/thefloweringash/e46f2d1f40a6c3ee784f250030f37947), so I think we need to support an idea of "SDK version" even though nixpkgs generally treats darwin as a set of independent and overridable packages.

Also tries to define a platform definition structure for all darwin targets including ios. Currently these have platforms have equivalent attributes which I would like to unify with the rest of darwin. The extra configuration here [pkgs/os-specific/darwin/xcode/sdk-pkgs.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/darwin/xcode/sdk-pkgs.nix) should be able to entirely removed, and instead be provided by the standard darwin stdenv and binutils.

Original PR: #77632
Related: #103053, #83180
Motivation: https://github.com/NixOS/nixpkgs/pull/105026#issuecomment-770341696

Tested:
 - [x] Default stdenv (clang 7)
 - [x] stdenv with clang 10
 - [x] stdenv with clang 11 (using #111701)

Untested:
 - [ ] ios cross

---

###### Motivating test case

The following set of test cases should include no information from the building host and produce no linker warnings.

See results in `$(nix-build version-test-case.nix)/summary`.

<details>
  <summary>version-test-case.nix</summary>

```nix
let
  pkgs = import ./. {};
  inherit (pkgs) lib;

  ## Default stdenv
  stdenv = pkgs.stdenv;

  ## With clang 11
  # stdenv = pkgs.overrideCC pkgs.stdenv pkgs.buildPackages.clang_11;

  ## With clang 10
  # stdenv = pkgs.overrideCC pkgs.stdenv pkgs.buildPackages.clang_10;

  source = pkgs.writeText "main.c" ''
    int main() {}
  '';

  tests = {
    clangDefault = ''
      $CC -v -o test ${source}
    '';

    clangExplicit = ''
      $CC -v -mmacos-version-min=10.14 -o test ${source}
    '';

    ldDefault = ''
      $CC -o test.o -c ${source}
      $LD -L${pkgs.darwin.Libsystem}/lib -lSystem -o test test.o
    '';

    ldMacosVersion = ''
      $CC -o test.o -c ${source}
      $LD \
        -macos_version_min 10.14 \
        -L${pkgs.darwin.Libsystem}/lib -lSystem -o test test.o
    '';

    ldBothLegacyFlags = ''
      $CC -o test.o -c ${source}
      $LD \
        -macos_version_min 10.14 \
        -sdk_version 10.14 \
        -L${pkgs.darwin.Libsystem}/lib -lSystem -o test test.o
    '';

    ldSdkVersion = ''
      $CC -o test.o -c ${source}
      $LD \
        -sdk_version 10.14 \
        -L${pkgs.darwin.Libsystem}/lib -lSystem -o test test.o
    '';

    ldPlatformVersion = ''
      $CC -o test.o -c ${source}
      $LD \
        -platform_version macos 10.14 10.14 \
        -L${pkgs.darwin.Libsystem}/lib -lSystem -o test test.o
    '';
  };

  buildTest = name: testScript: stdenv.mkDerivation {
    inherit name testScript;
    passAsFile = [ "testScript" "buildCommand" ];

    buildCommand = ''
      set -u
      echo $testScriptPath
      mkdir $out
      NIX_DEBUG=3 $SHELL -x $testScriptPath 2>&1 | tee $out/build.log
      ${pkgs.darwin.cctools}/bin/otool -l test> $out/load_commands
    '';
  };
in
  pkgs.runCommand "all-tests" {
    passthru = lib.mapAttrs buildTest tests;
  } (
    ''
      mkdir $out
    '' +
    lib.concatStringsSep "\n" (
      lib.mapAttrsToList (name: script: ''
        ln -s ${buildTest name script} $out/${name}
      '') tests
    ) + ''
      cd $out
      {
        showCommand() {
          local cmdName=$1
          echo -ne "\t$cmdName: "
          awk "/$cmdName/ { show = 1 }; /Load command/ { show = 0 }; show" < $i | tr '\n' '\t'
          echo
        }

        for i in */load_commands; do
          echo $i
          showCommand LC_BUILD_VERSION
          showCommand LC_UUID
          showCommand LC_VERSION_MIN_MACOSX
        done

        echo

        echo "Linker warnings:"
        grep -nH 'warning' */build.log || true
      } > summary 2>&1
    ''
  )
```

</details>

---

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
