### PR TITLE
zen-kernels: 5.10.10 -> 5.10.15

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-lqx.nix
+++ b/pkgs/os-specific/linux/kernel/linux-lqx.nix
@@ -1,7 +1,7 @@
 { lib, fetchFromGitHub, buildLinux, linux_zen, ... } @ args:
 
 let
-  version = "5.10.10";
+  version = "5.10.15";
   suffix = "lqx2";
 in
 
@@ -14,7 +14,7 @@ buildLinux (args // {
     owner = "zen-kernel";
     repo = "zen-kernel";
     rev = "v${version}-${suffix}";
-    sha256 = "1cjgx9qjfkiaalqkcdmibsrq2frwd621rwcg6w05ms4w9lnwi3af";
+    sha256 = "11dgaqj1xr5hq6wxscrkln68dwqq4lakvfkr646x2yfynry1jqjk";
   };
 
   extraMeta = {

--- a/pkgs/os-specific/linux/kernel/linux-zen.nix
+++ b/pkgs/os-specific/linux/kernel/linux-zen.nix
@@ -1,8 +1,8 @@
 { lib, fetchFromGitHub, buildLinux, ... } @ args:
 
 let
-  version = "5.10.10";
-  suffix = "zen1";
+  version = "5.10.15";
+  suffix = "zen2";
 in
 
 buildLinux (args // {
@@ -14,7 +14,7 @@ buildLinux (args // {
     owner = "zen-kernel";
     repo = "zen-kernel";
     rev = "v${version}-${suffix}";
-    sha256 = "0jsi2q8k1w5zs5l6z1brm2mxpl9arv6n6linc8yj6xc75nydw6w4";
+    sha256 = "18qgh79hi1ph6x16sbvq36icv7c5bkdvh193wqjnbvwf0yph09as";
   };
 
   extraMeta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>18 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxPackages_lqx.ixgbevf</li>
    <li>linuxPackages_lqx.lttng-modules</li>
    <li>linuxPackages_lqx.ndiswrapper</li>
    <li>linuxPackages_lqx.nvidia_x11_legacy304</li>
    <li>linuxPackages_lqx.phc-intel</li>
    <li>linuxPackages_lqx.r8125</li>
    <li>linuxPackages_lqx.rtl8723bs</li>
    <li>linuxPackages_lqx.sch_cake</li>
    <li>linuxPackages_lqx.tbs</li>
    <li>linuxPackages_zen.ixgbevf</li>
    <li>linuxPackages_zen.lttng-modules</li>
    <li>linuxPackages_zen.ndiswrapper</li>
    <li>linuxPackages_zen.nvidia_x11_legacy304</li>
    <li>linuxPackages_zen.phc-intel</li>
    <li>linuxPackages_zen.r8125</li>
    <li>linuxPackages_zen.rtl8723bs</li>
    <li>linuxPackages_zen.sch_cake</li>
    <li>linuxPackages_zen.tbs</li>
  </ul>
</details>
<details>
  <summary>38 packages failed to build:</summary>
  <ul>
    <li>linuxPackages_lqx.akvcam</li>
    <li>linuxPackages_lqx.amdgpu-pro</li>
    <li>linuxPackages_lqx.anbox</li>
    <li>linuxPackages_lqx.ati_drivers_x11</li>
    <li>linuxPackages_lqx.chipsec</li>
    <li>linuxPackages_lqx.cryptodev</li>
    <li>linuxPackages_lqx.dpdk</li>
    <li>linuxPackages_lqx.ena</li>
    <li>linuxPackages_lqx.mwprocapture</li>
    <li>linuxPackages_lqx.mxu11x0</li>
    <li>linuxPackages_lqx.nvidia_x11_legacy340</li>
    <li>linuxPackages_lqx.nvidia_x11_legacy390</li>
    <li>linuxPackages_lqx.rtl8192eu</li>
    <li>linuxPackages_lqx.rtl8812au</li>
    <li>linuxPackages_lqx.rtl8814au</li>
    <li>linuxPackages_lqx.rtl8821au</li>
    <li>linuxPackages_lqx.rtl88x2bu</li>
    <li>linuxPackages_lqx.rtl88xxau-aircrack</li>
    <li>linuxPackages_lqx.rtlwifi_new</li>
    <li>linuxPackages_zen.akvcam</li>
    <li>linuxPackages_zen.amdgpu-pro</li>
    <li>linuxPackages_zen.anbox</li>
    <li>linuxPackages_zen.ati_drivers_x11</li>
    <li>linuxPackages_zen.chipsec</li>
    <li>linuxPackages_zen.cryptodev</li>
    <li>linuxPackages_zen.dpdk</li>
    <li>linuxPackages_zen.ena</li>
    <li>linuxPackages_zen.mwprocapture</li>
    <li>linuxPackages_zen.mxu11x0</li>
    <li>linuxPackages_zen.nvidia_x11_legacy340</li>
    <li>linuxPackages_zen.nvidia_x11_legacy390</li>
    <li>linuxPackages_zen.rtl8192eu</li>
    <li>linuxPackages_zen.rtl8812au</li>
    <li>linuxPackages_zen.rtl8814au</li>
    <li>linuxPackages_zen.rtl8821au</li>
    <li>linuxPackages_zen.rtl88x2bu</li>
    <li>linuxPackages_zen.rtl88xxau-aircrack</li>
    <li>linuxPackages_zen.rtlwifi_new</li>
  </ul>
</details>
<details>
  <summary>108 packages built:</summary>
  <ul>
    <li>linuxPackages_lqx.acpi_call</li>
    <li>linuxPackages_lqx.asus-wmi-sensors</li>
    <li>linuxPackages_lqx.batman_adv</li>
    <li>linuxPackages_lqx.bbswitch</li>
    <li>linuxPackages_lqx.bcc</li>
    <li>linuxPackages_lqx.bpftrace</li>
    <li>linuxPackages_lqx.broadcom_sta</li>
    <li>linuxPackages_lqx.can-isotp</li>
    <li>linuxPackages_lqx.cpupower</li>
    <li>linuxPackages_lqx.ddcci-driver</li>
    <li>linuxPackages_lqx.digimend</li>
    <li>linuxPackages_lqx.evdi</li>
    <li>linuxPackages_lqx.facetimehd</li>
    <li>linuxPackages_lqx.fwts-efi-runtime</li>
    <li>linuxPackages_lqx.gcadapter-oc-kmod</li>
    <li>linuxPackages_lqx.hyperv-daemons</li>
    <li>linuxPackages_lqx.intel-speed-select</li>
    <li>linuxPackages_lqx.it87</li>
    <li>linuxPackages_lqx.jool</li>
    <li>linuxPackages_lqx.kernel</li>
    <li>linuxPackages_lqx.mba6x_bl</li>
    <li>linuxPackages_lqx.netatop</li>
    <li>linuxPackages_lqx.nvidia_x11</li>
    <li>linuxPackages_lqx.nvidia_x11_beta</li>
    <li>linuxPackages_lqx.nvidia_x11_vulkan_beta</li>
    <li>linuxPackages_lqx.nvidiabl</li>
    <li>linuxPackages_lqx.oci-seccomp-bpf-hook</li>
    <li>linuxPackages_lqx.openafs</li>
    <li>linuxPackages_lqx.openafs_1_9</li>
    <li>linuxPackages_lqx.openrazer</li>
    <li>linuxPackages_lqx.perf</li>
    <li>linuxPackages_lqx.ply</li>
    <li>linuxPackages_lqx.r8168</li>
    <li>linuxPackages_lqx.rtl8821ce</li>
    <li>linuxPackages_lqx.rtl8821cu</li>
    <li>linuxPackages_lqx.sysdig</li>
    <li>linuxPackages_lqx.system76</li>
    <li>linuxPackages_lqx.system76-acpi</li>
    <li>linuxPackages_lqx.system76-io</li>
    <li>linuxPackages_lqx.systemtap</li>
    <li>linuxPackages_lqx.tmon</li>
    <li>linuxPackages_lqx.tp_smapi</li>
    <li>linuxPackages_lqx.turbostat</li>
    <li>linuxPackages_lqx.tuxedo-keyboard</li>
    <li>linuxPackages_lqx.usbip</li>
    <li>linuxPackages_lqx.v4l2loopback</li>
    <li>linuxPackages_lqx.v86d</li>
    <li>linuxPackages_lqx.vhba</li>
    <li>linuxPackages_lqx.virtualbox</li>
    <li>linuxPackages_lqx.virtualboxGuestAdditions</li>
    <li>linuxPackages_lqx.x86_energy_perf_policy</li>
    <li>linuxPackages_lqx.xpadneo</li>
    <li>linuxPackages_lqx.zenpower</li>
    <li>linuxPackages_lqx.zfs (linuxPackages_lqx.zfsUnstable)</li>
    <li>linuxPackages_zen.acpi_call</li>
    <li>linuxPackages_zen.asus-wmi-sensors</li>
    <li>linuxPackages_zen.batman_adv</li>
    <li>linuxPackages_zen.bbswitch</li>
    <li>linuxPackages_zen.bcc</li>
    <li>linuxPackages_zen.bpftrace</li>
    <li>linuxPackages_zen.broadcom_sta</li>
    <li>linuxPackages_zen.can-isotp</li>
    <li>linuxPackages_zen.cpupower</li>
    <li>linuxPackages_zen.ddcci-driver</li>
    <li>linuxPackages_zen.digimend</li>
    <li>linuxPackages_zen.evdi</li>
    <li>linuxPackages_zen.facetimehd</li>
    <li>linuxPackages_zen.fwts-efi-runtime</li>
    <li>linuxPackages_zen.gcadapter-oc-kmod</li>
    <li>linuxPackages_zen.hyperv-daemons</li>
    <li>linuxPackages_zen.intel-speed-select</li>
    <li>linuxPackages_zen.it87</li>
    <li>linuxPackages_zen.jool</li>
    <li>linuxPackages_zen.kernel</li>
    <li>linuxPackages_zen.mba6x_bl</li>
    <li>linuxPackages_zen.netatop</li>
    <li>linuxPackages_zen.nvidia_x11</li>
    <li>linuxPackages_zen.nvidia_x11_beta</li>
    <li>linuxPackages_zen.nvidia_x11_vulkan_beta</li>
    <li>linuxPackages_zen.nvidiabl</li>
    <li>linuxPackages_zen.oci-seccomp-bpf-hook</li>
    <li>linuxPackages_zen.openafs</li>
    <li>linuxPackages_zen.openafs_1_9</li>
    <li>linuxPackages_zen.openrazer</li>
    <li>linuxPackages_zen.perf</li>
    <li>linuxPackages_zen.ply</li>
    <li>linuxPackages_zen.r8168</li>
    <li>linuxPackages_zen.rtl8821ce</li>
    <li>linuxPackages_zen.rtl8821cu</li>
    <li>linuxPackages_zen.sysdig</li>
    <li>linuxPackages_zen.system76</li>
    <li>linuxPackages_zen.system76-acpi</li>
    <li>linuxPackages_zen.system76-io</li>
    <li>linuxPackages_zen.systemtap</li>
    <li>linuxPackages_zen.tmon</li>
    <li>linuxPackages_zen.tp_smapi</li>
    <li>linuxPackages_zen.turbostat</li>
    <li>linuxPackages_zen.tuxedo-keyboard</li>
    <li>linuxPackages_zen.usbip</li>
    <li>linuxPackages_zen.v4l2loopback</li>
    <li>linuxPackages_zen.v86d</li>
    <li>linuxPackages_zen.vhba</li>
    <li>linuxPackages_zen.virtualbox</li>
    <li>linuxPackages_zen.virtualboxGuestAdditions</li>
    <li>linuxPackages_zen.x86_energy_perf_policy</li>
    <li>linuxPackages_zen.xpadneo</li>
    <li>linuxPackages_zen.zenpower</li>
    <li>linuxPackages_zen.zfs (linuxPackages_zen.zfsUnstable)</li>
  </ul>
</details>
