### PR TITLE
[20.09] zoom-us: 5.4.57862.0110 -> 5.5.6981.0202

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, mkDerivation
 , makeWrapper
 , fetchFromGitHub
 # Dynamic libraries
@@ -32,11 +31,11 @@
 assert pulseaudioSupport -> libpulseaudio != null;
 
 let
-  version = "5.4.57862.0110";
+  version = "5.5.6981.0202";
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${version}/zoom_x86_64.pkg.tar.xz";
-      sha256 = "sha256-ZAwXhbZ3nT6PGkSC1vnX2y/XUOZfped0r3OuedI62gY=";
+      sha256 = "05alb81cn1vbpva5rcfwh58sjbg4f2pils4vcdgw6dvi4pbvs694";
     };
   };
   dontUnpack = true;


### PR DESCRIPTION
(cherry picked from commit 11daaf463ca9c938453869c860df7e5b7c81f015)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
