### PR TITLE
tremor-rs: init at 0.10.1

### DIFF
--- a/pkgs/tools/misc/tremor-rs/default.nix
+++ b/pkgs/tools/misc/tremor-rs/default.nix
@@ -1,0 +1,43 @@
+{ lib, rustPlatform, pkg-config, cmake, llvmPackages, openssl, fetchFromGitHub
+, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tremor";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "tremor-rs";
+    repo = "tremor-runtime";
+    rev = "v${version}";
+    sha256 = "1z1khxfdj2j0xf7dp0x2cd9kl6r4qicp7kc4p4sdky2yib66512y";
+  };
+
+  cargoSha256 = "sha256-rN/d6BL2d0D0ichQR6v0543Bh/Y2ktz8ExMH50M8B8c=";
+
+  nativeBuildInputs = [ cmake pkg-config installShellFiles ];
+
+  buildInputs = [ openssl ];
+
+  postInstall = ''
+    installShellCompletion --cmd tremor \
+      --bash <($out/bin/tremor completions bash) \
+      --fish <($out/bin/tremor completions fish) \
+      --zsh <($out/bin/tremor completions zsh)
+  '';
+
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+
+  # OPENSSL_NO_VENDOR - If set, always find OpenSSL in the system, even if the vendored feature is enabled.
+  OPENSSL_NO_VENDOR = 1;
+
+  cargoBuildFlags = [ "--all" ];
+
+  meta = with lib; {
+    description =
+      "Early stage event processing system for unstructured data with rich support for structural pattern matching, filtering and transformation";
+    homepage = "https://www.tremor.rs/";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ humancalico ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8851,6 +8851,8 @@ in
 
   tre = callPackage ../development/libraries/tre { };
 
+  tremor-rs = callPackage ../tools/misc/tremor-rs { };
+
   ts = callPackage ../tools/system/ts { };
 
   transfig = callPackage ../tools/graphics/transfig {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
