### PR TITLE
prometheus: Added package prometheus-slurm-exporter

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7891,6 +7891,12 @@
     githubId = 3621083;
     name = "Roosembert (Roosemberth) Palacios";
   };
+  rovanion = {
+    email = "rovanion.luckey+nixpkgs@gmail.com";
+    github = "rovanion";
+    githubId = 632775;
+    name = "Rovanion Luckey";
+  };
   rople380 = {
     name = "rople380";
     email = "55679162+rople380@users.noreply.github.com";

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -47,6 +47,7 @@ let
     "redis"
     "rspamd"
     "rtl_433"
+    "slurm"
     "snmp"
     "smokeping"
     "sql"

--- a/nixos/modules/services/monitoring/prometheus/exporters/slurm.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/slurm.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, options }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.slurm;
+in
+{
+  port = 9341;
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-slurm-exporter}/bin/slurm_exporter \
+          -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/nixos/modules/services/monitoring/prometheus/exporters/slurm.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/slurm.nix
@@ -10,10 +10,11 @@ in
   serviceOpts = {
     serviceConfig = {
       ExecStart = ''
-        ${pkgs.prometheus-slurm-exporter}/bin/slurm_exporter \
-          -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+        ${pkgs.prometheus-slurm-exporter}/bin/prometheus-slurm-exporter \
+          --listen-address "${cfg.listenAddress}:${toString cfg.port}" \
           ${concatStringsSep " \\\n  " cfg.extraFlags}
       '';
+      Environment = [ "PATH=${pkgs.slurm}/bin/" ];
     };
   };
 }

--- a/pkgs/servers/monitoring/prometheus/slurm-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/slurm-exporter.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchFromGitHub, nixosTests }:
+
+buildGoModule rec {
+  pname = "slurm-exporter";
+  version = "0.18";
+
+  src = fetchFromGitHub {
+    owner = "rovanion";
+    repo = "prometheus-slurm-exporter";
+    rev = version;
+    sha256 = "052g9q4ma0dsggxb3pajl9ml4293xfv10ani0qlrzh20n22j5kva";
+  };
+
+  vendorSha256 = "sha256:0g3wmb5i0d97yv98921apw5w4vgd5w9zqlqvsq918v136bpyzf9y";
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) slurm; };
+
+  checkPhase = ''
+    make unittest
+  '';
+
+  meta = with lib; {
+    description = "A Prometheus stats exporter for the Slurm cluster manager. ";
+    homepage = "https://github.com/rovanion/prometheus-slurm-exporter";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ rovanion ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18145,6 +18145,7 @@ in
   prometheus-redis-exporter = callPackage ../servers/monitoring/prometheus/redis-exporter.nix { };
   prometheus-rabbitmq-exporter = callPackage ../servers/monitoring/prometheus/rabbitmq-exporter.nix { };
   prometheus-rtl_433-exporter = callPackage ../servers/monitoring/prometheus/rtl_433-exporter.nix { };
+  prometheus-slurm-exporter = callPackage ../servers/monitoring/prometheus/slurm-exporter.nix { };
   prometheus-smokeping-prober = callPackage ../servers/monitoring/prometheus/smokeping-prober.nix { };
   prometheus-snmp-exporter = callPackage ../servers/monitoring/prometheus/snmp-exporter.nix { };
   prometheus-sql-exporter = callPackage ../servers/monitoring/prometheus/sql-exporter.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added the package prometheus-slurm-exporter. A program for exposing statistics about the Slurm cluster scheduler to the Prometheus database.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
