### PR TITLE
flavours: init at 0.3.5

### DIFF
--- a/pkgs/applications/misc/flavours/default.nix
+++ b/pkgs/applications/misc/flavours/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "flavours";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "Misterio77";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1lvbq026ap02f22mv45s904a0f81dr2f07j6bq0wnwl5wd5w0wpj";
+  };
+
+  cargoSha256 = "0wgi65k180mq1q6j4nma0wpfdvl67im5v5gmhzv1ap6xg3bicdg1";
+
+  meta = with lib; {
+    description = "An easy to use base16 scheme manager/builder that integrates with any workflow";
+    homepage = "https://github.com/Misterio77/flavours";
+    changelog = "https://github.com/Misterio77/flavours/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fortuneteller2k ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1261,6 +1261,8 @@ in
 
   fitnesstrax = callPackage ../applications/misc/fitnesstrax/default.nix { };
 
+  flavours = callPackage ../applications/misc/flavours { };
+
   flood = nodePackages.flood;
 
   fxlinuxprintutil = callPackage ../tools/misc/fxlinuxprintutil { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
[Flavours](https://github.com/Misterio77/flavours) is manager/builder for Base16 that is written in Rust.

###### Motivation for this change
Add flavours

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
