### PR TITLE
nixos/service-runner: fix evaluation

### DIFF
--- a/nixos/modules/testing/service-runner.nix
+++ b/nixos/modules/testing/service-runner.nix
@@ -52,7 +52,7 @@ let
 
       # Run the ExecStartPre program.  FIXME: this could be a list.
       my $preStart = <<END_CMD;
-      ${service.serviceConfig.ExecStartPre or ""}
+      ${concatStringsSep "\n" (service.serviceConfig.ExecStartPre or [])}
       END_CMD
       if (defined $preStart && $preStart ne "\n") {
           print STDERR "running ExecStartPre: $preStart\n";
@@ -79,7 +79,7 @@ let
 
       # Run the ExecStartPost program.
       my $postStart = <<END_CMD;
-      ${service.serviceConfig.ExecStartPost or ""}
+      ${concatStringsSep "\n" (service.serviceConfig.ExecStartPost or [])}
       END_CMD
       if (defined $postStart && $postStart ne "\n") {
           print STDERR "running ExecStartPost: $postStart\n";


### PR DESCRIPTION
Follow-up to: nixos/systemd: allow preStart with other ExecStartPre cmdlines #109976

As the additional ExecStartPre and ExecStartPost are now lists, update
their processing by service-runner.nix

(Will self-merge if nobody cares, but not immediately)

###### Motivation for this change

#109976 requires changes in `service-runner.nix` for evaluation to succeed

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (NixOS-derived layout and Nix daemon starter, but no systemd)
- (N/A) Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of BIND script produced with the patch
- (N/A) Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
