### PR TITLE
mailcap: 2.1.48 -> 2.1.49

### DIFF
--- a/pkgs/data/misc/mailcap/default.nix
+++ b/pkgs/data/misc/mailcap/default.nix
@@ -1,23 +1,23 @@
 { lib, fetchzip }:
 
 let
-  version = "2.1.48";
+  version = "2.1.49";
 
 in fetchzip {
   name = "mailcap-${version}";
 
   url = "https://releases.pagure.org/mailcap/mailcap-${version}.tar.xz";
-  sha256 = "08d0avz8971hkggd60dk9yyd14izz24yag3prpfafbvm670jlmqg";
+  sha256 = "1nl6zv6lwjyg85m7ffxlfy9gmhicg76l7iiy3qnn2vhkmaxipmcy";
 
   postFetch = ''
     tar -xavf $downloadedFile --strip-components=1
     substituteInPlace mailcap --replace "/usr/bin/" ""
-    gzip mailcap.4
+    gzip mailcap.5
     sh generate-nginx-mimetypes.sh < mime.types > nginx-mime.types
 
     install -D -m0644 nginx-mime.types $out/etc/nginx/mime.types
     install -D -m0644 -t $out/etc mailcap mime.types
-    install -D -m0644 -t $out/share/man/man4 mailcap.4.gz
+    install -D -m0644 -t $out/share/man/man5 mailcap.5.gz
   '';
 
   meta = with lib; {


### PR DESCRIPTION
update version and move manpage to correct section

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New version of mailcap, also moves manpage to correct section (changed in upstream)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
