### PR TITLE
python3Packages.primer3: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/primer3/default.nix
+++ b/pkgs/development/python-modules/primer3/default.nix
@@ -1,7 +1,9 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , cython
+, gcc
 , click
 }:
 
@@ -16,7 +18,8 @@ buildPythonPackage rec {
     sha256 = "1glybwp9w2m1ydvaphr41gj31d8fvlh40s35galfbjqa563si72g";
   };
 
-  nativeBuildInputs = [ cython ];
+  nativeBuildInputs = [ cython ]
+    ++ lib.optionals stdenv.isDarwin [ gcc ];
 
   # pytestCheckHook leads to a circular import issue
   checkInputs = [ click ];


### PR DESCRIPTION
(the build requires gcc)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
