### PR TITLE
home-assistant: 2021.2.0 -> 2021.2.1 

### DIFF
--- a/pkgs/development/python-modules/awesomeversion/default.nix
+++ b/pkgs/development/python-modules/awesomeversion/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "awesomeversion";
-  version = "21.2.0";
+  version = "21.2.2";
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "ludeeus";
     repo = pname;
     rev = version;
-    sha256 = "1rzd0mcxdjnnzg35hvdvacwrr9brwmkw9bwlb5x6bcp24ry9yl0q";
+    sha256 = "1yl09csypa64nhsw7dc6kj8iybm1wkhfzylyfyq8b7jpwdx7ql31";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyicloud/default.nix
+++ b/pkgs/development/python-modules/pyicloud/default.nix
@@ -1,40 +1,46 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, requests
+, fetchFromGitHub
+, certifi
+, click
 , keyring
 , keyrings-alt
-, click
+, pytz
+, requests
 , six
 , tzlocal
-, certifi
-, bitstring
-, unittest2
+, pytest-mock
+, pytestCheckHook
 , future
 }:
 
 buildPythonPackage rec {
   pname = "pyicloud";
-  version = "0.9.7";
+  version = "0.10.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "dcebb32e474bc28aa77b944a0a64949ef3b5b852cbef6256fbc95347a04e777c";
+  src = fetchFromGitHub {
+    owner = "picklepete";
+    repo = pname;
+    rev = version;
+    sha256 = "0bxbhvimwbj2jm8dg7sil8yvln17xgjhvpwr4m783vwfcf76kdmy";
   };
 
   propagatedBuildInputs = [
-    requests
+    certifi
+    click
+    future
     keyring
     keyrings-alt
-    click
+    pytz
+    requests
     six
     tzlocal
-    certifi
-    bitstring
-    future
   ];
 
-  checkInputs = [ unittest2 ];
+  checkInputs = [
+    pytest-mock
+    pytestCheckHook
+  ];
 
   postPatch = ''
     sed -i \

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.2.0";
+  version = "2021.2.1";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -182,31 +182,23 @@ in with py.pkgs; buildPythonApplication rec {
 
   pytestFlagsArray = [
     "-n auto"
+    # assign tests grouped by file to workers
+    "--dist loadfile"
     # don't bulk test all components
     "--ignore tests/components"
-    # prone to race conditions due to parallel file access
-    "--ignore tests/test_config.py"
     # pyotp since v2.4.0 complains about the short mock keys, hass pins v2.3.0
     "--ignore tests/auth/mfa_modules/test_notify.py"
     "tests"
   ] ++ map (component: "tests/components/" + component) componentTests;
 
   disabledTests = [
-    # AssertionError: assert 'unknown' == 'not_home'
-    "test_device_tracker_not_home"
+    # AssertionError: assert 1 == 0
+    "test_merge"
+    # ModuleNotFoundError: No module named 'pyqwikswitch'
+    "test_merge_id_schema"
     # keyring.errors.NoKeyringError: No recommended backend was available.
     "test_secrets_from_unrelated_fails"
     "test_secrets_credstash"
-    # AssertionError: Expected 'start' to have been called once. Called 0 times.
-    "test_setup_and_stop"
-    # AssertionError: assert {} == {'test': <ANY...ckage': <ANY>}
-    "test_get_custom_components_internal"
-    # assert 0 == 1 where 0 = len([])
-    "test_error_posted_as_event"
-    # RuntimeError: Event loop is closed
-    "test_config_path"
-    "test_info_endpoint_register_callback_timeout"
-    "test_scan_match_st"
   ];
 
   preCheck = ''

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -57,7 +57,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.2.0";
+  hassVersion = "2021.2.1";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -76,7 +76,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "116aq683wy7sxdbxr43li90irpfbsz0dv8w0r1fghcjpwlj7ihwa";
+    sha256 = "0a8l23n6j0x1hjcifajgbrip7b4l8xcgxn2wa1lcg27p1cghrv5m";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling
@@ -101,6 +101,7 @@ in with py.pkgs; buildPythonApplication rec {
     astral
     async-timeout
     attrs
+    awesomeversion
     bcrypt
     certifi
     ciso8601
@@ -205,6 +206,7 @@ in with py.pkgs; buildPythonApplication rec {
     # RuntimeError: Event loop is closed
     "test_config_path"
     "test_info_endpoint_register_callback_timeout"
+    "test_scan_match_st"
   ];
 
   preCheck = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/2021.2.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
