### PR TITLE
farbfeld: enable on darwin

### DIFF
--- a/pkgs/development/libraries/farbfeld/default.nix
+++ b/pkgs/development/libraries/farbfeld/default.nix
@@ -1,27 +1,27 @@
-{ lib, stdenv, fetchgit, makeWrapper, file, libpng, libjpeg }:
+{ lib, stdenv, fetchurl, makeWrapper, file, libpng, libjpeg }:
 
 stdenv.mkDerivation rec {
   pname = "farbfeld";
   version = "4";
 
-  src = fetchgit {
-    url = "https://git.suckless.org/farbfeld";
-    rev = "refs/tags/${version}";
-    sha256 = "0pkmkvv5ggpzqwqdchd19442x8gh152xy5z1z13ipfznhspsf870";
+  src = fetchurl {
+    url = "https://dl.suckless.org/farbfeld/farbfeld-${version}.tar.gz";
+    sha256 = "0ap7rcngffhdd57jw9j22arzkbrhwh0zpxhwbdfwl8fixlhmkpy7";
   };
 
   buildInputs = [ libpng libjpeg ];
   nativeBuildInputs = [ makeWrapper ];
 
-  installFlags = [ "PREFIX=/" "DESTDIR=$(out)" ];
+  installFlags = [ "PREFIX=$(out)" ];
   postInstall = ''
     wrapProgram "$out/bin/2ff" --prefix PATH : "${file}/bin"
   '';
 
   meta = with lib; {
     description = "Suckless image format with conversion tools";
+    homepage = "https://tools.suckless.org/farbfeld/";
     license = licenses.isc;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ pSub ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
* enable on darwin
* fetchgit -> fetchurl
* add homepage

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
