### PR TITLE
qutebrowser: fixed darkmode for new qt versions

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -29,6 +29,8 @@ let
      Valid choices are qtwebengine (recommended) or qtwebkit.
    '';
 
+  qtVersion = with lib.versions; "qt_${major qtbase.version}${minor qtbase.version}_${patch qtbase.version}";
+
 in mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "qutebrowser";
   version = "2.0.2";
@@ -113,6 +115,7 @@ in mkDerivationWith python3Packages.buildPythonApplication rec {
     wrapProgram $out/bin/qutebrowser \
       "''${gappsWrapperArgs[@]}" \
       "''${qtWrapperArgs[@]}" \
+      --prefix QUTE_DARKMODE_VARIANT : ${qtVersion} \
       --add-flags '--backend ${backend}'
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
> When QtWebEngine has been updated but PyQtWebEngine hasn’t yet, the dark mode settings might stop working. As a (currently undocumented) escape hatch, this version adds a QUTE_DARKMODE_VARIANT=qt_515_2 environment variable which can be set to get the correct behavior in (transitive) situations like this.

quote from: 
https://github.com/qutebrowser/qutebrowser/blob/ee577b63c317ee7c85876bc2b510d65859f57766/doc/changelog.asciidoc#v200-2021-01-28

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
