### PR TITLE
python3Packages.linuxfd: mark linux only, clarify license

### DIFF
--- a/pkgs/development/python-modules/linuxfd/default.nix
+++ b/pkgs/development/python-modules/linuxfd/default.nix
@@ -19,6 +19,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python bindings for the Linux eventfd/signalfd/timerfd/inotify syscalls";
     homepage = "https://github.com/FrankAbelbeck/linuxfd";
-    license = with lib.licenses; [ lgpl3 ];
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [ lgpl3Plus ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Mark this package as linux-only, so that it doesn't fail to build on hydra, and correct the license (source: https://github.com/FrankAbelbeck/linuxfd/blob/master/setup.py#L8)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
