### PR TITLE
python3Packages.nbsphinx: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/nbconflux/default.nix
+++ b/pkgs/development/python-modules/nbconflux/default.nix
@@ -1,4 +1,12 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy27, nbconvert, pytest, requests, responses }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, nbconvert
+, pytestCheckHook
+, requests
+, responses
+}:
 
 buildPythonPackage rec {
   pname = "nbconflux";
@@ -14,11 +22,13 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ nbconvert requests ];
 
-  checkInputs = [ pytest responses ];
+  checkInputs = [ pytestCheckHook responses ];
 
-  checkPhase = ''
-    pytest tests
-  '';
+  JUPYTER_PATH="${nbconvert}/share/jupyter";
+  disabledTests = [
+    "test_post_to_confluence"
+    "test_optional_components"
+  ];
 
   meta = with lib; {
     description = "Converts Jupyter Notebooks to Atlassian Confluence (R) pages using nbconvert";

--- a/pkgs/development/python-modules/nbsphinx/default.nix
+++ b/pkgs/development/python-modules/nbsphinx/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "nbsphinx";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "369c16fe93af14c878d61fb3e81d838196fb35b27deade2cd7b95efe1fe56ea0";
+    sha256 = "19lf036h0d9ryqasrh91myhn3dq5zcw4rik9jy6sayq7l6irmm94";
   };
 
   propagatedBuildInputs = [
@@ -29,9 +29,13 @@ buildPythonPackage rec {
     traitlets
   ];
 
-  checkPhase = ''
-    ${python.interpreter} -m nbsphinx
-  '';
+  # The package has not tests
+  doCheck = false;
+
+  JUPYTER_PATH = "${nbconvert}/share/jupyter";
+  pythonImportsCheck = [
+    "nbsphinx"
+  ];
 
   disabled = !isPy3k;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes a [build failure on hydra](https://hydra.nixos.org/build/135943412). It looks like this environment variable needs to be set to run the tests during the build, or else something like `python.withPackages (ps: [ps.nbformat])'` would be need to be done during the build, rather than relying on propagatedBuildInputs to configure the environment correctly for testing, because it's looking for some /share paths that aren't set.

I did test that without setting any special environment variables, the package does work at runtime if you do something like

```
$ nix-shell -p '(import ./. {}).python38.withPackages (ps: [ps.nbsphinx])' --command "python -c 'import nbsphinx; print(nbsphinx)'"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
