### PR TITLE
python3Packages.nunavut: 0.6.2 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/nunavut/default.nix
+++ b/pkgs/development/python-modules/nunavut/default.nix
@@ -1,13 +1,18 @@
-{ lib, buildPythonPackage, pythonOlder, fetchPypi, pydsdl }:
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, pydsdl
+}:
 
  buildPythonPackage rec {
   pname = "nunavut";
-  version = "0.6.2";
+  version = "1.0.1";
   disabled = pythonOlder "3.5"; # only python>=3.5 is supported
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "48b6802722d78542ca5d7bbc0d6aa9b0a31e1be0070c47b41527f227eb6a1443";
+    sha256 = "1gvs3fx2l15y5ffqsxxjfa4p1ydaqbq7qp5nsgb8jbz871358jxm";
   };
 
   propagatedBuildInputs = [
@@ -19,7 +24,10 @@
     export HOME=$TMPDIR
   '';
 
-  # repo doesn't contain tests, ensure imports aren't broken
+  # No tests in pypy package and no git tags yet for release versions, see
+  # https://github.com/UAVCAN/nunavut/issues/182
+  doCheck = false;
+
   pythonImportsCheck = [
     "nunavut"
   ];

--- a/pkgs/development/python-modules/pydsdl/default.nix
+++ b/pkgs/development/python-modules/pydsdl/default.nix
@@ -2,25 +2,24 @@
 
  buildPythonPackage rec {
   pname = "pydsdl";
-  version = "1.4.2";
+  version = "1.9.4";
   disabled = pythonOlder "3.5"; # only python>=3.5 is supported
 
   src = fetchFromGitHub {
     owner = "UAVCAN";
     repo = pname;
     rev = version;
-    sha256 = "03kbpzdrjzj5vpgz5rhc110pm1axdn3ynv88b42zq6iyab4k8k1x";
+    sha256 = "1hmmc4sg6dckbx2ghcjpi74yprapa6lkxxzy0h446mvyngp0kwfv";
   };
-
-  propagatedBuildInputs = [
-  ];
 
   # allow for writable directory for darwin
   preBuild = ''
     export HOME=$TMPDIR
   '';
 
-  # repo doesn't contain tests, ensure imports aren't broken
+  # repo doesn't contain tests
+  doCheck = false;
+
   pythonImportsCheck = [
     "pydsdl"
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix `python3Packages.nunavut` (which was broken on hydra) by upgrading `python3Packages.pydsdl`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

------

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>9 packages built:</summary>
  <ul>
    <li>python37Packages.nunavut</li>
    <li>python37Packages.pydsdl</li>
    <li>python37Packages.pyuavcan</li>
    <li>python38Packages.nunavut</li>
    <li>python38Packages.pydsdl</li>
    <li>python38Packages.pyuavcan</li>
    <li>python39Packages.nunavut</li>
    <li>python39Packages.pydsdl</li>
    <li>python39Packages.pyuavcan</li>
  </ul>
</details>
