### PR TITLE
python3Packages.pysma: init at 0.3.5

### DIFF
--- a/pkgs/development/python-modules/pysma/default.nix
+++ b/pkgs/development/python-modules/pysma/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, aiohttp
+, attrs
+, buildPythonPackage
+, fetchPypi
+, jmespath
+, async-timeout
+}:
+
+buildPythonPackage rec {
+  pname = "pysma";
+  version = "0.3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1awcsbk14i2aw01f7b7hrmpn9q6vr9v6la0i9n7ldv1h8rzq6j16";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    attrs
+    jmespath
+  ];
+
+  # pypi does not contain tests and GitHub archive not available
+  doCheck = false;
+  pythonImportsCheck = [ "pysma" ];
+
+  meta = with lib; {
+    description = "Python library for interacting with SMA Solar's WebConnect";
+    homepage = "https://github.com/kellerza/pysma";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -744,7 +744,7 @@
     "slack" = ps: with ps; [ ]; # missing inputs: slackclient
     "sleepiq" = ps: with ps; [ ]; # missing inputs: sleepyq
     "slide" = ps: with ps; [ ]; # missing inputs: goslide-api
-    "sma" = ps: with ps; [ ]; # missing inputs: pysma
+    "sma" = ps: with ps; [ pysma ];
     "smappee" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pysmappee
     "smart_meter_texas" = ps: with ps; [ ]; # missing inputs: smart-meter-texas
     "smarthab" = ps: with ps; [ ]; # missing inputs: smarthab

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5929,6 +5929,8 @@ in {
 
   pyslurm = callPackage ../development/python-modules/pyslurm { slurm = pkgs.slurm; };
 
+  pysma = callPackage ../development/python-modules/pysma { };
+
   pysmb = callPackage ../development/python-modules/pysmb { };
 
   pysmbc = callPackage ../development/python-modules/pysmbc { inherit (pkgs) pkg-config; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for interacting with SMA Solar's WebConnect.

https://github.com/kellerza/pysma

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
