### PR TITLE
python3Packages.aioharmony: 0.2.6 -> 0.2.7

### DIFF
--- a/pkgs/development/python-modules/aioharmony/default.nix
+++ b/pkgs/development/python-modules/aioharmony/default.nix
@@ -1,27 +1,36 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k, slixmpp, async-timeout, aiohttp }:
+{ lib
+, aiohttp
+, async-timeout
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, slixmpp
+}:
 
 buildPythonPackage rec {
   pname = "aioharmony";
-  version = "0.2.6";
+  version = "0.2.7";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "90f4d1220d44b48b21a57e0273aa3c4a51599d0097af88e8be26df151e599344";
+    sha256 = "sha256-aej8xC0Bsy6ip7IwO6onp55p6afkz8yZnz14cCExSPA=";
   };
 
-  disabled = !isPy3k;
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    slixmpp
+  ];
 
-  #aioharmony does not seem to include tests
+  # aioharmony does not seem to include tests
   doCheck = false;
 
   pythonImportsCheck = [ "aioharmony.harmonyapi" "aioharmony.harmonyclient" ];
 
-  propagatedBuildInputs = [ slixmpp async-timeout aiohttp ];
-
   meta = with lib; {
     homepage = "https://github.com/ehendrix23/aioharmony";
-    description =
-      "Asyncio Python library for connecting to and controlling the Logitech Harmony";
+    description = "Python library for interacting the Logitech Harmony devices";
     license = licenses.asl20;
     maintainers = with maintainers; [ oro ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.7

Change log: https://github.com/ehendrix23/aioharmony/releases/tag/v0.2.7

Also, ran `nixpkgs-fmt` and align layout with other Python modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
