### PR TITLE
source combinators: extend, trace, cutAt, focusAt and more

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -84,4 +84,43 @@ in
       else
         hasPrefix (pre + "/") (other + "/");
 
+
+  # commonPath : PathLike -> PathLike -> Path
+  #
+  # Find the common ancestory; the longest prefix path that is common between
+  # the input paths.
+  commonPath = a: b:
+    let
+      b' = /. + b;
+      go = c:
+        if pathHasPrefix c b'
+        then c
+        else go (dirOf c);
+    in
+      go (/. + a);
+
+  # absolutePathComponentsBetween : PathOrString -> PathOrString -> [String]
+  # absolutePathComponentsBetween ancestor descendant
+  #
+  # Returns the path components that form the path from ancestor to descendant.
+  # Will not return ".." components, which is a feature. Throws when ancestor
+  # and descendant arguments aren't in said relation to each other.
+  #
+  # Example:
+  #
+  #   absolutePathComponentsBetween /a     /a/b/c == ["b" "c"]
+  #   absolutePathComponentsBetween /a/b/c /a/b/c == []
+  absolutePathComponentsBetween =
+    ancestor: descendant:
+      let
+        a' = /. + ancestor;
+        go = d:
+          if a' == d
+          then []
+          else if d == /.
+          then throw "absolutePathComponentsBetween: path ${toString ancestor} is not an ancestor of ${toString descendant}"
+          else go (dirOf d) ++ [(baseNameOf d)];
+      in
+        go (/. + descendant);
+
 }

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -1,4 +1,14 @@
 { lib }:
+
+let
+  inherit (lib.strings)
+    hasPrefix
+    ;
+  inherit (lib.filesystem)
+    pathHasPrefix
+    ;
+in
+
 { # haskellPathsInDir : Path -> Map String Path
   # A map of all haskell packages defined in the given path,
   # identified by having a cabal file with the same name as the
@@ -53,5 +63,25 @@
     else
       dir + "/${name}"
   ) (builtins.readDir dir));
+
+  # pathHasPrefix : Path -> Path -> Bool
+  # pathHasPrefix ancestor somePath
+  #
+  # Return true iff, disregarding trailing slashes,
+  #   - somePath is below ancestor
+  #   - or equal to ancestor
+  #
+  # Equivalently, return true iff you can reach ancestor by starting at somePath
+  # and traversing the `..` node zero or more times.
+  pathHasPrefix = prefixPath: otherPath:
+    let
+      normalizedPathString = pathLike: toString (/. + pathLike);
+      pre = normalizedPathString prefixPath;
+      other = normalizedPathString otherPath;
+    in
+      if pre == "/" # root is the only path that already ends in "/"
+      then true
+      else
+        hasPrefix (pre + "/") (other + "/");
 
 }

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -121,6 +121,9 @@ let
     When used in the `stdenv` `src` parameter, the whole source will be copied
     and the build script will `cd` into the path that corresponds to `base`.
 
+    The result will match the first argument with respect to the name and
+    original location of the subpath (see `sources.pointAt`).
+
     Type:
       extend : SourceLike -> [SourceLike] -> Source
   */
@@ -149,7 +152,7 @@ let
       fromSourceAttributes {
         origSrc = root;
         filter = path: type: sourcesIncludingPath path != [];
-        name = "source";
+        name = baseAttrs.name;
         subpath = absolutePathComponentsBetween root baseAttrs.origSrc ++ baseAttrs.subpath;
       };
 

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -144,6 +144,9 @@ let
   # points at the location of `base`. The returned source will be a reference
   # to a subpath of a store path when it is necessary to accomodate for the
   # relative locations of `extras`.
+  #
+  # When used in the `stdenv` `src` parameter, the whole source will be copied
+  # and the build script will `cd` into the path that corresponds to `base`.
   extend = base: lib.foldl union base;
 
   # Almost the identity of sources.extend when it comes to the filter function;
@@ -155,6 +158,9 @@ let
   #
   # Produce a new source identical to `source` except its string interpolation
   # (or `outPath`) resolves to a subpath that corresponds to `path`.
+  #
+  # When used in the `stdenv` `src` parameter, the whole of `source` will be
+  # copied and the build script will `cd` into the path that corresponds to `path`.
   pointAt = path: src:
     let
       orig = toSourceAttributes src;

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -189,6 +189,7 @@ let
       #  ^ does not exist (resolves to /nix/store/foo.json)
   */
   pointAt = path: srcRaw:
+    assert typeOf path == "path";
     let
       orig = toSourceAttributes srcRaw;
       valid =
@@ -235,6 +236,7 @@ let
     path:
     # A sourcelike that determines which nodes will be included, starting at `path`
     srcRaw:
+    assert typeOf path == "path";
     let
       orig = toSourceAttributes srcRaw;
       valid =

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -97,6 +97,7 @@ let
       filter = path: type: filter path type && orig.filter path type;
       name = if name != null then name else orig.name;
     };
+  _filter = fn: src: cleanSourceWith { filter = fn; inherit src; };
 
   # sources.union : Source -> Source -> Source
   # sources.union a b
@@ -382,4 +383,5 @@ in {
     trace
     union
     ;
+  filter = _filter;
 }

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -114,6 +114,8 @@ let
         satisfiesSubpathInvariant = src ? satisfiesSubpathInvariant && src.satisfiesSubpathInvariant;
       };
 
+  setName = name: src: cleanSourceWith { inherit name src; };
+
   # Filter sources by a list of regular expressions.
   #
   # E.g. `src = sourceByRegex ./my-subproject [".*\.py$" "^database.sql$"]`
@@ -258,6 +260,7 @@ in {
     sourceByRegex
     sourceFilesBySuffices
 
+    setName
     trace
     ;
 }

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -14,6 +14,7 @@ let
   inherit (lib)
     attrByPath
     boolToString
+    concatMapStrings
     filter
     getAttr
     isString
@@ -133,6 +134,13 @@ let
         satisfiesSubpathInvariant = true;
       }
     );
+
+  # extend : SourceLike -> [SourceLike] -> Source
+  # extend base extras : Source
+  #
+  # Produce a source that contains all the files in `base` and `extras` and
+  # points at the location of `base`.
+  extend = base: lib.foldl union base;
 
   # Identity of sources.union when it comes to the filter function
   empty = path: cleanSourceWith { src = path; filter = _: _: false; };
@@ -378,6 +386,7 @@ in {
     sourceFilesBySuffices
 
     empty
+    extend
     reparent
     setName
     trace

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -16,6 +16,7 @@ let
     attrByPath
     boolToString
     concatMapStrings
+    concatStringsSep
     filter
     getAttr
     head
@@ -233,6 +234,30 @@ let
       srcAttrs = toSourceAttributes srcRaw;
     in srcAttrs.origSrc + "${concatMapStrings (x: "/${x}") srcAttrs.subpath}";
 
+  /*
+    Returns the part of the path of `"${src}"` that is inside the store path
+    that is created for it.
+    This returns the empty string when `src` does not include any files or
+    directories outside of itself.
+
+    Type: sourceLike -> Path
+
+    Example:
+
+      getSubpath
+        (extend
+          (cleanSource ./css)
+          [ ../common.mk ]
+        )
+      == "resources/css"
+      #   ^ assuming the directory containing
+      # this expression is named `resources`.
+   */
+  getSubpath = srcRaw:
+    let
+      srcAttrs = toSourceAttributes srcRaw;
+    in
+      lib.concatStringsSep "/" srcAttrs.subpath;
   /*
     Produces a source that starts at `path` and only contains nodes that are in `src`.
 
@@ -522,6 +547,7 @@ in {
 
     # getters
     getOriginalFocusPath
+    getSubpath
     ;
 
   /*

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -446,6 +446,10 @@ let
           path string: ${src}''
       else
         toSourceAttributes (/. + src)
+    else if src ? outPath && typeOf src.outPath == "path" then
+      # Sometimes, path-like attrsets are constructed to augment a path with
+      # a bit of metadata.
+      toSourceAttributes src.outPath
     else
       throw "A value of type ${typeOf src} can not be automatically converted to a source.";
 

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -213,6 +213,27 @@ let
        }));
 
   /*
+    Returns the original path that is copied and returned by `"${src}"`.
+    This may be a subpath of a store path, for example when `src` was created
+    with `focusAt` or `extend`.
+
+    Type: sourceLike -> Path
+
+    Example:
+
+      getOriginalFocusPath
+        (extend
+          (cleanSource ./src)
+          [ ./README.md ]
+        )
+      == ./src
+   */
+  getOriginalFocusPath = srcRaw:
+    let
+      srcAttrs = toSourceAttributes srcRaw;
+    in srcAttrs.origSrc + "${concatMapStrings (x: "/${x}") srcAttrs.subpath}";
+
+  /*
     Produces a source that starts at `path` and only contains nodes that are in `src`.
 
     Type:
@@ -490,6 +511,7 @@ in {
   # part of the interface meant to be referenced as source.* or localized
   # let inherit.
   inherit
+    # combinators
     cutAt
     empty
     extend
@@ -497,6 +519,9 @@ in {
     reparent
     setName
     trace
+
+    # getters
+    getOriginalFocusPath
     ;
 
   /*

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -126,12 +126,12 @@ let
   */
   extend =
     # Source-like object that serves as the starting point. The path `"${extend base extras}"` points to the same file as `"${base}"`
-    base:
+    baseRaw:
     # List of sources that will also be included in the store path.
-    extras:
+    extrasRaw:
     let
-      baseAttrs = toSourceAttributes base;
-      extrasAttrs = map toSourceAttributes extras;
+      baseAttrs = toSourceAttributes baseRaw;
+      extrasAttrs = map toSourceAttributes extrasRaw;
       root = lib.foldl' (a: b: commonPath a b.origSrc) baseAttrs.origSrc extrasAttrs;
       sourcesIncludingPath =
         memoizePathFunction
@@ -150,7 +150,7 @@ let
         origSrc = root;
         filter = path: type: sourcesIncludingPath path != [];
         name = "source";
-        subpath = absolutePathComponentsBetween root base.origSrc ++ base.subpath;
+        subpath = absolutePathComponentsBetween root baseAttrs.origSrc ++ baseAttrs.subpath;
       };
 
   /*
@@ -188,9 +188,9 @@ let
       => "/nix/store/ls9...-source/../foo.json"
       #  ^ does not exist (resolves to /nix/store/foo.json)
   */
-  pointAt = path: src:
+  pointAt = path: srcRaw:
     let
-      orig = toSourceAttributes src;
+      orig = toSourceAttributes srcRaw;
       valid =
         if ! pathHasPrefix orig.origSrc path
         then throw "sources.pointAt: new path is must be a subpath (or self) of the original source directory. But ${toString path} is not a subpath (or self) of ${toString orig.origSrc}"
@@ -233,10 +233,10 @@ let
   cutAt =
     # The path that will form the new root of the source
     path:
-    # A source that determines which nodes will be included, starting at `path`
-    src:
+    # A sourcelike that determines which nodes will be included, starting at `path`
+    srcRaw:
     let
-      orig = toSourceAttributes src;
+      orig = toSourceAttributes srcRaw;
       valid =
         if ! pathHasPrefix orig.origSrc path
         then throw "sources.cutAt: new source root must be a subpath (or self) of the original source directory. But ${toString path} is not a subpath (or self) of ${toString orig.origSrc}"

--- a/lib/tests/filesystem-test.nix
+++ b/lib/tests/filesystem-test.nix
@@ -1,8 +1,13 @@
 let
   lib = import ../.;
   inherit (lib) filesystem concatMap;
-  inherit (filesystem) pathHasPrefix pathIntersects;
-  inherit (import ./property-test.nix) forceChecks withItems;
+  inherit (filesystem)
+    pathHasPrefix
+    pathIntersects
+    absolutePathComponentsBetween
+    commonPath
+    ;
+  inherit (import ./property-test.nix) forceChecks withItems throws;
 
   somePaths = [
     /.
@@ -64,4 +69,33 @@ assert forceChecks (
 );
 
 
+########################
+# absolutePathComponentsBetween
+
+assert absolutePathComponentsBetween /a /a/b/c == ["b" "c"];
+assert absolutePathComponentsBetween /a/b /a/b/c == ["c"];
+assert absolutePathComponentsBetween /a/b/c /a/b/c == [];
+assert throws (absolutePathComponentsBetween /a /.);
+assert throws (absolutePathComponentsBetween /a /b);
+
+
+################
+# commonPath
+
+assert commonPath /a /a == /a;
+assert commonPath /a "/a" == /a;
+assert commonPath "/a" /a == /a;
+
+assert commonPath /a /a/b == /a;
+assert commonPath /a/b /a == /a;
+
+assert commonPath /a /a/b == /a;
+assert commonPath /a/b /a/c == /a;
+assert commonPath /a/b /a/c/d == /a;
+assert commonPath /a/b/c /a/b/d == /a/b;
+assert commonPath /a/b/c /a/b/c == /a/b/c;
+assert commonPath /a/b /. == /.;
+assert commonPath /. /. == /.;
+
 {}
+

--- a/lib/tests/filesystem-test.nix
+++ b/lib/tests/filesystem-test.nix
@@ -1,0 +1,67 @@
+let
+  lib = import ../.;
+  inherit (lib) filesystem concatMap;
+  inherit (filesystem) pathHasPrefix pathIntersects;
+  inherit (import ./property-test.nix) forceChecks withItems;
+
+  somePaths = [
+    /.
+    /foo
+    /bar
+    "/bar"
+    /foo/foo
+    /foo/bar
+    /bar/foo/bar
+    /foo/bar/foo
+  ];
+
+  alternatePathHasPrefix = prefixPath: otherPath:
+    let
+      normalizedPathString = pathLike: toString (/. + pathLike);
+      pre = normalizedPathString prefixPath;
+      other = normalizedPathString otherPath;
+    in
+      if other == pre
+      then true
+      else if other == "/"
+      then false
+      else alternatePathHasPrefix pre (dirOf other);
+
+in
+
+################
+# pathHasPrefix
+
+# basics
+assert pathHasPrefix /foo /foo;
+assert pathHasPrefix /foo /foo/bar;
+assert !pathHasPrefix /foo /bar;
+assert pathHasPrefix /foo/a /foo/a;
+assert pathHasPrefix /foo/a /foo/a/b;
+assert !pathHasPrefix /foo/a/b /foo/a;
+assert pathHasPrefix /. /foo;
+assert !pathHasPrefix /foo /.;
+
+# strings are normalized
+assert pathHasPrefix "/foo" "/foo/bar";
+assert pathHasPrefix "/foo" "/foo////bar";
+assert pathHasPrefix "/foo" "/foo/bar/";
+# This fits Nix's disregard for trailing slashes. Not great, but doing the opposite isn't great either.
+assert pathHasPrefix "/foo/" "/foo";
+assert pathHasPrefix "/foo" "/foo/";
+
+assert !pathHasPrefix /foo /.;
+assert !pathHasPrefix /foo /bar/foo;
+assert !pathHasPrefix /foo /foof; # not a simple string comparison
+
+
+assert forceChecks (
+  withItems "prefix" somePaths (prefix:
+    withItems "other" somePaths (other:
+      assert pathHasPrefix prefix other == alternatePathHasPrefix prefix other; {}
+    )
+  )
+);
+
+
+{}

--- a/lib/tests/filesystem.sh
+++ b/lib/tests/filesystem.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use
+#     || die
+die() {
+  echo >&2 "test case failed: " "$@"
+  exit 1
+}
+
+cd "$(dirname ${BASH_SOURCE[0]})"
+
+nix-instantiate --eval --json --show-trace filesystem-test.nix >/dev/null || die filesystem-test.nix
+
+echo tests ok

--- a/lib/tests/property-test.nix
+++ b/lib/tests/property-test.nix
@@ -1,0 +1,83 @@
+
+/*
+This "property testing framework" leverages built-in asserts and traces in
+an attempt to provide the best feedback it can give with the limitations
+that:
+
+- the test writing experience is weird
+- only the first error is reported
+- no shrinking
+- no fuzzing
+
+To use it, stick to this pattern:
+
+    assert forceChecks (
+      withItems "prefix" somePaths (prefix:
+        withItems "other" somePaths (other:
+          assert pathHasPrefix prefix other == alternatePathHasPrefix prefix other; {}
+        )
+      )
+    );
+
+Let's have a look why everything is there.
+
+          assert pathHasPrefix prefix other == alternatePathHasPrefix prefix other; {}
+          ^^^^^^
+          reports the line number of the test failure, with an augmented stack
+          trace that contains the values that triggered the failure
+
+
+          assert pathHasPrefix prefix other == alternatePathHasPrefix prefix other; {}
+                                                                                    ^^
+          return non-bool, so we can detect when someone forgets
+          the essential assert keyword
+
+
+        withItems "other" somePaths (other:
+        ^^^^^^^^^
+        lets us do limited property testing, using examples instead of random generations
+
+
+        withItems "other" somePaths (other:
+                  ^^^^^^^
+        names the example when it is printed in the stack trace, so you know for
+        which values it failed
+
+
+        withItems "other" somePaths (other:
+                          ^^^^^^^^^  ^^^^^
+        a list of examples to test with. `other` will have each of these values
+
+      nesting of withItems:
+      tests all possible combinations
+
+    assert
+    ^^^^^^
+    while not essential, it's nice to reuse a syntax that doesn't produce
+    O(n) indentation pyramids. Lists would qualify for this purpose but turned
+    out to be messier.
+
+    assert forceChecks (
+           ^^^^^^^^^^^
+    because we want to detect accidental omissions of `assert`, we can't
+    normally return true, `forceChecks` forces its argument and then returns true.
+
+
+*/
+
+let
+  lib = import ../.;
+  inherit (builtins) concatMap seq addErrorContext;
+  inherit (lib.generators) toPretty;
+
+  forceChecks = x: builtins.seq x true;
+  checkAssert = r: if r == true || r == false then throw "Please use assert expressions in forceChecks and withItems." else r;
+  withItems = name: items: f:
+    lib.foldl'
+      (_prev: item: addErrorContext "while testing with ${name} = ${toPretty {} item}" (checkAssert (f item)))
+      true
+      items;
+
+in {
+  inherit forceChecks withItems;
+}

--- a/lib/tests/property-test.nix
+++ b/lib/tests/property-test.nix
@@ -78,6 +78,9 @@ let
       true
       items;
 
+  # true iff the argument throws an exception
+  throws = a: ! (builtins.tryEval a).success;
+
 in {
-  inherit forceChecks withItems;
+  inherit forceChecks withItems throws;
 }

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -32,5 +32,8 @@ pkgs.runCommandNoCC "nixpkgs-lib-tests" {
     echo "Running lib/tests/sources.sh"
     TEST_LIB=$PWD/lib bash lib/tests/sources.sh
 
+    echo "Running lib/tests/filesystem.sh"
+    bash lib/tests/filesystem.sh
+
     touch $out
 ''

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -251,4 +251,13 @@ dir="$(nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
 }")')"
 echo $dir | grep -- -anna >/dev/null || die "setName"
 
+{
+  (
+    nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
+      extend ./. [ ./does-not-exist ]
+    }")' || true
+  ) 2>&1 | grep 'error: Path does not exist while attempting to construct a source.' >/dev/null
+} || die "non-existing paths are an error, even when used lazily in, say, extend's list argument."
+echo $dir | grep -- -anna >/dev/null || die "setName"
+
 echo >&2 tests ok

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -47,6 +47,17 @@ dir="$(nix eval --raw '(with import <nixpkgs/lib>; "${
 EOF
 ) || die "cleanSourceWith 1"
 
+
+dir="$(nix eval --raw '(with import <nixpkgs/lib>; "${
+  sources.filter (path: type: ! hasSuffix ".bar" path) ./.
+}")')"
+(cd $dir; find) | sort -f | diff -U10 - <(cat <<EOF
+.
+./module.o
+./README.md
+EOF
+) || die "sources.filter"
+
 dir="$(nix eval --raw '(with import <nixpkgs/lib>; "${
   cleanSourceWith { src = cleanSource '"$work"'; filter = path: type: ! hasSuffix ".bar" path; }
 }")')"

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -56,4 +56,9 @@ dir="$(nix eval --raw '(with import <nixpkgs/lib>; "${
 EOF
 ) || die "cleanSourceWith + cleanSource"
 
+dir="$(nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
+  setName "anna" (cleanSource ./.)
+}")')"
+echo $dir | grep -- -anna >/dev/null || die "setName"
+
 echo >&2 tests ok

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -59,6 +59,16 @@ EOF
 ) || die "sources.filter"
 
 dir="$(nix eval --raw '(with import <nixpkgs/lib>; "${
+  sources.filter (path: type: ! hasSuffix ".bar" path) { outPath = ./.; fetcherLikeMetadata = "included"; }
+}")')"
+(cd $dir; find) | sort -f | diff -U10 - <(cat <<EOF
+.
+./module.o
+./README.md
+EOF
+) || die "paths with metadata are also sources"
+
+dir="$(nix eval --raw '(with import <nixpkgs/lib>; "${
   cleanSourceWith { src = cleanSource '"$work"'; filter = path: type: ! hasSuffix ".bar" path; }
 }")')"
 (cd $dir; find) | sort -f | diff -U10 - <(cat <<EOF

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -214,6 +214,22 @@ EOF
 
 dir="$(
   nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
+    cutAt ./src (
+      extend
+        ./README.md
+        [ (cleanSource ./src) ]
+    )
+  }")'
+)"
+(cd "$dir" && find .) | sort -f | diff -U10 - <(cat <<EOF
+.
+./bar.c
+EOF
+) || die "sources.cutAt only includes part of the tree"
+(echo "$dir" | grep -- '-source$' >/dev/null) || die "sources.cutAt produces a plain store path; not a subpath of a store path"
+
+dir="$(
+  nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
     extend
       (cleanSource ./src)
       [ ./README.md

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -217,6 +217,30 @@ bool="$(
 )"
 [[ true == "$bool" ]] || die "getOriginalFocusPath example 2"
 
+string="$(
+  nix eval --raw '(with import <nixpkgs/lib>; with sources; "${boolToString (
+    getSubpath (
+      (extend
+        (cleanSource ./src)
+        [ ./README.md ]
+      )
+    ) == "src"
+  )}")'
+)"
+[[ true == "$string" ]] || die "getSubpath example 1"
+
+string="$(
+  nix eval --raw '(with import <nixpkgs/lib>; with sources; "${boolToString (
+    getSubpath (
+      (extend
+        ./README.md
+        [ (cleanSource ./src) ]
+      )
+    ) == "README.md"
+  )}")'
+)"
+[[ true == "$string" ]] || die "getSubpath example 2"
+
 dir="$(
   nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
     focusAt ./src (

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -177,7 +177,7 @@ EOF
 
 dir="$(
   nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
-    pointAt ./. (
+    focusAt ./. (
       extend
         (cleanSource ./src)
         [ ./README.md ]
@@ -190,11 +190,11 @@ dir="$(
 ./src
 ./src/bar.c
 EOF
-) || die "sources.pointAt can change to parent directory"
+) || die "sources.focusAt can change to parent directory"
 
 dir="$(
   nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
-    pointAt ./src (
+    focusAt ./src (
       extend
         ./README.md
         [ (cleanSource ./src) ]
@@ -207,20 +207,20 @@ dir="$(
 ../src
 ../src/bar.c
 EOF
-) || die "sources.pointAt can change to subdirectory"
+) || die "sources.focusAt can change to subdirectory"
 
 
 (
   (
     nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
-      pointAt ./src (
+      focusAt ./src (
         extend
           ./README.md
           [ ./foo.bar ]
       )
       }")' || true
   ) 2>&1 | grep 'is not actually included in the source. Potential causes include an incorrect path, incorrect filter function or a forgotten sources.extend call.' >/dev/null
-) || die "sources.pointAt does not cause accidental inclusion"
+) || die "sources.focusAt does not cause accidental inclusion"
 
 dir="$(
   nix eval --raw '(with import <nixpkgs/lib>; with sources; "${

--- a/lib/tests/sources.sh
+++ b/lib/tests/sources.sh
@@ -192,6 +192,31 @@ dir="$(
 EOF
 ) || die "sources.focusAt can change to parent directory"
 
+bool="$(
+  nix eval --raw '(with import <nixpkgs/lib>; with sources; "${boolToString (
+     getOriginalFocusPath (
+      focusAt ./. (
+        extend
+          (cleanSource ./src)
+          [ ./README.md ]
+      )
+    ) == ./.
+  )}")'
+)"
+[[ true == "$bool" ]] || die "getOriginalFocusPath example 1"
+
+bool="$(
+  nix eval --raw '(with import <nixpkgs/lib>; with sources; "${boolToString (
+    getOriginalFocusPath (
+      (extend
+        (cleanSource ./src)
+        [ ./README.md ]
+      )
+    ) == ./src
+  )}")'
+)"
+[[ true == "$bool" ]] || die "getOriginalFocusPath example 2"
+
 dir="$(
   nix eval --raw '(with import <nixpkgs/lib>; with sources; "${
     focusAt ./src (


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

_Improve usability of `lib.sources`, specifically_

 - Extend the capabilities of `lib.sources`, primarily:
   - `extend` to construct sources from pre-existing sources in related directories
   - allow a source to point to a subpath inside the generated store path
 - Add documentation.
 - Add tests.

Refactor `cleanSourceWith` to operate on a simple internal representation, in preparation for new combinators to be added later.

I've discussed a union-like combinator [here before.](https://github.com/NixOS/nixpkgs/pull/56985#pullrequestreview-551210415)

`extend` combines naturally with the [`subDir`](https://github.com/input-output-hk/haskell.nix/blob/master/lib/clean-source-with.nix#L34-L36) feature in the `haskell.nix` library. This became `subpath`. `includeSiblings` was replaced by `cutAt` and/or `extend`.

###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] nix-build lib/tests/release.nix, also run by ofborg ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
