### PR TITLE
python3Packages.pymyq: 2.0.14 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/pkce/default.nix
+++ b/pkgs/development/python-modules/pkce/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pkce";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "RomeoDespres";
+    repo = pname;
+    rev = version;
+    sha256 = "15fzpp3b5qmj27hpgnwkzjwllgwwdfccizz8ydmliakm2hdr1xpn";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pkce" ];
+
+  meta = with lib; {
+    description = "Python module to work with PKCE";
+    homepage = "https://github.com/RomeoDespres/pkce";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pymyq/default.nix
+++ b/pkgs/development/python-modules/pymyq/default.nix
@@ -1,26 +1,26 @@
 { lib
-, aiodns
 , aiohttp
-, async-timeout
+, beautifulsoup4
 , buildPythonPackage
 , fetchFromGitHub
+, pkce
 }:
 
 buildPythonPackage rec {
   pname = "pymyq";
-  version = "2.0.14";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "arraylabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "18825b9c6qk4zcvva79hpg6098z4zqxyapnqmjsli23npw0zh67w";
+    sha256 = "sha256-uCXgJxMy5gZQBvhHnmfev/rfJXOjhLqZdOrn8SetUT0=";
   };
 
   propagatedBuildInputs = [
-    aiodns
     aiohttp
-    async-timeout
+    beautifulsoup4
+    pkce
   ];
 
   # Project has no tests

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4892,6 +4892,8 @@ in {
 
   pixelmatch = callPackage ../development/python-modules/pixelmatch { };
 
+  pkce = callPackage ../development/python-modules/pkce { };
+
   pkgconfig = callPackage ../development/python-modules/pkgconfig { inherit (pkgs) pkg-config; };
 
   pkginfo = callPackage ../development/python-modules/pkginfo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.0.0.

Change log: https://github.com/arraylabs/pymyq/releases/tag/v3.0.0

Add [pkcs](https://github.com/RomeoDespres/pkce) as a new requirement.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
