### PR TITLE
supertuxkart: fix build

### DIFF
--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -1,15 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, fetchsvn, cmake, pkg-config, makeWrapper
-, SDL2, glew, openal, libvorbis, libogg, curl, freetype, bluez, libjpeg, libpng, enet, harfbuzz
-, mcpp, wiiuse, angelscript
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, fetchsvn
+, cmake
+, pkg-config
+, makeWrapper
+, SDL2
+, glew
+, openal
+, libvorbis
+, libogg
+, curl
+, freetype
+, bluez
+, libjpeg
+, libpng
+, enet
+, harfbuzz
+, mcpp
+, wiiuse
+, angelscript
 }:
-
 let
   dir = "stk-code";
   assets = fetchsvn {
-    url    = "https://svn.code.sf.net/p/supertuxkart/code/stk-assets";
-    rev    = "18218";
+    url = "https://svn.code.sf.net/p/supertuxkart/code/stk-assets";
+    rev = "18218";
     sha256 = "11iv3cqzvbjg33zz5i5gkl2syn6mlw9wqv0jc7h36vjnjqjv17xw";
-    name   = "stk-assets";
+    name = "stk-assets";
   };
 
   # List of bundled libraries in stk-code/lib to keep
@@ -36,18 +55,27 @@ let
     # Not packaged to this date
     "sheenbidi"
   ];
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
 
   pname = "supertuxkart";
   version = "1.2";
 
   src = fetchFromGitHub {
-    owner  = "supertuxkart";
-    repo   = "stk-code";
-    rev    = version;
+    owner = "supertuxkart";
+    repo = "stk-code";
+    rev = version;
     sha256 = "1f98whk0v45jgwcsbdsb1qfambvrnbbgwq0w28kjz4278hinwzq6";
-    name   = dir;
+    name = dir;
   };
+
+  patches = [
+    (fetchpatch {
+      # Fix build with SDL 2.0.14
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/games-action/supertuxkart/files/supertuxkart-1.2-new-sdl.patch?id=288360dc7ce2f968a2f12099edeace3f3ed1a705";
+      sha256 = "1jgab9393qan8qbqf5bf8cgw4mynlr5a6pggqhybzsmaczgnns3n";
+    })
+  ];
 
   # Deletes all bundled libs in stk-code/lib except those
   # That couldn't be replaced with system packages
@@ -58,12 +86,25 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config makeWrapper ];
 
   buildInputs = [
-    SDL2 glew openal libvorbis libogg freetype curl bluez libjpeg libpng enet harfbuzz
-    mcpp wiiuse angelscript
+    SDL2
+    glew
+    openal
+    libvorbis
+    libogg
+    freetype
+    curl
+    bluez
+    libjpeg
+    libpng
+    enet
+    harfbuzz
+    mcpp
+    wiiuse
+    angelscript
   ];
 
   cmakeFlags = [
-    "-DBUILD_RECORDER=OFF"         # libopenglrecorder is not in nixpkgs
+    "-DBUILD_RECORDER=OFF" # libopenglrecorder is not in nixpkgs
     "-DUSE_SYSTEM_ANGELSCRIPT=OFF" # doesn't work with 2.31.2 or 2.32.0
     "-DCHECK_ASSETS=OFF"
     "-DUSE_SYSTEM_WIIUSE=ON"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix the super-tux-kart build by pulling in a patch from the kind gentoo folks. It was [failing on hydra](https://hydra.nixos.org/build/135957847).

The game is pretty fun.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
