### PR TITLE
 thunderbird, thunderbird-bin: 78.7.0 -> 78.7.1 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.7.0";
+  version = "78.7.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/af/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/af/thunderbird-78.7.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "2e5741f536243b84f6014c33b44900a01dcbe8c42e17f3d6acb62a2441708c69";
+      sha256 = "b9d7bacd982db97e531775ceca569e011603dbd2806a64bce43ef2ff30e6c8f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ar/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ar/thunderbird-78.7.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "bb2126528e1aa170fd0b59914fbcb3df3eba57aa83c995284ceadb40b24e65be";
+      sha256 = "144647297e15556de5273e4f41712fc348b3dd401d71356d556c1ed09221037d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ast/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ast/thunderbird-78.7.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "93b59d8d66b2d87076f680fd6e284f7f424a7925d82e3fa6e394388278a89a4a";
+      sha256 = "9adb0d16ab633e4ffa3628969ccb542488fc299da5250c058828144f6f773781";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/be/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/be/thunderbird-78.7.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "92dd5f24667a1886ab321df2148096ab7530c6fb8306d6d21e158c72dbcd8611";
+      sha256 = "3e54fa9ca34bcc11d411a979ed6bcd0a68b67da08cdba49e1f8a59794bc2dff0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/bg/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/bg/thunderbird-78.7.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "03444b4e10bbad0fec4928564d39b30f9e9ff8705adcc20706959eee357ee45c";
+      sha256 = "d576d3193c8e263d44942043b7e13c8861b2234ebb66969ac2cd20f84d6d769f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/br/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/br/thunderbird-78.7.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "088b6b2456f475c76527122d503f2d91c274e88cafa9a052029f2f4e00a0609d";
+      sha256 = "cd85058134a3b1364049d11a32bd964f8f9488fb48ece65d32fbb9005831b1d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ca/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ca/thunderbird-78.7.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "4be51f350929a907aa20a036c7ea7232d14874ff29c622cb4a6c917634a79019";
+      sha256 = "5bf9ac27b8401f7c1479cacddc48e6310e6ac52e038f824193788dd6883512a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/cak/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/cak/thunderbird-78.7.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "f50880a17573b1eb2bee79c2768eb04eaf2b715b7fbeb134e08634dac3ea7e22";
+      sha256 = "dfa2f97ee07f80adc5ded391bf01aea36e2aaf5a12ca9a510c5842756d9b9f8e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/cs/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/cs/thunderbird-78.7.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "e1971a4e5f91a7d6de06fd2121e7cc0169d5c8ec04418540a840c887b5c1a560";
+      sha256 = "c76d755c9b54921a4edc9521aea2c51aa6301d954154fa6228195193000be56f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/cy/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/cy/thunderbird-78.7.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "20f7086783ce5ed7bafa9875555008e62e146b080fe6eb1ad3ddf2e5fee9f0c1";
+      sha256 = "09475639dec1e370360c1c257b88ab45fbf2251bd22d1d50e9df078b035b8560";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/da/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/da/thunderbird-78.7.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "8ea77a13dd99252ada9a02115457ffd8a73e7422bd633d1f8dff835fef1daedf";
+      sha256 = "74cc98d1d99e9fd101e86051cf9aee26b40cfcb6203892adf6fd45fad5934926";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/de/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/de/thunderbird-78.7.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "9ba270c4013c0bee106ea45fc46b79f066daa1e1b90a03000ec93a54c80f65b6";
+      sha256 = "509648ba2c7d9ef4db1755ae5e017d3dc1c73c5a3a94a293bbc9a505b5349e2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/dsb/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/dsb/thunderbird-78.7.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "1e4394e4ecd44714abc0756054e751daeee4b2f485bcd3fa2db697dceb756c37";
+      sha256 = "03dff2bbcb39d967c96934675134acd3ec74b39df3b6cc76846229ff92653483";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/el/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/el/thunderbird-78.7.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "543d9343785f655caa637a2bdbf56a814b280efe206ef5868c855f2b397e0e88";
+      sha256 = "d6ec9ccdd2945d6de1718f32b551e922da1808d59acec937a16addaa0004e94a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/en-CA/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/en-CA/thunderbird-78.7.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "76e414cf62428874d4e9633fa6ae166ea16f6d295a4ddb4240c5f310557ec928";
+      sha256 = "bc97cadcf95bd0273708e1ea5cc8cdddd29f11b280213c1bd4f35a50d446763e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/en-GB/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/en-GB/thunderbird-78.7.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "cfbd194b58349fbd5d8dc0ccaeb36ea0fe21b28bf25f176ba8d12bb79ff25501";
+      sha256 = "82fd7e16cc8d5df4e775187d7f3e32b9b1dab3647cd766cec1649c39d08d5165";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/en-US/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/en-US/thunderbird-78.7.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "2e0501823951e4f5239b4c75a05f1d9d882d600a0080fd5cc7bc792990357b2f";
+      sha256 = "463c1164b80f0f8bcb72f04fb0c17e32a637df988c0ea14d90469b1d7a958f82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/es-AR/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/es-AR/thunderbird-78.7.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "37c8d43b674558fa7e8bfe9b276762562e9132daf377727ac77cd2869c16a628";
+      sha256 = "1ce69e73e8326e316d056a98efe601e7300714f1b65f69e2fcd175123fdca96b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/es-ES/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/es-ES/thunderbird-78.7.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "b79324ecdf228b24c7c51a1dc9129c39518d6a19c7a083364639bab16cc52214";
+      sha256 = "a04161f56944527f8537d46e046fbed715a554e4dc581aa636f1cec3fb1e1351";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/et/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/et/thunderbird-78.7.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "35c30673d027bfc465bb1ff9b5fa2f52487472ef870e6a8c08e0ec2d0ceacae2";
+      sha256 = "36c2e7ae029b65976b92cff62c3c3a97e8c44a73c2f5e48415260b23a23ff653";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/eu/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/eu/thunderbird-78.7.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "3af23e4364bb5a44f38a8931da270269780c0d8d0a115f77d16a15ff84f4c2bb";
+      sha256 = "538a42bb6eb11360fa70bd06058dbd47f2a3eec53fbbfe0232ddfbbeb4a4187c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/fa/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/fa/thunderbird-78.7.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "596877606b66903812ca456332aeb0c80d365255d99c6adc51d8606a5a80e024";
+      sha256 = "6e2b18166237fdf0d020570957ee7d0815d846a0aca8df2036cdf99e651cfce9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/fi/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/fi/thunderbird-78.7.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "e9fa8440743a8ff0ba6963e1d595e959791ad814bc3c239f63478ef1fe2fe05c";
+      sha256 = "1769213bf789a21572014d4d97c823db14e11f7a32b91d57d98bebe39a80786d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/fr/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/fr/thunderbird-78.7.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "5b41d9065654f248b3765c79872d6ab9f4333515f36d6bdd8306e73502100f54";
+      sha256 = "60017c2151aed3782567d9c10817e89c738d6bce322fd33f1188bc25dc12ac3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/fy-NL/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/fy-NL/thunderbird-78.7.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "f607c83d05d40ba9bb596819a86cc1c15fedc55ff47916f83650ef8f6e37251c";
+      sha256 = "3878ce39135e30a76c67182765f5fa7fc38b7019021aa86f0806028f67a7dfd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ga-IE/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ga-IE/thunderbird-78.7.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "b1a244481eef2a8a7796fb17ec6283ab44bce5ec04063a8b84a5fffef8ea70d0";
+      sha256 = "b2e66dd3fe5a78d2eb6691bc91521b3f22fbb5be88c556e2d5158057db0d6cfd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/gd/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/gd/thunderbird-78.7.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "bf30f3825599bc0168fe533a50481f779acd57432188fd0b90c98fa50ad23eb6";
+      sha256 = "c4722ceb4eca2afaa3502f2bc419b0ffc6cd2600100c5a91bf2cb7cdda60cd66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/gl/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/gl/thunderbird-78.7.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "3184484adade8ee8fd57570103fd3dce2f2ac582e9f4fb5bfc884fd3f0fa6630";
+      sha256 = "0f34fd28523062c90c521b40b0a67ad23e3b2ba05fe5c03cc1da29d480fde1e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/he/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/he/thunderbird-78.7.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "e34713989d1b98d55ea852f23e49353779be449142bdfa5098d68d076d6a9f69";
+      sha256 = "8cf8a0b5e1bd3ed116ac1dcbcb1857db9ccff8452ff0d1f3ac2957cada5883c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/hr/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/hr/thunderbird-78.7.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "a1833d7bbd438319f4dc37378c1dce49243f148db7f58f8063346bf9a5725653";
+      sha256 = "827d0c46d404d871661af45d301645a1c888941741c1b6cad27c7c37aed52800";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/hsb/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/hsb/thunderbird-78.7.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "359117a30c63a85b9d41f0369bb448ba470edd41f705070d9f7b4a805f89cf65";
+      sha256 = "83e965004f0293c324393914cc931ccfa608360982d338859da1e7e2ae0f333f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/hu/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/hu/thunderbird-78.7.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4d51554390fdab6caa01993697b1490d69504556207e9202d6e59614256dc941";
+      sha256 = "120ca3f7b356c57d7fa2af63ebcb974ad0ba313fe9c615afa5553b2e7ab75e62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/hy-AM/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/hy-AM/thunderbird-78.7.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "a838b6bfefa9c2852e4316f3665c37c1fcad8e8400fcf8fff769f1e44b4004eb";
+      sha256 = "7d0c2c5854f0a5a2288cacb6bf0d2f8ecd838dffcc8ccd040f993af94cb92d13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/id/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/id/thunderbird-78.7.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "b293c67ff239ac6632d9c914ba8c9f6a161c1400bf3dca3295683632d2e4e64b";
+      sha256 = "29462ae0dd0eaa8ac9370b8fc46ad8ad679ef44996a7f80468890b8a75ce4a29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/is/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/is/thunderbird-78.7.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "f5cce0c2dcaef81da19a2eaf3e294e9c72153d25be48d382ecd06aca430c76c8";
+      sha256 = "084aee31331bb0bbdf466d3c3a6bb1834dfbdddaefe0e8c6e1d4a91eec0725ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/it/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/it/thunderbird-78.7.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "1ab3587a7ba49e479588fba735571f458f378f4845a686a22bcd6e2483bbc3d7";
+      sha256 = "f180ceb0cd9f2e1d3e975f30fffa968e938b18ebb3c45108b6758d36989918e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ja/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ja/thunderbird-78.7.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "9ce1c13c539e3e11203ad35ef1f70e71204ceaf548279ac1dd8f39ee07f92013";
+      sha256 = "662f124e3a32ab9e6b6fbefed9b58779060d927558bbc9527d83936191e3e044";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ka/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ka/thunderbird-78.7.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "5174664bb0cd1dcbdc845664ba41c89ea0ae3bbd4c755219e709f1be76d99ef7";
+      sha256 = "2faece980493b0071e5d62a579f4e1c4d792a63293949d81fa96e70468044acc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/kab/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/kab/thunderbird-78.7.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "de5fc0cbc657d07138f8ba744903909133fe4cfeb5436c13a5c669573b4b5170";
+      sha256 = "7382fc4e006bcb05c0db2dc88f8aad32a3abbce2bcb32f28d6271658caf934b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/kk/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/kk/thunderbird-78.7.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "abbb0e5474a369c230a4faf386dbf6d663020ffbaa0bd75e69305e539006d6f4";
+      sha256 = "c8c52e06cd3ac3a02dc0081a82b25223a1da5a918335f770660122c8a6ba750c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ko/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ko/thunderbird-78.7.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "7b66371753ced2b07d136c67c3fc91a562a3fcee6b377fe1d35c550126358b91";
+      sha256 = "67928b2f6861b1071ff76c457f6aef4a9eb0d80f896331bdb847543c62b0dd11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/lt/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/lt/thunderbird-78.7.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "99811e5ecd83d827a3fbbe20666da7ea307e105fdf1090f0f61e3853a51bb53f";
+      sha256 = "aec1acfb847cea57772197d81d122e97915b03358c984293d40f6ce759b9e77a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ms/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ms/thunderbird-78.7.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "d2c11fb20170d2c9eec6b780532ac9aa4e7d8d705802e2b68a8d7c07d3d1e120";
+      sha256 = "9a4411e932789040abc939a64b9ad979104ffe868a969dabc27022dc9ff822fd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/nb-NO/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/nb-NO/thunderbird-78.7.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "19fb8d0d0f8d80c4ed9c45c861c98c862ae880bcefb365c86fc5bcea1ef19d8c";
+      sha256 = "c7cfcd78108d931c60e9a061ed459da9df0cee27b16085fd1c6f3d71d54cd2fd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/nl/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/nl/thunderbird-78.7.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "42855c4f257cad05b6f9c6c7c48ee9cf02a9159e5dd05619f3af4b473574bd87";
+      sha256 = "44e9a143f00636a9287b2f0774720fd372de25fff9de8ceb468bc81de1d7ade3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/nn-NO/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/nn-NO/thunderbird-78.7.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "c16c892b9a515700e328f01f5a92b7c4af199ae29a7c610d4795140c70bb83e5";
+      sha256 = "75269ac3171d14ca6145c3d00ba004489f89fc9210cf3af0d4e0248e24dac273";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/pa-IN/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/pa-IN/thunderbird-78.7.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "74c8bbf72b304d81d14fe9c1342c7b8bf17eb42dae52bb3b9ee043f0bdec94ec";
+      sha256 = "ef98d53446ad294eaa861919cc8e9e70f4f6458d3a4210a43ec37bd919db8aa7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/pl/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/pl/thunderbird-78.7.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "cadf3756acf8cbae0c2778edda4656589eb3d339a80736a9223c6add5c6fa99c";
+      sha256 = "682c6b2a5e808e65e1e233fb48bbd68058a7f2745648d01d6342c90316b8135c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/pt-BR/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/pt-BR/thunderbird-78.7.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "1fe1f6edbd9d38a9db30720413c48ef91e4be77b1c218fddcb3db1fb98017971";
+      sha256 = "761988b180f3077cd9710324fd87ec577de5f5ee11c79404b416c64ba322c65a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/pt-PT/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/pt-PT/thunderbird-78.7.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "ae5be903d29582feab6402b12034a01bbf338602a8739a1cad9d5d9806e4ed1c";
+      sha256 = "9182a7064d0f98a49b34b9bf78ae4d63fe6b588c51ceb48ffe0974455e767867";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/rm/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/rm/thunderbird-78.7.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "cfc9dba2b3977ac5721559746a1a1e071ff24116db5c52039ce9b40631e43619";
+      sha256 = "33a8bec5ee7240fb44e350139f60e1d7c92361020bba2857634af03e40ee0f87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ro/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ro/thunderbird-78.7.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "97bdb9a195a3b8a74d82dd373cd5b25ffb1d61178a9f2b0a3610341e9a207158";
+      sha256 = "a50168d1b5e62d7bec9d75714612614b9d2342fdc6b8f89959d50d1505cbf7d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/ru/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/ru/thunderbird-78.7.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "c16b656259451be87d5e86795bf2ee14322743046a0b6f3542369337494abc90";
+      sha256 = "555e630090fbc41711e88d0a8e822febf0619333c2bcace5bdfbfdfdddfbb0dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/si/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/si/thunderbird-78.7.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "34596141553b28a72b743cc7f80edb06549a71816f8caa4c7f9b20148a523fcc";
+      sha256 = "f977bd3fb4caaefb03eb8c967ae4850c0b7b2b8dfa0f7d7cedfba0847788cdb3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/sk/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/sk/thunderbird-78.7.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "71ec684701c5d42521e5e1f39601f0cbf8b9c082555dd593695288f327c1a44e";
+      sha256 = "f1e5c9787a2ae8f8aaceef1ca2963884031a6cb8dc0ab3c3230fa0021156cfc4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/sl/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/sl/thunderbird-78.7.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "9c4de92259c02966d8970fa7792d6a1d279d2021ecf78e4cdb5e992f4eae5e8d";
+      sha256 = "59a97046285bca3e5b8ba396d3afef69fe2cb5a41347e4e0a21e9ff66c03ae12";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/sq/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/sq/thunderbird-78.7.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "e05525980dba6605f4e722a42aa074a014c7a5786d261b3fa6f10570cfd952da";
+      sha256 = "ed0cf7d341d42dedeaa224f7f1f8e005172134da591f65664a4aca717e6db44a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/sr/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/sr/thunderbird-78.7.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "e05a147164785faa39ca35728cbc8f5e769267a546bb22cade4411e3cc34cc22";
+      sha256 = "fd61b2e8e048f162e59a1a428100e6d0556d7120de1f8b46decdfe60509de0d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/sv-SE/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/sv-SE/thunderbird-78.7.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "f1349dce69bc95329b7558cd7b87109ccbf201bb6f42040c1b1a034d48d7d62a";
+      sha256 = "87afa3b4b12848de156ea61d1727dea1ef5b86bc83b583df55f089bd1d1bec1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/th/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/th/thunderbird-78.7.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "e30b19275cfe460ebdf47c1c9bf8f97342568041ed16e925ddda334532ad1453";
+      sha256 = "0e9b959424106680bced6d924c184d1306f7f1fd34fb4d3e4d8a54cb191500bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/tr/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/tr/thunderbird-78.7.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "13d3264c891b198e4030334ee771919c8fa45ca4cee4a9c30e6776e258a15ed1";
+      sha256 = "f2d037cea39d2698e71a0885587302644450149434ac7c3234c7ae32c5f4d103";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/uk/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/uk/thunderbird-78.7.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "f3a3c098c71c7632c36da1e1f401db5dcb5fefe8c4658d2e221d429be4d0867d";
+      sha256 = "663aa8509cc75c074697509981bf54ab00eeddc50c53acc0221225c3d7c63f9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/uz/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/uz/thunderbird-78.7.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "8c4a4e904eb4ddc131dbec594ccc9e4faef209f746d999c08618ad9757ec300b";
+      sha256 = "892209fbe5d48532710feab4ad8f38f9387e10b088d91a12c9778bc465af194c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/vi/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/vi/thunderbird-78.7.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "bad2147d54293ce4b245df01d47ab2555811292ec117a1b74e49aece0a5aa625";
+      sha256 = "a66d1d470f4a76cfa8b31fa3d60acb91cc7657455f9aebf930e127c2acbf4c8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/zh-CN/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/zh-CN/thunderbird-78.7.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "000a1143b3f7c09717610459549305c99cedd4a4fc35d1b0bb276ae72b83c44e";
+      sha256 = "10830b4a84ca22c19ee329cb00b92816e9b74f99c99a1ba6cfc86171470d655d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-x86_64/zh-TW/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-x86_64/zh-TW/thunderbird-78.7.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "bae5923d844f137e38b46519420a6e765fa5457733a60ffa6bda70185993e575";
+      sha256 = "b88200643a70ba3391cfd3be6cbc7bb178c6170f26041d4153021736d03365f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/af/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/af/thunderbird-78.7.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "94e7737e9e06d84b336b5f69ff3a69220ff6ef12588857b8b8e4596f5f5ca7f3";
+      sha256 = "e78e2ef7411b3e6c0f2ed5c0729dfdc144f94e8575f2f30ae1cbaeb7c73188dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ar/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ar/thunderbird-78.7.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "2843aa9cbc0f102aae2abb192590445240568e94e35f4ed558fac446895c9daa";
+      sha256 = "42c3f3b177a50afd6640db6815e7c159048cebb6dd5613c2fdf9ef18871d40cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ast/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ast/thunderbird-78.7.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "01130d2e0bba48de5c9cdb3c0c83081e29ce8964218ab1e7f9d03b61facfb513";
+      sha256 = "b8fb786756051169d96a4fecf05cdabf4becc8fbcabd56ba676e96286a80b9d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/be/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/be/thunderbird-78.7.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "d8377688f8760afdea0ff93b37267b117090c311e0636aefe1185ab2ed0e0a05";
+      sha256 = "4e3f8f26b1321d130fb16b5eb30c3b3c3a7863e6d43ee9604f1a6da97228c85f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/bg/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/bg/thunderbird-78.7.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "2eca1032ae4bc73967fab319681a5123ae2681a0128de6efd0d7a58aa97986b3";
+      sha256 = "0385b615dfb21f33b3e84b6c9213d3d8980379bb4be07967f5309888078ac177";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/br/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/br/thunderbird-78.7.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "3c5b9e1a96be9f706f458480badcd4efb324d59c2e1227c31720c98eef19dac0";
+      sha256 = "e338d6b439577af562c4dbcd2951176d2c6cf87254203e6d20602de4563484c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ca/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ca/thunderbird-78.7.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "c31b3d7936726295e2e66a25b554af25fef04d76eeca0f0b2744dc6b38eb25d0";
+      sha256 = "71f1b5f1b35a9c5712ba6cedbf3de96f4a3814655c44ed1cda48d4e5a56c3e03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/cak/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/cak/thunderbird-78.7.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "8abbf5f08d4b9e606090a976bfc9e5cad794259cf2461c2a4edd028c783440e8";
+      sha256 = "0f616eb61c0de3e38d2092ae215613ba104be279027259def8bca4082bd74cd3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/cs/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/cs/thunderbird-78.7.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "63a6a2e0eab7f7ab0522d36369b4cd696af3b24e9a00977bf3ba1ae440ec077c";
+      sha256 = "8de26b3daa7b087fb94a349e909da703867665fb2b4add360584c8d61f0c84ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/cy/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/cy/thunderbird-78.7.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "5415f68080e95b331146a53d00b312882a8c0b904c91509785bf79139a1accd6";
+      sha256 = "74e28fb04e08bcfd68215eec443fde725077850e412798c1f0870e776ecbeeb1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/da/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/da/thunderbird-78.7.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "a43d6445cb39506a898e96432d1730b780bc745344011d230771e4592e34b49d";
+      sha256 = "d50f37a31e4e5805084fa14bf639057b543deac99738871c402ad9af9684ce20";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/de/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/de/thunderbird-78.7.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "b14360cbc698e636b56150bdf3ffd145d3bbb43c9f342eb56d74dca82674c25e";
+      sha256 = "7aa84ada2e6cb6b467a618b234a7cd0370f5d71fd1eb0f5da1addb6478665ad3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/dsb/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/dsb/thunderbird-78.7.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "dc83ee5540b4254cd01f67f72adad857774f23769748550fcf46e7f066a672a3";
+      sha256 = "e273b80d5039097a34e7e2c96f65aca112e68d72a82782e783ea9412e49ab21f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/el/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/el/thunderbird-78.7.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "5ca65866f1440ba2161d08005d3229e5f08c9a5696db51f633a8154c93d0ce97";
+      sha256 = "f31dfc543cca8d8f3c6e1cc40f8a07ead7b231222c8e04e5e2202c315c4708d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/en-CA/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/en-CA/thunderbird-78.7.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "35afceb267f29985ea068afb0358e3e73d120c7f63162ddd22854b1179a2c409";
+      sha256 = "534f8008886a3028c09afb1c030923359f8ee0c85c6e961faa4c974b6c2c30da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/en-GB/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/en-GB/thunderbird-78.7.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6f2cb3fe2d4223809ec7e842746bb6453ec741df59fcf63898af9e4c579158c9";
+      sha256 = "c9c138e5d92847c0c0ec82d1799fddf1267b95a5f6ef2cae7820f560aff53732";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/en-US/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/en-US/thunderbird-78.7.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "dc1dae45f45246c95861ef7a50c2acfd7ad343eb0bf39049094dd999e18338ee";
+      sha256 = "6ec06f3a432301745ed24607b0549602ae31bf6e051ca9a4079f4cd6caf2041f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/es-AR/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/es-AR/thunderbird-78.7.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "1d25b980227c60cff9db1c052167c82c06f853b0ebafb5144e53a1be6fbf4b49";
+      sha256 = "8debebc56ee0fbcbf2507f98f28f7807b55d4d768bd40c7820aa9e4f7dc9f0ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/es-ES/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/es-ES/thunderbird-78.7.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "c34971c9a52bb6174254d4bbb67b682e862187b008bd0fa3c07d3d6955da6f6d";
+      sha256 = "58ac431d1b48a1c8224e414577a7405f20336cd990f6e4d8399e304cc5f38a3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/et/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/et/thunderbird-78.7.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "da6305745f73ea4469d308c6ada3749b8c09852e57e9af6d00fe470e40092cf2";
+      sha256 = "a80917893c189acbd745e56820b7f4fce1ebf14e99be8700db75817ffa3eccf5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/eu/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/eu/thunderbird-78.7.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "406bb8b9a7c5eace3b84ed29e16dee077ee2e4f1b8ddd49afc9291e368b44ce0";
+      sha256 = "f305db54f9cc504777ee9d329ca1da97a8642f7505903b2744cb7d86382b0ccf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/fa/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/fa/thunderbird-78.7.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "4756eca3217756d540bf4e904bcda9f7259b65ae2062b493a8f05122a730130c";
+      sha256 = "0a90e573bf94097f790dec0ef2771266bf115c0c4768c3952758f8c17f7cfb70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/fi/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/fi/thunderbird-78.7.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "dbe77298a712a0a64a16fcf618b1e3fb21d1afbea8f7b93a9e6d7e43edbede6a";
+      sha256 = "264104b86cd034927586520b6c4df25b1c75da4d97ea18bffd74261e553b4eb5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/fr/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/fr/thunderbird-78.7.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "71ce692f4f46e8afe488581670c186c20eccb5bf78306452fd7b82964f6d1087";
+      sha256 = "2cbca14d94252f24dd50c971fd5ad367b4b3c0d3ccfd2d9ce8b18cb1df62a82c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/fy-NL/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/fy-NL/thunderbird-78.7.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "2f62f25c74e382cec5a9cccc24429cff5a5c36ab3810b5b43f194beb0a5b7a3a";
+      sha256 = "d60c543f59ebdb539b9d3799d77f4ad1d05738cc5d1b78d016a7d2f036d72095";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ga-IE/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ga-IE/thunderbird-78.7.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4da8e456e0e1f115e4018275c041fa345c02b635fd20ec0b3a5b3d1975dde52f";
+      sha256 = "2d0a19e3a702a72866af8c8e9aac64e9c41b3b1bc44de53ec42b56efd657cd63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/gd/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/gd/thunderbird-78.7.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "8517486ccdf76ac04b8e8c4df11e5bfd79375a8023efb63476232d985b47a8ca";
+      sha256 = "93eaaf7d5c6cdf1947e25fbd053185f09f60329ba729a53f12d272f24dca6bf7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/gl/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/gl/thunderbird-78.7.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "928f1721f4ca40f154041bc4ed4aa7b06e3508eba45c7f6ee889fb4e698fb6a6";
+      sha256 = "02d78333abaed79e7a2fccc6af3edef3077e08cadcc83fa2856779b6d24e9113";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/he/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/he/thunderbird-78.7.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "e49d647ee9d414cfd9dfecc4fdaa7931fd4d4a8ffab3fe9bd820023813d0d7b6";
+      sha256 = "d4dd60245672fc23e114d2cfef40ff69faf08a2f188969deff7d084d8aebd64f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/hr/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/hr/thunderbird-78.7.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "8c804b3288036619e0be76d9129102098f5406a00c6586a7edd1e35ac5ffe1ea";
+      sha256 = "0aba235af4ebdd924d9d909755dd059025c1b502ab0056a24ef0eb5aea05b9ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/hsb/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/hsb/thunderbird-78.7.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "846966d7f8dc6619afa7904debeaf3aeac95d040478fb3e29cae5cb116782d88";
+      sha256 = "acc53828d809a21b3a5bc6b00cf5681b376284e4818c8db250f61a3117573f78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/hu/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/hu/thunderbird-78.7.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "a05a7410d0f8ae016d3aa69152a381173c22f3361c7a940a2f7f1684a42ac0d7";
+      sha256 = "39aac6a7e96fbc71c9e537f4312fa528c0f3b56a5d669638ca2a4ff2a4823cb8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/hy-AM/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/hy-AM/thunderbird-78.7.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "93783417a9c065a4b53566d21bfd34f3a96c9cca7e6cd61c20474c63c28f5f15";
+      sha256 = "bb1fdc6084ca5d761823b5391aa237d14d62f783007cbb2d6ccff1b69a7b3142";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/id/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/id/thunderbird-78.7.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "3608569802e13a45feb519239f43bed7ee06f8e3198f188ba8f5c815ca9748bb";
+      sha256 = "340b91be60235a91b1a130d68e9b5ddc16d63eba381cc59efd2d396764bf2327";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/is/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/is/thunderbird-78.7.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "afbcee0a5c4926dc7ee089e6e11d83844d068bac2ddb71bf7cf29747dc753420";
+      sha256 = "4f3b255119669de976714089d11532342eb6c1ede95e98d8de09413cdaf28c4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/it/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/it/thunderbird-78.7.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "212d0125796a12ccde71939bf1b62b540a630a965f160ebe6199e8b1d3149043";
+      sha256 = "1fdda6110ef1eec5702490dfb786fadeb6bbb73fa849526327baebdf3aeaf348";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ja/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ja/thunderbird-78.7.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "c450ba455b8e8b846a6dfc6a380c672e6ed9d18553c07caae3cd3d24a9d21744";
+      sha256 = "fd10c2307c71e143d76dfba7d26ea15a6a211878bcf1287128d5706018fb3083";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ka/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ka/thunderbird-78.7.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "349da02164ef984dc22b85b9e4e7a09748cdd1d6325904b32c1e36a8a9f7c4f5";
+      sha256 = "b796f8b6aaa28a23726afe915b741b7c89ed73f4e731bf7fad3848aade16001c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/kab/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/kab/thunderbird-78.7.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "0f367818d4a7568e57ad9d06c52c55c2feebac351d164c434f86943a420c283b";
+      sha256 = "35941699918a3177b092c650a73d8bc8f6d06bdf8cbc5c33e492d93f6cb0f198";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/kk/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/kk/thunderbird-78.7.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "3274d7e4b787e5ed2f26ce11ff26e261e33a90b60bfef644f017215cbdaefc6e";
+      sha256 = "3ea99defb54f2e672d48b424e842c876ad0ceacd87cd19cc643acb55586948ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ko/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ko/thunderbird-78.7.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "8aa9eebe4ffeaa3f6d963806a6b5d0d3e6530b08476bf55e9cdc1b25cdc105d5";
+      sha256 = "4cfa908b81773b57486b8144eb61c949c70615eafc1b3d050b6ceb6292958769";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/lt/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/lt/thunderbird-78.7.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "2e811db91100b6e3671693fda6776406477ee3f71f4ae9431eb1b94e1aff4a19";
+      sha256 = "0d668e8a27f7044c610cff1028f245d2952abf6320ce905365bd42a39df85c23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ms/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ms/thunderbird-78.7.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "950a316e46a5f6bc127715295e00cf9c742d3bd7ef23a489e3fe4131f7394e2e";
+      sha256 = "a632e60198e189d33e87a01c084179bdfb8f8c1d1547dfa4747dec325d1c04c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/nb-NO/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/nb-NO/thunderbird-78.7.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "c3bcd1740b5288b9d0f486fc9d2f5936e38e869eab5bf84a92bfc50caa11c5cc";
+      sha256 = "d0336060f8e8b632462df91dc0e3ba33f2a7dbf1da6084d41961c05fbbedd46b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/nl/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/nl/thunderbird-78.7.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "f7eb04082ef4ff38e287016ea3b75e795eb7428c8271ae06a21930031de108bf";
+      sha256 = "4e9c1921dac5ce0008b7380d810d5ee4530c4d336c79c6a274c657ea338a4ca1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/nn-NO/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/nn-NO/thunderbird-78.7.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "01adbf1a345fa117ac8cf5ae65f11e5ce14dafe3f06d99fede51abaa4eee3f94";
+      sha256 = "c33045aaa5d9054022431cf66f03ba2485ea7c68553ea245b73c8cf33b4458fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/pa-IN/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/pa-IN/thunderbird-78.7.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "3d8b49a32080315c3726fbc77ff2de4eda453e4919b487af99cbc85a9e8b79fa";
+      sha256 = "8b3810587f61e029a2536cb0eceb8b0b26656adf9ce17e8a7f020ed41b6e5724";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/pl/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/pl/thunderbird-78.7.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "32429dee14ba7c405ccab71bc3a8ea24cc4a028ea331254c0b4e227c921da58b";
+      sha256 = "01c8e6ba91037b8e5f713fd7d0dc9b6025aa3dc83fd8b13f1490dd849ec5e87f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/pt-BR/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/pt-BR/thunderbird-78.7.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2709ac332c29c0d2dfb3e76c77e3af58cc27a9d23496fa7432fe043ebd486a35";
+      sha256 = "9ab3d18699c6de55a198028592da01b576d67920375cbc2154d356bdf7fd4ccc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/pt-PT/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/pt-PT/thunderbird-78.7.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "eca228d5846b51cbbd64888477e7514669dc1714dc07d1aab86e38ab0f7956b5";
+      sha256 = "3446b5b82aeb058ff880d82fa7da923231a7104bcef77bc08f640490c79b24b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/rm/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/rm/thunderbird-78.7.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "269e7483c5f1a884fd809dc3ccb5c1627573708c558a5f2acdd9ca6b925312b5";
+      sha256 = "0e1ba7a270021b2df2f189715ddd6b0d540c35dbfb3f45d8216b24e29c6ecd25";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ro/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ro/thunderbird-78.7.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "41d769fb26c99e66708c7c8884c822e863d8066b46512ec20b26c760e7c78916";
+      sha256 = "9845b2e33d758474c44e46804c7c49255f3acf9f25c8afa299320828cefb3ec8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/ru/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/ru/thunderbird-78.7.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "06ed87bfb7830607e87ef5f17f553e34275f3c0a56674f1f07e7e30b43c1f9d0";
+      sha256 = "60dc7072a6dfa0723972522d4a06be75c99e6e1b423e68e91af276f2a325913b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/si/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/si/thunderbird-78.7.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "09b96524a7b887ba0cdae931ca368f079d5c3536134f6d9798b0073cfa047332";
+      sha256 = "fd08c36b8143196ca73aade09e3a8292bab0ce8b6e6d18705eed2594f342ce86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/sk/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/sk/thunderbird-78.7.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "a9025df80c0dd8ebe96dec1503d11820ac7c48ea35ef695e883f1e01dbd0b6dd";
+      sha256 = "068d927b94908224c7a789bfe33d1e884228d82d3f30e573a0006136d5841c5f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/sl/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/sl/thunderbird-78.7.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "8db2dceecad941230113b079bd083d0548cafef3bab0b9698260ce3db28453fd";
+      sha256 = "27d3a7f5549c48fa2724dc98b8df72bf2b843b0cc34d55371f050ca217cd2ed3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/sq/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/sq/thunderbird-78.7.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "365db0f0872959400b5aaae94866f1a49e0b14db2fd55938c0084e983f06f2bc";
+      sha256 = "b8d3ca545ff88c854b13e1ee89793b33df39f3d6713aae8fb4a2fa3be2d6f73f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/sr/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/sr/thunderbird-78.7.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "252587e46e7cf1fbd83f9bc9da6b8273985f26d5ede94aab16a2d2ef1d92faa2";
+      sha256 = "10d0f70e52bbb8b0978ff6c26359120bb537cc9f15b47a93744ad8ee6dbd7b96";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/sv-SE/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/sv-SE/thunderbird-78.7.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "029d0a70f4c0bf770dc37263639097aed24b6186057cd9d81c50fb4657ce3e04";
+      sha256 = "15fd51de4cd82eaadfb0c9a5231cd6c8f83a58eca1eb66acafa037ca8ae76767";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/th/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/th/thunderbird-78.7.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "24b20e9cd1d9a5b863d4dcfd8d62599b52ba9a64126b6bf584d4ff5c3db524d8";
+      sha256 = "07a6289101aa3d105c2a358ea53d1045bfc3616cd909e57b5a577bcba38dba0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/tr/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/tr/thunderbird-78.7.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "d7d9878fbcf9b552164f588600ac1704a5e295fe73c333f0e838b5d99fbd5deb";
+      sha256 = "6253f5e59cf07cfe8bbdd566b27ad9cd56aab29f40c42df1368d7e14d064a27a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/uk/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/uk/thunderbird-78.7.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "3c8eef6d084fec6b0ac57ae6d2fce6dc7e02977ed10c670be30d032e417a50ce";
+      sha256 = "e4e37d8194d8df48810afc47463d044e4b4b9fdd0752b0199e4c6a7aa1b46d60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/uz/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/uz/thunderbird-78.7.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "545de649b406faa1b942020eb418c4e52054efcc8706a2f4881409d253ed5c4a";
+      sha256 = "983d9701e367017ada3b6583d9e6985a73609c642968f1c82ec9b08644fe82b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/vi/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/vi/thunderbird-78.7.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "86ae5dbef5ec4cdb0e25ce3cbe78b46ed35349d11038ed12a49dc0440dc7111e";
+      sha256 = "b743d0c18257880cf0d7c463a0e39f6029fede79a534bef9dbd5ffe6ba3b10e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/zh-CN/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/zh-CN/thunderbird-78.7.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "ce94974470209d9dc81f676f3e74a6359d4e97c7f8801f644c7ea0fe774ad6bc";
+      sha256 = "8cc5d4a05eef0498fe12476e7ee7a91dce0c69234b78278cc7985505708ff8ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.0/linux-i686/zh-TW/thunderbird-78.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.7.1/linux-i686/zh-TW/thunderbird-78.7.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "f013131307e31eed708f8a75e1313b2f94cd401de06e00053f4155aedca33b13";
+      sha256 = "5070474b2ac89d09e45bced9513b0f317d4dce76c57ce5f82c75feafb6d49ec3";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -73,13 +73,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.7.0";
+  version = "78.7.1";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "1fwi9dvh9q8pzwri6hyyg89zxkfpw3zin53nkqgvips43yq6jdmyxnz3y9qnk2f50d0lnkx12vvkzgirjhdz23gkf7y860zmwg85vpy";
+      "328p14mgcam4dxx0asbgp4v2v559bwbw7z2kxd5yfwkna040r9ccrkkirma5580z9vkwb0rcjlmai9wrbacxrg8hg65d8vylvnkampy";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- CardDAV address books now support OAuth2 and Google Contacts.
- Thunderbird will no longer allow installation of addons that use legacy APIs
- Other fixes

https://www.thunderbird.net/en-US/thunderbird/78.7.1/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
