### PR TITLE
python38Packages.rx: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/development/python-modules/rx/default.nix
+++ b/pkgs/development/python-modules/rx/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "rx";
-  version = "3.1.0";
+  version = "3.1.1";
   disabled = pythonOlder "3.6";
 
   # There are no tests on the pypi source
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "ReactiveX";
     repo = "rxpy";
     rev = "v${version}";
-    sha256 = "0rcwa8001il9p7s096b9gc5yld8cyxvrsmwh1gpc9b87j172z6ax";
+    sha256 = "0p0cs67l40npkvwgn5sb18l1b6df1b9fg6rzlqkwk2aa0v3cpvhf";
   };
 
   checkInputs = [ nose ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/ReactiveX/RxPY/releases/tag/v3.1.1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
