### PR TITLE
ht-rust: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7101,6 +7101,12 @@
     githubId = 15645854;
     name = "Brad Christensen";
   };
+  payas = {
+    email = "relekarpayas@gmail.com";
+    github = "payasrelekar";
+    githubId = 24254289;
+    name = "Payas Relekar";
+  };
   pawelpacana = {
     email = "pawel.pacana@gmail.com";
     github = "pawelpacana";

--- a/pkgs/tools/networking/ht-rust/default.nix
+++ b/pkgs/tools/networking/ht-rust/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, rustPlatform, fetchFromGitHub, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ht-rust";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "ducaale";
+    repo = "ht";
+    rev = "v${version}";
+    sha256 = "cr/iavCRdFYwVR6Iemm1hLKqd0OFG1iDmxpQ9fiwOmU=";
+  };
+
+  cargoSha256 = "uB23/9AjPwCwf9ljE8ai7zJQZqE0SoBPzRqqBOXa9QA=";
+
+  buildInputs = [ ] ++ lib.optional stdenv.isDarwin Security;
+
+  # Symlink to avoid conflict with pre-existing ht package
+  postInstall = ''
+    ln -s $out/bin/ht $out/bin/ht-rust
+  '';
+
+  doInstallCheck = true;
+  postInstallCheck = ''
+    $out/bin/ht-rust --help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "Yet another HTTPie clone in Rust";
+    homepage = "https://github.com/ducaale/ht";
+    license = licenses.mit;
+    maintainers = [ maintainers.payas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22662,6 +22662,10 @@ in
 
   ht = callPackage ../applications/editors/ht { };
 
+  ht-rust = callPackage ../tools/networking/ht-rust {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   hubstaff = callPackage ../applications/misc/hubstaff { };
 
   hue-cli = callPackage ../tools/networking/hue-cli { };


### PR DESCRIPTION
###### Motivation for this change
Add new package -> ht : Yet another HTTPie clone in Rust.

Note: "ht" clashes with pre-existing package, and editor named "ht". As such new package, and resulting binary is named ht-rs..

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
