### PR TITLE
xst: 0.7.2 -> 0.8.4.1

### DIFF
--- a/pkgs/applications/terminal-emulators/st/xst.nix
+++ b/pkgs/applications/terminal-emulators/st/xst.nix
@@ -1,18 +1,14 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, libX11, ncurses, libXext, libXft, fontconfig }:
 
-with lib;
-
-let
-  version = "0.7.2";
-  name = "xst-${version}";
-in stdenv.mkDerivation {
-  inherit name;
+stdenv.mkDerivation rec {
+  pname = "xst";
+  version = "0.8.4.1";
 
   src = fetchFromGitHub {
     owner = "gnotclub";
-    repo = "xst";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1fplgy30gyrwkjsw3z947327r98i13zd1whwkplpj9fzckhb9vs9";
+    sha256 = "nOJcOghtzFkl7B/4XeXptn2TdrGQ4QTKBo+t+9npxOA=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -22,8 +18,8 @@ in stdenv.mkDerivation {
     TERMINFO=$out/share/terminfo make install PREFIX=$out
   '';
 
-  meta = {
-    homepage = "https://github.com/neeasade/xst";
+  meta = with lib; {
+    homepage = "https://github.com/gnotclub/xst";
     description = "Simple terminal fork that can load config from Xresources";
     license = licenses.mit;
     maintainers = [ maintainers.vyp ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update, old one had memory leaks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
