### PR TITLE
azuredatastudio: 1.17.1 > 1.26.0

### DIFF
--- a/pkgs/applications/misc/azuredatastudio/default.nix
+++ b/pkgs/applications/misc/azuredatastudio/default.nix
@@ -13,23 +13,69 @@
 , gnutar
 , atomEnv
 , kerberos
+, libdrm
+, mesa
+, makeDesktopItem
+, copyDesktopItems
 }:
 
 # from justinwoo/azuredatastudio-nix
 # https://github.com/justinwoo/azuredatastudio-nix/blob/537c48aa3981cd1a82d5d6e508ab7e7393b3d7c8/default.nix
 
-stdenv.mkDerivation rec {
+let
+  desktopItem = makeDesktopItem {
+    name = "azuredatastudio";
+    desktopName = "Azure Data Studio";
+    comment = "Data Management Tool that enables you to work with SQL Server, Azure SQL DB and SQL DW from Windows, macOS and Linux.";
+    genericName = "Text Editor";
+    exec = "azuredatastudio --no-sandbox --unity-launch %F";
+    icon = "azuredatastudio";
+    startupNotify = "true";
+    categories = "Utility;TextEditor;Development;IDE;";
+    mimeType = "text/plain;inode/directory;application/x-azuredatastudio-workspace;";
+    extraEntries = ''
+      StartupWMClass=azuredatastudio
+      Actions=new-empty-window;
+      Keywords=azuredatastudio;
 
+      [Desktop Action new-empty-window]
+      Name=New Empty Window
+      Exec=azuredatastudio --no-sandbox --new-window %F
+      Icon=azuredatastudio
+    '';
+  };
+
+  urlHandlerDesktopItem = makeDesktopItem {
+    name = "azuredatastudio-url-handler";
+    desktopName = "Azure Data Studio - URL Handler";
+    comment = "Azure Data Studio";
+    genericName = "Text Editor";
+    exec = "azuredatastudio --no-sandbox --open-url %U";
+    icon = "azuredatastudio";
+    startupNotify = "true";
+    categories = "Utility;TextEditor;Development;IDE;";
+    mimeType = "x-scheme-handler/azuredatastudio;";
+    extraEntries = ''
+      NoDisplay=true
+      Keywords=azuredatastudio;
+    '';
+  };
+in
+stdenv.mkDerivation rec {
   pname = "azuredatastudio";
-  version = "1.17.1";
+  version = "1.26.0";
+
+  desktopItems = [ desktopItem urlHandlerDesktopItem ];
 
   src = fetchurl {
-    url = "https://azuredatastudiobuilds.blob.core.windows.net/releases/${version}/azuredatastudio-linux-${version}.tar.gz";
-    sha256 = "0px9n9vyjvyddca4x7d0zindd0dim7350vkjg5dd0506fm8dc38k";
+    name = "azuredatastudio-linux-${version}.tar.gz";
+    url = "https://azuredatastudio-update.azurewebsites.net/${version}/linux-x64/stable";
+    sha256 = "DMR4qFje94JhEjrpNhkTYM9oszD4eP8YJ3yzzx3IuoA=";
   };
 
   nativeBuildInputs = [
     makeWrapper
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -38,7 +84,7 @@ stdenv.mkDerivation rec {
     at-spi2-atk
   ];
 
-  phases = "unpackPhase fixupPhase";
+  phases = "unpackPhase installPhase";
 
   # change this to azuredatastudio-insiders for insiders releases
   edition = "azuredatastudio";
@@ -60,7 +106,7 @@ stdenv.mkDerivation rec {
   ];
 
   # this will most likely need to be updated when azuredatastudio's version changes
-  sqltoolsservicePath = "${targetPath}/resources/app/extensions/mssql/sqltoolsservice/Linux/2.0.0-release.56";
+  sqltoolsservicePath = "${targetPath}/resources/app/extensions/mssql/sqltoolsservice/Linux/3.0.0-release.68";
 
   rpath = lib.concatStringsSep ":" [
     atomEnv.libPath
@@ -71,13 +117,15 @@ stdenv.mkDerivation rec {
         at-spi2-atk
         stdenv.cc.cc.lib
         kerberos
+        libdrm
+        mesa
       ]
     )
     targetPath
     sqltoolsserviceRpath
   ];
 
-  fixupPhase = ''
+  installPhase = ''
     fix_sqltoolsservice()
     {
       mv ${sqltoolsservicePath}/$1 ${sqltoolsservicePath}/$1_old
@@ -104,6 +152,11 @@ stdenv.mkDerivation rec {
       ${targetPath}/bin/${edition} \
       $out/bin/azuredatastudio \
       --set LD_LIBRARY_PATH ${rpath}
+
+    mkdir -p $out/share/pixmaps
+    cp ${targetPath}/resources/app/resources/linux/code.png $out/share/pixmaps/azuredatastudio.png
+
+    runHook postInstall
   '';
 
   meta = {
@@ -111,5 +164,6 @@ stdenv.mkDerivation rec {
     description = "A data management tool that enables working with SQL Server, Azure SQL DB and SQL DW";
     homepage = "https://docs.microsoft.com/en-us/sql/azure-data-studio/download-azure-data-studio";
     license = lib.licenses.unfreeRedistributable;
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The package hadn't had an update in a long while.
I added the new dependencies and added the .desktop files from the Debian package in the same way as the VSCode package, where Azure Data Studio is a fork of.

I made x86_64-linux the only platform, because this package is clearly broken on anything else. In a future pull request, we should migrate the VSCode update scripts to Azure Data Studio.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
