### PR TITLE
nixos/acme: Backport account rate limit fixes and tmpfile removal

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -24,7 +24,7 @@ let
       Type = "oneshot";
       User = "acme";
       Group = mkDefault "acme";
-      UMask = 0027;
+      UMask = 0023;
       StateDirectoryMode = 750;
       ProtectSystem = "full";
       PrivateTmp = true;

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -271,13 +271,12 @@ let
 
       # Working directory will be /tmp
       script = ''
-        set -euo pipefail
+        set -euxo pipefail
 
         ${optionalString (data.webroot != null) ''
           # Ensure the webroot exists
           mkdir -p '${data.webroot}/.well-known/acme-challenge'
-          chown 'acme:${data.group}' ${data.webroot}/{.well-known,.well-known/acme-challenge} \
-          || echo "Please fix the permissions under ${data.webroot}/.well-known/acme-challenge" && exit 1
+          chown 'acme:${data.group}' ${data.webroot}/{.well-known,.well-known/acme-challenge}
         ''}
 
         echo '${domainHash}' > domainhash.txt

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -7,6 +7,11 @@ let
   numCerts = length (builtins.attrNames cfg.certs);
   _24hSecs = 60 * 60 * 24;
 
+  # Used to make unique paths for each cert/account config set
+  mkHash = with builtins; val: substring 0 20 (hashString "sha256" val);
+  mkAccountHash = acmeServer: data: mkHash "${toString acmeServer} ${data.keyType} ${data.email}";
+  accountDirRoot = "/var/lib/acme/.lego/accounts/";
+
   # There are many services required to make cert renewals work.
   # They all follow a common structure:
   #   - They inherit this commonServiceConfig
@@ -101,11 +106,10 @@ let
       ${toString acmeServer} ${toString data.dnsProvider}
       ${toString data.ocspMustStaple} ${data.keyType}
     '';
-    mkHash = with builtins; val: substring 0 20 (hashString "sha256" val);
     certDir = mkHash hashData;
     domainHash = mkHash "${concatStringsSep " " extraDomains} ${data.domain}";
-    othersHash = mkHash "${toString acmeServer} ${data.keyType} ${data.email}";
-    accountDir = "/var/lib/acme/.lego/accounts/" + othersHash;
+    accountHash = (mkAccountHash acmeServer data);
+    accountDir = accountDirRoot + accountHash;
 
     protocolOpts = if useDns then (
       [ "--dns" data.dnsProvider ]
@@ -141,7 +145,7 @@ let
     );
 
   in {
-    inherit accountDir selfsignedDeps;
+    inherit accountHash accountDir cert selfsignedDeps;
 
     webroot = data.webroot;
     group = data.group;
@@ -252,8 +256,7 @@ let
         echo '${domainHash}' > domainhash.txt
 
         # Check if we can renew
-        # Certificates and account credentials must exist
-        if [ -e 'certificates/${keyName}.key' -a -e 'certificates/${keyName}.crt' -a "$(ls -1 accounts)" ]; then
+        if [ -e 'certificates/${keyName}.key' -a -e 'certificates/${keyName}.crt' -a -n "$(ls -1 accounts)" ]; then
 
           # When domains are updated, there's no need to do a full
           # Lego run, but it's likely renew won't work if days is too low.
@@ -658,15 +661,32 @@ in {
         "d /var/lib/acme/.lego/accounts - acme acme"
       ] ++ (unique (concatMap (conf: [
           "d ${conf.accountDir} - acme acme"
-        ] ++ (optional (conf.webroot != null) "d ${conf.webroot}/.well-known/acme-challenge - acme ${conf.group}")
+        ] ++ (optionals (conf.webroot != null) [
+          "d ${conf.webroot} - acme ${conf.group}"
+          "d ${conf.webroot}/.well-known - acme ${conf.group}"
+          "d ${conf.webroot}/.well-known/acme-challenge - acme ${conf.group}"
+        ])
       ) (attrValues certConfigs)));
 
-      # Create some targets which can be depended on to be "active" after cert renewals
-      systemd.targets = mapAttrs' (cert: conf: nameValuePair "acme-finished-${cert}" {
-        wantedBy = [ "default.target" ];
-        requires = [ "acme-${cert}.service" ] ++ conf.selfsignedDeps;
-        after = [ "acme-${cert}.service" ] ++ conf.selfsignedDeps;
-      }) certConfigs;
+      systemd.targets = let
+        # Create some targets which can be depended on to be "active" after cert renewals
+        finishedTargets = mapAttrs' (cert: conf: nameValuePair "acme-finished-${cert}" {
+          wantedBy = [ "default.target" ];
+          requires = [ "acme-${cert}.service" ] ++ conf.selfsignedDeps;
+          after = [ "acme-${cert}.service" ] ++ conf.selfsignedDeps;
+        }) certConfigs;
+
+        # Create targets to limit the number of simultaneous account creations
+        accountTargets = mapAttrs' (hash: confs: let
+          leader = "acme-${(builtins.head confs).cert}.service";
+          dependantServices = map (conf: "acme-${conf.cert}.service") (builtins.tail confs);
+        in nameValuePair "acme-account-${hash}" {
+          requiredBy = dependantServices;
+          before = dependantServices;
+          requires = [ leader ];
+          after = [ leader ];
+        }) (groupBy (conf: conf.accountHash) (attrValues certConfigs));
+      in finishedTargets // accountTargets;
     })
   ];
 

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -59,9 +59,9 @@ let
     '';
   };
 
-  # Previously, all certs were owned by whatever user was configured in
-  # config.security.acme.certs.<cert>.user. Now everything is owned by and
-  # run by the acme user.
+  # Ensures that directories which are shared across all certs
+  # exist and have the correct user and group, since group
+  # is configurable on a per-cert basis.
   userMigrationService = {
     description = "Fix owner and group of all ACME certificates";
 
@@ -74,8 +74,13 @@ let
       done
     '') certConfigs);
 
-    # We don't want this to run every time a renewal happens
-    serviceConfig.RemainAfterExit = true;
+    serviceConfig = {
+      # We don't want this to run every time a renewal happens
+      RemainAfterExit = true;
+
+      # These StateDirectory entries negate the need for tmpfiles
+      StateDirectory = "acme acme/.lego acme/.lego/accounts";
+    };
   };
 
   certToConfig = cert: data: let
@@ -145,7 +150,7 @@ let
     );
 
   in {
-    inherit accountHash accountDir cert selfsignedDeps;
+    inherit accountHash cert selfsignedDeps;
 
     webroot = data.webroot;
     group = data.group;
@@ -225,10 +230,14 @@ let
       serviceConfig = commonServiceConfig // {
         Group = data.group;
 
-        # AccountDir dir will be created by tmpfiles to ensure correct permissions
-        # And to avoid deletion during systemctl clean
-        # acme/.lego/${cert} is listed so that it is deleted during systemctl clean
-        StateDirectory = "acme/${cert} acme/.lego/${cert} acme/.lego/${cert}/${certDir}";
+        # Keep in mind that these directories will be deleted if the user runs
+        # systemctl clean --what=state
+        # acme/.lego/${cert} is listed for this reason.
+        StateDirectory =
+          "acme/${cert} " +
+          "acme/.lego/${cert} " +
+          "acme/.lego/${cert}/${certDir} " +
+          "acme/.lego/accounts/${accountHash} ";
 
         # Needs to be space separated, but can't use a multiline string because that'll include newlines
         BindPaths =
@@ -655,18 +664,14 @@ in {
 
       systemd.timers = mapAttrs' (cert: conf: nameValuePair "acme-${cert}" conf.renewTimer) certConfigs;
 
-      # .lego and .lego/accounts specified to fix any incorrect permissions
-      systemd.tmpfiles.rules = [
-        "d /var/lib/acme/.lego - acme acme"
-        "d /var/lib/acme/.lego/accounts - acme acme"
-      ] ++ (unique (concatMap (conf: [
-          "d ${conf.accountDir} - acme acme"
-        ] ++ (optionals (conf.webroot != null) [
-          "d ${conf.webroot} - acme ${conf.group}"
-          "d ${conf.webroot}/.well-known - acme ${conf.group}"
-          "d ${conf.webroot}/.well-known/acme-challenge - acme ${conf.group}"
-        ])
-      ) (attrValues certConfigs)));
+      systemd.tmpfiles.rules = unique (
+        flatten (
+          mapAttrsToList (
+            cert: conf:
+              optional (conf.webroot != null) "d ${conf.webroot}/.well-known/acme-challenge - acme ${conf.group}"
+          ) certConfigs
+        )
+      );
 
       systemd.targets = let
         # Create some targets which can be depended on to be "active" after cert renewals

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -62,24 +62,30 @@ let
   # Ensures that directories which are shared across all certs
   # exist and have the correct user and group, since group
   # is configurable on a per-cert basis.
-  userMigrationService = {
-    description = "Fix owner and group of all ACME certificates";
-
+  userMigrationService = let
     script = with builtins; concatStringsSep "\n" (mapAttrsToList (cert: data: ''
-      for fixpath in /var/lib/acme/${escapeShellArg cert} /var/lib/acme/.lego/${escapeShellArg cert}; do
+      chown -R acme .lego/accounts
+      for fixpath in ${escapeShellArg cert} .lego/${escapeShellArg cert}; do
         if [ -d "$fixpath" ]; then
           chmod -R 750 "$fixpath"
           chown -R acme:${data.group} "$fixpath"
         fi
       done
     '') certConfigs);
+  in {
+    description = "Fix owner and group of all ACME certificates";
 
-    serviceConfig = {
+    serviceConfig = commonServiceConfig // {
       # We don't want this to run every time a renewal happens
       RemainAfterExit = true;
 
       # These StateDirectory entries negate the need for tmpfiles
-      StateDirectory = "acme acme/.lego acme/.lego/accounts";
+      StateDirectory = [ "acme" "acme/.lego" "acme/.lego/accounts" ];
+      StateDirectoryMode = 755;
+      WorkingDirectory = "/var/lib/acme";
+
+      # Run the start script as root
+      ExecStart = "+" + (pkgs.writeShellScript "acme-fixperms" script);
     };
   };
 
@@ -152,7 +158,6 @@ let
   in {
     inherit accountHash cert selfsignedDeps;
 
-    webroot = data.webroot;
     group = data.group;
 
     renewTimer = {
@@ -192,7 +197,10 @@ let
 
         StateDirectory = "acme/${cert}";
 
-        BindPaths = "/var/lib/acme/.minica:/tmp/ca /var/lib/acme/${cert}:/tmp/${keyName}";
+        BindPaths = [
+          "/var/lib/acme/.minica:/tmp/ca"
+          "/var/lib/acme/${cert}:/tmp/${keyName}"
+        ];
       };
 
       # Working directory will be /tmp
@@ -233,17 +241,19 @@ let
         # Keep in mind that these directories will be deleted if the user runs
         # systemctl clean --what=state
         # acme/.lego/${cert} is listed for this reason.
-        StateDirectory =
-          "acme/${cert} " +
-          "acme/.lego/${cert} " +
-          "acme/.lego/${cert}/${certDir} " +
-          "acme/.lego/accounts/${accountHash} ";
+        StateDirectory = [
+          "acme/${cert}"
+          "acme/.lego/${cert}"
+          "acme/.lego/${cert}/${certDir}"
+          "acme/.lego/accounts/${accountHash}"
+        ];
 
         # Needs to be space separated, but can't use a multiline string because that'll include newlines
-        BindPaths =
-          "${accountDir}:/tmp/accounts " +
-          "/var/lib/acme/${cert}:/tmp/out " +
-          "/var/lib/acme/.lego/${cert}/${certDir}:/tmp/certificates ";
+        BindPaths = [
+          "${accountDir}:/tmp/accounts"
+          "/var/lib/acme/${cert}:/tmp/out"
+          "/var/lib/acme/.lego/${cert}/${certDir}:/tmp/certificates"
+        ];
 
         # Only try loading the credentialsFile if the dns challenge is enabled
         EnvironmentFile = mkIf useDns data.credentialsFile;
@@ -256,7 +266,16 @@ let
             ${data.postRun}
           fi
         '');
-      };
+
+      } // (optionalAttrs (data.webroot != null) {
+        # Lego always tries to create .well-known/acme-challenge, but if webroot is owned
+        # by the wrong user then it will crash and break cert renewal.
+        ExecStartPre = "+" + pkgs.writeShellScript "acme-${cert}-make-webroot" ''
+          mkdir -p '${data.webroot}/.well-known/acme-challenge'
+          cd '${data.webroot}'
+          chown 'acme:${data.group}' . .well-known .well-known/acme-challenge
+        '';
+      });
 
       # Working directory will be /tmp
       script = ''
@@ -663,15 +682,6 @@ in {
       } // (mapAttrs' (cert: conf: nameValuePair "acme-selfsigned-${cert}" conf.selfsignService) certConfigs)));
 
       systemd.timers = mapAttrs' (cert: conf: nameValuePair "acme-${cert}" conf.renewTimer) certConfigs;
-
-      systemd.tmpfiles.rules = unique (
-        flatten (
-          mapAttrsToList (
-            cert: conf:
-              optional (conf.webroot != null) "d ${conf.webroot}/.well-known/acme-challenge - acme ${conf.group}"
-          ) certConfigs
-        )
-      );
 
       systemd.targets = let
         # Create some targets which can be depended on to be "active" after cert renewals

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -267,20 +267,18 @@ let
             ${data.postRun}
           fi
         '');
-
-      } // (optionalAttrs (data.webroot != null) {
-        # Lego always tries to create .well-known/acme-challenge, but if webroot is owned
-        # by the wrong user then it will crash and break cert renewal.
-        ExecStartPre = "+" + pkgs.writeShellScript "acme-${cert}-make-webroot" ''
-          mkdir -p '${data.webroot}/.well-known/acme-challenge'
-          cd '${data.webroot}'
-          chown 'acme:${data.group}' . .well-known .well-known/acme-challenge
-        '';
-      });
+      };
 
       # Working directory will be /tmp
       script = ''
         set -euo pipefail
+
+        ${optionalString (data.webroot != null) ''
+          # Ensure the webroot exists
+          mkdir -p '${data.webroot}/.well-known/acme-challenge'
+          chown 'acme:${data.group}' ${data.webroot}/{.well-known,.well-known/acme-challenge} \
+          || echo "Please fix the permissions under ${data.webroot}/.well-known/acme-challenge" && exit 1
+        ''}
 
         echo '${domainHash}' > domainhash.txt
 

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -63,15 +63,16 @@ let
   # exist and have the correct user and group, since group
   # is configurable on a per-cert basis.
   userMigrationService = let
-    script = with builtins; concatStringsSep "\n" (mapAttrsToList (cert: data: ''
+    script = with builtins; ''
       chown -R acme .lego/accounts
+    '' + (concatStringsSep "\n" (mapAttrsToList (cert: data: ''
       for fixpath in ${escapeShellArg cert} .lego/${escapeShellArg cert}; do
         if [ -d "$fixpath" ]; then
           chmod -R 750 "$fixpath"
           chown -R acme:${data.group} "$fixpath"
         fi
       done
-    '') certConfigs);
+    '') certConfigs));
   in {
     description = "Fix owner and group of all ACME certificates";
 
@@ -692,6 +693,14 @@ in {
         }) certConfigs;
 
         # Create targets to limit the number of simultaneous account creations
+        # How it works:
+        # - Pick a "leader" cert service, which will be in charge of creating the account,
+        #   and run first (requires + after)
+        # - Make all other cert services sharing the same account wait for the leader to
+        #   finish before starting (requiredBy + before).
+        # Using a target here is fine - account creation is a one time event. Even if
+        # systemd clean --what=state is used to delete the account, so long as the user
+        # then runs one of the cert services, there won't be any issues.
         accountTargets = mapAttrs' (hash: confs: let
           leader = "acme-${(builtins.head confs).cert}.service";
           dependantServices = map (conf: "acme-${conf.cert}.service") (builtins.tail confs);

--- a/nixos/modules/security/acme.xml
+++ b/nixos/modules/security/acme.xml
@@ -162,6 +162,9 @@ services.httpd = {
 <xref linkend="opt-security.acme.certs"/>."foo.example.com" = {
   <link linkend="opt-security.acme.certs._name_.webroot">webroot</link> = "/var/lib/acme/.challenges";
   <link linkend="opt-security.acme.certs._name_.email">email</link> = "foo@example.com";
+  # Ensure that the web server you use can read the generated certs
+  # Take a look at the <link linkend="opt-services.nginx.group">group</link> option for the web server you choose.
+  <link linkend="opt-security.acme.certs._name_.group">group</link> = "nginx";
   # Since we have a wildcard vhost to handle port 80,
   # we can generate certs for anything!
   # Just make sure your DNS resolves them.
@@ -257,10 +260,11 @@ chmod 400 /var/lib/secrets/certs.secret
   <para>
    Should you need to regenerate a particular certificate in a hurry, such
    as when a vulnerability is found in Let's Encrypt, there is now a convenient
-   mechanism for doing so. Running <literal>systemctl clean acme-example.com.service</literal>
-   will remove all certificate files for the given domain, allowing you to then
-   <literal>systemctl start acme-example.com.service</literal> to generate fresh
-   ones.
+   mechanism for doing so. Running
+   <literal>systemctl clean --what=state acme-example.com.service</literal>
+   will remove all certificate files and the account data for the given domain,
+   allowing you to then <literal>systemctl start acme-example.com.service</literal>
+   to generate fresh ones.
   </para>
  </section>
  <section xml:id="module-security-acme-fix-jws">

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -77,6 +77,27 @@ in import ./make-test-python.nix ({ lib, ... }: {
         after = [ "acme-a.example.test.service" "nginx-config-reload.service" ];
       };
 
+      # Test that account creation is collated into one service
+      specialisation.account-creation.configuration = { nodes, pkgs, lib, ... }: let
+        email = "newhostmaster@example.test";
+        caDomain = nodes.acme.config.test-support.acme.caDomain;
+        # Exit 99 to make it easier to track if this is the reason a renew failed
+        testScript = ''
+          test -e accounts/${caDomain}/${email}/account.json || exit 99
+        '';
+      in {
+        security.acme.email = lib.mkForce email;
+        systemd.services."b.example.test".serviceConfig.preStart = testScript;
+        systemd.services."c.example.test".serviceConfig.preStart = testScript;
+
+        services.nginx.virtualHosts."b.example.test" = (vhostBase pkgs) // {
+          enableACME = true;
+        };
+        services.nginx.virtualHosts."c.example.test" = (vhostBase pkgs) // {
+          enableACME = true;
+        };
+      };
+
       # Cert config changes will not cause the nginx configuration to change.
       # This tests that the reload service is correctly triggered.
       # It also tests that postRun is exec'd as root
@@ -289,7 +310,7 @@ in import ./make-test-python.nix ({ lib, ... }: {
       acme.start()
       webserver.start()
 
-      acme.wait_for_unit("default.target")
+      acme.wait_for_unit("network-online.target")
       acme.wait_for_unit("pebble.service")
 
       client.succeed("curl https://${caDomain}:15000/roots/0 > /tmp/ca.crt")
@@ -313,6 +334,15 @@ in import ./make-test-python.nix ({ lib, ... }: {
           webserver.succeed("systemctl start test-renew-nginx.target")
           check_issuer(webserver, "a.example.test", "pebble")
           check_connection(client, "a.example.test")
+
+      with subtest("Runs 1 cert for account creation before others"):
+          switch_to(webserver, "account-creation")
+          webserver.wait_for_unit("acme-finished-a.example.test.target")
+          check_connection(client, "a.example.test")
+          webserver.wait_for_unit("acme-finished-b.example.test.target")
+          webserver.wait_for_unit("acme-finished-c.example.test.target")
+          check_connection(client, "b.example.test")
+          check_connection(client, "c.example.test")
 
       with subtest("Can reload web server when cert configuration changes"):
           switch_to(webserver, "cert-change")

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -87,8 +87,8 @@ in import ./make-test-python.nix ({ lib, ... }: {
         '';
       in {
         security.acme.email = lib.mkForce email;
-        systemd.services."b.example.test".serviceConfig.preStart = testScript;
-        systemd.services."c.example.test".serviceConfig.preStart = testScript;
+        systemd.services."b.example.test".preStart = testScript;
+        systemd.services."c.example.test".preStart = testScript;
 
         services.nginx.virtualHosts."b.example.test" = (vhostBase pkgs) // {
           enableACME = true;


### PR DESCRIPTION
###### Motivation for this change

Backport of #106857 (excluding the merge commit, of course)

It [has been shown](https://github.com/NixOS/nixpkgs/issues/101445#issuecomment-771243252) to fix/prevent JWS issues pretty reliably at this point, and there has been demand to get these features backported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
