### PR TITLE
waypoint: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/applications/networking/cluster/waypoint/default.nix
+++ b/pkgs/applications/networking/cluster/waypoint/default.nix
@@ -2,45 +2,43 @@
 
 buildGoModule rec {
   pname = "waypoint";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-iGR2N1ZYA5G9K2cpfrwWRhSEfehRshx157ot1yq15AY=";
+    sha256 = "sha256-bCvi5xIL6xAtQ9mgf4feh076sAmog/3eGBlgvcLXJyc=";
   };
 
   deleteVendor = true;
   vendorSha256 = "sha256-ArebHOjP3zvpASVAoaPXpSbrG/jq+Jbx7+EaQ1uHSVY=";
 
-  subPackages = ["."];
-
   nativeBuildInputs = [ go-bindata ];
 
+  # GIT_{COMMIT,DIRTY} filled in blank to prevent trying to run git and ending up blank anyway
   buildPhase = ''
-    CGO_ENABLED=0 go build -ldflags '-s -w -extldflags "-static"' -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
-    cd internal/assets
-    go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
-    cd ../../
-    CGO_ENABLED=0 go build -ldflags '-s -w -X github.com/hashicorp/waypoint/version.GitDescribe=v${version}' -tags assetsembedded -o ./waypoint ./cmd/waypoint
-    CGO_ENABLED=0 go build -ldflags '-s -w' -tags assetsembedded -o ./waypoint-entrypoint ./cmd/waypoint-entrypoint
+    make bin GIT_DESCRIBE="v${version}" GIT_COMMIT="" GIT_DIRTY=""
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv waypoint{,-entrypoint} $out/bin/
+    install -D waypoint $out/bin/waypoint
   '';
 
+  dontPatchELF = true;
+  dontPatchShebangs = true;
+
   meta = with lib; {
+    homepage = "https://waypointproject.io";
+    changelog = "https://github.com/hashicorp/waypoint/blob/v${version}/CHANGELOG.md";
     description = "A tool to build, deploy, and release any application on any platform";
     longDescription = ''
-      Waypoint allows developers to define their application build, deploy, and release lifecycle as code, reducing the
-      time to deliver deployments through a consistent and repeatable workflow.
+      Waypoint allows developers to define their application build, deploy, and
+      release lifecycle as code, reducing the time to deliver deployments
+      through a consistent and repeatable workflow.
     '';
-    homepage = "https://waypointproject.io";
-    platforms = platforms.linux;
     license = licenses.mpl20;
     maintainers = with maintainers; [ winpat jk ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- General cleanup
- Restructured so make bin succeeds
- No need to destribute waypoint-entrypoint

Last time we had issues with the resulting binary not being able to successfully inject the `waypoint-entrypoint` without adding extra static flags.
(#103754)

![image](https://user-images.githubusercontent.com/9866621/107119902-671e2c80-6882-11eb-841e-9a00b7e3b382.png)

Using a more modern and maintained version of go-bindata resolved this issue.

@winpat if you could double check this works that'd be great but `waypoint build` and `waypoint up` with a the example project and no actual deploy target worked fine.


This version of go-bindata is also used by influxdb2.
https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/servers/nosql/influxdb2/default.nix#L77-L91

Potentially it should replace the current version we're using for go-bindata. It's used by homebrew.

If that's desireable I suggest that be done in a separate PR as there are plenty of packages that use it and it'll probably need to go into staging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
