### PR TITLE
cfitsio: 3.47 -> 3.49

### DIFF
--- a/pkgs/development/libraries/cfitsio/default.nix
+++ b/pkgs/development/libraries/cfitsio/default.nix
@@ -1,21 +1,18 @@
-{ fetchurl, lib, stdenv
-
-# Optional dependencies
-, bzip2 ? null }:
+{ fetchurl, lib, stdenv, bzip2 }:
 stdenv.mkDerivation rec {
   pname = "cfitsio";
-  version = "3.47";
+  version = "3.49";
 
   src = fetchurl {
     url = "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-${version}.tar.gz";
-    sha256 = "1vzlxnrjckz78p2wf148v2z3krkwnykfqvlj42sz3q711vqid1a1";
+    sha256 = "1cyl1qksnkl3cq1fzl4dmjvkd6329b57y9iqyv44wjakbh6s4rav";
   };
 
   buildInputs = [ bzip2 ];
 
   patches = [ ./darwin-rpath-universal.patch ];
 
-  configureFlags = lib.optional (bzip2 != null) "--with-bzip2=${bzip2.out}";
+  configureFlags = "--with-bzip2=${bzip2.out}";
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2018-3848 and CVE-2018-3849.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>10 packages built:</summary>
  <ul>
    <li>cfitsio</li>
    <li>gildas</li>
    <li>gwyddion</li>
    <li>indilib</li>
    <li>kstars</li>
    <li>nufraw</li>
    <li>nufraw-thumbnailer</li>
    <li>phd2</li>
    <li>siril</li>
    <li>stellarsolver</li>
  </ul>
</details>