### PR TITLE
go-bindata: use maintained copy

### DIFF
--- a/pkgs/development/tools/go-bindata/default.nix
+++ b/pkgs/development/tools/go-bindata/default.nix
@@ -1,22 +1,23 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
-buildGoPackage {
+buildGoPackage rec {
   pname = "go-bindata";
-  version = "unstable-2015-10-23";
+  version = "3.22.0";
 
-  goPackagePath = "github.com/jteeuwen/go-bindata";
+  goPackagePath = "github.com/kevinburke/go-bindata";
 
   src = fetchFromGitHub {
-    owner = "jteeuwen";
-    repo = "go-bindata";
-    rev = "a0ff2567cfb70903282db057e799fd826784d41d";
-    sha256 = "0d6zxv0hgh938rf59p1k5lj0ymrb8kcps2vfrb9kaarxsvg7y69v";
+    owner = "kevinburke";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "10dq77dml5jvvq2jkdq81a9yjg7rncq8iw8r84cc3dz6l9hxzj0x";
   };
 
-  excludedPackages = "testdata";
+  subPackages = [ "go-bindata" ];
 
   meta = with lib; {
-    homepage = "https://github.com/jteeuwen/go-bindata";
+    homepage = "https://github.com/kevinburke/go-bindata";
+    changelog = "https://github.com/kevinburke/go-bindata/blob/v${version}/CHANGELOG.md";
     description = "A small utility which generates Go code from any file, useful for embedding binary data in a Go program";
     maintainers = with maintainers; [ cstrahan ];
     license = licenses.cc0;

--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -73,28 +73,12 @@ let
         --replace /out $out
     '';
   };
-
-  # Can't use the nixpkgs version of go-bindata, it's an ancient
-  # ancestor of this more modern one.
-  bindata = buildGoPackage {
-    pname = "go-bindata";
-    version = "v3.22.0";
-    src = fetchFromGitHub {
-      owner = "kevinburke";
-      repo = "go-bindata";
-      rev = "v3.22.0";
-      sha256 = "10dq77dml5jvvq2jkdq81a9yjg7rncq8iw8r84cc3dz6l9hxzj0x";
-    };
-
-    goPackagePath = "github.com/kevinburke/go-bindata";
-    subPackages = [ "go-bindata" ];
-  };
 in buildGoModule {
   pname = "influxdb";
   version = version;
   src = src;
 
-  nativeBuildInputs = [ bindata pkg-config ];
+  nativeBuildInputs = [ go-bindata pkg-config ];
 
   vendorSha256 = "0lviz7l5zbghyfkp0lvlv8ykpak5hhkfal8d7xwvpsm8q3sghc8a";
   subPackages = [ "cmd/influxd" "cmd/influx" ];


### PR DESCRIPTION

**This might need to merge into staging instead?**

###### Motivation for this change

Existing go-bindata is old and unmaintained https://github.com/jteeuwen/go-bindata/issues/5

I've gone with https://github.com/kevinburke/go-bindata since that's the version used by HashiCorp for waypoint, Influx for InfluxDB2, and it's the copy in the homebrew repos.
It also has more recent changes and a more recent release than https://github.com/go-bindata/go-bindata

This more up-to-date copy also correctly resolves the issues we were having packaging waypoint
https://github.com/NixOS/nixpkgs/pull/100994#issuecomment-711429095
https://github.com/hashicorp/waypoint/pull/801

The bin works when running `--version`. It's also using identical details of the copy that was being used in influxdb2 for ages

```
./result/bin/go-bindata --version
go-bindata 3.22.0 (Go runtime go1.15.7).
Copyright (c) 2010-2015, Jim Teeuwen.
Copyright (c) 2017-2020, Kevin Burke.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
Use maintained version at https://github.com/kevinburke/go-bindata