### PR TITLE
python3Packages.phonopy: 2.8.1 -> 2.9.1

### DIFF
--- a/pkgs/development/python-modules/phonopy/default.nix
+++ b/pkgs/development/python-modules/phonopy/default.nix
@@ -1,19 +1,26 @@
-{ lib, buildPythonPackage, python, fetchPypi, numpy, pyyaml, matplotlib, h5py, spglib, pytestCheckHook }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, pyyaml
+, matplotlib
+, h5py
+, spglib
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "phonopy";
-  version = "2.8.1";
+  version = "2.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "28864b04adb900597705f1367a100da869af835088bdd13f1693c4382259f128";
+    sha256 = "1jaizhkb59ixknvc75nrhfq51bh75912q8ay36bxpf4g5hzyhw3a";
   };
 
   propagatedBuildInputs = [ numpy pyyaml matplotlib h5py spglib ];
 
   checkInputs = [ pytestCheckHook ];
-  # flakey due to floating point inaccuracy
-  disabledTests = [ "test_NaCl" ];
 
   # prevent pytest from importing local directory
   preCheck = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`python3Packages.phonopy` is currently broken on hydra. I was able to bisect the failure, and it was caused by a bump of openblas from 0.3.12 to 0.3.13 (gasp). The developer informed me that the new version's test suite is more numerically stable, so this should improve going forward with this version bump.

cc https://github.com/phonopy/phonopy/issues/140

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

-----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>python37Packages.phonopy</li>
    <li>python37Packages.sumo</li>
    <li>python38Packages.phonopy</li>
    <li>python38Packages.sumo</li>
    <li>python39Packages.phonopy</li>
  </ul>
</details>