### PR TITLE
labwc: unstable-2021-01-12 -> unstable-2021-02-06

### DIFF
--- a/pkgs/applications/window-managers/labwc/default.nix
+++ b/pkgs/applications/window-managers/labwc/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "labwc";
-  version = "unstable-2021-01-12";
+  version = "unstable-2021-02-06";
 
   src = fetchFromGitHub {
     owner = "johanmalm";
     repo = pname;
-    rev = "2a7086d9f7367d4a81bce58a6f7fc6614bbfbdb3";
-    sha256 = "ECwEbWkCjktNNtbLSCflOVlEyxkg4XTfRevq7+qQ2IA=";
+    rev = "4a8fcf5c6d0b730b1e2e17e544ce7d7d3c72cd13";
+    sha256 = "g1ba8dchUN393eis0VAu1bIjQfthDGLaSijSavz4lfU=";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja pandoc ];
@@ -54,4 +54,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
   };
 }
-# TODO: report a SIGSEGV when labwc starts inside a started Wayland window


### PR DESCRIPTION
Fixes a SIGSEGV bug when called from an already running session.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
