### PR TITLE
libpcap: disable universal build for libpcap on darwin

### DIFF
--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -21,12 +21,10 @@ stdenv.mkDerivation rec {
       linux = "linux";
       darwin = "bpf";
     }.${stdenv.hostPlatform.parsed.kernel.name})
+  ] ++ optionals stdenv.isDarwin [
+    "--disable-universal"
   ] ++ optionals (stdenv.hostPlatform == stdenv.buildPlatform)
     [ "ac_cv_linux_vers=2" ];
-
-  prePatch = optionalString stdenv.isDarwin ''
-    substituteInPlace configure --replace " -arch i386" ""
-  '';
 
   postInstall = ''
     if [ "$dontDisableStatic" -ne "1" ]; then


### PR DESCRIPTION
###### Motivation for this change

This allows building libpcap on top of #105026.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
