### PR TITLE
vsh: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/tools/misc/vsh/default.nix
+++ b/pkgs/tools/misc/vsh/default.nix
@@ -2,17 +2,21 @@
 
 buildGoModule rec {
   pname = "vsh";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "fishi0x01";
     repo = "vsh";
     rev = "v${version}";
-    sha256 = "0s4i4x8kd9s2igdshgsbs6n3k670h7r6g1mn1pzlj0kpmggnhfik";
+    sha256 = "1f6szcdakfx3zap1zpkrcs134plv7vnyilzcxs5jbhrrbr6q1807";
   };
 
-  # vendor dir is already part of repository
-  vendorSha256 = null;
+  vendorSha256 = "0a2kjql4ibglxkq5dgzr2sxxxm38nf83s4rsk2gd1cf7v0flr02j";
+
+  # vendor dir in vsh repo is incomplete
+  deleteVendor = true;
+
+  runVend = true;
 
   # make sure version gets set at compile time
   buildFlagsArray = [ "-ldflags=-s -w -X main.vshVersion=v${version}" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
