### PR TITLE
python3Packages.aiorecollect: init 1.0.2

### DIFF
--- a/pkgs/development/python-modules/aiorecollect/default.nix
+++ b/pkgs/development/python-modules/aiorecollect/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, aiohttp
+, aresponses
+, async-timeout
+, buildPythonPackage
+, fetchFromGitHub
+, freezegun
+, poetry-core
+, pytest-asyncio
+, pytest-cov
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "aiorecollect";
+  version = "1.0.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "bachya";
+    repo = pname;
+    rev = version;
+    sha256 = "0dlz8zmqcn6g6000lfgcy5krpfafzdzrznmk6iwra65wcs7l9392";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  checkInputs = [
+    aresponses
+    freezegun
+    pytest-asyncio
+    pytest-cov
+    pytestCheckHook
+  ];
+
+  # Ignore the examples as they are prefixed with test_
+  pytestFlagsArray = [ "--ignore examples/" ];
+  pythonImportsCheck = [ "aiorecollect" ];
+
+  meta = with lib; {
+    description = "Python library for the Recollect Waste API";
+    longDescription = ''
+      aiorecollect is a Python asyncio-based library for the ReCollect
+      Waste API. It allows users to programmatically retrieve schedules
+      for waste removal in their area, including trash, recycling, compost
+      and more.
+    '';
+    homepage = "https://github.com/bachya/aiorecollect";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -666,7 +666,7 @@
     "random" = ps: with ps; [ ];
     "raspihats" = ps: with ps; [ smbus-cffi ]; # missing inputs: raspihats
     "raspyrfm" = ps: with ps; [ ]; # missing inputs: raspyrfm-client
-    "recollect_waste" = ps: with ps; [ ]; # missing inputs: aiorecollect
+    "recollect_waste" = ps: with ps; [ aiorecollect ];
     "recorder" = ps: with ps; [ sqlalchemy ];
     "recswitch" = ps: with ps; [ ]; # missing inputs: pyrecswitch
     "reddit" = ps: with ps; [ praw ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -276,6 +276,8 @@ in {
 
   aiopulse = callPackage ../development/python-modules/aiopulse { };
 
+  aiorecollect = callPackage ../development/python-modules/aiorecollect { };
+
   aioredis = callPackage ../development/python-modules/aioredis { };
 
   aioresponses = callPackage ../development/python-modules/aioresponses { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
aiorecollect is a Python asyncio-based library for the ReCollect
Waste API. It allows users to programmatically retrieve schedules
for waste removal in their area, including trash, recycling, compost
and more.

https://github.com/bachya/aiorecollect

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
