### PR TITLE
pythonPackages.nmigen, glasgow: update to unstable-2021-02-04

### DIFF
--- a/pkgs/development/python-modules/glasgow/default.nix
+++ b/pkgs/development/python-modules/glasgow/default.nix
@@ -18,15 +18,15 @@
 
 buildPythonPackage rec {
   pname = "glasgow";
-  version = "unstable-2020-06-29";
+  version = "unstable-2021-01-09";
   # python software/setup.py --version
-  realVersion = "0.1.dev1352+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.1.dev1654+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "GlasgowEmbedded";
     repo = "glasgow";
-    rev = "f885790d7927b893e631c33744622d6ebc18b5e3";
-    sha256 = "sha256-fSorSEa5K09aPEOk4XPWOFRxYl1KGVy29jOBqIvs2hk=";
+    rev = "b1985b3c46b7aebc426f70ca22c5f1e05376238b";
+    sha256 = "sha256-rHz8jbAn8N6xFxDcVu6cEtcvvA8/lKrmcMrITdcApXI=";
   };
 
   nativeBuildInputs = [ setuptools_scm sdcc ];

--- a/pkgs/development/python-modules/nmigen/default.nix
+++ b/pkgs/development/python-modules/nmigen/default.nix
@@ -6,6 +6,7 @@
 , setuptools_scm
 , pyvcd
 , jinja2
+, importlib-resources
 
 # for tests
 , pytestCheckHook
@@ -16,21 +17,22 @@
 
 buildPythonPackage rec {
   pname = "nmigen";
-  version = "unstable-2020-04-02";
+  version = "unstable-2021-02-04";
   # python setup.py --version
-  realVersion = "0.2.dev49+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.3.dev243+g${lib.substring 0 7 src.rev}";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "nmigen";
     repo = "nmigen";
-    rev = "c79caead33fff14e2dec42b7e21d571a02526876";
-    sha256 = "sha256-3+mxHyg0a92/BfyePtKT5Hsk+ra+fQzTjCJ2Ech44/s=";
+    rev = "f7c2b9419f9de450be76a0e9cf681931295df65f";
+    sha256 = "0cjs9wgmxa76xqmjhsw4fsb2mhgvd85jgs2mrjxqp6fwp8rlgnl1";
   };
 
   nativeBuildInputs = [ setuptools_scm ];
 
-  propagatedBuildInputs = [ setuptools pyvcd jinja2 ];
+  propagatedBuildInputs = [ setuptools pyvcd jinja2 ]
+    ++ lib.optional (pythonOlder "3.9") importlib-resources;
 
   checkInputs = [ pytestCheckHook yosys symbiyosys yices ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The versions in nixpkgs are old and a lot of changes happened in the meantime. Nothing happened to glasgow between 2021-01-09 and 2021-02-06.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
