### PR TITLE
wmutils-core: 1.1 -> 1.5

### DIFF
--- a/pkgs/tools/X11/wmutils-core/default.nix
+++ b/pkgs/tools/X11/wmutils-core/default.nix
@@ -1,15 +1,15 @@
-{ lib, stdenv, fetchurl, libxcb }:
+{ lib, stdenv, fetchurl, libxcb, xcbutil, xcb-util-cursor }:
 
 stdenv.mkDerivation rec {
   pname = "wmutils-core";
-  version = "1.1";
+  version = "1.5";
 
   src = fetchurl {
     url = "https://github.com/wmutils/core/archive/v${version}.tar.gz";
-    sha256 = "0aq95khs154j004b79w9rgm80vpggxfqynha5rckm2cx20d1fa5s";
+    sha256 = "0wk39aq2lrnc0wjs8pv3cigw3lwy2qzaw0v61bwknd5wabm25bvj";
   };
 
-  buildInputs = [ libxcb ];
+  buildInputs = [ libxcb xcbutil xcb-util-cursor ];
 
   installFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bringing wmutils-core up to its most recent release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
