### PR TITLE
rust-ht: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5138,6 +5138,12 @@
     githubId = 45168934;
     name = "Louis Blin";
   };
+  lcycon = {
+    email = "luke@lukecycon.com";
+    github = "lcycon";
+    githubId = 471773;
+    name = "Luke Cycon";
+  };
   lucc = {
     email = "lucc+nix@posteo.de";
     github = "lucc";

--- a/pkgs/tools/networking/rust-ht/default.nix
+++ b/pkgs/tools/networking/rust-ht/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, nixosTests
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ht";
+  version = "v0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "ducaale";
+    repo = pname;
+    rev = version;
+    sha256 = "0w5wqxrjdl3c3gmf3gzwsglsbg11vla3g3rl7jccs2ppiblihgld";
+  };
+
+  cargoSha256 = "1zd2vpbh9sivb34pp8zyj4533zh42ra5k0jw9cjz749k7119ny12";
+
+  passthru.tests = { inherit (nixosTests) ht; };
+
+  meta = with lib; {
+    description = "Yet another HTTPie clone in Rust";
+    homepage = "https://github.com/ducaale/ht";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ lcycon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2716,6 +2716,8 @@ in
 
   remarkable-mouse = python3Packages.callPackage ../applications/misc/remarkable/remarkable-mouse { };
 
+  rust-ht = callPackage ../tools/networking/rust-ht { };
+
   ryujinx = callPackage ../misc/emulators/ryujinx { };
 
   scour = with python3Packages; toPythonApplication scour;


### PR DESCRIPTION
###### Motivation for this change

Packaging a new tool, `ht`, which is a Rust implementation of the HTTPie python tool.

This is my first time contributing a package to the main index, so forgive me if I've missed any steps! The name `ht` is taken by another piece of software, so I've named this package's attribute `rust-ht`. Suggestions on alternate names are more than welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
