### PR TITLE
pythonPackages.gusmobile: init at unstable-2020-03-17

### DIFF
--- a/pkgs/development/python-modules/gusmobile/default.nix
+++ b/pkgs/development/python-modules/gusmobile/default.nix
@@ -1,0 +1,19 @@
+{ lib, buildPythonPackage, fetchgit }:
+
+buildPythonPackage {
+  pname = "gusmobile";
+  version = "unstable-2020-03-17";
+
+  src = fetchgit {
+    url = "https://git.carcosa.net/jmcbray/gusmobile.git";
+    rev = "0a09aaaf00578d1389a4aa6b15f5c64867e0f8ca";
+    sha256 = "0wpvfk5kj23r83xfha6kidsh5c7y143y9ximlx3h92hih7rpskmn";
+  };
+
+  meta = with lib; {
+    homepage = "https://git.carcosa.net/jmcbray/gusmobile";
+    description = "A simple library for making Gemini protocol requests";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ jb55 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2841,6 +2841,8 @@ in {
 
   gumath = callPackage ../development/python-modules/gumath { };
 
+  gusmobile = callPackage ../development/python-modules/gusmobile { };
+
   gunicorn = if isPy27 then
     callPackage ../development/python-modules/gunicorn/19.nix { }
   else


### PR DESCRIPTION
```
A gemini protocol python library. This is needed for the CAPCOM gemini
feed aggregator.

Signed-off-by: William Casarin <jb55@jb55.com>
Reviewed-by: Matthias Beyer <mail@beyermatthias.de>
Reviewed-by: Xinglu Chen <public@yoctocell.xyz>
Message-Id: 20210206005608.10821-1-jb55@jb55.com
Link: https://lists.sr.ht/~andir/nixpkgs-dev/patches/20061
```