### PR TITLE
l2md: init at unstable-2020-07-31

### DIFF
--- a/pkgs/tools/text/l2md/default.nix
+++ b/pkgs/tools/text/l2md/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchgit, libgit2 }:
+
+stdenv.mkDerivation rec {
+  pname = "l2md";
+  version = "unstable-2020-07-31";
+
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/dborkman/l2md.git";
+    rev = "2b9fae141fc2129940e0337732a35a3fc1c33455";
+    sha256 = "PNNoD3a+rJwKH6wbOkvVU1IW4+xF7+zQaLFAlyLlYOI=";
+  };
+
+  buildInputs = [ libgit2 ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp l2md $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Convert public-inbox archives to maildir messages";
+    longDescription = ''
+      Quick and dirty hack to import lore.kernel.org list archives via git,
+      to export them in maildir format or through a pipe, and to keep them
+      periodically synced.
+    '';
+    homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/dborkman/l2md.git";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ yoctocell ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5561,6 +5561,8 @@ in
 
   k6 = callPackage ../development/tools/k6 { };
 
+  l2md = callPackage ../tools/text/l2md { };
+
   lab = callPackage ../applications/version-management/git-and-tools/lab { };
 
   lalezar-fonts = callPackage ../data/fonts/lalezar-fonts { };


### PR DESCRIPTION
```
l2md is a tool for converting public-inbox archives [1] to maildir
messages.

[1] https://80x24.org/public-inbox.git/about/

Reviewed-by: William Casarin <jb55@jb55.com>
Message-Id: 53327d3418ac20fa5e8f4c7bb524b6584c52c024.1612463858.git.public@yoctocell.xyz
Link: https://lists.sr.ht/~andir/nixpkgs-dev/patches/20022
```