### PR TITLE
swaks: 20190914.0 -> 20201014.0

### DIFF
--- a/pkgs/tools/networking/swaks/default.nix
+++ b/pkgs/tools/networking/swaks/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "swaks";
-  version = "20190914.0";
+  version = "20201014.0";
 
   src = fetchurl {
     url = "https://www.jetmore.org/john/code/swaks/files/${pname}-${version}.tar.gz";
-    sha256 = "12awq5z4sdd54cxprj834zajxhkpy4jwhzf1fhigcx1zbhdaacsp";
+    sha256 = "0c2sx4nrh4whsqzj6m5ay8d7yqan3aqgg436p8jb25bs91ykn2pv";
   };
 
   buildInputs = [ perl makeWrapper ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.jetmore.org/john/code/swaks/";
     description = "A featureful, flexible, scriptable, transaction-oriented SMTP test tool";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [];
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change
https://jetmore.org/john/code/swaks/files/swaks-20201014.0/doc/Changes.txt

https://www.jetmore.org/john/blog/2020/10/swaks-release-20201014-0-available/
https://www.jetmore.org/john/blog/2020/10/swaks-release-20201010-0-available/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (`mailhog` :eyes:)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
