### PR TITLE
ox: init at 0.2.7

### DIFF
--- a/pkgs/applications/editors/ox/default.nix
+++ b/pkgs/applications/editors/ox/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ox";
+  version = "0.2.7";
+
+  src = fetchFromGitHub {
+    owner = "curlpipe";
+    repo = pname;
+    rev = version;
+    sha256 = "18iffnmvax6mbnhypf7yma98y5q2zlsyp9q18f92fdwz426r33p0";
+  };
+
+  cargoSha256 = "0v0a1dl9rq5qyy9xwnb59w62qr9db3y3zlmnp60wafvj70zi9zxs";
+
+  meta = with lib; {
+    description = "An independent Rust text editor that runs in your terminal";
+    homepage = "https://github.com/curlpipe/ox";
+    changelog = "https://github.com/curlpipe/ox/releases/tag/${version}";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ fortuneteller2k ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5826,6 +5826,8 @@ in
 
   np2kai = callPackage ../misc/emulators/np2kai { };
 
+  ox = callPackage ../applications/editors/ox { };
+
   file-rename = callPackage ../tools/filesystems/file-rename { };
 
   kcollectd = libsForQt5.callPackage ../tools/misc/kcollectd {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
[Ox](https://github.com/curlpipe/ox) is an independent Rust text editor that runs in your terminal

###### Motivation for this change
Add ox editor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
