### PR TITLE
firefox-bin: 85.0 -> 85.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -201,6 +201,6 @@ stdenv.mkDerivation {
       url = "http://www.mozilla.org/en-US/foundation/trademarks/policy/";
     };
     platforms = builtins.attrNames mozillaPlatforms;
-    maintainers = with maintainers; [ taku0 ];
+    maintainers = with maintainers; [ taku0 lovesegfault ];
   };
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "85.0";
+  version = "85.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ach/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ach/firefox-85.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "af7632d2ec4772c1532745b44509ea429681fc41295e8cd577bded16aa56920a";
+      sha256 = "31196e3a9dca5c8b0d1e44455020fe40500e2e5e2b2e01b8ea6d29705967ea11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/af/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/af/firefox-85.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "9254217dadb1fbdc58d8f2cb565a43cf22a48a9621dd9b25c274b266dfaa4a94";
+      sha256 = "24505d0911f8ec1408508f719cdf9a3d11918dff04aa93c1e2ea41668e68724c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/an/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/an/firefox-85.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "e92e9b30f6646ec58a8a963b4017883058058e52bb392ac81eceb6cfaccc5f98";
+      sha256 = "8cb20d99a9ca151d53a3815b20d1f5f5f398e6d9d82e6b8d01390cbd6e261e46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ar/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ar/firefox-85.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "29d207b37c8b8832183256c5434da76bb41b8c893c728678877b6551b40f8d82";
+      sha256 = "8eec93e95d5b9aa7df47f3b91eff25b1f8e12213828adfcd98b6409c87b1780b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ast/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ast/firefox-85.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "aa68b7807a1cdaa0c780c0da2afcaa5b28946ead2c6f5ea5adfab798f9d223b1";
+      sha256 = "b565b06e2219b1e5d7fc85cd2208424392ca80ccc4c36049603bbfbdc9d0cfcc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/az/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/az/firefox-85.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "c193052c8ee725d6c909c4f84099d1f72de71ac59318f8fb7f959322ea78e315";
+      sha256 = "d6e26dae51ec386a49c0ac21b7cc5213101396f0630abaa167d886b23d4825a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/be/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/be/firefox-85.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "54bb585bfbc3b910ac95dbce7b1507b210a871bece19df250bd871fdd4354e18";
+      sha256 = "1fc9fd0348b818f710a8a7672d274ecd88f95d2ab3be549f3c283658d7757464";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/bg/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/bg/firefox-85.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "3199a6111d85e00c63314f842adc8277d54bfbb457172bfa03f59fc186d0213e";
+      sha256 = "ab0d3ff8b8bdcfb9dd740b97c9c6bd29f3499a0da94081d41c84d759db7f677e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/bn/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/bn/firefox-85.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "c9767a236edb36585348d7d69668074ff8b7bf0ce8bf9461660fa3f5002b5700";
+      sha256 = "2e6158c2fbf754a79f509e7880a6b19217f1d65599d46283f556cd8ae953982d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/br/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/br/firefox-85.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "4f5cc23bb984de4703f0861c06d51621851149cf7f140439f4e628b760f7e6b8";
+      sha256 = "534ef1278b858255f50bace759562174ee6c3ab7fb6cb063a6f5ff86f50cb59b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/bs/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/bs/firefox-85.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "fd09d9c54505ed70a94a861bac653c89b1401f3dd8bcfade90a0b43517e0bb12";
+      sha256 = "dc3a0a7499e7e400445d21050ec5633bce346448711887be546f5dd42de6431e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ca-valencia/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ca-valencia/firefox-85.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "3b16d75fcd1f5cb38df9a3bada0dd59c050f57d4b19988d413dfa910a07a21d8";
+      sha256 = "cf821b74bdba2b3e3d488e1918b1078893766e753d004ece5e48690736d43fc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ca/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ca/firefox-85.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "e3736de71272be8fb64762f48175d8f3c5efa001f5ef683327a706bacdbfe412";
+      sha256 = "465d0b094d3a12147bb18d9f052b64c2d39018bb84e9a077bf66fdf17b5b1bb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/cak/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/cak/firefox-85.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "a75a176b989383367b973b683a0755a283350aad43e2b9f8825561a3fefd9bd0";
+      sha256 = "387359eace3af8d11e2d8e7ea9f32fa8548ea5fbe7679eb5958bbb37afedd94c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/cs/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/cs/firefox-85.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "40060c9664c9518692601215e86047f05e9dc1d7a51454b4e2097f6dddab5be4";
+      sha256 = "967ab5becfb7d6143792a66f85375d55e740e4baa71f200534a9eaebdc96968c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/cy/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/cy/firefox-85.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "a015e8b04695fbbc19f98361ea1965cb5901ecf285ed2a56f073b8ff0abe98fd";
+      sha256 = "5f5306af912633302a35827694c2454794316322731577bbb1b43cec8c641f0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/da/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/da/firefox-85.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "976e53318750b552292d899f4534541cfd02d64c18f3f1f283ee6b5eba10f220";
+      sha256 = "8674921da901e31308205cd5d4489b9ba121af811e000f323fef3265ee57801d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/de/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/de/firefox-85.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "2951b14baacc84b9627b714a80dede18897a3f9696b50ce06c48131888b31322";
+      sha256 = "7efc9b0125a58dfad1fc372ea0e52c8bca4942909001d3b0e15d984f730d4477";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/dsb/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/dsb/firefox-85.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "7b878a3be6798bc19b06242696a61ea78536a1b39851f9a1d41797192d7313ef";
+      sha256 = "b67b965fb98b327a80e57e7782843345023a27087c107b4a087ac6f32bc9e242";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/el/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/el/firefox-85.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "86948d6656659180cc279401106ba7aa420e817b6cc2f633c5f9dde5f2753b33";
+      sha256 = "6f3d23f1ccb0fa9c803c9146c79e71674e8ea4af98aff4f6fae4b17a96783e72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/en-CA/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/en-CA/firefox-85.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "cebc4e8e9320d0141e2a81b4e54177103f6bcf69685055e3ee1bdf59b2188efd";
+      sha256 = "52a9d4e9d16afb7b8db26a0ccc1794cfb39bcbc311f673ea2cbbaff73dcc0ed9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/en-GB/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/en-GB/firefox-85.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "377b3afe2fbf6dc6d953658fe086347b795a25131eb9374465fe0b7089d22d04";
+      sha256 = "6fb66a9c6becb8e84b3910a390e99edd68a25510c7a156e6d369bd5512614c11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/en-US/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/en-US/firefox-85.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "addf2e4094d4b1f4d4445165a1f52fbd2198cde5fc9c213aef1145bfe8fffef2";
+      sha256 = "b8e7263fe020374f116d71020162f1011b9f759cc3673c22c9f60fdf277f1595";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/eo/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/eo/firefox-85.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0393c54f640bba1d73c5a8f7f128d6c3d28b633432f72ec9fadc5305c6a394ee";
+      sha256 = "413b0c757f906e8000bba8814abecb0702c1939b31f7d2d934d0726959b59696";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/es-AR/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/es-AR/firefox-85.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "700a5c7c906514dba573c72ebd92fd2809351382b870362a9e73d295ad68ee7e";
+      sha256 = "53185d003a12a68005aa2a1e5b9c8d9fcd84e32a2d27b1a87fab8569b7d5d09c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/es-CL/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/es-CL/firefox-85.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "dc76f5b7690326a51ef2606bc19946c329ed3a4174cbcffe9193ec7281c03d83";
+      sha256 = "0d42da5338a904e80e60c42535d3ff644eeb0166b7d4a2317ee5cf532736db45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/es-ES/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/es-ES/firefox-85.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "57e60cf15b7562d5766c3bffe511b43f50b9ee00c484344d7997b1dd74e6000e";
+      sha256 = "23ff6c4f37541e1af443540abfd7f2588d103345b557921fc5fd5312d601c315";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/es-MX/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/es-MX/firefox-85.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "77531203ff37345f9849b61f0c163c573c5ac5091e5d0e07037681609e0cac8e";
+      sha256 = "89151879dedcf0a3d41778a0adedb6eb9a780a238a32e521feeb03d829aeb635";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/et/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/et/firefox-85.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "a68e6825149007d042fc9f1fb359c18c8cf09da6bee0ef3d9f2a619bb2985b61";
+      sha256 = "c9e215310845f9cae62be559087145762a9790854e257f5ab09af6d7b0a4cf5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/eu/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/eu/firefox-85.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "7a94fa17efff869247b65eaf1c8731c536fedfc46edaaffba27d0367033a54f0";
+      sha256 = "f6942f741c03d5a1e246039bbe6d38024f3aeb15b0311318aacc17c7ec0613b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/fa/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/fa/firefox-85.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "732417908adb7da3a9a06ad9022d3f487f6650445b93c406d6bd03482a622401";
+      sha256 = "815636c8539d92c74767f5c8001e7894633c67ce2eecfe32584d9d654a8e94f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ff/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ff/firefox-85.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "defe2f208ba27521850ec1fd8abe73c181004ddd66bc15d45a2d01c8908fee97";
+      sha256 = "b2638766e7d538b6b9beb782406ab3ba9aeffe42201994be21dbb9d8e7c340ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/fi/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/fi/firefox-85.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "247ad848a34946c93129012de65da3153401b3a1dbd41d132d03904657b8ff87";
+      sha256 = "92d0e973e2e618be102cb057d0de62f1399ca65f05982f8db4188484b58a0cb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/fr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/fr/firefox-85.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "ac56118839123c10899e043fde74051b4dca211832c2ca4abffc42062773648b";
+      sha256 = "8ed02def2df76f31d72fa9b461efcba4d798d7a38b7ed530cefe786256188697";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/fy-NL/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/fy-NL/firefox-85.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "aff1bdd3559698eb253e6339088a1818490bc11fcec08560fed9732705d8f12d";
+      sha256 = "7a6ec5ed176fe70fafc94e0f85d7deae393f5db83cc7fe7f5478057be34a2e14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ga-IE/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ga-IE/firefox-85.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "b3aaaa9b45865d0be2fabaee45ec8ef481cc92afd93976058441c3c801f71761";
+      sha256 = "c36b5cdb6e41956cddac273ce4e997cc61f53627a94e565d99390779980d11b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/gd/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/gd/firefox-85.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "979140c1d5db3ee847af64eb86e97a657f7665cc85e0754d4f580229a81a6a56";
+      sha256 = "59835de77fbb13e425edb6d7bfdc6fa90b51f98f2977c3e6a91d424632046185";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/gl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/gl/firefox-85.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "8953815137c2f40fbf490ce41f09c9f1c44114cf0640478e22e16ad67397f99e";
+      sha256 = "8060e3ace951502b498a900c8904e32b643e682fcc7db3d960be5d3ef8efcab4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/gn/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/gn/firefox-85.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "5b8887274069e3c14ba4911cf64e01103ca2b2092f7819d535932ef09a486656";
+      sha256 = "5f9493a44aa5b6c39496bcb9c2f52f9312eb94667e64913610333b8ecfb9e2bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/gu-IN/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/gu-IN/firefox-85.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "f18ac181d0b5dedfc107ace1b257475d7ff75e15f069db183bd445e91ff066fd";
+      sha256 = "751e2cf9d6f050cba1f671052340de36ce255485fd3ccd528ba254e2f9acb678";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/he/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/he/firefox-85.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b1b4b4bba5379e6aea2052dce060a857d545abedb75beeb09132c83d89315772";
+      sha256 = "0a28f7d1925d471fd712ead92a3abc1a988215715e9663fafecfb0efddebbe7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hi-IN/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/hi-IN/firefox-85.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "9fa023800ee3db1485a18ba33ce6e4b004123434da4b7e177e9413cd9dc72293";
+      sha256 = "95ab7ac27f5a70d083514909c5233cc5b9619bb1ee2e75159ee6707a33033a05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/hr/firefox-85.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "5dd335bb622a37629874680a132b4199dddfc341ed6cab7c34cc8bc6fef8fd33";
+      sha256 = "ebaa6abc6d3ffcd1ec3e65682cee08f3a4a2f451cd27a07ff49e510ebf139cb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hsb/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/hsb/firefox-85.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "f89219c755fe8aaf1309c6b83feffaf6630816882563286e324a90ca62394a5f";
+      sha256 = "e6313e9ca2f5fc39ebd8e237096f4bfbef6d1a00277024b406bb123420790d5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hu/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/hu/firefox-85.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "8bff8576e76bc01e57838ec7751a8cf17d99e0c9dc153e91061ace650d8c058c";
+      sha256 = "7c261fcd5c2b3fbbb1a08d3d64e774c869f91cc5dc57c69c8182ea7d1e0a1f8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hy-AM/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/hy-AM/firefox-85.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "adab4ab3ce22632836266963323a75a81db9e653614b9b639a6f61eeb10543a5";
+      sha256 = "d19a967744f9867b07a86187d103ff245abe12cdda6ba3ffc6767b0d1535f4ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ia/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ia/firefox-85.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "8b4acfb5654eb694b50155cfa41e02e19316cb47e552fc6537339156bb5cbfca";
+      sha256 = "b044bf688fcf53565943d6da05dd76261dd42d61e0aee8d524f167d937d10a86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/id/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/id/firefox-85.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "e848c3877e0453d4ab9b6ccf6078fb919c4d15b1f0f20c1a975654c5e6182530";
+      sha256 = "aa84b7f4bf71246ae678ac01695b5b90ff7e3cf1f59efa5261a59fddef8cf5a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/is/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/is/firefox-85.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "00036a6977a932b547ee5b97f5c830456cb19393cda45c190ee5237e796a76e9";
+      sha256 = "de6ab2d654feb56956f0b0a31382957cf10b14bf35e3e9f22858f00728082992";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/it/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/it/firefox-85.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "81dc17afe61ed833494cca7687a1bea1f6a5a3d93571ae0522e481ba2c9e73aa";
+      sha256 = "1bffd4e8b86a96edf4a6b1b0bb5b3a22358d18e3d5c66cdf54ae5755cc8add4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ja/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ja/firefox-85.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "2f0a652d51740c9adc760a8843433a52226327600fc7e9e87b603e97c0541547";
+      sha256 = "e1d78e731415a15cedd07231c3ef75fc881b71bf2e5c8aee59dfebca1e940963";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ka/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ka/firefox-85.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "8f01dcfe02fd71d3c3d564ab111b34e4f2d5c58981233c5698c87bf449144015";
+      sha256 = "75426f16874db9daa7221ec860ae7e6a8549d8f2e3d41f063a575f29b93711c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/kab/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/kab/firefox-85.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "1163788f9d943533b124a57fb3e3fc1aae56793f929e5ac2d3f17b1826e3d353";
+      sha256 = "4c4fca660e8ef2d8755ac30f5c835d82d24c2e9f9a8774f0114137456a5356f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/kk/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/kk/firefox-85.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "f91eae3b5afcff6c49548c6d5d5d5b0fc0dd6a9500b87baaf00e0cee96efe22f";
+      sha256 = "c88f251fe8cc7ea5a52fd33b7f6eaac7d0e64ead921df96ee6528bd039ac52c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/km/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/km/firefox-85.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "2ab5040f15ceea952a7fb6d737eed93b23e1423e2298c31a5d7486c81ecab9af";
+      sha256 = "37535cc8a315d107af45cb678c386e73fcb3a13e33bbd55db5b98bb09a9b6eb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/kn/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/kn/firefox-85.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "c141f0e1c95c0630aecda5f929ea3720f3620ad9f30f95e4e371865c2d0eb96b";
+      sha256 = "dcdeb544cb9d9d29677f6b272ab33b7592005f7609d499bdd97b997bbbe7a2f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ko/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ko/firefox-85.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "8e87b7f748f2fddb3edf5f12fcd8238bf8f05b403c707471878ef540f8fa2a40";
+      sha256 = "ba0677d2bc8a66cbe0f3c7bcf256da8248cce604ca43c9db543c02d5a638599b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/lij/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/lij/firefox-85.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "99e4be7139c456c7a7da8d1ba1b845d381995241940b9e9f3db81892cb51231b";
+      sha256 = "f79c200904a60d9156a25ca9c968edff7df81a7faa01dae0436da22d941f87e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/lt/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/lt/firefox-85.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "acfc0ce0b56a15d2b5a7492807b9b70b801712b420a72d5b2e73a6e5021cce71";
+      sha256 = "866e8a42dd1a8fb6e43aa4c156da70c7ea01e57f98deb9733f2b91bc0b26c05a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/lv/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/lv/firefox-85.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "c8bab5353b01987b6e3ee434ec5460cb54d56183662fa9c7f3017ae018be575d";
+      sha256 = "e4c8675ff35bfae63fe38cea86283574fd51522c41e756c49f9437da4b0524c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/mk/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/mk/firefox-85.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "7ba1d47b8923862ff2228faeaf86a1277dd48f45ffa83230f3b9b22b1860febc";
+      sha256 = "cbba302366387806d3ae185b93e45df4a5e5c36b469233ffda3f9ef45c41c799";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/mr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/mr/firefox-85.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "acbc9dd00e31437bee02f9d3548af926ca021f128239f67ff5399e533923e2d4";
+      sha256 = "a26de1118be542a851e1033285e8517ea3eb3a1e2caf1f20018d98294df980c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ms/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ms/firefox-85.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "6293173ccfcd0475b6ee0baffb54d4b43776710b3c4ea97ef1437a8919aebc1d";
+      sha256 = "9637de49c5b17d9d4809c614ab0d1988a0ea1d86b5ea02482eaf70e415ca190f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/my/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/my/firefox-85.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "c4e075996c9a6c13e2631bd85d6f5b3015400dfa40116479e5a17c939d538cf6";
+      sha256 = "c6f87c7e25c324d4fa767b16b7b91af4efca5dadb5fe684eeaca4742abe5387a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/nb-NO/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/nb-NO/firefox-85.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "94d8f6ea965080e0b28d797c0c73813164216541bb6c008adffa523722a2727d";
+      sha256 = "f1d6d30ecc0b53f971a74dee11364f6fbcb6efdbb1951260b341bdb6c98a5ae2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ne-NP/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ne-NP/firefox-85.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "129ab6f7276d180c3adacfe970c4c870953481790b451f8dc98134c914daddd6";
+      sha256 = "8d6d976c897c9f9a3d520af1124ffc953eb9a3a7f35aabb94002c94841486805";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/nl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/nl/firefox-85.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "0f7efdcd52cf5c214da536261e539b45d8da3ad37543b6296feb92186053a59f";
+      sha256 = "6c5c15c780af0de9be4b70e3547d994b6d50d375067cc7e08377babb4335a52d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/nn-NO/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/nn-NO/firefox-85.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "2e42e0a8eb2dc2fcd217aacd7c0aa7eac5e673bad0d66f0555f7bb51ffb895fd";
+      sha256 = "488141d1dc9a9e5431baec0a89485061edadaf7a5762d284e3986206ca5b70ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/oc/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/oc/firefox-85.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "d4fabdd18ca199f6081093fe4c88191885ae0c19fc36fe574f546b26b5d2eacf";
+      sha256 = "bf332a5fae4298330e042c92d806cba19f12f8ca1f501f8e36b1b267f2486aed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/pa-IN/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/pa-IN/firefox-85.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "88ddf2bc486d13217edd3d325247dae774ba60d509481d7a6900e06ae30f70d8";
+      sha256 = "7108d6fa99eb2ab077edcdf1539a8437e664e528b73b6ae2cce3af6ab07a41ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/pl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/pl/firefox-85.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "9e6336fe8745e21674270a95bce7d24508c9585955c58ad74f631e1fa73c56f3";
+      sha256 = "40b7830f0dfc684b277c22aa6d558154aa4c37a2bdbf5d47add74ac406b6bfbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/pt-BR/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/pt-BR/firefox-85.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "68573084e4a826978bfae5c1c8cbfecba2fd578d0c6a07affebc2ba19f1d97e1";
+      sha256 = "1ba338037c07c2c77b3fe8767c8dbf240bd99ed9ffd33cf0cec1dd38adb7f196";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/pt-PT/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/pt-PT/firefox-85.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "6b6bcca14f08cb8fe07282a3b24797417ea73a60300cdf76c64ffda4bfb051c0";
+      sha256 = "6cff3b3f11364a7bd59f125854dff1c2d638287ee95f0a7bc6bdb075a0624f01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/rm/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/rm/firefox-85.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "331c0cd9510564ade274c209514dc5ec3647e3ea37da6b630a7cefb8c445332c";
+      sha256 = "7c626161a43e052978ecb6673cf3a6a5e57bdeaed52113da3ae52bc0db653f9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ro/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ro/firefox-85.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "52df2b116aaac13590076b86216b904def287e18828f040980cae01e8ae67b1c";
+      sha256 = "308ec282ca3850056370205fff303b75967051fd54058d1365949f1975793791";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ru/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ru/firefox-85.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "2fbcd36492688e21dc4e8fb1faf1ea67ecd745f3b7f58b0950786120c9043cf0";
+      sha256 = "48c445c3f25a9ef50fe81a59c8c70c9decab031c8d889da088616aab1e4d8b83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/si/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/si/firefox-85.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "2a4ab4bf9fee148931d09bae59ec1f049c09aafdcfee3c6a083adb3d2b1e42ee";
+      sha256 = "5170634c140ea5734f8141e11b9e67f2257d2b80a0b41efeb6223dda69a9f364";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sk/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/sk/firefox-85.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "4ba12a5d49a2ee0f5c41f63cab08b7c161f3546ca9195339e22d463879e7f45b";
+      sha256 = "0d8dd2d3c0269080cf77727950733f077d7db753ecdf910992292dfbcfcb79b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/sl/firefox-85.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "6f1f6379a9706d2af9c7797d8c1c86700f3e9ff7cd72fa35c3d602e6622de47e";
+      sha256 = "35177a269a4b4064bbb60f4d7d4fc0b9fe9e9227616a69efc0d9a3c4cc5c6417";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/son/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/son/firefox-85.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "b9292626bad35a50dcb81d34db417417b031a6ef9a215e26d5e1ee9456e244cf";
+      sha256 = "d594aec6adc95057c8ec786e07f72b8b63b3fd1f60bd056171ad1c1d08ea220f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sq/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/sq/firefox-85.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "077dbbaa904712782252e8f8a01b78237d51cbbeeda0e455ad5f2569f9a394d1";
+      sha256 = "77b925e4ab229b7b5347de2cb5ee8bf774d94b4db831e87c2b5f10c926dc9efc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/sr/firefox-85.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c537ab1e63530a82cf5c181d98895b580705e3418f598ab3f98fa67cd9a83f10";
+      sha256 = "e967cde12e9e916b5cadec9bb545291fac31fc287333d62d6d9e82fc69a0f028";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sv-SE/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/sv-SE/firefox-85.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "42e36cc411666fad716a60643eae0be0301783fda10cb07943c8b6df293430dd";
+      sha256 = "6d7bd35d5275fd73dedfef52a09d278efa74d3605000451553fa53c69e5d5cb0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ta/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ta/firefox-85.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "b77e5c448f6a1bde09da07c3b20339f54214d89b4394123809e7bec668d65abb";
+      sha256 = "7784e71986bfc5c0b471394ba3495a1d221fd7a863304f6db78791fef5a70838";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/te/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/te/firefox-85.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "8c700eb9c7a9057e4639c39643430667ed9099a37d2214c8ffc5d349e5b0fe79";
+      sha256 = "4d582c28386c13657b9983b8d6de9fabb021f5dc3c120162f370eec5fa7d0a7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/th/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/th/firefox-85.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "3a467b98fb435e80bb913c56291803a79a05a42c73576be49b014394a29002f1";
+      sha256 = "e265ee575e71cb940ad679dc6ea8a37a075882fb2ff5023f68d63eb86a642cd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/tl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/tl/firefox-85.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "599214c5dd5eb28d6ea3b7e2db8795ce4923284c721b15a85bcbdbe74b416c5f";
+      sha256 = "7bbfbd0538048692b0ee755df1c9ac004bc408bf814c95835f7e1ed3f05bf1da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/tr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/tr/firefox-85.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "1192f241df3a8691d0e895737c03a790f47a731a6335d2ee2fd1e1310b3d0cc0";
+      sha256 = "b81c231bc5039a1b91438ce6447f93b86ad1c8d248b67dc565d7da870ea61ff3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/trs/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/trs/firefox-85.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "f68c08305ec3d1396826e3310ac88b5b07beb71beebcbfaebf3ac81c543bc47e";
+      sha256 = "bc72b31236b7422fd29f900f2dc8d8e19ec3ecef7d365e31d492e1aa3bea0368";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/uk/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/uk/firefox-85.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "4705551ac9a02b450f5e81b05a08912b7b26bdba99b9e9095461aa9c70aeed36";
+      sha256 = "c79263d7040815726dd42fa2d20f624b10a0827c6ad48d09d394c614bed4bc64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ur/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/ur/firefox-85.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "ec84dd4c7a4e338a21ccf8f09c1dfb14a9e34e3240a55b92901cc5e6a89bb135";
+      sha256 = "eb89fc6f432125287059fc4d9a02e7a1609f8eb49ac3ac5504a9b278b4a97845";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/uz/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/uz/firefox-85.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "d7a5b1c95cd9c8bc20cff8add8a2fa9c9c909b3845cbdc6f593f2686f9f27a40";
+      sha256 = "cac15fcb96b8f0e79746e563ef786162f86c977251b8f3983ebfa5d163f9ab38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/vi/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/vi/firefox-85.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "a3c1a719317c9fc73371132dfc0349dce50db061c4f96d32585bb26d0aecc7c9";
+      sha256 = "37a966d4c4d3c58544596ab08a6e4b14d01cc40f36ace0039f2017df495795bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/xh/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/xh/firefox-85.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "cacdaf5b7044a7e951fd67c4ff25ed41f2fe05a6cf2f4ff5b9d8d9fb0cf211ca";
+      sha256 = "17c22a1737f48b4cba5da7ddaa00776da1bd3ae032b70b9faf35e719f42f865e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/zh-CN/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/zh-CN/firefox-85.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "888569bd9bf58a58ffd5effdc4f0c58ac53354cec5d2792f0d88cfb30efff4bd";
+      sha256 = "93b176d2814e9c6a24a95f6211e4b5b7eca28895ea100ffdbb46d8482b149e29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/zh-TW/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-x86_64/zh-TW/firefox-85.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "71e1fc336cfda1401b4d96ed185423486480a5ad4d267d3c94336470fa4a8bce";
+      sha256 = "bb33dc41bd7daddc954694fa72259c440d07ba84465b8b2fbe83f635b7400b22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ach/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ach/firefox-85.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "efcfa1aaac69712596c7f5ecbaf359c69980eb0b4d8c99857085f3a4564d5026";
+      sha256 = "ba34cc7c3ee0e0ac6ea0106874dc1860c08049700c4e9ba130d8417508edae6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/af/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/af/firefox-85.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "b5e1eb9041fdda259a3db87d784e6b633a18f18c46038361d4a6d2a8aeadcda3";
+      sha256 = "da95c9f5226d6a3ebe356c18249b026c535f803628f9697e19fb961a44aee70e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/an/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/an/firefox-85.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "35ecf29bbb2e65feb372c83d2bf6b1c28b6edd57873eaec3090ed0200121043a";
+      sha256 = "5b151a370954bf27def1577e42101b484335aec48f840e907a8f945065a33268";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ar/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ar/firefox-85.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "ef86ed77ac7de83e4e068970f57843ab801f89f180837015f1ea4e3ea11f3b6c";
+      sha256 = "c549b72bb31f1311c01b82a07271eb53964be982e889d04dbf63cd5d39d744d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ast/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ast/firefox-85.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "6b58d2d132944a5106b73f47bdffbd606df63173f817bbdb32c4d3b2354030a0";
+      sha256 = "c48cafd7ea778faebc31efd61bb090e9e55124f2a64f2b407a7aa7e19bd6e30b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/az/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/az/firefox-85.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "1ee85155d8d45fe003bea0d8ff9d5a1c40c4d52102e125b4bc1ad608b5383c39";
+      sha256 = "fab896b2ebff58d16baac7f00998e85978b1e41ad0b9b5a219b65bcc854ea192";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/be/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/be/firefox-85.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "e6f30798e101d73b0e359a63a35b044ea51df964f1e22a9c894f1b572cb99653";
+      sha256 = "d0dfc35174e9c02999e45ad25bea24332e71e860668211fd489c6e46f184b890";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/bg/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/bg/firefox-85.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "e3bbc6ca6c77fdb56dac6c8ad0c45d425485ef279c115651bb4824f6d52a14f8";
+      sha256 = "da6ab40fdffeaf8e1df8f379c3cf07f97da10590732d385a1bacacd3e5dd84fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/bn/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/bn/firefox-85.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "583762c0fb01f6ee1165eb98122940fc42286e6f8678679466a2b79051a45fd3";
+      sha256 = "c69fb64b3b47091ddefb4325d49aeb6e5b5a67bcaeea4240a0640fc38b821875";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/br/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/br/firefox-85.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "abef23deaac27bea07d0586f78578b34407765c05cdeaa9bd4d4ea0b552bafbe";
+      sha256 = "8a3ec06d6eba37877d9201651f912e686bf99babb384e379feefafc9533c5e74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/bs/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/bs/firefox-85.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "8f4385e1a8db5567d499a046a169d8a77c585a61734ee7257063a98d722cd278";
+      sha256 = "d771063134a01e5f7a07e403ac5c2d23f8c7792f298bef7862396094c99c7a52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ca-valencia/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ca-valencia/firefox-85.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "eca948e8e2020cf401ac4dcaefda2aaf967336122e1927418a80d9a854e2e52c";
+      sha256 = "a1ca0f3a80fb6d3f98b1d1e74d6b8e5f3e7a6a91ca81cc29aeeb1947e7562c33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ca/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ca/firefox-85.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "c46250371ac43baaed265e74998e0bc44fdf01c4308f1bae8e34896e75004096";
+      sha256 = "baa21f32930fdc55862fe1fa3bf07ea3c3a790233f8472cecf621dfef9fbe639";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/cak/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/cak/firefox-85.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "64dace82a39b131fad3509b2865a6cb22c5044a88838187f975a9c3bbb5cff2b";
+      sha256 = "b73a1347be66802aa55c5e2a068ab0556f1659e6e85289181c9d436698357ea0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/cs/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/cs/firefox-85.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "799c10e7f4068f4122637f4e8ae992f4da892b8f4ae17e47e2b93ff9f61f236c";
+      sha256 = "8731d781753c8a6652df2cf9120cda12e88e42f721c99b8867df971ac33ab6b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/cy/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/cy/firefox-85.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "9075bde46721937fc83f891a3f3162969e61c8ae6aa0904b6d597fd5c2872e81";
+      sha256 = "da6da7f9e69a8a36a4a0f1a388b5560dca4b1cb64154a9d77cc2bf398a41a5cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/da/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/da/firefox-85.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "d1bc56c35db77e1ed7c3b206ca7906834edd41e8d37f5fb467fa75eab22b1c6f";
+      sha256 = "42b9b30111d186fcd5422731236050157a4f7c7fdf928d4879fa90c4f37b9da2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/de/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/de/firefox-85.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "8430827afb4a748890d1b114d3363898ff6a882b2a17165a10abe8ef385ec83f";
+      sha256 = "e78fa2bd1b856d060a2093caf6dd79ff0d150e815a79b8831096df3315067c5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/dsb/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/dsb/firefox-85.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "e6985031027fc9d4e5d8ab0899daadd93a5333a668b116b632181ed34006ae64";
+      sha256 = "459e99e7636f1f09b5ae8a78b0be6dd69c3f1a53ccb7c1daeae1d8d146e61afd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/el/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/el/firefox-85.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "4e5bb6be18e963006f30a1478194b6613ff922e9dd3939ed7df5e2d79df5c630";
+      sha256 = "6a2aaf9ab9782919e1bbe0d010a2526bc0d63f8c6c8483281bc9a206a611b2b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/en-CA/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/en-CA/firefox-85.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "b172f0368b07b6f908035e7d41a95ee8abd9c21cfe77923d902ec53517716a6c";
+      sha256 = "3fd67f804366b7454b2988730181d09cdf536c8c1f4db1f7d68aa1baa9392fd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/en-GB/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/en-GB/firefox-85.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "3e64db811fa3cf989dff5b043b9ffc3349f119ce27185fcade110e57ccb66056";
+      sha256 = "e661161aa18f629ce4d5b06e543f2fb513e82d5656a756352f3ee94b59b9287a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/en-US/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/en-US/firefox-85.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "e6269d7b11bd0e2d918e45059d201a2ae329da6ae69d33648de1e8ed885c65fc";
+      sha256 = "e3a749f507b8bb5b380b4bedeee9dc360b8db4c1f61e6a54ad55d438907682d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/eo/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/eo/firefox-85.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "fa1e60db4ff414b96c7813545a5b67730f312cbd85bbf079aa4c03eed5dc0920";
+      sha256 = "b3d1b34a1dd3cd15735599a74650bae46ec359a70df09a0f5e26fdfc6df408ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/es-AR/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/es-AR/firefox-85.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "f65977cf029a0075e2214708719a6af4b8e41d39bbf59b1ad998a5fca460c717";
+      sha256 = "dbcc491813d8ac79faf53c3ca22a10c6239a761e115e209164cb034a4e7b4e64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/es-CL/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/es-CL/firefox-85.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "94cf0ad46c52685c03c385ca80e159e5ddf229f31c8ef764defa50dfb5e59857";
+      sha256 = "8cc7b31c01141caba6d5fc6267ad19b7b78ad10f15d6311961cc2ecbf033a636";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/es-ES/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/es-ES/firefox-85.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "6603132e1660a50ab3f0347a22b52b9480f4bac21f67f958fb0f112205f3dd3c";
+      sha256 = "ba7a70cd25045dc63d0da66336e171d548a35af029867ee8735ca04707ff560d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/es-MX/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/es-MX/firefox-85.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "325cefd6f0920207fdcb11674a4b5a3f8d71a4b65e64c11f7ab3681a7a1ffb08";
+      sha256 = "442428e833626e05e6f35bbface199a1384fedcbc835fb9bf67831e331e9ff5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/et/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/et/firefox-85.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "9e997aac788ad9c5d249a2e1cce5f3a968fb5564c67e585f842d576aad5b710f";
+      sha256 = "c0f9b7eb84f4d92ca2b47ebe82f25a5bb19cb2080a6a2cef1bc039ef9382db0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/eu/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/eu/firefox-85.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "c677e6c0e86ce007fd0027132891b0baeefb172dfe19b8a3b6c0a1fdb09413a5";
+      sha256 = "359918d8dcad304b5b2ee93b241d4d2ff1dfd59f5cdded964013ebacec5e3b60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/fa/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/fa/firefox-85.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "4961d99cfa342ff1148f751a7ecb480439f2850247e4b4815023ae767cb92c55";
+      sha256 = "36ba466eb9f086052515b88d784374fafc5c807a89e4159049be64d8126c6e9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ff/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ff/firefox-85.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "751d7fb2485d00f1653397cbab88e0131b959cb9fe94a2c74687b05967a0efe1";
+      sha256 = "4de5b8e9150eea72652b4f92ff342b341e9c3ca4415036c8137da4dded04c484";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/fi/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/fi/firefox-85.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "98244bbd2d914c14b66a2f1b58312fed6ad09d69a8c6e36c6a28b9d6f5b93bd1";
+      sha256 = "18cc61057ddb8f7e5001aa293b3cd71bec67af4859d6ca30e4ac2dc195553787";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/fr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/fr/firefox-85.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "c90054aa48353ecd2e7d8bec810e98b8706bc837216bd2237010c50d73890de1";
+      sha256 = "6314372c93709f3ed262171e94e94927997ed478167542d9840a4acb77b34ff5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/fy-NL/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/fy-NL/firefox-85.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "343559198dbea2cd4f4d66c83fb8c0f44fede93843d43421c9a7e5925a7f834c";
+      sha256 = "38b62d1de5b452f79be50875bd97317951d9359d76727fad9972a9aa00a1f4eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ga-IE/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ga-IE/firefox-85.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "44a19acee4c0a8e03604de46c19c28f54f9ecc8bbf8f32f2e7b3922c11659df9";
+      sha256 = "b77b30753800e5c95f8336d1b2a7cc39e011b38001d0f7b1f3755d69cf71e4cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/gd/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/gd/firefox-85.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "bad179771be3cb0fd0ed4dfb287f16df65a06b78b3741853f474184f534f1ec2";
+      sha256 = "5dcf35c3415eb2e296c3433ca2a7038ce8d9fb7793ae920401f43796ac22b077";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/gl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/gl/firefox-85.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "58732e181252d40d59e3acfaaa1da9533e659fa4d3c43f70c03801fe793c7280";
+      sha256 = "cd0f2128636ace6fd258f241ef5be40a05815ed3db18c2acb9200bcd5202b464";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/gn/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/gn/firefox-85.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "645d6840fa76e286bf107c526de0762c5074ef3b52bae49ee5f02307c52d02f6";
+      sha256 = "9d99e57af9c9cdc32e8c0b7198ee3d4f0ef11f7a1e653a4f6f9608ae2e6c8dda";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/gu-IN/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/gu-IN/firefox-85.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "f61f6b052a687807022b72629a22a6b53890487add36634d09e2860d92d6733e";
+      sha256 = "9bcfaad7478e6c4a3c01258c826254779410e95ed5c57bc0e272713446b07e36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/he/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/he/firefox-85.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "5b96a1b4298737182a7c7c99ea43eb7b6558593f9f7b18df4a0217101dc183e4";
+      sha256 = "0b62ba8fb9edc4fe6cad699fe1897910bd4043e17c9e699260504ed8a18fc824";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hi-IN/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/hi-IN/firefox-85.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "e4c393235aaa9d80d678ea2f69092462815705647022fb2635a00174e597eb60";
+      sha256 = "038569c047693b15c932b88c0db716ea4067c7f3989ee8e53af3b9a0f306a2ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/hr/firefox-85.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "3722f05edf8f9fd5adf782291be51b708e7f08943b2f03351b36df00a1ef0d1e";
+      sha256 = "08c738bd05d8997a156d87ea21c3ab979d7045d4bd0f7cef95bd10c68c7a55c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hsb/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/hsb/firefox-85.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "e79dc707afdd246540e886522890d6ae2f53c38054c8902303d9bdd03df02359";
+      sha256 = "199f9ee619eae1fbbbf2d2b39fd0a4cf142ca57894d12007c32d15a90bf2b030";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hu/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/hu/firefox-85.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "415edcbfa2cf3bd0cb1278799914ccd683af51b8e380039c4aaba118e66047af";
+      sha256 = "e13ab60488ba0ea2dbb5de33a09b2e5d6892216eb16bf629fbe4e271e29f04f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hy-AM/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/hy-AM/firefox-85.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "4561cf20fea47b11a330be2bc3b517c1c53b4577f250b531225c53f321df7382";
+      sha256 = "1d5646a2419e197a3726a9869ff443f5d2b73d855816b9c0f0f043bce5a8d098";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ia/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ia/firefox-85.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "97b44d0e08f79ad55aafe2384b523d24e0147d414b95ff81834feb59c6b07695";
+      sha256 = "2703c8337a5a41b5d48bab5d1dbe9d9a191f78b3a50942f454508239494b16b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/id/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/id/firefox-85.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "2b501c2b43fc54f1ba5a89f8b0d19f8d25626584d1bcc108e16e2287f11449a2";
+      sha256 = "b4f31fde1297d8c111e94eef2d8d14ac41e41d788ee0dcb91ef0c3d93a9d2b22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/is/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/is/firefox-85.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "2cc3d7b82be2bad7ab6dc5659bf7a4c8ce4d882964588a2a767e78a34d832b27";
+      sha256 = "092218c6719ea8455de72927dcb6bf905e1452d8f725ae9471613cffa58b767a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/it/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/it/firefox-85.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "68b3f63b6e561f038894d6503b4fba8177e3fc025a189b68e2da11f8bef11c2a";
+      sha256 = "99b7d253f83d9f861eeee85d898370b5c96d1bc06fe2633ebd5f8dc9420916a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ja/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ja/firefox-85.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "0023494cb7a5485b1d492c2b9f1eb40a9fed06db0de6a2bcc76b54c4c8b44b5b";
+      sha256 = "4df203562e717e738f00af034213e6e30f2969a63fa81c072c9997fd765b95dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ka/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ka/firefox-85.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "a6489db173bbf47f76379afd09c75912d2bc4b8fdd8023d654df9d5f257378ed";
+      sha256 = "f312d8e17f8ca7ef1641acb8be356f1dc7705373f93f58c7bf12f89864184b57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/kab/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/kab/firefox-85.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "3b060b719b8bf0993786b05753467534e10986304b3251f572603be5aaeec2eb";
+      sha256 = "9256a1473243411b86bbc2c0c241e0ab8755602a251dfb73243a6d26bf33d214";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/kk/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/kk/firefox-85.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "7c1139dad1b300c8450357356e6c317159b5d702db30747c1ff7aec31f33f82b";
+      sha256 = "6a2cbf1777f61add117921e4c95e3300abdee1b2ff85d12912e858796ee8a468";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/km/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/km/firefox-85.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "f9dbec23d5110b389fea294cdecad03772f2471952e9ea01bc9d0462f7541ca5";
+      sha256 = "3c6c9d7d635ba38c8fb31e760b1b0a2d41028be6462e9a0a6ef5648e237e8728";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/kn/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/kn/firefox-85.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "7521548f755d51ed47e9596d58223f699fd4494bd5af8fffc1c59018f20be8bc";
+      sha256 = "dfc497b7c576734d0e5eef4ba71d2b83b10dabacb7b00d3ee379a0f362daeab1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ko/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ko/firefox-85.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "bed7a64af30ad21413516c201498fbc335125768ebea48cc895e724e6208d566";
+      sha256 = "5f1bf45b3eaa39d01a96835d48eec83b41e64ea0a8a667e7b4446b02c1ec11d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/lij/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/lij/firefox-85.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "426c432ae9727806af45667948a1f1aed7196a245441054da590931f98b5e96a";
+      sha256 = "156d0d166dcaf8e711abe2bc6706a210e40ca52f84dbe309192f884bed4f57e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/lt/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/lt/firefox-85.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "badafabd22ea7934cc2099677c9890cca609c56f3b16a863fa2c977f1e86a9c2";
+      sha256 = "be07851e9501167e23170fdef7317239cf2b20e650fbd266cbf46d2758c7a108";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/lv/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/lv/firefox-85.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "7caf8f81efa55b69cd51fb5f75652c6d9aeacb2711d9bdbc29fa80dcfeda74df";
+      sha256 = "107c4285a3972d7d6b52cec8e560ea43f2d383a5f072f5d6d7f4fcccde47771d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/mk/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/mk/firefox-85.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "ef22239e208acfc9b0a57dd06781c09dea1afd0303a091cf075c021a5c85003a";
+      sha256 = "3b8f230ca42054fa478de727be855980d30fb7676a1d646a0e5768fa17c7b3f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/mr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/mr/firefox-85.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "99d2c32ea14feec74db39d1eabc0c914a8681bc216aa76cd970473fbc06e5dee";
+      sha256 = "ff0fa9e3aba32036ac14a4b0ff286d4c56743b2053c38cfea1701dc33b038df6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ms/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ms/firefox-85.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "43011dbbc33615a67088619053a2579098e2afaed43b09268e5117290f100101";
+      sha256 = "e87b449c93b85e02e2caedada6efcf15a424cc45addcb66cf6386c60f4a4ef17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/my/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/my/firefox-85.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "d78bb48ec1b01787037d575da259b724db2bfffb0cad1700801ac7696eeacc55";
+      sha256 = "52a3bf3baefaf1849fed451ee33e48af54e2f35d8a5269880fff37dfcef738fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/nb-NO/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/nb-NO/firefox-85.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "64f55d03bcdd9132b40cad1a5265cd81e2945022056141272dc0fca22aee2a71";
+      sha256 = "595a6bd542be8d2af1bec356cee0de1fefaa8f5190ff3d026de3afea97efb70c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ne-NP/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ne-NP/firefox-85.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "b3d7c64b087ccd67b56dbb0f9554dd3db6481fd59ec7f46db1a03dfea129c372";
+      sha256 = "517d36aece9e022c1c41cc528dcf0dac76c5be613d558f27de6aefe5d891b18f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/nl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/nl/firefox-85.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "f2c83282acb30108f4bb381eecc30d61758d1e2279abfb772050b3ed8827b8fa";
+      sha256 = "e355786c54fa0614580a45b027a2d23e34b91c08365c471d58aecfc87477ddf6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/nn-NO/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/nn-NO/firefox-85.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "534dbf0d58c85fe21ad9998a703ac4df5a0b7d124c80eaca0b72fe42b97628f4";
+      sha256 = "ff4ec96c42a4d4446755defe19da5f9f39ed052323adc6b576b101b10fd4388a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/oc/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/oc/firefox-85.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "c3eaa5dbee8ee90d735c5e6db3c397011837385d4ac4d46ba3693d3aebd03e1f";
+      sha256 = "54ca433f89e1815c1e5cc50c9e4a7f3c4b3c095e8408261f9eaf4e3c0c348aec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/pa-IN/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/pa-IN/firefox-85.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "66c640b7bfb626b8d851af9f3170356adb3436fe1adbce76961df586fcdac051";
+      sha256 = "ff0486665cf7645a36930e56f52dcb38457b361da7427572c57bc1a048e091f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/pl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/pl/firefox-85.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "64d5f25fc15cad09c103fd243d0767aa4d0a6e10940e9229e9fbf5e5354f14b3";
+      sha256 = "3749820c56b131a923a5384afd81ac8ce342667a5db1d956b312db6fc03a0786";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/pt-BR/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/pt-BR/firefox-85.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "8cbd4c44af5da9fff2baedddfda640661dc3c3e0a2541985a12b0a42a76bbece";
+      sha256 = "a95d7f4bda46d13d8f5d5907c53d29c8cbccb239ebbc9fac4309e4c981d4203f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/pt-PT/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/pt-PT/firefox-85.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "5fde2c95eafa41bd9c8da90fbc6408eee8fe8187d18ebc2b9e04a19e662eb7a8";
+      sha256 = "b15eadb24566535692f9b46f6e9c757f0efd6caab3ac67ae45ed8784600bcc72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/rm/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/rm/firefox-85.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "1f2b1d0c9695b7a8796670baefe35e95d91a4060137c01739e00033a2c50aae3";
+      sha256 = "f3054641f0168651132e5fc0c4c65b6d5d3fb6c3550ccb2842629c1fe7f7876d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ro/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ro/firefox-85.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "77fad9b28166ba65d8514f76f43f4686345ac7ce7cd8e08bb5575da1b042bba4";
+      sha256 = "46d4d15780be478f1bee7d621728643507e96fe8a78ac839d12a9dd146ea02b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ru/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ru/firefox-85.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "58b4896bf014197734a9d8fcd03e526be422858aa0ac109282f0dcd543bb8697";
+      sha256 = "fdc5baff45f39bd3322e849ec2d1124d3e1ea8a3b88717c3dad69983f0053337";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/si/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/si/firefox-85.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "8aee64af130801e33df0d2aa91ed0b1d1328e39963320a418fd04a3bb0a0ec89";
+      sha256 = "2bd63e7dcfb62649bb083a6ebecb36cdad8bea8a11b6c6bc49eb41b3dd8aa1ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sk/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/sk/firefox-85.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "2f7813dc98211b3cf8fd0d2d233e2c7dca7f94e85fb2a70df9c69aa6bd5add5e";
+      sha256 = "d6e575e676b776fd7c60f9a0025318c6d41e7e525d064da04d25da565c680f36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/sl/firefox-85.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "75564047dfa2bc5e4c0dd1d1dd1f15e1c59e96c203470731db143ae424cd8c2f";
+      sha256 = "db6d41f37fd8d1452f2a810cdab92a4abf276bb2b852ab016dc8a9cf9a42e134";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/son/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/son/firefox-85.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "3684681de408a4cd02fdb81c559bdb15252dc56c0376a94ee512d7cc49e67190";
+      sha256 = "dbe54692404e9aa2478f4d89288a5e4aabe03289531f0c70e752dbe28f128ad0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sq/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/sq/firefox-85.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "573e998a49756843d14f063d4e3aea23f7844076d8ed3b5a0409d0c3758d7a17";
+      sha256 = "13770eaa25dc493b7f9ccd52d05682eb7fedaf6eb71511375bf38c7147d7238f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/sr/firefox-85.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "9289ae5e5270553dfc11dd6a7b9db6e6afa106919daedf085494c96f79cd0c52";
+      sha256 = "3b72e4c6464c3ad2b3e314c46220f86348f583b4c382ebb07772bad79e67619d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sv-SE/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/sv-SE/firefox-85.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "4b97dd3f617774925a140edcde97b5e0864405401222f46bcc59d02537168ff9";
+      sha256 = "849c3c8628741e1f96408828996aa463b7b8cdc0f7e60eee712404db0dc98037";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ta/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ta/firefox-85.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "80273dacecd26e0dbf1dcc39858f05c5ef0415972851166c0761f553e832e071";
+      sha256 = "705bc6133fc936ed0057d61283783f7bcd1d4d08e8dabf2e25d3ec772d138fa3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/te/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/te/firefox-85.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "e074997f616b1b356f40dab47f25e13e8b9b143bfaf932a0a281eec8675b71dd";
+      sha256 = "7bedf0917824342facd96e426db6dd387ce4b425ca7a5e9803c03c869082c648";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/th/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/th/firefox-85.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "e28ae199709c1ab1d580f8bd83b7ef8cf56750f17b4c30bcd188b088a61d8ba7";
+      sha256 = "0767b03ead7c33c316923ab6a0978a7b970cfcd3afe8c46b6bb343d1df09cdc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/tl/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/tl/firefox-85.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "c8b5161094d3fbed51d4dc033804ce5c2e77f9d96172076edced695ba76922c9";
+      sha256 = "fd6f6432fb60ae420f29c7790d9e33782df353a353cdc8596492369156fa69ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/tr/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/tr/firefox-85.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "a5178b392fdf8b36292548c9a98e22b879eb19e0f6d237192b376b7df92ee219";
+      sha256 = "69c56cab60cc5f309957eeb55fefea654dd67edebefa4aacf9742820e42e7ab0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/trs/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/trs/firefox-85.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "38554c05e9122c71ea0910892e6c455c4402ead97c6f00d309391544ca208697";
+      sha256 = "945106e6e39f0b28f891606d9e991ad612f2712d2be04f1cb2aeee4739890289";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/uk/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/uk/firefox-85.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "d6b2fe56aae2b6f4543072f0968c357ab893d89b92ff6c053cc709df75a51aa8";
+      sha256 = "757ce998065bfcacc90f7a7e24b4b558def38673c03e01607913d40bb773ea33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ur/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/ur/firefox-85.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "fcd15754df86493bc627e8fd65f0237a7a10e6e5e5843715bd31445e4b99f2dd";
+      sha256 = "08c455a739c558b390001dfc955d7ace4ca0df484ed772816417393f9b01e296";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/uz/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/uz/firefox-85.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "2a9cfc082a01c6af057627f4d028b67e0f0b72f913994ac208cea6ccfcd7e41a";
+      sha256 = "ecf118f83fe6139e547757da784f438a990118351bdbb3417488eaa848d24066";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/vi/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/vi/firefox-85.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "b32b7b8ff09a0642d4636a1d6477ba3b14c0a47ef93407078998818e7fc23145";
+      sha256 = "ce5c52ff6a709ffa32a262ed2ba22d7120c153ec7d1d237ea4885b3c215be21a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/xh/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/xh/firefox-85.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "5a95cd2dbb58f739b58eb8ba5d829d1e7f4e7be405cc6659857432a5c10c8d21";
+      sha256 = "abef46a099e046e675c79b8e131897fca57c083626cda2bc67aa242a1e8ecbba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/zh-CN/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/zh-CN/firefox-85.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "e5f93c089a0de95e3e430ed7ad3b028ee7a427072ebb3a035451b5724ee248d7";
+      sha256 = "81b604aa7d452f7b07a719bfbfc1a583df2f9121cb9215b6f5671555d080def4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/zh-TW/firefox-85.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0.1/linux-i686/zh-TW/firefox-85.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "348b26495fca92805814ee355962741154654d9babe5959ed4f41065123a50d2";
+      sha256 = "2097306adf4e26a8ab039184b301a997d8ac1f19a494e2a9b9df5e1ec270fc14";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -16,7 +16,7 @@ rec {
     meta = {
       description = "A web browser built from Firefox source tree";
       homepage = "http://www.mozilla.com/en-US/firefox/";
-      maintainers = with lib.maintainers; [ eelco ];
+      maintainers = with lib.maintainers; [ eelco lovesegfault ];
       platforms = lib.platforms.unix;
       badPlatforms = lib.platforms.darwin;
       broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
```
- firefox-bin: add lovesegfault as a maintainer
- firefox: add lovesegfault as a maintainer
- firefox-bin: 85.0 -> 85.0.1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
