### PR TITLE
python3Packages.blinkstick: 1.1.8 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/blinkstick/default.nix
+++ b/pkgs/development/python-modules/blinkstick/default.nix
@@ -1,30 +1,34 @@
-{ lib, buildPythonPackage, fetchPypi, fetchpatch, pyusb }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyusb
+}:
 
 buildPythonPackage rec {
   pname = "BlinkStick";
-  version = "1.1.8";
+  version = "1.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3edf4b83a3fa1a7bd953b452b76542d54285ff6f1145b6e19f9b5438120fa408";
+    sha256 = "0rdk3i81s6byw23za0bxvkh7sj5l16qxxgc2c53qjg3klc24wcm9";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/arvydas/blinkstick-python/commit/a9227d0.patch";
-      sha256 = "1mcmxlnkbfxwp84qz32l5rlc7r9anh9yhnqaj1y8rny5s13jb01f";
-    })
-    (fetchpatch {
-      url = "https://github.com/arvydas/blinkstick-python/pull/54.patch";
-      sha256 = "1gjq6xbai794bbdyrv82i96l1a7qkwvlhzd6sa937dy5ivv6s6hl";
-    })
-  ];
+  # Upstream fix https://github.com/arvydas/blinkstick-python/pull/54
+  # https://github.com/arvydas/blinkstick-python/pull/54/commits/b9bee2cd72f799f1210e5d9e13207f93bbc2d244.patch
+  # has line ending issues after 1.2.0
+  postPatch = ''
+    substituteInPlace setup.py --replace "pyusb==1.0.0" "pyusb>=1.0.0"
+  '';
 
   propagatedBuildInputs = [ pyusb ];
 
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "blinkstick" ];
+
   meta = with lib; {
     description = "Python package to control BlinkStick USB devices";
-    homepage = "https://pypi.python.org/pypi/BlinkStick/";
+    homepage = "https://github.com/arvydas/blinkstick-python";
     license = licenses.bsd3;
     maintainers = with maintainers; [ np ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.2.0

Change log: https://github.com/arvydas/blinkstick-python/blob/master/CHANGES.txt

Upstream didn't apply an almost two years old patch (allow `pyusb>=1.0.0`, https://github.com/arvydas/blinkstick-python/pull/54). It seems that this patch can not be applied any longer due to an issue with line endings. Thus, the workaround with `substituteInPlace`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
