### PR TITLE
edir: init at 2.7.3

### DIFF
--- a/pkgs/tools/misc/edir/default.nix
+++ b/pkgs/tools/misc/edir/default.nix
@@ -1,0 +1,19 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "edir";
+  version = "2.7.3";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "06nsy9ikljc437368l38hsw75whacn3j6jwmdgg766q61pnifhkp";
+  };
+
+  meta = with lib; {
+    description = "Program to rename and remove files and directories using your editor";
+    homepage = "https://github.com/bulletmark/edir";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ guyonvarch ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3738,6 +3738,8 @@ in
 
   edid-generator = callPackage ../tools/misc/edid-generator { };
 
+  edir = callPackage ../tools/misc/edir { };
+
   editres = callPackage ../tools/graphics/editres { };
 
   edit = callPackage ../applications/editors/edit { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[edir](https://github.com/bulletmark/edir) is a command line utility to rename, remove, and copy filenames and directories using your text editor.

I am using `edir` with a local derivation since some months ago.

See [AUR](https://aur.archlinux.org/packages/edir/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).