### PR TITLE
reckon: 0.6.0 -> 0.7.1

### DIFF
--- a/pkgs/tools/text/reckon/Gemfile.lock
+++ b/pkgs/tools/text/reckon/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     chronic (0.10.2)
     highline (2.0.3)
     rchardet (1.8.0)
-    reckon (0.6.0)
+    reckon (0.7.1)
       chronic (>= 0.3.0)
       highline (>= 1.5.2)
       rchardet (>= 1.8.0)
@@ -16,4 +16,4 @@ DEPENDENCIES
   reckon
 
 BUNDLED WITH
-   2.1.4
+   1.17.2

--- a/pkgs/tools/text/reckon/default.nix
+++ b/pkgs/tools/text/reckon/default.nix
@@ -15,8 +15,10 @@ stdenv.mkDerivation rec {
       gemdir = ./.;
     };
   in ''
+    runHook preInstall
     mkdir -p $out/bin
     makeWrapper ${env}/bin/reckon $out/bin/reckon
+    runHook postInstall
   '';
 
   passthru.updateScript = bundlerUpdateScript "reckon";

--- a/pkgs/tools/text/reckon/gemset.nix
+++ b/pkgs/tools/text/reckon/gemset.nix
@@ -1,5 +1,7 @@
 {
   chronic = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1hrdkn4g8x7dlzxwb1rfgr8kw3bp4ywg5l4y4i9c2g5cwv62yvvn";
@@ -11,7 +13,7 @@
     groups = ["default"];
     platforms = [];
     source = {
-      remotes = ["http://rubygems.org"];
+      remotes = ["https://rubygems.org"];
       sha256 = "0yclf57n2j3cw8144ania99h1zinf8q3f5zrhqa754j6gl95rp9d";
       type = "gem";
     };
@@ -21,7 +23,7 @@
     groups = ["default"];
     platforms = [];
     source = {
-      remotes = ["http://rubygems.org"];
+      remotes = ["https://rubygems.org"];
       sha256 = "1isj1b3ywgg2m1vdlnr41lpvpm3dbyarf1lla4dfibfmad9csfk9";
       type = "gem";
     };
@@ -33,9 +35,9 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0zkbmwx5bp2dr54bwhkn831918ijwh022rq45qg38wz2skih7izp";
+      sha256 = "0hsmzjxj1f5ma816gag1b3bdjbynhj2szgar955fcs3gbbzv4sk7";
       type = "gem";
     };
-    version = "0.6.0";
+    version = "0.7.1";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Particularly nice improvements:
* [fail on unknown account](https://github.com/cantino/reckon/pull/102)
  in interactive mode
* [use - to read from stdin](https://github.com/cantino/reckon/pull/98)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).