### PR TITLE
sharness: Init at 1.1.0-dev

### DIFF
--- a/pkgs/development/libraries/sharness/default.nix
+++ b/pkgs/development/libraries/sharness/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchurl
+, perl
+, perlPackages
+, sharnessExtensions ? {} }:
+
+stdenv.mkDerivation rec {
+  pname = "sharness";
+  version = "1.1.0-dev";
+
+  src = fetchFromGitHub {
+    owner = "chriscool";
+    repo = pname;
+    rev = "3f238a740156dd2082f4bd60ced205e05894d367"; # 2020-12-09
+    sha256 = "FCYskpIqkrpNaWCi2LkhEkiow4/rXLe+lfEWNUthLUg=";
+  };
+
+  # Used for testing
+  nativeBuildInputs = [ perl perlPackages.IOTty ];
+
+  outputs = [ "out" "doc" ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  extensions = lib.mapAttrsToList (k: v: "${k}.sh ${v}") sharnessExtensions;
+
+  postInstall = lib.optionalString (sharnessExtensions != {}) ''
+    extDir=$out/share/sharness/sharness.d
+    mkdir -p "$extDir"
+    linkExtensions() {
+      set -- $extensions
+      while [ $# -ge 2 ]; do
+        ln -s "$2" "$extDir/$1"
+        shift 2
+      done
+    }
+    linkExtensions
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Portable shell library to write, run and analyze automated tests adhering to Test Anything Protocol (TAP)";
+    homepage = "https://github.com/chriscool/sharness";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.spacefrogg ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16610,6 +16610,8 @@ in
 
   shapelib = callPackage ../development/libraries/shapelib { };
 
+  sharness = callPackage ../development/libraries/sharness { };
+
   shibboleth-sp = callPackage ../development/libraries/shibboleth-sp { };
 
   skaffold = callPackage ../development/tools/skaffold { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A simple portable shell library to write and run tests adhering to the Test Anything Protocol.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
