### PR TITLE
python3Packages.autobahn: 20.12.3 -> 21.3.1

### DIFF
--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -1,34 +1,78 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k,
-  six, txaio, twisted, zope_interface, cffi,
-  mock, pytest, cryptography, pynacl
+{ lib
+, argon2_cffi
+, attrs
+, buildPythonPackage
+, cbor
+, cbor2
+, cffi
+, cryptography
+, fetchPypi
+, flatbuffers
+, mock
+, msgpack
+, passlib
+, pynacl
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, twisted
+, py-ubjson
+, txaio
+, ujson
+, zope_interface
 }:
+
 buildPythonPackage rec {
   pname = "autobahn";
   version = "21.3.1";
-  disabled = !isPy3k;
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e126c1f583e872fb59e79d36977cfa1f2d0a8a79f90ae31f406faae7664b8e03";
+    sha256 = "00wf9dkfgakg80gy62prg650lb8zz9y9fdlxwxcznwp8hgsw29p1";
   };
 
-  propagatedBuildInputs = [ six txaio twisted zope_interface cffi cryptography pynacl ];
+  propagatedBuildInputs = [
+    argon2_cffi
+    cbor
+    cbor2
+    cffi
+    cryptography
+    flatbuffers
+    msgpack
+    passlib
+    py-ubjson
+    pynacl
+    twisted
+    txaio
+    ujson
+    zope_interface
+  ];
 
-  checkInputs = [ mock pytest ];
-  checkPhase = ''
-    runHook preCheck
-    USE_TWISTED=true py.test $out
-    runHook postCheck
+  checkInputs = [
+    mock
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest>=2.8.6,<3.3.0" "pytest"
   '';
 
-  # Tests do no seem to be compatible yet with pytest 5.1
-  # https://github.com/crossbario/autobahn-python/issues/1235
-  doCheck = false;
+  preCheck = ''
+    # Run asyncio tests (requires twisted)
+    export USE_ASYNCIO=1
+  '';
+
+  pytestFlagsArray = [ "--pyargs autobahn" ];
+
+  pythonImportsCheck = [ "autobahn" ];
 
   meta = with lib; {
-    description = "WebSocket and WAMP in Python for Twisted and asyncio.";
-    homepage    = "https://crossbar.io/autobahn";
-    license     = licenses.mit;
+    description = "WebSocket and WAMP in Python for Twisted and asyncio";
+    homepage = "https://crossbar.io/autobahn";
+    license = licenses.mit;
     maintainers = with maintainers; [ nand0p ];
   };
 }

--- a/pkgs/development/python-modules/hyperlink/default.nix
+++ b/pkgs/development/python-modules/hyperlink/default.nix
@@ -1,4 +1,10 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, idna, typing ? null }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, idna
+, typing ? null
+}:
 
 buildPythonPackage rec {
   pname = "hyperlink";
@@ -6,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b";
+    sha256 = "0sx50lkivsfjxx9zr4yh7l9gll2l9kvl0v0w8w4wk2x5v9bzjyj2";
   };
 
   propagatedBuildInputs = [ idna ]
@@ -14,6 +20,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A featureful, correct URL for Python";
+    homepage = "https://github.com/python-hyper/hyperlink";
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ apeschar ];

--- a/pkgs/development/python-modules/py-ubjson/default.nix
+++ b/pkgs/development/python-modules/py-ubjson/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "py-ubjson";
+  version = "0.16.1";
+
+  src = fetchFromGitHub {
+    owner = "Iotic-Labs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1frn97xfa88zrfmpnvdk1pc03yihlchhph99bhjayvzlfcrhm5v3";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "test/test.py" ];
+
+  pythonImportsCheck = [ "ubjson" ];
+
+  meta = with lib; {
+    description = "Universal Binary JSON draft-12 serializer for Python";
+    homepage = "https://github.com/Iotic-Labs/py-ubjson";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -1,30 +1,55 @@
-{ lib, buildPythonPackage, fetchPypi, pytest, mock, six, twisted, isPy37, isPy27 }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, mock
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, six
+, twisted
+, zope_interface
+}:
 
 buildPythonPackage rec {
   pname = "txaio";
   version = "21.2.1";
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7d6f89745680233f1c4db9ddb748df5e88d2a7a37962be174c0fd04c8dba1dc8";
+    sha256 = "sha256-fW+JdFaAIz8cTbndt0jfXojSp6N5Yr4XTA/QTI26Hcg=";
   };
 
-  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [
+    six
+    twisted
+    zope_interface
+  ];
 
-  propagatedBuildInputs = [ six twisted ];
+  checkInputs = [
+    mock
+    pytest-asyncio
+    pytestCheckHook
+  ];
 
-  checkPhase = ''
-    py.test -k "not test_sdist"
-  '';
+  disabledTests = [
+    # No real value
+    "test_sdist"
+    # Some tests seems out-dated and require additional data
+    "test_as_future"
+    "test_errback"
+    "test_create_future"
+    "test_callback"
+    "test_immediate_result"
+    "test_cancel"
+  ];
 
-  # Needs some fixing
-  doCheck = false;
+  pythonImportsCheck = [ "txaio" ];
 
   meta = with lib; {
-    description = "Utilities to support code that runs unmodified on Twisted and asyncio.";
-    homepage    = "https://github.com/crossbario/txaio";
-    license     = licenses.mit;
+    description = "Utilities to support code that runs unmodified on Twisted and asyncio";
+    homepage = "https://github.com/crossbario/txaio";
+    license = licenses.mit;
     maintainers = with maintainers; [ nand0p ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5260,6 +5260,8 @@ in {
 
   py-air-control-exporter = callPackage ../development/python-modules/py-air-control-exporter { };
 
+  py-ubjson = callPackage ../development/python-modules/py-ubjson { };
+
   py2bit = callPackage ../development/python-modules/py2bit { };
 
   py3buddy = toPythonModule (callPackage ../development/python-modules/py3buddy { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 21.3.1.

Change log: https://autobahn.readthedocs.io/en/latest/changelog.html#id2

Also, ran `nixpkgs-fmt`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
