### PR TITLE
obfuscate: init at unstable

### DIFF
--- a/pkgs/applications/misc/obfuscate/default.nix
+++ b/pkgs/applications/misc/obfuscate/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, wrapGAppsHook
+, pkg-config
+, gtk4
+, glib
+, gdk-pixbuf
+, rustPlatform
+, desktop-file-utils
+, appstream-glib
+, python3
+, librsvg
+, libadwaita
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "obfuscate";
+  version = "0.0.4"; # latest tag v0.0.2 is broken
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
+    repo = "obfuscate";
+    rev = "dbbb44037b10b223e95e85d6025c2f8337b868fd";
+    hash = "sha256-P8Y2Eizn1BMZXuFjGMXF/3oAUzI8ZNTrnbLyU+V6uk4=";
+  };
+
+  cargoHash = "sha256-eKXVN3PHgeLeG4qxh30VhyMX0FMOO/ZlZ8trUGIs2sc=";
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    glib
+    gtk4
+    gdk-pixbuf
+    wrapGAppsHook
+    pkg-config
+    desktop-file-utils
+    appstream-glib
+    python3
+  ];
+
+  buildInputs = [
+    gtk4
+    glib
+    librsvg
+    gdk-pixbuf
+    libadwaita
+  ];
+
+  buildPhase = ''
+    patchShebangs build-aux/meson_post_install.py
+    mesonConfigurePhase
+    ninjaBuildPhase
+  '';
+
+  installPhase = ''
+    ninjaInstallPhase
+  '';
+
+  meta = with lib; {
+    description = "Censor private information";
+    homepage = "https://gitlab.gnome.org/World/obfuscate";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.mkg20001 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25515,6 +25515,8 @@ with pkgs;
 
   lollypop = callPackage ../applications/audio/lollypop { };
 
+  obfuscate = callPackage ../applications/misc/obfuscate { };
+
   losslessaudiochecker = callPackage ../applications/audio/losslessaudiochecker { };
 
   m32edit = callPackage ../applications/audio/midas/m32edit.nix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

More apps

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
