### PR TITLE
gnomecast: fix missing pixbuf module

### DIFF
--- a/pkgs/applications/video/gnomecast/default.nix
+++ b/pkgs/applications/video/gnomecast/default.nix
@@ -16,6 +16,10 @@ buildPythonApplication rec {
     gtk3 gobject-introspection
   ];
 
+  # NOTE: gdk-pixbuf setup hook does not run with strictDeps
+  # https://nixos.org/manual/nixpkgs/stable/#ssec-gnome-hooks-gobject-introspection
+  strictDeps = false;
+
   preFixup = ''
     gappsWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ ffmpeg_3 ]})
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes the following startup error:

```
[nix-shell:~]$ gnomecast
Traceback (most recent call last):
  File "/nix/store/klbpnf8vnprcmm3d5f0i96gbv5asacih-gnomecast-1.9.11/bin/..gnomecast-wrapped-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/klbpnf8vnprcmm3d5f0i96gbv5asacih-gnomecast-1.9.11/lib/python3.8/site-packages/gnomecast.py", line 1571, in main
    arg_parse(sys.argv[1:], {'s':'subtitles', 'd':'device'}, caster.run, USAGE)
  File "/nix/store/klbpnf8vnprcmm3d5f0i96gbv5asacih-gnomecast-1.9.11/lib/python3.8/site-packages/gnomecast.py", line 1530, in arg_parse
    f(*f_args, **f_kwargs)
  File "/nix/store/klbpnf8vnprcmm3d5f0i96gbv5asacih-gnomecast-1.9.11/lib/python3.8/site-packages/gnomecast.py", line 420, in run
    self.build_gui()
  File "/nix/store/klbpnf8vnprcmm3d5f0i96gbv5asacih-gnomecast-1.9.11/lib/python3.8/site-packages/gnomecast.py", line 605, in build_gui
    win.set_icon(self.get_logo_pixbuf(color='#000000'))
  File "/nix/store/klbpnf8vnprcmm3d5f0i96gbv5asacih-gnomecast-1.9.11/lib/python3.8/site-packages/gnomecast.py", line 904, in get_logo_pixbuf
    pixbuf = GdkPixbuf.Pixbuf.new_from_stream(f, None)
gi.repository.GLib.Error: gdk-pixbuf-error-quark: Unrecognized image file format (3)
```

Caused by missing pixbuf module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
