### PR TITLE
libhugetlbfs: 2.22 -> 2.23

### DIFF
--- a/pkgs/development/libraries/libhugetlbfs/default.nix
+++ b/pkgs/development/libraries/libhugetlbfs/default.nix
@@ -1,25 +1,15 @@
-{ stdenv, lib, fetchurl, fetchpatch }:
+{ stdenv, lib, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "libhugetlbfs";
-  version = "2.22";
+  version = "2.23";
 
   src = fetchurl {
     url = "https://github.com/libhugetlbfs/libhugetlbfs/releases/download/${version}/libhugetlbfs-${version}.tar.gz";
-    sha256 = "11b7k8xvgx68rjzidm12a6l6b23hwi7hj149y9xxfz2j5kmakp4l";
+    sha256 = "0ya4q001g111d3pqlzrf3yaifadl0ccirx5dndz1pih7x3qp41mp";
   };
 
   outputs = [ "bin" "dev" "man" "doc" "lib" "out" ];
-
-  patches = [
-    # Don't check that 32-bit and 64-bit libraries don't get installed
-    # to the same place if only one platform is being built for.
-    # Can be removed if build succeeds without it.
-    (fetchpatch {
-      url = "https://groups.google.com/forum/message/raw?msg=libhugetlbfs/IswjDAygfwA/PKy7MZbVAAAJ";
-      sha256 = "00fyrhn380d6swil8pcf4x0krl1113ghswrvjn3m9czc3h4p385a";
-    })
-  ];
 
   postConfigure = ''
     patchShebangs ld.hugetlbfs
@@ -34,8 +24,8 @@ stdenv.mkDerivation rec {
     "LIBDIR64=$(lib)/$(LIB64)"
     "EXEDIR=$(bin)/bin"
     "DOCDIR=$(doc)/share/doc/libhugetlbfs"
-  ] ++ map (n: "MANDIR${n}=$(man)/share/man/man${n}")
-    (lib.genList (n: toString (n + 1)) 8);
+    "MANDIR=$(man)/share/man"
+  ];
 
   # Default target builds tests as well, and the tests want a static
   # libc.


### PR DESCRIPTION
My patches to fix the library checks and add a MANDIR variable were
included in this release, so the build can be simplified a little.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
