### PR TITLE
 python3Packages.plexapi: 4.1.2 -> 4.3.1

### DIFF
--- a/pkgs/development/python-modules/plexapi/default.nix
+++ b/pkgs/development/python-modules/plexapi/default.nix
@@ -1,5 +1,11 @@
-{ lib, buildPythonPackage, fetchFromGitHub, requests
-, tqdm, websocket_client, pytest, pillow, isPy27 }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+, tqdm
+, websocket_client
+, isPy27
+}:
 
 buildPythonPackage rec {
   pname = "PlexAPI";
@@ -13,13 +19,19 @@ buildPythonPackage rec {
     sha256 = "sha256-gRXNOGd9YGcGysKbAtiNwi5NxPvv39F6PEXBjiYbVq4=";
   };
 
-  propagatedBuildInputs = [ requests tqdm websocket_client ];
+  propagatedBuildInputs = [
+    requests
+    tqdm
+    websocket_client
+  ];
 
-  checkInputs = [ pytest pillow ];
+  # Tests require a running Plex instance
+  doCheck = false;
+  pythonImportsCheck = [ "plexapi" ];
 
   meta = with lib; {
-    homepage = "https://github.com/pkkid/python-plexapi";
     description = "Python bindings for the Plex API";
+    homepage = "https://github.com/pkkid/python-plexapi";
     license = licenses.bsd3;
     maintainers = with maintainers; [ colemickens ];
   };

--- a/pkgs/development/python-modules/plexapi/default.nix
+++ b/pkgs/development/python-modules/plexapi/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "PlexAPI";
-  version = "4.1.2";
+  version = "4.3.1";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "pkkid";
     repo = "python-plexapi";
     rev = version;
-    sha256 = "1l955q1q6lljq3bmyiayr33gzxrlw16xdwgjdaflznvyg16fcjkk";
+    sha256 = "sha256-gRXNOGd9YGcGysKbAtiNwi5NxPvv39F6PEXBjiYbVq4=";
   };
 
   propagatedBuildInputs = [ requests tqdm websocket_client ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 4.3.1

Change log: https://github.com/pkkid/python-plexapi/releases/tag/4.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
