### PR TITLE
upterm: init at 0.5.2

### DIFF
--- a/pkgs/tools/misc/upterm/default.nix
+++ b/pkgs/tools/misc/upterm/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles }:
+
+buildGoModule rec {
+  pname = "upterm";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "owenthereal";
+    repo = "upterm";
+    rev = "v${version}";
+    sha256 = "007hgkkn1cq1i0rkn45i3bz5q9irzm67cz0j5glr6f6d4s0nkjiq";
+  };
+
+  vendorSha256 = null;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    $out/bin/gendoc
+    rm $out/bin/gendoc
+    installManPage etc/man/man*/*
+    installShellCompletion --bash --name upterm.bash etc/completion/upterm.bash_completion.sh
+    installShellCompletion --zsh --name _upterm etc/completion/upterm.zsh_completion
+  '';
+
+  doCheck = true;
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = with lib; {
+    description = "Secure terminal-session sharing";
+    homepage = "https://upterm.dev";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hax404 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8559,6 +8559,8 @@ in
 
   up = callPackage ../tools/misc/up { };
 
+  upterm = callPackage ../tools/misc/upterm { };
+
   upx = callPackage ../tools/compression/upx { };
 
   uq = callPackage ../misc/uq { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
We need a working replacement for tmate.

Thanks @gilligan for PR https://github.com/NixOS/nixpkgs/pull/102276

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS x86_64
     - upterm
     - uptermd 
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
