### PR TITLE
androidStudioPackages.{stable,beta,canary,dev}: Fix LLDB debugger

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -35,6 +35,7 @@
 , libXrender
 , libXtst
 , makeWrapper
+, ncurses5
 , nspr
 , nss
 , pciutils
@@ -141,8 +142,17 @@ let
         ]}" \
         --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb" \
         --set FONTCONFIG_FILE ${fontsConf}
+
+      # AS launches LLDBFrontend with a custom LD_LIBRARY_PATH
+      wrapProgram $out/bin/lldb/bin/LLDBFrontend --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
+        ncurses5
+        zlib
+      ]}"
     '';
   };
+
+  # Causes the shebangs in interpreter scripts deployed to mobile devices to be patched, which Android does not understand
+  dontPatchShebangs = true;
 
   desktopItem = makeDesktopItem {
     name = drvName;
@@ -161,7 +171,7 @@ let
   fhsEnv = buildFHSUserEnv {
     name = "${drvName}-fhs-env";
     multiPkgs = pkgs: [
-      pkgs.ncurses5
+      ncurses5
 
       # Flutter can only search for certs Fedora-way.
       (runCommand "fedoracert" {}


### PR DESCRIPTION

###### Motivation for this change
@PixelyIon encountered an issue with Android Studio's LLDB debugger not working on Nix, so together we fixed it.

Fixes: #112266

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
