### PR TITLE
libthai: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/libthai/default.nix
+++ b/pkgs/development/libraries/libthai/default.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "04g93bgxrcnay9fglpq2lj9nr7x1xh06i60m7haip8as9dxs3q7z";
   };
 
-  nativeBuildInputs = [ installShellFiles pkg-config ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ installShellFiles libdatrie pkg-config ];
 
   buildInputs = [ libdatrie ];
 


### PR DESCRIPTION
###### Motivation for this change
libthai uses trietool from libdatrie as a native build tool, so adding it to nativeBuildInputs fixes cross compilation.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (for armv7l)
         ```
         nix-build -A pkgsCross.armv7l-hf-multiplatform.libthai
         ```
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).