### PR TITLE
ocamlPackages.lwt: 5.3.0 → 5.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/irmin-watcher/default.nix
+++ b/pkgs/development/ocaml-modules/irmin-watcher/default.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
   pname = "irmin-watcher";
   version = "0.4.1";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/mirage/irmin-watcher/releases/download/${version}/irmin-watcher-${version}.tbz";
     sha256 = "00d4ph4jbsw6adp3zqdrwi099hfcf7p1xzi0685qr7bgcmandjfv";

--- a/pkgs/development/ocaml-modules/lwt-dllist/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-dllist/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "lwt-dllist";
   version = "1.0.0";
 
+  useDune2 = true;
+
   minimumOCamlVersion = "4.03";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -1,21 +1,25 @@
 { lib, fetchzip, pkg-config, ncurses, libev, buildDunePackage, ocaml
-, cppo, ocaml-migrate-parsetree, ocplib-endian, result
+, cppo, dune-configurator, ocaml-migrate-parsetree, ocplib-endian, result
 , mmap, seq
+, ocaml-syntax-shims
 }:
 
 let inherit (lib) optional versionAtLeast; in
 
 buildDunePackage rec {
   pname = "lwt";
-  version = "5.3.0";
+  version = "5.4.0";
+
+  useDune2 = true;
 
   src = fetchzip {
     url = "https://github.com/ocsigen/${pname}/archive/${version}.tar.gz";
-    sha256 = "15hgy3220m2b8imipa514n7l65m1h5lc6l1hanqwwvs7ghh2aqp2";
+    sha256 = "1ay1zgadnw19r9hl2awfjr22n37l7rzxd9v73pjbahavwm2ay65d";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ cppo ocaml-migrate-parsetree ]
+  buildInputs = [ cppo dune-configurator ocaml-migrate-parsetree ]
+   ++ optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims
    ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
   propagatedBuildInputs = [ libev mmap ocplib-endian seq result ];
 

--- a/pkgs/development/ocaml-modules/lwt_log/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_log/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "lwt_log";
   version = "1.1.1";
 
+  useDune2 = true;
+
   minimumOCamlVersion = "4.02";
 
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/mirage-bootvar-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-bootvar-unix/default.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
   pname = "mirage-bootvar-unix";
   version = "0.1.0";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/mirage/mirage-bootvar-unix/releases/download/${version}/mirage-bootvar-unix-${version}.tbz";
     sha256 = "0r92s6y7nxg0ci330a7p0hii4if51iq0sixn20cnm5j4a2clprbf";

--- a/pkgs/development/ocaml-modules/mirage-device/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-device/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "mirage-device";
   version = "2.0.0";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/mirage/mirage-device/releases/download/v${version}/mirage-device-v${version}.tbz";
     sha256 = "18alxyi6wlxqvb4lajjlbdfkgcajsmklxi9xqmpcz07j51knqa04";

--- a/pkgs/development/ocaml-modules/resource-pooling/default.nix
+++ b/pkgs/development/ocaml-modules/resource-pooling/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   version = "1.1";
   pname = "resource-pooling";
 
+  useDune2 = true;
+
   minimumOCamlVersion = "4.06";
 
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/zmq/default.nix
+++ b/pkgs/development/ocaml-modules/zmq/default.nix
@@ -1,9 +1,12 @@
-{ lib, fetchFromGitHub, buildDunePackage, czmq, stdint }:
+{ lib, fetchFromGitHub, buildDunePackage, dune-configurator, czmq, stdint }:
 
 buildDunePackage rec {
   minimumOCamlVersion = "4.03";
   pname = "zmq";
   version = "20180726";
+
+  useDune2 = true;
+
   src = fetchFromGitHub {
     owner = "issuu";
     repo = "ocaml-zmq";
@@ -11,7 +14,7 @@ buildDunePackage rec {
     sha256 = "1f5l4bw78y4drabhyvmpj3z8k30bill33ca7bzhr02m55yf6gqpf";
   };
 
-  buildInputs = [ czmq ];
+  buildInputs = [ czmq dune-configurator ];
 
   propagatedBuildInputs = [ stdint ];
 

--- a/pkgs/development/ocaml-modules/zmq/lwt.nix
+++ b/pkgs/development/ocaml-modules/zmq/lwt.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage {
   pname = "zmq-lwt";
-  inherit (zmq) version src meta;
+  inherit (zmq) version src useDune2 meta;
 
   propagatedBuildInputs = [ zmq ocaml_lwt ];
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/ocsigen/lwt/releases/tag/5.4.0
Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
