### PR TITLE
kustomize: 3.9.2 -> 3.9.3

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -2,9 +2,9 @@
 
 buildGoModule rec {
   pname = "kustomize";
-  version = "3.9.2";
-  # rev is the 3.9.2 commit, mainly for kustomize version command output
-  rev = "e98eada7365fc564c9aba392e954f306a9cbf1dd";
+  version = "3.9.3";
+  # rev is the 3.9.3 commit, mainly for kustomize version command output
+  rev = "1ae8303bdc9372bc7c15942df6e9cf5d67fdba1a";
 
   buildFlagsArray = let t = "sigs.k8s.io/kustomize/api/provenance"; in
     ''
@@ -17,13 +17,13 @@ buildGoModule rec {
     owner = "kubernetes-sigs";
     repo = pname;
     rev = "kustomize/v${version}";
-    sha256 = "0p1rxswfaj0g3y8nfw70qmxrlyv1pnzkapy1mxpzzyf04mmhg7wn";
+    sha256 = "147g8mhgcb8sjx10sz7r9yh84gqxwk6dald848jim2v2rax47v0p";
   };
 
   # avoid finding test and development commands
   sourceRoot = "source/kustomize";
 
-  vendorSha256 = "1pv8g0nnrpzbvd6dqgnrw2i27xkilbrr9npdz6pxr7mmbcg3w3w9";
+  vendorSha256 = "0ps4is8x2akvvvvin9sqdyjg4ms3b5b5y15923rs65fd7x33rxgp";
 
   meta = with lib; {
     description = "Customization of kubernetes YAML configurations";
@@ -34,6 +34,6 @@ buildGoModule rec {
     '';
     homepage = "https://github.com/kubernetes-sigs/kustomize";
     license = licenses.asl20;
-    maintainers = with maintainers; [ carlosdagos vdemeester periklis zaninime Chili-Man];
+    maintainers = with maintainers; [ carlosdagos vdemeester periklis zaninime Chili-Man ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update package to the latest version.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @carlosdagos @vdemeester @periklis @zaninime