### PR TITLE
libsemanage: fix build by disabling clobbered warning

### DIFF
--- a/pkgs/os-specific/linux/libsemanage/default.nix
+++ b/pkgs/os-specific/linux/libsemanage/default.nix
@@ -30,6 +30,16 @@ stdenv.mkDerivation rec {
     "DEFAULT_SEMANAGE_CONF_LOCATION=$(out)/etc/selinux/semanage.conf"
   ];
 
+  # The following turns the 'clobbered' error into a warning
+  # which should fix the following error:
+  #
+  # semanage_store.c: In function 'semanage_exec_prog':
+  # semanage_store.c:1278:6: error: variable 'i' might be clobbered by 'longjmp' or 'vfork' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wclobbered-Werror=clobbered8;;]
+  #  1278 |  int i;
+  #       |      ^
+  # cc1: all warnings being treated as errors
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=clobbered" ];
+
   installTargets = [ "install" ] ++ optionals enablePython [ "install-pywrap" ];
 
   meta = removeAttrs libsepol.meta ["outputsToInstall"] // {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`libsemanage` is currently failing to build (https://hydra.nixos.org/job/nixpkgs/trunk/libsemanage.x86_64-linux). This commit turns the GCC clobbered error into a warning which should fix:

```
emanage_store.c: In function 'semanage_exec_prog':
semanage_store.c:1278:6: error: variable 'i' might be clobbered by 'longjmp' or 'vfork' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wclobbered-Werror=clobbered8;;]
 1278 |  int i;
      |      ^
cc1: all warnings being treated as errors
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
