### PR TITLE
Add support for cross compiling to ESP MCUs

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -38,6 +38,10 @@ let
     "vc4-none"
     "or1k-none"
 
+    "esp32-none"
+    "esp32s2-none"
+    "lx106-none"
+
     "mmix-mmixware"
 
     "js-ghcjs"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -137,6 +137,19 @@ rec {
     libc = "newlib";
   };
 
+  esp8266 = {
+    config = "xtensa-lx106-elf";
+    libc = "newlib";
+  };
+  esp32 = {
+    config = "xtensa-esp32-elf";
+    libc = "newlib";
+  };
+  esp32s2 = {
+    config = "xtensa-esp32s2-elf";
+    libc = "newlib";
+  };
+
   arm-embedded = {
     config = "arm-none-eabi";
     libc = "newlib";

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -26,6 +26,7 @@ rec {
     isAvr          = { cpu = { family = "avr"; }; };
     isAlpha        = { cpu = { family = "alpha"; }; };
     isOr1k         = { cpu = { family = "or1k"; }; };
+    isXtensa       = { cpu = { family = "xtensa"; }; };
     isJavaScript   = { cpu = cpuTypes.js; };
 
     is32bit        = { cpu = { bits = 32; }; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -118,6 +118,10 @@ rec {
 
     or1k     = { bits = 32; significantByte = bigEndian; family = "or1k"; };
 
+    lx106    = { bits = 32; significantByte = littleEndian; family = "xtensa"; arch = "lx106"; };
+    esp32    = { bits = 32; significantByte = littleEndian; family = "xtensa"; arch = "esp32"; };
+    esp32s2  = { bits = 32; significantByte = littleEndian; family = "xtensa"; arch = "esp32s2"; };
+
     js       = { bits = 32; significantByte = littleEndian; family = "js"; };
   };
 
@@ -410,6 +414,8 @@ rec {
         then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "mmixware";                   }
       else if hasPrefix "netbsd" (elemAt l 2)
         then { cpu = elemAt l 0; vendor = elemAt l 1;    kernel = elemAt l 2;                }
+      else if (elem (elemAt l 1) ["lx106" "esp32" "esp32s2"])
+        then { cpu = elemAt l 1; vendor = "unknown"; kernel = "none"; abi = elemAt l 2; }
       else if (elem (elemAt l 2) ["eabi" "eabihf" "elf"])
         then { cpu = elemAt l 0; vendor = "unknown"; kernel = elemAt l 1; abi = elemAt l 2; }
       else if (elemAt l 2 == "ghcjs")

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -191,6 +191,7 @@ stdenv.mkDerivation {
       else if targetPlatform.isVc4 then "vc4"
       else if targetPlatform.isOr1k then "or1k"
       else if targetPlatform.isRiscV then "lriscv"
+      else if targetPlatform.isXtensa then "xtensa"
       else throw "unknown emulation for platform: ${targetPlatform.config}";
     in if targetPlatform.useLLVM or false then ""
        else targetPlatform.bfdEmulation or (fmt + sep + arch);

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -441,6 +441,9 @@ stdenv.mkDerivation {
                       isGccArchSupported targetPlatform.gcc.tune) ''
       echo "-mtune=${targetPlatform.gcc.tune}" >> $out/nix-support/cc-cflags-before
     ''
+    + optionalString targetPlatform.isXtensa ''
+      echo "-mlongcalls" >> $out/nix-support/cc-cflags-before
+    ''
 
     # TODO: categorize these and figure out a better place for them
     + optionalString hostPlatform.isCygwin ''

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -16,6 +16,7 @@ in
       ]);
     in mkFlags libcCross langD
     ++ lib.optionals (!crossStageStatic) (mkFlags threadsCross langD)
+    ++ lib.optional targetPlatform.isXtensa "-mlongcalls"
     ;
 
   EXTRA_LDFLAGS_FOR_TARGET = let

--- a/pkgs/development/misc/espressif/xtensa-overlays.nix
+++ b/pkgs/development/misc/espressif/xtensa-overlays.nix
@@ -1,0 +1,12 @@
+{ stdenv, fetchFromGitHub }:
+platform:
+assert platform.isXtensa;
+let
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "xtensa-overlays";
+    rev = "eb39108196b775b0544c65697e63899df2cf1bfd";
+    sha256 = "06335yf4z1j9vlmhkz1jf7np1rbfzinlzr5y1rsqagpa52a4kmfg";
+  };
+in
+  "${src}/xtensa_${platform.parsed.cpu.name}"

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation ((if (with stdenv.targetPlatform; isOr1k || isVc4 || isXtens
 }) // {
   src = with stdenv.targetPlatform;
     if isXtensa then xtensa-src
-    else default-src;
+    else normal-src;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   # newlib expects CC to build for build platform, not host platform

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -1,14 +1,28 @@
-{ stdenv, fetchurl, buildPackages }:
-
-let version = "3.3.0";
-in stdenv.mkDerivation {
-  pname = "newlib";
-  inherit version;
-  src = fetchurl {
-    url = "ftp://sourceware.org/pub/newlib/newlib-${version}.tar.gz";
+{ stdenv, lib, fetchurl, fetchFromGitHub, buildPackages, espressifXtensaOverlays }:
+let
+  normal-version = "3.3.0";
+  normal-src = fetchurl {
+    url = "ftp://sourceware.org/pub/newlib/newlib-${normal-version}.tar.gz";
     sha256 = "0ricyx792ig2cb2x31b653yb7w7f7mf2111dv5h96lfzmqz9xpaq";
   };
 
+  xtensa-src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "newlib-esp32";
+    rev = "esp-2020r3";
+    sha256 = "1azk8wdx62xpf6jpbxnk21adryyf9airs1xrr0iyhnfm8lhbxir0";
+  };
+
+in
+stdenv.mkDerivation ((if (with stdenv.targetPlatform; isOr1k || isVc4 || isXtensa) then {
+  name = "newlib";
+} else {
+  pname = "newlib";
+  version = normal-version;
+}) // {
+  src = with stdenv.targetPlatform;
+    if isXtensa then xtensa-src
+    else default-src;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   # newlib expects CC to build for build platform, not host platform
@@ -25,7 +39,15 @@ in stdenv.mkDerivation {
     "--enable-newlib-io-long-long"
     "--enable-newlib-register-fini"
     "--enable-newlib-retargetable-locking"
-  ];
+  ] ++ (lib.optional stdenv.targetPlatform.isXtensa [
+    "--disable-newlib-io-c99-formats"
+    "--disable-newlib-supplied-syscalls"
+    "--enable-newlib-nano-formatted-io"
+    "--enable-newlib-reent-small"
+    "--enable-target-optspace"
+    "--enable-newlib-long-time_t"
+    "--enable-newlib-nano-malloc"
+  ]);
 
   dontDisableStatic = true;
 
@@ -34,3 +56,10 @@ in stdenv.mkDerivation {
     libdir = "/${stdenv.targetPlatform.config}/lib";
   };
 }
+
+// lib.optionalAttrs stdenv.targetPlatform.isXtensa {
+  postPatch = ''
+    cp -RT ${espressifXtensaOverlays stdenv.targetPlatform}/newlib .
+  '';
+}
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9647,6 +9647,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   });
 
+  espressifXtensaOverlays = callPackage ../development/misc/espressif/xtensa-overlays.nix { };
+
   apache-flex-sdk = callPackage ../development/compilers/apache-flex-sdk { };
 
   fasm = pkgsi686Linux.callPackage ../development/compilers/fasm {
@@ -9674,12 +9676,16 @@ in
   gerbil-support = callPackage ../development/compilers/gerbil/gerbil-support.nix { };
   gerbilPackages-unstable = gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
 
-  gccFun = callPackage (if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then ../development/compilers/gcc/6
+  gccFun = callPackage (with stdenv.targetPlatform; 
+    if (isVc4 || libc == "relibc") then ../development/compilers/gcc/6
+    else if isXtensa then ../development/compilers/gcc/8
     else ../development/compilers/gcc/10);
-  gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then gcc6 else
-      if stdenv.targetPlatform.isAarch64 then gcc9 else gcc10;
+
+  gcc = with stdenv.targetPlatform;
+    if isVc4 || libc == "relibc" then gcc6
+    else if isXtensa then gcc8
+    else if isAarch64 then gcc9
+    else gcc10;
   gcc-unwrapped = gcc.cc;
 
   gccStdenv = if stdenv.cc.isGNU then stdenv else stdenv.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9676,7 +9676,7 @@ in
   gerbil-support = callPackage ../development/compilers/gerbil/gerbil-support.nix { };
   gerbilPackages-unstable = gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
 
-  gccFun = callPackage (with stdenv.targetPlatform; 
+  gccFun = callPackage (with stdenv.targetPlatform;
     if (isVc4 || libc == "relibc") then ../development/compilers/gcc/6
     else if isXtensa then ../development/compilers/gcc/8
     else ../development/compilers/gcc/10);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Provide a toolchain for Espressif's Xtensa-based MCUs. This uses Espressif's
GCC/binutils/newlib forks, as well as applies a variant specific overlay.

The toolchain can be used both with the ESP-IDF sdk or "bare-metal" (eg. using https://github.com/taktoa/esp32-baremetal).

This is a rebased / slightly improved version of #96131.

While the PR should support the esp32, esp32s2 and esp8266, I only have the first one to try. I should be able to get my hands on an esp8266 this week to have a try at it. It could also support the newly announced esp32s3, but since there are no publicly available boards yet I've omitted it for `lib/systems` for now.

There are still a couple of issues / potential changes to be made.
- I used a `isXtensa` predicate in a bunch of places. This isn't very accurate, since there could be some non-esp xtensa chips. A `isEspressif` predicate wouldn't work either since espressif has some RISC-V cores too. `isXtensa && isEspressif` is a bit verbose. I'm inclined to keep using `isXtensa` until another xtensa chip comes along and/or support for a RISC-V ESP core is added (for instance, I think the newlib package would be shared).
- The way the overlay package is downloaded and distributed is probably bad. I don't know what the best practice is for this.
- I've copied the gcc flags and newlib configuration flags from [Espressif's crosstool-ng config](https://github.com/espressif/crosstool-NG/blob/esp-1.23.x/samples/xtensa-esp32-elf/crosstool.config).
  - `-mlongcall` is required otherwise I get linker errors on anything non-trivial.
  - `--enable-newlib-long-time_t` (ie. 32bit time_t) is required by the default ESP-IDF configuration, but there's a flag in the IDF to use if the toolchain uses 64bit time_t.
  - The rest, I think, are strictly a matter of preference and space/time tradeoff.
- (Off-topic) `or1k` and `vc4` have their own newlib package definitions that could be merged with the default `development/misc/newlib` one. I'd originally done this, but decided to leave it for another time to keep this PR on-topic.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
