### PR TITLE
python3Packages.cryptography: 3.3.2 -> 3.4.2

### DIFF
--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -2,9 +2,8 @@
 , buildPythonPackage
 , fetchPypi
 , fetchpatch
-, isPy27
-, ipaddress
 , openssl
+, setuptools-rust
 , cryptography_vectors
 , darwin
 , packaging
@@ -13,20 +12,20 @@
 , isPyPy
 , cffi
 , pytest
+, pytest-subtests
 , pretend
 , iso8601
 , pytz
 , hypothesis
-, enum34
 }:
 
 buildPythonPackage rec {
   pname = "cryptography";
-  version = "3.3.2"; # Also update the hash in vectors.nix
+  version = "3.4.2"; # Also update the hash in vectors.nix
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1vcvw4lkw1spiq322pm1256kail8nck6bbgpdxx3pqa905wd6q2s";
+    sha256 = "1i1mx5y9hkyfi9jrrkcw804hmkcglxi6rmf7vin7jfnbr2bf4q64";
   };
 
   outputs = [ "out" "dev" ];
@@ -35,15 +34,13 @@ buildPythonPackage rec {
     cffi
   ];
 
-  buildInputs = [ openssl ]
+  buildInputs = [ openssl setuptools-rust ]
              ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
   propagatedBuildInputs = [
     packaging
     six
   ] ++ lib.optionals (!isPyPy) [
     cffi
-  ] ++ lib.optionals isPy27 [
-    ipaddress enum34
   ];
 
   checkInputs = [
@@ -52,8 +49,14 @@ buildPythonPackage rec {
     iso8601
     pretend
     pytest
+    pytest-subtests
     pytz
   ];
+
+  # TODO: This temporary workaround is only supported for Cryptography 3.4.x
+  # and we need to figure out how to build it with the Rust dependencies.
+  # https://cryptography.io/en/latest/faq.html?highlight=rust#installing-cryptography-fails-with-error-can-not-find-rust-compiler
+  CRYPTOGRAPHY_DONT_BUILD_RUST = 1;
 
   checkPhase = ''
     py.test --disable-pytest-warnings tests

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1yhaps0f3h2yjb6lmz953z1l1d84y9swk4k3gj9nqyk4vbx5m7cc";
+    sha256 = "0i888rrfn7116lj7f2nr4amd2z45sk6866zizjfpsn5wh2713cls";
   };
 
   # No tests included


### PR DESCRIPTION
Backwards incompatible changes: Support for Python 2 has been removed.
Note: This isn't a problem for Nixpkgs though because
pythonPackages.cryptography is frozen at version 3.3.2.

Other important packaging changes: "Cryptography now incorporates Rust
code. Users building cryptography themselves will need to have the Rust
toolchain installed. Users who use an officially produced wheel will not
need to make any changes. The minimum supported Rust version is 1.45.0."
Note: Fetching Rust dependencies via Cargo during a Python build will
likely be a challenge for Nixpkgs. For Cryptography 3.4.x we can disable
the Rust support but that is only a temporarily supported workaround.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
