### PR TITLE
brscan4: 0.4.8-1 -> 0.4.9-1

### DIFF
--- a/pkgs/applications/graphics/sane/backends/brscan4/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan4/default.nix
@@ -1,5 +1,4 @@
-{ lib, stdenv, fetchurl, callPackage, patchelf, makeWrapper, coreutils, libusb-compat-0_1 }:
-
+{ stdenv, lib, fetchurl, callPackage, patchelf, makeWrapper, coreutils, libusb-compat-0_1 }:
 let
   myPatchElf = file: with lib; ''
     patchelf --set-interpreter \
@@ -7,22 +6,23 @@ let
       ${file}
   '';
 
-  udevRules = callPackage ./udev_rules_type1.nix {};
+  udevRules = callPackage ./udev_rules_type1.nix { };
 
-in stdenv.mkDerivation rec {
-  name = "brscan4-0.4.8-1";
-  src =
-    if stdenv.hostPlatform.system == "i686-linux" then
-      fetchurl {
-        url = "http://download.brother.com/welcome/dlf006646/${name}.i386.deb";
-        sha256 = "15hrf1gpm36lniqi6yf47dvdqjinm644xb752c6rcv8n06wb79ag";
-      }
-    else if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        url = "https://download.brother.com/welcome/dlf006645/${name}.amd64.deb";
-        sha256 = "0pyprjl0capg403yp6pp07gd6msx9kn7bzjcdswdbn28fyxrk5l4";
-      }
-    else throw "${name} is not supported on ${stdenv.hostPlatform.system} (only i686-linux and x86_64 linux are supported)";
+in
+stdenv.mkDerivation rec {
+  pname = "brscan4";
+  version = "0.4.9-1";
+  src = {
+    "i686-linux" = fetchurl {
+      url = "http://download.brother.com/welcome/dlf006646/${pname}-${version}.i386.deb";
+      sha256 = "0pkg9aqvnkpjnb9cgzf7lxw2g4jqrf2w98irkv22r0gfsfs3nwma";
+    };
+    "x86_64-linux" = fetchurl {
+
+      url = "https://download.brother.com/welcome/dlf006645/${pname}-${version}.amd64.deb";
+      sha256 = "0kakkl8rmsi2yr3f8vd1kk8vsl9g2ijhqil1cvvbwrhwgi0b7ai7";
+    };
+  }."${stdenv.hostPlatform.system}";
 
   unpackPhase = ''
     ar x $src
@@ -87,7 +87,7 @@ in stdenv.mkDerivation rec {
   meta = {
     description = "Brother brscan4 sane backend driver";
     homepage = "http://www.brother.com";
-    platforms = lib.platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ jraygauthier ];
   };


### PR DESCRIPTION
Brother removed their old .deb files from the server.

Also, properly set meta.platforms, and switch to pname + version
(#103997)


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
