### PR TITLE
haskellPackages.haskell-language-server: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1413,6 +1413,8 @@ self: super: {
   # 2021-02-08: Jailbreaking because of
   # https://github.com/haskell/haskell-language-server/issues/1329
   hls-tactics-plugin = doJailbreak super.hls-tactics-plugin;
+  # 2021-02-11: Jailbreaking because of syntax error on bound revision
+  hls-explicit-imports-plugin = doJailbreak super.hls-explicit-imports-plugin;
 
   # 2021-02-08: Overrides because nightly is to old for hls 0.9.0
   lsp-test = doDistribute (dontCheck self.lsp-test_0_11_0_7);

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1410,10 +1410,14 @@ self: super: {
   # https://github.com/haskell/haskell-language-server/issues/611
   haskell-language-server = dontCheck super.haskell-language-server;
 
-  # 2021-01-20
-  # apply-refact 0.9.0.0 get's a build error with hls-hlint-plugin 0.8.0
-  # https://github.com/haskell/haskell-language-server/issues/1240
-  apply-refact = super.apply-refact_0_8_2_1;
+  # 2021-02-08: Jailbreaking because of
+  # https://github.com/haskell/haskell-language-server/issues/1329
+  hls-tactics-plugin = doJailbreak super.hls-tactics-plugin;
+
+  # 2021-02-08: Overrides because nightly is to old for hls 0.9.0
+  lsp-test = doDistribute (dontCheck self.lsp-test_0_11_0_7);
+  haskell-lsp = doDistribute self.haskell-lsp_0_23_0_0;
+  haskell-lsp-types = doDistribute self.haskell-lsp-types_0_23_0_0;
 
   # 1. test requires internet
   # 2. dependency shake-bench hasn't been published yet so we also need unmarkBroken and doDistribute

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2701,6 +2701,7 @@ default-package-overrides:
 extra-packages:
   - Cabal == 2.2.*                      # required for jailbreak-cabal etc.
   - Cabal == 2.4.*                      # required for cabal-install etc.
+  - Cabal == 3.2.*                      # required for cabal-install etc.
   - dhall == 1.29.0                     # required for ats-pkg
   - dhall == 1.37.1                     # required for spago 0.19.0.
   - Diff < 0.4                          # required by liquidhaskell-0.8.10.2: https://github.com/ucsd-progsys/liquidhaskell/issues/1729

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -73,6 +73,8 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
+  - ghcide < 0.7.4 # for hls 0.9.0
+  - hls-explicit-imports-plugin < 0.1.0.1 # for hls 0.9.0
 
   # Stackage Nightly 2021-02-10
   - abstract-deque ==0.3

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -73,10 +73,6 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  - hls-plugin-api == 0.6.0.0           # Needed for hls 0.8.0
-  - hls-eval-plugin == 0.1.0.0          # Needed for hls 0.8.0
-  - hls-hlint-plugin == 0.1.0.0         # Needed for hls 0.8.0
-  - ghcide == 0.7.0.0                   # Needed for hls 0.8.0
 
   # Stackage Nightly 2021-02-10
   - abstract-deque ==0.3
@@ -2719,8 +2715,10 @@ extra-packages:
   - dependent-map == 0.2.4.0            # required by Hasura 1.3.1, 2020-08-20
   - dependent-sum == 0.4                # required by Hasura 1.3.1, 2020-08-20
   - network == 2.6.3.1                  # required by pkgs/games/hedgewars/default.nix, 2020-11-15
-  - apply-refact == 0.8.2.1             # Needed for hls 0.8.0
   - mmorph == 1.1.3                     # Newest working version of mmorph on ghc 8.6.5. needed for hls
+  - haskell-lsp == 0.23.0.0             # required by hls-plugin-api 0.7.0.0, 2021-02-08
+  - haskell-lsp-types == 0.23.0.0       # required by hls-plugin-api 0.7.0.0, 2021-02-08
+  - lsp-test == 0.11.0.7                # required by hls-plugin-api 0.7.0.0, 2021-02-08
 
 package-maintainers:
   peti:


### PR DESCRIPTION
Here we go.

The version bump happened by hackage, I just needed to make it build successfully via overrides.

\cc @Lucus16 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
