### PR TITLE
python3Packages.py-multihash: mark not broken

### DIFF
--- a/pkgs/development/python-modules/py-multihash/default.nix
+++ b/pkgs/development/python-modules/py-multihash/default.nix
@@ -49,6 +49,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/multiformats/py-multihash";
     license = licenses.mit;
     maintainers = with maintainers; [ rakesh4g ];
-    broken = true; # no longer compatible with base58, no updates in 5 years. Added 2020-11-05
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This was marked broken in https://github.com/NixOS/nixpkgs/pull/101636, which was merged into the staging branch. Later, the package was updated and fixed in https://github.com/NixOS/nixpkgs/pull/101801. When the staging branch was then merged into master, the package was marked as broken while actually being fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).