### PR TITLE
mat2: Init at 0.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6649,6 +6649,21 @@
     githubId = 8214542;
     name = "Nicolò Balzarotti";
   };
+  nicoo = {
+    name = "nicoo";
+    email = "nicoo@debian.org";
+
+    github = "nicoo";
+    githubId = 1155801;
+    keys = [{
+      longkeyid = "rsa4096/0xEC9D370872BC7A8C";
+      fingerprint = "E44E 9EA5 4B8E 256A FB73  49D3 EC9D 3708 72BC 7A8C";
+    }, {
+      # TODO: Update after rollover
+      longkeyid = "ed25519/0x0F63562823B906C5";
+      fingerprint = "87F0 9D62 2010 10F0 6112  78E5 0F63 5628 23B9 06C5";
+    }];
+  };
   NieDzejkob = {
     email = "kuba@kadziolka.net";
     github = "NieDzejkob";

--- a/pkgs/tools/misc/mat2/default.nix
+++ b/pkgs/tools/misc/mat2/default.nix
@@ -1,40 +1,40 @@
 { python3Packages, fetchurl, lib, pkgs }:
 
 python3Packages.buildPythonPackage rec {
-	pname = "mat2";
-	version = "0.12.0";
+  pname = "mat2";
+  version = "0.12.0";
 
-	# TODO: Verify upstream's signature, to ensure maintainers get an authentic
-	#  archive when importing a new version and setting its hash.
-	# #43233 mentions adding support in Nix's tooling, but nothing seems to exist.
-	srcs = fetchurl {
-		url = "${meta.homepage}/-/archive/${version}/${pname}-${version}.tar.gz";
-		sha256 = "185shmq35y2qj8ydy9l6v53flv536b8hrmv35b6ly22bczfs99yj";
-	};
+  # TODO: Verify upstream's signature, to ensure maintainers get an authentic
+  #  archive when importing a new version and setting its hash.
+  # #43233 mentions adding support in Nix's tooling, but nothing seems to exist.
+  srcs = fetchurl {
+    url = "${meta.homepage}/-/archive/${version}/${pname}-${version}.tar.gz";
+    sha256 = "185shmq35y2qj8ydy9l6v53flv536b8hrmv35b6ly22bczfs99yj";
+  };
 
-	propagatedBuildInputs =
-		(with python3Packages; [
-			mutagen
-			pygobject3
-		]) ++ (with pkgs; [
-			bubblewrap
-			cairo
-			exiftool
-			ffmpeg
-			librsvg
-			poppler_gi
-			gdk_pixbuf
-		]);
+  propagatedBuildInputs =
+    (with python3Packages; [
+      mutagen
+      pygobject3
+    ]) ++ (with pkgs; [
+      bubblewrap
+      cairo
+      exiftool
+      ffmpeg
+      librsvg
+      poppler_gi
+      gdk_pixbuf
+    ]);
 
-	# Test runner seems to have incorrect PATH
-	doCheck = false;
+  # Test runner seems to have incorrect PATH
+  doCheck = false;
 
-	meta = with lib; {
-		homepage = "https://0xacab.org/jvoisin/${pname}";
-		description = "Metadata Anonymisation Toolkit — remove metadata from various media formats";
+  meta = with lib; {
+    homepage = "https://0xacab.org/jvoisin/${pname}";
+    description = "Metadata Anonymisation Toolkit — remove metadata from various media formats";
 
-		license = licenses.lgpl3Plus;
-		platforms = platforms.unix;
-		maintainers = with maintainers; [ nicoo ];
-	};
+    license = licenses.lgpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ nicoo ];
+  };
 }

--- a/pkgs/tools/misc/mat2/default.nix
+++ b/pkgs/tools/misc/mat2/default.nix
@@ -10,18 +10,18 @@ python3Packages.buildPythonPackage rec {
 	};
 
 	propagatedBuildInputs =
-		with python3Packages; [
+		(with python3Packages; [
 			mutagen
 			pygobject3
-		] ++ [
-			pkgs.bubblewrap
-			pkgs.cairo
-			pkgs.exiftool
-			pkgs.ffmpeg
-			pkgs.librsvg
-			pkgs.poppler_gi
-			pkgs.gdk_pixbuf
-		];
+		]) ++ (with pkgs; [
+			bubblewrap
+			cairo
+			exiftool
+			ffmpeg
+			librsvg
+			poppler_gi
+			gdk_pixbuf
+		]);
 
 	# Test runner seems to have incorrect PATH
 	doCheck = false;

--- a/pkgs/tools/misc/mat2/default.nix
+++ b/pkgs/tools/misc/mat2/default.nix
@@ -1,0 +1,37 @@
+{ python3Packages, fetchurl, lib, pkgs }:
+
+python3Packages.buildPythonPackage rec {
+	pname = "mat2";
+	version = "0.12.0";
+
+	srcs = fetchurl {
+		url = "${meta.homepage}/-/archive/${version}/${pname}-${version}.tar.gz";
+		sha256 = "185shmq35y2qj8ydy9l6v53flv536b8hrmv35b6ly22bczfs99yj";
+	};
+
+	propagatedBuildInputs =
+		with python3Packages; [
+			mutagen
+			pygobject3
+		] ++ [
+			pkgs.bubblewrap
+			pkgs.cairo
+			pkgs.exiftool
+			pkgs.ffmpeg
+			pkgs.librsvg
+			pkgs.poppler_gi
+			pkgs.gdk_pixbuf
+		];
+
+	# Test runner seems to have incorrect PATH
+	doCheck = false;
+
+	meta = with lib; {
+		homepage = "https://0xacab.org/jvoisin/${pname}";
+		description = "Metadata Anonymisation Toolkit — remove metadata from various media formats";
+
+		license = licenses.lgpl3Plus;
+		platforms = platforms.unix;
+		maintainers = with maintainers; [ nicoo ];
+	};
+}

--- a/pkgs/tools/misc/mat2/default.nix
+++ b/pkgs/tools/misc/mat2/default.nix
@@ -1,4 +1,5 @@
-{ python3Packages, fetchurl, lib, pkgs }:
+{ python3Packages, fetchurl, lib,
+  bubblewrap, cairo, exiftool, ffmpeg, gdk_pixbuf, librsvg, poppler_gi }:
 
 python3Packages.buildPythonPackage rec {
   pname = "mat2";
@@ -12,25 +13,28 @@ python3Packages.buildPythonPackage rec {
     sha256 = "185shmq35y2qj8ydy9l6v53flv536b8hrmv35b6ly22bczfs99yj";
   };
 
-  propagatedBuildInputs =
-    (with python3Packages; [
-      mutagen
-      pygobject3
-    ]) ++ (with pkgs; [
-      bubblewrap
-      cairo
-      exiftool
-      ffmpeg
-      librsvg
-      poppler_gi
-      gdk_pixbuf
-    ]);
+  propagatedBuildInputs = with python3Packages; [
+    # Python deps
+    mutagen
+    pygobject3
+
+    # Deps called through GObject
+    gdk_pixbuf
+    librsvg
+    poppler_gi
+
+    # External binaries called
+    bubblewrap
+    cairo
+    exiftool
+    ffmpeg
+  ];
 
   # Ensures mat2 is executed with the right interpreter.
   patchPhase = "patchShebangs ./mat2";
 
   # TODO: Figure out why the testsuite fails with bwrap present
-  checkInputs = with pkgs; [ exiftool ffmpeg ];
+  checkInputs = [ exiftool ffmpeg ];
   preCheck = "python3 ./mat2 --check-dependencies";
 
   meta = with lib; {

--- a/pkgs/tools/misc/mat2/default.nix
+++ b/pkgs/tools/misc/mat2/default.nix
@@ -26,8 +26,12 @@ python3Packages.buildPythonPackage rec {
       gdk_pixbuf
     ]);
 
-  # Test runner seems to have incorrect PATH
-  doCheck = false;
+  # Ensures mat2 is executed with the right interpreter.
+  patchPhase = "patchShebangs ./mat2";
+
+  # TODO: Figure out why the testsuite fails with bwrap present
+  checkInputs = with pkgs; [ exiftool ffmpeg ];
+  preCheck = "python3 ./mat2 --check-dependencies";
 
   meta = with lib; {
     homepage = "https://0xacab.org/jvoisin/${pname}";

--- a/pkgs/tools/misc/mat2/default.nix
+++ b/pkgs/tools/misc/mat2/default.nix
@@ -4,6 +4,9 @@ python3Packages.buildPythonPackage rec {
 	pname = "mat2";
 	version = "0.12.0";
 
+	# TODO: Verify upstream's signature, to ensure maintainers get an authentic
+	#  archive when importing a new version and setting its hash.
+	# #43233 mentions adding support in Nix's tooling, but nothing seems to exist.
 	srcs = fetchurl {
 		url = "${meta.homepage}/-/archive/${version}/${pname}-${version}.tar.gz";
 		sha256 = "185shmq35y2qj8ydy9l6v53flv536b8hrmv35b6ly22bczfs99yj";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29913,4 +29913,6 @@ in
   lc3tools = callPackage ../development/tools/lc3tools {};
 
   zktree = callPackage ../applications/misc/zktree {};
+
+  mat2 = callPackage ../tools/misc/mat2 {};
 }


### PR DESCRIPTION
###### Motivation for this change

`mat2` is a useful privacy tool.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
      Not applicable
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
      None (new pkg)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Things yet to do

- [ ] Check upstream's signature on the release tarball
- [ ] Run `mat2`'s testsuite
