### PR TITLE
python3Packages.base58: 2.0.1 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/base58/default.nix
+++ b/pkgs/development/python-modules/base58/default.nix
@@ -1,19 +1,29 @@
-{ lib, fetchPypi, buildPythonPackage, isPy27, pytest, pyhamcrest }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyhamcrest
+, pytest-benchmark
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "base58";
-  version = "2.0.1";
-  disabled = isPy27; # python 2 abandoned upstream
+  version = "2.1.0";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "365c9561d9babac1b5f18ee797508cd54937a724b6e419a130abad69cec5ca79";
+    sha256 = "sha256-FxpUe0o8YeGuOAciSm967HXjZMQ5XnViZJ1zNXaAAaI=";
   };
 
-  checkInputs = [ pytest pyhamcrest ];
-  checkPhase = ''
-    pytest
-  '';
+  checkInputs = [
+    pyhamcrest
+    pytest-benchmark
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "base58" ];
 
   meta = with lib; {
     description = "Base58 and Base58Check implementation";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.0 

Change log: https://github.com/keis/base58/blob/master/CHANGELOG.md#v210--2021-01-09

Also, switched to `pytestCheckHook`.

#112410 will unbreak `py-multihash`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
