### PR TITLE
aseq2json: init at 2018-04-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7561,6 +7561,12 @@
     githubId = 115877;
     name = "Kenny Shen";
   };
+  queezle = {
+    email = "git@queezle.net";
+    github = "qzle";
+    githubId = 1024891;
+    name = "Jens Nolte";
+  };
   quentini = {
     email = "quentini@airmail.cc";
     github = "QuentinI";

--- a/pkgs/os-specific/linux/aseq2json/default.nix
+++ b/pkgs/os-specific/linux/aseq2json/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, pkg-config, alsaLib, glib, json-glib }:
+
+stdenv.mkDerivation {
+  pname = "aseq2json";
+  version = "unstable-2018-04-28";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "midi-dump-tools";
+    rev = "8572e6313a0d7ec95492dcab04a46c5dd30ef33a";
+    sha256 = "LQ9LLVumi3GN6c9tuMSOd1Bs2pgrwrLLQbs5XF+NZeA=";
+  };
+  sourceRoot = "source/aseq2json";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ alsaLib glib json-glib ];
+
+  installPhase = ''
+    install -D --target-directory "$out/bin" aseq2json
+  '';
+
+  meta = with lib; {
+    description = "Listens for MIDI events on the Alsa sequencer and outputs as JSON to stdout";
+    homepage = "https://github.com/google/midi-dump-tools";
+    license = licenses.asl20;
+    maintainers = [ maintainers.queezle ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18634,6 +18634,8 @@ in
     libapparmor apparmor-utils apparmor-bin-utils apparmor-parser apparmor-pam
     apparmor-profiles apparmor-kernel-patches;
 
+  aseq2json = callPackage ../os-specific/linux/aseq2json {};
+
   atop = callPackage ../os-specific/linux/atop { };
 
   audit = callPackage ../os-specific/linux/audit { };


### PR DESCRIPTION
###### Motivation for this change
Adds a package for `aseq2json`, which is a program that connects to the ALSA sequencer and dumps midi events as json.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
