### PR TITLE
doc: improve documentation for specialised fetchers

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -47,24 +47,139 @@ A number of fetcher functions wrap part of `fetchurl` and `fetchzip`. They are m
 
 ## `fetchFromGitHub`
 
-`fetchFromGitHub` expects four arguments. `owner` is a string corresponding to the GitHub user or organization that controls this repository. `repo` corresponds to the name of the software repository. These are located at the top of every GitHub HTML page as `owner`/`repo`. `rev` corresponds to the Git commit hash or tag (e.g `v1.0`) that will be downloaded from Git. Finally, `sha256` corresponds to the hash of the extracted directory. Again, other hash algorithms are also available but `sha256` is currently preferred.
+Fetch a Git repository from [GitHub](https://github.com/).
+GitHub repository URLs are in the format `https://{githubBase}/{owner}/{repo}`.
+
+### Required arguments
+
+`owner`
+
+: GitHub user or organization that controls this repository.
+
+`repo`
+
+: Name of the repository.
+
+`rev`
+
+: Git commit hash or tag (e.g. v1.0) to fetch.
+
+`sha256`
+
+: Hash of the extracted directory.
+
+### Optional arguments
+
+`private`
+
+: If set to `true` the nix build process (nix-daemon in multi-user
+  mode) authenticate with GitHub using the `USERNAME` and `PASSWORD`
+  variables in its environment.
+
+`githubBase`
+
+: GitHub domain name.  Defaults to `github.com`, but can be overridden
+  for GitHub Enterprise repositories.
 
 ## `fetchFromGitLab`
 
-This is used with GitLab repositories. The arguments expected are very similar to fetchFromGitHub above.
+Fetch a Git repository from [GitLab](https://gitlab.com/).
+GitLab repository URLs are in the format `https://{domain}/{owner}/{repo}` or
+`https://{domain}/{owner}/{group}/{repo}`.
+
+### Required arguments
+
+`owner`
+
+: GitLab user or organization that controls this repository.
+
+`repo`
+
+: Name of the repository.
+
+`rev`
+
+: Git commit hash or tag (e.g. v1.0) to fetch.
+
+`sha256`
+
+: Hash of the extracted directory.
+
+### Optional arguments
+
+`group`
+
+: GitLab [group](https://docs.gitlab.com/ee/user/group/) the
+  repository is under.
+
+`domain`
+
+: Domain name of this GitLab instance.  Defaults to `gitlab.com`.
 
 ## `fetchFromGitiles`
 
-This is used with Gitiles repositories. The arguments expected are similar to fetchgit.
+This is used with [Gitiles](https://gerrit.googlesource.com/gitiles/)
+repositories. The arguments expected are similar to `fetchgit`.
 
 ## `fetchFromBitbucket`
 
-This is used with BitBucket repositories. The arguments expected are very similar to fetchFromGitHub above.
+Fetch a Git repository from [BitBucket](https://bitbucket.org/).
+Bitbucket repository URLs are in the format
+`https://bitbucket.org/{owner}/{repo}`.
+
+### Required arguments
+
+`owner`
+
+: BitBucket user or team that controls this repository.
+
+`repo`
+
+: Name of the repository.
+
+`rev`
+
+: Git commit hash or tag (e.g. v1.0) to fetch.
+
+`sha256`
+
+: Hash of the extracted directory.
 
 ## `fetchFromSavannah`
 
-This is used with Savannah repositories. The arguments expected are very similar to fetchFromGitHub above.
+Fetch a Git repository from [GNU Savannah](https://savannah.gnu.org/).
+Savannah URLs are in the format
+`https://git.savannah.gnu.org/cgit/{path}.git`.
+
+### Required arguments
+
+`repo`
+
+: Path of the repository.
+
+`rev`
+
+: Git commit hash or tag (e.g. v1.0) to fetch.
+
+`sha256`
+
+: Hash of the extracted directory.
 
 ## `fetchFromRepoOrCz`
 
-This is used with repo.or.cz repositories. The arguments expected are very similar to fetchFromGitHub above.
+Fetch a Git repository from [repo.or.cz](https://repo.or.cz/).
+repo.or.cz URLs are in the format `https://repo.or.cz/{repo}.git`.
+
+### Required arguments
+
+`repo`
+
+: Path of the repository.
+
+`rev`
+
+: Git commit hash or tag (e.g. v1.0) to fetch.
+
+`sha256`
+
+: Hash of the extracted directory.

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -21,7 +21,7 @@ The main difference between `fetchurl` and `fetchzip` is in how they store the c
 `fetchpatch` works very similarly to `fetchurl` with the same arguments expected. It expects patch files as a source and and performs normalization on them before computing the checksum. For example it will remove comments or other unstable parts that are sometimes added by version control systems and can change over time.
 
 
-Other fetcher functions allow you to add source code directly from a VCS such as subversion or git. These are mostly straightforward nambes based on the name of the command used with the VCS system. Because they give you a working repository, they act most like `fetchzip`.
+Other fetcher functions allow you to add source code directly from a VCS such as subversion or git. These are mostly straightforward names based on the name of the command used with the VCS system. Because they give you a working repository, they act most like `fetchzip`.
 
 ## `fetchsvn`
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

"The arguments expected are very similar to fetchFromGitHub above."
was not very good documentation, especially since every function that
said this differed from fetchFromGitHub in important ways that weren't
documented at all.

It makes a lot more sense to have seperate parameter listings for each
function, since the set of parameters each function takes is
completely different.  Additionally, proper lists of parameters are
much easier to read at a glance than a single long paragraph
describing each one in turn, as fetchFromGitHub used to have.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
