### PR TITLE
python3Packages.numba: add setuptools dependency

### DIFF
--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -23,8 +23,8 @@ buildPythonPackage rec {
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
-  propagatedBuildInputs = [numpy llvmlite setuptools];
-
+  propagatedBuildInputs = [ numpy llvmlite setuptools ];
+  pythonImportsCheck = [ "numba" ];
   # Copy test script into $out and run the test suite.
   checkPhase = ''
     ${python.interpreter} -m numba.runtests

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -8,6 +8,7 @@
 , isPy3k
 , numpy
 , llvmlite
+, setuptools
 , funcsigs
 , singledispatch
 , libcxx
@@ -26,7 +27,7 @@ buildPythonPackage rec {
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
-  propagatedBuildInputs = [numpy llvmlite]
+  propagatedBuildInputs = [numpy llvmlite setuptools]
     ++ lib.optionals isPy27 [ funcsigs singledispatch];
 
   # Copy test script into $out and run the test suite.

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -4,13 +4,9 @@
 , fetchPypi
 , python
 , buildPythonPackage
-, isPy27
-, isPy3k
 , numpy
 , llvmlite
 , setuptools
-, funcsigs
-, singledispatch
 , libcxx
 }:
 
@@ -27,8 +23,7 @@ buildPythonPackage rec {
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
-  propagatedBuildInputs = [numpy llvmlite setuptools]
-    ++ lib.optionals isPy27 [ funcsigs singledispatch];
+  propagatedBuildInputs = [numpy llvmlite setuptools];
 
   # Copy test script into $out and run the test suite.
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Numba needs `setuptools` as a runtime dependency: https://numba.readthedocs.io/en/stable/user/installing.html#dependency-list

Here's what happens when I try to import numba without setuptools:
```console
$ nix-shell -p "python3.withPackages (ps: [ps.numba])" --command "python"
Python 3.8.5 (default, Jul 20 2020, 13:26:22)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import numba
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/lybwd37fw0j2jyqp68jkkmb5kdz8hfxg-python3-3.8.5-env/lib/python3.8/site-packages/numba/__init__.py", line 34, in <module>
    from numba.core.decorators import (cfunc, generated_jit, jit, njit, stencil,
  File "/nix/store/lybwd37fw0j2jyqp68jkkmb5kdz8hfxg-python3-3.8.5-env/lib/python3.8/site-packages/numba/core/decorators.py", line 12, in <module>
    from numba.stencils.stencil import stencil
  File "/nix/store/lybwd37fw0j2jyqp68jkkmb5kdz8hfxg-python3-3.8.5-env/lib/python3.8/site-packages/numba/stencils/stencil.py", line 11, in <module>
    from numba.core import types, typing, utils, ir, config, ir_utils, registry
  File "/nix/store/lybwd37fw0j2jyqp68jkkmb5kdz8hfxg-python3-3.8.5-env/lib/python3.8/site-packages/numba/core/registry.py", line 4, in <module>
    from numba.core import utils, typing, dispatcher, cpu
  File "/nix/store/lybwd37fw0j2jyqp68jkkmb5kdz8hfxg-python3-3.8.5-env/lib/python3.8/site-packages/numba/core/dispatcher.py", line 15, in <module>
    from numba.core import utils, types, errors, typing, serialize, config, compiler, sigutils
  File "/nix/store/lybwd37fw0j2jyqp68jkkmb5kdz8hfxg-python3-3.8.5-env/lib/python3.8/site-packages/numba/core/compiler.py", line 6, in <module>
    from numba.core import (utils, errors, typing, interpreter, bytecode, postproc,
  File "/nix/store/lybwd37fw0j2jyqp68jkkmb5kdz8hfxg-python3-3.8.5-env/lib/python3.8/site-packages/numba/core/cpu.py", line 16, in <module>
    import numba.core.entrypoints
  File "/nix/store/lybwd37fw0j2jyqp68jkkmb5kdz8hfxg-python3-3.8.5-env/lib/python3.8/site-packages/numba/core/entrypoints.py", line 4, in <module>
    from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'
```

This PR also removes python 2-specific dependencies which never get included since the package doesn't support python <3.6 anymore.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
