### PR TITLE
bonnmotion: init at 3.0.1

### DIFF
--- a/pkgs/development/tools/misc/bonnmotion/default.nix
+++ b/pkgs/development/tools/misc/bonnmotion/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, lib, fetchzip, substituteAll, bash, jre }:
+
+stdenv.mkDerivation rec {
+  pname = "bonnmotion";
+  version = "3.0.1";
+
+  src = fetchzip {
+    url = "https://sys.cs.uos.de/bonnmotion/src/bonnmotion-${version}.zip";
+    sha256 = "16bjgr0hy6an892m5r3x9yq6rqrl11n91f9rambq5ik1cxjqarxw";
+  };
+
+  patches = [
+    # The software has a non-standard install bash script which kind of works.
+    # However, to make it fully functional, the automatically detection of the
+    # program paths must be substituted with full paths.
+    (substituteAll {
+      src = ./install.patch;
+      inherit bash jre;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    ./install
+
+    mkdir -p $out/bin $out/share/bonnmotion
+    cp -r ./classes ./lib $out/share/bonnmotion/
+    cp ./bin/bm $out/bin/
+
+    substituteInPlace $out/bin/bm \
+      --replace /build/source $out/share/bonnmotion
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A mobility scenario generation and analysis tool";
+    longDescription = ''
+      BonnMotion is a Java software which creates and analyzes mobility
+      scenarios and is most commonly used as a tool for the investigation of
+      mobile ad hoc network characteristics. The scenarios can also be exported
+      for several network simulators, such as ns-2, ns-3, GloMoSim/QualNet,
+      COOJA, MiXiM, and ONE.
+    '';
+    homepage = "https://sys.cs.uos.de/bonnmotion/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/development/tools/misc/bonnmotion/install.patch
+++ b/pkgs/development/tools/misc/bonnmotion/install.patch
@@ -1,0 +1,75 @@
+diff --git a/install b/install
+index 95afa2c..70c5fca 100755
+--- a/install
++++ b/install
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@bash@/bin/bash
+ 
+ echo "BonnMotion - a mobility scenario generation and analysis tool"
+ echo "Copyright (C) 2002-2012 University of Bonn"
+@@ -19,28 +19,11 @@ echo "along with this program; if not, write to the Free Software"
+ echo "Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA"
+ echo
+ 
+-OS=`uname -s | tr A-Z a-z | sed -e s/_.\*//`
+-
+ PACKAGE=edu.bonn.cs.iv.bonnmotion
+-JAVAPATH=`which java 2> /dev/null`
+-if [ ! "$JAVAPATH" = "" ]
+-then
+-	JAVAPATH=`dirname ${JAVAPATH}`
+-fi
+-echo -n Please enter your Java binary path \[$JAVAPATH\]:\ 
+-read KBDENTRY
+-if [ ! "$KBDENTRY" = "" ]
+-then
+-	JAVAPATH=$KBDENTRY
+-fi
++JAVAPATH="@jre@/bin"
+ if [ -x "${JAVAPATH}/java" ]
+ then
+-	cd `dirname $0`
+-	BONNMOTION=`pwd`
+-
+-	cd "${JAVAPATH}"
+-	JAVAPATH=`pwd`
+-	cd "${BONNMOTION}"
++  BONNMOTION="$(realpath .)"
+ 
+ 	CLASSPATH="${BONNMOTION}/classes"
+ 	DOCPATH="${BONNMOTION}/javadoc"
+@@ -52,14 +35,7 @@ then
+ 	then
+ 		mkdir "${DOCPATH}"
+ 	fi
+-	if [ $OS = "cygwin" ]
+-	then
+-		cd "${CLASSPATH}"
+-		CLASSPATH=`cmd.exe /c cd`
+-		cd "${DOCPATH}"
+-		DOCPATH=`cmd.exe /c cd`
+-	fi
+-	
++
+ 	for l in $BONNMOTION/lib/*.jar
+ 	do
+ 		LIBRARYPATH=$LIBRARYPATH:$l
+@@ -69,7 +45,7 @@ then
+ 	APPS=`ls`
+ 	cd "${BONNMOTION}/bin"
+ 
+-	echo \#\!/bin/bash > .head
++	echo \#\!@bash@/bin/bash > .head
+ 	echo >> .head
+ 	echo BONNMOTION=\"$BONNMOTION\" >> .head
+ 	echo PACKAGE=\"$PACKAGE\" >> .head
+@@ -103,8 +79,6 @@ then
+ 	fi
+ 	echo "done."
+ 	echo
+-	echo "$ ./bin/bm -h"
+-	./bm
+ else
+ 	echo No executable \"$JAVAPATH/java\", aborting.
+ fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1112,6 +1112,8 @@ in
 
   bmap-tools = callPackage ../tools/misc/bmap-tools { };
 
+  bonnmotion = callPackage ../development/tools/misc/bonnmotion { };
+
   bonnie = callPackage ../tools/filesystems/bonnie { };
 
   bonfire = callPackage ../tools/misc/bonfire { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the [BonnMotion](https://sys.cs.uos.de/bonnmotion/) tool to the nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
