### PR TITLE
python3Packages.py-multihash: 1.0.0 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/py-multihash/default.nix
+++ b/pkgs/development/python-modules/py-multihash/default.nix
@@ -1,48 +1,43 @@
 { base58
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
 , lib
 , morphys
-, pytest
-, pytestcov
-, pytestrunner
+, pytest-runner
+, pytestCheckHook
+, pythonOlder
 , six
-, variants
 , varint
 }:
 
 buildPythonPackage rec {
   pname = "py-multihash";
-  version = "1.0.0";
+  version = "2.0.1";
+  disabled = pythonOlder "3.4";
 
   src = fetchFromGitHub {
     owner = "multiformats";
     repo = pname;
     rev = "v${version}";
-    sha256 = "07qglrbgcb8sr9msqw2v7dqj9s4rs6nyvhdnx02i5w6xx5ibzi3z";
+    sha256 = "sha256-z1lmSypGCMFWJNzNgV9hx/IStyXbpd5jvrptFpewuOA=";
   };
 
   nativeBuildInputs = [
-    pytestrunner
+    pytest-runner
   ];
 
   propagatedBuildInputs = [
     base58
     morphys
     six
-    variants
     varint
   ];
 
   checkInputs = [
-    pytest
-    pytestcov
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [ "multihash" ];
-
-  disabled = isPy27;
 
   meta = with lib; {
     description = "Self describing hashes - for future proofing";


### PR DESCRIPTION
###### Motivation for this change
https://github.com/multiformats/py-multihash/releases/tag/v2.0.1
After marking it as not broken in #112410, I'm now updating it to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).