### PR TITLE
python3Packages.pyxbe: init at 0.0.2, python3Packages.angr: init at 9.0.5739

### DIFF
--- a/pkgs/development/python-modules/ailment/default.nix
+++ b/pkgs/development/python-modules/ailment/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "ailment";
-  version = "9.0.5903";
+  version = "9.0.6281";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-75Ul9JfMFYv3AfBlgmer6IDyfgOAS4AdXexznoxi35Y=";
+    sha256 = "sha256-IFUGtTO+DY8FIxLgvmwM/y/RQr42T9sABPpnJMILkqg=";
   };
 
   propagatedBuildInputs = [ pyvex ];

--- a/pkgs/development/python-modules/angr/default.nix
+++ b/pkgs/development/python-modules/angr/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, ailment
+, archinfo
+, buildPythonPackage
+, cachetools
+, capstone
+, cffi
+, claripy
+, cle
+, cppheaderparser
+, dpkt
+, fetchFromGitHub
+, GitPython
+, itanium_demangler
+, mulpyplexer
+, networkx
+, progressbar2
+, protobuf
+, psutil
+, pycparser
+, pkgs
+, pythonOlder
+, pyvex
+, sqlalchemy
+, rpyc
+, sortedcontainers
+, unicorn
+}:
+
+let
+  # Only the pinned release in setup.py works properly
+  unicorn' = unicorn.overridePythonAttrs (old: rec {
+      pname = "unicorn";
+      version = "1.0.2-rc4";
+      src =  fetchFromGitHub {
+        owner = "unicorn-engine";
+        repo = pname;
+        rev = version;
+        sha256 = "17nyccgk7hpc4hab24yn57f1xnmr7kq4px98zbp2bkwcrxny8gwy";
+    };
+  });
+in
+
+buildPythonPackage rec {
+  pname = "angr";
+  version = "9.0.6281";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "10i4qdk8f342gzxiwy0pjdc35lc4q5ab7l5q420ca61cgdvxkk4r";
+  };
+
+  propagatedBuildInputs = [
+    ailment
+    archinfo
+    cachetools
+    capstone
+    cffi
+    claripy
+    cle
+    cppheaderparser
+    dpkt
+    GitPython
+    itanium_demangler
+    mulpyplexer
+    networkx
+    progressbar2
+    protobuf
+    psutil
+    sqlalchemy
+    pycparser
+    pyvex
+    sqlalchemy
+    rpyc
+    sortedcontainers
+    unicorn'
+  ];
+
+  # Tests have additional requirements, e.g., pypcode and angr binaries
+  # cle is executing the tests with the angr binaries
+  doCheck = false;
+  pythonImportsCheck = [ "angr" ];
+
+  meta = with lib; {
+    description = "Powerful and user-friendly binary analysis platform";
+    homepage = "https://angr.io/";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/archinfo/default.nix
+++ b/pkgs/development/python-modules/archinfo/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "archinfo";
-  version = "9.0.5903";
+  version = "9.0.6281";
 
   src = fetchFromGitHub {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-4e+ZGIt/ouZj5rsmaVxUrz8gAq4Yq2+Qx4jdOojB4Sw=";
+    sha256 = "sha256-ZO2P53RdR3cYhDbtrdGJnadFZgKkBdDi5gR/CB7YTpI=";
   };
 
   checkInputs = [

--- a/pkgs/development/python-modules/claripy/default.nix
+++ b/pkgs/development/python-modules/claripy/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "claripy";
-  version = "9.0.5903";
+  version = "9.0.6281";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-NIKWUx1VT5TjnuqppuT6VzwNRwcBLc0xI5k3F2Nmj8A=";
+    sha256 = "sha256-gvo8I6LQRAEUa7QiV5Sugrt+e2SmGkkKfsGn/IKz+Mk=";
   };
 
   # Use upstream z3 implementation

--- a/pkgs/development/python-modules/cle/default.nix
+++ b/pkgs/development/python-modules/cle/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, buildPythonPackage
+, cffi
+, fetchFromGitHub
+, minidump
+, nose
+, pefile
+, pyelftools
+, pytestCheckHook
+, pythonOlder
+, pyvex
+, pyxbe
+, sortedcontainers
+}:
+
+let
+  # The binaries are following the argr projects release cycle
+  version = "9.0.6281";
+
+  # Binary files from https://github.com/angr/binaries (only used for testing and only here)
+  binaries = fetchFromGitHub {
+    owner = "angr";
+    repo = "binaries";
+    rev = "v${version}";
+    sha256 = "1qlrxfj1n34xvwkac6mbcc7zmixxbp34fj7lkf0fvp7zcz1rpla1";
+  };
+
+in
+buildPythonPackage rec {
+  pname = "cle";
+  inherit version;
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "angr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0f2zc02dljmgp6ny6ja6917j08kqhwckncan860dq4xv93g61rmg";
+  };
+
+  propagatedBuildInputs = [
+    cffi
+    minidump
+    pefile
+    pyelftools
+    pyvex
+    pyxbe
+    sortedcontainers
+  ];
+
+  checkInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  # Place test binaries in the right location (location is hard-coded in the tests)
+  preCheck = ''
+    export HOME=$TMPDIR
+    cp -r ${binaries} $HOME/binaries
+  '';
+
+  disabledTests = [
+    # PPC tests seems to fails
+    "test_ppc_rel24_relocation"
+    "test_ppc_addr16_ha_relocation"
+    "test_ppc_addr16_lo_relocation"
+  ];
+
+  pythonImportsCheck = [ "cle" ];
+
+  meta = with lib; {
+    description = "Python loader for many binary formats";
+    homepage = "https://github.com/angr/cle";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -2,20 +2,20 @@
 , stdenv
 , archinfo
 , bitstring
-, fetchPypi
-, cffi
 , buildPythonPackage
+, cffi
+, fetchPypi
 , future
 , pycparser
 }:
 
 buildPythonPackage rec {
   pname = "pyvex";
-  version = "9.0.5903";
+  version = "9.0.6281";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-qhLlRlmb48zhjX2u9w6TVVv2gb0E9kSapabiv+u4J2s=";
+    sha256 = "sha256-E8BYCzV71qVNRzWCCI2yTVU88JVMA08eqnIO8OtbNlM=";
   };
 
   propagatedBuildInputs = [
@@ -25,6 +25,11 @@ buildPythonPackage rec {
     future
     pycparser
   ];
+
+  postPatch = ''
+    substituteInPlace pyvex_c/Makefile \
+      --replace "CC=gcc" "CC=${stdenv.cc.targetPrefix}cc"
+  '';
 
   # No tests are available on PyPI, GitHub release has tests
   # Switch to GitHub release after all angr parts are present

--- a/pkgs/development/python-modules/pyxbe/default.nix
+++ b/pkgs/development/python-modules/pyxbe/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyxbe";
+  version = "unstable-2021-01-10";
+
+  src = fetchFromGitHub {
+    owner = "mborgerson";
+    repo = pname;
+    rev = "a7ae1bb21b02a57783831eb080c1edbafaad1d5d";
+    sha256 = "1cp9a5f41z8j7bzip6nhka8qnxs12v75cdf80sk2nzgf1k15wi2p";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # Update location for run with pytest
+  preCheck = ''
+    substituteInPlace tests/test_load.py \
+      --replace "'xbefiles'" "'tests/xbefiles'"
+  '';
+
+  pythonImportsCheck = [ "xbe" ];
+
+  meta = with lib; {
+    description = "Library to work with XBE files";
+    homepage = "https://github.com/mborgerson/pyxbe";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -378,6 +378,8 @@ in {
 
   androguard = callPackage ../development/python-modules/androguard { };
 
+  angr = callPackage ../development/python-modules/angr { };
+
   aniso8601 = callPackage ../development/python-modules/aniso8601 { };
 
   annexremote = callPackage ../development/python-modules/annexremote { };
@@ -1355,6 +1357,8 @@ in {
   claripy =  callPackage ../development/python-modules/claripy { };
 
   cld2-cffi = callPackage ../development/python-modules/cld2-cffi { };
+
+  cle = callPackage ../development/python-modules/cle { };
 
   cleo = callPackage ../development/python-modules/cleo { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7005,6 +7005,8 @@ in {
 
   pyx = callPackage ../development/python-modules/pyx { };
 
+  pyxbe = callPackage ../development/python-modules/pyxbe { };
+
   pyxdg = callPackage ../development/python-modules/pyxdg { };
 
   pyxeoma = callPackage ../development/python-modules/pyxeoma { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Library to work with XBE files.

https://github.com/mborgerson/pyxbe

Till https://github.com/mborgerson/pyxbe/issues/10 is fixed it's `unstable`.

This is an `angr` dependency #67413. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
