### PR TITLE
python3Packages.pyvex: init at 9.0.5739, python3Packages.ailment: init at 9.0.5739

### DIFF
--- a/pkgs/development/python-modules/ailment/default.nix
+++ b/pkgs/development/python-modules/ailment/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pyvex
+}:
+
+buildPythonPackage rec {
+  pname = "ailment";
+  version = "9.0.5739";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "angr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1fjwksia6h7w7m5zhys65yr4zxvyfgp9hr1k5dn802p9kvz34bpc";
+  };
+
+  propagatedBuildInputs = [ pyvex ];
+
+  # Tests depend on angr (possibly a circular dependency)
+  doCheck = false;
+  #pythonImportsCheck = [ "ailment" ];
+
+  meta = with lib; {
+    description = "The angr Intermediate Language";
+    homepage = "https://github.com/angr/ailment";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, archinfo
+, bitstring
+, fetchPypi
+, cffi
+, buildPythonPackage
+, future
+, pycparser
+}:
+
+buildPythonPackage rec {
+  pname = "pyvex";
+  version = "9.0.5739";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1jwxxw2kw7wkz7kh8m8vbavzw6m5k6xph7mazfn3k2qbsshh3lk3";
+  };
+
+  propagatedBuildInputs = [
+    archinfo
+    bitstring
+    cffi
+    future
+    pycparser
+  ];
+
+  # No tests are available on PyPI, GitHub release has tests
+  # Switch to GitHub release after all angr parts are present
+  doCheck = false;
+  pythonImportsCheck = [ "pyvex" ];
+
+  meta = with lib; {
+    description = "Python interface to libVEX and VEX IR";
+    homepage = "https://github.com/angr/pyvex";
+    license = with licenses; [ bsd2 gpl3Plus lgpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -204,6 +204,8 @@ in {
 
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
+  ailment = callPackage ../development/python-modules/ailment { };
+
   aiocoap = callPackage ../development/python-modules/aiocoap { };
 
   aioconsole = callPackage ../development/python-modules/aioconsole { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6520,6 +6520,8 @@ in {
 
   pyvera = callPackage ../development/python-modules/pyvera { };
 
+  pyvex = callPackage ../development/python-modules/pyvex { };
+
   pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
 
   pyvips = callPackage ../development/python-modules/pyvips {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- ailment: https://github.com/angr/ailment
- pyvex: https://github.com/angr/pyvex

Those are an `angr` dependencies #67413. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
