### PR TITLE
promscale: 0.1.4 -> 0.2.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/promscale.nix
+++ b/pkgs/servers/monitoring/prometheus/promscale.nix
@@ -1,26 +1,35 @@
-{ stdenv
+{ lib
 , buildGoModule
 , fetchFromGitHub
 }:
 
 buildGoModule rec {
   pname = "promscale";
-  version = "0.1.4";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = pname;
     rev = version;
-    sha256 = "0179sw5zx552y14lr56adxcgas642xvxpqly6y4m9pi33r1gs8lj";
+    sha256 = "sha256-rXOAAd08NTWFRGnJoAY9xllw6dAA7Xu3qcImIVq9ewE=";
   };
 
-  vendorSha256 = "sha256:04gzf0siz96ar4qdkcw6daswy14i1zvl7ir200adhw1c5phppab6";
+  vendorSha256 = "sha256-/woSbtrOI3BVBhh+A2kO1CB1BLzBciwOqvSbGkFeMEU=";
 
   buildFlagsArray = [ "-ldflags=-s -w -X github.com/timescale/promscale/pkg/version.Version=${version} -X github.com/timescale/promscale/pkg/version.CommitHash=${src.rev}" ];
 
   doCheck = false; # Requires access to a docker daemon
+  doInstallCheck = true;
+  installCheckPhase = ''
+    if [[ "$("$out/bin/${pname}" -version)" == "${version}" ]]; then
+      echo '${pname} smoke check passed'
+    else
+      echo '${pname} smoke check failed'
+      exit 1
+    fi
+  '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "An open-source analytical platform for Prometheus metrics";
     homepage = "https://github.com/timescale/promscale";
     license = licenses.asl20;


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to [0.2.0](https://github.com/timescale/promscale/releases/tag/0.2.0).

This release adds support for TimescaleDB 2.0 multinode. This means all of TimescaleDB 2.0 features are now fully supported. This also means that Promscale now supports horizontal scalability across the entire stack!

This release also includes performance improvements and bug fixes.

At a high-level, this release:
- Adds support for Multinode TimescaleDB.
- Improved promQL query latency by 4x in some cases.
- Reduced I/O used by the PostgreSQL stats collector substantially by changing autovacuum settings.
- Fixed metrics produced by Promscale itself
- PromQL engine supports @ modifier which is disabled by default. (see promql-evaluation-flags)
- Added configuration for query timeout and default step interval
- Improved UX

Notes for people upgrading from 0.1.4 and before
- The CLI and ENV option install-timescaledb was renamed to install-extension
- Two new flags are added upgrade-extensions by default set to true will upgrade extensions if newer versions are available and upgrade-prerelease-extensions by default set to false enabling it will upgrade extensions to pre-prelease versions if pre-release versions are available.
- We have changed the namespace of the metrics Promscale itself exposes from ts_prom to promscale. We have also updated the PromQL engine based metrics to have namespace as promscale instead of prometheus. So, metrics like prometheus_engine_query_duration_seconds will now be promscale_engine_query_duration_seconds.

Prom-Migrator
- Adds support for concurrent pulling and pushing to improve migration throughput. (Please note concurrent push is disabled by default as we've seen some issues migrating data to Thanos concurrently, which we are still working out).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
