### PR TITLE
qemu: darwin fixes

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -118,8 +118,6 @@ stdenv.mkDerivation rec {
       "--enable-tools"
       "--enable-guest-agent"
     ]
-    # disable sysctl check on darwin.
-    ++ optional stdenv.isDarwin "--cpu=x86_64"
     ++ optional numaSupport "--enable-numa"
     ++ optional seccompSupport "--enable-seccomp"
     ++ optional smartcardSupport "--enable-smartcard"

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -108,6 +108,10 @@ stdenv.mkDerivation rec {
     # this script isn't marked as executable b/c it's indirectly used by meson. Needed to patch its shebang
     chmod +x ./scripts/shaderinclude.pl
     patchShebangs .
+    # avoid conflicts with libc++ include for <version>
+    mv VERSION QEMU_VERSION
+    substituteInPlace meson.build \
+      --replace "'VERSION'" "'QEMU_VERSION'"
   '' + optionalString stdenv.hostPlatform.isMusl ''
     NIX_CFLAGS_COMPILE+=" -D_LINUX_SYSINFO_H"
   '';

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -50,8 +50,9 @@ stdenv.mkDerivation rec {
     sha256 = "1g0pvx4qbirpcn9mni704y03n3lvkmw2c0rbcwvydyr8ns4xh66b";
   };
 
-  nativeBuildInputs = [ python python.pkgs.sphinx pkg-config flex bison meson ninja autoPatchelfHook ]
-    ++ optionals gtkSupport [ wrapGAppsHook ];
+  nativeBuildInputs = [ python python.pkgs.sphinx pkg-config flex bison meson ninja ]
+    ++ optionals gtkSupport [ wrapGAppsHook ]
+    ++ optionals stdenv.isLinux [ autoPatchelfHook ];
   buildInputs =
     [ zlib glib perl pixman
       vde2 texinfo makeWrapper lzo snappy


### PR DESCRIPTION
###### Motivation for this change

Three commits:

##### `qemu: do not force x86_64 cpu on darwin`

This change produces the following warning:

```
... configure: line 619: sysctl: command not found
```

It's benign and sysctl is only useful on MacOS X Leopard:

* https://github.com/qemu/qemu/blob/v5.2.0/configure#L615-L621

Leopard is 13 years old and is not supported by Nix.

The sysctl check is removed in qemu master branch already.

Plus aarch64-darwin is coming in #105026, so there's no reason to force x86_64.

##### `qemu: rename VERSION to QEMU_VERSION to avoid name clash`

In libc++ starting with LLVM8 there's `<version>` include in `cstddef`:

The following things also align:

* QEMU has a file called `VERSION` in repo root
* QEMU prepends repo root to include path in build
* macOS has a case-insensetive filesystem

All of this combined means that `VERSION` file is included as a header.

Working around this be renaming `VERSION` -> `QEMU_VERSION` to resolve ambiguity.

The problem really only appears on `aarch64-darwin`, since on `x86_64-darwin`
there are no C++ files to compile. The workaround is harmless enough to apply.

##### `qemu: only apply autoPatchelfHook on linux`

It fails on darwin due to missing `patchelf` and the missing ELFs:

```
/nix/store/...-auto-patchelf-hook/nix-support/setup-hook: line 220: -l: command not found
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64 + x86_64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
