### PR TITLE
mandoc: set HOMEBREWDIR on macOS

### DIFF
--- a/pkgs/tools/misc/mandoc/default.nix
+++ b/pkgs/tools/misc/mandoc/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     LD_OHASH="-lutil"
     BUILD_DB=0
     CC=${stdenv.cc.targetPrefix}cc
+  '' + lib.optionalString stdenv.isDarwin ''
+    HOMEBREWDIR="/usr/local/Cellar"
   '';
 
   patches = [


### PR DESCRIPTION
makewhatis(8) from mandoc does some validation of man pages before
indexing them. Among other things it checks if the realpath of the
man page is below the directory that is to be indexed.

For software installed with homebrew man pages under /usr/local/share/man
will be symlinked to /usr/local/Cellar making makewhatis skipping them
while indexing. Setting HOMEBREWDIR creates an exception for this case.

Setting this in nixpkgs

* doesn't hurt in any conceivable way
* accounts for the rare use case that somebody uses homebrew and nix on
  macOS and wants to index their man pages using makewhatis from
  nixpkgs.

As a side note: Yes HOMEBREWDIR could also be (ab)used to allow for
makewhatis indexing man pages on NixOS (which symlink from
/run/current-system/sw/share/man to somewhere in /nix/store). This could
then be used to write an alternative module to documentation.man which
uses mandoc instead of man-db.

I'm very interested in this and currently trying to get a proper patch
for the /nix/store situation into mandoc (ideally for Guix' /gnu/store
as well). If that works out I'm planning to contribute a module for
mandoc based man pages in NixOS.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
