### PR TITLE
pkgsStatic.linux-pam: Remove no longer necessary musl patches.

### DIFF
--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPackages, fetchurl, fetchpatch, flex, cracklib, db4, gettext
+{ lib, stdenv, buildPackages, fetchurl, flex, cracklib, db4, gettext
 , nixosTests
 }:
 
@@ -10,17 +10,6 @@ stdenv.mkDerivation rec {
     url    = "https://github.com/linux-pam/linux-pam/releases/download/v${version}/Linux-PAM-${version}.tar.xz";
     sha256 = "sha256-IB1AcwsRNbGzzeoJ8sKKxjTXMYHM0Bcs7d7jZJxXkvw=";
   };
-
-  patches = lib.optionals (stdenv.hostPlatform.libc == "musl") [
-    (fetchpatch {
-      url = "https://git.alpinelinux.org/aports/plain/main/linux-pam/fix-compat.patch?id=05a62bda8ec255d7049a2bd4cf0fdc4b32bdb2cc";
-      sha256 = "1h5yp5h2mqp1fcwiwwklyfpa69a3i03ya32pivs60fd7g5bqa7sf";
-    })
-    (fetchpatch {
-      url = "https://git.alpinelinux.org/aports/plain/main/linux-pam/libpam-fix-build-with-eglibc-2.16.patch?id=05a62bda8ec255d7049a2bd4cf0fdc4b32bdb2cc";
-      sha256 = "1ib6shhvgzinjsc603k2x1lxh9dic6qq449fnk110gc359m23j81";
-    })
-  ];
 
   outputs = [ "out" "doc" "man" /* "modules" */ ];
 


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/109906#issuecomment-775630916.

These Alpine patches:

    libpam-fix-build-with-eglibc-2.16.patch
    fix-compat.patch

were removed in https://git.alpinelinux.org/aports/commit/main/linux-pam?id=9ba93cf3f515b4f0b9b3802b84d42c4e436afe8b

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
