### PR TITLE
elm-format: 0.8.4 -> 0.8.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -904,6 +904,12 @@
     githubId = 687218;
     name = "averelld";
   };
+  avh4 = {
+    email = "gruen0aermel@gmail.com";
+    github = "avh4";
+    githubId = 1222;
+    name = "Aaron VonderHaar";
+  };
   avitex = {
     email = "theavitex@gmail.com";
     github = "avitex";

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -7,7 +7,7 @@
 let
   fetchElmDeps = import ./fetchElmDeps.nix { inherit stdenv lib fetchurl; };
 
-  hsPkgs = haskell.packages.ghc883.override {
+  hsPkgs = haskell.packages.ghc8103.override {
     overrides = self: super: with haskell.lib; with lib;
       let elmPkgs = rec {
             elm = overrideCabal (self.callPackage ./packages/elm.nix { }) (drv: {
@@ -79,6 +79,11 @@ let
 
         # Needed for elm-format
         indents = self.callPackage ./packages/indents.nix {};
+        bimap = self.callPackage ./packages/bimap.nix {};
+        avh4-lib = self.callPackage ./packages/avh4-lib.nix {};
+        elm-format-lib = self.callPackage ./packages/elm-format-lib.nix {};
+        elm-format-test-lib = self.callPackage ./packages/elm-format-test-lib.nix {};
+        elm-format-markdown = self.callPackage ./packages/elm-format-markdown.nix {};
       };
   };
 

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -41,7 +41,7 @@ let
               description = "Formats Elm source code according to a standard set of rules based on the official Elm Style Guide";
               homepage = "https://github.com/avh4/elm-format";
               license = licenses.bsd3;
-              maintainers = with maintainers; [ turbomack ];
+              maintainers = with maintainers; [ avh4 turbomack ];
             }));
 
             elmi-to-json = justStaticExecutables (overrideCabal (self.callPackage ./packages/elmi-to-json.nix {}) (drv: {

--- a/pkgs/development/compilers/elm/packages/avh4-lib.nix
+++ b/pkgs/development/compilers/elm/packages/avh4-lib.nix
@@ -1,0 +1,29 @@
+{ mkDerivation, ansi-terminal, ansi-wl-pprint, array, base, bimap
+, binary, bytestring, containers, directory, fetchgit, filepath
+, lib, mtl, process, relude, tasty, tasty-discover, tasty-hspec
+, tasty-hunit, text
+}:
+mkDerivation {
+  pname = "avh4-lib";
+  version = "0.0.0.1";
+  src = fetchgit {
+    url = "https://github.com/avh4/elm-format";
+    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
+    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/avh4-lib; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    ansi-terminal ansi-wl-pprint array base bimap binary bytestring
+    containers directory filepath mtl process relude text
+  ];
+  testHaskellDepends = [
+    ansi-terminal ansi-wl-pprint array base bimap binary bytestring
+    containers directory filepath mtl process relude tasty tasty-hspec
+    tasty-hunit text
+  ];
+  testToolDepends = [ tasty-discover ];
+  doHaddock = false;
+  description = "Common code for haskell projects";
+  license = lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/bimap.nix
+++ b/pkgs/development/compilers/elm/packages/bimap.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, containers, exceptions, lib, QuickCheck
+, template-haskell
+}:
+mkDerivation {
+  pname = "bimap";
+  version = "0.3.3";
+  sha256 = "73829355c7bcbd3eedba22a382a04a3ab641702b00828790ec082ec2db3a8ad1";
+  libraryHaskellDepends = [ base containers exceptions ];
+  testHaskellDepends = [
+    base containers exceptions QuickCheck template-haskell
+  ];
+  homepage = "https://github.com/joelwilliamson/bimap";
+  description = "Bidirectional mapping between two key types";
+  license = lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/elm-format-lib.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format-lib.nix
@@ -1,0 +1,33 @@
+{ mkDerivation, ansi-terminal, ansi-wl-pprint, array, avh4-lib
+, base, bimap, binary, bytestring, containers, directory
+, elm-format-markdown, elm-format-test-lib, fetchgit, filepath
+, indents, json, lib, mtl, optparse-applicative, parsec, process
+, relude, split, tasty, tasty-discover, tasty-hspec, tasty-hunit
+, text
+}:
+mkDerivation {
+  pname = "elm-format-lib";
+  version = "0.0.0.1";
+  src = fetchgit {
+    url = "https://github.com/avh4/elm-format";
+    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
+    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/elm-format-lib; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    ansi-terminal ansi-wl-pprint array avh4-lib base bimap binary
+    bytestring containers directory elm-format-markdown filepath
+    indents json mtl optparse-applicative parsec process relude text
+  ];
+  testHaskellDepends = [
+    ansi-terminal ansi-wl-pprint array avh4-lib base bimap binary
+    bytestring containers directory elm-format-markdown
+    elm-format-test-lib filepath indents json mtl optparse-applicative
+    parsec process relude split tasty tasty-hspec tasty-hunit text
+  ];
+  testToolDepends = [ tasty-discover ];
+  doHaddock = false;
+  description = "Common code used by elm-format and elm-refactor";
+  license = lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/elm-format-markdown.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format-markdown.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, containers, fetchgit, lib, mtl, text }:
+mkDerivation {
+  pname = "elm-format-markdown";
+  version = "0.0.0.1";
+  src = fetchgit {
+    url = "https://github.com/avh4/elm-format";
+    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
+    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/elm-format-markdown; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [ base containers mtl text ];
+  doHaddock = false;
+  description = "Markdown parsing for Elm documentation comments";
+  license = lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/elm-format-test-lib.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format-test-lib.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, avh4-lib, base, containers, fetchgit, filepath
+, hspec-core, hspec-golden, lib, mtl, split, tasty, tasty-discover
+, tasty-hspec, tasty-hunit, text
+}:
+mkDerivation {
+  pname = "elm-format-test-lib";
+  version = "0.0.0.1";
+  src = fetchgit {
+    url = "https://github.com/avh4/elm-format";
+    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
+    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/elm-format-test-lib; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    avh4-lib base containers filepath hspec-core hspec-golden mtl split
+    tasty tasty-hspec tasty-hunit text
+  ];
+  testHaskellDepends = [
+    avh4-lib base containers filepath hspec-core hspec-golden mtl split
+    tasty tasty-hspec tasty-hunit text
+  ];
+  testToolDepends = [ tasty-discover ];
+  doHaddock = false;
+  description = "Test helpers used by elm-format-tests and elm-refactor-tests";
+  license = lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -1,40 +1,40 @@
-{ mkDerivation, fetchgit, ansi-terminal, ansi-wl-pprint, array, base, binary
-, bytestring, cmark, containers, directory, filepath, free, HUnit
-, indents, json, mtl, optparse-applicative, parsec, process
-, QuickCheck, quickcheck-io, split, lib, tasty, tasty-golden
-, tasty-hunit, tasty-quickcheck, text
+{ mkDerivation, ansi-wl-pprint, avh4-lib, base, bimap, cmark
+, containers, elm-format-lib, elm-format-test-lib, fetchgit, json
+, lib, mtl, optparse-applicative, parsec, QuickCheck, quickcheck-io
+, relude, tasty, tasty-hspec, tasty-hunit, tasty-quickcheck, text
 }:
 mkDerivation {
   pname = "elm-format";
-  version = "0.8.4";
+  version = "0.8.5";
   src = fetchgit {
     url = "https://github.com/avh4/elm-format";
-    sha256 = "0cxlhhdjx4h9g03z83pxv91qrysbi0ab92rl52jb0yvkaix989ai";
-    rev = "5bd4fbe591fe8b456160c180cb875ef60bc57890";
+    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
+    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    fetchSubmodules = true;
   };
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    ansi-wl-pprint avh4-lib base containers elm-format-lib json
+    optparse-applicative relude text
+  ];
+  testHaskellDepends = [
+    ansi-wl-pprint avh4-lib base bimap cmark containers elm-format-lib
+    elm-format-test-lib json mtl optparse-applicative parsec QuickCheck
+    quickcheck-io relude tasty tasty-hspec tasty-hunit tasty-quickcheck
+    text
+  ];
+  doHaddock = false;
+  homepage = "https://elm-lang.org";
+  description = "A source code formatter for Elm";
+  license = lib.licenses.bsd3;
   postPatch = ''
     mkdir -p ./generated
     cat <<EOHS > ./generated/Build_elm_format.hs
     module Build_elm_format where
 
     gitDescribe :: String
-    gitDescribe = "0.8.4"
+    gitDescribe = "0.8.5"
     EOHS
   '';
-  isLibrary = false;
-  isExecutable = true;
-  libraryHaskellDepends = [
-    ansi-terminal ansi-wl-pprint array base binary bytestring
-    containers directory filepath free indents json mtl
-    optparse-applicative parsec process split text
-  ];
-  executableHaskellDepends = [ base ];
-  testHaskellDepends = [
-    base cmark containers HUnit mtl parsec QuickCheck quickcheck-io
-    split tasty tasty-golden tasty-hunit tasty-quickcheck text
-  ];
-  doHaddock = false;
-  homepage = "https://elm-lang.org";
-  description = "A source code formatter for Elm";
-  license = lib.licenses.bsd3;
 }

--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -3,7 +3,7 @@
 , lib, mtl, optparse-applicative, parsec, QuickCheck, quickcheck-io
 , relude, tasty, tasty-hspec, tasty-hunit, tasty-quickcheck, text
 }:
-mkDerivation {
+mkDerivation rec {
   pname = "elm-format";
   version = "0.8.5";
   src = fetchgit {
@@ -34,7 +34,7 @@ mkDerivation {
     module Build_elm_format where
 
     gitDescribe :: String
-    gitDescribe = "0.8.5"
+    gitDescribe = "${version}"
     EOHS
   '';
 }

--- a/pkgs/development/compilers/elm/packages/indents.nix
+++ b/pkgs/development/compilers/elm/packages/indents.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, base, concatenative, mtl, parsec, lib }:
+{ mkDerivation, base, concatenative, lib, mtl, parsec }:
 mkDerivation {
   pname = "indents";
   version = "0.3.3";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New release of elm-format.

Notes:
- elm-format is now split into a few internal packages, which are now added via cabal2nix
- bimap-0.3.3 is added temporarily.  I think 0.4.0 should be safe to switch to (though haven't tried it yet), but I'd have to cut a new release tag to relax the version bounds.
- elm-format now uses ghc-8.10.4; I switched pkgs/development/compilers/elm/default.nix to use 8.10.3 instead of 8.8.3.  I tried building elm, elmi-to-json, and elm-instrument and they all seemed to work fine, but I think elm-format would also probably compile okay with 8.8.3 (though I didn't check for sure).   I think ideally things should be set up to allow the different tools to have different ghc versions, esp as I'm planning to move elm-format to ghc-9 in the next release, but I'm not sure I know enough about nixpkgs to attempt a change like that.

cc @turboMaCk  @domenkozar  


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
