### PR TITLE
stdenv/patchShebangs: fix off by one reading old interpreter

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -51,7 +51,7 @@ patchShebangs() {
         isScript "$f" || continue
 
         read -r oldInterpreterLine < "$f"
-        read -r oldPath arg0 args <<< "${oldInterpreterLine:3}"
+        read -r oldPath arg0 args <<< "${oldInterpreterLine:2}"
 
         if [[ -z "$pathName" ]]; then
             if [[ -n $strictDeps && $f == "$NIX_STORE"* ]]; then

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -88,17 +88,15 @@ patchShebangs() {
         newInterpreterLine=${newInterpreterLine%${newInterpreterLine##*[![:space:]]}}
 
         if [[ -n "$oldPath" && "${oldPath:0:${#NIX_STORE}}" != "$NIX_STORE" ]]; then
-            if [[ -n "$newPath" ]] && [[ "$newPath" != "$oldPath" ]]; then
+            if [[ -n "$newPath" && "$newPath" != "$oldPath" ]]; then
                 echo "$f: interpreter directive changed from \"$oldInterpreterLine\" to \"$newInterpreterLine\""
                 # escape the escape chars so that sed doesn't interpret them
                 escapedInterpreterLine=${newInterpreterLine//\\/\\\\}
 
                 # Preserve times, see: https://github.com/NixOS/nixpkgs/pull/33281
-                timestamp=$(mktemp)
-                touch -r "$f" "$timestamp"
+                timestamp=$(stat --printf "%y" "$f")
                 sed -i -e "1 s|.*|#\!$escapedInterpreterLine|" "$f"
-                touch -r "$timestamp" "$f"
-                rm "$timestamp"
+                touch --date "$timestamp" "$f"
             fi
         fi
     done < <(find "$@" -type f -perm -0100 -print0)

--- a/pkgs/test/patch-shebangs/default.nix
+++ b/pkgs/test/patch-shebangs/default.nix
@@ -1,26 +1,70 @@
 { lib, stdenv, runCommand }:
 
 let
-  bad-shebang = stdenv.mkDerivation {
-    name         = "bad-shebang";
-    dontUnpack = true;
-    installPhase = ''
-      mkdir -p $out/bin
-      echo "#!/bin/sh" > $out/bin/test
-      echo "echo -n hello" >> $out/bin/test
-      chmod +x $out/bin/test
-    '';
+  tests = {
+    bad-shebang = stdenv.mkDerivation {
+      name         = "bad-shebang";
+      dontUnpack = true;
+      installPhase = ''
+        mkdir -p $out/bin
+        echo "#!/bin/sh" > $out/bin/test
+        echo "echo -n hello" >> $out/bin/test
+        chmod +x $out/bin/test
+      '';
+      passthru = {
+        assertion = "grep -v '^#!/bin/sh' $out/bin/test > /dev/null";
+      };
+    };
+
+    ignores-nix-store = stdenv.mkDerivation {
+      name = "ignores-nix-store";
+      dontUnpack = true;
+      installPhase = ''
+        mkdir -p $out/bin
+        echo "#!$NIX_STORE/path/to/sh" > $out/bin/test
+        echo "echo -n hello" >> $out/bin/test
+        chmod +x $out/bin/test
+      '';
+      passthru = {
+        assertion = "grep \"^#!$NIX_STORE/path/to/sh\" $out/bin/test > /dev/null";
+      };
+    };
   };
 in runCommand "patch-shebangs-test" {
-  passthru = { inherit bad-shebang; };
+  passthru = { inherit (tests) bad-shebang ignores-nix-store; };
   meta.platforms = lib.platforms.all;
 } ''
-  printf "checking whether patchShebangs works properly... ">&2
-  if ! grep -q '^#!/bin/sh' ${bad-shebang}/bin/test; then
-    echo "yes" >&2
-    touch $out
-  else
-    echo "no" >&2
+  validate() {
+    local name=$1
+    local testout=$2
+    local assertion=$3
+
+    echo -n "... $name: " >&2
+
+    local rc=0
+    (out=$testout eval "$assertion") || rc=1
+
+    if [ "$rc" -eq 0 ]; then
+      echo "yes" >&2
+    else
+      echo "no" >&2
+    fi
+
+    return "$rc"
+  }
+
+  echo "checking whether patchShebangs works properly... ">&2
+
+  fail=
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (_: test: ''
+    validate "${test.name}" "${test}" ${lib.escapeShellArg test.assertion} || fail=1
+  '') tests)}
+
+  if [ "$fail" ]; then
+    echo "failed"
     exit 1
+  else
+    echo "succeeded"
+    touch $out
   fi
 ''


### PR DESCRIPTION
###### Motivation for this change

Fix an off-by-one introduced in #94642, and add a test.

Sending straight to `staging-next` because it fixes a subtle bug present in `staging-next`.

Fixes #112417

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
