### PR TITLE
nixos/docker: increase inotify user instances

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -150,6 +150,8 @@ in
 
   config = mkIf cfg.enable (mkMerge [{
       boot.kernelModules = [ "bridge" "veth" ];
+      # The kernel default of 128 is easily reached with containers.
+      boot.kernel.sysctl."fs.inotify.max_user_instances" = mkDefault 8192;
       environment.systemPackages = [ cfg.package ]
         ++ optional cfg.enableNvidia pkgs.nvidia-docker;
       users.groups.docker.gid = config.ids.gids.docker;


### PR DESCRIPTION
###### Motivation for this change

Per issue #36214, it's really common to run into limits here with the
kernel default of '128'.

One easy way to hit this limit is to run ~130 containers, and then run
software that tails their logs in realtime (such as to aggregate them),
since each call to 'docker logs' uses an inotify user instance.

This increases it to a value recommended in an upstream issue.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (`nix-build nixos/tests/docker.nix`)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
