### PR TITLE
gnu-config: 2020-05-04 -> 2021-01-25

### DIFF
--- a/pkgs/development/libraries/gnu-config/default.nix
+++ b/pkgs/development/libraries/gnu-config/default.nix
@@ -1,20 +1,20 @@
 { lib, stdenv, fetchurl }:
 
 let
-  rev = "e78c96e5288993aaea3ec44e5c6ee755c668da79";
+  rev = "6faca61810d335c7837f320733fe8e15a1431fc2";
 
   # Don't use fetchgit as this is needed during Aarch64 bootstrapping
   configGuess = fetchurl {
     url = "https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=${rev}";
-    sha256 = "sha256-TSLpYIDGSp1flqCBi2Sgg9IWDV5bcO+Hn2Menv3R6KU=";
+    sha256 = "06wkkhpbx9slmknr2g7mcd8x3zsdhnmmay25l31h3rkdp1wkq7kx";
   };
   configSub = fetchurl {
     url = "https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=${rev}";
-    sha256 = "sha256-DkCGDN/DE3phQ1GO/Ua5ZPPtp0Ya93PnW3yfSK8EV9s=";
+    sha256 = "1qkph8cqanmgy3s4a18bm1a4vk62i8pf8cy5pc1hkpqwn4g6l0di";
   };
 in stdenv.mkDerivation {
   pname = "gnu-config";
-  version = "2020-05-04";
+  version = "2021-01-25";
 
   buildCommand = ''
     mkdir -p $out


### PR DESCRIPTION
###### Motivation for this change

Package update to support newer platforms, like Apple Silicon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
