### PR TITLE
python3Packages.pysmt: init at 0.9.0, python3Packages.claripy: init at 9.0.5739

### DIFF
--- a/pkgs/development/python-modules/claripy/default.nix
+++ b/pkgs/development/python-modules/claripy/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, cachetools
+, decorator
+, fetchFromGitHub
+, future
+, nose
+, pysmt
+, pythonOlder
+, pytestCheckHook
+, z3
+}:
+
+buildPythonPackage rec {
+  pname = "claripy";
+  version = "9.0.5739";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "angr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1aym01f99zwb9w8qwy8gz631ka7g6akzdld0m4ykc5ip0rq70mki";
+  };
+
+  # Use upstream z3 implementation
+  postPatch = ''
+    substituteInPlace setup.py --replace "z3-solver>=4.8.5.0" ""
+  '';
+
+  propagatedBuildInputs = [
+    cachetools
+    decorator
+    future
+    pysmt
+    z3
+  ];
+
+  checkInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "claripy" ];
+
+  meta = with lib; {
+    description = "Python abstraction layer for constraint solvers";
+    homepage = "https://github.com/angr/claripy";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pysmt/default.nix
+++ b/pkgs/development/python-modules/pysmt/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nose
+, pytestCheckHook
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "pysmt";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "051j36kpz11ik9bhvp5jgxzc3h7f18i1pf5ssdhjwyabr0n0zra3";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pysmt" ];
+
+  meta = with lib; {
+    description = "Python library for SMT formulae manipulation and solving";
+    homepage = "https://github.com/pysmt/pysmt";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5947,6 +5947,8 @@ in {
 
   pysmi = callPackage ../development/python-modules/pysmi { };
 
+  pysmt = callPackage ../development/python-modules/pysmt { };
+
   pysnmp = callPackage ../development/python-modules/pysnmp { };
 
   pysnooper = callPackage ../development/python-modules/pysnooper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1281,6 +1281,8 @@ in {
 
   class-registry = callPackage ../development/python-modules/class-registry { };
 
+  claripy =  callPackage ../development/python-modules/claripy { };
+
   cld2-cffi = callPackage ../development/python-modules/cld2-cffi { };
 
   cleo = callPackage ../development/python-modules/cleo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- pysmt: https://github.com/pysmt/pysmt
- claripy: https://github.com/angr/claripy

`claripy` is an `angr` dependencies #67413. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
