### PR TITLE
nixos/bluetooth: add support for disabling plugins

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -1,12 +1,39 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.hardware.bluetooth;
-  bluez-bluetooth = cfg.package;
+  package = cfg.package;
 
-in {
+  inherit (lib)
+    mkDefault mkEnableOption mkIf mkOption
+    mkRenamedOptionModule mkRemovedOptionModule
+    concatStringsSep escapeShellArgs
+    optional optionals optionalAttrs recursiveUpdate types;
+
+  cfgFmt = pkgs.formats.ini { };
+
+  # bluez will complain if some of the sections are not found, so just make them
+  # empty (but present in the file) for now
+  defaults = {
+    General.ControllerMode = "dual";
+    Controller = { };
+    GATT = { };
+    Policy.AutoEnable = cfg.powerOnBoot;
+  };
+
+  hasDisabledPlugins = builtins.length cfg.disabledPlugins > 0;
+
+in
+{
+  imports = [
+    (mkRenamedOptionModule [ "hardware" "bluetooth" "config" ] [ "hardware" "bluetooth" "settings" ])
+    (mkRemovedOptionModule [ "hardware" "bluetooth" "extraConfig" ] ''
+      Use hardware.bluetooth.settings instead.
+
+      This is part of the general move to use structured settings instead of raw
+      text for config as introduced by RFC0042:
+      https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md
+    '')
+  ];
 
   ###### interface
 
@@ -18,7 +45,7 @@ in {
       hsphfpd.enable = mkEnableOption "support for hsphfpd[-prototype] implementation";
 
       powerOnBoot = mkOption {
-        type    = types.bool;
+        type = types.bool;
         default = true;
         description = "Whether to power up the default Bluetooth controller on boot.";
       };
@@ -38,8 +65,15 @@ in {
         '';
       };
 
-      config = mkOption {
-        type = with types; attrsOf (attrsOf (oneOf [ bool int str ]));
+      disabledPlugins = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Built-in plugins to disable";
+      };
+
+      settings = mkOption {
+        type = cfgFmt.type;
+        default = { };
         example = {
           General = {
             ControllerMode = "bredr";
@@ -47,79 +81,65 @@ in {
         };
         description = "Set configuration for system-wide bluetooth (/etc/bluetooth/main.conf).";
       };
-
-      extraConfig = mkOption {
-        type = with types; nullOr lines;
-        default = null;
-        example = ''
-          [General]
-          ControllerMode = bredr
-        '';
-        description = ''
-          Set additional configuration for system-wide bluetooth (/etc/bluetooth/main.conf).
-        '';
-      };
     };
-
   };
 
   ###### implementation
 
   config = mkIf cfg.enable {
-    warnings = optional (cfg.extraConfig != null) "hardware.bluetooth.`extraConfig` is deprecated, please use hardware.bluetooth.`config`.";
+    environment.systemPackages = [ package ]
+      ++ optional cfg.hsphfpd.enable pkgs.hsphfpd;
 
-    hardware.bluetooth.config = {
-      Policy = {
-        AutoEnable = mkDefault cfg.powerOnBoot;
-      };
-    };
-
-    environment.systemPackages = [ bluez-bluetooth ]
-      ++ optionals cfg.hsphfpd.enable [ pkgs.hsphfpd ];
-
-    environment.etc."bluetooth/main.conf"= {
-      source = pkgs.writeText "main.conf"
-        (generators.toINI { } cfg.config + optionalString (cfg.extraConfig != null) cfg.extraConfig);
-    };
-
-    services.udev.packages = [ bluez-bluetooth ];
-    services.dbus.packages = [ bluez-bluetooth ]
-      ++ optionals cfg.hsphfpd.enable [ pkgs.hsphfpd ];
-    systemd.packages       = [ bluez-bluetooth ];
+    environment.etc."bluetooth/main.conf".source =
+      cfgFmt.generate "main.conf" (recursiveUpdate defaults cfg.settings);
+    services.udev.packages = [ package ];
+    services.dbus.packages = [ package ]
+      ++ optional cfg.hsphfpd.enable pkgs.hsphfpd;
+    systemd.packages = [ package ];
 
     systemd.services = {
-      bluetooth = {
-        wantedBy = [ "bluetooth.target" ];
-        aliases  = [ "dbus-org.bluez.service" ];
-        # restarting can leave people without a mouse/keyboard
-        unitConfig.X-RestartIfChanged = false;
-      };
-    }
-      // (optionalAttrs cfg.hsphfpd.enable {
-        hsphfpd = {
-          after = [ "bluetooth.service" ];
-          requires = [ "bluetooth.service" ];
-          wantedBy = [ "multi-user.target" ];
-
-          description = "A prototype implementation used for connecting HSP/HFP Bluetooth devices";
-          serviceConfig.ExecStart = "${pkgs.hsphfpd}/bin/hsphfpd.pl";
+      bluetooth =
+        let
+          # `man bluetoothd` will refer to main.conf in the nix store but bluez
+          # will in fact load the configuration file at /etc/bluetooth/main.conf
+          # so force it here to avoid any ambiguity and things suddenly breaking
+          # if/when the bluez derivation is changed.
+          args = [ "-f /etc/bluetooth/main.conf" ]
+            ++ optional hasDisabledPlugins
+            "--noplugin=${concatStringsSep "," cfg.disabledPlugins}";
+        in
+        {
+          wantedBy = [ "bluetooth.target" ];
+          aliases = [ "dbus-org.bluez.service" ];
+          serviceConfig.ExecStart = [
+            ""
+            "${package}/libexec/bluetooth/bluetoothd ${escapeShellArgs " " args}"
+          ];
+          # restarting can leave people without a mouse/keyboard
+          unitConfig.X-RestartIfChanged = false;
         };
-      })
-      ;
+    }
+    // (optionalAttrs cfg.hsphfpd.enable {
+      hsphfpd = {
+        after = [ "bluetooth.service" ];
+        requires = [ "bluetooth.service" ];
+        wantedBy = [ "bluetooth.target" ];
+
+        description = "A prototype implementation used for connecting HSP/HFP Bluetooth devices";
+        serviceConfig.ExecStart = "${pkgs.hsphfpd}/bin/hsphfpd.pl";
+      };
+    });
 
     systemd.user.services = {
       obex.aliases = [ "dbus-org.bluez.obex.service" ];
     }
-      // (optionalAttrs cfg.hsphfpd.enable {
-        telephony_client = {
-          wantedBy = [ "default.target"];
+    // optionalAttrs cfg.hsphfpd.enable {
+      telephony_client = {
+        wantedBy = [ "default.target" ];
 
-          description = "telephony_client for hsphfpd";
-          serviceConfig.ExecStart = "${pkgs.hsphfpd}/bin/telephony_client.pl";
-        };
-      })
-      ;
-
+        description = "telephony_client for hsphfpd";
+        serviceConfig.ExecStart = "${pkgs.hsphfpd}/bin/telephony_client.pl";
+      };
+    };
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

bluez will complain if it tries to activate a built-in plugin that for whatever
reason doesn't work with your hardware so give an option to disable any broken plugin(s).

Additionally:
1. rename `hardware.bluetooth.config` to `.settings` as is the canonical name for these things
2. drop `hardware.bluetooth.extraConfig` (which was deprecated anyway) in favour of `.settings`
3. be specific about the `main.conf` config file being loaded to avoid ambiguity
4. assorted cleanups

This PR is noisier than it should be due to `nixpkgs-fmt` doing its thing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
