### PR TITLE
just: 0.8.3 -> 0.8.4

### DIFF
--- a/pkgs/development/tools/just/default.nix
+++ b/pkgs/development/tools/just/default.nix
@@ -18,9 +18,10 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     installManPage man/just.1
 
-    installShellCompletion --bash --name just.bash completions/just.bash
-    installShellCompletion --fish --name just.fish completions/just.fish
-    installShellCompletion --zsh  --name _just     completions/just.zsh
+    installShellCompletion --cmd just \
+      --bash completions/just.bash \
+      --fish completions/just.fish \
+      --zsh  completions/just.zsh
   '';
 
   checkInputs = [ coreutils bash ];

--- a/pkgs/development/tools/just/default.nix
+++ b/pkgs/development/tools/just/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "just";
-  version = "0.8.3";
+  version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = "casey";
     repo = pname;
     rev = "v${version}";
-    sha256 = "4B72VYQ+HBvhGQNl577DuZpvWNIvv/6fejRQtVKtFKY=";
+    sha256 = "sha256-K8jeX1/Wn6mbf48GIR2wRAwiwg1rxtbtCPjjH+4dPYw=";
   };
 
-  cargoSha256 = "uOOpDRWPSoH49NTu82rDxxDR/2icoe4ECxVQb/J/45w=";
+  cargoSha256 = "sha256-a9SBeX3oesdoC5G+4dK2tbt+W7VA4jPqCM9tOAex4DI=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

@xrelkd

- 0.8.3 -> 0.8.4
- use new installShellCompletion style

Structure before:

```
 result ⇒ /nix/store/lswqbqf9kzfvnkhk76kamz83pxm9pmfv-just-0.8.4
├──  bin
│  └──  just
└──  share
   ├──  bash-completion
   │  └──  completions
   │     └──  just.bash
   ├──  fish
   │  └──  vendor_completions.d
   │     └──  just.fish
   ├──  man
   │  └──  man1
   │     └──  just.1.gz
   └──  zsh
      └──  site-functions
         └──  _just
```

After:

```
 result ⇒ /nix/store/l0h01k0rfvn3fybnic1q6g779l63w2yk-just-0.8.4
├──  bin
│  └──  just
└──  share
   ├──  bash-completion
   │  └──  completions
   │     └──  just.bash
   ├──  fish
   │  └──  vendor_completions.d
   │     └──  just.fish
   ├──  man
   │  └──  man1
   │     └──  just.1.gz
   └──  zsh
      └──  site-functions
         └──  _just
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
