### PR TITLE
cudatext: 1.122.3 → 1.129.3

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.122.3";
+  version = "1.129.3";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "1h56hj433z0n4l97zl1cwkjv0qvz4qmvf469zzjzf1nj4zj8px2b";
+    sha256 = "1sg9wg6w3w0phrnnzpj7h2g22y0x7a3dl57djzydayxmg8fnn2ys";
   };
 
   postPatch = ''
@@ -91,7 +91,12 @@ stdenv.mkDerivation rec {
     install -Dm644 setup/debfiles/cudatext-512.png -t $out/share/pixmaps
     install -Dm644 setup/debfiles/cudatext.desktop -t $out/share/applications
   '' + lib.concatMapStringsSep "\n" (lexer: ''
-    install -Dm644 CudaText-lexers/${lexer}/*.{cuda-lexmap,lcf} $out/share/cudatext/data/lexlib
+    if [ -d "CudaText-lexers/${lexer}" ]; then
+      install -Dm644 CudaText-lexers/${lexer}/*.{cuda-lexmap,lcf} $out/share/cudatext/data/lexlib
+    else
+      echo "${lexer} lexer not found"
+      exit 1
+    fi
   '') additionalLexers;
 
   meta = with lib; {

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -6,38 +6,38 @@
   },
   "ATBinHex-Lazarus": {
     "owner": "Alexey-T",
-    "rev": "2020.11.22",
-    "sha256": "0dkvzm32ls03pfp40fxvsyrkfmyznc5yrj65cp4a8pp9kpkvzlz7"
+    "rev": "2021.02.13",
+    "sha256": "1p2r2q1al6rcsdbbg8ilm4xn6w48bj348khxdmpak7vfwx9741h8"
   },
   "ATFlatControls": {
     "owner": "Alexey-T",
-    "rev": "2021.01.12",
-    "sha256": "1mavv3krs4srdp362prf4sncssxjh11la5j4lkx0wk5csrmd1pc9"
+    "rev": "2021.03.05",
+    "sha256": "1p2pzha5dd4p23j2bv6jxphj596dlb5v8ixjzg4x2zglz2hir6yz"
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2021.01.19",
-    "sha256": "0lpgfwljwh9mypscbpj5c7fivhza0hizjgqypval3v0209cx38d1"
+    "rev": "2021.03.16",
+    "sha256": "1sq9j2zaif019gl6nf391lyp8k9s38f5s6ci7k3z5v90hkz1dcql"
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
-    "rev": "2021.01.17",
-    "sha256": "14i4jdpbmh6sjpvbwipdvvmmqqw8wg592b34a9wdf2f9qxq2p4ly"
+    "rev": "2021.03.08",
+    "sha256": "0xvnvx4qzp6nxi912i4zlnal91k6vbcsyfbz05ib73sz68xqd5qv"
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2021.01.12",
-    "sha256": "107zyd65vc72fl4mvyirhv2a9m47l9bs6gwqiwar7hrn02zns6bq"
+    "rev": "2021.03.16",
+    "sha256": "159s1rpl829bmaa4bllqhjm8z0vji1ncsd6hw2s8z8hz28n905k8"
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",
-    "rev": "2020.10.04",
-    "sha256": "0z66cm9pgdi7whqaim6hva4aa08zrr1881n1fal7lnz6wlla824k"
+    "rev": "2021.03.16",
+    "sha256": "1a4mxcwjm9naxh4piqm5y93w2xd5rgl0vcn108wy1pkr221agg2q"
   },
   "Python-for-Lazarus": {
     "owner": "Alexey-T",
-    "rev": "2021.01.16",
-    "sha256": "07qv3x1cm3r12gxfnqzxly6nff39bghwwgxzl2lxi1qbpqhcs2l5"
+    "rev": "2021.02.18",
+    "sha256": "0fy6bmpdcl2aa8pb7zban6midkfwdj99x14hdghrv7cp8l4gcsg5"
   },
   "Emmet-Pascal": {
     "owner": "Alexey-T",
@@ -46,8 +46,8 @@
   },
   "CudaText-lexers": {
     "owner": "Alexey-T",
-    "rev": "2021.01.16",
-    "sha256": "13zyg0cm1c1662l3f7sy462pbc39l1cwm5214nx8ijngf8kgn2zh"
+    "rev": "2021.02.01",
+    "sha256": "051jnrhfpl9n5pgrssf68lj732zxhvjbvna4746ngmdyxvw6dqfd"
   },
   "bgrabitmap": {
     "owner": "bgrabitmap",


### PR DESCRIPTION
###### Motivation for this change
[Changelog](http://uvviewsoft.com/cudatext/history.txt)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
