### PR TITLE
git: add osxkeychainSupport option

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -8,6 +8,7 @@
 , svnSupport, subversionClient, perlLibs, smtpPerlLibs
 , perlSupport ? true
 , nlsSupport ? true
+, osxkeychainSupport ? stdenv.isDarwin
 , guiSupport
 , withManual ? true
 , pythonSupport ? true
@@ -19,6 +20,7 @@
 , gzip # needed at runtime by gitweb.cgi
 }:
 
+assert osxkeychainSupport -> stdenv.isDarwin;
 assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
@@ -115,7 +117,7 @@ stdenv.mkDerivation {
     make -C contrib/subtree
   '' + (lib.optionalString perlSupport ''
     make -C contrib/diff-highlight
-  '') + (lib.optionalString stdenv.isDarwin ''
+  '') + (lib.optionalString osxkeychainSupport ''
     make -C contrib/credential/osxkeychain
   '') + (lib.optionalString withLibsecret ''
     make -C contrib/credential/libsecret
@@ -129,7 +131,7 @@ stdenv.mkDerivation {
 
   installFlags = [ "NO_INSTALL_HARDLINKS=1" ];
 
-  preInstall = (lib.optionalString stdenv.isDarwin ''
+  preInstall = (lib.optionalString osxkeychainSupport ''
     mkdir -p $out/bin
     ln -s $out/share/git/contrib/credential/osxkeychain/git-credential-osxkeychain $out/bin/
     rm -f $PWD/contrib/credential/osxkeychain/git-credential-osxkeychain.o
@@ -248,8 +250,8 @@ stdenv.mkDerivation {
          notSupported "$out/$prog"
        done
      '')
-   + lib.optionalString stdenv.isDarwin ''
-    # enable git-credential-osxkeychain by default if darwin
+   + lib.optionalString osxkeychainSupport ''
+    # enable git-credential-osxkeychain on darwin if desired (default)
     mkdir -p $out/etc
     cat > $out/etc/gitconfig << EOF
     [credential]


### PR DESCRIPTION
##### Motivation for this change

add a new `osxkeychainSupport` option to `git` package in order to be able to disable osxkeychain credential helper if no
wanted / necessary. Keep it `true` by default such that current logic is not affected.

I personally prefer [`git-pass-helper`](https://github.com/languitar/pass-git-helper) to manage my secrets because it is platform independent.


##### Workaround

Set environment variable `GIT_CONFIG_NOSYSTEM=1` which ignores all config from `/etc/gitconfig`.


##### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (-> on macOS)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date (-> however not sure if I overlooked some documentation)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


##### Disclaimer

* I am quite new to `nix` ecosystem and the first system I ported was a new MacBook and therefore MacOS. All other systems do not run nix yet but I am working on it.
* I didn't manage to test it using new `osxkeychainSupport` as it seems that my `--arg osxkeychainSupport false` is ignored while building `git` with `nix-build --argstr osxkeychainSupport false -A git -I $(pwd)` :-( (the resulting `git` works however but still has `/etc/gitconfig` with credential helper)
* However using `nix-build --argstr system "i686-linux" -A git -I $(pwd)` works and tries to generate new derivations...

Any help is appreciated :-)
