### PR TITLE
minizinc, minizincide: 2.4.3 -> 2.5.3

### DIFF
--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, flex, bison }:
+{ lib, stdenv, fetchFromGitHub, cmake, flex, bison }:
 let
-  version = "2.4.3";
+  version = "2.5.3";
 in
 stdenv.mkDerivation {
   pname = "minizinc";
@@ -12,27 +12,8 @@ stdenv.mkDerivation {
     owner = "MiniZinc";
     repo = "libminizinc";
     rev = version;
-    sha256 = "0mahf621zwwywimly5nd6j39j7qr48k5p7zwpfqnjq4wn010mbf8";
+    sha256 = "1kc65sxkc64pr560qaaznc44jnlvq7pbpzwijad410lpcnna5byg";
   };
-
-  patches = [
-    # Fix build with newer Bison versions:
-    # https://github.com/MiniZinc/libminizinc/issues/389
-    (fetchpatch {
-      url = "https://github.com/MiniZinc/libminizinc/commit/d3136f6f198d3081943c17ac6890dbe14a81d112.diff";
-      sha256 = "1f4wxn9422ndgq6dd0vqdxm2313srm7gn9nh82aas2xijdxlmz2c";
-    })
-    (fetchpatch {
-      name = "bison-3.7-compat-1.patch";
-      url = "https://github.com/MiniZinc/libminizinc/commit/8d4dcf302e78231f7c2665150e8178cacd06f91c.patch";
-      sha256 = "1wgciyrqijv7b4wqha94is5skji8j7b9wq6fkdsnsimfd3xpxhqw";
-    })
-    (fetchpatch {
-      name = "bison-3.7-compat-2.patch";
-      url = "https://github.com/MiniZinc/libminizinc/commit/952ffda0bd23dc21f83d3e3f080ea5b3a414e8e0.patch";
-      sha256 = "0cnsfqw0hwm7rmazqnb99725rm2vdwab75vdpr5x5l3kjwsn76rj";
-    })
-  ];
 
   meta = with lib; {
     homepage = "https://www.minizinc.org/";

--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -1,19 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, qtbase, qtwebengine, qtwebkit, qmake, makeWrapper, minizinc }:
+{ lib, mkDerivation, fetchFromGitHub, qtbase, qtwebengine, qtwebkit, qmake, minizinc }:
 let
-  version = "2.4.3";
+  version = "2.5.3";
 in
-stdenv.mkDerivation {
+mkDerivation {
   pname = "minizinc-ide";
   inherit version;
 
-  nativeBuildInputs = [ qmake makeWrapper ];
+  nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase qtwebengine qtwebkit ];
 
   src = fetchFromGitHub {
     owner = "MiniZinc";
     repo = "MiniZincIDE";
     rev = version;
-    sha256 = "0dfqh73rnp00336pyr1hlgl1wb4m2kh28zvdkamjgml60gmg6wdr";
+    sha256 = "1c80ilb1xbgzfadgal668h2zsaiv62il1jnljizrisgb7pszzyzw";
+    fetchSubmodules = true;
   };
 
   sourceRoot = "source/MiniZincIDE";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR updates minizinc and minizincide from versions 2.4.3 to 2.5.3 respectively.

The patches are no longer necessary as of https://github.com/MiniZinc/libminizinc/commit/952ffda0bd23dc21f83d3e3f080ea5b3a414e8e0.

For the IDE, `mkDerivation` is used so that Qt works and submodules must be fetched, since there is a new submodule that needs to be feched (see https://github.com/MiniZinc/MiniZincIDE/commit/9a8bb28f7d6784581f9da96a1355de3b23bacaa0).

This is related to #104331.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
