### PR TITLE
python3Packages.py-multicodec: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/py-multicodec/default.nix
+++ b/pkgs/development/python-modules/py-multicodec/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-runner
+, pytestCheckHook
+, pythonOlder
+, morphys
+, six
+, varint
+}:
+
+buildPythonPackage rec {
+  pname = "py-multicodec";
+  version = "0.2.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "multiformats";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-2aK+bfhqCMqSO+mtrHIfNQmQpQHpwd7yHseI/3O7Sp4=";
+  };
+
+  # Error when not substituting:
+  # Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "[pytest]" "[tool:pytest]"
+  '';
+
+  nativeBuildInputs = [
+    pytest-runner
+  ];
+
+  propagatedBuildInputs = [
+    varint
+    six
+    morphys
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "multicodec" ];
+
+  meta = with lib; {
+    description = "Compact self-describing codecs";
+    homepage = "https://github.com/multiformats/py-multicodec";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5666,6 +5666,8 @@ in {
 
   py-multibase = callPackage ../development/python-modules/py-multibase { };
 
+  py-multicodec = callPackage ../development/python-modules/py-multicodec { };
+
   py-multihash = callPackage ../development/python-modules/py-multihash { };
 
   pymumble = callPackage ../development/python-modules/pymumble { };


### PR DESCRIPTION
###### Motivation for this change
This adds py-multicodec from https://github.com/multiformats/py-multicodec.
This is the first python package I'm adding to nixpkgs, so I welcome any improvement suggestions.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).