### PR TITLE
spaceFM: Avoid segfault when running under Wayland

### DIFF
--- a/pkgs/applications/misc/spacefm/default.nix
+++ b/pkgs/applications/misc/spacefm/default.nix
@@ -13,7 +13,13 @@ stdenv.mkDerivation rec {
     sha256 = "089r6i40lxcwzp60553b18f130asspnzqldlpii53smz52kvpirx";
   };
 
-  patches = [ ./glibc-fix.patch ];
+  patches = [
+    # fix compilation error due to missing include
+    ./glibc-fix.patch
+
+    # restrict GDK backends to only X11
+    ./x11-only.patch
+  ];
 
   configureFlags = [
     "--with-bash-path=${pkgs.bash}/bin/bash"

--- a/pkgs/applications/misc/spacefm/x11-only.patch
+++ b/pkgs/applications/misc/spacefm/x11-only.patch
@@ -1,0 +1,10 @@
+--- a/src/main.c	2021-02-09 13:54:32.847364236 +0100
++++ b/src/main.c	2021-02-09 10:41:51.541203271 +0100
+@@ -1350,6 +1351,7 @@
+                 vfs_file_monitor_clean();
+                 return 1;
+             }
++            gdk_set_allowed_backends("x11");
+             gtk_init (&argc, &argv);
+             int ret = custom_dialog_init( argc, argv );
+             if ( ret != 0 )


### PR DESCRIPTION
###### Motivation for this change

SpaceFM crashes when run under Wayland because it was written with only the X11 backend in
mind.

Fixes #107242

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
