### PR TITLE
retext: remove markdown and chardet overrides

### DIFF
--- a/pkgs/applications/editors/retext/default.nix
+++ b/pkgs/applications/editors/retext/default.nix
@@ -6,30 +6,10 @@
 
 let
   version = "7.0.4";
-  python = let
-    packageOverrides = self: super: {
-      markdown = super.markdown.overridePythonAttrs(old: {
-        src = super.fetchPypi {
-          version = "3.0.1";
-          pname = "Markdown";
-          sha256 = "d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c";
-        };
-      });
-
-      chardet = super.chardet.overridePythonAttrs(old: {
-        src = super.fetchPypi {
-          version = "2.3.0";
-          pname = "chardet";
-          sha256 = "e53e38b3a4afe6d1132de62b7400a4ac363452dc5dfcf8d88e8e0cce663c68aa";
-        };
-        patches = [];
-      });
-    };
-    in python3.override { inherit packageOverrides; };
-  pythonEnv = python.withPackages (ps: with ps; [
+  pythonEnv = python3.withPackages (ps: with ps; [
     pyqt5 docutils pyenchant Markups markdown pygments chardet
   ]);
-in python.pkgs.buildPythonApplication {
+in python3.pkgs.buildPythonApplication {
   inherit version;
   pname = "retext";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

python-markdown 3.0.1 breaks the build, latest (3.2.2) works fine.

No need to pin chardet, latest (3.0.4) works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
