### PR TITLE
[20.09] firejail: 0.9.62 -> 0.9.64.4

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "firejail";
-  version = "0.9.64.2";
+  version = "0.9.64.4";
 
   src = fetchFromGitHub {
     owner = "netblue30";
     repo = "firejail";
     rev = version;
-    sha256 = "1adizsb7pxr101bvvd359hxympnv36rnikp78npdr5dcvwddv3dv";
+    sha256 = "sha256-q/XL8cznHlUXdubUEptEAVma1jRUqFb5XcLAV0RVCzs=";
   };
 
   buildInputs = [ which ];

--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -3,10 +3,10 @@ let
   s = # Generated upstream information
   rec {
     baseName="firejail";
-    version="0.9.62";
+    version="0.9.64";
     name="${baseName}-${version}";
     url="mirror://sourceforge/firejail/firejail/firejail-${version}.tar.xz";
-    sha256="1q2silgy882fl61p5qa9f9jqkxcqnwa71jig3c729iahx4f0hs05";
+    sha256="1zgjwy2k57nx0r63fzr15gijah098ig0bll66jd615vc9q3snfz5";
   };
   buildInputs = [
     which
@@ -21,16 +21,6 @@ stdenv.mkDerivation {
   };
 
   patches = [
-    (fetchpatch {
-      name = "CVE-2020-17367.patch";
-      url = "https://github.com/netblue30/firejail/commit/2c734d6350ad321fccbefc5ef0382199ac331b37.patch";
-      sha256 = "1gxz4jxp80gxnn46195qxcpmikwqab9d0ylj9zkm62lycp84ij6n";
-    })
-    (fetchpatch {
-      name = "CVE-2020-17368.patch";
-      url = "https://github.com/netblue30/firejail/commit/34193604fed04cad2b7b6b0f1a3a0428afd9ed5b.patch";
-      sha256 = "0n4ch3qykxx870201l8lz81f7h84vk93pzz77f5cjbd30cxnbddl";
-    })
     # Adds the /nix directory when using an overlay.
     # Required to run any programs under this mode.
     ./mount-nix-dir-on-overlay.patch

--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, fetchpatch, which, nixosTests}:
+{stdenv, fetchurl, fetchpatch, which, xdg-dbus-proxy, nixosTests}:
 let
   s = # Generated upstream information
   rec {
@@ -34,6 +34,10 @@ stdenv.mkDerivation {
     substituteInPlace etc/firejail.config --replace \
       '# follow-symlink-as-user yes' \
       'follow-symlink-as-user no'
+
+    # Fix the path to 'xdg-dbus-proxy' hardcoded in the 'common.h' file
+    substituteInPlace src/include/common.h \
+      --replace '/usr/bin/xdg-dbus-proxy' '${xdg-dbus-proxy}/bin/xdg-dbus-proxy'
   '';
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -1,24 +1,17 @@
-{stdenv, fetchurl, fetchpatch, which, xdg-dbus-proxy, nixosTests}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="firejail";
-    version="0.9.64";
-    name="${baseName}-${version}";
-    url="mirror://sourceforge/firejail/firejail/firejail-${version}.tar.xz";
-    sha256="1zgjwy2k57nx0r63fzr15gijah098ig0bll66jd615vc9q3snfz5";
+{ lib, stdenv, fetchFromGitHub, fetchpatch, which, xdg-dbus-proxy, nixosTests }:
+
+stdenv.mkDerivation rec {
+  pname = "firejail";
+  version = "0.9.64.2";
+
+  src = fetchFromGitHub {
+    owner = "netblue30";
+    repo = "firejail";
+    rev = version;
+    sha256 = "1adizsb7pxr101bvvd359hxympnv36rnikp78npdr5dcvwddv3dv";
   };
-  buildInputs = [
-    which
-  ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
-  src = fetchurl {
-    inherit (s) url sha256;
-    name = "${s.name}.tar.bz2";
-  };
+
+  buildInputs = [ which ];
 
   patches = [
     # Adds the /nix directory when using an overlay.
@@ -79,12 +72,10 @@ stdenv.mkDerivation {
   passthru.tests = nixosTests.firejail;
 
   meta = {
-    inherit (s) version;
-    description = ''Namespace-based sandboxing tool for Linux'';
-    license = stdenv.lib.licenses.gpl2Plus ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    description = "Namespace-based sandboxing tool for Linux";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.raskin ];
+    platforms = lib.platforms.linux;
     homepage = "https://firejail.wordpress.com/";
-    downloadPage = "https://sourceforge.net/projects/firejail/files/firejail/";
   };
 }

--- a/pkgs/os-specific/linux/firejail/default.upstream
+++ b/pkgs/os-specific/linux/firejail/default.upstream
@@ -1,3 +1,0 @@
-url https://sourceforge.net/projects/firejail/files/firejail/
-version_link '[-][0-9.]+[.]tar[.][a-z0-9]+/download$'
-SF_redirect


### PR DESCRIPTION
###### Motivation for this change

Backport of #112439

Fixed CVE-2021-26910 #112423

Cc: @NixOS/nixos-release-managers @mweinelt 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
