### PR TITLE
mysql57: Fix compile on macOS

### DIFF
--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -23,8 +23,9 @@ self = stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake bison pkg-config rpcsvc-proto ];
 
-  buildInputs = [ boost libedit libevent lz4 ncurses openssl protobuf readline zlib libtirpc ]
-     ++ lib.optionals stdenv.isDarwin [ perl cctools CoreServices developer_cmds ];
+  buildInputs = [ boost libedit libevent lz4 ncurses openssl protobuf readline zlib ]
+     ++ lib.optionals stdenv.isDarwin [ perl cctools CoreServices developer_cmds ]
+     ++ lib.optionals stdenv.isLinux [ libtirpc ];
 
   outputs = [ "out" "static" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

MySQL 5.7 would not compile on macOS, as it would attempt to compile libtirpc which is not required there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
