### PR TITLE
z3: 4.8.9 -> 4.8.10

### DIFF
--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -1,9 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, python, fixDarwinDylibNames
+{ lib
+, stdenv
+, fetchFromGitHub
+, python
+, fixDarwinDylibNames
 , javaBindings ? false
 , ocamlBindings ? false
 , pythonBindings ? true
 , jdk ? null
-, ocaml ? null, findlib ? null, zarith ? null
+, ocaml ? null
+, findlib ? null
+, zarith ? null
 }:
 
 assert javaBindings -> jdk != null;
@@ -13,19 +19,19 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "z3";
-  version = "4.8.9";
+  version = "4.8.10";
 
   src = fetchFromGitHub {
-    owner  = "Z3Prover";
-    repo   = pname;
-    rev    = "z3-${version}";
-    sha256 = "1hnbzq10d23drd7ksm3c1n2611c3kd0q0yxgz8y78zaafwczvwxx";
+    owner = "Z3Prover";
+    repo = pname;
+    rev = "z3-${version}";
+    sha256 = "1w1ym2l0gipvjx322npw7lhclv8rslq58gnj0d9i96masi3gbycf";
   };
 
   nativeBuildInputs = optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
   buildInputs = [ python ]
-  ++ optional javaBindings jdk
-  ++ optionals ocamlBindings [ ocaml findlib zarith ]
+    ++ optional javaBindings jdk
+    ++ optionals ocamlBindings [ ocaml findlib zarith ]
   ;
   propagatedBuildInputs = [ python.pkgs.setuptools ];
   enableParallelBuilding = true;
@@ -35,16 +41,17 @@ stdenv.mkDerivation rec {
     mkdir -p $OCAMLFIND_DESTDIR/stublibs
   '';
 
-  configurePhase = concatStringsSep " " (
-    [ "${python.interpreter} scripts/mk_make.py --prefix=$out" ]
-    ++ optional javaBindings   "--java"
-    ++ optional ocamlBindings  "--ml"
-    ++ optional pythonBindings "--python --pypkgdir=$out/${python.sitePackages}"
-  ) + "\n" + "cd build";
+  configurePhase = concatStringsSep " "
+    (
+      [ "${python.interpreter} scripts/mk_make.py --prefix=$out" ]
+        ++ optional javaBindings "--java"
+        ++ optional ocamlBindings "--ml"
+        ++ optional pythonBindings "--python --pypkgdir=$out/${python.sitePackages}"
+    ) + "\n" + "cd build";
 
   postInstall = ''
     mkdir -p $dev $lib
-    mv $out/lib     $lib/lib
+    mv $out/lib $lib/lib
     mv $out/include $dev/include
   '' + optionalString pythonBindings ''
     mkdir -p $python/lib
@@ -53,14 +60,13 @@ stdenv.mkDerivation rec {
   '';
 
   outputs = [ "out" "lib" "dev" "python" ]
-  ++ optional ocamlBindings "ocaml"
-  ;
+    ++ optional ocamlBindings "ocaml";
 
-  meta = {
+  meta = with lib; {
     description = "A high-performance theorem prover and SMT solver";
-    homepage    = "https://github.com/Z3Prover/z3";
-    license     = lib.licenses.mit;
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ thoughtpolice ttuegel ];
+    homepage = "https://github.com/Z3Prover/z3";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice ttuegel ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 4.8.10

Change log: https://github.com/Z3Prover/z3/releases/tag/z3-4.8.10

Also, ran `nixpkgs-fmt` but `nixpkgs-review` takes hours.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
