### PR TITLE
eiskaltdcpp: 2.2.10 -> 2.4.1

### DIFF
--- a/pkgs/applications/networking/p2p/eiskaltdcpp/default.nix
+++ b/pkgs/applications/networking/p2p/eiskaltdcpp/default.nix
@@ -1,47 +1,29 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, qt4, boost, bzip2, libX11
-, fetchpatch, libiconv, pcre-cpp, libidn, lua5, miniupnpc, aspell, gettext }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, boost, bzip2, libX11
+, mkDerivation, qtbase, qttools, qtmultimedia, qtscript
+, libiconv, pcre-cpp, libidn, lua5, miniupnpc, aspell, gettext, perl }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "eiskaltdcpp";
-  version = "2.2.10";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "eiskaltdcpp";
     repo = "eiskaltdcpp";
     rev = "v${version}";
-    sha256 = "1mqz0g69njmlghcra3izarjxbxi1jrhiwn4ww94b8jv8xb9cv682";
+    sha256 = "0ln8dafa8sni3289g30ndv1wr3ij5lz4abcb2qwcabb79zqxl8hy";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ qt4 boost bzip2 libX11 pcre-cpp libidn lua5 miniupnpc aspell gettext ]
+  buildInputs = [ qtbase qttools qtmultimedia qtscript boost bzip2 libX11 pcre-cpp libidn lua5 miniupnpc aspell gettext
+    (perl.withPackages (p: with p; [
+      GetoptLong
+      RpcXML
+      TermShellUI
+    ])) ]
     ++ lib.optional stdenv.isDarwin libiconv;
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/eiskaltdcpp/eiskaltdcpp/commit/3b7b56bd7060b426b1f1bfded392ae6853644e2e.patch";
-      sha256 = "1rqjdsvirn3ks9w9qn893fb73mz84xm04wl13fvsvj8p42i5cjas";
-    })
-    (fetchpatch {
-      url = "https://github.com/eiskaltdcpp/eiskaltdcpp/commit/bb9eb364a943fe2a67b3ea52ec6a3f9e911f07dc.patch";
-      sha256 = "1hjhf9a9j4z8v24g5qh5mcg3n0540lbn85y7kvxsh3khc5v3cywx";
-    })
-    (fetchpatch {
-      url = "https://github.com/eiskaltdcpp/eiskaltdcpp/commit/ef4426f1f9a8255e335b0862234e6cc28befef5e.patch";
-      sha256 = "13j018c499n4b5as2n39ws64yj0cf4fskxbqab309vmnjkirxv6x";
-    })
-    (fetchpatch {
-      url = "https://github.com/eiskaltdcpp/eiskaltdcpp/commit/a9c136c8707280d0eeb66be6b289d9718287c55c.patch";
-      sha256 = "0w8v4mbrzk7pmzc475ff96mzzwlh8a0p62kk7p829m5yqdwj4sc9";
-    })
-    (fetchpatch {
-      url = "https://github.com/eiskaltdcpp/eiskaltdcpp/commit/3b9c502ff5c98856d4f8fdb7ed3c6ef34448bfb7.patch";
-      sha256 = "0fjwaq0wd9a164k5ysdjy89hx0ixnxc6q7cvyn1ba28snm0pgxb8";
-    })
-  ];
 
   cmakeFlags = [
     "-DUSE_ASPELL=ON"
-    "-DUSE_QT_QML=ON"
     "-DFREE_SPACE_BAR_C=ON"
     "-DUSE_MINIUPNP=ON"
     "-DLOCAL_MINIUPNP=ON"
@@ -53,6 +35,11 @@ stdenv.mkDerivation rec {
     "-DLUA_SCRIPT=ON"
     "-DWITH_LUASCRIPTS=ON"
   ];
+
+  preFixup = ''
+    substituteInPlace $out/bin/eiskaltdcpp-cli-xmlrpc \
+      --replace "/usr/local" "$out"
+  '';
 
   meta = with lib; {
     description = "A cross-platform program that uses the Direct Connect and ADC protocols";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24433,10 +24433,7 @@ in
 
   qcomicbook = libsForQt5.callPackage ../applications/graphics/qcomicbook { };
 
-  eiskaltdcpp = callPackage ../applications/networking/p2p/eiskaltdcpp {
-    lua5 = lua5_1;
-    miniupnpc = miniupnpc_1;
-  };
+  eiskaltdcpp = libsForQt5.callPackage ../applications/networking/p2p/eiskaltdcpp { };
 
   qdirstat = libsForQt5.callPackage ../applications/misc/qdirstat {};
 


### PR DESCRIPTION
###### Motivation for this change
#33248

I only started the GUI, not the other two binaries and I'm not part of(?) any hubs, so I can't test it much, but it seems to run just fine.
If anyone actually still uses this, please test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
