### PR TITLE
staticjinja: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/development/python-modules/staticjinja/default.nix
+++ b/pkgs/development/python-modules/staticjinja/default.nix
@@ -1,32 +1,34 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
+, poetry
 , isPy27
 , docopt
 , easywatch
 , jinja2
 , pytestCheckHook
 , pytest-check
-, fetchPypi
 , markdown
-, sphinx
-, sphinx_rtd_theme
 }:
 
 buildPythonPackage rec {
   pname = "staticjinja";
-  version = "1.0.3";
+  version = "1.0.4";
+  format = "pyproject";
 
   disabled = isPy27; # 0.4.0 drops python2 support
 
-  # For some reason, in pypi the tests get disabled when using
-  # PY_IGNORE_IMPORTMISMATCH, so we just fetch from GitHub
+  # No tests in pypi
   src = fetchFromGitHub {
     owner = "staticjinja";
     repo = pname;
     rev = version;
-    sha256 = "12rpv5gv64i5j4w98wm1444xnnmarcn3pg783j3fkkzc58lk5wwj";
+    sha256 = "1saz6f71s693gz9c2k3bq2di2mrkj65mgmfdg86jk0z0zzjk90y1";
   };
+
+  nativeBuildInputs = [
+    poetry
+  ];
 
   propagatedBuildInputs = [
     jinja2
@@ -38,15 +40,10 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-check
     markdown
-    sphinx_rtd_theme
-    sphinx
   ];
 
+  # The tests need to find and call the installed staticjinja executable
   preCheck = ''
-    # Import paths differ by a "build/lib" subdirectory, but the files are
-    # the same, so we ignore import mismatches.
-    export PY_IGNORE_IMPORTMISMATCH=1
-    # The tests need to find and call the installed staticjinja executable
     export PATH="$PATH:$out/bin";
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
