### PR TITLE
Add/vim plugin shellcheck

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -7325,6 +7325,18 @@ let
     meta.homepage = "https://github.com/tpope/vim-sexp-mappings-for-regular-people/";
   };
 
+  vim-shellcheck = buildVimPluginFrom2Nix {
+    pname = "vim-shellcheck";
+    version = "2019-07-25";
+    src = fetchFromGitHub {
+      owner = "itspriddle";
+      repo = "vim-shellcheck";
+      rev = "4346419ac57ef341a15aa39c827c0848f17c6faf";
+      sha256 = "0j28nqmfjxzhwylp2r1mp5v39fws5jvn7k9maam97mi3j66a9jz5";
+    };
+    meta.homepage = "https://github.com/itspriddle/vim-shellcheck/";
+  };
+
   vim-signature = buildVimPluginFrom2Nix {
     pname = "vim-signature";
     version = "2018-07-06";

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -65,11 +65,11 @@ let
 
   ale = buildVimPluginFrom2Nix {
     pname = "ale";
-    version = "2021-02-06";
+    version = "2021-02-10";
     src = fetchFromGitHub {
       owner = "dense-analysis";
       repo = "ale";
-      rev = "388cf3374312b05122151bc68691bf09a69ff840";
+      rev = "1773a496ad39fdd3d904679955b39357f3f38442";
       sha256 = "1jzfdbfw333r929l5bl1ca1dv9b6yyhsjhk3gdf7wxklbzcrww3p";
     };
     meta.homepage = "https://github.com/dense-analysis/ale/";
@@ -389,12 +389,12 @@ let
 
   chadtree = buildVimPluginFrom2Nix {
     pname = "chadtree";
-    version = "2021-02-10";
+    version = "2021-02-11";
     src = fetchFromGitHub {
       owner = "ms-jpq";
       repo = "chadtree";
-      rev = "62e7bff3c4a29869423b88be2dff1314e1a34986";
-      sha256 = "07dqd2z9xjc89b9p8hp2pwfbrimva3yp5493gwcpfnqsncxshm37";
+      rev = "eeaff0c9db2779d93c36ab7266ccfb0129525f55";
+      sha256 = "1w3dpqs4k8hbzjl9q382wvrwjyk8j6xxq78r852cclnayyx9rw19";
     };
     meta.homepage = "https://github.com/ms-jpq/chadtree/";
   };
@@ -690,12 +690,12 @@ let
 
   conjure = buildVimPluginFrom2Nix {
     pname = "conjure";
-    version = "2021-02-07";
+    version = "2021-02-10";
     src = fetchFromGitHub {
       owner = "Olical";
       repo = "conjure";
-      rev = "831334312237a305d92e54092bfab447376cc844";
-      sha256 = "1y0a43j1rhqzfm9qmd7dax6bn1mg9vwvh3rc355k94ix3x82n93j";
+      rev = "88e7865b97737809d963b81b10737c41e90b4377";
+      sha256 = "075rm1s1y1cklnsqf7845s3knfwyiqs1wd82d9rvbvc3gs12xlpf";
     };
     meta.homepage = "https://github.com/Olical/conjure/";
   };
@@ -2356,8 +2356,8 @@ let
     src = fetchFromGitHub {
       owner = "wfxr";
       repo = "minimap.vim";
-      rev = "a05a32d70a043cc342d5e6e0a46432e294df7d8e";
-      sha256 = "16fqqp1di9abcvignz5d09hlc9qzafaa1d2v97lks28jjcri5616";
+      rev = "1964f5e56467be5f894c8a9c99db58794da38b36";
+      sha256 = "141p9hc343cgivp76bihv2l45l0yvznv2f2m9ndy3kdsh0ckwk0w";
     };
     meta.homepage = "https://github.com/wfxr/minimap.vim/";
   };
@@ -2812,8 +2812,8 @@ let
     src = fetchFromGitHub {
       owner = "preservim";
       repo = "nerdtree";
-      rev = "1d46d6df3e581984d4b31d30d362cb94bc993e1d";
-      sha256 = "1zm08jrc2grd7fbcsxwspsj4jlv92s45wa54x404vijxyvgis9bz";
+      rev = "d3f9fc44caaa5688b65ccc508af6fac7defa120f";
+      sha256 = "0rdz6li5qj6jl58731ddr3v8anx22ahvaqf5s19lnjakfdip3nn9";
     };
     meta.homepage = "https://github.com/preservim/nerdtree/";
   };
@@ -2976,12 +2976,12 @@ let
 
   nvim-highlite = buildVimPluginFrom2Nix {
     pname = "nvim-highlite";
-    version = "2021-02-04";
+    version = "2021-02-10";
     src = fetchFromGitHub {
       owner = "Iron-E";
       repo = "nvim-highlite";
-      rev = "daa245b13b77b478b5b9f62e2e0bb79e65dcf5e8";
-      sha256 = "19qibdkwzcqxkzzdc0bi2s1nf8rbzikkygs0yf41an5ll35xl528";
+      rev = "aa8e36bd4f34dd0157d725c74874dfa44841a5e7";
+      sha256 = "1zrqd3ndlv3393xjmf1n3w6im24fyqmnpldqvph5ix9lfrrf5vzh";
     };
     meta.homepage = "https://github.com/Iron-E/nvim-highlite/";
   };
@@ -3096,12 +3096,12 @@ let
 
   nvim-treesitter = buildVimPluginFrom2Nix {
     pname = "nvim-treesitter";
-    version = "2021-02-08";
+    version = "2021-02-10";
     src = fetchFromGitHub {
       owner = "nvim-treesitter";
       repo = "nvim-treesitter";
-      rev = "6533fb9af7f881c18b761ae94b2a502606f27989";
-      sha256 = "1rj9ndcvm24yirxg59y7sp6gs4dkyk0waa37j378liya5ia1cw48";
+      rev = "72ecefc859096cdea114f78ca09ad67970f8a1d8";
+      sha256 = "0jyq6qd7ykkdm4s1m6whmj0g4n1b4xvlhwiizim9vv2m86lnwfqb";
     };
     meta.homepage = "https://github.com/nvim-treesitter/nvim-treesitter/";
   };
@@ -3280,8 +3280,8 @@ let
     src = fetchFromGitHub {
       owner = "wbthomason";
       repo = "packer.nvim";
-      rev = "b57a0f2f02ffd3e5f1604fdea6b76d4f67502814";
-      sha256 = "06414cik0iqb6jwksqikin328mylfwxl6215036bb7rl2lc8cs99";
+      rev = "8d220a40b760fea7ee637602ec781bff80df5122";
+      sha256 = "1l4dwkq1rwb0dwd4xnhz6yisqqfgha9k92kgl73fldnx0pkcycbk";
     };
     meta.homepage = "https://github.com/wbthomason/packer.nvim/";
   };
@@ -8216,12 +8216,12 @@ let
 
   vimspector = buildVimPluginFrom2Nix {
     pname = "vimspector";
-    version = "2021-02-06";
+    version = "2021-02-10";
     src = fetchFromGitHub {
       owner = "puremourning";
       repo = "vimspector";
-      rev = "7f77842ab89524d2d3b45a4fe7198fb51ac9e0a8";
-      sha256 = "0njsncynnbyqwcj0lr13ycz7kl9yg0blmb1dizlvki5gwqlj881r";
+      rev = "e99ac0d65867f4d97e7b891ac21cd341de1ff53f";
+      sha256 = "1jxl33svlymcwc3dsalabpy7px91rgfpalpb2bhxkqd4vgxwcjql";
       fetchSubmodules = true;
     };
     meta.homepage = "https://github.com/puremourning/vimspector/";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -187,6 +187,7 @@ itchyny/lightline.vim
 itchyny/thumbnail.vim
 itchyny/vim-cursorword
 itchyny/vim-gitbranch
+itspriddle/vim-shellcheck
 ivanov/vim-ipython
 jackguo380/vim-lsp-cxx-highlight
 jacoborus/tender.vim


### PR DESCRIPTION

###### Motivation for this change
It would be nice to add  itspriddle/vim-shellcheck.
I'm not sure that's how it goes but if necessary here is my branch.
Thanks
@lovek323 @equirosa 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
