### PR TITLE
elixir: remove hardcoded certificate path for curl

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -46,8 +46,7 @@ in
        b=$(basename $f)
         if [ "$b" = mix ]; then continue; fi
         wrapProgram $f \
-          --prefix PATH ":" "${lib.makeBinPath [ erlang coreutils curl bash ]}" \
-          --set CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
+          --prefix PATH ":" "${lib.makeBinPath [ erlang coreutils curl bash ]}"
       done
 
       substituteInPlace $out/bin/mix \


### PR DESCRIPTION
###### Motivation for this change
Currently, elixir is wrapped in a script which sets `CURL_CA_BUNDLE` to `/etc/ssl/certs/ca-certificates.crt`. This hardcoded path does not exist on MacOS, which causes all curl calls (e.g. in build scripts) to fail with certificate errors.

Elixir used to depend explicitly on `cacert`, but that was removed in 55932c1beca26c7b5b7c259d95f6eb80644150a7 -- I think this has been broken since then.

###### Things done
This commit no longer sets `CURL_CA_BUNDLE`, causing curl fall back to (I believe) `NIX_SSL_CERT_FILE` instead.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
