### PR TITLE
pythonPackages.powerline: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/powerline/default.nix
+++ b/pkgs/development/python-modules/powerline/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     hglib
     pygit2
     pyuv
-  ] ++ lib.optionals (!stdenv.isDarwin) i3ipc;
+  ] ++ lib.optionals (!stdenv.isDarwin) [ i3ipc ];
 
   # tests are travis-specific
   doCheck = false;

--- a/pkgs/development/python-modules/powerline/default.nix
+++ b/pkgs/development/python-modules/powerline/default.nix
@@ -8,6 +8,7 @@
 , pygit2
 , pyuv
 , i3ipc
+, stdenv
 }:
 
 # TODO: bzr support is missing because nixpkgs switched to `breezy`
@@ -29,8 +30,7 @@ buildPythonPackage rec {
     hglib
     pygit2
     pyuv
-    i3ipc
-  ];
+  ] ++ lib.optionals (!stdenv.isDarwin) i3ipc;
 
   # tests are travis-specific
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding i3ipc causes powerline (and things that rely on it like vim-airline) to fail to build because i3ipc relies on i3 and i3 doesn't build (or run) on OSX.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
