### PR TITLE
xpdf: 4.02 → 4.03

### DIFF
--- a/pkgs/applications/misc/xpdf/default.nix
+++ b/pkgs/applications/misc/xpdf/default.nix
@@ -12,11 +12,11 @@ assert enablePrinting -> cups != null;
 
 stdenv.mkDerivation rec {
   pname = "xpdf";
-  version = "4.02";
+  version = "4.03";
 
   src = fetchzip {
-    url = "https://xpdfreader-dl.s3.amazonaws.com/${pname}-${version}.tar.gz";
-    sha256 = "0dzwq6fnk013wa4l5mjpvm4mms2mh5hbrxv4rhk2ab5ljbzz7b2w";
+    url = "https://dl.xpdfreader.com/xpdf-${version}.tar.gz";
+    sha256 = "09yhvmh1vxjy763nnmawynygp5bh3j4i8ixqja64j11676yl77n6";
   };
 
   # Fix "No known features for CXX compiler", see
@@ -36,8 +36,6 @@ stdenv.mkDerivation rec {
     lib.optional enablePrinting cups ++
     lib.optional enablePDFtoPPM freetype;
 
-  hardeningDisable = [ "format" ];
-
   desktopItem = makeDesktopItem {
     name = "xpdf";
     desktopName = "Xpdf";
@@ -48,9 +46,14 @@ stdenv.mkDerivation rec {
     terminal = "false";
   };
 
-  postInstall = ''
-    install -Dm644 ${desktopItem}/share/applications/xpdf.desktop $out/share/applications/xpdf.desktop
+  postInstall = lib.optionalString (!stdenv.isDarwin) ''
+    install -Dm644 ${desktopItem}/share/applications/xpdf.desktop -t $out/share/applications
     install -Dm644 $src/xpdf-qt/xpdf-icon.svg $out/share/pixmaps/xpdf.svg
+  '';
+
+  # wrapQtAppsHook broken on macOS (https://github.com/NixOS/nixpkgs/issues/102044)
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    wrapQtApp $out/bin/xpdf
   '';
 
   meta = with lib; {
@@ -69,7 +72,7 @@ stdenv.mkDerivation rec {
         pdffonts:  lists fonts used in PDF files
         pdfdetach: extracts attached files from PDF files
     '';
-    license = with licenses; [ gpl2 gpl3 ];
+    license = with licenses; [ gpl2Only gpl3Only ];
     platforms = platforms.unix;
     maintainers = with maintainers; [ sikmir ];
     knownVulnerabilities = [

--- a/pkgs/applications/misc/xpdf/libxpdf.nix
+++ b/pkgs/applications/misc/xpdf/libxpdf.nix
@@ -2,29 +2,33 @@
 }:
 
 stdenv.mkDerivation {
-  name = "libxpdf-3.02pl4";
+  name = "libxpdf-3.02pl5";
 
   src = fetchurl {
-    url = "ftp://ftp.foolabs.com/pub/xpdf/xpdf-3.02.tar.gz";
+    url = "https://dl.xpdfreader.com/old/xpdf-3.02.tar.gz";
     sha256 = "000zq4ddbwyxiki4vdwpmxbnw5n9hsg9hvwra2p33hslyib7sfmk";
   };
 
   patches = [
     (fetchurl {
-      url = "ftp://ftp.foolabs.com/pub/xpdf/xpdf-3.02pl1.patch";
+      url = "https://dl.xpdfreader.com/old/xpdf-3.02pl1.patch";
       sha256 = "1wxv9l0d2kkwi961ihpdwi75whdvk7cgqxkbfym8cjj11fq17xjq";
     })
     (fetchurl {
-      url = "ftp://ftp.foolabs.com/pub/xpdf/xpdf-3.02pl2.patch";
+      url = "https://dl.xpdfreader.com/old/xpdf-3.02pl2.patch";
       sha256 = "1nfrgsh9xj0vryd8h65myzd94bjz117y89gq0hzji9dqn23xihfi";
     })
     (fetchurl {
-      url = "ftp://ftp.foolabs.com/pub/xpdf/xpdf-3.02pl3.patch";
+      url = "https://dl.xpdfreader.com/old/xpdf-3.02pl3.patch";
       sha256 = "0jskkv8x6dqr9zj4azaglas8cziwqqrkbbnzrpm2kzrvsbxyhk2r";
     })
     (fetchurl {
-      url = "ftp://ftp.foolabs.com/pub/xpdf/xpdf-3.02pl4.patch";
+      url = "https://dl.xpdfreader.com/old/xpdf-3.02pl4.patch";
       sha256 = "1c48h7aizx0ngmzlzw0mpja1w8vqyy3pg62hyxp7c60k86al715h";
+    })
+    (fetchurl {
+      url = "https://dl.xpdfreader.com/old/xpdf-3.02pl5.patch";
+      sha256 = "1fki66pw56yr6aw38f6amrx7wxwcxbx4704pjqq7pqqr784b7z4j";
     })
     ./xpdf-3.02-protection.patch
     ./libxpdf.patch
@@ -48,6 +52,6 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     platforms = platforms.unix;
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
* Changelog:
```sh
$ cat ANNOUNCE | sed -n '13,24p'
4.03 is primarily a bug fix release.  There are some new features:

* XpdfReader improvements:
  - Implemented selection extension via shift-click, and word/line
    selection via double/triple click.
  - Added default bindings for ctrl-mousewheel-up/down to zoom in/out.
  - Added a help menu item that shows all of the key bindings.

* Various new command line options for pdftotext, pdftohtml, pdftoppm,
  pdftopng, and xpdf.

See the `CHANGES' file for a complete list of changes.
```
* replace download links from `xpdfreader-dl.s3.amazonaws.com` and `ftp.foolabs.com` to `dl.xpdfreader.com`
* fix wrapping on darwin
* fix licenses
* update libxpdf

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
