### PR TITLE
pulseeffects: 4.8.4 -> 5.0.0, pulseeffects-legacy: init at 4.8.4

### DIFF
--- a/pkgs/applications/audio/pulseeffects-legacy/default.nix
+++ b/pkgs/applications/audio/pulseeffects-legacy/default.nix
@@ -1,0 +1,115 @@
+{ lib, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, itstool
+, python3
+, libxml2
+, desktop-file-utils
+, wrapGAppsHook
+, gst_all_1
+, pulseaudio
+, gtk3
+, glib
+, glibmm
+, gtkmm3
+, lilv
+, lv2
+, serd
+, sord
+, sratom
+, libbs2b
+, libsamplerate
+, libsndfile
+, libebur128
+, rnnoise
+, boost
+, dbus
+, fftwFloat
+, calf
+, zita-convolver
+, zam-plugins
+, rubberband
+, lsp-plugins
+}:
+
+let
+  lv2Plugins = [
+    calf # limiter, compressor exciter, bass enhancer and others
+    lsp-plugins # delay
+  ];
+  ladspaPlugins = [
+    rubberband # pitch shifting
+    zam-plugins # maximizer
+  ];
+in stdenv.mkDerivation rec {
+  pname = "pulseeffects";
+  version = "4.8.4";
+
+  src = fetchFromGitHub {
+    owner = "wwmm";
+    repo = "pulseeffects";
+    rev = "v${version}";
+    sha256 = "19sndxvszafbd1l2033g2irpx2jrwi5bpbx8r35047wi0z7djiag";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    libxml2
+    itstool
+    python3
+    desktop-file-utils
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    pulseaudio
+    glib
+    glibmm
+    gtk3
+    gtkmm3
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base # gst-fft
+    gst_all_1.gst-plugins-good # pulsesrc
+    gst_all_1.gst-plugins-bad
+    lilv lv2 serd sord sratom
+    libbs2b
+    libebur128
+    libsamplerate
+    libsndfile
+    rnnoise
+    boost
+    dbus
+    fftwFloat
+    zita-convolver
+  ];
+
+  postPatch = ''
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --set LV2_PATH "${lib.makeSearchPath "lib/lv2" lv2Plugins}"
+      --set LADSPA_PATH "${lib.makeSearchPath "lib/ladspa" ladspaPlugins}"
+    )
+  '';
+
+  # Meson is no longer able to pick up Boost automatically.
+  # https://github.com/NixOS/nixpkgs/issues/86131
+  BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
+  BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
+
+  meta = with lib; {
+    description = "Limiter, compressor, reverberation, equalizer and auto volume effects for Pulseaudio applications";
+    homepage = "https://github.com/wwmm/pulseeffects";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+    badPlatforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/applications/audio/pulseeffects/default.nix
+++ b/pkgs/applications/audio/pulseeffects/default.nix
@@ -9,7 +9,7 @@
 , desktop-file-utils
 , wrapGAppsHook
 , gst_all_1
-, pulseaudio
+, pipewire
 , gtk3
 , glib
 , glibmm
@@ -45,13 +45,13 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "pulseeffects";
-  version = "4.8.4";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "wwmm";
     repo = "pulseeffects";
     rev = "v${version}";
-    sha256 = "19sndxvszafbd1l2033g2irpx2jrwi5bpbx8r35047wi0z7djiag";
+    sha256 = "1zs13bivxlgcb24lz1pgmgy2chcjxnmn4lz7g1n0ygiaaj4c30xj";
   };
 
   nativeBuildInputs = [
@@ -66,14 +66,14 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    pulseaudio
+    pipewire
     glib
     glibmm
     gtk3
     gtkmm3
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base # gst-fft
-    gst_all_1.gst-plugins-good # pulsesrc
+    gst_all_1.gst-plugins-good # spectrum plugin
     gst_all_1.gst-plugins-bad
     lilv lv2 serd sord sratom
     libbs2b
@@ -107,7 +107,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Limiter, compressor, reverberation, equalizer and auto volume effects for Pulseaudio applications";
     homepage = "https://github.com/wwmm/pulseeffects";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.linux;
     badPlatforms = [ "aarch64-linux" ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -533,6 +533,7 @@ mapAliases ({
   pyo3-pack = maturin;
   pmenu = throw "pmenu has been removed from nixpkgs, as its maintainer is no longer interested in the package."; # added 2019-12-10
   pulseaudioLight = pulseaudio; # added 2018-04-25
+  pulseeffects = throw "Use pulseeffects-legacy if you use PulseAudio and pulseeffects-pw if you use PipeWire."; # added 2021-02-13, move back once we default to PipeWire audio server.
   phonon-backend-gstreamer = throw "phonon-backend-gstreamer: Please use libsForQt5.phonon-backend-gstreamer, as Qt4 support in this package has been removed."; # added 2019-11-22
   phonon-backend-vlc = throw "phonon-backend-vlc: Please use libsForQt5.phonon-backend-vlc, as Qt4 support in this package has been removed."; # added 2019-11-22
   phonon = throw "phonon: Please use libsForQt5.phonon, as Qt4 support in this package has been removed."; # added 2019-11-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18083,7 +18083,7 @@ in
 
   libpulseaudio = libpulseaudio-vanilla;
 
-  pulseeffects = callPackage ../applications/audio/pulseeffects {
+  pulseeffects-pw = callPackage ../applications/audio/pulseeffects {
     boost = boost172;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18087,6 +18087,10 @@ in
     boost = boost172;
   };
 
+  pulseeffects-legacy = callPackage ../applications/audio/pulseeffects-legacy {
+    boost = boost172;
+  };
+
   tomcat_connectors = callPackage ../servers/http/apache-modules/tomcat-connectors { };
 
   tomcat-native = callPackage ../servers/http/tomcat/tomcat-native.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version 5.0.0 released:
https://github.com/wwmm/pulseeffects/releases/tag/v5.0.0

As of this version PulseEffects uses PipeWire instead of PulseAudio. Because of the currently lesser adoption of PipeWire, legacy version of PulseEffects (pulseeffects-legacy) was added. Further updates of the legacy version can be acquired from corresponding branch https://github.com/wwmm/pulseeffects/tree/pulseaudio-legacy. Please note, that legacy branch is in maintenance mode and no longer under development.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
