### PR TITLE
nmigen: update to current git HEAD

### DIFF
--- a/pkgs/applications/science/logic/symbiyosys/default.nix
+++ b/pkgs/applications/science/logic/symbiyosys/default.nix
@@ -31,6 +31,9 @@ stdenv.mkDerivation {
 
     substituteInPlace sbysrc/sby_core.py \
       --replace '##yosys-program-prefix##' '"${yosys}/bin/"'
+
+    substituteInPlace sbysrc/sby.py \
+      --replace '/usr/bin/env python3' '${python3}/bin/python'
   '';
 
   buildPhase = "true";

--- a/pkgs/development/python-modules/nmigen-boards/default.nix
+++ b/pkgs/development/python-modules/nmigen-boards/default.nix
@@ -8,15 +8,15 @@
 
 buildPythonPackage rec {
   pname = "nmigen-boards";
-  version = "unstable-2020-02-06";
+  version = "unstable-2021-02-09";
   # python setup.py --version
-  realVersion = "0.1.dev92+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.1.dev173+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "nmigen";
     repo = "nmigen-boards";
-    rev = "f37fe0295035db5f1bf82ed086b2eb349ab3a530";
-    sha256 = "16112ahil100anfwggj64nyrj3pf7mngwrjyqyhf2ggxx9ir24cc";
+    rev = "a35d870a994c2919116b2c06166dc127febb1512";
+    sha256 = "1flbcyb2xz174dgqv2964qra80xj2vbzbqwjb27shvxm6knj9ikf";
   };
 
   nativeBuildInputs = [ setuptools_scm ];

--- a/pkgs/development/python-modules/nmigen-soc/default.nix
+++ b/pkgs/development/python-modules/nmigen-soc/default.nix
@@ -8,15 +8,15 @@
 
 buildPythonPackage rec {
   pname = "nmigen-soc";
-  version = "unstable-2020-02-08";
+  version = "unstable-2021-02-09";
   # python setup.py --version
-  realVersion = "0.1.dev24+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.1.dev43+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "nmigen";
     repo = "nmigen-soc";
-    rev = "f5b5cd563e8e8d081b0535c4554c02b5456ee8b4";
-    sha256 = "04kjaq9qp6ac3h0r1wlb4jyz56bb52l1rikmz1x7azvnr10xhrad";
+    rev = "ecfad4d9abacf903a525f0a252c38844eda0d2dd";
+    sha256 = "0afmnfs1ms7p1r4c1nc0sfvlcq36zjwaim7775v5i2vajcn3020c";
   };
 
   nativeBuildInputs = [ setuptools_scm ];

--- a/pkgs/development/python-modules/nmigen/default.nix
+++ b/pkgs/development/python-modules/nmigen/default.nix
@@ -38,13 +38,6 @@ buildPythonPackage rec {
     export SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}"
   '';
 
-  # Fail b/c can't find sby (symbiyosys) executable, which should be on path.
-  disabledTests = [
-    "test_distance"
-    "test_reversible"
-    "FIFOFormalCase"
-  ];
-
   meta = with lib; {
     description = "A refreshed Python toolbox for building complex digital hardware";
     homepage = "https://nmigen.info/nmigen";

--- a/pkgs/development/python-modules/nmigen/default.nix
+++ b/pkgs/development/python-modules/nmigen/default.nix
@@ -6,6 +6,8 @@
 , setuptools_scm
 , pyvcd
 , jinja2
+, importlib-resources
+, importlib-metadata
 
 # for tests
 , pytestCheckHook
@@ -16,21 +18,27 @@
 
 buildPythonPackage rec {
   pname = "nmigen";
-  version = "unstable-2020-04-02";
+  version = "unstable-2021-02-09";
   # python setup.py --version
-  realVersion = "0.2.dev49+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.3.dev243+g${lib.substring 0 7 src.rev}";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "nmigen";
     repo = "nmigen";
-    rev = "c79caead33fff14e2dec42b7e21d571a02526876";
-    sha256 = "sha256-3+mxHyg0a92/BfyePtKT5Hsk+ra+fQzTjCJ2Ech44/s=";
+    rev = "f7c2b9419f9de450be76a0e9cf681931295df65f";
+    sha256 = "0cjs9wgmxa76xqmjhsw4fsb2mhgvd85jgs2mrjxqp6fwp8rlgnl1";
   };
 
   nativeBuildInputs = [ setuptools_scm ];
 
-  propagatedBuildInputs = [ setuptools pyvcd jinja2 ];
+  propagatedBuildInputs = [
+    setuptools
+    pyvcd
+    jinja2
+  ] ++
+    lib.optional (pythonOlder "3.9") importlib-resources ++
+    lib.optional (pythonOlder "3.8") importlib-metadata;
 
   checkInputs = [ pytestCheckHook yosys symbiyosys yices ];
 


### PR DESCRIPTION
###### Motivation for this change

The nmigen ecosystem is quite old in Nix. This PR updates the packages to the current git HEAD. While I was in there, I also fixed Symbiyosys, which had a broken interpreter line that caused some nmigen unit tests to be disabled.

I'm presenting these 4 commits as a single PR because 3 of them are trivial "update this python package" changes, and the 4th is a reasonably trivial bugfix to enable the other 3 commits.

Tested:

```
nix-build -A python38Packages.nmigen -A python38Packages.nmigen-boards -A python38Packages.nmigen-soc -A symbiyosys
```

Ran the `sby` binary to confirm that it now works (but also, the re-enabled nmigen tests now pass).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
