### PR TITLE
json-glib: fix build issue on clang 11

### DIFF
--- a/pkgs/development/libraries/json-glib/default.nix
+++ b/pkgs/development/libraries/json-glib/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, glib, meson, ninja, pkg-config, gettext
+{ lib, stdenv, fetchurl, fetchpatch, glib, meson, ninja, pkg-config, gettext
 , gobject-introspection, fixDarwinDylibNames, gnome3
 }:
 
@@ -12,6 +12,14 @@ in stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0ixwyis47v5bkx6h8a1iqlw3638cxcv57ivxv4gw2gaig51my33j";
   };
+
+  patches = [
+    (fetchpatch {
+      # included in next release (> 1.4.4)
+      url = "https://github.com/GNOME/json-glib/commit/8c5fabe962b7337066dac7a697d23fce257a5d64.patch";
+      sha256 = "0y6jwvb52i8q0hpp58lx49nj59ii59rs980ib8i3v2nmjz9qfy34";
+    })
+  ];
 
   propagatedBuildInputs = [ glib ];
   nativeBuildInputs = [ meson ninja pkg-config gettext gobject-introspection glib ]


### PR DESCRIPTION
###### Motivation for this change

Upgrade for the latest version is non-trivial, but lifting this one patch really helps with #105026.

cc @thefloweringash 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
