### PR TITLE
openfpgaloader: init at 0.2.1

### DIFF
--- a/pkgs/development/tools/misc/openfpgaloader/default.nix
+++ b/pkgs/development/tools/misc/openfpgaloader/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libftdi1
+, libusb1
+, udev
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openfpgaloader";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "trabucayre";
+    repo = "openFPGALoader";
+    rev = "v${version}";
+    sha256 = "0j87mlghbanh6c7lrxv0x3p6zgd0wrkcs9b8jf6ifh7b3ivcfg82";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    libftdi1
+    libusb1
+    udev
+  ];
+
+  meta = with lib; {
+    description = "Universal utility for programming FPGAs";
+    homepage = "https://github.com/trabucayre/openFPGALoader";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ danderson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6677,6 +6677,8 @@ in
 
   opencorsairlink = callPackage ../tools/misc/opencorsairlink { };
 
+  openfpgaloader = callPackage ../development/tools/misc/openfpgaloader { };
+
   openfortivpn = callPackage ../tools/networking/openfortivpn { };
 
   obexfs = callPackage ../tools/bluetooth/obexfs { };


### PR DESCRIPTION
Signed-off-by: David Anderson <dave@natulte.net>

###### Motivation for this change

The yosys/nmigen ecosystem uses OpenFPGALoader to load gateware onto FPGAs. It seems to support a lot more targets than other (often single-vendor) programming tools, and complements other bits of the ecosystem nicely.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
