### PR TITLE
pythonPackages.protobuf: remove no longer useful NIX_CFLAGS_COMPILE

### DIFF
--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -20,12 +20,6 @@ buildPythonPackage {
   inherit disabled;
   doCheck = doCheck && !isPy27; # setuptools>=41.4 no longer collects correctly on python2
 
-  NIX_CFLAGS_COMPILE = toString (
-    # work around python distutils compiling C++ with $CC
-    lib.optional stdenv.isDarwin "-I${libcxx}/include/c++/v1"
-    ++ lib.optional (lib.versionOlder protobuf.version "2.7.0") "-std=c++98"
-  );
-
   outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [ six ] ++ lib.optionals isPy27 [ google-apputils ];


### PR DESCRIPTION
###### Motivation for this change

* It builds fine on `x86_64-darwin`
* It allows builds on `aarch64-darwin` (#105026)
* There are no Python versions older than 2.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
