### PR TITLE
gstreamer: Enable sctp plugin

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -237,7 +237,6 @@ in stdenv.mkDerivation rec {
     "-Dopenmpt=disabled" # `libopenmpt` not packaged in nixpkgs as of writing
     "-Dopenni2=disabled" # not packaged in nixpkgs as of writing
     "-Dopensles=disabled" # not packaged in nixpkgs as of writing
-    "-Dsctp=disabled" # required `usrsctp` library not packaged in nixpkgs as of writing
     "-Dsvthevcenc=disabled" # required `SvtHevcEnc` library not packaged in nixpkgs as of writing
     "-Dteletext=disabled" # required `zvbi` library not packaged in nixpkgs as of writing
     "-Dtinyalsa=disabled" # not packaged in nixpkgs as of writing


### PR DESCRIPTION
GStreamer (gst-plugins-bad) now directly vendors libusrsctp so no external dependency is
needed. As of 1.18 this just works if `-Dsctp=disabled` is removed.

See: https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/blob/7cb583bb/NEWS#L1738

###### Motivation for this change

gst-plugins-bad was building with `-Dsctp=disabled` because libusrsctp wasn't included in nixpkgs. Since the plugin was disabled, gst-plugins-bad has switched to directly vendoring their own libusrsctp. The external library is now optional but not required and the sctp plugin builds without it.

###### Things done

Warning: First time contributor. Shout if I'm missing obvious stuff that needs doing.

I've tested this in my own NixOS environment (useSandbox = default) and verified that it builds, the SCTP plugin is properly registered, and it works at runtime with GST's samples (WebRTC stuff in my case).

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
