### PR TITLE
lib.systems: add mips-embedded

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -33,6 +33,7 @@ let
     "avr-none"
     "i686-none" "x86_64-none"
     "powerpc-none"
+    "mips-none"
     "msp430-none"
     "riscv64-none" "riscv32-none"
     "vc4-none"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -162,6 +162,11 @@ rec {
     libc = "newlib";
   };
 
+  mips-embedded = {
+    config = "mips-none-elf";
+    libc = "newlib";
+  };
+
   ppc-embedded = {
     config = "powerpc-none-eabi";
     libc = "newlib";

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -17,7 +17,7 @@ with lib.systems.doubles; lib.runTests {
 
   testarm = mseteq arm [ "armv5tel-linux" "armv6l-linux" "armv6l-none" "armv7a-linux" "armv7l-linux" "arm-none" "armv7a-darwin" ];
   testi686 = mseteq i686 [ "i686-linux" "i686-freebsd" "i686-genode" "i686-netbsd" "i686-openbsd" "i686-cygwin" "i686-windows" "i686-none" "i686-darwin" ];
-  testmips = mseteq mips [ "mipsel-linux" ];
+  testmips = mseteq mips [ "mipsel-linux" "mips-none" ];
   testmmix = mseteq mmix [ "mmix-mmixware" ];
   testx86_64 = mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-genode" "x86_64-redox" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" "x86_64-windows" "x86_64-none" ];
 


### PR DESCRIPTION
###### Motivation for this change
Add another system supported by GCC.

@Ericson2314 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
