### PR TITLE
garble: init at 2020-01-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2091,6 +2091,12 @@
     email = "christoph.senjak@googlemail.com";
     name = "Christoph-Simon Senjak";
   };
+  davhau = {
+    email = "d.hauer.it@gmail.com";
+    name = "David Hauer";
+    github = "DavHau";
+    githubId = 42246742;
+  };
   david-sawatzke = {
     email = "d-nix@sawatzke.dev";
     github = "david-sawatzke";

--- a/pkgs/build-support/go/garble.nix
+++ b/pkgs/build-support/go/garble.nix
@@ -1,0 +1,24 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+buildGoModule rec {
+  pname = "garble";
+  version = "20200107";
+
+  src = fetchFromGitHub {
+    owner = "burrowers";
+    repo = pname;
+    rev = "835f4aadf321521acf06aac4d5068473dc4b2ac1";
+    sha256 = "sha256-NodsVHRll2YZoxrhmniJvelQOStG82u3kJyc0t8OXD8=";
+  };
+
+  vendorSha256 = "sha256-x2fk2QmZDK2yjyfYdK7x+sQjvt7tuggmm8ieVjsNKek=";
+
+  meta = {
+    description = "Obfuscate Go code by wrapping the Go toolchain";
+    homepage = "https://github.com/burrowers/garble/";
+    maintainers = with lib.maintainers; [ davhau ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13698,6 +13698,8 @@ in
 
   ganv = callPackage ../development/libraries/ganv { };
 
+  garble = callPackage ../build-support/go/garble.nix { };
+
   gcab = callPackage ../development/libraries/gcab { };
 
   gcovr = with python3Packages; toPythonApplication gcovr;


### PR DESCRIPTION
###### Motivation for this change
Garble: Obfuscate Go code by wrapping the Go toolchain.

I have been using this tool to add some protection against analysis of binaries built via go.

###### Things doneObfuscate Go code by wrapping the Go toolchain. Requires Go 1.15 or later,

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
