### PR TITLE
magma: fix CUDA 11 build

### DIFF
--- a/pkgs/development/libraries/science/math/magma/default.nix
+++ b/pkgs/development/libraries/science/math/magma/default.nix
@@ -1,8 +1,40 @@
 { lib, stdenv, fetchurl, cmake, gfortran, ninja, cudatoolkit, libpthreadstubs, lapack, blas }:
 
-with lib;
+assert let majorIs = lib.versions.major cudatoolkit.version;
+       in majorIs == "9" || majorIs == "10" || majorIs == "11";
 
-let version = "2.5.4";
+let
+  version = "2.5.4";
+
+  # We define a specific set of CUDA compute capabilities here,
+  # because CUDA 11 does not support compute capability 3.0. Also,
+  # we use it to enable newer capabilities that are not enabled
+  # by magma by default. The list of supported architectures
+  # can be found in magma's top-level CMakeLists.txt.
+  cudaCapabilities = rec {
+    cuda9 = [
+      "Kepler"  # 3.0, 3.5
+      "Maxwell" # 5.0
+      "Pascal"  # 6.0
+      "Volta"   # 7.0
+    ];
+
+    cuda10 = [
+      "Turing"  # 7.5
+    ] ++ cuda9;
+
+    cuda11 = [
+      "sm_35"   # sm_30 is not supported by CUDA 11
+      "Maxwell" # 5.0
+      "Pascal"  # 6.0
+      "Volta"   # 7.0
+      "Turing"  # 7.5
+      "Ampere"  # 8.0
+    ];
+  };
+
+  capabilityString = lib.strings.concatStringsSep ","
+    cudaCapabilities."cuda${lib.versions.major cudatoolkit.version}";
 
 in stdenv.mkDerivation {
   pname = "magma";
@@ -16,6 +48,8 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ gfortran cmake ninja ];
 
   buildInputs = [ cudatoolkit libpthreadstubs lapack blas ];
+
+  cmakeFlags = [ "-DGPU_TARGET=${capabilityString}" ];
 
   doCheck = false;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

By default, MAGMA builds against compute capability 3.0 (among other
capabilities). However, support for this capability was dropped in
CUDA 11. This change fixes CUDA 11 support by excluding 3.0.

While at it, this change also adds support for newer compute
capabilities that are not enabled by MAGMA by default (to support
older CUDA versions).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
