### PR TITLE
fetchgit: specify provided hash as refspec in `git fetch` invocation

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -139,7 +139,7 @@ url_to_name(){
     fi
 }
 
-# Fetch everything and checkout the right sha1
+# Fetch and checkout the right sha1
 checkout_hash(){
     local hash="$1"
     local ref="$2"
@@ -148,7 +148,7 @@ checkout_hash(){
         hash=$(hash_from_ref "$ref")
     fi
 
-    clean_git fetch -t ${builder:+--progress} origin || return 1
+    clean_git fetch -t ${builder:+--progress} origin "$hash" || return 1
     clean_git checkout -b "$branchName" "$hash" || return 1
 }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
When trying to update the illum package to v0.5, I ran into an issue where fetchgit wouldn't fetch the repo properly.  Specifically, when trying to check out the submodule, fetchgit errored trying to `git checkout "$hash"` after fetching the submodule repo.

E.g. an example of manually invoking `nix-prefetch-git`:

    % /etc/nixos/nixpkgs/pkgs/build-support/fetchgit/nix-prefetch-git --fetch-submodules https://github.com/jmesmon/illum v0.5
    Initialized empty Git repository in /tmp/git-checkout-tmp-KMzfSgz5/illum/.git
    <...snip...>
    fatal: reference is not a tree: 1cebc0895d236bfc5cd6797d03e02c55c773ddf1
    Unable to checkout 1cebc0895d236bfc5cd6797d03e02c55c773ddf1 from https://github.com/jmesmon/ccan.

However, it works just fine to clone with a regular `git clone --recurse-submodules`, so it seems the behaviour here diverges from the `git clone` logic.  I'm guessing what's happening here is that the requested object isn't part of the history of any of the default-fetched branches, and therefore isn't part of what's fetched with a plain `git fetch`.  The changes in this PR specifically fetches `"$hash"` instead, and with these changes the `fetchgit` invocation works just fine as expected.

The thing I'm not certain of here is if the deviation from ẁhat `git clone --recurse-submodules` does is intentional or not... if the deviation is intentional and the issue is with the repo in question somehow, we should probably make sure to document the difference to a plain `git clone`.

###### Things done
Updated `nix-prefetch-git` to specifically fetch the object described by the given hash, when a hash is provided.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
