### PR TITLE
cudatoolkit_11, cudnn_cudatoolkit_11: 11.1 -> 11.2

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -153,5 +153,12 @@ in rec {
     gcc = gcc9;
   };
 
+  cudatoolkit_11_2 = common {
+    version = "11.2.1";
+    url = "https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run";
+    sha256 = "sha256-HamMuJfMX1inRFpKZspPaSaGdwbLOvWKZpzc2Nw9F8g=";
+    gcc = gcc9;
+  };
+
   cudatoolkit_11 = cudatoolkit_11_1;
 }

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -160,5 +160,5 @@ in rec {
     gcc = gcc9;
   };
 
-  cudatoolkit_11 = cudatoolkit_11_1;
+  cudatoolkit_11 = cudatoolkit_11_2;
 }

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9_1, cudatoolkit_9_2, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2, cudatoolkit_11_0 }:
+{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9_1, cudatoolkit_9_2, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2, cudatoolkit_11_0, cudatoolkit_11_1 }:
 
 let
   generic = args: callPackage (import ./generic.nix (removeAttrs args ["cudatoolkit"])) {
@@ -88,6 +88,10 @@ in rec {
     # https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
     srcName = "cudnn-11.2-linux-x64-v8.1.0.77.tgz";
     sha256 = "sha256-2+gvrwcdkbqbzwBIAUatM/RiSC3+5WyvRHnBuNq+Pss=";
+  };
+
+  cudnn_cudatoolkit_11_1 = cudnn_cudatoolkit_11_0.override {
+    cudatoolkit = cudatoolkit_11_1;
   };
 
   cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_0;

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -98,5 +98,5 @@ in rec {
     cudatoolkit = cudatoolkit_11_2;
   };
 
-  cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_0;
+  cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_2;
 }

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9_1, cudatoolkit_9_2, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2, cudatoolkit_11_0, cudatoolkit_11_1 }:
+{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9_1, cudatoolkit_9_2, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2 }:
 
 let
   generic = args: callPackage (import ./generic.nix (removeAttrs args ["cudatoolkit"])) {
@@ -92,6 +92,10 @@ in rec {
 
   cudnn_cudatoolkit_11_1 = cudnn_cudatoolkit_11_0.override {
     cudatoolkit = cudatoolkit_11_1;
+  };
+
+  cudnn_cudatoolkit_11_2 = cudnn_cudatoolkit_11_0.override {
+    cudatoolkit = cudatoolkit_11_2;
   };
 
   cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_0;

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -82,10 +82,12 @@ in rec {
   cudnn_cudatoolkit_10 = cudnn_cudatoolkit_10_2;
 
   cudnn_cudatoolkit_11_0 = generic rec {
-    version = "8.0.2";
+    version = "8.1.0";
     cudatoolkit = cudatoolkit_11_0;
-    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v8.0.2.39.tgz";
-    sha256 = "0ib3v3bgcdxarqapkxngw1nwl0c2a7zz392ns7w9ipcficl4cbv7";
+    # 8.1.0 is compatible with CUDA 11.0, 11.1, and 11.2:
+    # https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
+    srcName = "cudnn-11.2-linux-x64-v8.1.0.77.tgz";
+    sha256 = "sha256-2+gvrwcdkbqbzwBIAUatM/RiSC3+5WyvRHnBuNq+Pss=";
   };
 
   cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3401,7 +3401,8 @@ in
     cudatoolkit_10_1
     cudatoolkit_10_2
     cudatoolkit_11
-    cudatoolkit_11_0;
+    cudatoolkit_11_0
+    cudatoolkit_11_2;
 
   cudatoolkit = cudatoolkit_10;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3402,6 +3402,7 @@ in
     cudatoolkit_10_2
     cudatoolkit_11
     cudatoolkit_11_0
+    cudatoolkit_11_1
     cudatoolkit_11_2;
 
   cudatoolkit = cudatoolkit_10;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3422,7 +3422,8 @@ in
     cudnn_cudatoolkit_10_1
     cudnn_cudatoolkit_10_2
     cudnn_cudatoolkit_11
-    cudnn_cudatoolkit_11_0;
+    cudnn_cudatoolkit_11_0
+    cudnn_cudatoolkit_11_1;
 
   cudnn = cudnn_cudatoolkit_10;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3423,7 +3423,8 @@ in
     cudnn_cudatoolkit_10_2
     cudnn_cudatoolkit_11
     cudnn_cudatoolkit_11_0
-    cudnn_cudatoolkit_11_1;
+    cudnn_cudatoolkit_11_1
+    cudnn_cudatoolkit_11_2;
 
   cudnn = cudnn_cudatoolkit_10;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR bundles a lot of updates and a fix:

- Add `cudatoolkit_11_2` (11.2.1)
- The cudatoolkit_11_1 top-level attribute was missing, add it.
- cudnn_cudatoolkit_11_0: 8.0.2 -> 8.1.0
- Add cudnn_cudatoolkit_11_1 and cudnn_cudatoolkit_11_1,
  which also use CDNN 8.1.0.
- Switch the cudatoolkit_11 and cudnn_cudatoolkit_11 aliases to 11_2 versions.

This PR and #112636 prepare for updating PyTorch to support the latest
GPUs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
