### PR TITLE
hound: unstable-2018-11-02 -> unstable-2021-01-26

### DIFF
--- a/pkgs/development/tools/misc/hound/default.nix
+++ b/pkgs/development/tools/misc/hound/default.nix
@@ -1,39 +1,38 @@
-{ lib, stdenv
-, buildGoPackage
+{ lib
+, buildGoModule
 , fetchFromGitHub
 , makeWrapper
 , mercurial
 , git
 }:
 
-buildGoPackage rec {
-  pname = "hound-unstable";
-  version = "2018-11-02";
-  rev = "74ec7448a234d8d09e800b92e52c92e378c07742";
+buildGoModule rec {
+  pname = "hound";
+  version = "unstable-2021-01-26";
+
+  src = fetchFromGitHub {
+    owner = "hound-search";
+    repo = "hound";
+    rev = "b88fc1f79d668e6671a478ddf4fb3e73a63067b9";
+    sha256 = "00xc3cj7d3klvhsh9hivvjwgzb6lycw3r3w7nch98nv2j8iljc44";
+  };
+
+  vendorSha256 = "0x1nhhhvqmz3qssd2d44zaxbahj8lh9r4m5jxdvzqk6m3ly7y0b6";
 
   nativeBuildInputs = [ makeWrapper ];
 
-  goPackagePath = "github.com/etsy/hound";
+  # requires network access
+  doCheck = false;
 
-  src = fetchFromGitHub {
-    inherit rev;
-    owner = "etsy";
-    repo = "hound";
-    sha256 = "0g6nvgqjabprcl9z5ci5frhbam1dzq978h1d6aanf8vvzslfgdpq";
-  };
-
-  postInstall = with stdenv; let
-    binPath = lib.makeBinPath [ mercurial git ];
-  in ''
-    wrapProgram $out/bin/houndd --prefix PATH : ${binPath}
+  postInstall = ''
+    wrapProgram $out/bin/houndd --prefix PATH : ${lib.makeBinPath [ mercurial git ]}
   '';
 
-  meta = {
+  meta = with lib; {
     inherit (src.meta) homepage;
-
     description = "Lightning fast code searching made easy";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ grahamc ];
-    platforms = lib.platforms.unix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ grahamc SuperSandro2000 ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

Tested search and works like a charm.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
