### PR TITLE
fscryptctl: init at 1.0.0

### DIFF
--- a/pkgs/os-specific/linux/fscryptctl/legacy.nix
+++ b/pkgs/os-specific/linux/fscryptctl/legacy.nix
@@ -1,8 +1,11 @@
 { lib, stdenv, fetchFromGitHub }:
 
+# Don't use this for anything important!
+# TODO: Drop fscryptctl-experimental after the NixOS 21.03/21.05 release.
+
 stdenv.mkDerivation rec {
   pname = "fscryptctl";
-  version = "1.0.0";
+  version = "0.1.0";
 
   goPackagePath = "github.com/google/fscrypt";
 
@@ -10,10 +13,10 @@ stdenv.mkDerivation rec {
     owner = "google";
     repo = "fscryptctl";
     rev = "v${version}";
-    sha256 = "1hwj726mm0yhlcf6523n07h0yq1rvkv4km64h3ydpjcrcxklhw6l";
+    sha256 = "1853hlpklisbqnkb7a921dsf0vp2nr2im26zpmrs592cnpsvk3hb";
   };
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  makeFlags = [ "DESTDIR=$(out)/bin" ];
 
   meta = with lib; {
     description = "Small C tool for Linux filesystem encryption";
@@ -32,9 +35,17 @@ stdenv.mkDerivation rec {
       documentation for filesystem encryption before using fscryptctl.
     '';
     inherit (src.meta) homepage;
-    changelog = "https://github.com/google/fscryptctl/releases/tag/v{version}";
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = with maintainers; [ primeos ];
+    knownVulnerabilities = [ ''
+      fscryptctl version 1.0.0 was released and now uses v2 encryption
+      policies. fscryptctl-experimental will remain at version 0.1.0 which
+      still supports the v1 encryption policies. Please try to switch from the
+      "fscryptctl-experimental" package to "fscryptctl". The v1 encryption
+      policies can be insecure, are hard to use correctly, and have different
+      semantics from v2 policies (which is why they are no longer supported in
+      fscryptctl 1.0.0+).
+    '' ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18786,9 +18786,10 @@ in
 
   erofs-utils = callPackage ../os-specific/linux/erofs-utils { };
 
+  fscryptctl = callPackage ../os-specific/linux/fscryptctl { };
   # unstable until the first 1.x release
   fscrypt-experimental = callPackage ../os-specific/linux/fscrypt { };
-  fscryptctl-experimental = callPackage ../os-specific/linux/fscryptctl { };
+  fscryptctl-experimental = callPackage ../os-specific/linux/fscryptctl/legacy.nix { };
 
   fwupd = callPackage ../os-specific/linux/firmware/fwupd { };
 


### PR DESCRIPTION
Release notes: https://github.com/google/fscryptctl/releases/tag/v1.0.0

fscryptctl-experimental will remain at version 0.1.0 to ensure a smooth
transition.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
