### PR TITLE
tests/vscodium: Fix race condition

### DIFF
--- a/nixos/tests/vscodium.nix
+++ b/nixos/tests/vscodium.nix
@@ -29,33 +29,18 @@ import ./make-test-python.nix ({ pkgs, ...} :
     start_all()
     machine.wait_for_x()
 
-    # Create a file that we'll open
-    machine.succeed("su - alice -c 'echo \"   Hello World\" > foo.txt'")
-
-    # It's one line long
-    assert "1 foo.txt" in machine.succeed(
-        "su - alice -c 'wc foo.txt -l'"
-    ), "File has wrong length"
-
-    # Start VSCodium with that file
+    # Start VSCodium with a file that doesn't exist yet
+    machine.fail("ls /home/alice/foo.txt")
     machine.succeed("su - alice -c 'codium foo.txt' &")
 
     # Wait for the window to appear
     machine.wait_for_text("VSCodium")
 
-    # Add a line
-    machine.send_key("ret")
-
     # Save file
     machine.send_key("ctrl-s")
 
     # Wait until the file has been saved
-    machine.sleep(1)
-
-    # Now the file is 2 lines long
-    assert "2 foo.txt" in machine.succeed(
-        "su - alice -c 'wc foo.txt -l'"
-    ), "File has wrong length"
+    machine.wait_for_file("/home/alice/foo.txt")
 
     machine.screenshot("VSCodium")
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix race condition introduced in https://github.com/NixOS/nixpkgs/pull/112394

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@kevincox Sorry, I sneaked a mistake in my last PR. Apparently in the VM it can take more than 1 second guest time to save a file. I replaced the test by another, simple one, that doesn't have race conditions.