### PR TITLE
python.nbxmpp: Fix dependency specs

### DIFF
--- a/pkgs/development/python-modules/nbxmpp/default.nix
+++ b/pkgs/development/python-modules/nbxmpp/default.nix
@@ -15,8 +15,7 @@ in buildPythonPackage {
   };
 
   buildInputs = [ precis-i18n ];
-  checkInputs = [ gobject-introspection libsoup pygobject3 ];
-  propagatedBuildInputs = [ idna pyopenssl ];
+  propagatedBuildInputs = [ gobject-introspection idna libsoup pygobject3 pyopenssl ];
 
   meta = with lib; {
     homepage = "https://dev.gajim.org/gajim/python-nbxmpp";


### PR DESCRIPTION
These deps are actually needed at runtime, not just for the test suite.

This presumably hasn't been noticed until now because gajim, the only
consumer of nbxmpp, already depends on all three of these packages
anyway.

However, gajim only depends on libsoup transitively through gupnp-igd, and
thus fails to build if the dependency on that is disabled by passing
enableUPnP = false.


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
