### PR TITLE
nixos/tests/networking: fix DHCP race condition

### DIFF
--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -35,7 +35,7 @@ let
         extraConfig = flip concatMapStrings vlanIfs (n: ''
           subnet 192.168.${toString n}.0 netmask 255.255.255.0 {
             option routers 192.168.${toString n}.1;
-            range 192.168.${toString n}.2 192.168.${toString n}.254;
+            range 192.168.${toString n}.3 192.168.${toString n}.254;
           }
         '')
         ;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Should fix #102482.

The `dhcp4` configuration in `nixos/tests/networking.nix` uses fixed `192.168.*.2` addresses from inside the `192.168.*.2-254` dynamic range:

```nix
{
  services.dhcpd4 = {
    enable = true;
    interfaces = map (n: "eth${toString n}") vlanIfs;
    extraConfig = flip concatMapStrings vlanIfs (n: ''
      subnet 192.168.${toString n}.0 netmask 255.255.255.0 {
        option routers 192.168.${toString n}.1;
        range 192.168.${toString n}.2 192.168.${toString n}.254;
      }
    '')
    ;
    machines = flip map vlanIfs (vlan:
      {
        hostName = "client${toString vlan}";
        ethernetAddress = qemu-flags.qemuNicMac vlan 1;
        ipAddress = "192.168.${toString vlan}.2";
      }
    );
  };
}
```

Apparently, configuring a fixed IPv4 address with a `fixed-address` directive in `dhcpd.conf` does not automatically exclude it from the dynamic address range. This causes a race condition in `nixos.tests.networking.scripted.macvlan` where two different interfaces can sometimes get the same `192.168.1.2` address, which makes the test fail.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
