### PR TITLE
nixos rpi bootloader: install files for raspberry pi 4 (rpi4)

### DIFF
--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
@@ -37,6 +37,9 @@ let
     '' else ''
       kernel=kernel.img
       initramfs initrd followkernel
+    '') + (optional (cfg.version == 4) ''
+      enable_gic=1
+      armstub=armstub8-gic.bin
     '') + optional (cfg.firmwareConfig != null) cfg.firmwareConfig);
 
 in

--- a/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.nix
@@ -15,8 +15,13 @@ let
         pkgs.ubootRaspberryPi3_64bit
       else
         pkgs.ubootRaspberryPi3_32bit
+    else if version == 4 then
+      if isAarch64 then
+        pkgs.ubootRaspberryPi4_64bit
+      else
+        pkgs.ubootRaspberryPi4_32bit
     else
-      throw "U-Boot is not yet supported on the raspberry pi 4.";
+      throw "U-Boot is not yet supported on the raspberry pi ${toString version}.";
 
   extlinuxConfBuilder =
     import ../generic-extlinux-compatible/extlinux-conf-builder.nix {
@@ -29,6 +34,7 @@ pkgs.substituteAll {
   inherit (pkgs) bash;
   path = [pkgs.coreutils pkgs.gnused pkgs.gnugrep];
   firmware = pkgs.raspberrypifw;
+  armstubs = pkgs.raspberrypi-armstubs;
   inherit uboot;
   inherit configTxt;
   inherit extlinuxConfBuilder;

--- a/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.sh
+++ b/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.sh
@@ -12,7 +12,8 @@ done
 copyForced() {
     local src="$1"
     local dst="$2"
-    cp $src $dst.tmp
+    cp -r $src $dst.tmp
+    rm -rf $dst
     mv $dst.tmp $dst
 }
 
@@ -21,6 +22,7 @@ copyForced() {
 
 # Add the firmware files
 fwdir=@firmware@/share/raspberrypi/boot/
+copyForced $fwdir/overlays  $target/overlays
 copyForced $fwdir/bootcode.bin  $target/bootcode.bin
 copyForced $fwdir/fixup.dat     $target/fixup.dat
 copyForced $fwdir/fixup_cd.dat  $target/fixup_cd.dat
@@ -31,8 +33,26 @@ copyForced $fwdir/start_cd.elf  $target/start_cd.elf
 copyForced $fwdir/start_db.elf  $target/start_db.elf
 copyForced $fwdir/start_x.elf   $target/start_x.elf
 
+# Add the config.txt
+copyForced @configTxt@ $target/config.txt
+
 # Add the uboot file
 copyForced @uboot@/u-boot.bin $target/u-boot-rpi.bin
 
-# Add the config.txt
-copyForced @configTxt@ $target/config.txt
+# Add the raspberry pi 4 specific files
+if [[ "@version@" == "4" ]]; then
+    copyForced @armstubs@/armstub8-gic.bin $target/armstub8-gic.bin
+
+    copyForced $fwdir/fixup4.dat    $target/fixup4.dat
+    copyForced $fwdir/fixup4cd.dat  $target/fixup4cd.dat
+    copyForced $fwdir/fixup4db.dat  $target/fixup4db.dat
+    copyForced $fwdir/fixup4x.dat   $target/fixup4x.dat
+    copyForced $fwdir/start4.elf    $target/start4.elf
+    copyForced $fwdir/start4cd.elf  $target/start4cd.elf
+    copyForced $fwdir/start4db.elf  $target/start4db.elf
+    copyForced $fwdir/start4x.elf   $target/start4x.elf
+
+    copyForced @firmware@/share/raspberrypi/boot/bcm2711-rpi-4-b.dtb $target/bcm2711-rpi-4-b.dtb
+    copyForced @firmware@/share/raspberrypi/boot/bcm2711-rpi-400.dtb $target/bcm2711-rpi-400.dtb
+    copyForced @firmware@/share/raspberrypi/boot/bcm2711-rpi-cm4.dtb $target/bcm2711-rpi-cm4.dtb
+fi


### PR DESCRIPTION
###### Motivation for this change

NixOS currently has a few bootloader "builders":
* generations-dir
* generic-extlinux-compatible
* grub
* init-script
* raspberrypi
* systemd-boot

The `raspberrypi` option, itself, has multiple different bootloader builders that you choose from:
* raspberry-pi-builder
  * just drops a config.txt, kernel, initrd and an `old` dir with old generation kernel/initrd
* u-boot
  * drops the version-appropriate u-boot binary to /boot
  * drops the rpi firmware files to /boot
  * calls the `generic-extlinux-compatible` bootloader builder which in turn drops extlinux-compatible files and dir structures.

The u-boot scenario is more ideal because the user has a chance to choose a different generation to boot, including kernel and initrd. Without u-boot, the user must manually intervene and edit the sd card to switch to an old generation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
