### PR TITLE
cinelerra: unbreak the build (make compatible with gcc10)

### DIFF
--- a/pkgs/applications/video/cinelerra/default.nix
+++ b/pkgs/applications/video/cinelerra/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoconf, automake, libtool
 , pkg-config, faad2, faac, a52dec, alsaLib, fftw, lame, libavc1394
 , libiec61883, libraw1394, libsndfile, libvorbis, libogg, libjpeg
 , libtiff, freetype, mjpegtools, x264, gettext, openexr
@@ -10,11 +10,19 @@ stdenv.mkDerivation {
   name = "cinelerra-cv-2018-05-16";
 
   src = fetchFromGitHub {
-    owner = "ratopi";
-    repo = "CinelerraCV";
+    owner = "cinelerra-cv-team";
+    repo = "cinelerra-cv";
     rev = "d9c0dbf4393717f0a42f4b91c3e1ed5b16f955dc";
     sha256 = "0a8kfm1v96sv6jh4568crg6nkr6n3579i9xksfj8w199s6yxzsbk";
   };
+
+  patches = [
+    # avoid gcc10 error about narrowing
+    (fetchpatch {
+      url = "https://github.com/cinelerra-cv-team/cinelerra-cv/pull/2/commits/a1b2d9c3bd5730ec0284894f3d81892af3e77f1f.patch";
+      sha256 = "1cjyv1m174dblpa1bs5dggk24h4477zqvc5sbfc0m5rpkndx5ycp";
+    })
+  ];
 
   preConfigure = ''
     find -type f -print0 | xargs --null sed -e "s@/usr/bin/perl@${perl}/bin/perl@" -i
@@ -28,10 +36,9 @@ stdenv.mkDerivation {
   '';
   enableParallelBuilding = true;
 
+  nativeBuildInputs = [ automake autoconf libtool pkg-config file intltool ];
   buildInputs =
-    [ automake
-      autoconf libtool pkg-config file
-      faad2 faac
+    [ faad2 faac
       a52dec alsaLib   fftw lame libavc1394 libiec61883
       libraw1394 libsndfile libvorbis libogg libjpeg libtiff freetype
       mjpegtools x264 gettext openexr
@@ -39,13 +46,13 @@ stdenv.mkDerivation {
       libtheora libpng libdv libuuid
       nasm
       perl
-      fontconfig intltool
+      fontconfig
     ];
 
-  meta = {
+  meta = with lib; {
     description = "Video Editor";
-    homepage = "http://www.cinelerra.org";
-    maintainers = [ lib.maintainers.marcweber ];
-    license = lib.licenses.gpl2;
+    homepage = "https://www.cinelerra.org/";
+    maintainers = with maintainers; [ marcweber ];
+    license = licenses.gpl2Only;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
