### PR TITLE
nixos boot rpi: add rpi4uefi+grub as rpi4 bootldr

### DIFF
--- a/nixos/modules/system/boot/loader/raspberrypi/rpi4uefi-builder.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/rpi4uefi-builder.nix
@@ -1,0 +1,44 @@
+{ pkgs, config, lib }:
+
+let
+  # TODO: allow user to extend this maybe?
+  # but for now we use the config.txt directly from the rpi4_uefi release
+  configTxt = ''
+  '';
+
+  grubBootBuilder =
+    (import ../systemd-boot/gummiboot-builder.nix {
+      pkgs = pkgs.buildPackages;
+      inherit config lib;
+    });
+
+  rpi4uefi = pkgs.callPackage (
+    { stdenv, runCommandNoCC, unzip }:
+    let
+      version = "v1.22";
+      sha256 = "0yklg00fmg82rg1plyz6wc3kdgss9xp85ilhmc61p6jgvn0s138q";
+      src = builtins.fetchurl {
+        url = "https://github.com/pftf/RPi4/releases/download/${version}/RPi4_UEFI_Firmware_${version}.zip";
+        inherit sha256;
+      };
+    in
+      runCommandNoCC "rpi4-uefi-fw-${version}" {} ''
+        mkdir -p $out/
+        echo ${unzip}/bin/unzip "${src}" -d $out/
+        ${unzip}/bin/unzip "${src}" -d $out/
+      ''
+  ) {};
+
+  nextStage = grubBootBuilder;
+in
+pkgs.substituteAll {
+  src = ./rpi4uefi-builder.sh;
+  isExecutable = true;
+  inherit (pkgs) bash;
+  path = [pkgs.coreutils pkgs.gnused pkgs.gnugrep];
+  rpi4uefi = rpi4-uefi;
+  systemdBootBuilder = "${systemdBootBuilder}";
+  grubBootBuilder = "${grubBootBuilder}";
+  efiSysMountPoint = config.boot.loader.efi.efiSysMountPoint;
+  inherit configTxt;
+}

--- a/nixos/modules/system/boot/loader/raspberrypi/rpi4uefi-builder.sh
+++ b/nixos/modules/system/boot/loader/raspberrypi/rpi4uefi-builder.sh
@@ -1,0 +1,31 @@
+#! @bash@/bin/sh -e
+
+target=@efiSysMountPoint@ # Target directory
+config=""
+
+while getopts "t:c:d:g:" opt; do
+    case "$opt" in
+        d) target="$OPTARG" ;;
+        c) config="$OPTARG" ;;
+        *) ;;
+    esac
+done
+
+copyForced() {
+    local src="$1"
+    local dst="$2"
+    cp $src $dst.tmp
+    mv $dst.tmp $dst
+}
+
+"@grubBootBuilder@" "${config}"
+
+# Add the firmware files
+rpi4uefidir=@rpi4uefi@
+copyForced $rpi4uefidir/start4.elf $target/start4.elf
+copyForced $rpi4uefidir/fixup4.dat $target/fixup4.dat
+copyForced $rpi4uefidir/RPI_EFI.fd $target/RPI_EFI.fd
+copyForced $rpi4uefidir/config.txt $target/config.txt
+copyForced $rpi4uefidir/bcm2711-rpi-4-b.dtb $target/bcm2711-rpi-4-b.dtb
+copyForced $rpi4uefidir/bcm2711-rpi-400.dtb $target/bcm2711-rpi-400.dtb
+copyForced $rpi4uefidir/bcm2711-rpi-cm4.dtb $target/bcm2711-rpi-cm4.dtb


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I don't know if I will pursue this:
* we'd probably want to build rpi4uefi (edk2) from source and I have no desire/time to do that

Reasons to continue this:
* grub can do more things than u-boot

But I wanted to at least send it out, so someone can pick it up if they want, and at least it's not only in my head.

There's another outstanding chore for this PR, to finish it -- Right now the assumption is to use the rpi-bootloader generator, unless uboot is true. Now that we have another option this logic/api needs to be bolstered.

(Also, I hacked on the assertions right before sending this PR, so if this doesn't build just revert that bit)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
