### PR TITLE
jrnl: 1.9.8 -> 2.7

### DIFF
--- a/pkgs/applications/misc/jrnl/default.nix
+++ b/pkgs/applications/misc/jrnl/default.nix
@@ -1,30 +1,56 @@
 { lib
-, python3
+, ansiwrap
+, asteval
+, buildPythonApplication
+, colorama
+, cryptography
+, fetchFromGitHub
+, keyring
+, parsedatetime
+, poetry
+, pytestCheckHook
+, python-dateutil
+, pytz
+, pyxdg
+, pyyaml
+, tzlocal
 }:
-
-with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "jrnl";
-  version = "1.9.8";
+  version = "2.7";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "d254c9c8f24dcf985b98a1d5311337c7f416e6305107eec34c567f58c95b06f4";
+  src = fetchFromGitHub {
+    owner = "jrnl-org";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1hyjjw9mxy73n3pkliaaif135h2sd4iy43pw9d5zynid5abnr3yz";
   };
 
+  nativeBuildInputs = [ poetry ];
+
   propagatedBuildInputs = [
-    pytz six tzlocal keyring dateutil
-    parsedatetime pycrypto
+    ansiwrap
+    asteval
+    colorama
+    cryptography
+    keyring
+    parsedatetime
+    python-dateutil
+    pytz
+    pyxdg
+    pyyaml
+    tzlocal
   ];
 
-  # No tests in archive
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "jrnl" ];
 
   meta = with lib; {
     homepage = "http://maebert.github.io/jrnl/";
     description = "A simple command line journal application that stores your journal in a plain text file";
-    license = licenses.mit;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ zalakain ];
   };
 }

--- a/pkgs/applications/networking/browsers/av-98/default.nix
+++ b/pkgs/applications/networking/browsers/av-98/default.nix
@@ -12,6 +12,10 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [ ansiwrap cryptography ];
 
+  # No tests are available
+  doCheck = false;
+  pythonImportsCheck = [ "av98" ];
+
   meta = with lib; {
     homepage = "https://tildegit.org/solderpunk/AV-98";
     description = "Experimental console client for the Gemini protocol";

--- a/pkgs/development/python-modules/ansiwrap/default.nix
+++ b/pkgs/development/python-modules/ansiwrap/default.nix
@@ -1,11 +1,10 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-, tox
-, pytest
 , ansicolors
+, buildPythonPackage
 , coverage
-, pytestcov
+, fetchPypi
+, pytest-cov
+, pytestCheckHook
 , textwrap3
 }:
 
@@ -20,20 +19,15 @@ buildPythonPackage rec {
   };
 
   checkInputs = [
-    tox
-    pytest
     ansicolors
     coverage
-    pytestcov
+    pytest-cov
+    pytestCheckHook
   ];
 
-  propagatedBuildInputs = [
-    textwrap3
-  ];
+  propagatedBuildInputs = [ textwrap3 ];
 
-  checkPhase = ''
-    pytest
-  '';
+  pythonImportsCheck = [ "ansiwrap" ];
 
   meta = with lib; {
     description = "Textwrap, but savvy to ANSI colors and styles";

--- a/pkgs/development/python-modules/asteval/default.nix
+++ b/pkgs/development/python-modules/asteval/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "asteval";
+  version = "0.9.21";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "newville";
+    repo = pname;
+    rev = version;
+    sha256 = "1bhdj7zybsqghgd7qx50il7nwfg79qx9wg03n0z96jgq5gydqd9w";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "asteval" ];
+
+  meta = with lib; {
+    description = "AST evaluator of Python expression using ast module";
+    homepage = "https://github.com/newville/asteval";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5428,7 +5428,7 @@ in
 
   jo = callPackage ../development/tools/jo { };
 
-  jrnl = callPackage ../applications/misc/jrnl { };
+  jrnl = python3Packages.callPackage ../applications/misc/jrnl { };
 
   jsawk = callPackage ../tools/text/jsawk { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -461,6 +461,8 @@ in {
 
   aspy-yaml = callPackage ../development/python-modules/aspy.yaml { };
 
+  asteval = callPackage ../development/python-modules/asteval { };
+
   astor = callPackage ../development/python-modules/astor { };
 
   astral = callPackage ../development/python-modules/astral { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.7

Change log: https://github.com/jrnl-org/jrnl/releases/tag/v2.7

Also, enabled tests and migrate `ansiwrap` to `pytestCheckHook`.

[`asteval`](https://github.com/newville/asteval) is a new dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
