### PR TITLE
libaom: disable runtime cpu detection on darwin

### DIFF
--- a/pkgs/development/libraries/libaom/default.nix
+++ b/pkgs/development/libraries/libaom/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     "-DBUILD_SHARED_LIBS=ON"
     "-DENABLE_TESTS=OFF"
   ] ++ lib.optionals stdenv.isDarwin [
+    # CPU detection isn't supported on Darwin and breaks the aarch64-darwin build:
     "-DCONFIG_RUNTIME_CPU_DETECT=OFF"
   ];
 

--- a/pkgs/development/libraries/libaom/default.nix
+++ b/pkgs/development/libraries/libaom/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
     "-DENABLE_TESTS=OFF"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DCONFIG_RUNTIME_CPU_DETECT=OFF"
   ];
 
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change

CPU detection is only enabled for PPC and ARM. It's also not implemented on Darwin, so no reason to keep it enabled there. This helps #105026.

cc @thefloweringash 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
