### PR TITLE
json-glib: 1.4.4 → 1.6.2

### DIFF
--- a/pkgs/development/libraries/json-glib/default.nix
+++ b/pkgs/development/libraries/json-glib/default.nix
@@ -1,23 +1,47 @@
-{ lib, stdenv, fetchurl, glib, meson, ninja, pkg-config, gettext
-, gobject-introspection, fixDarwinDylibNames, gnome3
+{ lib
+, stdenv
+, fetchurl
+, glib
+, meson
+, ninja
+, pkg-config
+, gettext
+, gobject-introspection
+, fixDarwinDylibNames
+, gtk-doc
+, docbook-xsl-nons
+, docbook_xml_dtd_43
+, gnome3
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "json-glib";
-  version = "1.4.4";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  version = "1.6.2";
+
+  outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0ixwyis47v5bkx6h8a1iqlw3638cxcv57ivxv4gw2gaig51my33j";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "092g2dyy1hhl0ix9kp33wcab0pg1qicnsv0cj5ms9g9qs336cgd3";
   };
 
-  propagatedBuildInputs = [ glib ];
-  nativeBuildInputs = [ meson ninja pkg-config gettext gobject-introspection glib ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+    gobject-introspection
+    glib
+    gtk-doc
+    docbook-xsl-nons
+    docbook_xml_dtd_43
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin [
+    fixDarwinDylibNames
+  ];
 
-  outputs = [ "out" "dev" ];
+  propagatedBuildInputs = [
+    glib
+  ];
 
   doCheck = true;
 
@@ -30,8 +54,8 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A library providing (de)serialization support for the JavaScript Object Notation (JSON) format";
     homepage = "https://wiki.gnome.org/Projects/JsonGlib";
-    license = licenses.lgpl2;
-    maintainers = with maintainers; [ lethalman ];
+    license = licenses.lgpl21Plus;
+    maintainers = teams.gnome.members;
     platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* https://gitlab.gnome.org/GNOME/json-glib/-/tags/1.5.2
* https://gitlab.gnome.org/GNOME/json-glib/-/tags/1.6.0
* https://gitlab.gnome.org/GNOME/json-glib/-/tags/1.6.2

gtk-doc is enabled by default so I had to add it plus DocBook files to dependencies.

Also added GNOME team to maintainers so that it is not forgotten the next time (lethalman is no longer maintaining GNOME packages).

And correct license and clean up the code a bit while at it.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
