### PR TITLE
harfbuzz: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -15,6 +15,7 @@ let
   inherit (lib) optional optionals optionalString;
   mesonFeatureFlag = opt: b:
     "-D${opt}=${if b then "enabled" else "disabled"}";
+  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
 in
 
 stdenv.mkDerivation {
@@ -43,21 +44,25 @@ stdenv.mkDerivation {
     (mesonFeatureFlag "graphite" withGraphite2)
     (mesonFeatureFlag "icu" withIcu)
     (mesonFeatureFlag "coretext" withCoreText)
+    (mesonFeatureFlag "introspection" (!isCross))
   ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     meson
     ninja
-    gobject-introspection
     libintl
     pkg-config
     python3
     gtk-doc
     docbook-xsl-nons
     docbook_xml_dtd_43
-  ];
+    glib # glib-mkenums
+  ] ++ lib.optional (!isCross) gobject-introspection;
 
   buildInputs = [ glib freetype cairo ] # recommended by upstream
+    ++ lib.optional (!isCross) gobject-introspection
     ++ lib.optionals withCoreText [ ApplicationServices CoreText ];
 
   propagatedBuildInputs = []


### PR DESCRIPTION
###### Motivation for this change
This change indirectly fixes cross compilation for Emacs

Fixes build errors:
- ```src/meson.build:639:4: ERROR: Problem encountered: Introspection support is requested but it isn't available in cross builds```
- ```Program glib-mkenums mkenums found: NO```

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (for armv7l-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@edolstra