### PR TITLE
python3Packages.starlette: 0.13.8 -> 0.14.2

### DIFF
--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -10,7 +10,6 @@
 , python-multipart
 , pyyaml
 , requests
-, ujson
 , aiosqlite
 , databases
 , pytestCheckHook
@@ -21,15 +20,20 @@
 
 buildPythonPackage rec {
   pname = "starlette";
-  version = "0.13.8";
+  version = "0.14.2";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "11i0yd8cqwscixajl734g11vf8pghki11c81chzfh8ifmj6mf9jk";
+    sha256 = "0fz28czvwiww693ig9vwdja59xxs7m0yp1df32ms1hzr99666bia";
   };
+
+  postPatch = ''
+    # remove coverage arguments to pytest
+    sed -i '/--cov/d' setup.cfg
+  '';
 
   propagatedBuildInputs = [
     aiofiles
@@ -39,7 +43,6 @@ buildPythonPackage rec {
     python-multipart
     pyyaml
     requests
-    ujson
   ] ++ lib.optional stdenv.isDarwin [ ApplicationServices ];
 
   checkInputs = [
@@ -50,9 +53,10 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
+  # fails to import graphql, but integrated graphql support is about to
+  # be removed in 0.15, see https://github.com/encode/starlette/pull/1135.
   disabledTestPaths = [ "tests/test_graphql.py" ];
-  # https://github.com/encode/starlette/issues/1131
-  disabledTests = [ "test_debug_html" ];
+
   pythonImportsCheck = [ "starlette" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/encode/starlette/releases/tag/0.14.0
https://github.com/encode/starlette/releases/tag/0.14.1
https://github.com/encode/starlette/releases/tag/0.14.2

- ujson was dropped in https://github.com/encode/starlette/pull/1047
  - removal of `UJSONResponse` breaks fastapi https://github.com/tiangolo/fastapi/pull/2335
- test_debug_html was fixed in https://github.com/encode/starlette/pull/1132

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
