### PR TITLE
frozen-bubble: add desktop file

### DIFF
--- a/pkgs/games/frozen-bubble/default.nix
+++ b/pkgs/games/frozen-bubble/default.nix
@@ -1,5 +1,6 @@
-{ lib, fetchurl, perlPackages, pkg-config, SDL, SDL_mixer, SDL_Pango, glib }:
-
+{ lib, fetchurl, perlPackages, pkg-config, SDL, SDL_mixer, SDL_Pango, glib
+, copyDesktopItems, makeDesktopItem
+}:
 perlPackages.buildPerlModule {
   pname = "frozen-bubble";
   version = "2.212";
@@ -10,12 +11,23 @@ perlPackages.buildPerlModule {
   };
   patches = [ ./fix-compilation.patch ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ copyDesktopItems pkg-config ];
 
   buildInputs =  [ glib SDL SDL_mixer SDL_Pango perlPackages.SDL perlPackages.FileSlurp ];
   propagatedBuildInputs = with perlPackages; [ AlienSDL CompressBzip2 FileShareDir FileWhich IPCSystemSimple LocaleMaketextLexicon ];
 
   perlPreHook = "export LD=$CC";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "frozen-bubble";
+      exec = "frozen-bubble";
+      desktopName = "Frozen Bubble";
+      genericName = "Frozen Bubble";
+      comment = "Arcade/reflex colour matching game";
+      categories = "Game;";
+    })
+  ];
 
   meta = {
     description = "Puzzle with Bubbles";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

GUI games should have desktop files!  Frozen Bubble doesn't ship a desktop file, so we write our own.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Net +552 bytes.
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
