### PR TITLE
ecl: 20.4.24 -> 21.2.1, enable Darwin

### DIFF
--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl
+{lib, stdenv, fetchurl, fetchpatch
 , libtool, autoconf, automake
 , texinfo
 , gmp, mpfr, libffi, makeWrapper
@@ -37,10 +37,9 @@ stdenv.mkDerivation {
 
   patches = [
     # https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/1
-    (fetchurl {
-      name = "write_error.patch";
+    (fetchpatch {
       url = "https://git.sagemath.org/sage.git/plain/build/pkgs/ecl/patches/write_error.patch?h=9.2";
-      sha256 = "1lvdvh77blnxp0zbd27dsbq1ljkb5qblabf1illszn4j7qgq88fh";
+      sha256 = "0hfxacpgn4919hg0mn4wf4m8r7y592r4gw7aqfnva7sckxi6w089";
     })
   ];
 

--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -11,10 +11,10 @@ let
   s = # Generated upstream information
   rec {
     baseName="ecl";
-    version="20.4.24";
+    version="21.2.1";
     name="${baseName}-${version}";
     url="https://common-lisp.net/project/ecl/static/files/release/${name}.tgz";
-    sha256="01qgdmr54wkj854f69qdm9sybrvd6gd21dpx4askdaaqybnkh237";
+    sha256="000906nnq25177bgsfndiw3iqqgrjc9spk10hzk653sbz3f7anmi";
   };
   buildInputs = [
     libtool autoconf automake texinfo makeWrapper
@@ -36,37 +36,11 @@ stdenv.mkDerivation {
   };
 
   patches = [
-    # https://trac.sagemath.org/ticket/22191#comment:237
-    (fetchurl {
-      name = "ECL_WITH_LISP_FPE.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/ecl/patches/ECL_WITH_LISP_FPE.patch?h=9.2";
-      sha256 = "0b194613avcmzr1k9gq725z41wdkg5rsa0q21kdw050iqpprcj1c";
-    })
-
     # https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/1
     (fetchurl {
       name = "write_error.patch";
       url = "https://git.sagemath.org/sage.git/plain/build/pkgs/ecl/patches/write_error.patch?h=9.2";
       sha256 = "1lvdvh77blnxp0zbd27dsbq1ljkb5qblabf1illszn4j7qgq88fh";
-    })
-
-    # Three patches to fix ecl's unicode handling (https://trac.sagemath.org/ticket/30122)
-    (fetchurl {
-      name = "0001-unicode-fix-ecl_string_case-for-non-ascii-characters.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/ecl/patches/0001-unicode-fix-ecl_string_case-for-non-ascii-characters.patch?h=9.2";
-      sha256 = "0z8pnhawivrrbg4vz144nr2sz64jxp7764hn6df13bgkz84iqbmk";
-    })
-
-    (fetchurl {
-      name = "0002-cosmetic-fix-some-compiler-warnings.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/ecl/patches/0002-cosmetic-fix-some-compiler-warnings.patch?h=9.2";
-      sha256 = "0msx3say9igwr9z5ywnr3gs6vsndnzlx47fmzwzh4l0m274cnia8";
-    })
-
-    (fetchurl {
-      name = "0003-printer-fix-printing-of-symbols-with-non-ascii-names.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/ecl/patches/0003-printer-fix-printing-of-symbols-with-non-ascii-names.patch?h=9.2";
-      sha256 = "0ln5dsx6p265fkph3bl5wblgfi3f7frb4jl6v473wz3ibvcx1x9a";
     })
   ];
 
@@ -96,6 +70,6 @@ stdenv.mkDerivation {
     homepage = "https://common-lisp.net/project/ecl/";
     license = lib.licenses.mit ;
     maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Incorporates the latest upstream release
- Removes now-defunct patches
- Enable builds on non-Linux Unixes, ie. Darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
      - No, could not be built locally previously. Looks reasonable though, given that it includes gcc.
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
