### PR TITLE
bzflag: install desktop file and icon; enable parallel building

### DIFF
--- a/pkgs/games/bzflag/bzflag-2.4.20-desktop-file.patch
+++ b/pkgs/games/bzflag/bzflag-2.4.20-desktop-file.patch
@@ -1,0 +1,12 @@
+diff -ru bzflag-2.4.20/data/bzflag.desktop bzflag-2.4.20.b/data/bzflag.desktop
+--- bzflag-2.4.20/data/bzflag.desktop	2019-03-03 11:34:43.000000000 -0800
++++ bzflag-2.4.20.b/data/bzflag.desktop	2021-03-20 21:51:13.722381294 -0700
+@@ -3,7 +3,7 @@
+ GenericName=Tank Battle Game
+ Comment=Battle enemy tanks
+ Keywords=capture;flag;tank;game;multiplayer;network;
+-Exec=/usr/games/bzflag
++Exec=bzflag
+ Icon=bzflag-48x48
+ Type=Application
+ Categories=Game;ActionGame;

--- a/pkgs/games/bzflag/default.nix
+++ b/pkgs/games/bzflag/default.nix
@@ -11,9 +11,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-nmRlMwK2V72LX5b+EVCp/4Ch1Tptfoo1E4xrGwIAak0=";
   };
 
+  patches = [ ./bzflag-2.4.20-desktop-file.patch ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ curl SDL2 libGLU libGL glew ncurses c-ares ]
     ++ lib.optionals stdenv.isDarwin [ Carbon CoreServices ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    mkdir -p $out/share/{applications,pixmaps}
+    ln -st $out/share/applications $out/share/bzflag/bzflag.desktop
+    ln -st $out/share/pixmaps $out/share/bzflag/bzflag-48x48.png
+  '';
 
   meta = with lib; {
     description = "Multiplayer 3D Tank game";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

GUI games deserve desktop files!  bzflag ships one but we're not installing it yet.  Actually it ships two, one in its data dir (with a old/bad absolute path in its Exec= line) and one in `misc/` that's buildable via make (the build here configures the path to the icon file; its Exec= line just has the binary name as expected).  This PR builds and installs the latter one.

This also enables parallel building; please let me know if this is not generally desirable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Net +3040 bytes.
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
