### PR TITLE
inih: r52 -> r53

### DIFF
--- a/pkgs/development/libraries/inih/default.nix
+++ b/pkgs/development/libraries/inih/default.nix
@@ -2,22 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "inih";
-  version = "r52";
+  version = "r53";
 
   src = fetchFromGitHub {
     owner = "benhoyt";
     repo = pname;
     rev = version;
-    sha256 = "0lsvm34zabvi1xlximybzvgc58zb90mm3b9babwxlqs05jy871m4";
+    sha256 = "0dqf5j2sw4hq68rqvxbrsf44ygfzx9ypiyzipk4cvp9aimbvsbc6";
   };
 
   nativeBuildInputs = [ meson ninja ];
-
-  mesonFlags = [
-    "-Ddefault_library=shared"
-    "-Ddistro_install=true"
-    "-Dwith_INIReader=true"
-  ];
 
   meta = with lib; {
     description = "Simple .INI file parser in C, good for embedded systems";


### PR DESCRIPTION
###### Motivation for this change
https://github.com/benhoyt/inih/releases/tag/r53

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).