### PR TITLE
qemu-vm: add virtualisation.fileSystems to allow extra vm mounts

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -7,7 +7,7 @@
 # the VM in the host.  On the other hand, the root filesystem is a
 # read/writable disk image persistent across VM reboots.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, options, ... }:
 
 with lib;
 with import ../../lib/qemu-flags.nix { inherit pkgs; };
@@ -265,6 +265,8 @@ in
   ];
 
   options = {
+
+    virtualisation.fileSystems = options.fileSystems;
 
     virtualisation.memorySize =
       mkOption {
@@ -659,6 +661,7 @@ in
     # attribute should be disregarded for the purpose of building a VM
     # test image (since those filesystems don't exist in the VM).
     fileSystems = mkVMOverride (
+      cfg.fileSystems //
       { "/".device = cfg.bootDevice;
         ${if cfg.writableStore then "/nix/.ro-store" else "/nix/store"} =
           { device = "store";

--- a/nixos/tests/bees.nix
+++ b/nixos/tests/bees.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
       ${pkgs.btrfs-progs}/bin/mkfs.btrfs -f -L aux2 /dev/vdc
     '';
     virtualisation.emptyDiskImages = [ 4096 4096 ];
-    fileSystems = lib.mkVMOverride {
+    virtualisation.fileSystems = {
       "/aux1" = { # filesystem configured to be deduplicated
         device = "/dev/disk/by-label/aux1";
         fsType = "btrfs";

--- a/nixos/tests/fsck.nix
+++ b/nixos/tests/fsck.nix
@@ -4,7 +4,7 @@ import ./make-test-python.nix {
   machine = { lib, ... }: {
     virtualisation.emptyDiskImages = [ 1 ];
 
-    fileSystems = lib.mkVMOverride {
+    virtualisation.fileSystems = {
       "/mnt" = {
         device = "/dev/vdb";
         fsType = "ext4";

--- a/nixos/tests/glusterfs.nix
+++ b/nixos/tests/glusterfs.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix ({pkgs, lib, ...}:
 let
   client = { pkgs, ... } : {
     environment.systemPackages = [ pkgs.glusterfs ];
-    fileSystems = pkgs.lib.mkVMOverride
+    virtualisation.fileSystems =
       { "/gluster" =
           { device = "server1:/gv0";
             fsType = "glusterfs";
@@ -22,7 +22,7 @@ let
 
     virtualisation.emptyDiskImages = [ 1024 ];
 
-    fileSystems = pkgs.lib.mkVMOverride
+    virtualisation.fileSystems =
       { "/data" =
           { device = "/dev/disk/by-label/data";
             fsType = "ext4";

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -18,7 +18,7 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... } : {
       boot.initrd.postDeviceCommands = ''
         ${pkgs.dosfstools}/bin/mkfs.vfat -n EFISYS /dev/vdb
       '';
-      fileSystems = lib.mkVMOverride {
+      virtualisation.fileSystems = {
         "/efi" = {
           device = "/dev/disk/by-label/EFISYS";
           fsType = "vfat";

--- a/nixos/tests/locate.nix
+++ b/nixos/tests/locate.nix
@@ -7,7 +7,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
     nodes = rec {
       a = {
         environment.systemPackages = with pkgs; [ sshfs ];
-        fileSystems = lib.mkVMOverride {
+        virtualisation.fileSystems = {
           "/ssh" = {
             device = "alice@b:/";
             fsType = "fuse.sshfs";

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -16,7 +16,7 @@ import ./make-test-python.nix ({ pkgs, ...} : rec {
       environment.variables.EDITOR = mkOverride 0 "emacs";
       documentation.nixos.enable = mkOverride 0 true;
       systemd.tmpfiles.rules = [ "d /tmp 1777 root root 10d" ];
-      fileSystems = mkVMOverride { "/tmp2" =
+      virtualisation.fileSystems = { "/tmp2" =
         { fsType = "tmpfs";
           options = [ "mode=1777" "noauto" ];
         };

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -15,7 +15,7 @@ in {
         echo "http://nextcloud/remote.php/webdav/ ${adminuser} ${adminpass}" > /tmp/davfs2-secrets
         chmod 600 /tmp/davfs2-secrets
       '';
-      fileSystems = pkgs.lib.mkVMOverride {
+      virtualisation.fileSystems = {
         "/mnt/dav" = {
           device = "http://nextcloud/remote.php/webdav/";
           fsType = "davfs";

--- a/nixos/tests/nfs/kerberos.nix
+++ b/nixos/tests/nfs/kerberos.nix
@@ -40,7 +40,7 @@ in
         networking.domain = "nfs.test";
         networking.hostName = "client";
 
-        fileSystems = lib.mkVMOverride
+        virtualisation.fileSystems =
           { "/data" = {
               device  = "server.nfs.test:/";
               fsType  = "nfs";

--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -4,7 +4,7 @@ let
 
   client =
     { pkgs, ... }:
-    { fileSystems = pkgs.lib.mkVMOverride
+    { virtualisation.fileSystems =
         { "/data" =
            { # nfs4 exports the export with fsid=0 as a virtual root directory
              device = if (version == 4) then "server:/" else "server:/data";

--- a/nixos/tests/orangefs.nix
+++ b/nixos/tests/orangefs.nix
@@ -9,7 +9,7 @@ let
 
     virtualisation.emptyDiskImages = [ 4096 ];
 
-    fileSystems = pkgs.lib.mkVMOverride
+    virtualisation.fileSystems =
       { "/data" =
           { device = "/dev/disk/by-label/data";
             fsType = "ext4";

--- a/nixos/tests/samba.nix
+++ b/nixos/tests/samba.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
   nodes =
     { client =
         { pkgs, ... }:
-        { fileSystems = pkgs.lib.mkVMOverride
+        { virtualisation.fileSystems =
             { "/public" = {
                 fsType = "cifs";
                 device = "//server/public";

--- a/nixos/tests/snapper.nix
+++ b/nixos/tests/snapper.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ ... }:
 
     virtualisation.emptyDiskImages = [ 4096 ];
 
-    fileSystems = lib.mkVMOverride {
+    virtualisation.fileSystems = {
       "/home" = {
         device = "/dev/disk/by-label/aux";
         fsType = "btrfs";

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
     environment.systemPackages = [ pkgs.cryptsetup ];
 
-    fileSystems = lib.mkVMOverride {
+    virtualisation.fileSystems = {
       "/test-x-initrd-mount" = {
         device = "/dev/vdb";
         fsType = "ext2";

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -29,7 +29,7 @@ let
 
         # Setup regular fileSystems machinery to ensure forceImportAll can be
         # tested via the regular service units.
-        fileSystems = lib.mkVMOverride {
+        virtualisation.fileSystems = {
           "/forcepool" = {
             device = "forcepool";
             fsType = "zfs";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Resolves #112742

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
