### PR TITLE
python3Packages.pypcap: fix build on Python 3.9

### DIFF
--- a/pkgs/development/python-modules/pypcap/default.nix
+++ b/pkgs/development/python-modules/pypcap/default.nix
@@ -1,34 +1,50 @@
-{ lib, writeText, buildPythonPackage, fetchPypi, libpcap, dpkt }:
+{ lib
+, buildPythonPackage
+, dpkt
+, fetchFromGitHub
+, fetchpatch
+, libpcap
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pypcap";
   version = "1.2.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1w5i79gh7cswvznr8rhilcmzhnh2y5c4jwh2qrfnpx05zqigm1xd";
+
+  src = fetchFromGitHub {
+    owner = "pynetwork";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zscfk10jpqwxgc8d84y8bffiwr92qrg2b24afhjwiyr352l67cf";
   };
 
   patches = [
-    # The default setup.py searchs for pcap.h in a static list of default
-    # folders. So we have to add the path to libpcap in the nix-store.
-    (writeText "libpcap-path.patch"
-      ''
-      --- a/setup.py
-      +++ b/setup.py
-      @@ -28,6 +28,7 @@ def recursive_search(path, target_files):
-
-       def find_prefix_and_pcap_h():
-           prefixes = chain.from_iterable((
-      +        '${libpcap}',
-               ('/usr', sys.prefix),
-               glob.glob('/opt/libpcap*'),
-               glob.glob('../libpcap*'),
-      '')
+    # Support for Python 3.9, https://github.com/pynetwork/pypcap/pull/102
+    (fetchpatch {
+      name = "support-python-3.9.patch";
+      url = "https://github.com/pynetwork/pypcap/pull/102/commits/e22f5d25f0d581d19ef337493434e72cd3a6ae71.patch";
+      sha256 = "0n1syh1vcplgsf6njincpqphd2w030s3b2jyg86d7kbqv1w5wk0l";
+    })
   ];
 
+  postPatch = ''
+    # Add the path to libpcap in the nix-store
+    substituteInPlace setup.py --replace "('/usr', sys.prefix)" "'${libpcap}'"
+    # Remove coverage from test run
+    sed -i "/--cov/d" setup.cfg
+  '';
+
   buildInputs = [ libpcap ];
-  checkInputs = [ dpkt ];
+
+  checkInputs = [
+    dpkt
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests" ];
+
+  pythonImportsCheck = [ "pcap" ];
 
   meta = with lib; {
     homepage = "https://github.com/pynetwork/pypcap";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build on Python 3.9.

Additionally enable tests.

Mentioned in #112711

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
