### PR TITLE
gkrellm: add desktop file, maintainer; other fixups

### DIFF
--- a/pkgs/applications/misc/gkrellm/default.nix
+++ b/pkgs/applications/misc/gkrellm/default.nix
@@ -1,5 +1,6 @@
 { lib, fetchurl, stdenv, gettext, pkg-config, glib, gtk2, libX11, libSM, libICE, which
-, IOKit ? null }:
+, IOKit, copyDesktopItems, makeDesktopItem, wrapGAppsHook
+}:
 
 with lib;
 
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "01lccz4fga40isv09j8rjgr0qy10rff9vj042n6gi6gdv4z69q0y";
   };
 
-  nativeBuildInputs = [ pkg-config which ];
+  nativeBuildInputs = [ copyDesktopItems pkg-config which wrapGAppsHook ];
   buildInputs = [gettext glib gtk2 libX11 libSM libICE]
     ++ optionals stdenv.isDarwin [ IOKit ];
 
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
 
   # Makefiles are patched to fix references to `/usr/X11R6' and to add
   # `-lX11' to make sure libX11's store path is in the RPATH.
-  patchPhase = ''
+  postPatch = ''
     echo "patching makefiles..."
     for i in Makefile src/Makefile server/Makefile
     do
@@ -29,6 +30,23 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "STRIP=-s" ];
   installFlags = [ "DESTDIR=$(out)" ];
+
+  # This icon is used by the desktop file.
+  postInstall = ''
+    install -Dm444 -T src/icon.xpm $out/share/pixmaps/gkrellm.xpm
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "gkrellm";
+      exec = "gkrellm";
+      icon = "gkrellm";
+      desktopName = "GKrellM";
+      genericName = "System monitor";
+      comment = "The GNU Krell Monitors";
+      categories = "System;Monitor;";
+    })
+  ];
 
   meta = {
     description = "Themeable process stack of system monitors";
@@ -40,7 +58,7 @@ stdenv.mkDerivation rec {
 
     homepage = "http://gkrellm.srcbox.net";
     license = licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with maintainers; [ khumba ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22485,7 +22485,7 @@ in
   gitit = callPackage ../applications/misc/gitit {};
 
   gkrellm = callPackage ../applications/misc/gkrellm {
-    inherit (darwin) IOKit;
+    inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
   glow = callPackage ../applications/editors/glow { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

GKrellm has a GUI, so it should have a desktop file too.  It doesn't ship with one, so let's create one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Net +2648 bytes.
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
