### PR TITLE
home-assistant: 2021.2.2 -> 2021.2.3

### DIFF
--- a/pkgs/development/python-modules/pymyq/default.nix
+++ b/pkgs/development/python-modules/pymyq/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "pymyq";
-  version = "3.0.0";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "arraylabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-uCXgJxMy5gZQBvhHnmfev/rfJXOjhLqZdOrn8SetUT0=";
+    sha256 = "1wrfnbz87ns2ginyvljna0axl35s0xfaiqwzapxm8ira40ax5wrl";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.2.2";
+  version = "2021.2.3";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -181,7 +181,8 @@ in with py.pkgs; buildPythonApplication rec {
   ];
 
   pytestFlagsArray = [
-    "-n auto"
+    # limit amout of runners to reduce race conditions
+    "-n 2"
     # assign tests grouped by file to workers
     "--dist loadfile"
     # don't bulk test all components
@@ -199,14 +200,6 @@ in with py.pkgs; buildPythonApplication rec {
     # keyring.errors.NoKeyringError: No recommended backend was available.
     "test_secrets_from_unrelated_fails"
     "test_secrets_credstash"
-    # system_log/test_init.py: assert 0 == 1 where 0 = len([])
-    "test_error_posted_as_event"
-    # ssdp/test_init.py: RuntimeError: Event loop is closed
-    "test_scan_match_st"
-    # sun/test_init.py: RuntimeError: Event loop is closed
-    "test_setting_rising"
-    # sun/test_trigger.py: RuntimeError Event loop is closed
-    "test_sunset_trigger"
   ];
 
   preCheck = ''

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, nixosTests, lib, fetchurl, fetchFromGitHub, fetchpatch, python3, protobuf3_6
+{ stdenv, nixosTests, lib, fetchFromGitHub, python3
 
 # Look up dependencies of specified components in component-packages.nix
 , extraComponents ? [ ]
@@ -57,7 +57,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.2.2";
+  hassVersion = "2021.2.3";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -76,7 +76,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "0y7yj3kwk2454yghslvv5s2783rch9pznhxrw4mh3plr6qzi70rp";
+    sha256 = "0s1jcd94wwvmvzq86w8s9dwfvnmjs9l661z9pc6kwgagggjjgd8c";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling
@@ -203,6 +203,10 @@ in with py.pkgs; buildPythonApplication rec {
     "test_error_posted_as_event"
     # ssdp/test_init.py: RuntimeError: Event loop is closed
     "test_scan_match_st"
+    # sun/test_init.py: RuntimeError: Event loop is closed
+    "test_setting_rising"
+    # sun/test_trigger.py: RuntimeError Event loop is closed
+    "test_sunset_trigger"
   ];
 
   preCheck = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/2021.2.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
