### PR TITLE
python.precis-i18n: 1.0.0 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/precis-i18n/default.nix
+++ b/pkgs/development/python-modules/precis-i18n/default.nix
@@ -1,15 +1,16 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k }:
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k }:
 
 buildPythonPackage rec {
   pname = "precis-i18n";
-  version = "1.0.0";
+  version = "1.0.2";
 
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    pname = "precis_i18n";
-    inherit version;
-    sha256 = "0gjhvwd8aifx94rl1ag08vlmndyx2q3fkyqb0c4i46x3p2bc2yi2";
+  src = fetchFromGitHub {
+    owner = "byllyfish";
+    repo = "precis_i18n";
+    rev = "v${version}";
+    hash = "sha256:1r9pah1kgik6valf15ac7ybw0szr92cq84kwjvm6mq3z46j1pmkr";
   };
 
   meta = {


### PR DESCRIPTION
1.0.0 is 3 years old and fails to build against python 3.9.

Fetch from github rather than pypi; the pypi release lacks supporting
files that are required to run the test suite.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
