### PR TITLE
python3Packages.python-magic: 0.4.18 -> 0.4.20

### DIFF
--- a/pkgs/development/python-modules/python-magic/default.nix
+++ b/pkgs/development/python-modules/python-magic/default.nix
@@ -1,28 +1,43 @@
-{ buildPythonPackage, lib, fetchPypi, file, stdenv }:
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, file
+, pytestCheckHook
+, glibcLocales
+}:
 
 buildPythonPackage rec {
   pname = "python-magic";
-  version = "0.4.18";
+  version = "0.4.20";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b757db2a5289ea3f1ced9e60f072965243ea43a2221430048fd8cacab17be0ce";
+  src = fetchFromGitHub {
+    owner = "ahupp";
+    repo = pname;
+    rev = version;
+    sha256 = "1zk9jqzfnkgmizislyb8nq6vvikylaybf1rrgd25pn8d4sf5iqp0";
   };
+
+  propagatedBuildInputs = [ file ];
 
   postPatch = ''
-    substituteInPlace magic.py --replace "ctypes.util.find_library('magic')" "'${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
+    substituteInPlace magic/__init__.py --replace "ctypes.util.find_library('magic')" "'${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 
-  doCheck = false;
+  checkInputs = [ pytestCheckHook glibcLocales ];
 
-  # TODO: tests are failing
-  #checkPhase = ''
-  #  ${python}/bin/${python.executable} ./test.py
-  #'';
+  preCheck = ''
+    export LC_ALL=en_US.UTF-8
+  '';
 
-  meta = {
-    description = "A python interface to the libmagic file type identification library";
+  pytestFlagsArray = [ "test/test.py" ];
+
+  pythonImportsCheck = [ "magic" ];
+
+  meta = with lib; {
+    description = "Python interface to the libmagic file type identification library";
     homepage = "https://github.com/ahupp/python-magic";
-    license = lib.licenses.mit;
+    license = licenses.mit;
   };
 }
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6331,7 +6331,9 @@ in {
 
   python-lzo = callPackage ../development/python-modules/python-lzo { inherit (pkgs) lzo; };
 
-  python_magic = callPackage ../development/python-modules/python-magic { };
+  python-magic = callPackage ../development/python-modules/python-magic { };
+  python_magic = self.python-magic; # Old attr, 2021-02-10
+
 
   pythonmagick = callPackage ../development/python-modules/pythonmagick { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.4.20

- Tests are now enabled
- Follow PEP 0503

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
