### PR TITLE
terraform-providers.aws: 3.20.0 -> 3.27.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -70,10 +70,10 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/aws",
     "repo": "terraform-provider-aws",
-    "rev": "v3.20.0",
-    "sha256": "18zccjkdxzcprhpv3cn3b9fbp0h81pkj0dsygfz2islclljc3x17",
-    "vendorSha256": "0lalcp3wwjbwhp1rwidpndjmilfsc7cb79diicn02a207y277gji",
-    "version": "3.20.0"
+    "rev": "v3.27.0",
+    "sha256": "0hn55mpg64bibf10m7x7wpfkipvlm8q4avgqcf0rf8rmprwvdlxd",
+    "vendorSha256": "0ph106bqsy988s20adf6gyc5jfvvy9zsj74lkbciwx7mvw5f514s",
+    "version": "3.27.0"
   },
   "azuread": {
     "owner": "terraform-providers",


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
