### PR TITLE
haskellPackages.net-mqtt: remove from broken packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8286,9 +8286,6 @@ broken-packages:
   - nested-sequence
   - NestedFunctor
   - nestedmap
-  - net-mqtt
-  - net-mqtt-lens
-  - net-mqtt-rpc
   - net-spider
   - net-spider-cli
   - net-spider-pangraph


### PR DESCRIPTION
###### Motivation for this change
`haskellPackages.net-mqtt` had a release that bumped dependency version bounds (0.7.1.0) and is no longer broken.

I have built net-mqtt using `haskell.lib.unmarkBroken` (Is this sufficient or should I regenerate `hackage-packages.nix`? If yes, how?).

I have not tested `net-mqtt-lens` and `net-mqtt-rpc`, I assume they were only broken because of their direct dependency on `net-mqtt`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
