### PR TITLE
buildRustPackage: factor out setting up cargoBuildHook, add maturinBuildHook

### DIFF
--- a/pkgs/build-support/rust/fetchCargoTarball.nix
+++ b/pkgs/build-support/rust/fetchCargoTarball.nix
@@ -21,7 +21,7 @@ in
 , src ? null
 , srcs ? []
 , patches ? []
-, sourceRoot
+, sourceRoot ? ""
 , hash ? ""
 , sha256 ? ""
 , cargoUpdateHook ? ""

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -1,0 +1,33 @@
+cargoBuildHook() {
+    echo "Executing cargoBuildHook"
+
+    runHook preBuild
+
+    if [ ! -z "${buildAndTestSubdir-}" ]; then
+        pushd "${buildAndTestSubdir}"
+    fi
+
+    (
+    set -x
+    env \
+      "CC_@rustBuildPlatform@=@ccForBuild@" \
+      "CXX_@rustBuildPlatform@=@cxxForBuild@" \
+      "CC_@rustTargetPlatform@=@ccForHost@" \
+      "CXX_@rustTargetPlatform@=@cxxForHost@" \
+      cargo build -j $NIX_BUILD_CORES \
+        --target @rustTargetPlatformSpec@ \
+        --frozen \
+        ${cargoBuildType} \
+        ${cargoBuildFlags}
+    )
+
+    runHook postBuild
+
+    if [ ! -z "${buildAndTestSubdir-}" ]; then
+        popd
+    fi
+
+    echo "Finished cargoBuildHook"
+}
+
+buildPhase=cargoBuildHook

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -1,5 +1,6 @@
 { buildPackages
 , callPackage
+, cargo
 , diffutils
 , lib
 , makeSetupHook
@@ -16,9 +17,24 @@ let
   shortTarget = if targetIsJSON then
       (lib.removeSuffix ".json" (builtins.baseNameOf "${target}"))
     else target;
-  ccForBuild="${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc";
-  ccForHost="${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
+  ccForBuild = "${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc";
+  cxxForBuild = "${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}c++";
+  ccForHost = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
+  cxxForHost = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++";
+  rustBuildPlatform = rust.toRustTarget stdenv.buildPlatform;
+  rustTargetPlatform = rust.toRustTarget stdenv.hostPlatform;
+  rustTargetPlatformSpec = rust.toRustTargetSpec stdenv.hostPlatform;
 in {
+  cargoBuildHook = callPackage ({ }:
+    makeSetupHook {
+      name = "cargo-build-hook.sh";
+      deps = [ cargo ];
+      substitutions = {
+        inherit ccForBuild ccForHost cxxForBuild cxxForHost
+          rustBuildPlatform rustTargetPlatform rustTargetPlatformSpec;
+      };
+    } ./cargo-build-hook.sh) {};
+
   cargoSetupHook = callPackage ({ }:
     makeSetupHook {
       name = "cargo-setup-hook.sh";

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -4,6 +4,7 @@
 , diffutils
 , lib
 , makeSetupHook
+, maturin
 , rust
 , stdenv
 , target ? rust.toRustTargetSpec stdenv.hostPlatform
@@ -62,4 +63,14 @@ in {
         '';
       };
     } ./cargo-setup-hook.sh) {};
+
+  maturinBuildHook = callPackage ({ }:
+    makeSetupHook {
+      name = "maturin-build-hook.sh";
+      deps = [ cargo maturin ];
+      substitutions = {
+        inherit ccForBuild ccForHost cxxForBuild cxxForHost
+          rustBuildPlatform rustTargetPlatform rustTargetPlatformSpec;
+      };
+    } ./maturin-build-hook.sh) {};
 }

--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -1,0 +1,39 @@
+maturinBuildHook() {
+    echo "Executing maturinBuildHook"
+
+    runHook preBuild
+
+    if [ ! -z "${buildAndTestSubdir-}" ]; then
+        pushd "${buildAndTestSubdir}"
+    fi
+
+    (
+    set -x
+    env \
+      "CC_@rustBuildPlatform@=@ccForBuild@" \
+      "CXX_@rustBuildPlatform@=@cxxForBuild@" \
+      "CC_@rustTargetPlatform@=@ccForHost@" \
+      "CXX_@rustTargetPlatform@=@cxxForHost@" \
+      maturin build \
+        --cargo-extra-args="-j $NIX_BUILD_CORES --frozen" \
+        --target @rustTargetPlatformSpec@ \
+        --manylinux off \
+        --strip \
+        --release \
+        ${maturinBuildFlags-}
+    )
+
+    runHook postBuild
+
+    if [ ! -z "${buildAndTestSubdir-}" ]; then
+        popd
+    fi
+
+    # Move the wheel to dist/ so that regular Python tooling can find it.
+    mkdir -p dist
+    mv target/wheels/*.whl dist/
+
+    echo "Finished maturinBuildHook"
+}
+
+buildPhase=maturinBuildHook

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -26,5 +26,5 @@ rec {
   # Hooks
   inherit (callPackage ../../../build-support/rust/hooks {
     inherit cargo;
-  }) cargoBuildHook cargoSetupHook;
+  }) cargoBuildHook cargoSetupHook maturinBuildHook;
 }

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -12,7 +12,7 @@ rec {
   };
 
   buildRustPackage = callPackage ../../../build-support/rust {
-    inherit rustc cargo cargoSetupHook fetchCargoTarball;
+    inherit rustc cargo cargoBuildHook cargoSetupHook fetchCargoTarball;
   };
 
   rustcSrc = callPackage ./rust-src.nix {
@@ -24,5 +24,7 @@ rec {
   };
 
   # Hooks
-  inherit (callPackage ../../../build-support/rust/hooks { }) cargoSetupHook;
+  inherit (callPackage ../../../build-support/rust/hooks {
+    inherit cargo;
+  }) cargoBuildHook cargoSetupHook;
 }

--- a/pkgs/development/python-modules/adblock/default.nix
+++ b/pkgs/development/python-modules/adblock/default.nix
@@ -1,10 +1,9 @@
 { stdenv
 , lib
-, rustPlatform
 , fetchFromGitHub
-, pipInstallHook
+, buildPythonPackage
+, rustPlatform
 , pythonImportsCheckHook
-, maturin
 , pkg-config
 , openssl
 , publicsuffix-list
@@ -13,7 +12,7 @@
 , Security
 }:
 
-rustPlatform.buildRustPackage rec {
+buildPythonPackage rec {
   pname = "adblock";
   version = "0.4.0";
   disabled = isPy27;
@@ -25,33 +24,27 @@ rustPlatform.buildRustPackage rec {
     rev = version;
     sha256 = "10d6ks2fyzbizq3kb69q478idj0h86k6ygjb6wl3zq3mf65ma4zg";
   };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-gEFmj3/KvhvvsOK2nX2L1RUD4Wfp3nYzEzVnQZIsIDY=";
+  };
+
   format = "pyproject";
 
-  cargoSha256 = "0di05j942rrm2crpdpp9czhh65fmidyrvdp2n3pipgnagy7nchc0";
-
-  nativeBuildInputs = [ pipInstallHook maturin pkg-config pythonImportsCheckHook ];
+  nativeBuildInputs = [ pkg-config pythonImportsCheckHook ]
+    ++ (with rustPlatform; [ cargoSetupHook maturinBuildHook ]);
 
   buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ CoreFoundation Security ];
 
   PSL_PATH = "${publicsuffix-list}/share/publicsuffix/public_suffix_list.dat";
 
-  buildPhase = ''
-    runHook preBuild
-    maturin build --release --manylinux off --strip
-    runHook postBuild
-  '';
-
   # There are no rust tests
   doCheck = false;
-  pythonImportsCheck = [ "adblock" ];
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm644 -t dist target/wheels/*.whl
-    pipInstallPhase
-    runHook postInstall
-  '';
+  pythonImportsCheck = [ "adblock" ];
 
   passthru.meta = with lib; {
     description = "Python wrapper for Brave's adblocking library, which is written in Rust";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Convert the build phase of `buildRustPackage` into the `cargoBuildHook` hook. Also add a `maturinBuildHook` and convert the derivations that use `maturin` to `buildPythonPackage` + `cargoSetupHook` + `maturinBuildHook`.

Additional comments:

- `buildRustPackage` has an API change: remove the `target` argument of `buildRustPackage`, the target should always be in sync with the C/C++ compiler that is used.    
- Gathering of binaries has moved from `buildPhase` to `installPhase`, this simplifies the hook and orders this functionality logically with the installation logic.

Todo:

- [x] Add documentation (will keep this a draft request until this is done).
- [ ] Read the changes once more to see if I missed something.

Related issues:

- #83614
- #112438

CC @FRidh @Mic92 @adisbladis @DavHau

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
