### PR TITLE
bambootracker: 0.4.5 -> 0.4.6

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -1,48 +1,36 @@
 { mkDerivation
-, lib, stdenv
+, lib
 , fetchFromGitHub
 , qmake
-, qtbase
+, pkg-config
 , qttools
-, alsaSupport ? stdenv.hostPlatform.isLinux
-, alsaLib
-, pulseSupport ? stdenv.hostPlatform.isLinux
-, libpulseaudio
-, jackSupport ? stdenv.hostPlatform.isUnix
-, libjack2
+, qtbase
+, rtaudio
+, rtmidi
 }:
-let
 
-  inherit (lib) optional optionals;
-
-in
 mkDerivation rec {
   pname = "bambootracker";
-  version = "0.4.5";
+  version = "0.4.6";
 
   src = fetchFromGitHub {
     owner = "rerrahkr";
     repo = "BambooTracker";
     rev = "v${version}";
-    sha256 = "0ibi0sykxf6cp5la2c4pgxf5gvy56yv259fbmdwdrdyv6vlddf42";
+    sha256 = "0iddqfw951dw9xpl4w7310sl4z544507ppb12i8g4fzvlxfw2ifc";
   };
 
-  sourceRoot = "source/BambooTracker";
+  nativeBuildInputs = [ qmake qttools pkg-config ];
 
-  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [ qtbase rtaudio rtmidi ];
 
-  buildInputs = [ qtbase ]
-    ++ optional alsaSupport alsaLib
-    ++ optional pulseSupport libpulseaudio
-    ++ optional jackSupport libjack2;
+  qmakeFlags = [ "CONFIG+=system_rtaudio" "CONFIG+=system_rtmidi" ];
 
-  qmakeFlags = [ "CONFIG+=release" "CONFIG-=debug" ]
-    ++ optional pulseSupport "CONFIG+=use_pulse"
-    ++ optionals jackSupport [ "CONFIG+=use_jack" "CONFIG+=jack_has_rename" ];
+  postConfigure = "make qmake_all";
 
   meta = with lib; {
     description = "A tracker for YM2608 (OPNA) which was used in NEC PC-8801/9801 series computers";
-    homepage = "https://github.com/rerrahkr/BambooTracker";
+    homepage = "https://rerrahkr.github.io/BambooTracker";
     license = licenses.gpl2Only;
     platforms = platforms.all;
     maintainers = with maintainers; [ OPNA2608 ];


### PR DESCRIPTION
###### Motivation for this change
New release today. We've worked on improving the repo structure & build process and devendoring the RtAudio & RtMidi dependencies.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
