### PR TITLE
nodePackages.svelte-language-server: init at 0.12.9

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -200,6 +200,7 @@
 , "stackdriver-statsd-backend"
 , "stf"
 , "stylelint"
+, "svelte-language-server"
 , "svgo"
 , "swagger"
 , {"tedicross": "git+https://github.com/TediCross/TediCross.git#v0.8.7"}

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -22,13 +22,13 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
-    "@angular-devkit/architect-0.1101.2" = {
+    "@angular-devkit/architect-0.1101.4" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.1101.2";
+      version = "0.1101.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1101.2.tgz";
-        sha512 = "MLmBfHiiyPhbFSSAX4oMecPjEuBauOui5uBpI6BKNnk/7783fznbkbAKjXlOco7M81gkNeEoHMR8c+mOfcvv7g==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1101.4.tgz";
+        sha512 = "yur0mX156ZX1aXE7d8Z1z6sYjDk771iCyijLCN8MCx35lHIPGwMZwsB/dkttTChVHS8wJ+9YZnIucEBoh9ij3g==";
       };
     };
     "@angular-devkit/core-11.0.3" = {
@@ -49,13 +49,13 @@ let
         sha512 = "O2oIcqpQKGvYJH88d/NCgLYZGc9laA1eo2d1s0FH1Udu4c2L+bAsviQqtTKNmzyaqODHrlkt+eKx7uakdwWtnQ==";
       };
     };
-    "@angular-devkit/core-11.1.2" = {
+    "@angular-devkit/core-11.1.4" = {
       name = "_at_angular-devkit_slash_core";
       packageName = "@angular-devkit/core";
-      version = "11.1.2";
+      version = "11.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz";
-        sha512 = "V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==";
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.4.tgz";
+        sha512 = "xqjUIdMTDNjZ8jkzlDSQbhmTwF2tOLlT0iRI9mb7pN4VIS0LI/Xu0iTqDUrVs0Hqtb9609dz13LXu5zbQSb+cw==";
       };
     };
     "@angular-devkit/schematics-11.0.3" = {
@@ -76,13 +76,13 @@ let
         sha512 = "6qfR5w1jyk8MC+5Tfimz+Czsq3WlsVoB57dpxSZfhGGsv1Vxc8Q41y5f3BrAyEqHYjcH7NtaoLQoJjtra5KaAg==";
       };
     };
-    "@angular-devkit/schematics-11.1.2" = {
+    "@angular-devkit/schematics-11.1.4" = {
       name = "_at_angular-devkit_slash_schematics";
       packageName = "@angular-devkit/schematics";
-      version = "11.1.2";
+      version = "11.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.1.2.tgz";
-        sha512 = "wIWI4+EPsjbN+23Rs0zE4GarKrUm8gMR3MpGAtlEmGG2ZsXEVdfiKUebBdWGrx0sEfgLN9JfePbZQFvqN5ifyw==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.1.4.tgz";
+        sha512 = "WWHmBHPabKgrBDM2M5ayA0OdhonNQHld8NjY8jEdwyWI4xEj23C/qDfgQc8sssvpi4LauKSaPozDELl7ItBPXA==";
       };
     };
     "@angular-devkit/schematics-cli-0.1100.3" = {
@@ -364,13 +364,13 @@ let
         sha512 = "Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==";
       };
     };
-    "@babel/generator-7.12.13" = {
+    "@babel/generator-7.12.15" = {
       name = "_at_babel_slash_generator";
       packageName = "@babel/generator";
-      version = "7.12.13";
+      version = "7.12.15";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.12.13.tgz";
-        sha512 = "9qQ8Fgo8HaSvHEt6A5+BATP7XktD/AdAnObUeTRz5/e2y3kbrxZgz32qUJJsdmwUvBJzF4AeV21nGTNwv05Mpw==";
+        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz";
+        sha512 = "6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==";
       };
     };
     "@babel/helper-annotate-as-pure-7.12.13" = {
@@ -589,13 +589,13 @@ let
         sha512 = "kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==";
       };
     };
-    "@babel/parser-7.12.14" = {
+    "@babel/parser-7.12.15" = {
       name = "_at_babel_slash_parser";
       packageName = "@babel/parser";
-      version = "7.12.14";
+      version = "7.12.15";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.12.14.tgz";
-        sha512 = "xcfxDq3OrBnDsA/Z8eK5/2iPcLD8qbOaSSfOw4RA6jp4i7e6dEQ7+wTwxItEwzcXPQcsry5nZk96gmVPKletjQ==";
+        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz";
+        sha512 = "AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==";
       };
     };
     "@babel/plugin-external-helpers-7.8.3" = {
@@ -1165,13 +1165,13 @@ let
         sha512 = "xhUPzDXxZN1QfiOy/I5tyye+TRz6lA7z6xaT4CLOjPRMVg1ldRf0LHw0TDBpYL4vG78556WuHdyO9oi5UmzZBg==";
       };
     };
-    "@babel/plugin-transform-runtime-7.12.13" = {
+    "@babel/plugin-transform-runtime-7.12.15" = {
       name = "_at_babel_slash_plugin-transform-runtime";
       packageName = "@babel/plugin-transform-runtime";
-      version = "7.12.13";
+      version = "7.12.15";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.13.tgz";
-        sha512 = "ho1CV2lm8qn2AxD3JdvPgtLVHCYLDaOszlf0gosdHcJAIfgNizag76WI+FoibrvfT+h117fgf8h+wgvo4O2qbA==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.15.tgz";
+        sha512 = "OwptMSRnRWJo+tJ9v9wgAf72ydXWfYSXWhnQjZing8nGZSDFqU1MBleKM3+DriKkcbv7RagA8gVeB0A1PNlNow==";
       };
     };
     "@babel/plugin-transform-shorthand-properties-7.12.13" = {
@@ -1939,22 +1939,22 @@ let
         sha512 = "HLZNtkETFUuCP76Wk/oF54+tVp6aPGzsoJRsmnkh78gloC9CGp8JK+LQUYfj9dtzcHDHq64/dAA2e4j2tzjhaQ==";
       };
     };
-    "@fluentui/react-7.158.1" = {
+    "@fluentui/react-7.160.0" = {
       name = "_at_fluentui_slash_react";
       packageName = "@fluentui/react";
-      version = "7.158.1";
+      version = "7.160.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@fluentui/react/-/react-7.158.1.tgz";
-        sha512 = "AbmLB14+RA5Bf5P40/KdsaHxTr2IDwmU9q9vJsrzDOzGGhv13w6qVhdahJvTR8a5TFLPCob7wWhPRtKrTGZCxw==";
+        url = "https://registry.npmjs.org/@fluentui/react/-/react-7.160.0.tgz";
+        sha512 = "ckbM7zFAob59vHqfKz+K9Gmivqp9YmAF1TIMJX6RKC/MEVpeA4s5G412/J0SgFNsWwwdCYaqh0UL9W/pnwuE8A==";
       };
     };
-    "@fluentui/react-focus-7.17.1" = {
+    "@fluentui/react-focus-7.17.4" = {
       name = "_at_fluentui_slash_react-focus";
       packageName = "@fluentui/react-focus";
-      version = "7.17.1";
+      version = "7.17.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.17.1.tgz";
-        sha512 = "Nulq2pE4pX6Pf+tGZl8uLp8VfqUzx3elC5v7QvYSBdjnZK8ykitdsa+Sd3PKYWW2EMlzVRSptlzbuJ6JyEDQKQ==";
+        url = "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.17.4.tgz";
+        sha512 = "L7MK538JOSpLQubyVxYZV1ftd3hViBQhcFftuJfah/mdekQkIcFTS0fsymQ4MK5i7bn13jE7lPM8QfH23wpaJg==";
       };
     };
     "@fluentui/react-window-provider-1.0.1" = {
@@ -1966,13 +1966,13 @@ let
         sha512 = "5hvruDyF0uE8+6YN6Y+d2sEzexBadxUNxUjDcDreTPsmtHPwF5FPBYLhoD7T84L5U4YNvKxKh25tYJm6E0GE2w==";
       };
     };
-    "@fluentui/theme-1.7.1" = {
+    "@fluentui/theme-1.7.3" = {
       name = "_at_fluentui_slash_theme";
       packageName = "@fluentui/theme";
-      version = "1.7.1";
+      version = "1.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.1.tgz";
-        sha512 = "cwx8gJ0O9d+Z8g6Lq7BgDgH8XPfSloUSy0GN3fWHJGrDCBPcnmz6/GKbbvxw9PZ2t1iNcAzJEJNT6NyuOOobPA==";
+        url = "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.3.tgz";
+        sha512 = "S97i1SBL5ytQtZQpygAIvOnQSg9tFZM25843xCY40eWRA/eAdPixzWvVmV8PPQs/K5WmXhghepWaC1SjxVO90g==";
       };
     };
     "@gardenapple/yargs-17.0.0-candidate.0" = {
@@ -2056,13 +2056,13 @@ let
         sha512 = "+ywPfK6N2Ddna6oOa5Qb1Mv7EA8LOwRNOAPP9dL37FEhksJM9pYqPSceUcqMqg7S9b0+Cgr78s408rgvurV3/Q==";
       };
     };
-    "@graphql-tools/delegate-7.0.9" = {
+    "@graphql-tools/delegate-7.0.10" = {
       name = "_at_graphql-tools_slash_delegate";
       packageName = "@graphql-tools/delegate";
-      version = "7.0.9";
+      version = "7.0.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-7.0.9.tgz";
-        sha512 = "nlelOb354cyweV+SpTXkoGZHKgJ1PwPkHWq/0RXM5LllQsR3OrSQKKWMrd1g9dyawEZbadCF3fDJJWSQ4HOg2g==";
+        url = "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-7.0.10.tgz";
+        sha512 = "6Di9ia5ohoDvrHuhj2cak1nJGhIefJmUsd3WKZcJ2nu2yZAFawWMxGvQImqv3N7iyaWKiVhrrK8Roi/JrYhdKg==";
       };
     };
     "@graphql-tools/graphql-file-loader-6.2.7" = {
@@ -2731,22 +2731,22 @@ let
         sha512 = "EjPkDQOzV/oZfbolEUgFT6SE++PtCccVBvjuACkttyCfl0P2jnpR49SwstyVLc2u8AwBAZEHHAw9lPYaMjtbXQ==";
       };
     };
-    "@joplin/fork-htmlparser2-4.1.22" = {
+    "@joplin/fork-htmlparser2-4.1.23" = {
       name = "_at_joplin_slash_fork-htmlparser2";
       packageName = "@joplin/fork-htmlparser2";
-      version = "4.1.22";
+      version = "4.1.23";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@joplin/fork-htmlparser2/-/fork-htmlparser2-4.1.22.tgz";
-        sha512 = "SJe+XezlNUN6p7ndRL1HqzfJtgz0JKI0UlXq+sBndRenyOuiSbPygYmU5rvxPG203mgPuOSI2a+qM+jlFCrvPw==";
+        url = "https://registry.npmjs.org/@joplin/fork-htmlparser2/-/fork-htmlparser2-4.1.23.tgz";
+        sha512 = "nTbOVZJbF02d32AhvwhWME2uQbbCZsFYulMgqRZ/I4realfJgqkaUfXclLxYcyOPAjzngXd+Wb1/M/Pz6luXGw==";
       };
     };
-    "@joplin/fork-sax-1.2.26" = {
+    "@joplin/fork-sax-1.2.27" = {
       name = "_at_joplin_slash_fork-sax";
       packageName = "@joplin/fork-sax";
-      version = "1.2.26";
+      version = "1.2.27";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@joplin/fork-sax/-/fork-sax-1.2.26.tgz";
-        sha512 = "CZJ0WRXel6hzwmUIylZG9pr3FOW6bF30ppip3KK+7G8Lq6K0onS86/1u1IDT5wtwAKRQqWXr7NNOlCMPvdndJQ==";
+        url = "https://registry.npmjs.org/@joplin/fork-sax/-/fork-sax-1.2.27.tgz";
+        sha512 = "ON/8pg90WCRHKj8HttziC7Rtef+DKSSDZD9J3zjHYUvrXB0pu+7eZvRP8vF3Y2MSZnlshtFGQqiIRbwk3GVA+Q==";
       };
     };
     "@joplin/lib-1.0.18" = {
@@ -2767,22 +2767,22 @@ let
         sha512 = "RDRYjuPCn1ltematEZQhgvZbIGBQ+2F3jgAdXpqByg71pmxrMZyOLLbNVYJyKK4w2Ecvmbpwuo0h9RbMb/56Ow==";
       };
     };
-    "@joplin/turndown-4.0.44" = {
+    "@joplin/turndown-4.0.45" = {
       name = "_at_joplin_slash_turndown";
       packageName = "@joplin/turndown";
-      version = "4.0.44";
+      version = "4.0.45";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@joplin/turndown/-/turndown-4.0.44.tgz";
-        sha512 = "o7t4/6fFwTlJc2oALaL+K2MJFOZh2+ybscK5XBZeAY81j0KTopoKE94FxIzOm1M20R1cNSXDRyWBKol/9GCIyA==";
+        url = "https://registry.npmjs.org/@joplin/turndown/-/turndown-4.0.45.tgz";
+        sha512 = "u4J/ka4szy34ioQ5UVaCdLlfzfOxEQH/lDReHauYoNhH+H+EWt1qOwMh9A8fuTfoK2vnUUiPKHsWhOYCe+LRiw==";
       };
     };
-    "@joplin/turndown-plugin-gfm-1.0.26" = {
+    "@joplin/turndown-plugin-gfm-1.0.27" = {
       name = "_at_joplin_slash_turndown-plugin-gfm";
       packageName = "@joplin/turndown-plugin-gfm";
-      version = "1.0.26";
+      version = "1.0.27";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.26.tgz";
-        sha512 = "Bl1QmWWe4XPUCWJKdXKP7Hyw6qANnbke6QRTfJPbeIKPZraOuL1zy7jTfRjQLHFxxT/8LXKmQ5sf9fz101MuWw==";
+        url = "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.27.tgz";
+        sha512 = "4BPgTSkhvxPI3tbjG4BPiBq0VuNZji1Y77DRWHb09GnzsrgwBI+gpo3EI6obkyIeRuN/03wzf98W5u1iau2vpQ==";
       };
     };
     "@jsdevtools/ono-7.1.3" = {
@@ -2794,13 +2794,13 @@ let
         sha512 = "4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==";
       };
     };
-    "@jsii/spec-1.20.0" = {
+    "@jsii/spec-1.20.1" = {
       name = "_at_jsii_slash_spec";
       packageName = "@jsii/spec";
-      version = "1.20.0";
+      version = "1.20.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@jsii/spec/-/spec-1.20.0.tgz";
-        sha512 = "7KwIuFTAcT4N7tOBQSacaIK3TEkCrWjTHY1iSWh5VNF9Yrc5I6KQ/WmGa/5yC3jZThR3J/+z1H/IIUVPhfiUYw==";
+        url = "https://registry.npmjs.org/@jsii/spec/-/spec-1.20.1.tgz";
+        sha512 = "+ot9SPb/lFnRiPlhWUGLMp8owpr/pnpFX0/iIUhZ0kJ1LIAUde7TSuaz70mV6x+ES2wvVXKsgfu2WTMFHIAwZQ==";
       };
     };
     "@kwsites/file-exists-1.1.1" = {
@@ -3388,13 +3388,13 @@ let
         sha512 = "/NdX1Ql8hKNM0vHFJnEr/bcw6BG0ULHD3HhInpniZw5ixpl+n/QIRfMEEmLCn7acedbM1zGdZvU5ZMbn9kcF5Q==";
       };
     };
-    "@microsoft/load-themed-styles-1.10.146" = {
+    "@microsoft/load-themed-styles-1.10.147" = {
       name = "_at_microsoft_slash_load-themed-styles";
       packageName = "@microsoft/load-themed-styles";
-      version = "1.10.146";
+      version = "1.10.147";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.146.tgz";
-        sha512 = "qQZ4J58J2VMe/XRpr2YRDusQB9uRBJ1SjJB76x7uH94t9hqxjVVxn2qL99Bl+ERbfrACZ9peGn2uamt4ponqZQ==";
+        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.147.tgz";
+        sha512 = "fqkftQUoc2fjR9F+4uZkCt2hJhgZlkgM33k4qD4UdI75+SDOK9Zp5iU3dWzvwDWWVIXTOE+GKMFlmUtrlKZ+fg==";
       };
     };
     "@mozilla/readability-0.4.1" = {
@@ -3442,13 +3442,13 @@ let
         sha512 = "b+MGNyP9/LXkapreJzNUzcvuzZslj/RGgdVVJ16P2wSlYatfLycPObImqVJSmNAdyeShvNeM/pl3sVZsObFueg==";
       };
     };
-    "@netlify/build-8.4.0" = {
+    "@netlify/build-9.1.1" = {
       name = "_at_netlify_slash_build";
       packageName = "@netlify/build";
-      version = "8.4.0";
+      version = "9.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/build/-/build-8.4.0.tgz";
-        sha512 = "FKjJB9vYZVQUij1cHF1gztKX5qbKsZ8t0vSJtZuziLYCAH4KqWdLxKAZX9UNGw8tNe9SVRDknr6juGuePtozow==";
+        url = "https://registry.npmjs.org/@netlify/build/-/build-9.1.1.tgz";
+        sha512 = "e2oCBUfq0/odlcopN3mv9kVbTywhvTAk6V7r8AutnHFsLj9SKcb/RbmLIJQGJWUUAdYp2eeC52T3V4QvHM6uZQ==";
       };
     };
     "@netlify/cache-utils-1.0.6" = {
@@ -3460,31 +3460,31 @@ let
         sha512 = "Pz/TzLZhMUACT+X7Un6jZCXgEUwLPVNbx69DQtEOMZ6hNBE1b1ErTHFbSaHA0KfDn/yqCII5vS274DERvNuRwg==";
       };
     };
-    "@netlify/config-3.1.2" = {
+    "@netlify/config-4.0.1" = {
       name = "_at_netlify_slash_config";
       packageName = "@netlify/config";
-      version = "3.1.2";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/config/-/config-3.1.2.tgz";
-        sha512 = "a56KY1o1oMX5HAIsbQjsIxgZAdyVm8dU98VDxgmPciogJ+ZmlDba4PhZ5FilmUSy2XsCszRg05FtSW9NVzXcEw==";
+        url = "https://registry.npmjs.org/@netlify/config/-/config-4.0.1.tgz";
+        sha512 = "qI/PxBx5RGuQbVgYOtbEJ498+yDWqfqetDOHYzxJEFZYpZjS5Effu4jt92amnW55pzOZvTk/vQZQx8zLb4N2WQ==";
       };
     };
-    "@netlify/framework-info-2.1.1" = {
+    "@netlify/framework-info-2.3.0" = {
       name = "_at_netlify_slash_framework-info";
       packageName = "@netlify/framework-info";
-      version = "2.1.1";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-2.1.1.tgz";
-        sha512 = "JblagtBYtOwuxZy94jXPNc3p+QOuyx+kZurfduswYbT8VWPlyuiL4AQFKaIJvdZS6O9G8uKEiFGsKFhRTx6vAA==";
+        url = "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-2.3.0.tgz";
+        sha512 = "vqy9wbBRP8qWnkzA/OQsThr1+cfqapMrORJ4hWcrjhIPRmXIJtwB6OWuLIUalMeSGCwqZjYpKfudc4BLuxxvjw==";
       };
     };
-    "@netlify/functions-utils-1.3.10" = {
+    "@netlify/functions-utils-1.3.11" = {
       name = "_at_netlify_slash_functions-utils";
       packageName = "@netlify/functions-utils";
-      version = "1.3.10";
+      version = "1.3.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-1.3.10.tgz";
-        sha512 = "cakXwiNWNau80ZLU33nbmBxNfFmMwrwgy+P9U9ep3NXxocWJeMVjCPoXzpoE3VydnOoyVJNy6erTziNdOVykEA==";
+        url = "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-1.3.11.tgz";
+        sha512 = "cGVOQ2BubMHfUNAGpqAcFmpAm2gh1A1aDD0cIMvZ48bIve0153AYCSvQXVFBqxxdLQbcfN2VHUd9LkSdu9+Hyg==";
       };
     };
     "@netlify/git-utils-1.0.7" = {
@@ -3568,13 +3568,13 @@ let
         sha512 = "ea6S9ik5X0TlA2e+jXk5D7lfvArPZjyQoIBEo7G1Tjw/vUU5Fx6KLfXv1iy7eJy+ENTLoyidscAjJ2wXlHI47g==";
       };
     };
-    "@netlify/zip-it-and-ship-it-2.1.3" = {
+    "@netlify/zip-it-and-ship-it-2.3.0" = {
       name = "_at_netlify_slash_zip-it-and-ship-it";
       packageName = "@netlify/zip-it-and-ship-it";
-      version = "2.1.3";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-2.1.3.tgz";
-        sha512 = "nYHM4dnlua/aCe74ZPZcIlWAN1QbyGDaWbJi+Qkb0VSe4yX6PYvPNeymABggDbA9xFhk+nEA98wSu2A/beHPfQ==";
+        url = "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-2.3.0.tgz";
+        sha512 = "dqYXA/e2ZY6bO7fvp18YKXLYE/CK8cAbjBE2mo339sA+xchoV3ryYEjsLpoYqFWofUBLQnCYahm4D9a4H7RT0A==";
       };
     };
     "@node-red/editor-api-1.2.9" = {
@@ -3685,13 +3685,13 @@ let
         sha512 = "OJZCmJ9DNn1cz9HPXXsPmUBnqaArot3CGYo63CyajHQk+g87rPXVOJByGsskQJhPsUUEXJcsZ2Q6bWd2jSwnBA==";
       };
     };
-    "@npmcli/installed-package-contents-1.0.5" = {
+    "@npmcli/installed-package-contents-1.0.7" = {
       name = "_at_npmcli_slash_installed-package-contents";
       packageName = "@npmcli/installed-package-contents";
-      version = "1.0.5";
+      version = "1.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.5.tgz";
-        sha512 = "aKIwguaaqb6ViwSOFytniGvLPb9SMCUm39TgM3SfUo7n0TxUMbwoXfpwyvQ4blm10lzbAwTsvjr7QZ85LvTi4A==";
+        url = "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz";
+        sha512 = "9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==";
       };
     };
     "@npmcli/move-file-1.1.1" = {
@@ -3703,13 +3703,13 @@ let
         sha512 = "LtWTicuF2wp7PNTuyCwABx7nNG+DnzSE8gN0iWxkC6mpgm/iOPu0ZMTkXuCxmJxtWFsDxUaixM9COSNJEMUfuQ==";
       };
     };
-    "@npmcli/node-gyp-1.0.1" = {
+    "@npmcli/node-gyp-1.0.2" = {
       name = "_at_npmcli_slash_node-gyp";
       packageName = "@npmcli/node-gyp";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.1.tgz";
-        sha512 = "pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA==";
+        url = "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.2.tgz";
+        sha512 = "yrJUe6reVMpktcvagumoqD9r08fH1iRo01gn1u0zoCApa9lnZGEigVKUd2hzsCId4gdtkZZIVscLhNxMECKgRg==";
       };
     };
     "@npmcli/promise-spawn-1.3.2" = {
@@ -3721,13 +3721,13 @@ let
         sha512 = "QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==";
       };
     };
-    "@npmcli/run-script-1.8.1" = {
+    "@npmcli/run-script-1.8.3" = {
       name = "_at_npmcli_slash_run-script";
       packageName = "@npmcli/run-script";
-      version = "1.8.1";
+      version = "1.8.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.1.tgz";
-        sha512 = "G8c86g9cQHyRINosIcpovzv0BkXQc3urhL1ORf3KTe4TS4UBsg2O4Z2feca/W3pfzdHEJzc83ETBW4aKbb3SaA==";
+        url = "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.3.tgz";
+        sha512 = "ELPGWAVU/xyU+A+H3pEPj0QOvYwLTX71RArXcClFzeiyJ/b/McsZ+d0QxpznvfFtZzxGN/gz/1cvlqICR4/suQ==";
       };
     };
     "@oclif/color-0.1.2" = {
@@ -3883,13 +3883,13 @@ let
         sha512 = "fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==";
       };
     };
-    "@octokit/openapi-types-4.0.1" = {
+    "@octokit/openapi-types-4.0.2" = {
       name = "_at_octokit_slash_openapi-types";
       packageName = "@octokit/openapi-types";
-      version = "4.0.1";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.1.tgz";
-        sha512 = "k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q==";
+        url = "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.2.tgz";
+        sha512 = "quqmeGTjcVks8YaatVGCpt7QpUTs2PK0D3mW5aEQqmFKOuIZ/CxwWrgnggPjqP3CNp6eALdQRgf0jUpcG8X1/Q==";
       };
     };
     "@octokit/plugin-enterprise-rest-6.0.1" = {
@@ -3973,23 +3973,22 @@ let
         sha512 = "O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==";
       };
     };
-    "@octokit/types-6.8.2" = {
+    "@octokit/types-6.8.3" = {
       name = "_at_octokit_slash_types";
       packageName = "@octokit/types";
-      version = "6.8.2";
+      version = "6.8.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz";
-        sha512 = "RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==";
+        url = "https://registry.npmjs.org/@octokit/types/-/types-6.8.3.tgz";
+        sha512 = "ZNAy8z77ewKZ5LCX0KaUm4tWdgloWQ6FWJCh06qgahq/MH13sQefIPKSo0dBdPU3bcioltyZUcC0k8oHHfjvnQ==";
       };
     };
-    "@open-policy-agent/opa-wasm-git+https://github.com/open-policy-agent/npm-opa-wasm.git#f4a21fe6f4d70706f85106dc6ea867983747e040" = {
+    "@open-policy-agent/opa-wasm-1.2.0" = {
       name = "_at_open-policy-agent_slash_opa-wasm";
       packageName = "@open-policy-agent/opa-wasm";
-      version = "1.1.0";
-      src = fetchgit {
-        url = "https://github.com/open-policy-agent/npm-opa-wasm.git";
-        rev = "f4a21fe6f4d70706f85106dc6ea867983747e040";
-        sha256 = "148ed1d81abef5779491612e4d4850ed748177a95157e9f81e3b7bdb53614b3d";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@open-policy-agent/opa-wasm/-/opa-wasm-1.2.0.tgz";
+        sha512 = "CtUBTnzvDrT0NASa8IuGQTxFGgt2vxbLnMYuTA+uDFxOcA4uK4mGFgrhHJtxUZnWHiwemOvKKSY3BMCo7qiAsQ==";
       };
     };
     "@opencensus/core-0.0.8" = {
@@ -4685,6 +4684,15 @@ let
         sha512 = "YXJqp9gdHcZKAmBY/WnwFpPtNQp2huD/ME2YMurH2YHJvxrVzYsmpKw/pb7yINArRpp8E++fwbQd3ajYXGA45Q==";
       };
     };
+    "@sammacbeth/random-access-idb-mutable-file-0.1.1" = {
+      name = "_at_sammacbeth_slash_random-access-idb-mutable-file";
+      packageName = "@sammacbeth/random-access-idb-mutable-file";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@sammacbeth/random-access-idb-mutable-file/-/random-access-idb-mutable-file-0.1.1.tgz";
+        sha512 = "jHnpuu2qtFgwCmhgrpCCk3/hU3XqXTqhidh4XmcTijkVsGwh1c2T0+r2hkHs1PRfsxeimx8qDAotphpRoYB2eg==";
+      };
+    };
     "@samverschueren/stream-to-observable-0.3.1" = {
       name = "_at_samverschueren_slash_stream-to-observable";
       packageName = "@samverschueren/stream-to-observable";
@@ -4694,13 +4702,22 @@ let
         sha512 = "c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==";
       };
     };
-    "@schematics/angular-11.1.2" = {
+    "@scarf/scarf-1.1.0" = {
+      name = "_at_scarf_slash_scarf";
+      packageName = "@scarf/scarf";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.1.0.tgz";
+        sha512 = "b2iE8kjjzzUo2WZ0xuE2N77kfnTds7ClrDxcz3Atz7h2XrNVoAPUoT75i7CY0st5x++70V91Y+c6RpBX9MX7Jg==";
+      };
+    };
+    "@schematics/angular-11.1.4" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "11.1.2";
+      version = "11.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-11.1.2.tgz";
-        sha512 = "ZhaB/QBwfWsvZYJplLH8VK/7vnFpUbk1nptjC106K/I38xlmWdB4pStLJK94eyJk0KlItnsPvE0a9KuLPKA/Ow==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-11.1.4.tgz";
+        sha512 = "UWhUPxRarbK4AWTcOBmCOYMZwuxnJRo/Ts/0yyNqUkj6gHieyv0hsOi10f8Ofn34MyvPnUpDnCT/o9bzanmqog==";
       };
     };
     "@schematics/schematics-0.1100.3" = {
@@ -4712,13 +4729,13 @@ let
         sha512 = "tzjKnjD90FQ4LgRN9ALT2qCqgJYZrAKoy1embFJRuGKA8vv1hTG4JonVDqQEUoNwTc9r/Ok2Z1eenAI9TSUd1A==";
       };
     };
-    "@schematics/update-0.1101.2" = {
+    "@schematics/update-0.1101.4" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.1101.2";
+      version = "0.1101.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1101.2.tgz";
-        sha512 = "WwMsIkhR3hq7gvfB5HsuTK2Sz9iZmpz0/AiFYRJbX+mXL/KgONcridyorW45Dg1Q2sRXVGiAUxWsQYzjmeLO7g==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1101.4.tgz";
+        sha512 = "aEb/kqNgdVZ53lGQBIE4vPBGwlnqv2hRp3dyrhe++PJOyQf4cf0iJwfL0tB3pSHwjialaHtsrMybOs0a/81alA==";
       };
     };
     "@segment/loosely-validate-event-2.0.0" = {
@@ -4748,13 +4765,13 @@ let
         sha512 = "lOUyRopNTKJYVEU9T6stp2irwlTDsYMmUKBOUjnMcwGveuUfIJqrCOtFLtIPPj3XJlbZy5F68l4KP9rZ8Ipang==";
       };
     };
-    "@serverless/components-3.6.1" = {
+    "@serverless/components-3.6.2" = {
       name = "_at_serverless_slash_components";
       packageName = "@serverless/components";
-      version = "3.6.1";
+      version = "3.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/components/-/components-3.6.1.tgz";
-        sha512 = "B6X+jV9zu8NPavTDiUVvRTOZeREUiJ8D1RT8BpKB6kJubPS6h/RTBjdPrt3Y+DQBX4AfMb9xa2G4L4rj2shHJQ==";
+        url = "https://registry.npmjs.org/@serverless/components/-/components-3.6.2.tgz";
+        sha512 = "JT8+t3J90WF/ZjizTbIUbmwzLJFAybP6S2T8TK9TtHl1imeeIIu69LcFAth7fFYdPn6LrACSEMZMXJ2+QlLM6w==";
       };
     };
     "@serverless/core-1.1.2" = {
@@ -4766,13 +4783,13 @@ let
         sha512 = "PY7gH+7aQ+MltcUD7SRDuQODJ9Sav9HhFJsgOiyf8IVo7XVD6FxZIsSnpMI6paSkptOB7n+0Jz03gNlEkKetQQ==";
       };
     };
-    "@serverless/enterprise-plugin-4.4.2" = {
+    "@serverless/enterprise-plugin-4.4.3" = {
       name = "_at_serverless_slash_enterprise-plugin";
       packageName = "@serverless/enterprise-plugin";
-      version = "4.4.2";
+      version = "4.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-4.4.2.tgz";
-        sha512 = "w5xD8R8tFK6B7QiLvWI5jqVHTtH1LdTyGp5eRcjkdJBa10/D2IZFpJimMAGsBxk9U1JGKO4j0miVnRHIW8ppeg==";
+        url = "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-4.4.3.tgz";
+        sha512 = "2HKtgzv4c9yr9dyecbTJlSnYWaIJL4TQJ4YtVORzeBAm812r8PDK1XS9X8tvLlk2+DF2gu+Tb/Umnxl2rqhqZg==";
       };
     };
     "@serverless/event-mocks-1.1.1" = {
@@ -4827,15 +4844,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@serverless/utils/-/utils-1.2.0.tgz";
         sha512 = "aI/cpGVUhWbJUR8QDMtPue28EU4ViG/L4/XKuZDfAN2uNQv3NRjwEFIBi/cxyfQnMTYVtMLe9wDjuwzOT4ENzA==";
-      };
-    };
-    "@serverless/utils-2.2.0" = {
-      name = "_at_serverless_slash_utils";
-      packageName = "@serverless/utils";
-      version = "2.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/utils/-/utils-2.2.0.tgz";
-        sha512 = "0TqmLwH9r2GAewvz9mhZ+TSyQBoE9ANuB4nNhn6lJvVUgzlzji3aqeFbAuDt+Z60ZkaIDNipU/J5Vf2Lo/QTQQ==";
       };
     };
     "@serverless/utils-3.1.0" = {
@@ -4991,13 +4999,13 @@ let
         sha512 = "+xwiU1zw+Z1V6RaIL7oWUqZo8jDIpoKfzvv8xGiq0hYxsiP9tGSUNuFXwQzAFEP60kJyD2a/nptdRPjsKD0jPw==";
       };
     };
-    "@snyk/dep-graph-1.23.0" = {
+    "@snyk/dep-graph-1.23.1" = {
       name = "_at_snyk_slash_dep-graph";
       packageName = "@snyk/dep-graph";
-      version = "1.23.0";
+      version = "1.23.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.23.0.tgz";
-        sha512 = "qR0ENrbcNWHYmSRZCxjrlFy2T7i+rJjL6Rnd2e+NByJgn8zBmX6Qf5FjqNbZAI0AYjOlzXMZjGrbAbe4QkWV+w==";
+        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.23.1.tgz";
+        sha512 = "bSlTRVJP0PHtvoilhE463AMt0fhsf9PxCEqJ28VHCVSe5QFzIlgGdljtytV+2DheadGwu27BgLGqPDGMdTBHRQ==";
       };
     };
     "@snyk/docker-registry-v2-client-1.13.9" = {
@@ -5207,130 +5215,130 @@ let
         sha512 = "2QBwlqi2SU83vTHibfdTxGiLdIqR0btNyMGfVl0bwA6FI85HnSYoGFLrdCnq2V0nxpbhuvwzcm2Ja81w0VkMGA==";
       };
     };
-    "@textlint/ast-tester-2.3.1" = {
+    "@textlint/ast-tester-2.3.2" = {
       name = "_at_textlint_slash_ast-tester";
       packageName = "@textlint/ast-tester";
-      version = "2.3.1";
+      version = "2.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-2.3.1.tgz";
-        sha512 = "L9M2VNTYJ5sVdkPs9jH7s01Gg900Nuk7m9zQmCz9WFa3YyzJFEd7GCSmAvLMgX31jw5bbvvmj7DngymlP+PahQ==";
+        url = "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-2.3.2.tgz";
+        sha512 = "4e1kyqsHks5POcQmuh7ITVrU/dbYyRUfQarQbeVRPP271n2HnlgnoYyZ10yV2Sb/Ksw+lQf7DPSnwNewXdCWww==";
       };
     };
-    "@textlint/ast-traverse-2.3.1" = {
+    "@textlint/ast-traverse-2.3.2" = {
       name = "_at_textlint_slash_ast-traverse";
       packageName = "@textlint/ast-traverse";
-      version = "2.3.1";
+      version = "2.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-2.3.1.tgz";
-        sha512 = "uOFKqm3M9by55Zl2ryZ7jOSiLdLhDmVgX0IG/MJfGKY1a/MSyt5qwy9cvZNcob6hNCPeRMW8boAH2uRJOwRcoQ==";
+        url = "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-2.3.2.tgz";
+        sha512 = "Dt1s/6x0XWhUNFH2rAa9gL6ODtq232BZuBHuHiOg+SrVwzl+VjOfa3fMQ0LoYixGSyDtwqAlksWcC0KyLz0eSw==";
       };
     };
-    "@textlint/feature-flag-3.3.1" = {
+    "@textlint/feature-flag-3.3.2" = {
       name = "_at_textlint_slash_feature-flag";
       packageName = "@textlint/feature-flag";
-      version = "3.3.1";
+      version = "3.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-3.3.1.tgz";
-        sha512 = "0a1UopFf30UrmEDKFNATXlotMqwbLGjJa1GTuljL/AKn2Adz7rPawclW4pHf/b//K7Da5GOtuzbIfVAZSFQRxA==";
+        url = "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-3.3.2.tgz";
+        sha512 = "7ErQ/UF0IBAd+PkQNBD7yYCDqL2o6leErMDENSWAgUHWLy5TcHr3Orn7qswtBMW5gIyXW9lh+EpllwLJ5qv35w==";
       };
     };
-    "@textlint/fixer-formatter-3.3.1" = {
+    "@textlint/fixer-formatter-3.3.2" = {
       name = "_at_textlint_slash_fixer-formatter";
       packageName = "@textlint/fixer-formatter";
-      version = "3.3.1";
+      version = "3.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-3.3.1.tgz";
-        sha512 = "ZPK66J61lv8UMdqJeG4YUPfKPlCom/jiv8kZkz5ELnLA587HLOlEIYLaNjKop0viW5z3Fz9cZd5glIHrPymiqQ==";
+        url = "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-3.3.2.tgz";
+        sha512 = "aTEyH/rHSzxRLrluSjNhDnMSgIYK60J5AAgprKJCkb9h3dDRuNoiJ+BXh5FXVSSm1tGF0d8pu+Ph8OFBgQOchQ==";
       };
     };
-    "@textlint/kernel-3.4.1" = {
+    "@textlint/kernel-3.4.2" = {
       name = "_at_textlint_slash_kernel";
       packageName = "@textlint/kernel";
-      version = "3.4.1";
+      version = "3.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/kernel/-/kernel-3.4.1.tgz";
-        sha512 = "8ZpiLy5KgmIMjda7RNgbNzoHpDnF51OC0rmMBTUl5xFMrpOcmnKZ6qcnmP7hlyR1MQJxQVzG0PvWnLHFUZL53w==";
+        url = "https://registry.npmjs.org/@textlint/kernel/-/kernel-3.4.2.tgz";
+        sha512 = "PpxAtvLGI9ewn+Dbt4j0KMfmMM39/AY3cikmZffu59nyTdIymXMeVMEVkpVZTEUk5OlL27RAON9FF+2u+0fshg==";
       };
     };
-    "@textlint/linter-formatter-3.3.1" = {
+    "@textlint/linter-formatter-3.3.2" = {
       name = "_at_textlint_slash_linter-formatter";
       packageName = "@textlint/linter-formatter";
-      version = "3.3.1";
+      version = "3.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-3.3.1.tgz";
-        sha512 = "tBtOSfpZWr3AwIJ1vbBSD+fwB4JSEtCQIE+AgfFqO8eDMOssjxKgVtIPX9dwh3/+6vlc6KozBJjIfXoxLuaWlg==";
+        url = "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-3.3.2.tgz";
+        sha512 = "MRa8D1/x6pWycKTwb1QLjtY7GyjgcsYRfV0Gu0Aze5szCa3UDwZSewHycpcAGlIqr8AkqPRfyXi653M47eJ0rA==";
       };
     };
-    "@textlint/markdown-to-ast-6.3.1" = {
+    "@textlint/markdown-to-ast-6.3.2" = {
       name = "_at_textlint_slash_markdown-to-ast";
       packageName = "@textlint/markdown-to-ast";
-      version = "6.3.1";
+      version = "6.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.3.1.tgz";
-        sha512 = "piqeTN6dzMr7ljlo7GbRBILMcZ8zW2H9raN48qH+HYhfrGZfEOmL5HAMMeF8h0sDz9CzTvZixEwGWLMdlwsb+A==";
+        url = "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.3.2.tgz";
+        sha512 = "uwndF3PRJ48wTVAEDSy0IAEVJg/scxpdZ1r+QKeGuFfdtaGSrtcgROI6qiVU1g/WNyNfQw+DAA7F8HfM+pmleg==";
       };
     };
-    "@textlint/module-interop-1.2.1" = {
+    "@textlint/module-interop-1.2.2" = {
       name = "_at_textlint_slash_module-interop";
       packageName = "@textlint/module-interop";
-      version = "1.2.1";
+      version = "1.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-1.2.1.tgz";
-        sha512 = "ZvxTTvEm7nmkRctWKREfvNvnVtRxRbdUms8cqkiYbP2K0fRIMacrWpL8z8cdkkdNZbaYciaUnyE3be7UD4J8EA==";
+        url = "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-1.2.2.tgz";
+        sha512 = "B8HPS129lOqzEpRcafYl/OJ2TDxfBw1jGfEhebzwt3kGoMd5pQVih+hUIOl+SfAmLWqCDEniaKn0gw1s+hjSXA==";
       };
     };
-    "@textlint/source-code-fixer-3.4.1" = {
+    "@textlint/source-code-fixer-3.4.2" = {
       name = "_at_textlint_slash_source-code-fixer";
       packageName = "@textlint/source-code-fixer";
-      version = "3.4.1";
+      version = "3.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-3.4.1.tgz";
-        sha512 = "FqL+xdjIU2hswS4Cmhf/bL7SWTpXkKoK/wb8Lmo9sNmEE481fc5Ey/s8JgxAaOHRpwOcmErGd16c3gXcG6Y2ow==";
+        url = "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-3.4.2.tgz";
+        sha512 = "mSGQNO8is21KcHgDh4S8Cx88r7uU+7xpzHLuEuzhgEZfgwz3+tnpk22TrEjNYe1V1+aseU9iCQegVQQr1wroKQ==";
       };
     };
-    "@textlint/text-to-ast-3.3.1" = {
+    "@textlint/text-to-ast-3.3.2" = {
       name = "_at_textlint_slash_text-to-ast";
       packageName = "@textlint/text-to-ast";
-      version = "3.3.1";
+      version = "3.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-3.3.1.tgz";
-        sha512 = "aN1IY3u98Wig2PTF/eEJdb7XfCH5VEwZagGdG1vajx6sdc7Sc3265UVv9uEB/ypJDteYnURRICfTd6NCGwkVGA==";
+        url = "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-3.3.2.tgz";
+        sha512 = "+DKAP62ho21KID8IcKy1kP6K+kUZk+Z0MwvS9u2l39J0cK+vX523KI+sA6AXxEhOMDA8zhdIsBf3onGvrAtyhA==";
       };
     };
-    "@textlint/textlint-plugin-markdown-5.3.1" = {
+    "@textlint/textlint-plugin-markdown-5.3.2" = {
       name = "_at_textlint_slash_textlint-plugin-markdown";
       packageName = "@textlint/textlint-plugin-markdown";
-      version = "5.3.1";
+      version = "5.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-5.3.1.tgz";
-        sha512 = "IhQVGW9YqylkuZ4AjOfLFtOWHPXtLMhWTVfvIFzMQ2TIpquIaybws8KiFN2yZzLBNNduF+PFvm+H2NRhR0w/lQ==";
+        url = "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-5.3.2.tgz";
+        sha512 = "6Ph7ESKR48tEz5Pnog3PpvF84LU3jkADvr4iBkkVz9vLQt3KbqGnmk8EV94Y0hLEX+UrZKWmH3cJfh6O1Zy/eA==";
       };
     };
-    "@textlint/textlint-plugin-text-4.3.1" = {
+    "@textlint/textlint-plugin-text-4.3.2" = {
       name = "_at_textlint_slash_textlint-plugin-text";
       packageName = "@textlint/textlint-plugin-text";
-      version = "4.3.1";
+      version = "4.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-4.3.1.tgz";
-        sha512 = "IqtO6TWOfVaw8sXMdVVwsvEYuqYk13ApKXBVjjJoLux0g+6G1rCEhFSZtopkrpC1Srr/OZCfb4nk8/zx+5M6Ng==";
+        url = "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-4.3.2.tgz";
+        sha512 = "xnjad0bXaM6ZtgffuFKogHYkzXymUK3VTLP5MGA00kLitADlNUtwXQk82TebkXFcSPRhePU9+2XFipXNQDsg7g==";
       };
     };
-    "@textlint/types-1.5.1" = {
+    "@textlint/types-1.5.2" = {
       name = "_at_textlint_slash_types";
       packageName = "@textlint/types";
-      version = "1.5.1";
+      version = "1.5.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/types/-/types-1.5.1.tgz";
-        sha512 = "YgPmxEeFUXuCjWOFx4p0afxFCHJbTf9Muw/6SJDLd/txQ6YrStst3Kvw+6QGefdJe44/UdiUYtI8sYa5T1ejaQ==";
+        url = "https://registry.npmjs.org/@textlint/types/-/types-1.5.2.tgz";
+        sha512 = "IdS0h2MCzdY+wjM0+qvl8IW/IxhmVFAVrGu5TmIBpJkihIV7WMa3ITFXIVb0oqwnePUmyLBRIVsCtC66E3QbfQ==";
       };
     };
-    "@textlint/utils-1.2.1" = {
+    "@textlint/utils-1.2.2" = {
       name = "_at_textlint_slash_utils";
       packageName = "@textlint/utils";
-      version = "1.2.1";
+      version = "1.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/utils/-/utils-1.2.1.tgz";
-        sha512 = "X/rLpqskTLWDPO5cvQO5CcA7zNnDimeBokwehiDwTg6aP9LYqFeOw5mKZ5lb4purY9zN9tLRxJGLle4Py1QobQ==";
+        url = "https://registry.npmjs.org/@textlint/utils/-/utils-1.2.2.tgz";
+        sha512 = "7Mqcl9G9YYrPBv5d/tZ2NlWC66hTUpQEQxZEHDMTdF3gPmQUSNRNGjqUR9mhw00Wy8Wo6i3LUWuxwMT6heHNBQ==";
       };
     };
     "@tokenizer/token-0.1.1" = {
@@ -5709,15 +5717,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz";
         sha512 = "wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==";
-      };
-    };
-    "@types/express-serve-static-core-4.17.17" = {
-      name = "_at_types_slash_express-serve-static-core";
-      packageName = "@types/express-serve-static-core";
-      version = "4.17.17";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.17.tgz";
-        sha512 = "YYlVaCni5dnHc+bLZfY908IG1+x5xuibKZMGv8srKkvtul3wUuanYvpIj9GXXoWkQbaAdR+kgX46IETKUALWNQ==";
       };
     };
     "@types/express-serve-static-core-4.17.18" = {
@@ -6539,13 +6538,13 @@ let
         sha512 = "I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==";
       };
     };
-    "@types/uglify-js-3.11.1" = {
+    "@types/uglify-js-3.12.0" = {
       name = "_at_types_slash_uglify-js";
       packageName = "@types/uglify-js";
-      version = "3.11.1";
+      version = "3.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.1.tgz";
-        sha512 = "7npvPKV+jINLu1SpSYVWG8KvyJBhBa8tmzMMdDoVc2pWUYHN8KIXlPJhjJ4LT97c4dXJA2SHL/q6ADbDriZN+Q==";
+        url = "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.12.0.tgz";
+        sha512 = "sYAF+CF9XZ5cvEBkI7RtrG9g2GtMBkviTnBxYYyq+8BWvO4QtXfwwR6a2LFwCi4evMKZfpv6U43ViYvv17Wz3Q==";
       };
     };
     "@types/unist-2.0.3" = {
@@ -6593,13 +6592,13 @@ let
         sha512 = "GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==";
       };
     };
-    "@types/vscode-1.52.0" = {
+    "@types/vscode-1.53.0" = {
       name = "_at_types_slash_vscode";
       packageName = "@types/vscode";
-      version = "1.52.0";
+      version = "1.53.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz";
-        sha512 = "Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==";
+        url = "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz";
+        sha512 = "XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==";
       };
     };
     "@types/webpack-4.41.25" = {
@@ -6701,13 +6700,13 @@ let
         sha512 = "HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==";
       };
     };
-    "@typescript-eslint/eslint-plugin-4.14.2" = {
+    "@typescript-eslint/eslint-plugin-4.15.0" = {
       name = "_at_typescript-eslint_slash_eslint-plugin";
       packageName = "@typescript-eslint/eslint-plugin";
-      version = "4.14.2";
+      version = "4.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.2.tgz";
-        sha512 = "uMGfG7GFYK/nYutK/iqYJv6K/Xuog/vrRRZX9aEP4Zv1jsYXuvFUMDFLhUnc8WFv3D2R5QhNQL3VYKmvLS5zsQ==";
+        url = "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.0.tgz";
+        sha512 = "DJgdGZW+8CFUTz5C/dnn4ONcUm2h2T0itWD85Ob5/V27Ndie8hUoX5HKyGssvR8sUMkAIlUc/AMK67Lqa3kBIQ==";
       };
     };
     "@typescript-eslint/experimental-utils-3.10.1" = {
@@ -6719,13 +6718,13 @@ let
         sha512 = "DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==";
       };
     };
-    "@typescript-eslint/experimental-utils-4.14.2" = {
+    "@typescript-eslint/experimental-utils-4.15.0" = {
       name = "_at_typescript-eslint_slash_experimental-utils";
       packageName = "@typescript-eslint/experimental-utils";
-      version = "4.14.2";
+      version = "4.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.2.tgz";
-        sha512 = "mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==";
+        url = "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz";
+        sha512 = "V4vaDWvxA2zgesg4KPgEGiomWEBpJXvY4ZX34Y3qxK8LUm5I87L+qGIOTd9tHZOARXNRt9pLbblSKiYBlGMawg==";
       };
     };
     "@typescript-eslint/parser-3.10.1" = {
@@ -6737,22 +6736,22 @@ let
         sha512 = "Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==";
       };
     };
-    "@typescript-eslint/parser-4.14.2" = {
+    "@typescript-eslint/parser-4.15.0" = {
       name = "_at_typescript-eslint_slash_parser";
       packageName = "@typescript-eslint/parser";
-      version = "4.14.2";
+      version = "4.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.14.2.tgz";
-        sha512 = "ipqSP6EuUsMu3E10EZIApOJgWSpcNXeKZaFeNKQyzqxnQl8eQCbV+TSNsl+s2GViX2d18m1rq3CWgnpOxDPgHg==";
+        url = "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.0.tgz";
+        sha512 = "L6Dtbq8Bc7g2aZwnIBETpmUa9XDKCMzKVwAArnGp5Mn7PRNFjf3mUzq8UeBjL3K8t311hvevnyqXAMSmxO8Gpg==";
       };
     };
-    "@typescript-eslint/scope-manager-4.14.2" = {
+    "@typescript-eslint/scope-manager-4.15.0" = {
       name = "_at_typescript-eslint_slash_scope-manager";
       packageName = "@typescript-eslint/scope-manager";
-      version = "4.14.2";
+      version = "4.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.14.2.tgz";
-        sha512 = "cuV9wMrzKm6yIuV48aTPfIeqErt5xceTheAgk70N1V4/2Ecj+fhl34iro/vIssJlb7XtzcaD07hWk7Jk0nKghg==";
+        url = "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz";
+        sha512 = "CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==";
       };
     };
     "@typescript-eslint/types-3.10.1" = {
@@ -6764,13 +6763,13 @@ let
         sha512 = "+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==";
       };
     };
-    "@typescript-eslint/types-4.14.2" = {
+    "@typescript-eslint/types-4.15.0" = {
       name = "_at_typescript-eslint_slash_types";
       packageName = "@typescript-eslint/types";
-      version = "4.14.2";
+      version = "4.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.14.2.tgz";
-        sha512 = "LltxawRW6wXy4Gck6ZKlBD05tCHQUj4KLn4iR69IyRiDHX3d3NCAhO+ix5OR2Q+q9bjCrHE/HKt+riZkd1At8Q==";
+        url = "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz";
+        sha512 = "su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==";
       };
     };
     "@typescript-eslint/typescript-estree-2.34.0" = {
@@ -6791,13 +6790,13 @@ let
         sha512 = "QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==";
       };
     };
-    "@typescript-eslint/typescript-estree-4.14.2" = {
+    "@typescript-eslint/typescript-estree-4.15.0" = {
       name = "_at_typescript-eslint_slash_typescript-estree";
       packageName = "@typescript-eslint/typescript-estree";
-      version = "4.14.2";
+      version = "4.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.2.tgz";
-        sha512 = "ESiFl8afXxt1dNj8ENEZT12p+jl9PqRur+Y19m0Z/SPikGL6rqq4e7Me60SU9a2M28uz48/8yct97VQYaGl0Vg==";
+        url = "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz";
+        sha512 = "jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==";
       };
     };
     "@typescript-eslint/visitor-keys-3.10.1" = {
@@ -6809,31 +6808,31 @@ let
         sha512 = "9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==";
       };
     };
-    "@typescript-eslint/visitor-keys-4.14.2" = {
+    "@typescript-eslint/visitor-keys-4.15.0" = {
       name = "_at_typescript-eslint_slash_visitor-keys";
       packageName = "@typescript-eslint/visitor-keys";
-      version = "4.14.2";
+      version = "4.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.2.tgz";
-        sha512 = "KBB+xLBxnBdTENs/rUgeUKO0UkPBRs2vD09oMRRIkj5BEN8PX1ToXV532desXfpQnZsYTyLLviS7JrPhdL154w==";
+        url = "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz";
+        sha512 = "RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==";
       };
     };
-    "@uifabric/foundation-7.9.21" = {
+    "@uifabric/foundation-7.9.24" = {
       name = "_at_uifabric_slash_foundation";
       packageName = "@uifabric/foundation";
-      version = "7.9.21";
+      version = "7.9.24";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.21.tgz";
-        sha512 = "z58pcC0hJr6S0iYLxNFoqfrfLIMxbSxFHRirk5LDT2HXbiVIYbJwbK4O0InS+sz3chdx8GGSdIUz7muXeT/D+A==";
+        url = "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.24.tgz";
+        sha512 = "f9W6x6gqczgkayA89TsiGzdze2A8RJXc/GbANYvBad3zeyDlQahepMrlgRMOXcTiwZIiltTje+7ADtvD/o176Q==";
       };
     };
-    "@uifabric/icons-7.5.18" = {
+    "@uifabric/icons-7.5.21" = {
       name = "_at_uifabric_slash_icons";
       packageName = "@uifabric/icons";
-      version = "7.5.18";
+      version = "7.5.21";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.18.tgz";
-        sha512 = "gLPEccWlTER9NiXcOHZ+dSJ3tgLAQ4mTf3hTlKV7e7dKBTl95jzcemG5S2NJQ7xWPTH3+5K1Bpd+nqZo9EJw3w==";
+        url = "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.21.tgz";
+        sha512 = "ZTqLpdCZeCChcMWCgEyWUke2wJxfi3SNdSjNFXWK90SsDWlafg3s/eDd7+n6oRi4pHlF6eBnc4oTLR6PFXt8kQ==";
       };
     };
     "@uifabric/merge-styles-7.19.1" = {
@@ -6845,13 +6844,13 @@ let
         sha512 = "yqUwmk62Kgu216QNPE9vOfS3h0kiSbTvoqM5QcZi+IzpqsBOlzZx3A9Er9UiDaqHRd5lsYF5pO/jeUULmBWF/A==";
       };
     };
-    "@uifabric/react-hooks-7.13.9" = {
+    "@uifabric/react-hooks-7.13.11" = {
       name = "_at_uifabric_slash_react-hooks";
       packageName = "@uifabric/react-hooks";
-      version = "7.13.9";
+      version = "7.13.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.9.tgz";
-        sha512 = "VtDg2b3ypYXX7MLp1STk1Fj6ZIeZktXnm0hu1Os/pGvq6xkuLRly5XP6ZSHitm8K7ZcMo48CcNL8smmiXprBQg==";
+        url = "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.11.tgz";
+        sha512 = "9qX4hiZ4MelUxOxx4IPl+vgn9/e43KkYTpYedl2QtUxFpDjsOVJ0jbG3Dkokyl+Kvw1gerYCT1SXL8UC4kG97w==";
       };
     };
     "@uifabric/set-version-7.0.23" = {
@@ -6863,22 +6862,22 @@ let
         sha512 = "9E+YKtnH2kyMKnK9XZZsqyM8OCxEJIIfxtaThTlQpYOzrWAGJxQADFbZ7+Usi0U2xHnWNPFROjq+B9ocEzhqMA==";
       };
     };
-    "@uifabric/styling-7.16.19" = {
+    "@uifabric/styling-7.18.0" = {
       name = "_at_uifabric_slash_styling";
       packageName = "@uifabric/styling";
-      version = "7.16.19";
+      version = "7.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.19.tgz";
-        sha512 = "T5fjUCx0LbzUC8Myw15YCaBjdGbSrihWSiPHtLVW77k59yWAW947XnH73QngE8xU7kyKPH3AhQrUEBMB2NjHag==";
+        url = "https://registry.npmjs.org/@uifabric/styling/-/styling-7.18.0.tgz";
+        sha512 = "PuCSr2PeVDLTtyqOjS67QBgN7rDYf044oRvMEkSCP57p9Du8rIAJio0LQjVNRKo+QlmfgFzmT3XjpS2LYkhFIg==";
       };
     };
-    "@uifabric/utilities-7.33.2" = {
+    "@uifabric/utilities-7.33.4" = {
       name = "_at_uifabric_slash_utilities";
       packageName = "@uifabric/utilities";
-      version = "7.33.2";
+      version = "7.33.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.33.2.tgz";
-        sha512 = "v2c3IUJdpru/hoGNOwIW549O5D4XBAc5sLpB7RREGI5ywoWuIJlNyYtBEGOwhAY62J2blj11qi86Ep+oZDM/Kw==";
+        url = "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.33.4.tgz";
+        sha512 = "FgEL2+GWOHMNMQqmI5Mko293W3c9PWIc/WrlU6jQ5AU83M1BQSxhS0LPNnRbahukiEFNkosCOOKzKCNdjzkCwA==";
       };
     };
     "@ungap/from-entries-0.2.1" = {
@@ -8132,13 +8131,13 @@ let
         sha512 = "e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==";
       };
     };
-    "agentkeepalive-4.1.3" = {
+    "agentkeepalive-4.1.4" = {
       name = "agentkeepalive";
       packageName = "agentkeepalive";
-      version = "4.1.3";
+      version = "4.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.3.tgz";
-        sha512 = "wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==";
+        url = "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz";
+        sha512 = "+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==";
       };
     };
     "aggregate-error-3.1.0" = {
@@ -8222,13 +8221,13 @@ let
         sha512 = "LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==";
       };
     };
-    "ajv-7.0.4" = {
+    "ajv-7.1.0" = {
       name = "ajv";
       packageName = "ajv";
-      version = "7.0.4";
+      version = "7.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ajv/-/ajv-7.0.4.tgz";
-        sha512 = "xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==";
+        url = "https://registry.npmjs.org/ajv/-/ajv-7.1.0.tgz";
+        sha512 = "svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==";
       };
     };
     "ajv-errors-1.0.1" = {
@@ -8969,13 +8968,13 @@ let
         sha512 = "iMi3087iphDAI0U2iSBE9qtx9kQoMMEWr6w+LwXruBD95ek9DWyj7OeC2U/ngLjRsXM43DoBDXlu7R+uMjahrQ==";
       };
     };
-    "apollo-server-core-2.19.2" = {
+    "apollo-server-core-2.20.0" = {
       name = "apollo-server-core";
       packageName = "apollo-server-core";
-      version = "2.19.2";
+      version = "2.20.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.19.2.tgz";
-        sha512 = "liLgLhTIGWZtdQbxuxo3/Yv8j+faKQcI60kOL+uwfByGhoKLZEQp5nqi2IdMK6JXt1VuyKwKu7lTzj02a9S3jA==";
+        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.20.0.tgz";
+        sha512 = "tteFTl6y9c3MtuhePOs9IbCccaKVXELttLvefMzd7EfR3CPgIfIbxpy2ZEcDys8NteYXoJ+4LiM8Eh9kLgkKmQ==";
       };
     };
     "apollo-server-env-2.4.5" = {
@@ -9005,13 +9004,13 @@ let
         sha512 = "FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==";
       };
     };
-    "apollo-server-express-2.19.2" = {
+    "apollo-server-express-2.20.0" = {
       name = "apollo-server-express";
       packageName = "apollo-server-express";
-      version = "2.19.2";
+      version = "2.20.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.19.2.tgz";
-        sha512 = "1v2H6BgDkS4QzRbJ9djn2o0yv5m/filbpiupxAsCG9f+sAoSlY3eYSj84Sbex2r5+4itAvT9y84WI7d9RBYs/Q==";
+        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.20.0.tgz";
+        sha512 = "Bf2c/1J/ScXmioWi+0HFIsZ1bt8zFlI2VV/7oUn+Dd/lUBHLVfMNKvEJNMwjRkIrI9b9+eqANDrO6lf2ruC52w==";
       };
     };
     "apollo-server-plugin-base-0.10.4" = {
@@ -10067,6 +10066,15 @@ let
         sha512 = "TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==";
       };
     };
+    "async-append-only-log-3.0.3" = {
+      name = "async-append-only-log";
+      packageName = "async-append-only-log";
+      version = "3.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async-append-only-log/-/async-append-only-log-3.0.3.tgz";
+        sha512 = "w6F/oWReK4qyNBnCFe/cfYZHXMs07BZjS0LmpHQ5JByK5yEVzvvWGdNMStFPVbQhVJnT1PdmP+/LwEzmoe33qA==";
+      };
+    };
     "async-done-1.3.2" = {
       name = "async-done";
       packageName = "async-done";
@@ -10265,6 +10273,15 @@ let
         sha512 = "Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==";
       };
     };
+    "atomically-universal-0.1.1" = {
+      name = "atomically-universal";
+      packageName = "atomically-universal";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/atomically-universal/-/atomically-universal-0.1.1.tgz";
+        sha512 = "0bqmz+wKlA9hIiH/C4R3K8dpsVV6mM/X76QZ70LMHW0XzCDXzxdWD5gfkmRXxTM5txlbYE/06iz0IziohUQVzw==";
+      };
+    };
     "attach-ware-1.1.1" = {
       name = "attach-ware";
       packageName = "attach-ware";
@@ -10355,13 +10372,13 @@ let
         sha512 = "+KBkqH7t/XE91Fqn8eyJeNIWsnhSWL8bSUqFD7TfE3FN07MTlC0nprGYp+2WfcYNz5i8Bus1vY2DHNVhtTImnw==";
       };
     };
-    "aws-sdk-2.836.0" = {
+    "aws-sdk-2.841.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.836.0";
+      version = "2.841.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.836.0.tgz";
-        sha512 = "lVOT5/yr9ONfbn6UXYYIdFlVIFmSoX0CnjAQzXkfcYg+k7CZklbqqVIdgdLoiQYwQGLceoWghSevPGe7fjFg9Q==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.841.0.tgz";
+        sha512 = "pMgFr0B4WFIZEKc6EPAcyrvafkqoE1JwU6DJuE4UmT2ntat87DnbWUzFRP2HB4HuJvP1F7KNmElMz8p8j8bkNg==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -11525,6 +11542,15 @@ let
         sha512 = "nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==";
       };
     };
+    "binary-search-bounds-2.0.5" = {
+      name = "binary-search-bounds";
+      packageName = "binary-search-bounds";
+      version = "2.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz";
+        sha512 = "H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==";
+      };
+    };
     "binaryextensions-2.3.0" = {
       name = "binaryextensions";
       packageName = "binaryextensions";
@@ -11595,6 +11621,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz";
         sha1 = "01fa8748785ca70955d5011217d1b3139969ca22";
+      };
+    };
+    "bipf-1.4.0" = {
+      name = "bipf";
+      packageName = "bipf";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bipf/-/bipf-1.4.0.tgz";
+        sha512 = "8b2T/OWIRI73kcPXhI+jqK+0QyxRlZ6HIzQBK8tRxIZ2NO0dBxJ4T9eeX6XsYEHy2cqM69n+rOZyVjhvRUGRig==";
       };
     };
     "bitcoin-core-2.3.0" = {
@@ -11696,13 +11731,13 @@ let
         sha512 = "tSh9HdQgwyEAfo1jzoGEis6o/zs4CcdRTchG93XVl5jct+DCAN90M5MVUV76k2vJ9Xg3GAzLB5NLsY/vnVTh6w==";
       };
     };
-    "bittorrent-protocol-3.2.0" = {
+    "bittorrent-protocol-3.3.1" = {
       name = "bittorrent-protocol";
       packageName = "bittorrent-protocol";
-      version = "3.2.0";
+      version = "3.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bittorrent-protocol/-/bittorrent-protocol-3.2.0.tgz";
-        sha512 = "8xgCgK8xUg7MXZBxhqJapZy9hexHwN2TCD+b8m4yWg56/ZFfdkULxhxQkzuhpXyUfvKIKxeRzGmLT43li7FDKg==";
+        url = "https://registry.npmjs.org/bittorrent-protocol/-/bittorrent-protocol-3.3.1.tgz";
+        sha512 = "DJy0/jjqJD62PPJY79duCccmPMihp3KPowlmd7BLEU8FTtnDsYjso6BAx+pWwCKOeDORdc9RiJ7L72x3taCh6g==";
       };
     };
     "bittorrent-tracker-7.7.0" = {
@@ -11714,13 +11749,13 @@ let
         sha1 = "ffd2eabc141d36ed5c1817df7e992f91fd7fc65c";
       };
     };
-    "bittorrent-tracker-9.16.0" = {
+    "bittorrent-tracker-9.16.1" = {
       name = "bittorrent-tracker";
       packageName = "bittorrent-tracker";
-      version = "9.16.0";
+      version = "9.16.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.16.0.tgz";
-        sha512 = "6VEaW1rYA6f8H2VATlrXrTtgqB4WF7+BMIuVMsoLPgdK43d5VDPdI/ky9gpeRHcY9qmVJv+kHfkwH8G16sNbNw==";
+        url = "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.16.1.tgz";
+        sha512 = "JjegXwpWK8xRTHd5sqKTVqPhlhzAqJrR37gSiciTa1UkSSM6SWKVUDq7ZiGS3d8FhqonDSuPLQ9wUOC2q2jeIA==";
       };
     };
     "bl-1.2.3" = {
@@ -11748,6 +11783,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz";
         sha512 = "7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==";
+      };
+    };
+    "bl-4.1.0" = {
+      name = "bl";
+      packageName = "bl";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz";
+        sha512 = "1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==";
       };
     };
     "blake2b-2.1.3" = {
@@ -12632,6 +12676,15 @@ let
         sha512 = "xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==";
       };
     };
+    "buffer-5.1.0" = {
+      name = "buffer";
+      packageName = "buffer";
+      version = "5.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz";
+        sha512 = "YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==";
+      };
+    };
     "buffer-5.2.1" = {
       name = "buffer";
       packageName = "buffer";
@@ -13451,13 +13504,13 @@ let
         sha512 = "bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==";
       };
     };
-    "caniuse-lite-1.0.30001183" = {
+    "caniuse-lite-1.0.30001185" = {
       name = "caniuse-lite";
       packageName = "caniuse-lite";
-      version = "1.0.30001183";
+      version = "1.0.30001185";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz";
-        sha512 = "7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw==";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001185.tgz";
+        sha512 = "Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==";
       };
     };
     "canvas-2.6.1" = {
@@ -14153,13 +14206,13 @@ let
         sha1 = "04a106672c18b085ab774d983dfa3ea138f22205";
       };
     };
-    "chunk-store-stream-4.1.1" = {
+    "chunk-store-stream-4.2.0" = {
       name = "chunk-store-stream";
       packageName = "chunk-store-stream";
-      version = "4.1.1";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-4.1.1.tgz";
-        sha512 = "2nVS+VLMCHNW+S1Y3bOlCtUL4ABPA4zeAcP8E/m15AAc+8fw1elEKIhs/Wg5EZNSfqIk24kUd9rvewmGNPehGQ==";
+        url = "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-4.2.0.tgz";
+        sha512 = "90iueoPoqT2isnmy1fyqwzgFy5FokuaxQuijOQG1VgC/6DaXRfeYN0da8iWENkzqElWhqLxo8pWc7pH9dmxlcA==";
       };
     };
     "ci-info-1.6.0" = {
@@ -14286,6 +14339,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz";
         sha512 = "VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==";
+      };
+    };
+    "clean-css-5.0.1" = {
+      name = "clean-css";
+      packageName = "clean-css";
+      version = "5.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/clean-css/-/clean-css-5.0.1.tgz";
+        sha512 = "F1zAGOowUCg8yxT0O4UR+nmbMauf3YwbiUS60CPxpzJU7ulpamGzQomFrJSK4w/HqHtMmQKSHJUNue+dQQYQdg==";
       };
     };
     "clean-deep-3.4.0" = {
@@ -15008,13 +15070,13 @@ let
         sha512 = "3WQV/Fpa77nvzjUlc+0u53uIroJyyMB2Qwl++aXpAiDIsrsiAQq4uCURwdRBRX+eLkOTIAmT0L4qna3T7+2pUg==";
       };
     };
-    "codemaker-1.20.0" = {
+    "codemaker-1.20.1" = {
       name = "codemaker";
       packageName = "codemaker";
-      version = "1.20.0";
+      version = "1.20.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/codemaker/-/codemaker-1.20.0.tgz";
-        sha512 = "ubrKzvcYARQdyjEOaNrcoqnEw8HBwo5mYeq9/Uwf3QnTkKUhgFEY3fQYIBKENUd0C4LtAygjvDKd4VDF+E+fAQ==";
+        url = "https://registry.npmjs.org/codemaker/-/codemaker-1.20.1.tgz";
+        sha512 = "AhDdoC0jhSw8VhbHBH2WN8CDp8PZKnO0YMAlZXG9BRLJnu4ztOQkYuB8BWipNydRHS3Zj1LQX4lPtTQkJN4vWg==";
       };
     };
     "codepage-1.4.0" = {
@@ -15962,13 +16024,13 @@ let
         sha1 = "7890482bf5c71af6c5ca192be3136aed74428aad";
       };
     };
-    "consola-2.15.2" = {
+    "consola-2.15.3" = {
       name = "consola";
       packageName = "consola";
-      version = "2.15.2";
+      version = "2.15.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/consola/-/consola-2.15.2.tgz";
-        sha512 = "VxqWw5C8O/mQpZYtfaaSCDJcVK3AxyvQ26rhgvyAI4j/QJISh8DLwFS8GQU+9154u4ngyCsSlnyIAYJme9kQug==";
+        url = "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz";
+        sha512 = "9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==";
       };
     };
     "console-browserify-1.1.0" = {
@@ -16043,13 +16105,13 @@ let
         sha1 = "c20b96d8c617748aaf1c16021760cd27fcb8cb75";
       };
     };
-    "constructs-3.3.11" = {
+    "constructs-3.3.18" = {
       name = "constructs";
       packageName = "constructs";
-      version = "3.3.11";
+      version = "3.3.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/constructs/-/constructs-3.3.11.tgz";
-        sha512 = "yis7ff0LPa1bgXBKKEU4BiS9sGCuRqCqHU6F12b2PnDurKQDMvy2meDzre15uaTf4mrxYmsezIGhiy9+GkIguw==";
+        url = "https://registry.npmjs.org/constructs/-/constructs-3.3.18.tgz";
+        sha512 = "aoFeZLctXI17AYApAc9Ilg/kTY3m7e29VbxeGnNiKvrsj9+UyC1setKozYPxtxr1dVC0UTUrOEYdP1rIAVGffQ==";
       };
     };
     "constructs-3.3.5" = {
@@ -16413,13 +16475,13 @@ let
         sha512 = "8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==";
       };
     };
-    "copy-anything-2.0.1" = {
+    "copy-anything-2.0.3" = {
       name = "copy-anything";
       packageName = "copy-anything";
-      version = "2.0.1";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.1.tgz";
-        sha512 = "lA57e7viQHOdPQcrytv5jFeudZZOXuyk47lZym279FiDQ8jeZomXiGuVf6ffMKkJ+3TIai3J1J3yi6M+/4U35g==";
+        url = "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.3.tgz";
+        sha512 = "GK6QUtisv4fNS+XcI7shX0Gx9ORg7QqIznyfho79JTnX1XhLiyZHfftvGiziqzRiEi/Bjhgpi+D2o7HxJFPnDQ==";
       };
     };
     "copy-concurrently-1.0.5" = {
@@ -16494,13 +16556,13 @@ let
         sha512 = "WxZRTnt5RHxSAB9urnHFUtVBcIe1YjR4sfwHLsxakNoKkFhcie3HrV5QmNBgRQ5DkxmanRN3VSx4OrPVsNmAaQ==";
       };
     };
-    "cordova-fetch-3.0.0" = {
+    "cordova-fetch-3.0.1" = {
       name = "cordova-fetch";
       packageName = "cordova-fetch";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-3.0.0.tgz";
-        sha512 = "N6mB/1GD8BNclxnfO85E4/s46nEJjIxYeJYHRGi6MjofhigJ3NlGwTCslbTcq8IOYEh0RdoA0mS4W2jA5UcWeQ==";
+        url = "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-3.0.1.tgz";
+        sha512 = "bxXk6H3FtGXpCtlO+XyXM4pa72azQomdurNeHbZai9eYBzA5vjyPnsgxsYcylLUc1wQFeR+XWQVfgJitx6ghEw==";
       };
     };
     "cordova-lib-10.0.0" = {
@@ -16674,6 +16736,15 @@ let
         sha512 = "0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==";
       };
     };
+    "cpu-percentage-1.0.3" = {
+      name = "cpu-percentage";
+      packageName = "cpu-percentage";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cpu-percentage/-/cpu-percentage-1.0.3.tgz";
+        sha1 = "868fd9092f439d1ef95f4a85e5fa4b9f07efc95c";
+      };
+    };
     "cpy-8.1.1" = {
       name = "cpy";
       packageName = "cpy";
@@ -16773,13 +16844,13 @@ let
         sha512 = "MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==";
       };
     };
-    "create-torrent-4.4.4" = {
+    "create-torrent-4.4.5" = {
       name = "create-torrent";
       packageName = "create-torrent";
-      version = "4.4.4";
+      version = "4.4.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-torrent/-/create-torrent-4.4.4.tgz";
-        sha512 = "VvKEgpRZvqqkw00Ab+j+EGy8VAr8Q6t+ZiJAbFeBaiQDklY/eRIkAqKIsKenMTFi1J28l4IgQJ4UQ1vgccPweA==";
+        url = "https://registry.npmjs.org/create-torrent/-/create-torrent-4.4.5.tgz";
+        sha512 = "6odHpDbUVAekmhG54TgHpv6PlUrfw9fCAq5jxv8nOlhHBeGZAhA4iLwjJyp1tjOdsrYsjqojK/gjY/mLfVdQXg==";
       };
     };
     "cron-1.7.2" = {
@@ -19707,15 +19778,6 @@ let
         sha512 = "cwaRptBmYZwu/FyhGcqBm2MzXA77W2/E6eVkpOZVDk6PkI9Bjj84xPrXiHMA+OWjzNy+DFjgKh8Q+1hMR7/OHg==";
       };
     };
-    "dockerfile-ast-0.0.30" = {
-      name = "dockerfile-ast";
-      packageName = "dockerfile-ast";
-      version = "0.0.30";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.30.tgz";
-        sha512 = "QOeP5NjbjoSLtnMz6jzBLsrKtywLEVPoCOAwA54cQpulyKb1gBnZ63tr6Amq8oVDvu5PXa3aifBVw+wcoCGHKg==";
-      };
-    };
     "dockerfile-ast-0.1.0" = {
       name = "dockerfile-ast";
       packageName = "dockerfile-ast";
@@ -20445,13 +20507,22 @@ let
         sha512 = "dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==";
       };
     };
-    "electron-to-chromium-1.3.653" = {
+    "ejs-3.1.6" = {
+      name = "ejs";
+      packageName = "ejs";
+      version = "3.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz";
+        sha512 = "9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==";
+      };
+    };
+    "electron-to-chromium-1.3.662" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.653";
+      version = "1.3.662";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.653.tgz";
-        sha512 = "LehOhcl74u9fkV9Un6WahJ+Xh+0FZLCCDnKYis1Olx1DX2ugRww5PJicE65OG8yznMj8EOQZRcz6FSV1xKxqsA==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.662.tgz";
+        sha512 = "IGBXmTGwdVGUVTnZ8ISEvkhDfhhD+CDFndG4//BhvDcEtPYiVrzoB+rzT/Y12OQCf5bvRCrVmrUbGrS9P7a6FQ==";
       };
     };
     "electrum-client-git://github.com/janoside/electrum-client" = {
@@ -21302,6 +21373,15 @@ let
         sha512 = "p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==";
       };
     };
+    "esbuild-0.8.44" = {
+      name = "esbuild";
+      packageName = "esbuild";
+      version = "0.8.44";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/esbuild/-/esbuild-0.8.44.tgz";
+        sha512 = "m9yyBZMgWuAB7e7tA2g9L4PovoLa5Xb73+Yg9uBBR2w3Fe4P9/nxqj/HLrw1k/rjdjF1eX1kNJRytboqOtRCCQ==";
+      };
+    };
     "esc-exit-2.0.2" = {
       name = "esc-exit";
       packageName = "esc-exit";
@@ -21734,13 +21814,13 @@ let
         sha1 = "633acdb40d9bd4db8a1c1d68c06a942959fad2b0";
       };
     };
-    "esquery-1.3.1" = {
+    "esquery-1.4.0" = {
       name = "esquery";
       packageName = "esquery";
-      version = "1.3.1";
+      version = "1.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz";
-        sha512 = "olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==";
+        url = "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz";
+        sha512 = "cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==";
       };
     };
     "esrecurse-4.3.0" = {
@@ -23003,6 +23083,15 @@ let
         sha512 = "On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==";
       };
     };
+    "fastintcompression-0.0.4" = {
+      name = "fastintcompression";
+      packageName = "fastintcompression";
+      version = "0.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fastintcompression/-/fastintcompression-0.0.4.tgz";
+        sha512 = "sRtejNHcWjJl0Fr+gsbybbgOKKj0sQYvv7rA787EbeFu1fMpmzjHuBW8fLBImSZeqDuR++TZU2n60mRrpAUR9g==";
+      };
+    };
     "fastparse-1.1.2" = {
       name = "fastparse";
       packageName = "fastparse";
@@ -23336,13 +23425,13 @@ let
         sha512 = "hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==";
       };
     };
-    "filelist-1.0.1" = {
+    "filelist-1.0.2" = {
       name = "filelist";
       packageName = "filelist";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz";
-        sha512 = "8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==";
+        url = "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz";
+        sha512 = "z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==";
       };
     };
     "filename-regex-2.0.1" = {
@@ -23442,6 +23531,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz";
         sha512 = "qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==";
+      };
+    };
+    "filter-obj-1.1.0" = {
+      name = "filter-obj";
+      packageName = "filter-obj";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz";
+        sha1 = "9b311112bc6c6127a16e016c6c5d7f19e0805c5b";
       };
     };
     "filter-obj-2.0.1" = {
@@ -23813,13 +23911,13 @@ let
         sha512 = "jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg==";
       };
     };
-    "flow-parser-0.143.1" = {
+    "flow-parser-0.144.0" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.143.1";
+      version = "0.144.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.143.1.tgz";
-        sha512 = "DWmnt0P1tieuQErYeWmxCNIkzm5Fqd5sMH685v/jCtu8CAvdLEwKi45jqYhij178k+NAy+FNe2jDvQNs7WLBIA==";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.144.0.tgz";
+        sha512 = "si2lCamPs0N1QcTiQY8p9RxvVsVGbx4rpkX6dcfUQ2OOvEg6Cya7LItlPqcx54Gtakdx1St6TseQlV8nafYW5g==";
       };
     };
     "fluent-ffmpeg-2.1.2" = {
@@ -24353,13 +24451,13 @@ let
         sha512 = "KhjJmZAs2eqfhCb6PdPx4RcZtheGTz86tpTC5JTvqBn/xda+Nb+0C7dCyjOSN7T76H6a56LvH0SVXQMchLXDRw==";
       };
     };
-    "fs-chunk-store-2.0.2" = {
+    "fs-chunk-store-2.0.3" = {
       name = "fs-chunk-store";
       packageName = "fs-chunk-store";
-      version = "2.0.2";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fs-chunk-store/-/fs-chunk-store-2.0.2.tgz";
-        sha512 = "4nSngo6KyoGguscb5sTxjcxOvtRiMxuQl4vFK9SnYYMjmy08Nm095ACoM3lxj1KmCuxO4JMnuo4EebMWHlagjQ==";
+        url = "https://registry.npmjs.org/fs-chunk-store/-/fs-chunk-store-2.0.3.tgz";
+        sha512 = "qQi93nHX3880gtoQPt1hKQcuYBNVfCbMk8OVRDqR0cJ0riheELW25ry9yl7pII8E9gOAONTGKBD5N/zGHFSVQg==";
       };
     };
     "fs-constants-1.0.0" = {
@@ -24623,13 +24721,13 @@ let
         sha512 = "bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==";
       };
     };
-    "fsevents-2.3.1" = {
+    "fsevents-2.3.2" = {
       name = "fsevents";
       packageName = "fsevents";
-      version = "2.3.1";
+      version = "2.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz";
-        sha512 = "YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==";
+        url = "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz";
+        sha512 = "xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==";
       };
     };
     "fstream-0.1.31" = {
@@ -24873,15 +24971,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz";
         sha512 = "3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==";
-      };
-    };
-    "geoip-country-4.0.54" = {
-      name = "geoip-country";
-      packageName = "geoip-country";
-      version = "4.0.54";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/geoip-country/-/geoip-country-4.0.54.tgz";
-        sha512 = "lljh5cAhSVJzysNR3NBMw6jqf95HyvfZQJ8+LeR+LIX0R2Kd2Ab8wx6F/xsdHgwbEi7jYENy8J73QOhxjqIjXA==";
       };
     };
     "get-amd-module-type-3.0.0" = {
@@ -26082,13 +26171,13 @@ let
         sha512 = "6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==";
       };
     };
-    "graceful-fs-4.2.4" = {
+    "graceful-fs-4.2.6" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.2.4";
+      version = "4.2.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz";
-        sha512 = "WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz";
+        sha512 = "nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==";
       };
     };
     "graceful-readlink-1.0.1" = {
@@ -26199,13 +26288,13 @@ let
         sha512 = "xjsSaB6yKt9jarFNNdivl2VOx52WySYhxPgf8Y16g6GKZyAzBoIFiwyGw5PJDlOSUa6cpmzn6o7z8fVMbSAbkg==";
       };
     };
-    "graphql-subscriptions-1.1.0" = {
+    "graphql-subscriptions-1.2.0" = {
       name = "graphql-subscriptions";
       packageName = "graphql-subscriptions";
-      version = "1.1.0";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz";
-        sha512 = "6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==";
+        url = "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.0.tgz";
+        sha512 = "uXvp729fztqwa7HFUFaAqKwNMwwOfsvu4HwOu7/35Cd44bNrMPCn97mNGN0ybuuZE36CPXBTaW/4U/xyOS4D9w==";
       };
     };
     "graphql-tag-2.11.0" = {
@@ -27126,13 +27215,13 @@ let
         sha1 = "b86ce808598e8a9d1892c571f3cedd86fc9f0653";
       };
     };
-    "highlight.js-10.5.0" = {
+    "highlight.js-10.6.0" = {
       name = "highlight.js";
       packageName = "highlight.js";
-      version = "10.5.0";
+      version = "10.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz";
-        sha512 = "xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==";
+        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz";
+        sha512 = "8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==";
       };
     };
     "highlight.js-8.2.0" = {
@@ -27989,15 +28078,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz";
         sha1 = "c6019a7595f2cefca702eab694a010bcd9298d20";
-      };
-    };
-    "iconv-lite-0.5.2" = {
-      name = "iconv-lite";
-      packageName = "iconv-lite";
-      version = "0.5.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz";
-        sha512 = "kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==";
       };
     };
     "iconv-lite-0.6.2" = {
@@ -28952,15 +29032,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ip-address/-/ip-address-6.1.0.tgz";
         sha512 = "u9YYtb1p2fWSbzpKmZ/b3QXWA+diRYPxc2c4y5lFB/MMk5WZ7wNZv8S3CFcIGVJ5XtlaCAl/FQy/D3eQ2XtdOA==";
-      };
-    };
-    "ip-address-6.4.0" = {
-      name = "ip-address";
-      packageName = "ip-address";
-      version = "6.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ip-address/-/ip-address-6.4.0.tgz";
-        sha512 = "c5uxc2WUTuRBVHT/6r4m7HIr/DfV0bF6DvLH3iZGSK8wp8iMwwZSgIq2do0asFf8q9ECug0SE+6+1ACMe4sorA==";
       };
     };
     "ip-regex-2.1.0" = {
@@ -30862,6 +30933,15 @@ let
         sha512 = "0soPJif+yjmzmOF+4cF2hyhxUWWpXpQntsm2joJXFFoRcQiPzsG4dbLKYqYPT3Fc6PjZ8MaLtCkDqqckVSfmRw==";
       };
     };
+    "jitdb-2.0.7" = {
+      name = "jitdb";
+      packageName = "jitdb";
+      version = "2.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jitdb/-/jitdb-2.0.7.tgz";
+        sha512 = "Ymkv6cQg6NUPXu6890NY4/xWgn08+YYz4gy9VMerzgC1jx5L38ggzfz6m2ylm0COoHE4Ni5QlxO43+lJoTGPuw==";
+      };
+    };
     "jju-1.4.0" = {
       name = "jju";
       packageName = "jju";
@@ -31240,49 +31320,58 @@ let
         sha512 = "OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==";
       };
     };
-    "jsii-1.20.0" = {
+    "jsesc-3.0.2" = {
+      name = "jsesc";
+      packageName = "jsesc";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz";
+        sha512 = "xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==";
+      };
+    };
+    "jsii-1.20.1" = {
       name = "jsii";
       packageName = "jsii";
-      version = "1.20.0";
+      version = "1.20.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii/-/jsii-1.20.0.tgz";
-        sha512 = "jAA0wEV1wjc6i5514tTY4KHXczxnSbpzP6991SDRGNNW0h8iPws07G2tWG4I3qjnuecbC8oiWuVA1tsjXjy+uQ==";
+        url = "https://registry.npmjs.org/jsii/-/jsii-1.20.1.tgz";
+        sha512 = "e4LS9u4QhhsqDN/JlK7JHDhYXhg3fiw+nq1xU5EeAtHQJvmM7CXTXhgDT9FjtnkWbnnjCOd0hgLcE8yIIZ8Lkw==";
       };
     };
-    "jsii-pacmak-1.20.0" = {
+    "jsii-pacmak-1.20.1" = {
       name = "jsii-pacmak";
       packageName = "jsii-pacmak";
-      version = "1.20.0";
+      version = "1.20.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.20.0.tgz";
-        sha512 = "e2wdE1cBDmxJ6buUe5WbYXQ6dcG4eQLYBsurO6bTo8RWMm7mvb1dDWIzgwK41C6TGWzPpMrygKUpDNeaUQZkHA==";
+        url = "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.20.1.tgz";
+        sha512 = "mNViMzB+wqDKowjmcOMa4qLmkhZ4GAs2wOjNiHcWTN9ZtdyjG5BoRgJrKChlRYQfjRuE+EmqiHpZyH8IzPo8SQ==";
       };
     };
-    "jsii-reflect-1.20.0" = {
+    "jsii-reflect-1.20.1" = {
       name = "jsii-reflect";
       packageName = "jsii-reflect";
-      version = "1.20.0";
+      version = "1.20.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.20.0.tgz";
-        sha512 = "W3UBQLW2pVaWkdSBRnQJOSEtzsphypCaskxlW/dSPf0ikULjoSDOMdC6oJEUNp8uzYAdpXo/uFYJZnBDk+Dafw==";
+        url = "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.20.1.tgz";
+        sha512 = "TkimkYu25H6YtfKRz7D/ZXbquXbhylS60TxgSPZC85iItCpZMwTlbIdvnpBKasx8e7MtJO6xYoAHEYHRhs8djQ==";
       };
     };
-    "jsii-rosetta-1.20.0" = {
+    "jsii-rosetta-1.20.1" = {
       name = "jsii-rosetta";
       packageName = "jsii-rosetta";
-      version = "1.20.0";
+      version = "1.20.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.20.0.tgz";
-        sha512 = "xIRnNlyr4ybbEx4i3WRcdLBActMAj270Nb5buGTvYHWyEF6T4r1Dv/BFO1S4iwmvYw7ZyFtpx8RJ+CcJLOge/A==";
+        url = "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.20.1.tgz";
+        sha512 = "3F01+B8zahWD4GhTMWPzlaGhuGvdPdYyIdhIe1bkHCYJuL1ttcf+ulCxVeF4qkBAxB2+/cfHBvEMHfSMoYCISA==";
       };
     };
-    "jsii-srcmak-0.1.218" = {
+    "jsii-srcmak-0.1.222" = {
       name = "jsii-srcmak";
       packageName = "jsii-srcmak";
-      version = "0.1.218";
+      version = "0.1.222";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.218.tgz";
-        sha512 = "e9J3Fx76Ic+EFptAUAdj3nhLuJBPpoqCTgxtuqIOzTYgJuoiUff3PXk8qQtAxCQWLsmBV0F8oP6U3ovgRtdL1g==";
+        url = "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.222.tgz";
+        sha512 = "OLeezlo5ag/GoW+7YmiYVfE8zItDmV+rFcovlfYQCjCnksg6nX/e0t1mXOeLmCSetUNnu0DNrzwuqiO4hhgODQ==";
       };
     };
     "json-bigint-0.2.3" = {
@@ -31870,13 +31959,13 @@ let
         sha512 = "gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==";
       };
     };
-    "jszip-3.5.0" = {
+    "jszip-3.6.0" = {
       name = "jszip";
       packageName = "jszip";
-      version = "3.5.0";
+      version = "3.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz";
-        sha512 = "WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==";
+        url = "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz";
+        sha512 = "jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==";
       };
     };
     "junk-3.1.0" = {
@@ -31996,13 +32085,13 @@ let
         sha512 = "YvDpmY3waI999h1zZoW1rJ04fZrgZ+5PAlVmvwDHT6YO/Q1AOhdel07xsKy9eAvJjQ9xZV1wz3rXKqEfaWvlcQ==";
       };
     };
-    "k-bucket-5.0.0" = {
+    "k-bucket-5.1.0" = {
       name = "k-bucket";
       packageName = "k-bucket";
-      version = "5.0.0";
+      version = "5.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/k-bucket/-/k-bucket-5.0.0.tgz";
-        sha512 = "r/q+wV/Kde62/tk+rqyttEJn6h0jR7x+incdMVSYTqK73zVxVrzJa70kJL49cIKen8XjIgUZKSvk8ktnrQbK4w==";
+        url = "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz";
+        sha512 = "Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==";
       };
     };
     "k-rpc-3.7.0" = {
@@ -32312,13 +32401,13 @@ let
         sha512 = "wRJ9I4az0QcsH7A4v4l0enUpkS++MBx0BnL/68KaLzJg7x1qmbjSlwEoCNol7KTYZ+pmtI7Eh2J0Nu6/2Z5J/Q==";
       };
     };
-    "known-css-properties-0.20.0" = {
+    "known-css-properties-0.21.0" = {
       name = "known-css-properties";
       packageName = "known-css-properties";
-      version = "0.20.0";
+      version = "0.21.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.20.0.tgz";
-        sha512 = "URvsjaA9ypfreqJ2/ylDr5MUERhJZ+DhguoWRr2xgS5C7aGCalXo+ewL+GixgKBfhT2vuL02nbIgNGqVWgTOYw==";
+        url = "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz";
+        sha512 = "sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==";
       };
     };
     "known-css-properties-0.5.0" = {
@@ -33644,6 +33733,15 @@ let
         sha1 = "e23f3f9c4f8fbdde872529c1071857a086e5ccef";
       };
     };
+    "lodash.constant-3.0.0" = {
+      name = "lodash.constant";
+      packageName = "lodash.constant";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.constant/-/lodash.constant-3.0.0.tgz";
+        sha1 = "bfe05cce7e515b3128925d6362138420bd624910";
+      };
+    };
     "lodash.debounce-4.0.8" = {
       name = "lodash.debounce";
       packageName = "lodash.debounce";
@@ -33714,15 +33812,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz";
         sha1 = "668b1d4981603ae1cc5a6fa760143e480b4c4ace";
-      };
-    };
-    "lodash.find-4.6.0" = {
-      name = "lodash.find";
-      packageName = "lodash.find";
-      version = "4.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz";
-        sha1 = "cb0704d47ab71789ffa0de8b97dd926fb88b13b1";
       };
     };
     "lodash.findkey-4.6.0" = {
@@ -33822,6 +33911,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz";
         sha1 = "0b08a1dcf68397c397855c3239783832df7403d1";
+      };
+    };
+    "lodash.has-4.5.2" = {
+      name = "lodash.has";
+      packageName = "lodash.has";
+      version = "4.5.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz";
+        sha1 = "d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862";
       };
     };
     "lodash.identity-2.4.1" = {
@@ -34067,6 +34165,15 @@ let
         sha1 = "4dbc0472b156be50a0b286855d1bd0b0c656098a";
       };
     };
+    "lodash.keys-4.2.0" = {
+      name = "lodash.keys";
+      packageName = "lodash.keys";
+      version = "4.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz";
+        sha1 = "a08602ac12e4fb83f91fc1fb7a360a4d9ba35205";
+      };
+    };
     "lodash.map-4.6.0" = {
       name = "lodash.map";
       packageName = "lodash.map";
@@ -34074,15 +34181,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz";
         sha1 = "771ec7839e3473d9c4cde28b19394c3562f4f6d3";
-      };
-    };
-    "lodash.max-4.0.1" = {
-      name = "lodash.max";
-      packageName = "lodash.max";
-      version = "4.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz";
-        sha1 = "8735566c618b35a9f760520b487ae79658af136a";
       };
     };
     "lodash.memoize-3.0.4" = {
@@ -34227,6 +34325,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz";
         sha1 = "d8757b1da807dde24816b0d6a84bea1a76230b23";
+      };
+    };
+    "lodash.size-4.2.0" = {
+      name = "lodash.size";
+      packageName = "lodash.size";
+      version = "4.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.size/-/lodash.size-4.2.0.tgz";
+        sha1 = "71fe75ed3eabdb2bcb73a1b0b4f51c392ee27b86";
       };
     };
     "lodash.snakecase-4.1.1" = {
@@ -34380,6 +34487,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz";
         sha1 = "abf514436b3cb705001627978cbcf30b1280eea4";
+      };
+    };
+    "lodash.values-4.3.0" = {
+      name = "lodash.values";
+      packageName = "lodash.values";
+      version = "4.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz";
+        sha1 = "a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347";
       };
     };
     "lodash.xorby-4.7.0" = {
@@ -35687,13 +35803,13 @@ let
         sha512 = "2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==";
       };
     };
-    "mdast-util-to-markdown-0.6.2" = {
+    "mdast-util-to-markdown-0.6.5" = {
       name = "mdast-util-to-markdown";
       packageName = "mdast-util-to-markdown";
-      version = "0.6.2";
+      version = "0.6.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.2.tgz";
-        sha512 = "iRczns6WMvu0hUw02LXsPDJshBIwtUPbvHBWo19IQeU0YqmzlA8Pd30U8V7uiI0VPkxzS7A/NXBXH6u+HS87Zg==";
+        url = "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz";
+        sha512 = "XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==";
       };
     };
     "mdast-util-to-nlcst-4.0.1" = {
@@ -35921,13 +36037,13 @@ let
         sha1 = "7890b01d52c00c8ebc9d533e1f8eb17e3034871a";
       };
     };
-    "memory-chunk-store-1.3.0" = {
+    "memory-chunk-store-1.3.2" = {
       name = "memory-chunk-store";
       packageName = "memory-chunk-store";
-      version = "1.3.0";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/memory-chunk-store/-/memory-chunk-store-1.3.0.tgz";
-        sha512 = "6LsOpHKKhxYrLhHmOJdBCUtSO7op5rUs1pag0fhjHo0QiXRyna0bwYf4EmQuL7InUeF2J7dUMPr6VMogRyf9NA==";
+        url = "https://registry.npmjs.org/memory-chunk-store/-/memory-chunk-store-1.3.2.tgz";
+        sha512 = "EBcbwpdQlzT5aNV0FTT+RAfh1cGEssjiCcRGcTk57mKsnZlRMOtH4Cfk/AqQnkz8xP2dUF+/lgpmErSGwwE1FA==";
       };
     };
     "memory-fs-0.3.0" = {
@@ -36956,13 +37072,13 @@ let
         sha1 = "ebb3a977e7af1c683ae6fda12b545a6ba6c5853d";
       };
     };
-    "mobx-6.1.5" = {
+    "mobx-6.1.6" = {
       name = "mobx";
       packageName = "mobx";
-      version = "6.1.5";
+      version = "6.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mobx/-/mobx-6.1.5.tgz";
-        sha512 = "BsVAHEk/Ty+6BmCis0CUvA7E9u5aJpUkdRM91YwBt4lVha4heDLjRT43z2pqENeFuVZPfA1RRaf7sRcqRB2i4Q==";
+        url = "https://registry.npmjs.org/mobx/-/mobx-6.1.6.tgz";
+        sha512 = "3by0Avodad/3cdPAuJuj8jWXhe1YByHKaEkonD9yOdcMoMuot2jrjlSXmQPhR1bJpNHfSsOx122tM9Pv3IzFWA==";
       };
     };
     "mobx-react-7.1.0" = {
@@ -37136,6 +37252,15 @@ let
         sha512 = "Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==";
       };
     };
+    "moment-timezone-0.5.33" = {
+      name = "moment-timezone";
+      packageName = "moment-timezone";
+      version = "0.5.33";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz";
+        sha512 = "PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==";
+      };
+    };
     "monotonic-timestamp-0.0.9" = {
       name = "monotonic-timestamp";
       packageName = "monotonic-timestamp";
@@ -37242,6 +37367,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.7.0.tgz";
         sha512 = "GzgeeCirQpB59FyhHvf8BLiIYgxctPSxuSyaF2vWnkt7paX7jtuQ8Gpl+DkHCxZmYuv7GQE6zcUAegpafd0MqQ==";
+      };
+    };
+    "mri-1.1.6" = {
+      name = "mri";
+      packageName = "mri";
+      version = "1.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz";
+        sha512 = "oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==";
       };
     };
     "mrmr-0.1.10" = {
@@ -38181,13 +38315,13 @@ let
         sha512 = "AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==";
       };
     };
-    "netlify-6.1.6" = {
+    "netlify-6.1.7" = {
       name = "netlify";
       packageName = "netlify";
-      version = "6.1.6";
+      version = "6.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/netlify/-/netlify-6.1.6.tgz";
-        sha512 = "hjXoiqKHetP+OD/DmOLHeTW/AZvsitFCz5d1mOAivrnQXVKrKRS6XHbsLELiUuXv8hW1PrWnImFF0VdLPKo0wA==";
+        url = "https://registry.npmjs.org/netlify/-/netlify-6.1.7.tgz";
+        sha512 = "6eSG7gtjOKNDUMjk/s35auWJJ4o03j+iy6eY4L3Fe2p0FoSm6x5wGk0ZCnD9o0QCleXubSJIPe6MCYa/fwdpqg==";
       };
     };
     "netlify-plugin-deploy-preview-commenting-0.0.1-alpha.16" = {
@@ -38199,13 +38333,13 @@ let
         sha512 = "5Rvi17CKgPpZTazEV2wkSj4IbS2zJpoKuytaYCyvemV/CMVeZUUPRwNPWm7+NjxObqJHgzUyi2FmWql8HfWhGA==";
       };
     };
-    "netlify-redirect-parser-3.0.2" = {
+    "netlify-redirect-parser-3.0.3" = {
       name = "netlify-redirect-parser";
       packageName = "netlify-redirect-parser";
-      version = "3.0.2";
+      version = "3.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/netlify-redirect-parser/-/netlify-redirect-parser-3.0.2.tgz";
-        sha512 = "ZpYwJh/aTBAYuS9dLTVTfDu1rf/+qJ3hsjiawW7A2NmIErN9qb9k08s5I6AUwPQlG4U50MtUnUwpHyMobcbkzA==";
+        url = "https://registry.npmjs.org/netlify-redirect-parser/-/netlify-redirect-parser-3.0.3.tgz";
+        sha512 = "Enafs4wGjLXry4SREr0Rhc6A3k7hLhlJA/+M/jYzoDza9aK+xTV6Y0rHmWFW1ffUe2fN8kyrtxW++Fdipxffbw==";
       };
     };
     "netlify-redirector-0.2.1" = {
@@ -39920,13 +40054,13 @@ let
         sha512 = "fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==";
       };
     };
-    "office-ui-fabric-react-7.158.1" = {
+    "office-ui-fabric-react-7.160.0" = {
       name = "office-ui-fabric-react";
       packageName = "office-ui-fabric-react";
-      version = "7.158.1";
+      version = "7.160.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.158.1.tgz";
-        sha512 = "fnPK3w0GZaOmtd5rd/1kOwHJa4wf/arplYn4I3TrFaQ+y+cOtTUU2yXGTaC9v0Q80NQjjLwTfRTHg0+sHXpqxg==";
+        url = "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.160.0.tgz";
+        sha512 = "HMEqVKCjCmWckgnwNZtOZfSffrkfoAiUlqyi5Ypzs/QJsnUaclwhPPo8mwfWGEDInsrLgfT6OQvehWqWBfusJg==";
       };
     };
     "omggif-1.0.10" = {
@@ -40100,13 +40234,13 @@ let
         sha512 = "jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==";
       };
     };
-    "oo-ascii-tree-1.20.0" = {
+    "oo-ascii-tree-1.20.1" = {
       name = "oo-ascii-tree";
       packageName = "oo-ascii-tree";
-      version = "1.20.0";
+      version = "1.20.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.20.0.tgz";
-        sha512 = "LUWabLSB7XYAzIz3QxuinYdaW0/WAJAifr/mlEH5PRjOLe37pBJ1H0aMSbpwZXYQR9bND57pT5JfLeItIbY2JA==";
+        url = "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.20.1.tgz";
+        sha512 = "imKW5pdztAEqtl5pmNTM9Rva53XOcuY91YL9jTuwFGJpBGqT6pnyxXJOFdwc5TRaQr9+GdpWTpByGRvgNPbdvQ==";
       };
     };
     "opal-runtime-1.0.11" = {
@@ -41360,13 +41494,13 @@ let
         sha512 = "6c5OhQelaJFDfiw/Zd8MfGCvvFHurSdeGzufZMPvRFImdbNOYFciOINf3DtUNUaU3h98eCb749UyHDsgvL19+A==";
       };
     };
-    "pacote-11.2.4" = {
+    "pacote-11.2.6" = {
       name = "pacote";
       packageName = "pacote";
-      version = "11.2.4";
+      version = "11.2.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pacote/-/pacote-11.2.4.tgz";
-        sha512 = "GfTeVQGJ6WyBQbQD4t3ocHbyOmTQLmWjkCKSZPmKiGFKYKNUaM5U2gbLzUW8WG1XmS9yQFnsTFA0k3o1+q4klQ==";
+        url = "https://registry.npmjs.org/pacote/-/pacote-11.2.6.tgz";
+        sha512 = "xCl++Hb3aBC7LaWMimbO4xUqZVsEbKDVc6KKDIIyAeBYrmMwY1yJC2nES/lsGd8sdQLUosgBxQyuVNncZ2Ru0w==";
       };
     };
     "pad-0.0.5" = {
@@ -41765,13 +41899,13 @@ let
         sha512 = "to8zT7+o6bVTyP35r2QgG1svuFGMFO1mE6ri1oWHgL9tlgnOtfjmfHmA3mOuP9HTIU/8OiZw0NG5zbyqVLxhvA==";
       };
     };
-    "parse-torrent-9.1.1" = {
+    "parse-torrent-9.1.3" = {
       name = "parse-torrent";
       packageName = "parse-torrent";
-      version = "9.1.1";
+      version = "9.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/parse-torrent/-/parse-torrent-9.1.1.tgz";
-        sha512 = "QQePPIN0cX6bEjwAT6x2o5fUgOsz2SwXlZqzz2uvt12+uiCrgU4WYAsy3wEthQWLZQpn1utMbSbHCRDvjAnhMA==";
+        url = "https://registry.npmjs.org/parse-torrent/-/parse-torrent-9.1.3.tgz";
+        sha512 = "/Yr951CvJM8S6TjMaqrsmMxeQEAjDeCX+MZ3hGXXc7DG2wqzp/rzOsHtDzIVqN6NsFRCqy6wYLF/W7Sgvq7bXw==";
       };
     };
     "parse-torrent-file-2.1.4" = {
@@ -43025,13 +43159,22 @@ let
         sha512 = "7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==";
       };
     };
-    "polished-3.6.7" = {
+    "polished-3.7.0" = {
       name = "polished";
       packageName = "polished";
-      version = "3.6.7";
+      version = "3.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/polished/-/polished-3.6.7.tgz";
-        sha512 = "b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==";
+        url = "https://registry.npmjs.org/polished/-/polished-3.7.0.tgz";
+        sha512 = "1tnvQ2wsxfR/DyPE2Xu9sRbnLAwXAarCWiZJ8Hfirw59bTigqjbzEWSAmzYizT6ocQW995V8n7RP48jq50DjJA==";
+      };
+    };
+    "polyraf-1.1.0" = {
+      name = "polyraf";
+      packageName = "polyraf";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/polyraf/-/polyraf-1.1.0.tgz";
+        sha512 = "wKRyhZQE6AC70nJyMCWbwd/dX4S6UsFz+58qAF8HTpCn6C7pvr63FiH4vR9vT6VrhZrJKuT7A81ea/lIslS0bA==";
       };
     };
     "poor-mans-t-sql-formatter-1.6.10" = {
@@ -43224,13 +43367,13 @@ let
         sha512 = "7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==";
       };
     };
-    "postcss-load-config-3.0.0" = {
+    "postcss-load-config-3.0.1" = {
       name = "postcss-load-config";
       packageName = "postcss-load-config";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.0.0.tgz";
-        sha512 = "lErrN8imuEF1cSiHBV8MiR7HeuzlDpCGNtaMyYHlOBuJHHOGw6S4xOMZp8BbXPr7AGQp14L6PZDlIOpfFJ6f7w==";
+        url = "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.0.1.tgz";
+        sha512 = "/pDHe30UYZUD11IeG8GWx9lNtu1ToyTsZHnyy45B4Mrwr/Kb6NgYl7k753+05CJNKnjbwh4975amoPJ+TEjHNQ==";
       };
     };
     "postcss-media-query-parser-0.2.3" = {
@@ -43980,6 +44123,15 @@ let
         sha512 = "4gaK1skD2gwscCfkswYQRmddUb2GJZtzDGRjHWadVHtK/DIKFufa12MvES6/xu1tVbUYeia5bmLcwJtZJQUqnw==";
       };
     };
+    "pretty-quick-3.1.0" = {
+      name = "pretty-quick";
+      packageName = "pretty-quick";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.0.tgz";
+        sha512 = "DtxIxksaUWCgPFN7E1ZZk4+Aav3CCuRdhrDSFZENb404sYMtuo9Zka823F+Mgeyt8Zt3bUiCjFzzWYE9LYqkmQ==";
+      };
+    };
     "pretty-time-1.1.0" = {
       name = "pretty-time";
       packageName = "pretty-time";
@@ -44259,6 +44411,15 @@ let
         sha1 = "6739e968e3051da20ce6497fb2b50f6911df3d6d";
       };
     };
+    "promise-retry-2.0.1" = {
+      name = "promise-retry";
+      packageName = "promise-retry";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz";
+        sha512 = "y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==";
+      };
+    };
     "promise.prototype.finally-3.1.2" = {
       name = "promise.prototype.finally";
       packageName = "promise.prototype.finally";
@@ -44275,6 +44436,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/promised-temp/-/promised-temp-0.1.0.tgz";
         sha1 = "5f8a704ccdf5f2ac23996fcafe2b301bc2a8d0eb";
+      };
+    };
+    "promisify-4loc-1.0.0" = {
+      name = "promisify-4loc";
+      packageName = "promisify-4loc";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/promisify-4loc/-/promisify-4loc-1.0.0.tgz";
+        sha512 = "u/XtndUyqqDXAuhFEgFgkpjHG8IizREoj80j5dL4t41eE9yH0gzFPyOD21/VnikdPJtRziuqf6ryTu1HoTjyog==";
       };
     };
     "promisify-child-process-4.1.1" = {
@@ -44689,6 +44859,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.0.0.tgz";
         sha1 = "7017a984c3b834de77bac38c10b776f22dfc1843";
+      };
+    };
+    "pull-async-1.0.0" = {
+      name = "pull-async";
+      packageName = "pull-async";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-async/-/pull-async-1.0.0.tgz";
+        sha1 = "146b36e3e043d7a666b59a14165fdd3bef3cf44c";
+      };
+    };
+    "pull-awaitable-1.0.0" = {
+      name = "pull-awaitable";
+      packageName = "pull-awaitable";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-awaitable/-/pull-awaitable-1.0.0.tgz";
+        sha512 = "tfufzU9wMd1rM38tcgunaKMUNGXMj1Qms1ygEw+ZerkMmLAwilEtMsyzrDSLhNlnfhSzHXovOarieSNrTD1ovQ==";
       };
     };
     "pull-block-filter-1.0.0" = {
@@ -45114,6 +45302,15 @@ let
         sha512 = "KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==";
       };
     };
+    "pull-thenable-1.0.0" = {
+      name = "pull-thenable";
+      packageName = "pull-thenable";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-thenable/-/pull-thenable-1.0.0.tgz";
+        sha512 = "gio2Yanuj5lcN8X+VXtx6F2iWxnhxfaHSKaSJHUzJMNNboEz48/+udzZFDaya8kAwj3DbuFFt1pbb8m1tIS6PQ==";
+      };
+    };
     "pull-through-1.0.18" = {
       name = "pull-through";
       packageName = "pull-through";
@@ -45292,6 +45489,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/push-stream/-/push-stream-10.1.2.tgz";
         sha512 = "wCDN1KkAWOMXsiV0XxH/CggHqOYeXvyn00t9Zjp5RKsLZ2rzg/lLJIMAVxYLyh79T168W3fBYcG5TRRJAlQr6g==";
+      };
+    };
+    "push-stream-11.0.0" = {
+      name = "push-stream";
+      packageName = "push-stream";
+      version = "11.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/push-stream/-/push-stream-11.0.0.tgz";
+        sha512 = "rDVD2f3wOztI/59/fukGLwZkUOC55674hncsSwgKF/yLlkkL594AoWTlkF6SGF0x8O5o1j92ObXk8Cxc1llhYg==";
       };
     };
     "push-stream-to-pull-stream-1.0.3" = {
@@ -45510,13 +45716,13 @@ let
         sha512 = "gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==";
       };
     };
-    "query-string-6.13.8" = {
+    "query-string-6.14.0" = {
       name = "query-string";
       packageName = "query-string";
-      version = "6.13.8";
+      version = "6.14.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz";
-        sha512 = "jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==";
+        url = "https://registry.npmjs.org/query-string/-/query-string-6.14.0.tgz";
+        sha512 = "In3o+lUxlgejoVJgwEdYtdxrmlL0cQWJXj0+kkI7RWVo7hg5AhFtybeKlC9Dpgbr8eOC4ydpEh8017WwyfzqVQ==";
       };
     };
     "querystring-0.2.0" = {
@@ -45598,6 +45804,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz";
         sha512 = "WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==";
+      };
+    };
+    "quicktask-1.0.1" = {
+      name = "quicktask";
+      packageName = "quicktask";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/quicktask/-/quicktask-1.0.1.tgz";
+        sha512 = "+jhR01aSsi6Iw9wbYumKusRK72QK1ub2oE0kOnRyMkMdD/rXMMGW/TVl5edjcLjuuIKP1ezkr+xQzUMD5/4JHw==";
       };
     };
     "quicktask-1.1.0" = {
@@ -45690,6 +45905,15 @@ let
         sha512 = "maAX1cnBkzIZ89O4tSQUOF098xjGMC8N+9vuY/WfHwg87THw6odD2Br35donlj5e6KnB1SB0QBHhTQhhDHuTPQ==";
       };
     };
+    "random-access-chrome-file-1.1.4" = {
+      name = "random-access-chrome-file";
+      packageName = "random-access-chrome-file";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/random-access-chrome-file/-/random-access-chrome-file-1.1.4.tgz";
+        sha512 = "xZW1BT26g+gl8AF1kC/oXX97jCMVoLIbf6yx4eVMwLgOddGhhkJygimnfERSEmhUKiGs3DTymNao6wf/P23Nkg==";
+      };
+    };
     "random-access-file-2.1.5" = {
       name = "random-access-file";
       packageName = "random-access-file";
@@ -45697,6 +45921,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/random-access-file/-/random-access-file-2.1.5.tgz";
         sha512 = "lqmUGgF9X+LD0XSeWSHcs7U2nSLYp+RQvkDDqKWoxW8jcd13tZ00G6PHV32OZqDIHmS9ewoEUEa6jcvyB7UCvg==";
+      };
+    };
+    "random-access-idb-1.2.1" = {
+      name = "random-access-idb";
+      packageName = "random-access-idb";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/random-access-idb/-/random-access-idb-1.2.1.tgz";
+        sha512 = "5rZRPhjgfR222n+dmZtRYhu0CF9dDEwxaS+UgeWursIWPmNirR6BajzOB4wG5I7WAeYZea9HCqYKk/Tin3s9cA==";
+      };
+    };
+    "random-access-idb-mutable-file-0.3.0" = {
+      name = "random-access-idb-mutable-file";
+      packageName = "random-access-idb-mutable-file";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/random-access-idb-mutable-file/-/random-access-idb-mutable-file-0.3.0.tgz";
+        sha512 = "CdVAoFNNDn5uAgYOJ8J3ICSaFzaMOa95XnYcX+taj4jirJuRASiTyQSOGR+Z0K8ZkBGuj0A8ivyeRAWuxRCgQA==";
       };
     };
     "random-access-memory-3.1.2" = {
@@ -45708,6 +45950,15 @@ let
         sha512 = "wIfh4OZ9T+FRNf6rbXLvEb4FfSxyZpvGnC5kC7Xi39SyPkRYfeJyR9Xwa13iLbNyoNKNIkTFUE4g9lXFb1ZflA==";
       };
     };
+    "random-access-storage-1.3.0" = {
+      name = "random-access-storage";
+      packageName = "random-access-storage";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz";
+        sha512 = "pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==";
+      };
+    };
     "random-access-storage-1.4.1" = {
       name = "random-access-storage";
       packageName = "random-access-storage";
@@ -45715,6 +45966,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.1.tgz";
         sha512 = "DbCc2TIzOxPaHF6KCbr8zLtiYOJQQQCBHUVNHV/SckUQobCBB2YkDtbLdxGnPwPNpJfEyMWxDAm36A2xkbxxtw==";
+      };
+    };
+    "random-access-web-2.0.3" = {
+      name = "random-access-web";
+      packageName = "random-access-web";
+      version = "2.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/random-access-web/-/random-access-web-2.0.3.tgz";
+        sha512 = "nN3AAgl4/lTOYMk5Qm44SzFsglOmaG2d0Kh0603umh35+rk9QXYLFf0nFJ0GOv9INBsP9iT1lub24r8PjyCtvA==";
       };
     };
     "random-bytes-1.0.0" = {
@@ -46014,13 +46274,13 @@ let
         sha512 = "X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==";
       };
     };
-    "react-tabs-3.1.2" = {
+    "react-tabs-3.2.0" = {
       name = "react-tabs";
       packageName = "react-tabs";
-      version = "3.1.2";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/react-tabs/-/react-tabs-3.1.2.tgz";
-        sha512 = "OKS1l7QzSNcn+L2uFsxyGFHdXp9YsPGf/YOURWcImp7xLN36n0Wz+/j9HwlwGtlXCZexwshScR5BrcFbw/3P9Q==";
+        url = "https://registry.npmjs.org/react-tabs/-/react-tabs-3.2.0.tgz";
+        sha512 = "q7oNapNRoYTQq8gDhApXwdBheuuN5qQ4YvUaQUAkb6OSSttJulBAvxJ0FS6W5uojvMxbbIZKu1f2I+GXISoLjw==";
       };
     };
     "read-1.0.7" = {
@@ -46113,13 +46373,22 @@ let
         sha512 = "D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==";
       };
     };
-    "read-package-json-fast-1.2.1" = {
+    "read-package-json-fast-1.2.2" = {
       name = "read-package-json-fast";
       packageName = "read-package-json-fast";
-      version = "1.2.1";
+      version = "1.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-1.2.1.tgz";
-        sha512 = "OFbpwnHcv74Oa5YN5WvbOBfLw6yPmPcwvyJJw/tj9cWFBF7juQUDLDSZiOjEcgzfweWeeROOmbPpNN1qm4hcRg==";
+        url = "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-1.2.2.tgz";
+        sha512 = "39DbPJjkltEzfXJXB6D8/Ir3GFOU2YbSKa2HaB/Y3nKrc/zY+0XrALpID6/13ezWyzqvOHrBbR4t4cjQuTdBVQ==";
+      };
+    };
+    "read-package-json-fast-2.0.1" = {
+      name = "read-package-json-fast";
+      packageName = "read-package-json-fast";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.1.tgz";
+        sha512 = "bp6z0tdgLy9KzdfENDIw/53HWAolOVoQTRWXv7PUiqAo3YvvoUVeLr7RWPWq+mu7KUOu9kiT4DvxhUgNUBsvug==";
       };
     };
     "read-package-tree-5.3.1" = {
@@ -46509,13 +46778,13 @@ let
         sha512 = "M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==";
       };
     };
-    "redis-commands-1.6.0" = {
+    "redis-commands-1.7.0" = {
       name = "redis-commands";
       packageName = "redis-commands";
-      version = "1.6.0";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz";
-        sha512 = "2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ==";
+        url = "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz";
+        sha512 = "nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==";
       };
     };
     "redis-parser-2.6.0" = {
@@ -47391,6 +47660,15 @@ let
         sha512 = "rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==";
       };
     };
+    "resolve-1.20.0" = {
+      name = "resolve";
+      packageName = "resolve";
+      version = "1.20.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz";
+        sha512 = "wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==";
+      };
+    };
     "resolve-1.7.1" = {
       name = "resolve";
       packageName = "resolve";
@@ -47400,13 +47678,13 @@ let
         sha512 = "c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==";
       };
     };
-    "resolve-2.0.0-next.2" = {
+    "resolve-2.0.0-next.3" = {
       name = "resolve";
       packageName = "resolve";
-      version = "2.0.0-next.2";
+      version = "2.0.0-next.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.2.tgz";
-        sha512 = "oHC2H45OCkhIeS45uW5zCsSinW+hgWwRtfobOhmkXiO4Q6e6fpZpBuBkZxAqTfoC1O6VIclqK6RjyeGVaxEYtA==";
+        url = "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz";
+        sha512 = "W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==";
       };
     };
     "resolve-alpn-1.0.0" = {
@@ -47895,13 +48173,13 @@ let
         sha512 = "/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==";
       };
     };
-    "rollup-2.38.4" = {
+    "rollup-2.38.5" = {
       name = "rollup";
       packageName = "rollup";
-      version = "2.38.4";
+      version = "2.38.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rollup/-/rollup-2.38.4.tgz";
-        sha512 = "B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==";
+        url = "https://registry.npmjs.org/rollup/-/rollup-2.38.5.tgz";
+        sha512 = "VoWt8DysFGDVRGWuHTqZzT02J0ASgjVq/hPs9QcBOGMd7B+jfTr/iqMVEyOi901rE3xq+Deq66GzIT1yt7sGwQ==";
       };
     };
     "rollup-plugin-babel-4.4.0" = {
@@ -48102,22 +48380,22 @@ let
         sha512 = "tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==";
       };
     };
-    "run-parallel-1.1.10" = {
+    "run-parallel-1.2.0" = {
       name = "run-parallel";
       packageName = "run-parallel";
-      version = "1.1.10";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz";
-        sha512 = "zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==";
+        url = "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz";
+        sha512 = "5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==";
       };
     };
-    "run-parallel-limit-1.0.6" = {
+    "run-parallel-limit-1.1.0" = {
       name = "run-parallel-limit";
       packageName = "run-parallel-limit";
-      version = "1.0.6";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.0.6.tgz";
-        sha512 = "yFFs4Q2kECi5mWXyyZj3UlAZ5OFq5E07opABC+EmhZdjEkrxXaUwFqOaaNF4tbayMnBxrsbujpeCYTVjGufZGQ==";
+        url = "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz";
+        sha512 = "jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==";
       };
     };
     "run-queue-1.0.3" = {
@@ -48372,13 +48650,13 @@ let
         sha512 = "y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==";
       };
     };
-    "sass-1.32.6" = {
+    "sass-1.32.7" = {
       name = "sass";
       packageName = "sass";
-      version = "1.32.6";
+      version = "1.32.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz";
-        sha512 = "1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==";
+        url = "https://registry.npmjs.org/sass/-/sass-1.32.7.tgz";
+        sha512 = "C8Z4bjqGWnsYa11o8hpKAuoyFdRhrSHcYjCr+XAWVPSIQqC8mp2f5Dx4em0dKYehPzg5XSekmCjqJnEZbIls9A==";
       };
     };
     "sax-0.5.8" = {
@@ -49479,13 +49757,13 @@ let
         sha512 = "rohCHmEjD/ESXFLxF4bVeqgdb4Awc65ZyyuCKl3f7BvgMbZOBa/Ye3HN/GFnvruiUOAWWNupxhz3Rz5/3vJLTg==";
       };
     };
-    "simple-git-2.31.0" = {
+    "simple-git-2.34.2" = {
       name = "simple-git";
       packageName = "simple-git";
-      version = "2.31.0";
+      version = "2.34.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-git/-/simple-git-2.31.0.tgz";
-        sha512 = "/+rmE7dYZMbRAfEmn8EUIOwlM2G7UdzpkC60KF86YAfXGnmGtsPrKsym0hKvLBdFLLW019C+aZld1+6iIVy5xA==";
+        url = "https://registry.npmjs.org/simple-git/-/simple-git-2.34.2.tgz";
+        sha512 = "/EX4FtcpAj5L/Bs5zgaBGYDrnkrKflFVNppNLH9VXpIjZBLHx5cZ6/mOYJCoKXKlLRuk3iTvzrIsHo7v42zWHg==";
       };
     };
     "simple-markdown-0.4.4" = {
@@ -49893,13 +50171,13 @@ let
         sha512 = "NFwVLMCqKTocY66gcim0ukF6e31VRDJqDapg5sy3vCHqlD1OCNUXSK/aI4VQEEndDrsnFmQepsL5KpEU0dDRIQ==";
       };
     };
-    "snyk-docker-plugin-4.13.1" = {
+    "snyk-docker-plugin-4.16.0" = {
       name = "snyk-docker-plugin";
       packageName = "snyk-docker-plugin";
-      version = "4.13.1";
+      version = "4.16.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.13.1.tgz";
-        sha512 = "KS2G2cBdwKhyRta85uv3q/xUmFSC9lVCu8MUxgm7IDNn8ImjmCIkSp5SsI0qu5jYXJhZZnX6jjj5gzI0QP0WXw==";
+        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.16.0.tgz";
+        sha512 = "bsKvWJ2ic5vzCcpjRWDTMumfXNuyIiQfsDcpNb/Hhev3UhKu6vb3KXaS6kPg360r5o/KxY7xOjW1L9VjZ0zZeA==";
       };
     };
     "snyk-go-parser-1.4.1" = {
@@ -49927,15 +50205,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.12.3.tgz";
         sha512 = "1LdlB/tDGqeeh5xgJYmv2Rw9eeYsbZ9VX9MS+u6V/DwdzbiXZvFeqexdCqwVOKwBtYUeQfg/QXm5AAd0hQwxCA==";
-      };
-    };
-    "snyk-module-1.9.1" = {
-      name = "snyk-module";
-      packageName = "snyk-module";
-      version = "1.9.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-module/-/snyk-module-1.9.1.tgz";
-        sha512 = "A+CCyBSa4IKok5uEhqT+hV/35RO6APFNLqk9DRRHg7xW2/j//nPX8wTSZUPF8QeRNEk/sX+6df7M1y6PBHGSHA==";
       };
     };
     "snyk-module-2.1.0" = {
@@ -50001,13 +50270,13 @@ let
         sha512 = "IQcdsQBqqXVRY5DatlI7ASy4flbhtU2V7cr4P2rK9rkFnVHO6LHcitwKXVZa9ocdOmpZDzk7U6iwHJkVFcR6OA==";
       };
     };
-    "snyk-poetry-lockfile-parser-1.1.2" = {
+    "snyk-poetry-lockfile-parser-1.1.5" = {
       name = "snyk-poetry-lockfile-parser";
       packageName = "snyk-poetry-lockfile-parser";
-      version = "1.1.2";
+      version = "1.1.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-poetry-lockfile-parser/-/snyk-poetry-lockfile-parser-1.1.2.tgz";
-        sha512 = "qaLNhVw/og6LXRmSuPiXcwre07ybJWh8RASF3aumk5R0cmxCU3YLmJ7pfi/N+PMpwiHCfSZFOMIGIL9jXcX9zQ==";
+        url = "https://registry.npmjs.org/snyk-poetry-lockfile-parser/-/snyk-poetry-lockfile-parser-1.1.5.tgz";
+        sha512 = "HR5XjWyueRZc0mWlcXD+OidyDnZ83tgAqJN+n7DGxqTv1z00eogkTxsW2DwNvXevF7ItoBaN80t14oicNQ8GlA==";
       };
     };
     "snyk-policy-1.14.1" = {
@@ -50019,13 +50288,13 @@ let
         sha512 = "C5vSkoBYxPnaqb218sm4m6N5s1BhIXlldpIX5xRNnZ0QkDwVj3dy/PfgwxRgVQh7QFGa1ajbvKmsGmm4RRsN8g==";
       };
     };
-    "snyk-python-plugin-1.19.2" = {
+    "snyk-python-plugin-1.19.4" = {
       name = "snyk-python-plugin";
       packageName = "snyk-python-plugin";
-      version = "1.19.2";
+      version = "1.19.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.19.2.tgz";
-        sha512 = "n5Z7WiMTNtrBaDE9blnYVoX5fyXeMVhDNrQ/q21lHRAvDKDCY9tNNfduUjOVG6HbIH89mW8lLUdBNAMu/hpl+Q==";
+        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.19.4.tgz";
+        sha512 = "d1c/QKb3Il3xF1HY0IYoqQ+16+i0Ex5ai+J4KqOMbcKFvNcfkiOSPpCsrgSNJtBa50srbRleUrILdorALxaV2w==";
       };
     };
     "snyk-resolve-1.0.1" = {
@@ -50037,13 +50306,13 @@ let
         sha512 = "7+i+LLhtBo1Pkth01xv+RYJU8a67zmJ8WFFPvSxyCjdlKIcsps4hPQFebhz+0gC5rMemlaeIV6cqwqUf9PEDpw==";
       };
     };
-    "snyk-resolve-deps-4.4.0" = {
+    "snyk-resolve-deps-4.7.2" = {
       name = "snyk-resolve-deps";
       packageName = "snyk-resolve-deps";
-      version = "4.4.0";
+      version = "4.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.4.0.tgz";
-        sha512 = "aFPtN8WLqIk4E1ulMyzvV5reY1Iksz+3oPnUVib1jKdyTHymmOIYF7z8QZ4UUr52UsgmrD9EA/dq7jpytwFoOQ==";
+        url = "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.7.2.tgz";
+        sha512 = "Bmtr7QdRL2b3Js+mPDmvXbkprOpzO8aUFXqR0nJKAOlUVQqZ84yiuT0n/mssEiJJ0vP+k0kZvTeiTwgio4KZRg==";
       };
     };
     "snyk-sbt-plugin-2.11.0" = {
@@ -50397,13 +50666,13 @@ let
         sha512 = "csdVyakzHJRyCevY4aZC2Eacda8paf+4nmRGF2N7KxCLKY2Ajn72JsExaQlJQ2BiXJncp44p3T+b80cU+2TTsg==";
       };
     };
-    "sonic-boom-1.3.0" = {
+    "sonic-boom-1.3.2" = {
       name = "sonic-boom";
       packageName = "sonic-boom";
-      version = "1.3.0";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz";
-        sha512 = "4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==";
+        url = "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.2.tgz";
+        sha512 = "/B4tAuK2+hIlR94GhhWU1mJHWk5lt0CEuBvG0kvk1qIAzQc4iB1TieMio8DCZxY+Y7tsuzOxSUDOGmaUm3vXMg==";
       };
     };
     "sorcery-0.10.0" = {
@@ -51072,6 +51341,15 @@ let
         sha512 = "pJAFizB6OcuJLX4RJJuU9HWyPwM2CqLi/vs08lhVIR3TGxacxpavvK5LzbxT+Y3iWkBchOTKS5hHCigA5aaung==";
       };
     };
+    "ssb-db2-1.11.2" = {
+      name = "ssb-db2";
+      packageName = "ssb-db2";
+      version = "1.11.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-db2/-/ssb-db2-1.11.2.tgz";
+        sha512 = "nwo7Ope08o6yVSbSH3F0YbU/X8rLw79b+s+++X07Aheg9GBaZOgTUp8DgF9ZDywkqqUPSG7agyX+o/icmYCe/g==";
+      };
+    };
     "ssb-ebt-5.6.7" = {
       name = "ssb-ebt";
       packageName = "ssb-ebt";
@@ -51081,13 +51359,13 @@ let
         sha512 = "ifPgPNmDE8EKuuoqtXibwgYNtDZNry7sJL1epSUb3XgQr62bUV31N9R5LHKDsI2kx96OgWRwWY2PfZ7vf/hU8Q==";
       };
     };
-    "ssb-friends-4.3.0" = {
+    "ssb-friends-4.4.3" = {
       name = "ssb-friends";
       packageName = "ssb-friends";
-      version = "4.3.0";
+      version = "4.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.3.0.tgz";
-        sha512 = "5NgtiuYM8M2g8crzQF2nCpenM70zhsb6PNeL6B0iXalAl/IN2wwEWSUhU8++2gTh9dZ7icZJ8nC/kCzIoUdmgA==";
+        url = "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.4.3.tgz";
+        sha512 = "9LY+XH05epjsJD7MPyuz1OHnErfNI4DJbAqMgees3DtEOfb2wYjeTzfsR3xUnayCgHJQ0p3SVmUhQVyKAy0xkg==";
       };
     };
     "ssb-git-0.5.0" = {
@@ -51142,6 +51420,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz";
         sha512 = "FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==";
+      };
+    };
+    "ssb-keys-8.0.2" = {
+      name = "ssb-keys";
+      packageName = "ssb-keys";
+      version = "8.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.2.tgz";
+        sha512 = "u2U9t5YLbFShKQzr+ayMx9cYNvUJzDeOScodMwfP5zM3+/1AStvc5W91knZGllGwsmGjNC57KW+whRun+H/dBQ==";
       };
     };
     "ssb-links-3.0.10" = {
@@ -51295,6 +51582,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ssb-replicate/-/ssb-replicate-1.3.2.tgz";
         sha512 = "r/34OHn5wDkVUu0UNdKdPjmd3cPDmgknA5nK+gXBZj9ugSDwmdDsfEUavGtA7hlO+He1pC4EXtBa14dqgTqJCg==";
+      };
+    };
+    "ssb-sort-1.1.3" = {
+      name = "ssb-sort";
+      packageName = "ssb-sort";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-sort/-/ssb-sort-1.1.3.tgz";
+        sha512 = "oPsF8lGgcHcIb4F1GddV3CbZTJZ0OzxI9fHXH0Zc7ZjqjFlYdqMDxFSuvqJnmtDydJcswyGANiziP1ghd69jOw==";
       };
     };
     "ssb-unix-socket-1.0.0" = {
@@ -52638,13 +52934,13 @@ let
         sha512 = "7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==";
       };
     };
-    "stylelint-13.9.0" = {
+    "stylelint-13.10.0" = {
       name = "stylelint";
       packageName = "stylelint";
-      version = "13.9.0";
+      version = "13.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stylelint/-/stylelint-13.9.0.tgz";
-        sha512 = "VVWH2oixOAxpWL1vH+V42ReCzBjW2AeqskSAbi8+3OjV1Xg3VZkmTcAqBZfRRvJeF4BvYuDLXebW3tIHxgZDEg==";
+        url = "https://registry.npmjs.org/stylelint/-/stylelint-13.10.0.tgz";
+        sha512 = "eDuLrL0wzPKbl5/TbNGZcbw0lTIGbDEr5W6lCODvb1gAg0ncbgCRt7oU0C2VFDvbrcY0A3MFZOwltwTRmc0XCw==";
       };
     };
     "stylelint-8.4.0" = {
@@ -53052,13 +53348,13 @@ let
         sha512 = "xk5CMbwoQVI53rTq9o/iMojAqXP5NT4/+TMeTP4uXWDIH18pB9AXgO5Olqt0RXuf3jH032DA4DS4qzem6XdXAw==";
       };
     };
-    "swagger-ui-dist-3.41.1" = {
+    "swagger-ui-dist-3.42.0" = {
       name = "swagger-ui-dist";
       packageName = "swagger-ui-dist";
-      version = "3.41.1";
+      version = "3.42.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.41.1.tgz";
-        sha512 = "Wg3RqMBp8dSYEwyvXOWuOTwh3fTxYxmtAvLjEbUwRlPXKEHcde3BG/v2zjswrDVcumUpPQ6Cp5RG3LMz6M0YIw==";
+        url = "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.42.0.tgz";
+        sha512 = "hTNX6cX7KWtBZgk6ZQSOzsBJhqdCmD5NOIjb6dBPKSnYZidSkIXOcaPMR3+kwxLrj8bDC881bSDlNbLsHikacg==";
       };
     };
     "swagger2openapi-6.2.3" = {
@@ -54547,6 +54843,15 @@ let
         sha512 = "2Ulkc8T7mXJ2l0W476YC/A209PR38Nw8PuaCNtk9uI3t1zzFdGQeWYGQvmj2PZkVvRC/Yoi4xQKMRnWc/N29tQ==";
       };
     };
+    "too-hot-1.0.0" = {
+      name = "too-hot";
+      packageName = "too-hot";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/too-hot/-/too-hot-1.0.0.tgz";
+        sha512 = "RqtHvVffaf+ORMlpFjEWh3czDy6Q5wFfdGq9JXVBXu2L8/ssjDTnong8f1+I2xWGlKslXUkHU7m1HBj6MyoLqw==";
+      };
+    };
     "too-wordy-0.1.6" = {
       name = "too-wordy";
       packageName = "too-wordy";
@@ -54556,13 +54861,13 @@ let
         sha512 = "MV5F74YF9+UYsvwXGXTh+5YP3EqH/ivwWfyFE2/YHWQQxm9jDPmkIC23nkN133Ye4nO3HTXmiMcfGqJ5xRPfOA==";
       };
     };
-    "too-wordy-0.2.2" = {
+    "too-wordy-0.3.0" = {
       name = "too-wordy";
       packageName = "too-wordy";
-      version = "0.2.2";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/too-wordy/-/too-wordy-0.2.2.tgz";
-        sha512 = "ePZfjs1ajL4b8jT4MeVId+9Ci5hJCzAtNIEXIHyFYmKmQuX+eHC/RNv6tuLMUhrGrhJ+sYWW/lBF/LKILHGZEA==";
+        url = "https://registry.npmjs.org/too-wordy/-/too-wordy-0.3.0.tgz";
+        sha512 = "Yk2hzecuFYHw64YwVXy30CuCXXOCgCM/+QvLmXX6CyR9+pyA/Y00cY8cmiTW2mzvWqMpVf9BPJXK6Y4kOXSMzg==";
       };
     };
     "topo-2.0.2" = {
@@ -55321,13 +55626,13 @@ let
         sha512 = "+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==";
       };
     };
-    "type-2.1.0" = {
+    "type-2.2.0" = {
       name = "type";
       packageName = "type";
-      version = "2.1.0";
+      version = "2.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/type/-/type-2.1.0.tgz";
-        sha512 = "G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==";
+        url = "https://registry.npmjs.org/type/-/type-2.2.0.tgz";
+        sha512 = "M/u37b4oSGlusaU8ZB96BfFPWQ8MbsZYXB+kXGMiDj6IKinkcNaQvmirBuWj8mAXqP6LYn1rQvbTYum3yPhaOA==";
       };
     };
     "type-check-0.3.2" = {
@@ -55510,6 +55815,24 @@ let
         sha512 = "zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==";
       };
     };
+    "typedarray-to-buffer-4.0.0" = {
+      name = "typedarray-to-buffer";
+      packageName = "typedarray-to-buffer";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz";
+        sha512 = "6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==";
+      };
+    };
+    "typedfastbitset-0.2.1" = {
+      name = "typedfastbitset";
+      packageName = "typedfastbitset";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/typedfastbitset/-/typedfastbitset-0.2.1.tgz";
+        sha512 = "B2B+wo5gC7VRAqcFEiUCjS6CJ1vmeYZ7uzY3Jsu6UNStHiF+W0vkhZAmQaj5m9sC2KVrpyHGRzGuhz3M6+n/8A==";
+      };
+    };
     "typeforce-1.18.0" = {
       name = "typeforce";
       packageName = "typeforce";
@@ -55546,13 +55869,13 @@ let
         sha512 = "0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==";
       };
     };
-    "typescript-3.9.7" = {
+    "typescript-3.9.9" = {
       name = "typescript";
       packageName = "typescript";
-      version = "3.9.7";
+      version = "3.9.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz";
-        sha512 = "BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==";
+        url = "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz";
+        sha512 = "kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==";
       };
     };
     "typescript-4.0.3" = {
@@ -55573,13 +55896,13 @@ let
         sha512 = "ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==";
       };
     };
-    "typescript-4.1.3" = {
+    "typescript-4.1.5" = {
       name = "typescript";
       packageName = "typescript";
-      version = "4.1.3";
+      version = "4.1.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz";
-        sha512 = "B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==";
+        url = "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz";
+        sha512 = "6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==";
       };
     };
     "typescript-eslint-parser-16.0.1" = {
@@ -55681,13 +56004,13 @@ let
         sha512 = "L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==";
       };
     };
-    "uglify-js-3.12.6" = {
+    "uglify-js-3.12.7" = {
       name = "uglify-js";
       packageName = "uglify-js";
-      version = "3.12.6";
+      version = "3.12.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.6.tgz";
-        sha512 = "aqWHe3DfQmZUDGWBbabZ2eQnJlQd1fKlMUu7gV+MiTuDzdgDw31bI3wA2jLLsV/hNcDP26IfyEgSVoft5+0SVw==";
+        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.7.tgz";
+        sha512 = "SIZhkoh+U/wjW+BHGhVwE9nt8tWJspncloBcFapkpGRwNPqcH8pzX36BXe3TPBjzHWPMUZotpCigak/udWNr1Q==";
       };
     };
     "uglify-js-3.4.10" = {
@@ -56095,13 +56418,13 @@ let
         sha512 = "vLUezxCnjzz+ya4pYouRQVMT8k82Rk4fIj406UidRnSFJdGXFaQyQklAnalsQHJrLqAlaYPkXPUa1upfVSHGCA==";
       };
     };
-    "unified-message-control-3.0.2" = {
+    "unified-message-control-3.0.3" = {
       name = "unified-message-control";
       packageName = "unified-message-control";
-      version = "3.0.2";
+      version = "3.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/unified-message-control/-/unified-message-control-3.0.2.tgz";
-        sha512 = "lhF8fKjDo2cIPx1re5X1QinqUonl+AN6F0XfEaab8w/hjqX7FZAhzu4P8g6pmYp09ld+HSWFwdRJj+Y8xD0q7Q==";
+        url = "https://registry.npmjs.org/unified-message-control/-/unified-message-control-3.0.3.tgz";
+        sha512 = "oY5z2n8ugjpNHXOmcgrw0pQeJzavHS0VjPBP21tOcm7rc2C+5Q+kW9j5+gqtf8vfW/8sabbsK5+P+9QPwwEHDA==";
       };
     };
     "union-0.5.0" = {
@@ -58796,13 +59119,13 @@ let
         sha512 = "9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==";
       };
     };
-    "watchpack-2.1.0" = {
+    "watchpack-2.1.1" = {
       name = "watchpack";
       packageName = "watchpack";
-      version = "2.1.0";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/watchpack/-/watchpack-2.1.0.tgz";
-        sha512 = "UjgD1mqjkG99+3lgG36at4wPnUXNvis2v1utwTgQ43C22c4LD71LsYMExdWXh4HZ+RmW+B0t1Vrg2GpXAkTOQw==";
+        url = "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz";
+        sha512 = "Oo7LXCmc1eE1AjyuSBmtC3+Wy4HcV8PxWh2kP6fOl8yTlNS7r0K9l1ao2lrrUza7V39Y3D/BbJgY8VeSlc5JKw==";
       };
     };
     "watchpack-chokidar2-2.0.1" = {
@@ -59102,13 +59425,13 @@ let
         sha512 = "OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==";
       };
     };
-    "webtorrent-0.113.0" = {
+    "webtorrent-0.114.0" = {
       name = "webtorrent";
       packageName = "webtorrent";
-      version = "0.113.0";
+      version = "0.114.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.113.0.tgz";
-        sha512 = "j4vhBl5nKo7p/tLwbBl+OlLKLvTrFOEFNlGghsBA2NR30SPHee7gXOmv59elB4gjxKKWAF3rtyoJPZ8UNaKpWw==";
+        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.114.0.tgz";
+        sha512 = "jOdohvSNewT0CSCRp37NYrq6OEwPiVJ6GuSijeelZ8JCwrUUz//tsEGyKXv4/DlsTYFPhwvWuKXZKMy5yagh4Q==";
       };
     };
     "well-known-symbols-2.0.0" = {
@@ -61098,29 +61421,33 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "11.1.2";
+    version = "11.1.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-11.1.2.tgz";
-      sha512 = "qOAkxCzBPm+QdXpSHxLERw1Vag8S0JHMY0zCwtG63XFvwHZCIihHRkOR3xHDWlVnGTmnUixg4Mt5s/4GGPuDJg==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-11.1.4.tgz";
+      sha512 = "IGGKtMWtUBkEEzFcd0wP/SFricOg5Mc0l7BG4m6kRtCU34wQVbvc5h6xQIGrhKOJyLQ/gGZkqSWY+21Hun5jgQ==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.1101.2"
-      sources."@angular-devkit/core-11.1.2"
-      sources."@angular-devkit/schematics-11.1.2"
+      sources."@angular-devkit/architect-0.1101.4"
+      sources."@angular-devkit/core-11.1.4"
+      sources."@angular-devkit/schematics-11.1.4"
       sources."@npmcli/ci-detect-1.3.0"
       sources."@npmcli/git-2.0.4"
-      sources."@npmcli/installed-package-contents-1.0.5"
+      sources."@npmcli/installed-package-contents-1.0.7"
       sources."@npmcli/move-file-1.1.1"
-      sources."@npmcli/node-gyp-1.0.1"
+      sources."@npmcli/node-gyp-1.0.2"
       sources."@npmcli/promise-spawn-1.3.2"
-      sources."@npmcli/run-script-1.8.1"
-      sources."@schematics/angular-11.1.2"
-      sources."@schematics/update-0.1101.2"
+      (sources."@npmcli/run-script-1.8.3" // {
+        dependencies = [
+          sources."read-package-json-fast-2.0.1"
+        ];
+      })
+      sources."@schematics/angular-11.1.4"
+      sources."@schematics/update-0.1101.4"
       sources."@tootallnate/once-1.1.2"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."abbrev-1.1.1"
       sources."agent-base-6.0.2"
-      sources."agentkeepalive-4.1.3"
+      sources."agentkeepalive-4.1.4"
       sources."aggregate-error-3.1.0"
       sources."ajv-6.12.6"
       sources."ansi-colors-4.1.1"
@@ -61135,7 +61462,6 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."asap-2.0.6"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."asynckit-0.4.0"
@@ -61144,7 +61470,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."bl-4.0.4"
+      sources."bl-4.1.0"
       sources."brace-expansion-1.1.11"
       sources."buffer-5.7.1"
       sources."builtins-1.0.3"
@@ -61167,12 +61493,10 @@ in
       sources."core-util-is-1.0.2"
       sources."dashdash-1.14.1"
       sources."debug-4.3.1"
-      sources."debuglog-1.0.1"
       sources."defaults-1.0.3"
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
       sources."depd-1.1.2"
-      sources."dezalgo-1.0.3"
       sources."ecc-jsbn-0.1.2"
       sources."emoji-regex-8.0.0"
       (sources."encoding-0.1.13" // {
@@ -61204,7 +61528,7 @@ in
       })
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
@@ -61295,9 +61619,8 @@ in
       sources."puka-1.0.1"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
-      sources."read-package-json-fast-1.2.1"
+      sources."read-package-json-fast-1.2.2"
       sources."readable-stream-3.6.0"
-      sources."readdir-scoped-modules-1.1.0"
       (sources."request-2.88.2" // {
         dependencies = [
           sources."uuid-3.4.0"
@@ -61551,7 +61874,7 @@ in
           sources."mimic-response-1.0.1"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       (sources."gulp-vinyl-zip-2.2.1" // {
         dependencies = [
           sources."readable-stream-2.3.7"
@@ -61690,7 +62013,7 @@ in
         ];
       })
       sources."to-utf8-0.0.1"
-      sources."uglify-js-3.12.6"
+      sources."uglify-js-3.12.7"
       sources."unc-path-regex-0.1.2"
       sources."unique-stream-2.3.1"
       sources."universalify-0.1.2"
@@ -61790,7 +62113,7 @@ in
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.2"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-flag-3.0.0"
@@ -61937,7 +62260,7 @@ in
       sources."@types/parse-json-4.0.0"
       sources."@types/source-list-map-0.1.2"
       sources."@types/tapable-1.0.6"
-      (sources."@types/uglify-js-3.11.1" // {
+      (sources."@types/uglify-js-3.12.0" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -61980,14 +62303,14 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-1.5.1"
       sources."binary-extensions-2.2.0"
-      sources."bl-4.0.4"
+      sources."bl-4.1.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
       sources."browserslist-4.16.3"
       sources."buffer-5.7.1"
       sources."buffer-from-1.1.1"
       sources."callsites-3.1.0"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       sources."chalk-3.0.0"
       sources."chardet-0.7.0"
       sources."chokidar-3.4.3"
@@ -62008,7 +62331,7 @@ in
       sources."cross-spawn-7.0.3"
       sources."deepmerge-4.2.2"
       sources."defaults-1.0.3"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."enhanced-resolve-4.5.0"
@@ -62045,7 +62368,7 @@ in
       sources."glob-7.1.6"
       sources."glob-parent-5.1.1"
       sources."glob-to-regexp-0.4.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-flag-4.0.0"
       sources."human-signals-1.1.1"
@@ -62144,7 +62467,7 @@ in
       sources."readable-stream-3.6.0"
       sources."readdirp-3.5.0"
       sources."rechoir-0.6.2"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-4.0.0"
       sources."restore-cursor-3.1.0"
       sources."rimraf-3.0.2"
@@ -62213,7 +62536,7 @@ in
       sources."universalify-2.0.0"
       sources."uri-js-4.4.1"
       sources."util-deprecate-1.0.2"
-      sources."watchpack-2.1.0"
+      sources."watchpack-2.1.1"
       sources."wcwidth-1.0.1"
       (sources."webpack-5.9.0" // {
         dependencies = [
@@ -62275,7 +62598,7 @@ in
       sources."@babel/compat-data-7.12.13"
       (sources."@babel/core-7.12.13" // {
         dependencies = [
-          sources."@babel/generator-7.12.13"
+          sources."@babel/generator-7.12.15"
           sources."@babel/types-7.12.13"
           sources."semver-5.7.1"
         ];
@@ -62381,7 +62704,7 @@ in
         ];
       })
       sources."@babel/highlight-7.12.13"
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/plugin-proposal-async-generator-functions-7.12.13"
       sources."@babel/plugin-proposal-class-properties-7.12.13"
       sources."@babel/plugin-proposal-dynamic-import-7.12.1"
@@ -62467,7 +62790,7 @@ in
       })
       (sources."@babel/traverse-7.12.13" // {
         dependencies = [
-          sources."@babel/generator-7.12.13"
+          sources."@babel/generator-7.12.15"
           sources."@babel/types-7.12.13"
         ];
       })
@@ -62609,7 +62932,7 @@ in
       sources."@types/cors-2.8.8"
       sources."@types/ejs-2.7.0"
       sources."@types/express-4.17.7"
-      sources."@types/express-serve-static-core-4.17.17"
+      sources."@types/express-serve-static-core-4.17.18"
       sources."@types/fs-capacitor-2.0.0"
       sources."@types/glob-7.1.3"
       (sources."@types/graphql-upload-8.0.4" // {
@@ -62755,7 +63078,7 @@ in
           sources."lru-cache-6.0.0"
         ];
       })
-      (sources."apollo-server-core-2.19.2" // {
+      (sources."apollo-server-core-2.20.0" // {
         dependencies = [
           sources."lru-cache-6.0.0"
           sources."uuid-8.3.2"
@@ -62763,7 +63086,7 @@ in
       })
       sources."apollo-server-env-3.0.0"
       sources."apollo-server-errors-2.4.2"
-      sources."apollo-server-express-2.19.2"
+      sources."apollo-server-express-2.20.0"
       sources."apollo-server-plugin-base-0.10.4"
       sources."apollo-server-types-0.6.3"
       sources."apollo-tracing-0.12.2"
@@ -62891,7 +63214,7 @@ in
         ];
       })
       sources."camelcase-4.1.0"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       (sources."capital-case-1.0.4" // {
         dependencies = [
           sources."tslib-2.1.0"
@@ -63118,7 +63441,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."ejs-2.7.4"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       sources."elegant-spinner-1.0.1"
       sources."emoji-regex-8.0.0"
       sources."emojis-list-3.0.0"
@@ -63196,6 +63519,7 @@ in
       sources."filename-reserved-regex-2.0.0"
       sources."filenamify-2.1.0"
       sources."fill-range-7.0.1"
+      sources."filter-obj-1.1.0"
       (sources."finalhandler-1.1.2" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -63210,7 +63534,7 @@ in
       })
       sources."find-up-3.0.0"
       sources."fkill-6.2.0"
-      sources."flow-parser-0.143.1"
+      sources."flow-parser-0.144.0"
       sources."for-each-0.3.3"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
@@ -63306,7 +63630,7 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."graphql-14.7.0"
       (sources."graphql-anywhere-4.2.7" // {
         dependencies = [
@@ -63314,7 +63638,7 @@ in
         ];
       })
       sources."graphql-extensions-0.12.8"
-      sources."graphql-subscriptions-1.1.0"
+      sources."graphql-subscriptions-1.2.0"
       sources."graphql-tag-2.12.0"
       sources."graphql-tools-4.0.8"
       sources."graphql-type-json-0.3.2"
@@ -63784,7 +64108,8 @@ in
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
-      sources."query-string-6.13.8"
+      sources."query-string-6.14.0"
+      sources."queue-microtask-1.2.2"
       sources."range-parser-1.2.1"
       (sources."raw-body-2.4.0" // {
         dependencies = [
@@ -63853,7 +64178,7 @@ in
       sources."request-2.88.2"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-3.0.0"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
@@ -63865,7 +64190,7 @@ in
       sources."roarr-2.15.4"
       sources."rss-parser-3.11.0"
       sources."run-async-2.4.1"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."rxjs-6.6.3"
       sources."safe-buffer-5.2.1"
       sources."safe-regex-1.1.0"
@@ -64105,7 +64430,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-fest-0.6.0"
       sources."type-is-1.6.18"
-      sources."typescript-3.9.7"
+      sources."typescript-3.9.9"
       sources."unbzip2-stream-1.4.3"
       (sources."undefsafe-2.0.3" // {
         dependencies = [
@@ -64377,10 +64702,10 @@ in
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
-      sources."@babel/generator-7.12.13"
+      sources."@babel/generator-7.12.15"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/highlight-7.12.13"
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/template-7.12.13"
       sources."@babel/types-7.12.13"
       sources."@webassemblyjs/ast-1.11.0"
@@ -64463,7 +64788,7 @@ in
           sources."source-map-0.5.7"
         ];
       })
-      (sources."@babel/generator-7.12.13" // {
+      (sources."@babel/generator-7.12.15" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
@@ -64480,7 +64805,7 @@ in
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helpers-7.12.13"
       sources."@babel/highlight-7.12.13"
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/template-7.12.13"
       sources."@babel/traverse-7.12.13"
       sources."@babel/types-7.12.13"
@@ -64501,7 +64826,7 @@ in
       sources."ejs-3.1.5"
       sources."ensure-posix-path-1.1.1"
       sources."escape-string-regexp-1.0.5"
-      sources."filelist-1.0.1"
+      sources."filelist-1.0.2"
       sources."fs-extra-5.0.0"
       sources."function-bind-1.1.1"
       sources."gensync-1.0.0-beta.2"
@@ -64517,7 +64842,7 @@ in
         ];
       })
       sources."globals-11.12.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-color-0.1.7"
       sources."has-flag-3.0.0"
@@ -64553,7 +64878,7 @@ in
       sources."parse-passwd-1.0.0"
       sources."path-parse-1.0.6"
       sources."pkginfo-0.4.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."safe-buffer-5.1.2"
       sources."sax-0.5.8"
       sources."semver-5.7.1"
@@ -64804,7 +65129,7 @@ in
       sources."find-up-1.1.2"
       (sources."fs-extra-0.26.7" // {
         dependencies = [
-          sources."graceful-fs-4.2.4"
+          sources."graceful-fs-4.2.6"
         ];
       })
       sources."fs.realpath-1.0.0"
@@ -64825,17 +65150,17 @@ in
       sources."is-utf8-0.2.1"
       (sources."jsonfile-2.4.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.4"
+          sources."graceful-fs-4.2.6"
         ];
       })
       (sources."klaw-1.3.1" // {
         dependencies = [
-          sources."graceful-fs-4.2.4"
+          sources."graceful-fs-4.2.6"
         ];
       })
       (sources."load-json-file-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.4"
+          sources."graceful-fs-4.2.6"
         ];
       })
       sources."lodash-4.2.1"
@@ -64858,7 +65183,7 @@ in
       sources."path-parse-1.0.6"
       (sources."path-type-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.4"
+          sources."graceful-fs-4.2.6"
         ];
       })
       sources."pify-2.3.0"
@@ -64870,7 +65195,7 @@ in
       sources."read-pkg-up-1.0.1"
       sources."redent-1.0.0"
       sources."repeating-2.0.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       (sources."rimraf-2.7.1" // {
         dependencies = [
           sources."glob-7.1.6"
@@ -65075,7 +65400,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."ripemd160-2.0.2"
       sources."safe-buffer-5.2.1"
       sources."safer-buffer-2.1.2"
@@ -65306,7 +65631,7 @@ in
       sources."get-intrinsic-1.1.1"
       sources."getpass-0.1.7"
       sources."glob-6.0.4"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
@@ -65471,7 +65796,7 @@ in
       sources."readable-stream-3.6.0"
       sources."redent-2.0.0"
       sources."redis-2.8.0"
-      sources."redis-commands-1.6.0"
+      sources."redis-commands-1.7.0"
       sources."redis-parser-2.6.0"
       sources."regenerator-runtime-0.11.1"
       sources."repeat-string-1.6.1"
@@ -65482,7 +65807,7 @@ in
       })
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."right-align-0.1.3"
       sources."rimraf-2.4.5"
       sources."ripemd160-2.0.2"
@@ -65734,7 +66059,7 @@ in
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
       sources."got-1.2.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
@@ -65867,6 +66192,7 @@ in
       sources."qap-3.3.1"
       sources."qs-6.5.2"
       sources."query-string-1.0.1"
+      sources."queue-microtask-1.2.2"
       sources."random-access-file-2.1.5"
       sources."random-access-storage-1.4.1"
       sources."random-iterate-1.0.1"
@@ -65896,10 +66222,10 @@ in
       sources."redent-1.0.0"
       sources."repeating-2.0.1"
       sources."request-2.88.2"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."rimraf-2.7.1"
       sources."router-0.6.2"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."run-series-1.1.9"
       sources."rusha-0.8.13"
       sources."rx-2.5.3"
@@ -66022,7 +66348,7 @@ in
       sha512 = "3gtzVdy2/KcfUsXmbEuehe8O1L1EtjzEvfzBYcQtZ1VYJK+X95H2UXlDwI6ug+K8A/Fmnrh2TjtIq1Vakv0fcQ==";
     };
     dependencies = [
-      sources."@jsii/spec-1.20.0"
+      sources."@jsii/spec-1.20.1"
       sources."@types/node-10.17.51"
       sources."ansi-regex-5.0.0"
       sources."ansi-styles-4.3.0"
@@ -66035,7 +66361,7 @@ in
       sources."cdk8s-1.0.0-beta.8"
       sources."cliui-7.0.4"
       sources."clone-2.1.2"
-      (sources."codemaker-1.20.0" // {
+      (sources."codemaker-1.20.1" // {
         dependencies = [
           sources."fs-extra-9.1.0"
         ];
@@ -66072,7 +66398,7 @@ in
       sources."function-bind-1.1.1"
       sources."get-caller-file-2.0.5"
       sources."get-intrinsic-1.1.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-symbols-1.0.1"
       sources."is-arguments-1.1.0"
@@ -66092,31 +66418,31 @@ in
       sources."is-weakmap-2.0.1"
       sources."is-weakset-2.0.1"
       sources."isarray-2.0.5"
-      (sources."jsii-1.20.0" // {
+      (sources."jsii-1.20.1" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-pacmak-1.20.0" // {
+      (sources."jsii-pacmak-1.20.1" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-reflect-1.20.0" // {
+      (sources."jsii-reflect-1.20.1" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-rosetta-1.20.0" // {
+      (sources."jsii-rosetta-1.20.1" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-srcmak-0.1.218" // {
+      (sources."jsii-srcmak-0.1.222" // {
         dependencies = [
           sources."fs-extra-9.1.0"
         ];
@@ -66138,7 +66464,7 @@ in
       sources."object-is-1.1.4"
       sources."object-keys-1.1.1"
       sources."object.assign-4.1.2"
-      sources."oo-ascii-tree-1.20.0"
+      sources."oo-ascii-tree-1.20.1"
       sources."p-limit-2.3.0"
       sources."p-locate-4.1.0"
       sources."p-try-2.2.0"
@@ -66170,7 +66496,7 @@ in
       sources."string.prototype.trimstart-1.0.3"
       sources."strip-ansi-6.0.0"
       sources."tslib-2.1.0"
-      sources."typescript-3.9.7"
+      sources."typescript-3.9.9"
       sources."universalify-2.0.0"
       sources."which-boxed-primitive-1.0.2"
       sources."which-collection-1.0.1"
@@ -66213,7 +66539,7 @@ in
       sha512 = "tlkYo1SbitrwfqcTK0S5ZsGasRaJtN5tRP3VxgIszJZggav7mpRGABjTkqY23GzG8UXIaUTvH4uBGshx+iqcOA==";
     };
     dependencies = [
-      sources."@jsii/spec-1.20.0"
+      sources."@jsii/spec-1.20.1"
       sources."@skorfmann/terraform-cloud-1.7.1"
       sources."@types/archiver-5.1.0"
       sources."@types/glob-7.1.3"
@@ -66244,7 +66570,7 @@ in
       sources."axios-0.21.1"
       sources."balanced-match-1.0.0"
       sources."base64-js-1.5.1"
-      sources."bl-4.0.4"
+      sources."bl-4.1.0"
       sources."brace-expansion-1.1.11"
       sources."buffer-5.7.1"
       sources."buffer-crc32-0.2.13"
@@ -66271,7 +66597,7 @@ in
       sources."commonmark-0.29.3"
       sources."compress-commons-4.0.2"
       sources."concat-map-0.0.1"
-      sources."constructs-3.3.11"
+      sources."constructs-3.3.18"
       sources."core-util-is-1.0.2"
       sources."crc-32-1.2.0"
       sources."crc32-stream-4.0.2"
@@ -66313,7 +66639,7 @@ in
       sources."get-caller-file-2.0.5"
       sources."get-intrinsic-1.1.1"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-flag-4.0.0"
       sources."has-symbols-1.0.1"
@@ -66355,7 +66681,7 @@ in
       sources."is-wsl-2.2.0"
       sources."isarray-1.0.0"
       sources."js-tokens-4.0.0"
-      (sources."jsii-1.20.0" // {
+      (sources."jsii-1.20.1" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
@@ -66363,10 +66689,10 @@ in
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-pacmak-1.20.0" // {
+      (sources."jsii-pacmak-1.20.1" // {
         dependencies = [
           sources."camelcase-6.2.0"
-          sources."codemaker-1.20.0"
+          sources."codemaker-1.20.1"
           sources."decamelize-5.0.0"
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
@@ -66374,7 +66700,7 @@ in
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-reflect-1.20.0" // {
+      (sources."jsii-reflect-1.20.1" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
@@ -66382,7 +66708,7 @@ in
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-rosetta-1.20.0" // {
+      (sources."jsii-rosetta-1.20.1" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
@@ -66390,7 +66716,7 @@ in
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-srcmak-0.1.218" // {
+      (sources."jsii-srcmak-0.1.222" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
@@ -66451,7 +66777,7 @@ in
       sources."object.values-1.1.2"
       sources."once-1.4.0"
       sources."onetime-5.1.2"
-      sources."oo-ascii-tree-1.20.0"
+      sources."oo-ascii-tree-1.20.1"
       sources."open-7.4.0"
       sources."p-limit-2.3.0"
       sources."p-locate-4.1.0"
@@ -66472,7 +66798,7 @@ in
       sources."regexp.prototype.flags-1.3.1"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."restore-cursor-3.1.0"
       sources."rfdc-1.2.0"
       sources."safe-buffer-5.1.2"
@@ -66513,7 +66839,7 @@ in
       sources."supports-color-7.2.0"
       sources."tar-stream-2.2.0"
       sources."type-fest-0.11.0"
-      sources."typescript-3.9.7"
+      sources."typescript-3.9.9"
       sources."universalify-0.1.2"
       sources."util-deprecate-1.0.2"
       sources."uuid-8.3.2"
@@ -66553,16 +66879,16 @@ in
   clean-css-cli = nodeEnv.buildNodePackage {
     name = "clean-css-cli";
     packageName = "clean-css-cli";
-    version = "4.3.0";
+    version = "5.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/clean-css-cli/-/clean-css-cli-4.3.0.tgz";
-      sha512 = "8GHZfr+mG3zB/Lgqrr27qHBFsPSn0fyEI3f2rIZpxPxUbn2J6A8xyyeBRVTW8duDuXigN0s80vsXiXJOEFIO5Q==";
+      url = "https://registry.npmjs.org/clean-css-cli/-/clean-css-cli-5.0.1.tgz";
+      sha512 = "6Y+G8FmQu76rSWQjSBY5rVcdgatknjvzfEUU5xtx1uaYovClg7jap7ol3Xf3NP7vMd1fs38TtfhsyIS8Dq0Jvw==";
     };
     dependencies = [
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
-      sources."clean-css-4.2.3"
-      sources."commander-2.20.3"
+      sources."clean-css-5.0.1"
+      sources."commander-7.0.0"
       sources."concat-map-0.0.1"
       sources."fs.realpath-1.0.0"
       sources."glob-7.1.6"
@@ -66613,6 +66939,7 @@ in
       sources."escape-string-regexp-1.0.5"
       sources."eyes-0.1.8"
       sources."fetch-everywhere-1.0.5"
+      sources."filter-obj-1.1.0"
       sources."fs.realpath-1.0.0"
       sources."glob-7.1.6"
       sources."has-flag-3.0.0"
@@ -66635,7 +66962,7 @@ in
       sources."path-is-absolute-1.0.1"
       sources."prompt-1.1.0"
       sources."punycode-2.1.1"
-      sources."query-string-6.13.8"
+      sources."query-string-6.14.0"
       sources."read-1.0.7"
       sources."revalidator-0.1.8"
       sources."rimraf-2.7.1"
@@ -66747,10 +67074,10 @@ in
   coc-git = nodeEnv.buildNodePackage {
     name = "coc-git";
     packageName = "coc-git";
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-git/-/coc-git-2.2.0.tgz";
-      sha512 = "afm5SjyvQl21+4oGotX8mxjiwEBw8veRJun+sZQ5S4ZXMH6tQBZexE0Nyydcaoa5U0P1TBlI7Ywt+e/IZZxleA==";
+      url = "https://registry.npmjs.org/coc-git/-/coc-git-2.2.1.tgz";
+      sha512 = "UlT5D++GU9vWlK/bANGHDxtThdPOWWiVRg9Fsist2ytrg6pjNPSDT/f6US1J7aBCRCB9p2463e/G7JSUT4WTow==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -66813,7 +67140,7 @@ in
       sha512 = "7SHQYzpRKPrpaLcTm1UUk1zu9VvFEJKFqxwDIuqv/CL0cBTtEvlsfpVh9DOaMHlZPu8U8Lgyf04bHV/sFS1zJw==";
     };
     dependencies = [
-      sources."typescript-4.1.3"
+      sources."typescript-4.1.5"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -66881,10 +67208,10 @@ in
   coc-json = nodeEnv.buildNodePackage {
     name = "coc-json";
     packageName = "coc-json";
-    version = "1.3.3";
+    version = "1.3.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-json/-/coc-json-1.3.3.tgz";
-      sha512 = "yMayIIMn/+JaSxHbAG2384sr1/1jvhDCuvRWXeWI+yLLVNCQ7pizGW8EeLC2bSkd01PORRWT4LBn7mNMs6dPRw==";
+      url = "https://registry.npmjs.org/coc-json/-/coc-json-1.3.4.tgz";
+      sha512 = "IK3JYMiJALMMhUlFgl4HxW2dvJdmUr86Hve+ngVATLpT2vWHG5V3sXjuHq7c7RlE7+oWS2CNoxIPf8oiuZesPQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -66998,7 +67325,7 @@ in
       sources."get-intrinsic-1.1.1"
       sources."get-stream-4.1.0"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-symbols-1.0.1"
       sources."http-proxy-agent-4.0.1"
@@ -67212,7 +67539,7 @@ in
       sources."callsites-3.1.0"
       sources."camelcase-2.1.1"
       sources."camelcase-keys-2.1.0"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       sources."capture-stack-trace-1.0.1"
       sources."ccount-1.1.0"
       sources."chalk-2.4.2"
@@ -67309,7 +67636,7 @@ in
       sources."domutils-1.7.0"
       sources."dot-prop-5.3.0"
       sources."duplexer3-0.1.4"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
@@ -67326,7 +67653,7 @@ in
       sources."eslint-visitor-keys-1.3.0"
       sources."espree-6.2.1"
       sources."esprima-4.0.1"
-      (sources."esquery-1.3.1" // {
+      (sources."esquery-1.4.0" // {
         dependencies = [
           sources."estraverse-5.2.0"
         ];
@@ -67458,7 +67785,7 @@ in
       sources."globjoin-0.1.4"
       sources."gonzales-pe-4.3.0"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       (sources."has-ansi-2.0.0" // {
         dependencies = [
@@ -67818,7 +68145,7 @@ in
       sources."require-from-string-2.0.2"
       sources."require-main-filename-1.0.1"
       sources."require-relative-0.8.7"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       (sources."resolve-cwd-2.0.0" // {
         dependencies = [
           sources."resolve-from-3.0.0"
@@ -68001,7 +68328,7 @@ in
       sources."tsutils-3.20.0"
       sources."type-check-0.3.2"
       sources."type-fest-0.8.1"
-      sources."typescript-3.9.7"
+      sources."typescript-3.9.9"
       sources."unherit-1.1.3"
       sources."unified-6.2.0"
       sources."union-value-1.0.1"
@@ -68150,10 +68477,10 @@ in
   coc-rust-analyzer = nodeEnv.buildNodePackage {
     name = "coc-rust-analyzer";
     packageName = "coc-rust-analyzer";
-    version = "0.31.0";
+    version = "0.32.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.31.0.tgz";
-      sha512 = "AvkJvFfQoZvC6xQi7GiSX3M8UaWuruNHfnE9fag/U8huhsTPe6UN52dEGIqkFPLvGqpSddsCx/Gvk9MptfXtFA==";
+      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.32.0.tgz";
+      sha512 = "AwUqoPFeetwDcCe6BpCRMsW+/VtPJ/I/wJA/3ycArSx2mYy+P2IBfBW62NERmw9RNopUbHQKjr6JBTXbl9T/uA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -68228,7 +68555,7 @@ in
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/core-7.12.13"
-      sources."@babel/generator-7.12.13"
+      sources."@babel/generator-7.12.15"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
       sources."@babel/helper-member-expression-to-functions-7.12.13"
@@ -68245,7 +68572,7 @@ in
           sources."chalk-2.4.2"
         ];
       })
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/template-7.12.13"
       sources."@babel/traverse-7.12.13"
       sources."@babel/types-7.12.13"
@@ -68259,7 +68586,7 @@ in
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/parse-json-4.0.0"
       sources."@types/unist-2.0.3"
-      sources."ajv-7.0.4"
+      sources."ajv-7.1.0"
       sources."ansi-regex-5.0.0"
       sources."ansi-styles-3.2.1"
       sources."array-union-2.1.0"
@@ -68274,7 +68601,7 @@ in
       sources."callsites-3.1.0"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       (sources."chalk-4.1.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
@@ -68312,7 +68639,7 @@ in
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       sources."emoji-regex-8.0.0"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
@@ -68382,7 +68709,7 @@ in
       sources."json-schema-traverse-1.0.0"
       sources."json5-2.2.0"
       sources."kind-of-6.0.3"
-      sources."known-css-properties-0.20.0"
+      sources."known-css-properties-0.21.0"
       sources."lines-and-columns-1.1.6"
       sources."locate-path-5.0.0"
       sources."lodash-4.17.20"
@@ -68392,7 +68719,7 @@ in
       sources."map-obj-4.1.0"
       sources."mathml-tag-names-2.1.3"
       sources."mdast-util-from-markdown-0.8.5"
-      sources."mdast-util-to-markdown-0.6.2"
+      sources."mdast-util-to-markdown-0.6.5"
       sources."mdast-util-to-string-2.0.0"
       sources."meow-9.0.0"
       sources."merge2-1.4.1"
@@ -68451,6 +68778,7 @@ in
       sources."postcss-syntax-0.36.2"
       sources."postcss-value-parser-4.1.0"
       sources."punycode-2.1.1"
+      sources."queue-microtask-1.2.2"
       sources."quick-lru-4.0.1"
       (sources."read-pkg-5.2.0" // {
         dependencies = [
@@ -68471,11 +68799,11 @@ in
       sources."remark-stringify-9.0.1"
       sources."repeat-string-1.6.1"
       sources."require-from-string-2.0.2"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-5.0.0"
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."safe-buffer-5.1.2"
       sources."semver-5.7.1"
       sources."signal-exit-3.0.3"
@@ -68502,7 +68830,7 @@ in
       sources."strip-ansi-6.0.0"
       sources."strip-indent-3.0.0"
       sources."style-search-0.1.0"
-      sources."stylelint-13.9.0"
+      sources."stylelint-13.10.0"
       sources."sugarss-2.0.0"
       sources."supports-color-5.5.0"
       sources."svg-tags-1.0.0"
@@ -68609,14 +68937,14 @@ in
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."path-parse-1.0.6"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."semver-5.7.1"
       sources."sprintf-js-1.0.3"
       sources."supports-color-5.5.0"
       sources."tslib-1.14.1"
       sources."tslint-5.20.1"
       sources."tsutils-2.29.0"
-      sources."typescript-3.9.7"
+      sources."typescript-3.9.9"
       sources."wrappy-1.0.2"
     ];
     buildInputs = globalBuildInputs;
@@ -68671,7 +68999,7 @@ in
       sha512 = "NVBl6AEbEax6GQdBlBy/SelJ5TXCkrnLN/dDqgDWwhIPX6UBFhFTFCLcqcHbfMjLM/MDvP/t85w+OYBGe2gXxg==";
     };
     dependencies = [
-      sources."typescript-4.1.3"
+      sources."typescript-4.1.5"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -68748,7 +69076,7 @@ in
         ];
       })
       sources."esprima-4.0.1"
-      (sources."esquery-1.3.1" // {
+      (sources."esquery-1.4.0" // {
         dependencies = [
           sources."estraverse-5.2.0"
         ];
@@ -68808,7 +69136,7 @@ in
       sources."punycode-2.1.1"
       sources."regexpp-3.1.0"
       sources."require-from-string-2.0.2"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-4.0.0"
       sources."rimraf-3.0.2"
       sources."semver-7.3.4"
@@ -68828,7 +69156,7 @@ in
       sources."supports-color-5.5.0"
       (sources."table-6.0.7" // {
         dependencies = [
-          sources."ajv-7.0.4"
+          sources."ajv-7.1.0"
           sources."json-schema-traverse-1.0.0"
         ];
       })
@@ -68843,7 +69171,7 @@ in
       sources."tsutils-2.29.0"
       sources."type-check-0.4.0"
       sources."type-fest-0.8.1"
-      sources."typescript-4.1.3"
+      sources."typescript-4.1.5"
       sources."uri-js-4.4.1"
       sources."v8-compile-cache-2.2.0"
       sources."vls-0.5.10"
@@ -69142,20 +69470,40 @@ in
       sources."@nodelib/fs.scandir-2.1.4"
       sources."@nodelib/fs.stat-2.0.4"
       sources."@nodelib/fs.walk-1.2.6"
+      sources."@npmcli/ci-detect-1.3.0"
+      (sources."@npmcli/git-2.0.4" // {
+        dependencies = [
+          sources."promise-retry-1.1.1"
+        ];
+      })
+      sources."@npmcli/installed-package-contents-1.0.7"
+      sources."@npmcli/move-file-1.1.1"
+      sources."@npmcli/node-gyp-1.0.2"
+      sources."@npmcli/promise-spawn-1.3.2"
+      sources."@npmcli/run-script-1.8.3"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
+      sources."@tootallnate/once-1.1.2"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
+      sources."agent-base-6.0.2"
+      sources."agentkeepalive-4.1.4"
+      sources."aggregate-error-3.1.0"
       sources."ajv-6.12.6"
       sources."ansi-0.3.1"
       (sources."ansi-align-3.0.0" // {
         dependencies = [
+          sources."ansi-regex-4.1.0"
+          sources."is-fullwidth-code-point-2.0.0"
           sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
         ];
       })
       sources."ansi-escapes-3.2.0"
-      sources."ansi-regex-3.0.0"
+      sources."ansi-regex-2.1.1"
       sources."ansi-styles-4.3.0"
+      sources."aproba-1.2.0"
+      sources."are-we-there-yet-1.1.5"
       sources."array-find-index-1.0.2"
       sources."array-flatten-1.1.1"
       sources."array-union-2.1.0"
@@ -69173,6 +69521,10 @@ in
       (sources."body-parser-1.19.0" // {
         dependencies = [
           sources."bytes-3.1.0"
+          sources."debug-2.6.9"
+          sources."iconv-lite-0.4.24"
+          sources."ms-2.0.0"
+          sources."qs-6.7.0"
         ];
       })
       (sources."boxen-4.2.0" // {
@@ -69189,6 +69541,7 @@ in
       sources."braces-3.0.2"
       sources."builtins-1.0.3"
       sources."bytes-3.0.0"
+      sources."cacache-15.0.5"
       (sources."cacheable-request-6.1.0" // {
         dependencies = [
           sources."lowercase-keys-2.0.0"
@@ -69199,20 +69552,29 @@ in
       sources."caseless-0.12.0"
       sources."chalk-3.0.0"
       sources."chardet-0.7.0"
+      sources."chownr-2.0.0"
       sources."ci-info-2.0.0"
+      sources."clean-stack-2.2.0"
       sources."cli-boxes-2.2.1"
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.1"
       sources."clone-response-1.0.2"
+      sources."code-point-at-1.1.0"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
       sources."combined-stream-1.0.8"
       sources."compressible-2.0.18"
-      sources."compression-1.7.4"
+      (sources."compression-1.7.4" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
       sources."concat-map-0.0.1"
       (sources."conf-1.4.0" // {
         dependencies = [
           sources."dot-prop-4.2.1"
+          sources."env-paths-1.0.0"
           sources."is-obj-1.0.1"
           sources."make-dir-1.3.0"
           sources."pify-3.0.0"
@@ -69220,6 +69582,7 @@ in
         ];
       })
       sources."configstore-5.0.1"
+      sources."console-control-strings-1.1.0"
       sources."content-disposition-0.5.3"
       sources."content-type-1.0.4"
       sources."cookie-0.4.0"
@@ -69227,7 +69590,7 @@ in
       sources."cordova-app-hello-world-5.0.0"
       sources."cordova-common-4.0.2"
       sources."cordova-create-3.0.0"
-      (sources."cordova-fetch-3.0.0" // {
+      (sources."cordova-fetch-3.0.1" // {
         dependencies = [
           sources."pify-5.0.0"
         ];
@@ -69243,12 +69606,13 @@ in
       sources."crypto-random-string-2.0.0"
       sources."currently-unhandled-0.4.1"
       sources."dashdash-1.14.1"
-      sources."debug-2.6.9"
+      sources."debug-4.3.2"
       sources."decompress-response-3.3.0"
       sources."dedent-0.7.0"
       sources."deep-extend-0.6.0"
       sources."defer-to-connect-1.1.3"
       sources."delayed-stream-1.0.0"
+      sources."delegates-1.0.0"
       (sources."dep-graph-1.1.0" // {
         dependencies = [
           sources."underscore-1.2.1"
@@ -69267,18 +69631,27 @@ in
       sources."elementtree-0.1.7"
       sources."emoji-regex-7.0.3"
       sources."encodeurl-1.0.2"
+      sources."encoding-0.1.13"
       sources."end-of-stream-1.4.4"
       sources."endent-1.4.1"
-      sources."env-paths-1.0.0"
+      sources."env-paths-2.2.0"
+      sources."err-code-1.1.2"
       sources."escape-goat-2.1.1"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."etag-1.8.1"
       sources."execa-4.1.0"
-      sources."express-4.17.1"
+      (sources."express-4.17.1" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+          sources."qs-6.7.0"
+        ];
+      })
       sources."extend-3.0.2"
       (sources."external-editor-3.1.0" // {
         dependencies = [
+          sources."iconv-lite-0.4.24"
           sources."tmp-0.0.33"
         ];
       })
@@ -69290,15 +69663,22 @@ in
       sources."fastq-1.10.1"
       sources."figures-2.0.0"
       sources."fill-range-7.0.1"
-      sources."finalhandler-1.1.2"
+      (sources."finalhandler-1.1.2" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
       sources."find-up-2.1.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."fs-extra-9.1.0"
+      sources."fs-minipass-2.1.0"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
+      sources."gauge-2.7.4"
       sources."get-stream-5.2.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
@@ -69310,11 +69690,12 @@ in
           sources."get-stream-4.1.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
       sources."has-flag-4.0.0"
+      sources."has-unicode-2.0.1"
       sources."has-yarn-2.1.0"
       sources."hosted-git-info-3.0.8"
       sources."http-cache-semantics-4.1.0"
@@ -69323,13 +69704,19 @@ in
           sources."inherits-2.0.3"
         ];
       })
+      sources."http-proxy-agent-4.0.1"
       sources."http-signature-1.2.0"
+      sources."https-proxy-agent-5.0.0"
       sources."human-signals-1.1.1"
-      sources."iconv-lite-0.4.24"
+      sources."humanize-ms-1.2.1"
+      sources."iconv-lite-0.6.2"
       sources."ignore-5.1.8"
+      sources."ignore-walk-3.0.3"
       sources."import-fresh-3.3.0"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
+      sources."indent-string-4.0.0"
+      sources."infer-owner-1.0.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.7"
@@ -69342,12 +69729,24 @@ in
       })
       (sources."inquirer-6.5.2" // {
         dependencies = [
+          sources."ansi-regex-3.0.0"
           sources."ansi-styles-3.2.1"
           sources."chalk-2.4.2"
           sources."color-convert-1.9.3"
           sources."color-name-1.1.3"
           sources."has-flag-3.0.0"
+          sources."is-fullwidth-code-point-2.0.0"
           sources."mute-stream-0.0.7"
+          (sources."string-width-2.1.1" // {
+            dependencies = [
+              sources."strip-ansi-4.0.0"
+            ];
+          })
+          (sources."strip-ansi-5.2.0" // {
+            dependencies = [
+              sources."ansi-regex-4.1.0"
+            ];
+          })
           sources."supports-color-5.5.0"
         ];
       })
@@ -69359,17 +69758,20 @@ in
           sources."color-name-1.1.3"
           sources."has-flag-3.0.0"
           sources."supports-color-5.5.0"
+          sources."tough-cookie-3.0.1"
         ];
       })
+      sources."ip-1.1.5"
       sources."ip-regex-2.1.0"
       sources."ipaddr.js-1.9.1"
       sources."is-ci-2.0.0"
       sources."is-core-module-2.2.0"
       sources."is-docker-2.1.1"
       sources."is-extglob-2.1.1"
-      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-fullwidth-code-point-1.0.0"
       sources."is-glob-4.0.1"
       sources."is-installed-globally-0.3.2"
+      sources."is-lambda-1.0.1"
       sources."is-npm-4.0.0"
       sources."is-number-7.0.0"
       sources."is-obj-2.0.0"
@@ -69378,6 +69780,7 @@ in
       sources."is-typedarray-1.0.0"
       sources."is-wsl-2.2.0"
       sources."is-yarn-global-0.3.0"
+      sources."isarray-1.0.0"
       sources."isexe-2.0.0"
       sources."isobject-4.0.0"
       sources."isstream-0.1.2"
@@ -69388,6 +69791,7 @@ in
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-6.1.0"
+      sources."jsonparse-1.3.1"
       (sources."jsprim-1.4.1" // {
         dependencies = [
           sources."extsprintf-1.3.0"
@@ -69407,6 +69811,11 @@ in
           sources."semver-6.3.0"
         ];
       })
+      (sources."make-fetch-happen-8.0.13" // {
+        dependencies = [
+          sources."promise-retry-1.1.1"
+        ];
+      })
       sources."md5-file-5.0.0"
       sources."media-typer-0.3.0"
       sources."merge-descriptors-1.0.1"
@@ -69421,10 +69830,24 @@ in
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
-      sources."ms-2.0.0"
+      sources."minipass-3.1.3"
+      sources."minipass-collect-1.0.2"
+      sources."minipass-fetch-1.3.3"
+      sources."minipass-flush-1.0.5"
+      sources."minipass-json-stream-1.0.1"
+      sources."minipass-pipeline-1.2.4"
+      sources."minipass-sized-1.0.3"
+      sources."minizlib-2.1.2"
+      sources."mkdirp-1.0.4"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.8"
       sources."negotiator-0.6.2"
       sources."nice-try-1.0.5"
+      (sources."node-gyp-7.1.2" // {
+        dependencies = [
+          sources."nopt-5.0.0"
+        ];
+      })
       sources."nopt-4.0.3"
       (sources."normalize-package-data-2.5.0" // {
         dependencies = [
@@ -69433,10 +69856,18 @@ in
         ];
       })
       sources."normalize-url-4.5.0"
+      sources."npm-bundled-1.1.1"
+      sources."npm-install-checks-4.0.0"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-package-arg-8.1.0"
+      sources."npm-packlist-2.1.4"
+      sources."npm-pick-manifest-6.1.0"
+      sources."npm-registry-fetch-9.0.0"
       sources."npm-run-path-4.0.1"
+      sources."npmlog-4.1.2"
+      sources."number-is-nan-1.0.1"
       sources."oauth-sign-0.9.0"
+      sources."object-assign-4.1.1"
       sources."objectorarray-1.0.4"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
@@ -69455,12 +69886,14 @@ in
         ];
       })
       sources."p-locate-2.0.0"
+      sources."p-map-4.0.0"
       sources."p-try-2.2.0"
       (sources."package-json-6.5.0" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
       })
+      sources."pacote-11.2.6"
       sources."parent-module-1.0.1"
       sources."parseurl-1.3.3"
       sources."path-exists-3.0.0"
@@ -69476,33 +69909,41 @@ in
       sources."pkg-up-2.0.0"
       sources."plist-3.0.1"
       sources."prepend-http-2.0.0"
+      sources."process-nextick-args-2.0.1"
+      sources."promise-inflight-1.0.1"
+      (sources."promise-retry-2.0.1" // {
+        dependencies = [
+          sources."err-code-2.0.3"
+          sources."retry-0.12.0"
+        ];
+      })
       sources."promzard-0.3.0"
       sources."proxy-addr-2.0.6"
       sources."psl-1.8.0"
+      sources."puka-1.0.1"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."pupa-2.1.1"
       sources."q-1.5.1"
-      sources."qs-6.7.0"
+      sources."qs-6.5.2"
+      sources."queue-microtask-1.2.2"
       sources."range-parser-1.2.1"
       (sources."raw-body-2.4.0" // {
         dependencies = [
           sources."bytes-3.1.0"
+          sources."iconv-lite-0.4.24"
         ];
       })
       sources."rc-1.2.8"
       sources."read-1.0.7"
       sources."read-chunk-3.2.0"
       sources."read-package-json-2.1.2"
+      sources."read-package-json-fast-2.0.1"
+      sources."readable-stream-2.3.7"
       sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
-      (sources."request-2.88.2" // {
-        dependencies = [
-          sources."qs-6.5.2"
-          sources."tough-cookie-2.5.0"
-        ];
-      })
-      sources."resolve-1.19.0"
+      sources."request-2.88.2"
+      sources."resolve-1.20.0"
       sources."resolve-from-4.0.0"
       sources."responselike-1.0.2"
       (sources."restore-cursor-2.0.0" // {
@@ -69511,10 +69952,11 @@ in
           sources."onetime-2.0.1"
         ];
       })
+      sources."retry-0.10.1"
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
       sources."run-async-2.4.1"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."rxjs-6.6.3"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
@@ -69527,45 +69969,49 @@ in
       })
       (sources."send-0.17.1" // {
         dependencies = [
+          (sources."debug-2.6.9" // {
+            dependencies = [
+              sources."ms-2.0.0"
+            ];
+          })
           sources."ms-2.1.1"
         ];
       })
       sources."serve-static-1.14.1"
+      sources."set-blocking-2.0.0"
       sources."setprototypeof-1.1.1"
       sources."shebang-command-2.0.0"
       sources."shebang-regex-3.0.0"
       sources."signal-exit-3.0.3"
       sources."slash-3.0.0"
+      sources."smart-buffer-4.1.0"
+      sources."socks-2.5.1"
+      sources."socks-proxy-agent-5.0.0"
       sources."spdx-correct-3.1.1"
       sources."spdx-exceptions-2.3.0"
       sources."spdx-expression-parse-3.0.1"
       sources."spdx-license-ids-3.0.7"
       sources."sshpk-1.16.1"
+      sources."ssri-8.0.1"
       sources."statuses-1.5.0"
-      (sources."string-width-2.1.1" // {
-        dependencies = [
-          sources."strip-ansi-4.0.0"
-        ];
-      })
+      sources."string-width-1.0.2"
+      sources."string_decoder-1.1.1"
       sources."stringify-package-1.0.1"
-      (sources."strip-ansi-5.2.0" // {
-        dependencies = [
-          sources."ansi-regex-4.1.0"
-        ];
-      })
+      sources."strip-ansi-3.0.1"
       sources."strip-bom-4.0.0"
       sources."strip-eof-1.0.0"
       sources."strip-final-newline-2.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-7.2.0"
       sources."systeminformation-4.34.9"
+      sources."tar-6.1.0"
       sources."term-size-2.2.1"
       sources."through-2.3.8"
       sources."tmp-0.2.1"
       sources."to-readable-stream-1.0.0"
       sources."to-regex-range-5.0.1"
       sources."toidentifier-1.0.0"
-      sources."tough-cookie-3.0.1"
+      sources."tough-cookie-2.5.0"
       sources."tslib-1.14.1"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
@@ -69573,12 +70019,15 @@ in
       sources."type-is-1.6.18"
       sources."typedarray-to-buffer-3.1.5"
       sources."underscore-1.12.0"
+      sources."unique-filename-1.1.1"
+      sources."unique-slug-2.0.2"
       sources."unique-string-2.0.0"
       sources."universalify-2.0.0"
       sources."unpipe-1.0.0"
       sources."update-notifier-4.1.3"
       sources."uri-js-4.4.1"
       sources."url-parse-lax-3.0.0"
+      sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
       sources."uuid-3.4.0"
       sources."valid-identifier-0.0.2"
@@ -69587,6 +70036,7 @@ in
       sources."vary-1.1.2"
       sources."verror-1.10.0"
       sources."which-2.0.2"
+      sources."wide-align-1.1.3"
       (sources."widest-line-3.1.0" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
@@ -69762,7 +70212,7 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globby-9.2.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."hard-rejection-2.1.0"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
@@ -69895,7 +70345,7 @@ in
       sources."regex-not-1.0.2"
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
       sources."safe-regex-1.1.0"
@@ -70059,7 +70509,7 @@ in
       sources."event-emitter-0.3.5"
       (sources."ext-1.4.0" // {
         dependencies = [
-          sources."type-2.1.0"
+          sources."type-2.2.0"
         ];
       })
       sources."extend-3.0.2"
@@ -70188,7 +70638,7 @@ in
       sources."fstream-1.0.12"
       sources."fstream-ignore-1.0.5"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-flag-4.0.0"
       sources."hyperquest-2.1.3"
       sources."inflight-1.0.6"
@@ -70258,10 +70708,10 @@ in
   create-react-native-app = nodeEnv.buildNodePackage {
     name = "create-react-native-app";
     packageName = "create-react-native-app";
-    version = "3.5.2";
+    version = "3.5.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/create-react-native-app/-/create-react-native-app-3.5.2.tgz";
-      sha512 = "qRsvaxOV0b/O+Tk1SznarDNbwqY83OhXCeQ9nb1VH4oUd1TrjB5NoFdJWWu9tOhzfV1M9NVgqd0hCoMOvICf5g==";
+      url = "https://registry.npmjs.org/create-react-native-app/-/create-react-native-app-3.5.3.tgz";
+      sha512 = "YJWlLKBx4tdOJ7NbUVqKATTAHB4IJTHSTJBAj0eBbdXdmpI4WGGS725MzoapgJPiBWUMtjgZcVcR5MHe3UHczQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -70542,7 +70992,7 @@ in
       sources."global-4.4.0"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-flag-3.0.0"
@@ -71004,7 +71454,7 @@ in
       sources."glob-7.1.6"
       sources."glob-parent-5.1.1"
       sources."globby-11.0.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."ignore-5.1.8"
       sources."indent-string-4.0.0"
       sources."inflight-1.0.6"
@@ -71029,9 +71479,10 @@ in
       sources."path-is-absolute-1.0.1"
       sources."path-type-4.0.0"
       sources."picomatch-2.2.2"
+      sources."queue-microtask-1.2.2"
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."rxjs-6.6.3"
       sources."slash-3.0.0"
       sources."temp-dir-2.0.0"
@@ -71260,7 +71711,7 @@ in
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/core-7.12.13"
-      sources."@babel/generator-7.12.13"
+      sources."@babel/generator-7.12.15"
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
@@ -71275,7 +71726,7 @@ in
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helpers-7.12.13"
       sources."@babel/highlight-7.12.13"
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/plugin-proposal-object-rest-spread-7.12.13"
       sources."@babel/plugin-syntax-jsx-7.12.13"
       sources."@babel/plugin-syntax-object-rest-spread-7.8.3"
@@ -71509,7 +71960,7 @@ in
         ];
       })
       sources."redent-3.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-alpn-1.0.0"
       sources."resolve-from-3.0.0"
       sources."responselike-2.0.0"
@@ -71618,10 +72069,10 @@ in
       sources."@fluentui/date-time-utilities-7.9.0"
       sources."@fluentui/dom-utilities-1.1.1"
       sources."@fluentui/keyboard-key-0.2.13"
-      sources."@fluentui/react-7.158.1"
-      sources."@fluentui/react-focus-7.17.1"
+      sources."@fluentui/react-7.160.0"
+      sources."@fluentui/react-focus-7.17.4"
       sources."@fluentui/react-window-provider-1.0.1"
-      sources."@fluentui/theme-1.7.1"
+      sources."@fluentui/theme-1.7.3"
       (sources."@gulp-sourcemaps/identity-map-1.0.2" // {
         dependencies = [
           sources."normalize-path-2.1.1"
@@ -71632,7 +72083,7 @@ in
           sources."normalize-path-2.1.1"
         ];
       })
-      sources."@microsoft/load-themed-styles-1.10.146"
+      sources."@microsoft/load-themed-styles-1.10.147"
       sources."@nodelib/fs.scandir-2.1.4"
       sources."@nodelib/fs.stat-2.0.4"
       sources."@nodelib/fs.walk-1.2.6"
@@ -71681,13 +72132,13 @@ in
       sources."@types/sqlite3-3.1.6"
       sources."@types/tough-cookie-4.0.0"
       sources."@types/url-join-4.0.0"
-      sources."@uifabric/foundation-7.9.21"
-      sources."@uifabric/icons-7.5.18"
+      sources."@uifabric/foundation-7.9.24"
+      sources."@uifabric/icons-7.5.21"
       sources."@uifabric/merge-styles-7.19.1"
-      sources."@uifabric/react-hooks-7.13.9"
+      sources."@uifabric/react-hooks-7.13.11"
       sources."@uifabric/set-version-7.0.23"
-      sources."@uifabric/styling-7.16.19"
-      sources."@uifabric/utilities-7.33.2"
+      sources."@uifabric/styling-7.18.0"
+      sources."@uifabric/utilities-7.33.4"
       sources."@webassemblyjs/ast-1.9.0"
       sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
       sources."@webassemblyjs/helper-api-error-1.9.0"
@@ -72142,7 +72593,7 @@ in
       sources."express-openapi-7.0.1"
       (sources."ext-1.4.0" // {
         dependencies = [
-          sources."type-2.1.0"
+          sources."type-2.2.0"
         ];
       })
       sources."extend-3.0.2"
@@ -72254,7 +72705,7 @@ in
       sources."globby-10.0.2"
       sources."glogg-1.0.2"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."gulp-4.0.2"
       (sources."gulp-clean-css-4.3.0" // {
         dependencies = [
@@ -72655,7 +73106,7 @@ in
       sources."object.map-1.0.1"
       sources."object.pick-1.3.0"
       sources."object.reduce-1.0.1"
-      sources."office-ui-fabric-react-7.158.1"
+      sources."office-ui-fabric-react-7.160.0"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -72815,6 +73266,7 @@ in
       sources."qs-6.7.0"
       sources."querystring-0.2.0"
       sources."querystring-es3-0.2.1"
+      sources."queue-microtask-1.2.2"
       sources."randombytes-2.1.0"
       sources."randomfill-1.0.4"
       sources."range-parser-1.2.1"
@@ -72863,7 +73315,7 @@ in
       })
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-options-1.1.0"
       sources."resolve-url-0.2.1"
@@ -72875,13 +73327,13 @@ in
       sources."rimraf-2.7.1"
       sources."ripemd160-2.0.2"
       sources."run-async-2.4.1"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."run-queue-1.0.3"
       sources."rx-4.1.0"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."sass-1.32.6"
+      sources."sass-1.32.7"
       sources."sax-1.2.4"
       sources."scheduler-0.19.1"
       sources."schema-utils-2.7.1"
@@ -73182,7 +73634,7 @@ in
           sources."anymatch-3.1.1"
           sources."binary-extensions-2.2.0"
           sources."chokidar-3.5.1"
-          sources."fsevents-2.3.1"
+          sources."fsevents-2.3.2"
           sources."is-binary-path-2.1.0"
           sources."readdirp-3.5.0"
         ];
@@ -73345,7 +73797,7 @@ in
         ];
       })
       sources."esprima-4.0.1"
-      (sources."esquery-1.3.1" // {
+      (sources."esquery-1.4.0" // {
         dependencies = [
           sources."estraverse-5.2.0"
         ];
@@ -73417,7 +73869,7 @@ in
       sources."supports-color-5.5.0"
       (sources."table-6.0.7" // {
         dependencies = [
-          sources."ajv-7.0.4"
+          sources."ajv-7.1.0"
           sources."json-schema-traverse-1.0.0"
         ];
       })
@@ -73444,10 +73896,10 @@ in
   eslint_d = nodeEnv.buildNodePackage {
     name = "eslint_d";
     packageName = "eslint_d";
-    version = "10.0.0";
+    version = "10.0.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint_d/-/eslint_d-10.0.0.tgz";
-      sha512 = "rMZDE3kiJ2JXv1qk3i3xa5lzelEVQuTNRF5nMHQNX2SDzHKucisbNQh9ExvXU3Wd+jNjeVOSmZ6Ir0gY3COf2w==";
+      url = "https://registry.npmjs.org/eslint_d/-/eslint_d-10.0.2.tgz";
+      sha512 = "owgGugHDhfzqe2tjbkz+Htv4stRwFfXJEG6lc+c9dKxwgAvuYNurldosLJ2gyC66Uv/cPf4IS70wuUTmNLTrOQ==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
@@ -73504,7 +73956,7 @@ in
         ];
       })
       sources."esprima-4.0.1"
-      (sources."esquery-1.3.1" // {
+      (sources."esquery-1.4.0" // {
         dependencies = [
           sources."estraverse-5.2.0"
         ];
@@ -73577,7 +74029,7 @@ in
       sources."supports-color-8.1.1"
       (sources."table-6.0.7" // {
         dependencies = [
-          sources."ajv-7.0.4"
+          sources."ajv-7.1.0"
           sources."json-schema-traverse-1.0.0"
         ];
       })
@@ -73637,7 +74089,7 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."@babel/generator-7.12.13"
+      sources."@babel/generator-7.12.15"
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.12.13"
       (sources."@babel/helper-compilation-targets-7.12.13" // {
@@ -73670,7 +74122,7 @@ in
           sources."chalk-2.4.2"
         ];
       })
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/plugin-proposal-async-generator-functions-7.12.13"
       sources."@babel/plugin-proposal-class-properties-7.12.13"
       sources."@babel/plugin-proposal-dynamic-import-7.12.1"
@@ -73731,7 +74183,7 @@ in
       sources."@babel/plugin-transform-react-jsx-source-7.12.13"
       sources."@babel/plugin-transform-regenerator-7.12.13"
       sources."@babel/plugin-transform-reserved-words-7.12.13"
-      (sources."@babel/plugin-transform-runtime-7.12.13" // {
+      (sources."@babel/plugin-transform-runtime-7.12.15" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
@@ -73894,19 +74346,21 @@ in
       (sources."@npmcli/git-2.0.4" // {
         dependencies = [
           sources."mkdirp-1.0.4"
+          sources."promise-retry-1.1.1"
+          sources."retry-0.10.1"
           sources."which-2.0.2"
         ];
       })
-      sources."@npmcli/installed-package-contents-1.0.5"
+      sources."@npmcli/installed-package-contents-1.0.7"
       (sources."@npmcli/move-file-1.1.1" // {
         dependencies = [
           sources."mkdirp-1.0.4"
           sources."rimraf-3.0.2"
         ];
       })
-      sources."@npmcli/node-gyp-1.0.1"
+      sources."@npmcli/node-gyp-1.0.2"
       sources."@npmcli/promise-spawn-1.3.2"
-      sources."@npmcli/run-script-1.8.1"
+      sources."@npmcli/run-script-1.8.3"
       sources."@pmmmwh/react-refresh-webpack-plugin-0.3.3"
       sources."@react-native-community/cli-debugger-ui-4.13.1"
       (sources."@react-native-community/cli-platform-ios-4.13.0" // {
@@ -73967,7 +74421,7 @@ in
       sources."@types/tapable-1.0.6"
       sources."@types/text-table-0.2.1"
       sources."@types/tmp-0.0.33"
-      (sources."@types/uglify-js-3.11.1" // {
+      (sources."@types/uglify-js-3.12.0" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -74010,7 +74464,7 @@ in
       sources."acorn-6.4.2"
       sources."address-1.1.2"
       sources."agent-base-6.0.2"
-      sources."agentkeepalive-4.1.3"
+      sources."agentkeepalive-4.1.4"
       sources."aggregate-error-3.1.0"
       sources."ajv-5.5.2"
       sources."ajv-errors-1.0.1"
@@ -74059,7 +74513,6 @@ in
       sources."array-uniq-1.0.3"
       sources."array-unique-0.3.2"
       sources."arrify-2.0.1"
-      sources."asap-2.0.6"
       sources."asn1-0.2.4"
       (sources."asn1.js-5.4.1" // {
         dependencies = [
@@ -74196,7 +74649,7 @@ in
       })
       sources."camelcase-5.3.1"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       sources."caseless-0.12.0"
       (sources."chalk-4.1.0" // {
         dependencies = [
@@ -74292,7 +74745,7 @@ in
         ];
       })
       sources."connect-history-api-fallback-1.6.0"
-      sources."consola-2.15.2"
+      sources."consola-2.15.3"
       sources."console-browserify-1.2.0"
       sources."console-control-strings-1.1.0"
       sources."constants-browserify-1.0.0"
@@ -74393,7 +74846,6 @@ in
       sources."dashdash-1.14.1"
       sources."dateformat-3.0.3"
       sources."debug-4.3.2"
-      sources."debuglog-1.0.1"
       sources."decache-4.4.0"
       sources."decamelize-1.2.0"
       sources."decode-uri-component-0.2.0"
@@ -74440,7 +74892,6 @@ in
           sources."sudo-prompt-8.2.5"
         ];
       })
-      sources."dezalgo-1.0.3"
       (sources."diffie-hellman-5.0.3" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -74477,7 +74928,7 @@ in
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       (sources."elliptic-6.5.4" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -74644,7 +75095,7 @@ in
       })
       sources."fs-write-stream-atomic-1.0.10"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."function-bind-1.1.1"
       (sources."gauge-2.7.4" // {
         dependencies = [
@@ -74691,7 +75142,7 @@ in
           sources."responselike-2.0.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."graphql-0.13.2"
       (sources."graphql-tools-3.0.0" // {
         dependencies = [
@@ -74960,6 +75411,8 @@ in
       (sources."make-fetch-happen-8.0.13" // {
         dependencies = [
           sources."minipass-3.1.3"
+          sources."promise-retry-1.1.1"
+          sources."retry-0.10.1"
         ];
       })
       sources."map-cache-0.2.2"
@@ -75202,7 +75655,7 @@ in
           sources."semver-6.3.0"
         ];
       })
-      (sources."pacote-11.2.4" // {
+      (sources."pacote-11.2.6" // {
         dependencies = [
           sources."minipass-3.1.3"
           sources."mkdirp-1.0.4"
@@ -75421,9 +75874,9 @@ in
       sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
       sources."promise-inflight-1.0.1"
-      (sources."promise-retry-1.1.1" // {
+      (sources."promise-retry-2.0.1" // {
         dependencies = [
-          sources."retry-0.10.1"
+          sources."err-code-2.0.3"
         ];
       })
       sources."prompts-2.4.0"
@@ -75449,6 +75902,7 @@ in
       sources."querystring-0.2.0"
       sources."querystring-es3-0.2.1"
       sources."querystringify-2.2.0"
+      sources."queue-microtask-1.2.2"
       sources."quick-lru-5.1.1"
       sources."randombytes-2.1.0"
       sources."randomfill-1.0.4"
@@ -75493,13 +75947,12 @@ in
       sources."react-refresh-0.4.3"
       sources."read-chunk-3.2.0"
       sources."read-last-lines-1.6.0"
-      sources."read-package-json-fast-1.2.1"
+      sources."read-package-json-fast-2.0.1"
       (sources."readable-stream-2.3.7" // {
         dependencies = [
           sources."isarray-1.0.0"
         ];
       })
-      sources."readdir-scoped-modules-1.1.0"
       sources."readdirp-3.5.0"
       sources."recursive-readdir-2.2.2"
       sources."regenerate-1.4.2"
@@ -75556,7 +76009,7 @@ in
         ];
       })
       sources."requires-port-1.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-alpn-1.0.0"
       (sources."resolve-cwd-2.0.0" // {
         dependencies = [
@@ -75579,7 +76032,7 @@ in
       })
       sources."ripemd160-2.0.2"
       sources."router-ips-1.0.0"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."run-queue-1.0.3"
       sources."safe-buffer-5.1.2"
       sources."safe-json-stringify-1.2.0"
@@ -76250,7 +76703,7 @@ in
       sources."function-bind-1.1.1"
       sources."get-stdin-4.0.1"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
@@ -76336,7 +76789,7 @@ in
       sources."repeating-2.0.1"
       sources."request-2.88.2"
       sources."request-progress-2.0.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."restore-cursor-1.0.1"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
@@ -76646,7 +77099,7 @@ in
         ];
       })
       sources."got-8.3.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-flag-3.0.0"
@@ -76787,6 +77240,7 @@ in
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."query-string-5.1.1"
+      sources."queue-microtask-1.2.2"
       (sources."readable-stream-2.3.7" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
@@ -76803,7 +77257,7 @@ in
       sources."responselike-1.0.2"
       sources."ret-0.1.15"
       sources."reusify-1.0.4"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."safe-buffer-5.2.1"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
@@ -77047,7 +77501,7 @@ in
       sources."bignumber.js-9.0.1"
       sources."binary-0.3.0"
       sources."binary-extensions-2.2.0"
-      sources."bl-4.0.4"
+      sources."bl-4.1.0"
       sources."blakejs-1.1.0"
       sources."bluebird-3.4.7"
       (sources."body-parser-1.19.0" // {
@@ -77225,7 +77679,7 @@ in
       })
       (sources."ext-1.4.0" // {
         dependencies = [
-          sources."type-2.1.0"
+          sources."type-2.2.0"
         ];
       })
       sources."extend-3.0.2"
@@ -77276,7 +77730,7 @@ in
       })
       sources."fs-minipass-2.1.0"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       (sources."fstream-1.0.12" // {
         dependencies = [
           sources."rimraf-2.7.1"
@@ -77315,7 +77769,7 @@ in
       sources."google-gax-2.10.2"
       sources."google-p12-pem-3.0.3"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."gtoken-5.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
@@ -77969,7 +78423,7 @@ in
         ];
       })
       sources."redent-3.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."restore-cursor-3.1.0"
       sources."run-async-2.4.1"
       sources."rxjs-6.6.3"
@@ -78019,44 +78473,11 @@ in
   flood = nodeEnv.buildNodePackage {
     name = "flood";
     packageName = "flood";
-    version = "4.4.0";
+    version = "4.4.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/flood/-/flood-4.4.0.tgz";
-      sha512 = "rLyGvvlEY0Vh2ExK0iB4GSLXYlsBvpT3vJQox4aPQV78j+jX5kLgdFqiwMBs5F7IhJ3JeC0CCyxYnta30sB2PQ==";
+      url = "https://registry.npmjs.org/flood/-/flood-4.4.1.tgz";
+      sha512 = "C15ULT/FBNrjhF4Qf6d235+Pnmyv9TO6fqy4t/dS41emoHAjJsFZe5opefo6OQXtZ7BBvUz0flgPclq4zM3mkg==";
     };
-    dependencies = [
-      sources."async-2.6.3"
-      sources."balanced-match-1.0.0"
-      sources."brace-expansion-1.1.11"
-      sources."buffer-crc32-0.2.13"
-      sources."colors-1.4.0"
-      sources."concat-map-0.0.1"
-      sources."fd-slicer-1.1.0"
-      sources."fs.realpath-1.0.0"
-      sources."geoip-country-4.0.54"
-      sources."glob-7.1.6"
-      sources."iconv-lite-0.5.2"
-      sources."inflight-1.0.6"
-      sources."inherits-2.0.4"
-      sources."ip-address-6.4.0"
-      sources."jsbn-1.1.0"
-      sources."lazy-1.0.11"
-      sources."lodash-4.17.20"
-      sources."lodash.find-4.6.0"
-      sources."lodash.max-4.0.1"
-      sources."lodash.merge-4.6.2"
-      sources."lodash.padstart-4.6.1"
-      sources."lodash.repeat-4.1.0"
-      sources."minimatch-3.0.4"
-      sources."once-1.4.0"
-      sources."path-is-absolute-1.0.1"
-      sources."pend-1.2.0"
-      sources."rimraf-2.7.1"
-      sources."safer-buffer-2.1.2"
-      sources."sprintf-js-1.1.2"
-      sources."wrappy-1.0.2"
-      sources."yauzl-2.10.0"
-    ];
     buildInputs = globalBuildInputs;
     meta = {
       description = "A modern Web UI for various torrent clients with multi-user and multi-client support";
@@ -78213,7 +78634,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-symbols-1.0.1"
       sources."has-value-1.0.0"
@@ -78790,7 +79211,7 @@ in
       sources."arrify-1.0.1"
       sources."atomically-1.7.0"
       sources."base64-js-1.5.1"
-      sources."bl-4.0.4"
+      sources."bl-4.1.0"
       (sources."boxen-5.0.0" // {
         dependencies = [
           sources."camelcase-6.2.0"
@@ -78855,7 +79276,7 @@ in
           sources."get-stream-4.1.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."hard-rejection-2.1.0"
       sources."has-1.0.3"
       sources."has-flag-4.0.0"
@@ -78978,7 +79399,7 @@ in
       sources."redent-3.0.0"
       sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."responselike-1.0.2"
       sources."restore-cursor-3.1.0"
       sources."run-async-2.4.1"
@@ -79072,7 +79493,7 @@ in
           })
         ];
       })
-      (sources."@graphql-tools/delegate-7.0.9" // {
+      (sources."@graphql-tools/delegate-7.0.10" // {
         dependencies = [
           sources."@graphql-tools/utils-7.2.5"
           sources."tslib-2.1.0"
@@ -79286,14 +79707,14 @@ in
           sources."p-cancelable-1.1.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."graphql-15.3.0"
       (sources."graphql-config-3.0.3" // {
         dependencies = [
           sources."cosmiconfig-6.0.0"
         ];
       })
-      sources."graphql-subscriptions-1.1.0"
+      sources."graphql-subscriptions-1.2.0"
       sources."graphql-type-json-0.3.2"
       sources."graphql-upload-11.0.0"
       sources."graphql-ws-4.1.0"
@@ -79497,6 +79918,7 @@ in
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."querystringify-2.2.0"
+      sources."queue-microtask-1.2.2"
       sources."rc-1.2.8"
       sources."reftools-1.1.8"
       sources."regexp.prototype.flags-1.3.1"
@@ -79512,7 +79934,7 @@ in
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
       sources."run-async-2.4.1"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       (sources."rxjs-6.6.3" // {
         dependencies = [
           sources."tslib-1.14.1"
@@ -79782,7 +80204,7 @@ in
       sources."regex-not-1.0.2"
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
@@ -79878,10 +80300,10 @@ in
   makam = nodeEnv.buildNodePackage {
     name = "makam";
     packageName = "makam";
-    version = "0.7.38";
+    version = "0.7.39";
     src = fetchurl {
-      url = "https://registry.npmjs.org/makam/-/makam-0.7.38.tgz";
-      sha512 = "xRlCK3zKbEvQqDUH8C6dW6O+LdV6QDoxzbe2LSghO+ZrZq+iRbnXJvvNFvFRkGFW7fqciGvGq1P1dX5Rkul12w==";
+      url = "https://registry.npmjs.org/makam/-/makam-0.7.39.tgz";
+      sha512 = "6XvSBJfpz1Jr5UHajYsKKLDlFcdYuhVmOJu3IqKsD14BcYoi+oZ+wfta8CVbKvRJDT7mF7e9dzCei8+nlsA3kA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -80265,7 +80687,7 @@ in
       sources."expand-tilde-2.0.2"
       (sources."ext-1.4.0" // {
         dependencies = [
-          sources."type-2.1.0"
+          sources."type-2.2.0"
         ];
       })
       sources."extend-3.0.2"
@@ -80314,7 +80736,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."gulp-cli-2.3.0"
       sources."gulplog-1.0.0"
       sources."has-1.0.3"
@@ -80451,7 +80873,7 @@ in
       sources."replace-homedir-1.0.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-options-1.1.0"
       sources."resolve-url-0.2.1"
@@ -80671,7 +81093,7 @@ in
       sources."expand-tilde-2.0.2"
       (sources."ext-1.4.0" // {
         dependencies = [
-          sources."type-2.1.0"
+          sources."type-2.2.0"
         ];
       })
       sources."extend-3.0.2"
@@ -80706,7 +81128,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."gulplog-1.0.0"
       sources."has-1.0.3"
       sources."has-symbols-1.0.1"
@@ -80842,7 +81264,7 @@ in
       sources."replace-homedir-1.0.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
@@ -80980,7 +81402,7 @@ in
       sources."param-case-2.1.1"
       sources."relateurl-0.2.7"
       sources."source-map-0.6.1"
-      sources."uglify-js-3.12.6"
+      sources."uglify-js-3.12.7"
       sources."upper-case-1.1.3"
     ];
     buildInputs = globalBuildInputs;
@@ -81304,7 +81726,7 @@ in
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
       sources."base64-js-1.5.1"
-      (sources."bl-4.0.4" // {
+      (sources."bl-4.1.0" // {
         dependencies = [
           sources."readable-stream-3.6.0"
         ];
@@ -81460,7 +81882,7 @@ in
           sources."object-assign-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-ansi-2.0.0"
@@ -81717,7 +82139,7 @@ in
       sources."get-stream-4.1.0"
       sources."glob-7.1.6"
       sources."good-listener-1.2.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."historic-readline-1.0.8"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -81868,7 +82290,7 @@ in
       sources."get-stream-4.1.0"
       sources."get-uri-3.0.2"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-flag-4.0.0"
       sources."http-errors-1.7.3"
       sources."http-proxy-agent-4.0.1"
@@ -82182,7 +82604,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
       sources."ecc-jsbn-0.1.2"
-      sources."ejs-3.1.5"
+      sources."ejs-3.1.6"
       sources."emoji-regex-8.0.0"
       sources."error-ex-1.3.2"
       sources."escape-string-regexp-1.0.5"
@@ -82218,7 +82640,7 @@ in
       sources."fast-json-stable-stringify-2.1.0"
       sources."fast-levenshtein-2.0.6"
       sources."file-uri-to-path-1.0.0"
-      sources."filelist-1.0.1"
+      sources."filelist-1.0.2"
       sources."find-up-1.1.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -82230,7 +82652,7 @@ in
       sources."get-caller-file-1.0.3"
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
@@ -82343,7 +82765,7 @@ in
       sources."request-2.88.2"
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-url-0.2.1"
       sources."restore-cursor-3.1.0"
       sources."resumer-0.0.0"
@@ -82477,7 +82899,7 @@ in
       sources."color-name-1.1.3"
       sources."concat-map-0.0.1"
       sources."escape-string-regexp-1.0.5"
-      sources."filelist-1.0.1"
+      sources."filelist-1.0.2"
       sources."has-flag-3.0.0"
       sources."minimatch-3.0.4"
       sources."supports-color-5.5.0"
@@ -82589,8 +83011,8 @@ in
     dependencies = [
       sources."@braintree/sanitize-url-3.1.0"
       sources."@cronvel/get-pixels-3.4.0"
-      sources."@joplin/fork-htmlparser2-4.1.22"
-      sources."@joplin/fork-sax-1.2.26"
+      sources."@joplin/fork-htmlparser2-4.1.23"
+      sources."@joplin/fork-sax-1.2.27"
       sources."@joplin/lib-1.0.18"
       (sources."@joplin/renderer-1.0.26" // {
         dependencies = [
@@ -82599,8 +83021,8 @@ in
           sources."uslug-git+https://github.com/laurent22/uslug.git#emoji-support"
         ];
       })
-      sources."@joplin/turndown-4.0.44"
-      sources."@joplin/turndown-plugin-gfm-1.0.26"
+      sources."@joplin/turndown-4.0.45"
+      sources."@joplin/turndown-plugin-gfm-1.0.27"
       sources."abab-2.0.5"
       sources."abbrev-1.1.1"
       sources."acorn-7.4.1"
@@ -82640,7 +83062,7 @@ in
       sources."async-mutex-0.1.4"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
-      (sources."aws-sdk-2.836.0" // {
+      (sources."aws-sdk-2.841.0" // {
         dependencies = [
           sources."sax-1.2.1"
           sources."uuid-3.3.2"
@@ -82656,7 +83078,7 @@ in
       sources."base64-stream-1.0.0"
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-extensions-2.2.0"
-      (sources."bl-4.0.4" // {
+      (sources."bl-4.1.0" // {
         dependencies = [
           sources."buffer-5.7.1"
           sources."readable-stream-3.6.0"
@@ -82816,7 +83238,7 @@ in
       })
       sources."fs-minipass-1.2.7"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."fstream-1.0.12"
       (sources."gauge-2.7.4" // {
         dependencies = [
@@ -82829,7 +83251,7 @@ in
       sources."github-from-package-0.0.0"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."graphlib-2.1.8"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
@@ -82838,7 +83260,7 @@ in
       sources."has-flag-4.0.0"
       sources."has-unicode-2.0.1"
       sources."he-1.2.0"
-      sources."highlight.js-10.5.0"
+      sources."highlight.js-10.6.0"
       sources."html-encoding-sniffer-1.0.2"
       sources."html-entities-1.4.0"
       sources."html-minifier-3.5.21"
@@ -82998,7 +83420,7 @@ in
           sources."debug-4.3.2"
           sources."html-minifier-4.0.0"
           sources."ms-2.1.2"
-          sources."uglify-js-3.12.6"
+          sources."uglify-js-3.12.7"
         ];
       })
       sources."minimatch-3.0.4"
@@ -83386,13 +83808,13 @@ in
       sha512 = "znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==";
     };
     dependencies = [
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."argparse-1.0.10"
       sources."bluebird-3.7.2"
       sources."catharsis-0.8.11"
       sources."entities-2.0.3"
       sources."escape-string-regexp-2.0.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."js2xmlparser-4.0.1"
       sources."klaw-3.0.0"
       sources."linkify-it-2.2.0"
@@ -83658,7 +84080,7 @@ in
       sources."get-stream-4.1.0"
       sources."global-dirs-3.0.0"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-flag-4.0.0"
       sources."has-yarn-2.1.0"
       sources."http-cache-semantics-4.1.0"
@@ -83903,11 +84325,11 @@ in
       sources."follow-redirects-1.13.2"
       sources."fs-extra-8.1.0"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."get-caller-file-2.0.5"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."http-errors-1.7.2"
       sources."http-proxy-1.18.1"
       sources."iconv-lite-0.4.24"
@@ -84036,7 +84458,7 @@ in
       sources."glob-7.1.6"
       sources."glob-parent-3.1.0"
       sources."glob-stream-6.1.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-symbols-1.0.1"
       sources."inflight-1.0.6"
@@ -84470,7 +84892,7 @@ in
           sources."universal-user-agent-6.0.0"
         ];
       })
-      sources."@octokit/openapi-types-4.0.1"
+      sources."@octokit/openapi-types-4.0.2"
       sources."@octokit/plugin-enterprise-rest-6.0.1"
       (sources."@octokit/plugin-paginate-rest-1.1.2" // {
         dependencies = [
@@ -84496,7 +84918,7 @@ in
         ];
       })
       sources."@octokit/rest-16.43.2"
-      sources."@octokit/types-6.8.2"
+      sources."@octokit/types-6.8.3"
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
       sources."@types/minimist-1.2.1"
@@ -84761,6 +85183,7 @@ in
           sources."extend-shallow-2.0.1"
         ];
       })
+      sources."filter-obj-1.1.0"
       sources."find-up-3.0.0"
       sources."flush-write-stream-1.1.1"
       sources."for-in-1.0.2"
@@ -84852,7 +85275,7 @@ in
           sources."pify-4.0.1"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       (sources."handlebars-4.7.6" // {
         dependencies = [
           sources."source-map-0.6.1"
@@ -85143,7 +85566,7 @@ in
       sources."punycode-2.1.1"
       sources."q-1.5.1"
       sources."qs-6.5.2"
-      sources."query-string-6.13.8"
+      sources."query-string-6.14.0"
       sources."quick-lru-4.0.1"
       sources."read-1.0.7"
       sources."read-cmd-shim-1.0.5"
@@ -85177,7 +85600,7 @@ in
       sources."request-2.88.2"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       (sources."resolve-cwd-2.0.0" // {
         dependencies = [
           sources."resolve-from-3.0.0"
@@ -85324,7 +85747,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
-      sources."uglify-js-3.12.6"
+      sources."uglify-js-3.12.7"
       sources."uid-number-0.0.6"
       sources."umask-1.1.0"
       sources."union-value-1.0.1"
@@ -85412,10 +85835,10 @@ in
       sha512 = "w09o8tZFPThBscl5d0Ggp3RcrKIouBoQscnOMgFH3n5V3kN/CXGHNfCkRPtxJk6nKryDXaV9aHLK55RXuH4sAw==";
     };
     dependencies = [
-      sources."copy-anything-2.0.1"
+      sources."copy-anything-2.0.3"
       sources."debug-3.2.7"
       sources."errno-0.1.8"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."iconv-lite-0.4.24"
       sources."image-size-0.5.5"
       sources."is-what-3.12.0"
@@ -85590,7 +86013,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -85938,7 +86361,7 @@ in
       sources."github-slugger-1.3.0"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       (sources."has-binary2-1.0.3" // {
@@ -86303,7 +86726,7 @@ in
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.12.13"
       sources."@babel/core-7.12.13"
-      sources."@babel/generator-7.12.13"
+      sources."@babel/generator-7.12.15"
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.12.13"
       sources."@babel/helper-compilation-targets-7.12.13"
@@ -86332,7 +86755,7 @@ in
           sources."chalk-2.4.2"
         ];
       })
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/plugin-external-helpers-7.8.3"
       sources."@babel/plugin-proposal-async-generator-functions-7.12.13"
       sources."@babel/plugin-proposal-class-properties-7.12.13"
@@ -86386,7 +86809,7 @@ in
       sources."@babel/plugin-transform-property-literals-7.12.13"
       sources."@babel/plugin-transform-regenerator-7.12.13"
       sources."@babel/plugin-transform-reserved-words-7.12.13"
-      sources."@babel/plugin-transform-runtime-7.12.13"
+      sources."@babel/plugin-transform-runtime-7.12.15"
       sources."@babel/plugin-transform-shorthand-properties-7.12.13"
       sources."@babel/plugin-transform-spread-7.12.13"
       sources."@babel/plugin-transform-sticky-regex-7.12.13"
@@ -86542,7 +86965,7 @@ in
       sources."big.js-5.2.2"
       sources."binary-extensions-2.2.0"
       sources."bindings-1.5.0"
-      (sources."bl-4.0.4" // {
+      (sources."bl-4.1.0" // {
         dependencies = [
           sources."buffer-5.7.1"
           sources."readable-stream-3.6.0"
@@ -86591,7 +87014,7 @@ in
       sources."cached-path-relative-1.0.2"
       sources."call-bind-1.0.2"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       sources."capture-exit-2.0.0"
       sources."caseless-0.12.0"
       (sources."chalk-3.0.0" // {
@@ -86714,7 +87137,7 @@ in
       sources."duplexer2-0.1.4"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       (sources."elliptic-6.5.4" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -86809,7 +87232,7 @@ in
       sources."fs-constants-1.0.0"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."function-bind-1.1.1"
       sources."gensync-1.0.0-beta.2"
       sources."get-assigned-identifiers-1.2.0"
@@ -86834,7 +87257,7 @@ in
       })
       sources."globals-11.12.0"
       sources."google-closure-compiler-js-20170910.0.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       (sources."gunzip-maybe-1.4.2" // {
         dependencies = [
           sources."browserify-zlib-0.1.4"
@@ -87131,7 +87554,7 @@ in
       sources."request-2.88.2"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       (sources."resolve-cwd-2.0.0" // {
         dependencies = [
           sources."resolve-from-3.0.0"
@@ -87640,7 +88063,7 @@ in
       sources."eslint-3.19.0"
       sources."espree-3.5.4"
       sources."esprima-4.0.1"
-      (sources."esquery-1.3.1" // {
+      (sources."esquery-1.4.0" // {
         dependencies = [
           sources."estraverse-5.2.0"
         ];
@@ -87656,7 +88079,7 @@ in
       sources."exit-hook-1.1.1"
       (sources."ext-1.4.0" // {
         dependencies = [
-          sources."type-2.1.0"
+          sources."type-2.2.0"
         ];
       })
       sources."extend-3.0.2"
@@ -87679,7 +88102,7 @@ in
       sources."glob-7.1.6"
       sources."globals-9.18.0"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."gulp-eslint-3.0.1"
       (sources."gulp-util-3.0.8" // {
         dependencies = [
@@ -87780,7 +88203,7 @@ in
       sources."replace-ext-0.0.1"
       sources."request-2.88.0"
       sources."require-uncached-1.0.3"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-1.0.1"
       sources."restore-cursor-1.0.1"
       sources."rimraf-2.6.3"
@@ -87919,7 +88342,7 @@ in
       sources."ansi-styles-4.3.0"
       sources."balanced-match-1.0.0"
       sources."base64-js-1.5.1"
-      sources."bl-4.0.4"
+      sources."bl-4.1.0"
       sources."brace-expansion-1.1.11"
       sources."buffer-5.7.1"
       sources."buffer-crc32-0.2.13"
@@ -88041,7 +88464,7 @@ in
       sources."through-2.3.8"
       sources."try-catch-2.0.1"
       sources."try-to-catch-1.1.1"
-      sources."uglify-js-3.12.6"
+      sources."uglify-js-3.12.7"
       sources."unbzip2-stream-1.4.3"
       sources."upper-case-1.1.3"
       sources."util-deprecate-1.0.2"
@@ -88071,20 +88494,20 @@ in
       sources."@fluentui/date-time-utilities-7.9.0"
       sources."@fluentui/dom-utilities-1.1.1"
       sources."@fluentui/keyboard-key-0.2.13"
-      sources."@fluentui/react-7.158.1"
-      sources."@fluentui/react-focus-7.17.1"
+      sources."@fluentui/react-7.160.0"
+      sources."@fluentui/react-focus-7.17.4"
       sources."@fluentui/react-window-provider-1.0.1"
-      sources."@fluentui/theme-1.7.1"
-      sources."@microsoft/load-themed-styles-1.10.146"
+      sources."@fluentui/theme-1.7.3"
+      sources."@microsoft/load-themed-styles-1.10.147"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@uifabric/foundation-7.9.21"
-      sources."@uifabric/icons-7.5.18"
+      sources."@uifabric/foundation-7.9.24"
+      sources."@uifabric/icons-7.5.21"
       sources."@uifabric/merge-styles-7.19.1"
-      sources."@uifabric/react-hooks-7.13.9"
+      sources."@uifabric/react-hooks-7.13.11"
       sources."@uifabric/set-version-7.0.23"
-      sources."@uifabric/styling-7.16.19"
-      sources."@uifabric/utilities-7.33.2"
+      sources."@uifabric/styling-7.18.0"
+      sources."@uifabric/utilities-7.33.4"
       sources."accepts-1.3.7"
       sources."ajv-6.12.6"
       sources."ansi-escapes-1.4.0"
@@ -88211,7 +88634,7 @@ in
       sources."node-fetch-1.6.3"
       sources."normalize-url-4.5.0"
       sources."object-assign-4.1.1"
-      sources."office-ui-fabric-react-7.158.1"
+      sources."office-ui-fabric-react-7.160.0"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -88302,7 +88725,7 @@ in
       sources."strip-json-comments-2.0.1"
       sources."supports-color-2.0.0"
       sources."swagger-schema-official-2.0.0-bab6bed"
-      sources."swagger-ui-dist-3.41.1"
+      sources."swagger-ui-dist-3.42.0"
       sources."tail-2.2.0"
       sources."through-2.3.8"
       sources."tmp-0.0.33"
@@ -88593,10 +89016,10 @@ in
   netlify-cli = nodeEnv.buildNodePackage {
     name = "netlify-cli";
     packageName = "netlify-cli";
-    version = "3.4.7";
+    version = "3.7.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-3.4.7.tgz";
-      sha512 = "hPfrUlBIA21FgEc/8gXehR5hQ5N5NvFNE9vXojJ+ou93gkeddh6AfKxx29XsOoH+ht7XqAJMf+vbdSZULo+8XQ==";
+      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-3.7.1.tgz";
+      sha512 = "hqvtdK1A6COn6JDw9jJPs02RN9XJmI/ke1LsO8CmtsoDByvhUfjnOUmtX00lk5KHBCMEkmxKBNkG5AVZyhjZSw==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
@@ -88606,7 +89029,7 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."@babel/generator-7.12.13"
+      sources."@babel/generator-7.12.15"
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.12.13"
       (sources."@babel/helper-compilation-targets-7.12.13" // {
@@ -88635,7 +89058,7 @@ in
       sources."@babel/helper-wrap-function-7.12.13"
       sources."@babel/helpers-7.12.13"
       sources."@babel/highlight-7.12.13"
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/plugin-proposal-async-generator-functions-7.12.13"
       sources."@babel/plugin-proposal-class-properties-7.12.13"
       sources."@babel/plugin-proposal-dynamic-import-7.12.1"
@@ -88712,13 +89135,13 @@ in
       sources."@dabh/diagnostics-2.0.2"
       sources."@jest/types-24.9.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
-      (sources."@netlify/build-8.4.0" // {
+      (sources."@netlify/build-9.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."execa-3.4.0"
           sources."locate-path-5.0.0"
-          sources."resolve-2.0.0-next.2"
+          sources."resolve-2.0.0-next.3"
         ];
       })
       (sources."@netlify/cache-utils-1.0.6" // {
@@ -88726,19 +89149,19 @@ in
           sources."locate-path-5.0.0"
         ];
       })
-      (sources."@netlify/config-3.1.2" // {
+      (sources."@netlify/config-4.0.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."execa-3.4.0"
         ];
       })
-      (sources."@netlify/framework-info-2.1.1" // {
+      (sources."@netlify/framework-info-2.3.0" // {
         dependencies = [
           sources."locate-path-5.0.0"
         ];
       })
-      sources."@netlify/functions-utils-1.3.10"
+      sources."@netlify/functions-utils-1.3.11"
       (sources."@netlify/git-utils-1.0.7" // {
         dependencies = [
           sources."braces-3.0.2"
@@ -88779,10 +89202,10 @@ in
       sources."@netlify/traffic-mesh-agent-darwin-x64-0.27.10"
       sources."@netlify/traffic-mesh-agent-linux-x64-0.27.10"
       sources."@netlify/traffic-mesh-agent-win32-x64-0.27.10"
-      (sources."@netlify/zip-it-and-ship-it-2.1.3" // {
+      (sources."@netlify/zip-it-and-ship-it-2.3.0" // {
         dependencies = [
           sources."locate-path-5.0.0"
-          sources."resolve-2.0.0-next.2"
+          sources."resolve-2.0.0-next.3"
         ];
       })
       (sources."@nodelib/fs.scandir-2.1.4" // {
@@ -88913,7 +89336,7 @@ in
           sources."universal-user-agent-6.0.0"
         ];
       })
-      sources."@octokit/openapi-types-4.0.1"
+      sources."@octokit/openapi-types-4.0.2"
       (sources."@octokit/plugin-paginate-rest-1.1.2" // {
         dependencies = [
           sources."@octokit/types-2.16.2"
@@ -88938,7 +89361,7 @@ in
         ];
       })
       sources."@octokit/rest-16.43.2"
-      sources."@octokit/types-6.8.2"
+      sources."@octokit/types-6.8.3"
       sources."@rollup/plugin-babel-5.2.3"
       (sources."@rollup/plugin-commonjs-17.1.0" // {
         dependencies = [
@@ -88987,7 +89410,7 @@ in
       sources."accepts-1.3.7"
       sources."agent-base-6.0.2"
       sources."aggregate-error-3.1.0"
-      sources."ajv-7.0.4"
+      sources."ajv-7.1.0"
       (sources."ansi-align-3.0.0" // {
         dependencies = [
           sources."emoji-regex-7.0.3"
@@ -89031,7 +89454,7 @@ in
       sources."at-least-node-1.0.0"
       sources."atob-2.1.2"
       sources."atob-lite-2.0.0"
-      (sources."aws-sdk-2.836.0" // {
+      (sources."aws-sdk-2.841.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."ieee754-1.1.13"
@@ -89050,7 +89473,7 @@ in
       sources."base64-js-1.5.1"
       sources."before-after-hook-2.1.1"
       sources."binary-extensions-2.2.0"
-      sources."bl-4.0.4"
+      sources."bl-4.1.0"
       (sources."body-parser-1.19.0" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -89092,7 +89515,7 @@ in
       sources."call-bind-1.0.2"
       sources."call-me-maybe-1.0.1"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       sources."cardinal-2.1.1"
       sources."caw-2.0.1"
       sources."ccount-1.1.0"
@@ -89335,7 +89758,7 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       sources."elf-cam-0.1.1"
       sources."emoji-regex-8.0.0"
       sources."enabled-2.0.0"
@@ -89345,6 +89768,7 @@ in
       sources."envinfo-7.7.4"
       sources."error-ex-1.3.2"
       sources."error-stack-parser-2.0.6"
+      sources."esbuild-0.8.44"
       sources."escalade-3.1.1"
       sources."escape-goat-2.1.1"
       sources."escape-html-1.0.3"
@@ -89466,7 +89890,7 @@ in
       sources."fs-constants-1.0.0"
       sources."fs-extra-8.1.0"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."function-bind-1.1.1"
       sources."fuzzy-0.1.3"
       sources."gensync-1.0.0-beta.2"
@@ -89521,7 +89945,7 @@ in
           sources."to-readable-stream-1.0.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       (sources."has-ansi-0.1.0" // {
         dependencies = [
@@ -89809,13 +90233,13 @@ in
       sources."natural-orderby-2.0.3"
       sources."negotiator-0.6.2"
       sources."nested-error-stacks-2.1.0"
-      (sources."netlify-6.1.6" // {
+      (sources."netlify-6.1.7" // {
         dependencies = [
           sources."qs-6.9.6"
         ];
       })
       sources."netlify-plugin-deploy-preview-commenting-0.0.1-alpha.16"
-      sources."netlify-redirect-parser-3.0.2"
+      sources."netlify-redirect-parser-3.0.3"
       sources."netlify-redirector-0.2.1"
       sources."nice-try-1.0.5"
       sources."node-fetch-2.6.1"
@@ -89979,6 +90403,7 @@ in
       sources."qs-6.7.0"
       sources."query-string-5.1.1"
       sources."querystring-0.2.0"
+      sources."queue-microtask-1.2.2"
       sources."random-bytes-1.0.0"
       sources."random-item-3.1.0"
       sources."randombytes-2.1.0"
@@ -90023,7 +90448,7 @@ in
       sources."require-main-filename-2.0.0"
       sources."require-package-name-2.0.1"
       sources."requires-port-1.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
       (sources."restore-cursor-2.0.0" // {
@@ -90035,7 +90460,7 @@ in
       sources."ret-0.1.15"
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
-      sources."rollup-2.38.4"
+      sources."rollup-2.38.5"
       (sources."rollup-plugin-inject-3.0.2" // {
         dependencies = [
           sources."estree-walker-0.6.1"
@@ -90049,7 +90474,7 @@ in
         ];
       })
       sources."run-async-2.4.1"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."rxjs-6.6.3"
       sources."safe-buffer-5.2.1"
       sources."safe-join-0.1.3"
@@ -90259,7 +90684,7 @@ in
       sources."type-fest-0.8.1"
       sources."type-is-1.6.18"
       sources."typedarray-to-buffer-3.1.5"
-      sources."typescript-3.9.7"
+      sources."typescript-3.9.9"
       sources."uid-safe-2.1.5"
       sources."unbzip2-stream-1.4.3"
       sources."unicode-canonical-property-names-ecmascript-1.0.4"
@@ -90456,7 +90881,7 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-unicode-2.0.1"
@@ -90638,7 +91063,7 @@ in
         ];
       })
       sources."glob-5.0.15"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-1.0.5"
       sources."har-validator-4.2.1"
       sources."has-1.0.3"
@@ -90742,7 +91167,7 @@ in
           sources."qs-6.4.0"
         ];
       })
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."rimraf-2.2.8"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
@@ -91012,7 +91437,7 @@ in
       })
       sources."bcrypt-pbkdf-1.0.2"
       sources."bcryptjs-2.4.3"
-      (sources."bl-4.0.4" // {
+      (sources."bl-4.1.0" // {
         dependencies = [
           sources."inherits-2.0.4"
           sources."readable-stream-3.6.0"
@@ -91137,7 +91562,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-flag-3.0.0"
@@ -91498,7 +91923,7 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
@@ -91574,7 +91999,7 @@ in
         ];
       })
       sources."request-2.88.2"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."retry-0.10.1"
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.2.1"
@@ -91686,12 +92111,12 @@ in
       sources."end-of-stream-1.4.4"
       sources."escape-goat-2.1.1"
       sources."fill-range-7.0.1"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."get-stream-4.1.0"
       sources."glob-parent-5.1.1"
       sources."global-dirs-2.1.0"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-flag-3.0.0"
       sources."has-yarn-2.1.0"
       sources."http-cache-semantics-4.1.0"
@@ -91795,10 +92220,10 @@ in
   np = nodeEnv.buildNodePackage {
     name = "np";
     packageName = "np";
-    version = "7.2.0";
+    version = "7.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/np/-/np-7.2.0.tgz";
-      sha512 = "jfMFJXAJlGkCowMPGzA8Ywbmywk7I9hT96DsOcWjDsjq/zP5h6m3VZDcZ1AWYoCBPg4E/lFrJxROmiQH3OWnzA==";
+      url = "https://registry.npmjs.org/np/-/np-7.3.0.tgz";
+      sha512 = "rbKZ7YMtdyv7k2ViAfhkcmDUimQxTMDyGs8qH3Ex2tzoxei9ZSrQUm2LkTzZ7Uwtde9pIAyud/rwsyxS4w9lDg==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
@@ -91946,7 +92371,7 @@ in
           sources."type-fest-0.10.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."hard-rejection-2.1.0"
       sources."has-1.0.3"
       (sources."has-ansi-2.0.0" // {
@@ -92215,6 +92640,7 @@ in
           sources."escape-goat-2.1.1"
         ];
       })
+      sources."queue-microtask-1.2.2"
       sources."quick-lru-4.0.1"
       sources."rc-1.2.8"
       (sources."read-pkg-5.2.0" // {
@@ -92233,7 +92659,7 @@ in
       sources."redent-3.0.0"
       sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       (sources."resolve-cwd-3.0.0" // {
         dependencies = [
           sources."resolve-from-5.0.0"
@@ -92245,7 +92671,7 @@ in
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
       sources."run-async-2.4.1"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."rxjs-6.6.3"
       sources."safer-buffer-2.1.2"
       sources."scoped-regex-2.1.0"
@@ -92325,11 +92751,16 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "7.5.2";
+    version = "7.5.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-7.5.2.tgz";
-      sha512 = "ViuWTzFbHvjvdGDAa5HGsB3kIg3W1FfOxSuKPnjWzewZ0txVhDL/FzxA9bUVnvX8kXvL89Ps0vRhdaiWfDA8NQ==";
+      url = "https://registry.npmjs.org/npm/-/npm-7.5.3.tgz";
+      sha512 = "4MhBvHrQ82v5cvoWe7tX+IK8Z2xsbde9IS9sCP3SKpRo4JOHxe14tpZ/ZOTCy8xkp0DhBYqjxECmWv2EZK8BXg==";
     };
+    dependencies = [
+      sources."@npmcli/installed-package-contents-1.0.7"
+      sources."npm-bundled-1.1.1"
+      sources."npm-normalize-package-bin-1.0.1"
+    ];
     buildInputs = globalBuildInputs;
     meta = {
       description = "a package manager for JavaScript";
@@ -92353,18 +92784,22 @@ in
       sources."@nodelib/fs.stat-2.0.4"
       sources."@nodelib/fs.walk-1.2.6"
       sources."@npmcli/ci-detect-1.3.0"
-      sources."@npmcli/git-2.0.4"
-      sources."@npmcli/installed-package-contents-1.0.5"
+      (sources."@npmcli/git-2.0.4" // {
+        dependencies = [
+          sources."promise-retry-1.1.1"
+        ];
+      })
+      sources."@npmcli/installed-package-contents-1.0.7"
       sources."@npmcli/move-file-1.1.1"
-      sources."@npmcli/node-gyp-1.0.1"
+      sources."@npmcli/node-gyp-1.0.2"
       sources."@npmcli/promise-spawn-1.3.2"
-      sources."@npmcli/run-script-1.8.1"
+      sources."@npmcli/run-script-1.8.3"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@tootallnate/once-1.1.2"
       sources."abbrev-1.1.1"
       sources."agent-base-6.0.2"
-      sources."agentkeepalive-4.1.3"
+      sources."agentkeepalive-4.1.4"
       sources."aggregate-error-3.1.0"
       sources."ajv-6.12.6"
       (sources."ansi-align-3.0.0" // {
@@ -92382,7 +92817,6 @@ in
       sources."are-we-there-yet-1.1.5"
       sources."argparse-2.0.1"
       sources."array-union-2.1.0"
-      sources."asap-2.0.6"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."asynckit-0.4.0"
@@ -92432,14 +92866,12 @@ in
       sources."crypto-random-string-2.0.0"
       sources."dashdash-1.14.1"
       sources."debug-4.3.2"
-      sources."debuglog-1.0.1"
       sources."decompress-response-3.3.0"
       sources."deep-extend-0.6.0"
       sources."defer-to-connect-1.1.3"
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
       sources."depd-1.1.2"
-      sources."dezalgo-1.0.3"
       sources."dir-glob-3.0.1"
       sources."dot-prop-5.3.0"
       sources."duplexer3-0.1.4"
@@ -92485,7 +92917,7 @@ in
       })
       sources."globby-11.0.2"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-flag-4.0.0"
@@ -92557,7 +92989,11 @@ in
           sources."semver-6.3.0"
         ];
       })
-      sources."make-fetch-happen-8.0.13"
+      (sources."make-fetch-happen-8.0.13" // {
+        dependencies = [
+          sources."promise-retry-1.1.1"
+        ];
+      })
       sources."map-age-cleaner-0.1.3"
       sources."mem-8.0.0"
       sources."merge2-1.4.1"
@@ -92604,7 +93040,7 @@ in
           sources."semver-6.3.0"
         ];
       })
-      sources."pacote-11.2.4"
+      sources."pacote-11.2.6"
       sources."parse-github-url-1.0.2"
       sources."path-exists-4.0.0"
       sources."path-is-absolute-1.0.1"
@@ -92615,7 +93051,12 @@ in
       sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
       sources."promise-inflight-1.0.1"
-      sources."promise-retry-1.1.1"
+      (sources."promise-retry-2.0.1" // {
+        dependencies = [
+          sources."err-code-2.0.3"
+          sources."retry-0.12.0"
+        ];
+      })
       sources."prompts-2.4.0"
       sources."psl-1.8.0"
       sources."puka-1.0.1"
@@ -92623,11 +93064,11 @@ in
       sources."punycode-2.1.1"
       sources."pupa-2.1.1"
       sources."qs-6.5.2"
+      sources."queue-microtask-1.2.2"
       sources."rc-1.2.8"
       sources."rc-config-loader-4.0.0"
-      sources."read-package-json-fast-1.2.1"
+      sources."read-package-json-fast-2.0.1"
       sources."readable-stream-2.3.7"
-      sources."readdir-scoped-modules-1.1.0"
       sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."remote-git-tags-3.0.0"
@@ -92637,7 +93078,7 @@ in
       sources."retry-0.10.1"
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."semver-7.3.4"
@@ -92939,7 +93380,7 @@ in
           sources."source-map-0.5.7"
         ];
       })
-      (sources."@babel/generator-7.12.13" // {
+      (sources."@babel/generator-7.12.15" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
@@ -92968,7 +93409,7 @@ in
       sources."@babel/helper-wrap-function-7.12.13"
       sources."@babel/helpers-7.12.13"
       sources."@babel/highlight-7.12.13"
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/plugin-proposal-async-generator-functions-7.12.13"
       sources."@babel/plugin-proposal-class-properties-7.12.13"
       sources."@babel/plugin-proposal-dynamic-import-7.12.1"
@@ -93150,7 +93591,7 @@ in
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chokidar-2.1.8"
@@ -93285,7 +93726,7 @@ in
       sources."duplexer2-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       (sources."elliptic-6.5.4" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -93356,7 +93797,7 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globals-11.12.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."grapheme-breaker-0.3.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
@@ -93702,7 +94143,7 @@ in
       sources."request-2.88.2"
       sources."request-promise-core-1.1.4"
       sources."request-promise-native-1.0.9"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-3.0.0"
       sources."resolve-url-0.2.1"
       sources."restore-cursor-2.0.0"
@@ -94005,7 +94446,7 @@ in
       sources."get-intrinsic-1.1.1"
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."handlebars-4.7.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
@@ -94146,7 +94587,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.18"
-      sources."uglify-js-3.12.6"
+      sources."uglify-js-3.12.7"
       sources."unix-dgram-2.0.4"
       sources."unpipe-1.0.0"
       sources."uri-js-4.4.1"
@@ -94286,7 +94727,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."get-value-2.0.6"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -94551,7 +94992,7 @@ in
       sources."get-intrinsic-1.1.1"
       sources."get-stdin-4.0.1"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
@@ -94664,6 +95105,7 @@ in
       sources."plist-1.2.0"
       sources."process-nextick-args-2.0.1"
       sources."pump-2.0.1"
+      sources."queue-microtask-1.2.2"
       sources."random-access-file-2.1.5"
       sources."random-access-storage-1.4.1"
       sources."random-iterate-1.0.1"
@@ -94677,12 +95119,12 @@ in
       sources."redent-1.0.0"
       sources."regexp.prototype.flags-1.3.1"
       sources."repeating-2.0.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."restore-cursor-2.0.0"
       sources."reverse-http-1.3.0"
       sources."rimraf-2.7.1"
       sources."run-async-2.4.1"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."run-series-1.1.9"
       sources."rusha-0.8.13"
       sources."rxjs-5.5.12"
@@ -94809,7 +95251,7 @@ in
           sources."ws-1.1.5"
         ];
       })
-      sources."bl-4.0.4"
+      sources."bl-4.1.0"
       sources."blob-0.0.5"
       sources."bn.js-4.11.9"
       sources."bncode-0.5.3"
@@ -94896,7 +95338,7 @@ in
       sources."get-browser-rtc-1.1.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       (sources."has-binary2-1.0.3" // {
@@ -95012,6 +95454,7 @@ in
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.7.0"
+      sources."queue-microtask-1.2.2"
       sources."random-access-file-2.1.5"
       sources."random-access-storage-1.4.1"
       sources."random-bytes-1.0.0"
@@ -95028,7 +95471,7 @@ in
         ];
       })
       sources."rimraf-2.7.1"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."run-series-1.1.9"
       sources."rusha-0.8.13"
       sources."safe-buffer-5.1.2"
@@ -95260,7 +95703,7 @@ in
       sources."fill-range-7.0.1"
       sources."follow-redirects-1.13.2"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       (sources."ftp-0.3.10" // {
         dependencies = [
           sources."readable-stream-1.1.14"
@@ -95312,7 +95755,7 @@ in
       sources."mkdirp-1.0.4"
       sources."module-details-from-path-1.0.3"
       sources."moment-2.29.1"
-      sources."moment-timezone-0.5.32"
+      sources."moment-timezone-0.5.33"
       sources."ms-2.1.3"
       sources."mute-stream-0.0.8"
       (sources."needle-2.4.0" // {
@@ -95364,7 +95807,7 @@ in
       })
       sources."readdirp-3.5.0"
       sources."require-in-the-middle-5.1.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."run-series-1.1.9"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
@@ -95426,10 +95869,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "5.16.0";
+    version = "5.17.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-5.16.0.tgz";
-      sha512 = "f7bNVvYGK24eiZ5gYX4wKOSohg6kIybEhrprHqUtFsP3TfttGSLqid1OTzLvVzwVp58QBj9ifOVwRQ+RiSmE0A==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-5.17.1.tgz";
+      sha512 = "jSQZCzWyf3tZSANyWnA/errzlnomqrZQO11yvURLxkLDyJvzi5D1equahjJXyT/ubd7S2iJb8dlkHvqR5ORb3w==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -95453,7 +95896,7 @@ in
       sources."commander-2.11.0"
       sources."file-or-stdin-1.0.2"
       sources."get-stdin-5.0.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."inspect-with-kind-1.0.5"
       sources."kind-of-6.0.3"
       sources."poor-mans-t-sql-formatter-1.6.10"
@@ -95519,12 +95962,12 @@ in
       sources."fastq-1.10.1"
       sources."fill-range-7.0.1"
       sources."fs-extra-9.1.0"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."get-caller-file-2.0.5"
       sources."get-stdin-8.0.0"
       sources."glob-parent-5.1.1"
       sources."globby-11.0.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-flag-4.0.0"
       sources."ignore-5.1.8"
       sources."import-cwd-3.0.0"
@@ -95557,15 +96000,16 @@ in
       sources."path-type-4.0.0"
       sources."picomatch-2.2.2"
       sources."pify-2.3.0"
-      sources."postcss-load-config-3.0.0"
+      sources."postcss-load-config-3.0.1"
       sources."postcss-reporter-7.0.2"
       sources."pretty-hrtime-1.0.3"
+      sources."queue-microtask-1.2.2"
       sources."read-cache-1.0.0"
       sources."readdirp-3.5.0"
       sources."require-directory-2.1.1"
       sources."resolve-from-4.0.0"
       sources."reusify-1.0.4"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."slash-3.0.0"
       sources."string-width-4.2.0"
       sources."strip-ansi-6.0.0"
@@ -95751,7 +96195,7 @@ in
       sources."get-assigned-identifiers-1.2.0"
       sources."glob-7.1.6"
       sources."globule-1.3.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       (sources."hash-base-3.1.0" // {
         dependencies = [
@@ -95843,7 +96287,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."rimraf-2.7.1"
       sources."ripemd160-2.0.2"
       sources."safe-buffer-5.2.1"
@@ -95959,10 +96403,10 @@ in
   purty = nodeEnv.buildNodePackage {
     name = "purty";
     packageName = "purty";
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/purty/-/purty-6.3.0.tgz";
-      sha512 = "l70uQyz+t5GvCPzOorUbIhRX3oQW9i8Kgwr0LvS6nUq+UM4rMJdYcHazuupcLVInvNsbd290EnpjaRgAITt0dw==";
+      url = "https://registry.npmjs.org/purty/-/purty-6.3.1.tgz";
+      sha512 = "KfOSejzz4PExqRwhRuLIJoggKY+cCVLGt+fB4csiyEv3ATX0IB93udl66UW4ZVj/zNJ4Ds+FK9nLfEXcNwBo5A==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -95977,10 +96421,10 @@ in
   pyright = nodeEnv.buildNodePackage {
     name = "pyright";
     packageName = "pyright";
-    version = "1.1.108";
+    version = "1.1.109";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.108.tgz";
-      sha512 = "LX6nLg1uu9DXSuvM4PeqSX2mVAzwoh8RfhTLK/W7zpEFYmdKVZXpJlgzwSfPVrRWjq/bEmj+hIYckkx0adBMjQ==";
+      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.109.tgz";
+      sha512 = "CAaPMKMmeucbbaDLADjhtOdr/KEKknALovBlGh+VbFqAVta1rxrytiIzF2V6xKWx0QpKdkRixkItSa8rTWalnw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -96123,7 +96567,7 @@ in
       sources."reduce-flatten-1.0.1"
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."semver-5.7.1"
@@ -96337,7 +96781,7 @@ in
       sources."esprima-3.1.3"
       sources."esprima-fb-13001.1001.0-dev-harmony-fb"
       sources."glob-5.0.15"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."iconv-lite-0.4.24"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -96371,10 +96815,10 @@ in
   readability-cli = nodeEnv.buildNodePackage {
     name = "readability-cli";
     packageName = "readability-cli";
-    version = "2.0.0-pre.5";
+    version = "2.2.1-pre";
     src = fetchurl {
-      url = "https://registry.npmjs.org/readability-cli/-/readability-cli-2.0.0-pre.5.tgz";
-      sha512 = "FCo6lqXhdj7sn7c2dzT+sp/DiQ9EsFnm+hVs5uzH2tP/qYahcwZN8vfKi+iJaoBfOgWgfnOH/1MM8IDj8lGGXg==";
+      url = "https://registry.npmjs.org/readability-cli/-/readability-cli-2.2.1-pre.tgz";
+      sha512 = "1f8y1ZeGRYskJyZZQzXVw5OlzQKs597JEr48wBzD6ZhmDhUbtqxswsFYROfCigWpkxywBsykesDy8ENKDOYQZg==";
     };
     dependencies = [
       sources."@gardenapple/yargs-17.0.0-candidate.0"
@@ -96525,7 +96969,7 @@ in
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
-      (sources."@babel/generator-7.12.13" // {
+      (sources."@babel/generator-7.12.15" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
@@ -96537,7 +96981,7 @@ in
       sources."@babel/helper-split-export-declaration-7.12.13"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/highlight-7.12.13"
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/runtime-7.12.13"
       sources."@babel/template-7.12.13"
       sources."@babel/traverse-7.12.13"
@@ -96548,6 +96992,7 @@ in
       sources."@emotion/unitless-0.7.5"
       sources."@exodus/schemasafe-1.0.0-rc.3"
       sources."@redocly/react-dropdown-aria-2.0.11"
+      sources."@scarf/scarf-1.1.0"
       sources."@types/node-13.13.41"
       sources."ajv-5.5.2"
       sources."ansi-regex-5.0.0"
@@ -96651,7 +97096,7 @@ in
       sources."find-up-4.1.0"
       sources."foreach-2.0.5"
       sources."format-util-1.0.5"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."get-caller-file-2.0.5"
       sources."glob-parent-5.1.1"
       sources."globals-11.12.0"
@@ -96708,7 +97153,7 @@ in
       sources."minimalistic-crypto-utils-1.0.1"
       sources."minimist-1.2.5"
       sources."mkdirp-1.0.4"
-      sources."mobx-6.1.5"
+      sources."mobx-6.1.6"
       sources."mobx-react-7.1.0"
       sources."mobx-react-lite-3.2.0"
       sources."ms-2.1.2"
@@ -96740,7 +97185,7 @@ in
       sources."pbkdf2-3.1.1"
       sources."perfect-scrollbar-1.5.0"
       sources."picomatch-2.2.2"
-      sources."polished-3.6.7"
+      sources."polished-3.7.0"
       sources."postcss-value-parser-4.1.0"
       sources."prismjs-1.23.0"
       sources."process-0.11.10"
@@ -96759,7 +97204,7 @@ in
       sources."react-16.14.0"
       sources."react-dom-16.14.0"
       sources."react-is-16.13.1"
-      sources."react-tabs-3.1.2"
+      sources."react-tabs-3.2.0"
       (sources."readable-stream-2.3.7" // {
         dependencies = [
           sources."inherits-2.0.4"
@@ -96808,7 +97253,7 @@ in
       sources."to-regex-range-5.0.1"
       sources."tslib-2.1.0"
       sources."tty-browserify-0.0.0"
-      sources."uglify-js-3.12.6"
+      sources."uglify-js-3.12.7"
       (sources."url-0.11.0" // {
         dependencies = [
           sources."punycode-1.3.2"
@@ -96878,13 +97323,13 @@ in
   rollup = nodeEnv.buildNodePackage {
     name = "rollup";
     packageName = "rollup";
-    version = "2.38.4";
+    version = "2.38.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/rollup/-/rollup-2.38.4.tgz";
-      sha512 = "B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==";
+      url = "https://registry.npmjs.org/rollup/-/rollup-2.38.5.tgz";
+      sha512 = "VoWt8DysFGDVRGWuHTqZzT02J0ASgjVq/hPs9QcBOGMd7B+jfTr/iqMVEyOi901rE3xq+Deq66GzIT1yt7sGwQ==";
     };
     dependencies = [
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -96933,14 +97378,14 @@ in
       sources."@types/node-12.12.70"
       sources."@types/node-fetch-2.5.8"
       sources."@types/resolve-1.17.1"
-      sources."@types/vscode-1.52.0"
-      sources."@typescript-eslint/eslint-plugin-4.14.2"
-      sources."@typescript-eslint/experimental-utils-4.14.2"
-      sources."@typescript-eslint/parser-4.14.2"
-      sources."@typescript-eslint/scope-manager-4.14.2"
-      sources."@typescript-eslint/types-4.14.2"
-      sources."@typescript-eslint/typescript-estree-4.14.2"
-      sources."@typescript-eslint/visitor-keys-4.14.2"
+      sources."@types/vscode-1.53.0"
+      sources."@typescript-eslint/eslint-plugin-4.15.0"
+      sources."@typescript-eslint/experimental-utils-4.15.0"
+      sources."@typescript-eslint/parser-4.15.0"
+      sources."@typescript-eslint/scope-manager-4.15.0"
+      sources."@typescript-eslint/types-4.15.0"
+      sources."@typescript-eslint/typescript-estree-4.15.0"
+      sources."@typescript-eslint/visitor-keys-4.15.0"
       sources."@ungap/promise-all-settled-1.1.2"
       sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
@@ -97046,7 +97491,7 @@ in
         ];
       })
       sources."esprima-4.0.1"
-      (sources."esquery-1.3.1" // {
+      (sources."esquery-1.4.0" // {
         dependencies = [
           sources."estraverse-5.2.0"
         ];
@@ -97086,7 +97531,7 @@ in
       sources."glob-parent-5.1.1"
       sources."globals-12.4.0"
       sources."globby-11.0.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."growl-1.10.5"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
@@ -97182,6 +97627,7 @@ in
       sources."progress-2.0.3"
       sources."pseudomap-1.0.2"
       sources."punycode-2.1.1"
+      sources."queue-microtask-1.2.2"
       sources."randombytes-2.1.0"
       sources."read-1.0.7"
       (sources."readable-stream-2.3.7" // {
@@ -97194,16 +97640,16 @@ in
       sources."require-directory-2.1.1"
       sources."require-from-string-2.0.2"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-4.0.0"
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
-      (sources."rollup-2.38.4" // {
+      (sources."rollup-2.38.5" // {
         dependencies = [
-          sources."fsevents-2.3.1"
+          sources."fsevents-2.3.2"
         ];
       })
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."safe-buffer-5.2.1"
       sources."semver-7.3.4"
       sources."serialize-javascript-5.0.1"
@@ -97233,7 +97679,7 @@ in
       sources."supports-color-5.5.0"
       (sources."table-6.0.7" // {
         dependencies = [
-          sources."ajv-7.0.4"
+          sources."ajv-7.1.0"
           sources."json-schema-traverse-1.0.0"
         ];
       })
@@ -97251,7 +97697,7 @@ in
       sources."type-check-0.4.0"
       sources."type-fest-0.8.1"
       sources."typed-rest-client-1.2.0"
-      sources."typescript-4.1.3"
+      sources."typescript-4.1.5"
       sources."typescript-formatter-7.2.2"
       sources."uc.micro-1.0.6"
       sources."underscore-1.8.3"
@@ -97463,10 +97909,10 @@ in
   sass = nodeEnv.buildNodePackage {
     name = "sass";
     packageName = "sass";
-    version = "1.32.6";
+    version = "1.32.7";
     src = fetchurl {
-      url = "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz";
-      sha512 = "1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==";
+      url = "https://registry.npmjs.org/sass/-/sass-1.32.7.tgz";
+      sha512 = "C8Z4bjqGWnsYa11o8hpKAuoyFdRhrSHcYjCr+XAWVPSIQqC8mp2f5Dx4em0dKYehPzg5XSekmCjqJnEZbIls9A==";
     };
     dependencies = [
       sources."anymatch-3.1.1"
@@ -97474,7 +97920,7 @@ in
       sources."braces-3.0.2"
       sources."chokidar-3.5.1"
       sources."fill-range-7.0.1"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."glob-parent-5.1.1"
       sources."is-binary-path-2.1.0"
       sources."is-extglob-2.1.1"
@@ -97626,10 +98072,10 @@ in
   serverless = nodeEnv.buildNodePackage {
     name = "serverless";
     packageName = "serverless";
-    version = "2.22.0";
+    version = "2.23.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serverless/-/serverless-2.22.0.tgz";
-      sha512 = "uXKeoPZfOrTU6ZpHUng7cYZfKQd8aFHfDsX11JHeznPGhBuq1KfF/14o2VEOoFPeTHTHKmHzkWbIKYhJHHBxuw==";
+      url = "https://registry.npmjs.org/serverless/-/serverless-2.23.0.tgz";
+      sha512 = "D5RN0ywVPxL4EFfIzREx9K7vgkHlXBQQn9zTfDzlfz2WHkmKX0kW3LG89J51UYNdeKlBN1YXPIphybzZH3ujOw==";
     };
     dependencies = [
       sources."2-thenable-1.0.0"
@@ -97661,23 +98107,12 @@ in
         ];
       })
       sources."@serverless/component-metrics-1.0.8"
-      (sources."@serverless/components-3.6.1" // {
+      (sources."@serverless/components-3.6.2" // {
         dependencies = [
-          (sources."@serverless/utils-2.2.0" // {
-            dependencies = [
-              sources."js-yaml-4.0.0"
-            ];
-          })
           sources."ansi-regex-5.0.0"
-          sources."argparse-2.0.1"
-          (sources."js-yaml-3.14.1" // {
-            dependencies = [
-              sources."argparse-1.0.10"
-            ];
-          })
+          sources."js-yaml-3.14.1"
           sources."ramda-0.27.1"
           sources."strip-ansi-6.0.0"
-          sources."write-file-atomic-3.0.3"
         ];
       })
       (sources."@serverless/core-1.1.2" // {
@@ -97687,7 +98122,7 @@ in
           sources."semver-6.3.0"
         ];
       })
-      (sources."@serverless/enterprise-plugin-4.4.2" // {
+      (sources."@serverless/enterprise-plugin-4.4.3" // {
         dependencies = [
           sources."js-yaml-3.14.1"
         ];
@@ -97763,7 +98198,7 @@ in
       (sources."archiver-5.2.0" // {
         dependencies = [
           sources."async-3.2.0"
-          sources."bl-4.0.4"
+          sources."bl-4.1.0"
           sources."tar-stream-2.2.0"
         ];
       })
@@ -97790,7 +98225,7 @@ in
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."at-least-node-1.0.0"
-      (sources."aws-sdk-2.836.0" // {
+      (sources."aws-sdk-2.841.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."ieee754-1.1.13"
@@ -98049,7 +98484,7 @@ in
       sources."fs-minipass-2.1.0"
       sources."fs.realpath-1.0.0"
       sources."fs2-0.3.9"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       (sources."gauge-2.7.4" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -98079,7 +98514,7 @@ in
           sources."responselike-2.0.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."graphlib-2.1.8"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
@@ -98162,7 +98597,7 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-4.0.0"
       sources."jsprim-1.4.1"
-      (sources."jszip-3.5.0" // {
+      (sources."jszip-3.6.0" // {
         dependencies = [
           sources."readable-stream-2.3.7"
           sources."safe-buffer-5.1.2"
@@ -98314,6 +98749,7 @@ in
       sources."qs-6.5.2"
       sources."query-string-5.1.1"
       sources."querystring-0.2.0"
+      sources."queue-microtask-1.2.2"
       sources."quick-lru-5.1.1"
       sources."ramda-0.26.1"
       sources."rc-1.2.8"
@@ -98338,8 +98774,8 @@ in
       sources."retry-0.10.1"
       sources."reusify-1.0.4"
       sources."run-async-2.4.1"
-      sources."run-parallel-1.1.10"
-      sources."run-parallel-limit-1.0.6"
+      sources."run-parallel-1.2.0"
+      sources."run-parallel-limit-1.1.0"
       sources."rxjs-6.6.3"
       sources."safe-buffer-5.2.1"
       sources."safer-buffer-2.1.2"
@@ -98354,7 +98790,7 @@ in
       sources."signal-exit-3.0.3"
       sources."simple-concat-1.0.1"
       sources."simple-get-2.8.1"
-      (sources."simple-git-2.31.0" // {
+      (sources."simple-git-2.34.2" // {
         dependencies = [
           sources."debug-4.3.2"
           sources."ms-2.1.2"
@@ -98465,7 +98901,7 @@ in
       sources."tslib-1.14.1"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."type-2.1.0"
+      sources."type-2.2.0"
       sources."type-fest-0.11.0"
       sources."typedarray-to-buffer-3.1.5"
       sources."unbzip2-stream-1.4.3"
@@ -98868,7 +99304,7 @@ in
       sources."for-in-1.0.2"
       sources."fragment-cache-0.2.1"
       sources."get-value-2.0.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."graceful-readlink-1.0.1"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
@@ -99177,13 +99613,13 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.441.0";
+    version = "1.452.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.441.0.tgz";
-      sha512 = "eMiggcjoGuV9rhg7nHdhb7e1JUAvOCz+nWo/+5wpmU6C22RBDqpkktvrdRbKO816exJr1rFLPRSqbzN1efyjnA==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.452.0.tgz";
+      sha512 = "afwZGN8ze1J1SMGtI5TbjYtESREWFD78oqum1azV6fuCOwS5j8aYcEFep358dqUcKnKEG5TIJ0J09+fW/AvSjw==";
     };
     dependencies = [
-      sources."@open-policy-agent/opa-wasm-git+https://github.com/open-policy-agent/npm-opa-wasm.git#f4a21fe6f4d70706f85106dc6ea867983747e040"
+      sources."@open-policy-agent/opa-wasm-1.2.0"
       sources."@sindresorhus/is-2.1.1"
       sources."@snyk/cli-interface-2.11.0"
       (sources."@snyk/cocoapods-lockfile-parser-3.5.2" // {
@@ -99222,7 +99658,6 @@ in
       sources."@types/keyv-3.1.1"
       sources."@types/node-14.14.25"
       sources."@types/responselike-1.0.0"
-      sources."@types/semver-5.5.0"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."abbrev-1.1.1"
       sources."agent-base-4.3.0"
@@ -99254,7 +99689,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
-      (sources."bl-4.0.4" // {
+      (sources."bl-4.1.0" // {
         dependencies = [
           sources."readable-stream-3.6.0"
           sources."safe-buffer-5.2.1"
@@ -99330,7 +99765,7 @@ in
           sources."string_decoder-1.3.0"
         ];
       })
-      sources."dockerfile-ast-0.0.30"
+      sources."dockerfile-ast-0.1.0"
       sources."dot-prop-5.3.0"
       sources."dotnet-deps-parser-5.0.0"
       sources."duplexer3-0.1.4"
@@ -99373,7 +99808,7 @@ in
       sources."glob-7.1.6"
       sources."global-dirs-2.1.0"
       sources."got-11.4.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."graphlib-2.1.8"
       sources."gunzip-maybe-1.4.2"
       sources."has-flag-3.0.0"
@@ -99437,7 +99872,7 @@ in
       sources."isexe-2.0.0"
       sources."js-yaml-3.14.1"
       sources."json-buffer-3.0.1"
-      (sources."jszip-3.5.0" // {
+      (sources."jszip-3.6.0" // {
         dependencies = [
           sources."pako-1.0.11"
         ];
@@ -99451,17 +99886,30 @@ in
       sources."lodash.assignin-4.2.0"
       sources."lodash.clone-4.5.0"
       sources."lodash.clonedeep-4.5.0"
+      sources."lodash.constant-3.0.0"
+      sources."lodash.filter-4.6.0"
       sources."lodash.findkey-4.6.0"
       sources."lodash.flatmap-4.5.0"
       sources."lodash.flatten-4.4.0"
+      sources."lodash.foreach-4.5.0"
       sources."lodash.get-4.4.2"
+      sources."lodash.has-4.5.2"
       sources."lodash.invert-4.3.0"
       sources."lodash.isempty-4.4.0"
       sources."lodash.isequal-4.5.0"
+      sources."lodash.isfunction-3.0.9"
+      sources."lodash.isundefined-3.0.1"
+      sources."lodash.keys-4.2.0"
+      sources."lodash.map-4.6.0"
       sources."lodash.merge-4.6.2"
+      sources."lodash.reduce-4.6.0"
       sources."lodash.set-4.3.2"
+      sources."lodash.size-4.2.0"
       sources."lodash.topairs-4.3.0"
+      sources."lodash.transform-4.6.0"
+      sources."lodash.union-4.6.0"
       sources."lodash.uniq-4.5.0"
+      sources."lodash.values-4.3.0"
       sources."lowercase-keys-2.0.0"
       sources."lru-cache-5.1.1"
       sources."macos-release-2.4.1"
@@ -99577,7 +100025,7 @@ in
           sources."tslib-2.1.0"
         ];
       })
-      (sources."snyk-docker-plugin-4.13.1" // {
+      (sources."snyk-docker-plugin-4.16.0" // {
         dependencies = [
           sources."rimraf-3.0.2"
           sources."tmp-0.2.1"
@@ -99650,9 +100098,9 @@ in
           sources."tslib-1.11.1"
         ];
       })
-      (sources."snyk-poetry-lockfile-parser-1.1.2" // {
+      (sources."snyk-poetry-lockfile-parser-1.1.5" // {
         dependencies = [
-          (sources."@snyk/dep-graph-1.23.0" // {
+          (sources."@snyk/dep-graph-1.23.1" // {
             dependencies = [
               sources."tslib-1.14.1"
             ];
@@ -99671,20 +100119,16 @@ in
           })
         ];
       })
-      sources."snyk-python-plugin-1.19.2"
+      sources."snyk-python-plugin-1.19.4"
       (sources."snyk-resolve-1.0.1" // {
         dependencies = [
           sources."debug-3.2.7"
         ];
       })
-      (sources."snyk-resolve-deps-4.4.0" // {
+      (sources."snyk-resolve-deps-4.7.2" // {
         dependencies = [
-          sources."@types/node-6.14.13"
-          sources."debug-3.2.7"
-          sources."hosted-git-info-2.8.8"
           sources."lru-cache-4.1.5"
           sources."semver-5.7.1"
-          sources."snyk-module-1.9.1"
           sources."yallist-2.1.2"
         ];
       })
@@ -99905,7 +100349,7 @@ in
       sources."get-stream-3.0.0"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
       sources."hosted-git-info-2.8.8"
@@ -99974,7 +100418,7 @@ in
       sources."redent-2.0.0"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."restore-cursor-2.0.0"
       sources."round-to-3.0.0"
       sources."safe-buffer-5.2.1"
@@ -100034,6 +100478,13 @@ in
       sha512 = "+KXfMBecoFFAo0C4FTfSsH2ZXtrL2aQDXgVlQ0NrYdNLHW2TEnibV0hG3yq3hOlAEUQmrwVHZATfVToO825gxA==";
     };
     dependencies = [
+      (sources."@sammacbeth/random-access-idb-mutable-file-0.1.1" // {
+        dependencies = [
+          sources."buffer-5.1.0"
+          sources."random-access-storage-1.3.0"
+        ];
+      })
+      sources."@types/minimatch-3.0.3"
       sources."abstract-leveldown-6.0.3"
       sources."aligned-block-file-1.2.2"
       sources."ansi-escapes-1.4.0"
@@ -100044,17 +100495,25 @@ in
       sources."arr-diff-2.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
+      sources."array-differ-3.0.0"
       sources."array-filter-1.0.0"
       sources."array-union-1.0.2"
       sources."array-uniq-1.0.3"
       sources."array-unique-0.2.1"
       sources."arrify-1.0.1"
       sources."assign-symbols-1.0.0"
+      (sources."async-append-only-log-3.0.3" // {
+        dependencies = [
+          sources."push-stream-11.0.0"
+        ];
+      })
       sources."async-each-1.0.3"
       sources."async-single-1.0.5"
       sources."async-write-2.1.0"
       sources."atob-2.1.2"
       sources."atomic-file-1.1.5"
+      sources."atomically-1.7.0"
+      sources."atomically-universal-0.1.1"
       sources."attach-ware-1.1.1"
       sources."available-typed-arrays-1.0.2"
       sources."bail-1.0.5"
@@ -100070,12 +100529,17 @@ in
       sources."bash-color-0.0.4"
       sources."binary-extensions-1.13.1"
       sources."binary-search-1.3.6"
+      sources."binary-search-bounds-2.0.5"
       sources."bindings-1.5.0"
+      sources."bipf-1.4.0"
       sources."blake2s-1.1.0"
       sources."brace-expansion-1.1.11"
       sources."braces-1.8.5"
       sources."broadcast-stream-0.2.2"
       sources."buffer-5.7.1"
+      sources."buffer-alloc-1.2.0"
+      sources."buffer-alloc-unsafe-1.1.0"
+      sources."buffer-fill-1.0.0"
       sources."buffer-from-1.1.1"
       (sources."cache-base-1.0.1" // {
         dependencies = [
@@ -100117,6 +100581,8 @@ in
       sources."code-point-at-1.1.0"
       sources."collapse-white-space-1.0.6"
       sources."collection-visit-1.0.0"
+      sources."color-convert-2.0.1"
+      sources."color-name-1.1.4"
       sources."commander-2.20.3"
       sources."compare-at-paths-1.0.0"
       sources."component-emitter-1.3.0"
@@ -100138,6 +100604,7 @@ in
       sources."continuable-series-1.2.0"
       sources."copy-descriptor-0.1.1"
       sources."core-util-is-1.0.2"
+      sources."cpu-percentage-1.0.3"
       sources."cross-spawn-6.0.5"
       sources."debug-4.3.2"
       sources."decode-uri-component-0.2.0"
@@ -100168,6 +100635,7 @@ in
           sources."abstract-leveldown-6.3.0"
         ];
       })
+      sources."end-of-stream-1.4.4"
       sources."epidemic-broadcast-trees-7.0.0"
       sources."errno-0.1.8"
       (sources."es-abstract-1.18.0-next.2" // {
@@ -100182,6 +100650,16 @@ in
       })
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
+      (sources."execa-4.1.0" // {
+        dependencies = [
+          sources."cross-spawn-7.0.3"
+          sources."onetime-5.1.2"
+          sources."path-key-3.1.1"
+          sources."shebang-command-2.0.0"
+          sources."shebang-regex-3.0.0"
+          sources."which-2.0.2"
+        ];
+      })
       sources."exit-hook-1.1.1"
       sources."expand-brackets-0.1.5"
       sources."expand-range-1.8.2"
@@ -100194,9 +100672,11 @@ in
       })
       sources."extend.js-0.0.2"
       sources."extglob-0.3.2"
+      sources."fastintcompression-0.0.4"
       sources."file-uri-to-path-1.0.0"
       sources."filename-regex-2.0.1"
       sources."fill-range-2.2.4"
+      sources."find-up-4.1.0"
       (sources."flumecodec-0.0.0" // {
         dependencies = [
           sources."level-codec-6.2.0"
@@ -100242,15 +100722,17 @@ in
       sources."fsevents-1.2.13"
       sources."function-bind-1.1.1"
       sources."get-intrinsic-1.1.1"
+      sources."get-stream-5.2.0"
       sources."get-value-2.0.6"
       sources."glob-6.0.4"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
       sources."globby-4.1.0"
       sources."gossip-query-2.0.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
+      sources."has-flag-4.0.0"
       sources."has-network-0.0.1"
       sources."has-symbols-1.0.1"
       (sources."has-value-1.0.0" // {
@@ -100272,8 +100754,10 @@ in
       sources."he-0.5.0"
       sources."heap-0.2.6"
       sources."hoox-0.0.1"
+      sources."human-signals-1.1.1"
       sources."idb-kv-store-4.5.0"
       sources."ieee754-1.2.1"
+      sources."ignore-5.1.8"
       sources."immediate-3.2.3"
       sources."increment-buffer-1.0.1"
       sources."inflight-1.0.6"
@@ -100319,6 +100803,7 @@ in
       sources."is-negative-zero-2.0.1"
       sources."is-number-2.1.0"
       sources."is-number-object-1.0.4"
+      sources."is-options-1.0.1"
       (sources."is-plain-object-2.0.4" // {
         dependencies = [
           sources."isobject-3.0.1"
@@ -100328,6 +100813,7 @@ in
       sources."is-primitive-2.0.0"
       sources."is-regex-1.1.2"
       sources."is-set-2.0.2"
+      sources."is-stream-2.0.0"
       sources."is-string-1.0.5"
       sources."is-symbol-1.0.3"
       sources."is-typed-array-1.1.4"
@@ -100339,6 +100825,14 @@ in
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
       sources."isobject-2.1.0"
+      (sources."jitdb-2.0.7" // {
+        dependencies = [
+          sources."mkdirp-1.0.4"
+          sources."push-stream-11.0.0"
+          sources."typedarray-to-buffer-4.0.0"
+        ];
+      })
+      sources."jsesc-3.0.2"
       sources."json-buffer-2.0.11"
       sources."kind-of-3.2.2"
       sources."layered-graph-1.1.3"
@@ -100365,6 +100859,8 @@ in
       sources."libnested-1.5.0"
       sources."libsodium-0.7.9"
       sources."libsodium-wrappers-0.7.9"
+      sources."locate-path-5.0.0"
+      sources."lodash.debounce-4.0.8"
       sources."lodash.get-4.4.2"
       sources."log-symbols-1.0.2"
       sources."log-update-1.0.2"
@@ -100379,7 +100875,9 @@ in
       sources."markdown-table-0.4.0"
       sources."math-random-1.0.4"
       sources."mdmanifest-1.0.8"
+      sources."merge-stream-2.0.0"
       sources."micromatch-2.3.11"
+      sources."mimic-fn-2.1.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
       (sources."mixin-deep-1.3.2" // {
@@ -100388,12 +100886,20 @@ in
         ];
       })
       sources."mkdirp-0.5.5"
+      sources."mkdirp-classic-0.5.3"
       sources."monotonic-timestamp-0.0.9"
       sources."moo-0.5.1"
+      sources."mri-1.1.6"
       sources."ms-2.1.2"
       sources."multiblob-1.13.7"
       sources."multiblob-http-1.0.0"
       sources."multicb-1.2.2"
+      (sources."multimatch-4.0.0" // {
+        dependencies = [
+          sources."array-union-2.1.0"
+          sources."arrify-2.0.1"
+        ];
+      })
       sources."multiserver-3.7.0"
       sources."multiserver-address-1.0.1"
       sources."multiserver-scopes-1.0.0"
@@ -100418,12 +100924,18 @@ in
       sources."napi-macros-2.0.0"
       sources."ncp-2.0.0"
       sources."nearley-2.20.1"
+      sources."next-tick-1.1.0"
       sources."nice-try-1.0.5"
       sources."node-gyp-build-4.2.3"
       sources."non-private-ip-1.4.4"
       sources."normalize-path-2.1.1"
       sources."normalize-uri-1.1.3"
       sources."npm-prefix-1.2.0"
+      (sources."npm-run-path-4.0.1" // {
+        dependencies = [
+          sources."path-key-3.1.1"
+        ];
+      })
       sources."number-is-nan-1.0.1"
       sources."object-assign-4.1.1"
       (sources."object-copy-0.1.0" // {
@@ -100466,11 +100978,16 @@ in
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
+      sources."p-defer-3.0.0"
+      sources."p-limit-2.3.0"
+      sources."p-locate-4.1.0"
+      sources."p-try-2.2.0"
       sources."packet-stream-2.0.5"
       sources."packet-stream-codec-1.1.3"
       sources."parse-entities-1.2.2"
       sources."parse-glob-3.0.4"
       sources."pascalcase-0.1.1"
+      sources."path-exists-4.0.0"
       sources."path-is-absolute-1.0.1"
       sources."path-key-2.0.1"
       sources."path-parse-1.0.6"
@@ -100478,13 +100995,25 @@ in
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
       sources."plur-2.1.2"
+      sources."polyraf-1.1.0"
       sources."posix-character-classes-0.1.1"
       sources."preserve-0.2.0"
+      sources."prettier-2.2.1"
+      (sources."pretty-quick-3.1.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."chalk-3.0.0"
+          sources."supports-color-7.2.0"
+        ];
+      })
       sources."private-box-0.3.1"
       sources."process-nextick-args-2.0.1"
+      sources."promisify-4loc-1.0.0"
       sources."promisize-1.1.2"
       sources."prr-1.0.1"
       sources."pull-abortable-4.0.0"
+      sources."pull-async-1.0.0"
+      sources."pull-awaitable-1.0.0"
       sources."pull-box-stream-1.0.13"
       sources."pull-cat-1.1.11"
       sources."pull-catch-1.0.1"
@@ -100522,6 +101051,7 @@ in
       sources."pull-sink-through-0.0.0"
       sources."pull-sort-1.0.2"
       sources."pull-stream-3.6.14"
+      sources."pull-thenable-1.0.0"
       (sources."pull-through-1.0.18" // {
         dependencies = [
           sources."looper-3.0.0"
@@ -100537,10 +101067,28 @@ in
       sources."pull-write-1.1.4"
       sources."pull-write-file-0.2.4"
       sources."pull-ws-3.3.2"
+      sources."pump-3.0.0"
       sources."push-stream-10.1.2"
       sources."push-stream-to-pull-stream-1.0.3"
+      sources."quicktask-1.0.1"
       sources."railroad-diagrams-1.0.0"
       sources."randexp-0.4.6"
+      sources."random-access-chrome-file-1.1.4"
+      sources."random-access-file-2.1.5"
+      (sources."random-access-idb-1.2.1" // {
+        dependencies = [
+          sources."buffer-from-0.1.2"
+        ];
+      })
+      (sources."random-access-idb-mutable-file-0.3.0" // {
+        dependencies = [
+          sources."buffer-5.1.0"
+          sources."random-access-storage-1.3.0"
+        ];
+      })
+      sources."random-access-memory-3.1.2"
+      sources."random-access-storage-1.4.1"
+      sources."random-access-web-2.0.3"
       (sources."randomatic-3.1.1" // {
         dependencies = [
           sources."is-number-4.0.0"
@@ -100632,6 +101180,7 @@ in
       sources."rwlock-5.0.0"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
+      sources."sanitize-filename-1.6.3"
       sources."secret-handshake-1.1.20"
       sources."secret-stack-6.3.2"
       sources."semver-5.7.1"
@@ -100650,6 +101199,7 @@ in
           sources."object-inspect-1.9.0"
         ];
       })
+      sources."signal-exit-3.0.3"
       sources."smart-buffer-4.1.0"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
@@ -100698,8 +101248,30 @@ in
       sources."ssb-client-4.9.0"
       sources."ssb-config-3.4.5"
       sources."ssb-db-19.2.0"
+      (sources."ssb-db2-1.11.2" // {
+        dependencies = [
+          sources."abstract-leveldown-6.2.3"
+          sources."flumecodec-0.0.1"
+          sources."level-6.0.1"
+          sources."level-codec-6.2.0"
+          sources."level-js-5.0.2"
+          sources."mkdirp-1.0.4"
+          sources."push-stream-11.0.0"
+          (sources."ssb-keys-8.0.2" // {
+            dependencies = [
+              sources."mkdirp-0.5.5"
+            ];
+          })
+          sources."typedarray-to-buffer-4.0.0"
+        ];
+      })
       sources."ssb-ebt-5.6.7"
-      sources."ssb-friends-4.3.0"
+      (sources."ssb-friends-4.4.3" // {
+        dependencies = [
+          sources."flumecodec-0.0.1"
+          sources."level-codec-6.2.0"
+        ];
+      })
       sources."ssb-gossip-1.1.1"
       (sources."ssb-invite-2.1.6" // {
         dependencies = [
@@ -100726,6 +101298,7 @@ in
       sources."ssb-query-2.4.5"
       sources."ssb-ref-2.14.3"
       sources."ssb-replicate-1.3.2"
+      sources."ssb-sort-1.1.3"
       sources."ssb-unix-socket-1.0.0"
       sources."ssb-validate-4.1.3"
       sources."ssb-ws-6.2.3"
@@ -100760,6 +101333,7 @@ in
       sources."string_decoder-1.1.1"
       sources."stringify-entities-1.3.2"
       sources."strip-ansi-3.0.1"
+      sources."strip-final-newline-2.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-2.0.0"
       (sources."tape-4.13.3" // {
@@ -100781,13 +101355,17 @@ in
       })
       sources."to-space-case-1.0.0"
       sources."to-vfile-1.0.0"
+      sources."too-hot-1.0.0"
+      sources."traverse-0.6.6"
       sources."trim-0.0.1"
       sources."trim-lines-1.1.3"
       sources."trim-trailing-lines-1.1.4"
+      sources."truncate-utf8-bytes-1.0.2"
       sources."tweetnacl-0.14.5"
       sources."tweetnacl-auth-0.3.1"
       sources."typedarray-0.0.6"
       sources."typedarray-to-buffer-3.1.5"
+      sources."typedfastbitset-0.2.1"
       sources."typewiselite-1.0.0"
       sources."uint48be-2.0.1"
       sources."ultron-1.0.2"
@@ -100812,7 +101390,9 @@ in
       sources."urix-0.1.0"
       sources."use-3.1.1"
       sources."user-home-2.0.0"
+      sources."utf8-byte-length-1.0.4"
       sources."util-deprecate-1.0.2"
+      sources."varint-5.0.2"
       sources."vfile-1.4.0"
       sources."vfile-find-down-1.0.0"
       sources."vfile-find-up-1.0.0"
@@ -100926,7 +101506,7 @@ in
       sources."async-1.5.2"
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      (sources."aws-sdk-2.836.0" // {
+      (sources."aws-sdk-2.841.0" // {
         dependencies = [
           sources."uuid-3.3.2"
         ];
@@ -101134,7 +101714,7 @@ in
           sources."debug-3.2.7"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."graphlib-2.1.8"
       sources."har-schema-2.0.0"
       sources."har-validator-2.0.6"
@@ -101418,7 +101998,7 @@ in
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
       sources."requires-port-1.0.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."ret-0.2.2"
       sources."rethinkdb-2.4.2"
       sources."retry-0.9.0"
@@ -101694,15 +102274,15 @@ in
   stylelint = nodeEnv.buildNodePackage {
     name = "stylelint";
     packageName = "stylelint";
-    version = "13.9.0";
+    version = "13.10.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/stylelint/-/stylelint-13.9.0.tgz";
-      sha512 = "VVWH2oixOAxpWL1vH+V42ReCzBjW2AeqskSAbi8+3OjV1Xg3VZkmTcAqBZfRRvJeF4BvYuDLXebW3tIHxgZDEg==";
+      url = "https://registry.npmjs.org/stylelint/-/stylelint-13.10.0.tgz";
+      sha512 = "eDuLrL0wzPKbl5/TbNGZcbw0lTIGbDEr5W6lCODvb1gAg0ncbgCRt7oU0C2VFDvbrcY0A3MFZOwltwTRmc0XCw==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/core-7.12.13"
-      sources."@babel/generator-7.12.13"
+      sources."@babel/generator-7.12.15"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
       sources."@babel/helper-member-expression-to-functions-7.12.13"
@@ -101719,7 +102299,7 @@ in
           sources."chalk-2.4.2"
         ];
       })
-      sources."@babel/parser-7.12.14"
+      sources."@babel/parser-7.12.15"
       sources."@babel/template-7.12.13"
       sources."@babel/traverse-7.12.13"
       sources."@babel/types-7.12.13"
@@ -101733,7 +102313,7 @@ in
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/parse-json-4.0.0"
       sources."@types/unist-2.0.3"
-      sources."ajv-7.0.4"
+      sources."ajv-7.1.0"
       sources."ansi-regex-5.0.0"
       sources."ansi-styles-3.2.1"
       sources."array-union-2.1.0"
@@ -101748,7 +102328,7 @@ in
       sources."callsites-3.1.0"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       (sources."chalk-4.1.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
@@ -101786,7 +102366,7 @@ in
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       sources."emoji-regex-8.0.0"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
@@ -101855,7 +102435,7 @@ in
       sources."json-schema-traverse-1.0.0"
       sources."json5-2.2.0"
       sources."kind-of-6.0.3"
-      sources."known-css-properties-0.20.0"
+      sources."known-css-properties-0.21.0"
       sources."lines-and-columns-1.1.6"
       sources."locate-path-5.0.0"
       sources."lodash-4.17.20"
@@ -101865,7 +102445,7 @@ in
       sources."map-obj-4.1.0"
       sources."mathml-tag-names-2.1.3"
       sources."mdast-util-from-markdown-0.8.5"
-      sources."mdast-util-to-markdown-0.6.2"
+      sources."mdast-util-to-markdown-0.6.5"
       sources."mdast-util-to-string-2.0.0"
       sources."meow-9.0.0"
       sources."merge2-1.4.1"
@@ -101923,6 +102503,7 @@ in
       sources."postcss-syntax-0.36.2"
       sources."postcss-value-parser-4.1.0"
       sources."punycode-2.1.1"
+      sources."queue-microtask-1.2.2"
       sources."quick-lru-4.0.1"
       (sources."read-pkg-5.2.0" // {
         dependencies = [
@@ -101943,11 +102524,11 @@ in
       sources."remark-stringify-9.0.1"
       sources."repeat-string-1.6.1"
       sources."require-from-string-2.0.2"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-5.0.0"
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."safe-buffer-5.1.2"
       sources."semver-5.7.1"
       sources."signal-exit-3.0.3"
@@ -102304,7 +102885,7 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       (sources."graphlib-2.1.8" // {
         dependencies = [
           sources."lodash-4.17.20"
@@ -102671,7 +103252,7 @@ in
       sources."truncate-utf8-bytes-1.0.2"
       sources."type-is-1.6.18"
       sources."typedarray-0.0.6"
-      sources."uglify-js-3.12.6"
+      sources."uglify-js-3.12.7"
       sources."undefsafe-2.0.3"
       (sources."union-value-1.0.1" // {
         dependencies = [
@@ -102871,7 +103452,7 @@ in
       sources."errno-0.1.8"
       sources."fs.realpath-1.0.0"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."isarray-1.0.0"
@@ -102903,29 +103484,29 @@ in
   textlint = nodeEnv.buildNodePackage {
     name = "textlint";
     packageName = "textlint";
-    version = "11.8.1";
+    version = "11.8.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/textlint/-/textlint-11.8.1.tgz";
-      sha512 = "FlXzJrR008O/H/ynCTVQnsaW2kX2I1zb/rIxkn0HIAoNxU/A4au+P4QJkeDg7FRE6h8qdlZjrXHx79MfSTWzDw==";
+      url = "https://registry.npmjs.org/textlint/-/textlint-11.8.2.tgz";
+      sha512 = "YrTGagGzWKXYw6VjW4uhJ1y7LoW8zqWZIr8sWgeQVIFE84+G/cHPoZ8RhFlia+RZ4YryZPNOqevuF4vG+dbKNQ==";
     };
     dependencies = [
       sources."@azu/format-text-1.0.1"
       sources."@azu/style-format-1.0.0"
       sources."@textlint/ast-node-types-4.4.1"
-      sources."@textlint/ast-tester-2.3.1"
-      sources."@textlint/ast-traverse-2.3.1"
-      sources."@textlint/feature-flag-3.3.1"
-      sources."@textlint/fixer-formatter-3.3.1"
-      sources."@textlint/kernel-3.4.1"
-      sources."@textlint/linter-formatter-3.3.1"
-      sources."@textlint/markdown-to-ast-6.3.1"
-      sources."@textlint/module-interop-1.2.1"
-      sources."@textlint/source-code-fixer-3.4.1"
-      sources."@textlint/text-to-ast-3.3.1"
-      sources."@textlint/textlint-plugin-markdown-5.3.1"
-      sources."@textlint/textlint-plugin-text-4.3.1"
-      sources."@textlint/types-1.5.1"
-      sources."@textlint/utils-1.2.1"
+      sources."@textlint/ast-tester-2.3.2"
+      sources."@textlint/ast-traverse-2.3.2"
+      sources."@textlint/feature-flag-3.3.2"
+      sources."@textlint/fixer-formatter-3.3.2"
+      sources."@textlint/kernel-3.4.2"
+      sources."@textlint/linter-formatter-3.3.2"
+      sources."@textlint/markdown-to-ast-6.3.2"
+      sources."@textlint/module-interop-1.2.2"
+      sources."@textlint/source-code-fixer-3.4.2"
+      sources."@textlint/text-to-ast-3.3.2"
+      sources."@textlint/textlint-plugin-markdown-5.3.2"
+      sources."@textlint/textlint-plugin-text-4.3.2"
+      sources."@textlint/types-1.5.2"
+      sources."@textlint/utils-1.2.2"
       sources."ajv-4.11.8"
       sources."ajv-keywords-1.5.1"
       sources."ansi-regex-2.1.1"
@@ -102974,7 +103555,7 @@ in
       sources."get-intrinsic-1.1.1"
       sources."get-stdin-5.0.1"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-symbols-1.0.1"
@@ -103056,7 +103637,7 @@ in
       sources."repeat-string-1.6.1"
       sources."replace-ext-1.0.0"
       sources."require-from-string-2.0.2"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.1.2"
       sources."semver-5.7.1"
@@ -103193,7 +103774,7 @@ in
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@textlint/ast-node-types-4.4.1"
-      sources."@textlint/types-1.5.1"
+      sources."@textlint/types-1.5.2"
       sources."@types/hast-2.3.1"
       sources."@types/minimist-1.2.1"
       sources."@types/normalize-package-data-2.4.0"
@@ -103303,7 +103884,7 @@ in
         ];
       })
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."hard-rejection-2.1.0"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
@@ -103450,7 +104031,7 @@ in
       sources."remark-retext-4.0.0"
       sources."remark-stringify-8.1.1"
       sources."repeat-string-1.6.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-5.0.0"
       sources."responselike-1.0.2"
       sources."retext-english-3.0.4"
@@ -103540,7 +104121,7 @@ in
           sources."is-plain-obj-2.1.0"
         ];
       })
-      sources."unified-message-control-3.0.2"
+      sources."unified-message-control-3.0.3"
       sources."unique-string-2.0.0"
       sources."unist-util-inspect-5.0.1"
       sources."unist-util-is-4.0.4"
@@ -103724,7 +104305,7 @@ in
     };
     dependencies = [
       sources."@textlint/ast-node-types-4.4.1"
-      sources."@textlint/types-1.5.1"
+      sources."@textlint/types-1.5.2"
       sources."boundary-1.0.1"
       sources."buffer-from-1.1.1"
       sources."call-bind-1.0.2"
@@ -103822,7 +104403,7 @@ in
     };
     dependencies = [
       sources."@textlint/ast-node-types-4.4.1"
-      sources."@textlint/types-1.5.1"
+      sources."@textlint/types-1.5.2"
       sources."boundary-1.0.1"
       sources."lodash-4.17.20"
       sources."split-lines-2.0.0"
@@ -103852,7 +104433,7 @@ in
     };
     dependencies = [
       sources."@textlint/ast-node-types-4.4.1"
-      sources."@textlint/types-1.5.1"
+      sources."@textlint/types-1.5.2"
       sources."boundary-1.0.1"
       sources."lodash-4.17.20"
       sources."strip-json-comments-3.1.1"
@@ -103923,7 +104504,7 @@ in
     };
     dependencies = [
       sources."@textlint/ast-node-types-4.4.1"
-      sources."@textlint/types-1.5.1"
+      sources."@textlint/types-1.5.2"
       sources."adverb-where-0.0.9"
       sources."boundary-1.0.1"
       sources."call-bind-1.0.2"
@@ -104125,7 +104706,7 @@ in
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
       sources."got-11.5.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."grapheme-splitter-1.0.4"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
@@ -104486,7 +105067,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."http-signature-1.2.0"
@@ -104838,10 +105419,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "4.1.3";
+    version = "4.1.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz";
-      sha512 = "B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==";
+      url = "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz";
+      sha512 = "6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -104866,7 +105447,7 @@ in
       sources."commander-2.20.3"
       sources."crypto-random-string-1.0.0"
       sources."fs-extra-7.0.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."jsonfile-4.0.0"
       sources."p-debounce-1.0.0"
       sources."temp-dir-1.0.0"
@@ -104893,10 +105474,10 @@ in
   uglify-js = nodeEnv.buildNodePackage {
     name = "uglify-js";
     packageName = "uglify-js";
-    version = "3.12.6";
+    version = "3.12.7";
     src = fetchurl {
-      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.6.tgz";
-      sha512 = "aqWHe3DfQmZUDGWBbabZ2eQnJlQd1fKlMUu7gV+MiTuDzdgDw31bI3wA2jLLsV/hNcDP26IfyEgSVoft5+0SVw==";
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.7.tgz";
+      sha512 = "SIZhkoh+U/wjW+BHGhVwE9nt8tWJspncloBcFapkpGRwNPqcH8pzX36BXe3TPBjzHWPMUZotpCigak/udWNr1Q==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -105316,7 +105897,7 @@ in
       sources."rc-1.2.8"
       sources."readable-stream-2.3.7"
       sources."require-directory-2.1.1"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."rimraf-2.7.1"
       sources."rw-1.3.3"
       sources."safe-buffer-5.1.2"
@@ -105628,7 +106209,7 @@ in
       sources."@types/json5-0.0.30"
       sources."@types/mocha-7.0.2"
       sources."@types/node-8.10.66"
-      sources."@types/vscode-1.52.0"
+      sources."@types/vscode-1.53.0"
       sources."@types/yauzl-2.9.1"
       sources."@webassemblyjs/ast-1.9.0"
       sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
@@ -105927,7 +106508,7 @@ in
         ];
       })
       sources."global-prefix-1.0.2"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."growl-1.10.5"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
@@ -106311,7 +106892,7 @@ in
       sources."tunnel-0.0.4"
       sources."typed-rest-client-1.2.0"
       sources."typedarray-0.0.6"
-      sources."typescript-3.9.7"
+      sources."typescript-3.9.9"
       sources."uc.micro-1.0.6"
       sources."underscore-1.8.3"
       sources."union-value-1.0.1"
@@ -106352,7 +106933,7 @@ in
       (sources."watchpack-1.7.5" // {
         dependencies = [
           sources."chokidar-3.5.1"
-          sources."fsevents-2.3.1"
+          sources."fsevents-2.3.2"
           sources."readdirp-3.5.0"
         ];
       })
@@ -106529,7 +107110,7 @@ in
       sources."git-clone-0.1.0"
       sources."glob-7.1.6"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."gray-matter-2.1.1"
       sources."handlebars-4.7.6"
       sources."har-schema-2.0.0"
@@ -106674,7 +107255,7 @@ in
       sources."tslib-1.14.1"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."uglify-js-3.12.6"
+      sources."uglify-js-3.12.7"
       sources."uid-0.0.2"
       sources."unbzip2-stream-1.4.3"
       sources."unyield-0.0.1"
@@ -106941,7 +107522,7 @@ in
       sources."eslint-visitor-keys-1.3.0"
       sources."espree-5.0.1"
       sources."esprima-4.0.1"
-      (sources."esquery-1.3.1" // {
+      (sources."esquery-1.4.0" // {
         dependencies = [
           sources."estraverse-5.2.0"
         ];
@@ -107008,7 +107589,7 @@ in
       sources."format-0.2.2"
       sources."fragment-cache-0.2.1"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.3.1"
+      sources."fsevents-2.3.2"
       sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
       sources."get-caller-file-1.0.3"
@@ -107029,7 +107610,7 @@ in
           sources."get-stream-4.1.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."gridsome-helper-json-1.0.3"
       sources."has-1.0.3"
       (sources."has-ansi-2.0.0" // {
@@ -107338,7 +107919,7 @@ in
           sources."resolve-from-1.0.1"
         ];
       })
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-from-5.0.0"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
@@ -107507,7 +108088,7 @@ in
       sources."type-check-0.3.2"
       sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
-      sources."typescript-3.9.7"
+      sources."typescript-3.9.9"
       (sources."typescript-eslint-parser-16.0.1" // {
         dependencies = [
           sources."semver-5.5.0"
@@ -107752,7 +108333,7 @@ in
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-extensions-2.2.0"
       sources."bindings-1.5.0"
-      sources."bl-4.0.4"
+      sources."bl-4.1.0"
       sources."bluebird-2.9.34"
       sources."boolbase-1.0.0"
       (sources."boxen-4.2.0" // {
@@ -107782,7 +108363,7 @@ in
       sources."cheerio-1.0.0-rc.3"
       (sources."chokidar-3.5.1" // {
         dependencies = [
-          sources."fsevents-2.3.1"
+          sources."fsevents-2.3.2"
         ];
       })
       (sources."chrome-launcher-0.13.4" // {
@@ -107912,7 +108493,7 @@ in
         ];
       })
       sources."esprima-4.0.1"
-      (sources."esquery-1.3.1" // {
+      (sources."esquery-1.4.0" // {
         dependencies = [
           sources."estraverse-5.2.0"
         ];
@@ -108028,7 +108609,7 @@ in
           sources."get-stream-4.1.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."graceful-readlink-1.0.1"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
@@ -108385,7 +108966,7 @@ in
           sources."kind-of-3.2.2"
         ];
       })
-      sources."sonic-boom-1.3.0"
+      sources."sonic-boom-1.3.2"
       sources."source-map-0.6.1"
       sources."source-map-resolve-0.5.3"
       sources."source-map-support-0.5.19"
@@ -108577,10 +109158,10 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "5.20.1";
+    version = "5.21.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-5.20.1.tgz";
-      sha512 = "cStILc8W14WZXsgfeJmNIQlmQU06F7THfCJ6id3pIB/EXuR6nquolJ2ZJoaLNb6zdec6O2jOAzVKtBYc7vGDjg==";
+      url = "https://registry.npmjs.org/webpack/-/webpack-5.21.2.tgz";
+      sha512 = "xHflCenx+AM4uWKX71SWHhxml5aMXdy2tu/vdi4lClm7PADKxlyDAFFN1rEFzNV0MAoPpHtBeJnl/+K6F4QBPg==";
     };
     dependencies = [
       sources."@types/eslint-7.2.6"
@@ -108610,11 +109191,11 @@ in
       sources."ajv-keywords-3.5.2"
       sources."browserslist-4.16.3"
       sources."buffer-from-1.1.1"
-      sources."caniuse-lite-1.0.30001183"
+      sources."caniuse-lite-1.0.30001185"
       sources."chrome-trace-event-1.0.2"
       sources."colorette-1.2.1"
       sources."commander-2.20.3"
-      sources."electron-to-chromium-1.3.653"
+      sources."electron-to-chromium-1.3.662"
       sources."enhanced-resolve-5.7.0"
       sources."es-module-lexer-0.3.26"
       sources."escalade-3.1.1"
@@ -108629,7 +109210,7 @@ in
       sources."fast-deep-equal-3.1.3"
       sources."fast-json-stable-stringify-2.1.0"
       sources."glob-to-regexp-0.4.1"
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."has-flag-4.0.0"
       sources."jest-worker-26.6.2"
       sources."json-parse-better-errors-1.0.2"
@@ -108659,7 +109240,7 @@ in
       sources."terser-webpack-plugin-5.1.1"
       sources."tslib-1.14.1"
       sources."uri-js-4.4.1"
-      sources."watchpack-2.1.0"
+      sources."watchpack-2.1.1"
       sources."webpack-sources-2.2.0"
       sources."yocto-queue-0.1.0"
     ];
@@ -108721,7 +109302,7 @@ in
       sources."path-parse-1.0.6"
       sources."pkg-dir-4.2.0"
       sources."rechoir-0.7.0"
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-cwd-3.0.0"
       sources."resolve-from-5.0.0"
       sources."shallow-clone-3.0.1"
@@ -108963,7 +109544,7 @@ in
           sources."pify-2.3.0"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."handle-thing-2.0.1"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
@@ -109367,9 +109948,10 @@ in
       sources."path-type-4.0.0"
       sources."picomatch-2.2.2"
       sources."punycode-2.1.1"
+      sources."queue-microtask-1.2.2"
       sources."randombytes-2.1.0"
       sources."reusify-1.0.4"
-      sources."run-parallel-1.1.10"
+      sources."run-parallel-1.2.0"
       sources."safe-buffer-5.2.1"
       sources."schema-utils-3.0.0"
       sources."serialize-javascript-5.0.1"
@@ -109430,13 +110012,13 @@ in
         ];
       })
       sources."bittorrent-peerid-1.3.3"
-      (sources."bittorrent-protocol-3.2.0" // {
+      (sources."bittorrent-protocol-3.3.1" // {
         dependencies = [
           sources."debug-4.3.2"
           sources."ms-2.1.2"
         ];
       })
-      (sources."bittorrent-tracker-9.16.0" // {
+      (sources."bittorrent-tracker-9.16.1" // {
         dependencies = [
           sources."debug-4.3.2"
           sources."decompress-response-6.0.0"
@@ -109473,7 +110055,7 @@ in
           sources."mime-1.6.0"
         ];
       })
-      sources."chunk-store-stream-4.1.1"
+      sources."chunk-store-stream-4.2.0"
       sources."clivas-0.2.0"
       sources."common-tags-1.8.0"
       sources."compact2string-1.4.1"
@@ -109486,7 +110068,7 @@ in
         ];
       })
       sources."core-util-is-1.0.2"
-      sources."create-torrent-4.4.4"
+      sources."create-torrent-4.4.5"
       sources."debug-2.6.9"
       sources."decompress-response-3.3.0"
       (sources."dlnacasts-0.1.0" // {
@@ -109505,7 +110087,7 @@ in
       sources."executable-4.1.1"
       sources."filestream-5.0.0"
       sources."freelist-1.0.3"
-      (sources."fs-chunk-store-2.0.2" // {
+      (sources."fs-chunk-store-2.0.3" // {
         dependencies = [
           sources."thunky-1.1.0"
         ];
@@ -109531,7 +110113,7 @@ in
       sources."is-wsl-2.2.0"
       sources."isarray-1.0.0"
       sources."junk-3.1.0"
-      sources."k-bucket-5.0.0"
+      sources."k-bucket-5.1.0"
       sources."k-rpc-5.1.0"
       sources."k-rpc-socket-1.11.1"
       sources."last-one-wins-1.0.4"
@@ -109548,7 +110130,7 @@ in
       sources."mdns-js-0.5.0"
       sources."mdns-js-packet-0.2.0"
       sources."mediasource-2.4.0"
-      sources."memory-chunk-store-1.3.0"
+      sources."memory-chunk-store-1.3.2"
       sources."mime-2.5.0"
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
@@ -109611,8 +110193,8 @@ in
         ];
       })
       sources."rimraf-3.0.2"
-      sources."run-parallel-1.1.10"
-      sources."run-parallel-limit-1.0.6"
+      sources."run-parallel-1.2.0"
+      sources."run-parallel-limit-1.1.0"
       sources."run-series-1.1.9"
       sources."rusha-0.8.13"
       sources."safe-buffer-5.2.1"
@@ -109676,7 +110258,7 @@ in
       sources."utp-native-2.3.0"
       sources."videostream-3.2.2"
       sources."vlc-command-1.2.0"
-      (sources."webtorrent-0.113.0" // {
+      (sources."webtorrent-0.114.0" // {
         dependencies = [
           sources."debug-4.3.2"
           sources."decompress-response-6.0.0"
@@ -109684,7 +110266,7 @@ in
           sources."magnet-uri-6.1.0"
           sources."mimic-response-3.1.0"
           sources."ms-2.1.2"
-          sources."parse-torrent-9.1.1"
+          sources."parse-torrent-9.1.3"
           sources."simple-get-4.0.0"
         ];
       })
@@ -109726,10 +110308,10 @@ in
   write-good = nodeEnv.buildNodePackage {
     name = "write-good";
     packageName = "write-good";
-    version = "1.0.4";
+    version = "1.0.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/write-good/-/write-good-1.0.4.tgz";
-      sha512 = "NA7P2MQ2yw4k+SYq9NQMB0GLchzoprbMRoJgMquLoWzucTozni8k/3hvXvldyDQbgPpPZObzOGvcB6UgqzggzQ==";
+      url = "https://registry.npmjs.org/write-good/-/write-good-1.0.6.tgz";
+      sha512 = "7oWy7O3sGnc7ht7pL0ki5SDIt746vgthEdoKT5ldFYkTQ2J7xJn998qHRiiR1SEpFhNZYd0gZUwoRN3xM/GSkQ==";
     };
     dependencies = [
       sources."adverb-where-0.2.1"
@@ -109737,7 +110319,7 @@ in
       sources."e-prime-0.10.4"
       sources."no-cliches-0.2.2"
       sources."passive-voice-0.1.0"
-      sources."too-wordy-0.2.2"
+      sources."too-wordy-0.3.0"
       sources."weasel-words-0.1.1"
     ];
     buildInputs = globalBuildInputs;
@@ -109753,10 +110335,10 @@ in
   yaml-language-server = nodeEnv.buildNodePackage {
     name = "yaml-language-server";
     packageName = "yaml-language-server";
-    version = "0.14.0";
+    version = "0.15.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.14.0.tgz";
-      sha512 = "aMNzS7YoMrgG0QdCMonlrFS/fPiag4zVs9cJ7RB0ZzwiALB2446UFXwy6SaTmKfJq353rjGJ+d7j1HHKSX/IqA==";
+      url = "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.15.0.tgz";
+      sha512 = "idaCYstdGoV5Pi7PKxbUkGHt6jAI3l+nxNWrsVCetxrEgfH6T7qytfT0pF3n4NdfDNPHPHcqnl69FzCFDVfHnQ==";
     };
     dependencies = [
       sources."agent-base-4.3.0"
@@ -110055,7 +110637,7 @@ in
       sources."fast-glob-2.2.7"
       sources."fast-json-stable-stringify-2.1.0"
       sources."figures-2.0.0"
-      sources."filelist-1.0.1"
+      sources."filelist-1.0.2"
       (sources."fill-range-4.0.0" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
@@ -110111,7 +110693,7 @@ in
           sources."p-cancelable-0.4.1"
         ];
       })
-      sources."graceful-fs-4.2.4"
+      sources."graceful-fs-4.2.6"
       sources."grouped-queue-1.1.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
@@ -110437,7 +111019,7 @@ in
           sources."tough-cookie-2.5.0"
         ];
       })
-      sources."resolve-1.19.0"
+      sources."resolve-1.20.0"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
       sources."restore-cursor-2.0.0"
@@ -110736,7 +111318,7 @@ in
           sources."debug-4.3.2"
           sources."diff-4.0.2"
           sources."dir-glob-2.2.2"
-          sources."ejs-3.1.5"
+          sources."ejs-3.1.6"
           sources."find-up-3.0.0"
           sources."globby-9.2.0"
           sources."ignore-4.0.6"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -1588,6 +1588,24 @@ let
         sha512 = "HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==";
       };
     };
+    "@emmetio/abbreviation-2.2.0" = {
+      name = "_at_emmetio_slash_abbreviation";
+      packageName = "@emmetio/abbreviation";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.2.0.tgz";
+        sha512 = "NPGVUmnr7cLj4i6MKS4c8NjuoIIJROrruJl/8nXsp2MdbDRHvtfq25foySvv/NbfqTQm+P9JzVLDD9JxGIpvkQ==";
+      };
+    };
+    "@emmetio/css-abbreviation-2.1.2" = {
+      name = "_at_emmetio_slash_css-abbreviation";
+      packageName = "@emmetio/css-abbreviation";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.2.tgz";
+        sha512 = "CvYTzJltVpLqJaCZ1Qn97LVAKsl2Uwl2fzir1EX/WuMY3xWxgc3BWRCheL6k65km6GyDrLVl6RhrrNb/pxOiAQ==";
+      };
+    };
     "@emmetio/extract-abbreviation-0.1.6" = {
       name = "_at_emmetio_slash_extract-abbreviation";
       packageName = "@emmetio/extract-abbreviation";
@@ -1595,6 +1613,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@emmetio/extract-abbreviation/-/extract-abbreviation-0.1.6.tgz";
         sha512 = "Ce3xE2JvTSEbASFbRbA1gAIcMcZWdS2yUYRaQbeM0nbOzaZrUYfa3ePtcriYRZOZmr+CkKA+zbjhvTpIOAYVcw==";
+      };
+    };
+    "@emmetio/scanner-1.0.0" = {
+      name = "_at_emmetio_slash_scanner";
+      packageName = "@emmetio/scanner";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.0.tgz";
+        sha512 = "8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==";
       };
     };
     "@emotion/is-prop-valid-0.8.8" = {
@@ -6313,6 +6340,15 @@ let
         sha512 = "a+fLdul8OczRvPWPf8eTb6wPhxzyWQwRGhNN0ugtOtk6yFOG53i2LwXaA0d2D6bsJlWxi6eCuGZLGoCcdOlWZA==";
       };
     };
+    "@types/pug-2.0.4" = {
+      name = "_at_types_slash_pug";
+      packageName = "@types/pug";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/pug/-/pug-2.0.4.tgz";
+        sha1 = "8772fcd0418e3cd2cc171555d73007415051f4b2";
+      };
+    };
     "@types/q-1.5.4" = {
       name = "_at_types_slash_q";
       packageName = "@types/q";
@@ -6410,6 +6446,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.4.tgz";
         sha512 = "8gBudvllD2A/c0CcEX/BivIDorHFt5UI5m46TsNj8DjWCCTTZT74kEe4g+QsY7P/B9WdO98d82zZgXO/RQzu2Q==";
+      };
+    };
+    "@types/sass-1.16.0" = {
+      name = "_at_types_slash_sass";
+      packageName = "@types/sass";
+      version = "1.16.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/sass/-/sass-1.16.0.tgz";
+        sha512 = "2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==";
       };
     };
     "@types/semver-5.5.0" = {
@@ -18689,6 +18734,15 @@ let
         sha1 = "2495ddbaf6eb874abb0e1be9df22d2e5a544326c";
       };
     };
+    "dedent-js-1.0.1" = {
+      name = "dedent-js";
+      packageName = "dedent-js";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz";
+        sha1 = "bee5fb7c9e727d85dffa24590d10ec1ab1255305";
+      };
+    };
     "deep-eql-3.0.1" = {
       name = "deep-eql";
       packageName = "deep-eql";
@@ -20615,6 +20669,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz";
         sha512 = "Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==";
+      };
+    };
+    "emmet-2.3.0" = {
+      name = "emmet";
+      packageName = "emmet";
+      version = "2.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/emmet/-/emmet-2.3.0.tgz";
+        sha512 = "/9jfXVKjODNt1QBpMkfUp2SlyYNfi0CcWLpiYCQmwnsLmME/To3lScw+Ip4V7Pasp0O0uYUU0Um0M9ewSIfx3g==";
       };
     };
     "emoji-named-characters-1.0.2" = {
@@ -44024,6 +44087,15 @@ let
         sha512 = "2UzApPuxi2yRoyMlXMazgR6UcH9DKJhNgCviIwY3ixZ9THWSSrUww5vkiZ3C48WvpFl1M1y/oU63deSy1puWEA==";
       };
     };
+    "prettier-plugin-svelte-2.1.4" = {
+      name = "prettier-plugin-svelte";
+      packageName = "prettier-plugin-svelte";
+      version = "2.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.1.4.tgz";
+        sha512 = "fQfcIyl04VNWI3+JeseT+gLljs2bJJifbKmrTe8yMnTCdv0unfM1jnY2p4etzCfOj6skC1FPFaqBayYk3+7ZZg==";
+      };
+    };
     "prettier-stylelint-0.4.2" = {
       name = "prettier-stylelint";
       packageName = "prettier-stylelint";
@@ -53222,6 +53294,33 @@ let
         sha512 = "zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==";
       };
     };
+    "svelte-3.32.3" = {
+      name = "svelte";
+      packageName = "svelte";
+      version = "3.32.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/svelte/-/svelte-3.32.3.tgz";
+        sha512 = "5etu/wDwtewhnYO/631KKTjSmFrKohFLWNm1sWErVHXqGZ8eJLqrW0qivDSyYTcN8GbUqsR4LkIhftNFsjNehg==";
+      };
+    };
+    "svelte-preprocess-4.6.8" = {
+      name = "svelte-preprocess";
+      packageName = "svelte-preprocess";
+      version = "4.6.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.6.8.tgz";
+        sha512 = "yrT+vuHPoGnNx5Oxa6gMqWV5ZhLgA4isfhUOBwv9iVqZAro9/Nyy8XF5sahAglfMmnCxJkDZSwg7CdAwGpVxhw==";
+      };
+    };
+    "svelte2tsx-0.1.169" = {
+      name = "svelte2tsx";
+      packageName = "svelte2tsx";
+      version = "0.1.169";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.1.169.tgz";
+        sha512 = "E4AM2WGMdsYWe8z3BQXbvKQ9dWrOPDrO9xx5V7e+5MHFhyof1a5ZupY6LprJlwQYmWm0Vj9HUGkm8fdVFCfnhA==";
+      };
+    };
     "sver-compat-1.5.0" = {
       name = "sver-compat";
       packageName = "sver-compat";
@@ -58498,6 +58597,15 @@ let
         sha512 = "jWi+297PJUUWTHwlcrZz0zIuEXuHOBJIQMapXmEzbosWGv/gMnNSAMV4hTKnl5wzxvZKZzV6j+WFdrSlKQ5qnw==";
       };
     };
+    "vscode-css-languageservice-5.0.0" = {
+      name = "vscode-css-languageservice";
+      packageName = "vscode-css-languageservice";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-5.0.0.tgz";
+        sha512 = "DTMa8QbVmujFPvD3NxoC5jjIXCyCG+cvn3hNzwQRhvhsk8LblNymBZBwzfcDdgEtqsi4O/2AB5HnMIRzxhzEzg==";
+      };
+    };
     "vscode-debugadapter-testsupport-1.44.0" = {
       name = "vscode-debugadapter-testsupport";
       packageName = "vscode-debugadapter-testsupport";
@@ -58525,6 +58633,15 @@ let
         sha512 = "X4pzcrJ8dE7M3ArFuySF5fgipKDd/EauXkiJwtjBIVRWpVNq0tF9+lNCyuC7iDUwP3Oq7ow/TGssD3GdG96Jow==";
       };
     };
+    "vscode-emmet-helper-2.1.2" = {
+      name = "vscode-emmet-helper";
+      packageName = "vscode-emmet-helper";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-2.1.2.tgz";
+        sha512 = "Fy6UNawSgxE3Kuqi54vSXohf03iOIrp1A74ReAgzvGP9Yt7fUAvkqF6No2WAc34/w0oWAHAeqoBNqmKKWh6U5w==";
+      };
+    };
     "vscode-html-languageservice-2.1.12" = {
       name = "vscode-html-languageservice";
       packageName = "vscode-html-languageservice";
@@ -58532,6 +58649,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-2.1.12.tgz";
         sha512 = "mIb5VMXM5jI97HzCk2eadI1K//rCEZXte0wBqA7PGXsyJH4KTyJUaYk9MR+mbfpUl2vMi3HZw9GUOLGYLc6l5w==";
+      };
+    };
+    "vscode-html-languageservice-4.0.0" = {
+      name = "vscode-html-languageservice";
+      packageName = "vscode-html-languageservice";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-4.0.0.tgz";
+        sha512 = "UmC+GS0IqBeZnOAmdtQvaDzoH1c5/un+b7qALUziu/Y4SOPXso5dF+YkJeTqsde6YU2pLm78RtMDzl9BParwbw==";
       };
     };
     "vscode-json-languageservice-3.11.0" = {
@@ -102588,6 +102714,100 @@ in
     meta = {
       description = "A mighty, modern CSS linter.";
       homepage = "https://stylelint.io";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  svelte-language-server = nodeEnv.buildNodePackage {
+    name = "svelte-language-server";
+    packageName = "svelte-language-server";
+    version = "0.12.9";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/svelte-language-server/-/svelte-language-server-0.12.9.tgz";
+      sha512 = "a1J4BTiP2uJ4LLk3/iuw4G9t2FbmTel0V8wyeuSVBPk+aZVAvt9sQ19Um0OFyUdwXWQVJn/jRTcrFYVXqE4Bgg==";
+    };
+    dependencies = [
+      sources."@babel/code-frame-7.12.13"
+      sources."@babel/helper-validator-identifier-7.12.11"
+      sources."@babel/highlight-7.12.13"
+      sources."@emmetio/abbreviation-2.2.0"
+      sources."@emmetio/css-abbreviation-2.1.2"
+      sources."@emmetio/scanner-1.0.0"
+      sources."@types/node-14.14.25"
+      sources."@types/parse-json-4.0.0"
+      sources."@types/pug-2.0.4"
+      sources."@types/sass-1.16.0"
+      sources."ansi-styles-3.2.1"
+      sources."anymatch-3.1.1"
+      sources."binary-extensions-2.2.0"
+      sources."braces-3.0.2"
+      sources."callsites-3.1.0"
+      sources."chalk-2.4.2"
+      sources."chokidar-3.5.1"
+      sources."color-convert-1.9.3"
+      sources."color-name-1.1.3"
+      sources."cosmiconfig-7.0.0"
+      sources."dedent-js-1.0.1"
+      sources."detect-indent-6.0.0"
+      sources."emmet-2.3.0"
+      sources."error-ex-1.3.2"
+      sources."escape-string-regexp-1.0.5"
+      sources."estree-walker-2.0.2"
+      sources."fill-range-7.0.1"
+      sources."fsevents-2.3.2"
+      sources."glob-parent-5.1.1"
+      sources."has-flag-3.0.0"
+      sources."import-fresh-3.3.0"
+      sources."is-arrayish-0.2.1"
+      sources."is-binary-path-2.1.0"
+      sources."is-extglob-2.1.1"
+      sources."is-glob-4.0.1"
+      sources."is-number-7.0.0"
+      sources."js-tokens-4.0.0"
+      sources."json-parse-even-better-errors-2.3.1"
+      sources."jsonc-parser-2.3.1"
+      sources."lines-and-columns-1.1.6"
+      sources."lodash-4.17.20"
+      sources."lower-case-2.0.2"
+      sources."min-indent-1.0.1"
+      sources."no-case-3.0.4"
+      sources."normalize-path-3.0.0"
+      sources."parent-module-1.0.1"
+      sources."parse-json-5.2.0"
+      sources."pascal-case-3.1.2"
+      sources."path-type-4.0.0"
+      sources."picomatch-2.2.2"
+      sources."prettier-2.2.1"
+      sources."prettier-plugin-svelte-2.1.4"
+      sources."readdirp-3.5.0"
+      sources."resolve-from-4.0.0"
+      sources."source-map-0.7.3"
+      sources."strip-indent-3.0.0"
+      sources."supports-color-5.5.0"
+      sources."svelte-3.32.3"
+      sources."svelte-preprocess-4.6.8"
+      sources."svelte2tsx-0.1.169"
+      sources."to-regex-range-5.0.1"
+      sources."tslib-2.1.0"
+      sources."typescript-4.1.5"
+      sources."vscode-css-languageservice-5.0.0"
+      sources."vscode-emmet-helper-2.1.2"
+      sources."vscode-html-languageservice-4.0.0"
+      sources."vscode-jsonrpc-6.0.0"
+      sources."vscode-languageserver-7.0.0"
+      sources."vscode-languageserver-protocol-3.16.0"
+      sources."vscode-languageserver-textdocument-1.0.1"
+      sources."vscode-languageserver-types-3.16.0"
+      sources."vscode-nls-5.0.0"
+      sources."vscode-uri-2.1.2"
+      sources."yaml-1.10.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "A language server for Svelte";
+      homepage = "https://github.com/sveltejs/language-tools#readme";
       license = "MIT";
     };
     production = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the [svelte-language-server](https://github.com/sveltejs/language-tools#svelte-language-server) node package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
