### PR TITLE
libmodulemd: 2.9.2 -> 2.12.0

### DIFF
--- a/pkgs/development/libraries/libmodulemd/default.nix
+++ b/pkgs/development/libraries/libmodulemd/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv
 , substituteAll
 , fetchFromGitHub
-, fetchpatch
 , pkg-config
 , meson
 , ninja
@@ -19,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libmodulemd";
-  version = "2.9.2";
+  version = "2.12.0";
 
   outputs = [ "bin" "out" "dev" "devdoc" "man" "py" ];
 
@@ -27,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "fedora-modularity";
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "0xl5f6a32hmli29b0rfp54h7vnagxdv9qa2r871mrgrr6fzjwvbn";
+    sha256 = "1mq9as98q4wyka404f8xwfc44cn5j4bsk0fch5pf07v81sagc1q9";
   };
 
   patches = [
@@ -35,17 +34,6 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./glib-devdoc.patch;
       glib_devdoc = glib.devdoc;
-    })
-
-    # Install pygobject overrides to our prefix instead of python3 one.
-    # https://github.com/fedora-modularity/libmodulemd/pull/469
-    (fetchpatch {
-      url = "https://github.com/fedora-modularity/libmodulemd/commit/f72a4bea092f4d84cfc48a3e820eb10270e828d0.patch";
-      sha256 = "1rrf94q1yf98w6b9bm67mb6w6qv1zqi306iv1vzspvjhsqvzmzpg";
-    })
-    (fetchpatch {
-      url = "https://github.com/fedora-modularity/libmodulemd/commit/021ab08006b5cf601ce153174fdf403b910b8273.patch";
-      sha256 = "0z35jpnnzzb5bvmc2lglrpfnwarhky2jqmhq9avnnki22fdw89i6";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

I am trying to update microDNF which needs an updated libdnf which needs an updated libmodulemd :)
The custom patches from in here have been merged!


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
