### PR TITLE
libdnf: 0.55.2 -> 0.58.0

### DIFF
--- a/pkgs/tools/package-management/libdnf/darwin.patch
+++ b/pkgs/tools/package-management/libdnf/darwin.patch
@@ -1,5 +1,25 @@
---- src/libdnf/hy-iutil.cpp	2020-12-02 07:53:42.000000000 -0800
-+++ src/libdnf/hy-iutil.cpp	2020-12-21 14:24:14.000000000 -0800
+diff --git src/libdnf/config.h src/libdnf/config.h
+index 16121f6f..737d0bc4 100644
+--- src/libdnf/config.h
++++ src/libdnf/config.h
+@@ -18,7 +18,12 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++
++#ifdef __APPLE__
++#include <stdint.h>
++#else
+ #include <bits/wordsize.h>
++#endif
+
+ 
+ #if __WORDSIZE == 32
+ #include "config-32.h"
+diff --git src/libdnf/hy-iutil.cpp src/libdnf/hy-iutil.cpp
+index 497c560d..5de077fa 100644
+--- src/libdnf/hy-iutil.cpp
++++ src/libdnf/hy-iutil.cpp
 @@ -22,7 +22,7 @@
  #include <errno.h>
  #include <dirent.h>
@@ -9,8 +29,10 @@
  #include <pwd.h>
  #include <unistd.h>
  #include <stdio.h>
---- src/libdnf/hy-util.cpp	2020-12-02 07:53:42.000000000 -0800
-+++ src/libdnf/hy-util.cpp	2020-12-21 14:23:21.000000000 -0800
+diff --git src/libdnf/hy-util.cpp src/libdnf/hy-util.cpp
+index 295fdc1b..9d584b8a 100644
+--- src/libdnf/hy-util.cpp
++++ src/libdnf/hy-util.cpp
 @@ -24,7 +24,20 @@
  #include <ctype.h>
  #include <sys/utsname.h>

--- a/pkgs/tools/package-management/libdnf/default.nix
+++ b/pkgs/tools/package-management/libdnf/default.nix
@@ -1,15 +1,15 @@
 { gcc9Stdenv, lib, stdenv, fetchFromGitHub, cmake, gettext, pkg-config, gpgme, libsolv, openssl, check
-, pcre, json_c, libmodulemd, libsmartcols, sqlite, librepo, libyaml, rpm }:
+, json_c, libmodulemd, libsmartcols, sqlite, librepo, libyaml, rpm }:
 
 gcc9Stdenv.mkDerivation rec {
   pname = "libdnf";
-  version = "0.55.2";
+  version = "0.58.0";
 
   src = fetchFromGitHub {
     owner = "rpm-software-management";
     repo = pname;
     rev = version;
-    sha256 = "0hiydwfa90nsrqk5ffa6ks1g73wnsgjgq7z7gwq9jj76a7gpfbfq";
+    sha256 = "0an8giv0lm0qqc76fpmqg42ra081mlj62b9r0s1p0sgb3270l76l";
   };
 
   patches = lib.optionals stdenv.isDarwin [ ./darwin.patch ];


### PR DESCRIPTION
###### Motivation for this change

A new requirement for the lastest microdnf release.
I will take the darwin.patch that I had to extend in here and will upstream it over the next few days.
It would be great if we can merge it here to unblock the microdnf upgrade and I'll do a 2nd diff to change the patch to point to the upstream PR this weekend.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
