### PR TITLE
microdnf: 3.6.0 -> 3.7.1

### DIFF
--- a/pkgs/tools/package-management/microdnf/default.nix
+++ b/pkgs/tools/package-management/microdnf/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "microdnf";
-  version = "3.6.0";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "rpm-software-management";
     repo = pname;
     rev = version;
-    sha256 = "0a7lc3qsnblvznzsz3544l3n84184xi85zf7c3m3jhnmpmxsg39h";
+    sha256 = "1is8hqckjdz1h9w44iq1ljyfs5b0qd2cyivl30ny4dv8m8zba4zv";
   };
 
   nativeBuildInputs = [ pkg-config cmake gettext help2man ];


### PR DESCRIPTION
###### Motivation for this change

Keeping things current, some upstream fixes + new options.

```
% /nix/store/kivlwnxfzpdrsrwgxsyjzq6w2j7cgcpj-microdnf-3.7.1/bin/microdnf --help
Usage:
  microdnf [OPTION…] COMMAND

Commands:
  module reset         Reset a module stream
  repoquery            Search for packages matching keyword
  reinstall            Reinstall packages
  clean                Remove cached data
  repolist             List repositories
  module enable        Enable a module stream
  download             Download packages
  remove               Remove packages
  upgrade              Upgrade packages
  update               Compatibility alias for the "upgrade" command
  install              Install packages
  module disable       Disable a module stream

Help Options:
  -h, --help                    Show help options

Application Options:
  --assumeno                    Automatically answer no for all questions
  -y, --assumeyes               Automatically answer yes for all questions
  --best                        Try the best available package versions in transactions
  --config=<config file>        Configuration file location
  --disablerepo=ID              Disable repository by an id
  --disableplugin=name          Disable plugins by name
  --enablerepo=ID               Enable repository by an id
  --enableplugin=name           Enable plugins by name
  --nobest                      Do not limit the transaction to the best candidates
  --installroot=PATH            Set install root
  --nodocs                      Install packages without docs
  --noplugins                   Disable loading of plugins
  --refresh                     Set metadata as expired before running the command
  --releasever=RELEASEVER       Override the value of $releasever in config and repo files
  --setopt=<option>=<value>     Override a configuration option (install_weak_deps=0/1, allow_vendor_change=0/1, keepcache=0/1, module_platform_id=<name:stream>, cachedir=<path>, reposdir=<path1>,<path2>,..., tsflags=nodocs/test, varsdir=<path1>,<path2>,..., repo_id.option_name=<value>)
```

###### Things done


- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
