### PR TITLE
postgresql: 9.5.24 -> 9.5.25, 9.6.20 -> 9.6.21, 10.15 -> 10.16, 11.10 -> 11.11, 12.5 -> 12.6, 13.1 -> 13.2 

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -219,9 +219,9 @@ in self: {
   };
 
   postgresql_11 = self.callPackage generic {
-    version = "11.10";
+    version = "11.11";
     psqlSchema = "11.1"; # should be 11, but changing it is invasive
-    sha256 = "16bqp6ds37kbwqx7mk5gg3y6gv59wq6xz33iqwxldzk20vwd5rhk";
+    sha256 = "0v0qk298nxmpzpgsxcsxma328hdkyzd7fwjs0zsn6zavl5zpnq20";
     this = self.postgresql_11;
     thisAttr = "postgresql_11";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -210,9 +210,9 @@ in self: {
   };
 
   postgresql_10 = self.callPackage generic {
-    version = "10.15";
+    version = "10.16";
     psqlSchema = "10.0"; # should be 10, but changing it is invasive
-    sha256 = "0zhzj9skag1pgqas2rnd217vj41ilaalqna17j47gyngpvhbqmjr";
+    sha256 = "1cvv8qw0gkkczqhiwx6ns7w88dwkvdz4cvb2d4ff14363f5p2p53";
     this = self.postgresql_10;
     thisAttr = "postgresql_10";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -192,9 +192,9 @@ let
 in self: {
 
   postgresql_9_5 = self.callPackage generic {
-    version = "9.5.24";
+    version = "9.5.25";
     psqlSchema = "9.5";
-    sha256 = "0an2k4m1da96897hyxlff8p4p63wg4dffwsfg57aib7mp4yzsp06";
+    sha256 = "00yny0sskxrqk4ji2phgv3iqxd1aiy6rh660k73s4s1pn9gcaa3n";
     this = self.postgresql_9_5;
     thisAttr = "postgresql_9_5";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -237,9 +237,9 @@ in self: {
   };
 
   postgresql_13 = self.callPackage generic {
-    version = "13.1";
+    version = "13.2";
     psqlSchema = "13";
-    sha256 = "07z6zwr58dckaa97yl9ml240z83d1lhgaxw9aq49i8lsp21mqd0j";
+    sha256 = "1z5d847jnajcfr3wa6jn52a8xjhamvwzmz18xlm5nvxqip8grmsz";
     this = self.postgresql_13;
     thisAttr = "postgresql_13";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -228,9 +228,9 @@ in self: {
   };
 
   postgresql_12 = self.callPackage generic {
-    version = "12.5";
+    version = "12.6";
     psqlSchema = "12";
-    sha256 = "15gzg778da23sbfmy7sqg443f9ny480301lm7i3vay4m3ls2a3dx";
+    sha256 = "028asz92mi3706zabfs8w9z03mzyx62d1l71qy9zdwfabj6xjzfz";
     this = self.postgresql_12;
     thisAttr = "postgresql_12";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -201,9 +201,9 @@ in self: {
   };
 
   postgresql_9_6 = self.callPackage generic {
-    version = "9.6.20";
+    version = "9.6.21";
     psqlSchema = "9.6";
-    sha256 = "1dkv916y7vrfbygrfbfvs6y3fxaysnh32i5j88nvcnnl16jcn21x";
+    sha256 = "0d0ngpadf1i7c0i2psaxcbmiwx8334ibcsn283n9fp4853pyl3wk";
     this = self.postgresql_9_6;
     thisAttr = "postgresql_9_6";
     inherit self;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.postgresql.org/about/news/postgresql-132-126-1111-1016-9621-and-9525-released-2165/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
