### PR TITLE
python39Packages.fixtures: fix build

### DIFF
--- a/pkgs/development/python-modules/fixtures/default.nix
+++ b/pkgs/development/python-modules/fixtures/default.nix
@@ -1,11 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
+, pythonAtLeast
 , pbr
 , testtools
 , mock
 , python
-, isPy39
 }:
 
 buildPythonPackage rec {
@@ -16,6 +17,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "fcf0d60234f1544da717a9738325812de1f42c2fa085e2d9252d8fff5712b2ef";
   };
+
+  patches = lib.optional (pythonAtLeast "3.9") [
+    # drop tests that try to monkeypatch a classmethod, which fails on python3.9
+    # https://github.com/testing-cabal/fixtures/issues/44
+    (fetchpatch {
+       url = "https://salsa.debian.org/openstack-team/python/python-fixtures/-/raw/debian/victoria/debian/patches/remove-broken-monkey-patch-test.patch";
+       sha256 = "1s3hg2zmqc4shmnf90kscphzj5qlqpxghzw2a59p8f88zrbsj97r";
+    })
+  ];
 
   nativeBuildInputs = [
     pbr
@@ -37,6 +47,5 @@ buildPythonPackage rec {
     description = "Reusable state for writing clean tests and more";
     homepage = "https://pypi.python.org/pypi/fixtures";
     license = lib.licenses.asl20;
-    broken = isPy39; # see https://github.com/testing-cabal/fixtures/issues/44
   };
 }

--- a/pkgs/development/python-modules/fixtures/default.nix
+++ b/pkgs/development/python-modules/fixtures/default.nix
@@ -17,7 +17,17 @@ buildPythonPackage rec {
     sha256 = "fcf0d60234f1544da717a9738325812de1f42c2fa085e2d9252d8fff5712b2ef";
   };
 
-  propagatedBuildInputs = [ pbr testtools mock ];
+  nativeBuildInputs = [
+    pbr
+  ];
+
+  propagatedBuildInputs = [
+    testtools
+  ];
+
+  checkInputs = [
+    mock
+  ];
 
   checkPhase = ''
     ${python.interpreter} -m testtools.run fixtures.test_suite


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Drops two tests that try to monkeypatch a classmethod, which breaks due
to changes in Python 3.9. The project isn't really that well maintained
anymore and Debian started dropping those two tests in November 2020, so
let's follow suit

Also separate checkInputs from propagatedBuildInputs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
