### PR TITLE
grub2: fix cross-compilation

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchgit, flex, bison, python3, autoconf, automake, gnulib, libtool
 , gettext, ncurses, libusb-compat-0_1, freetype, qemu, lvm2, unifont, pkg-config
 , pkgsBuildBuild
+, nixosTests
 , fuse # only needed for grub-mount
 , runtimeShell
 , zfs ? null
@@ -124,6 +125,14 @@ stdenv.mkDerivation rec {
     # Avoid a runtime reference to gcc
     sed -i $out/lib/grub/*/modinfo.sh -e "/grub_target_cppflags=/ s|'.*'|' '|"
   '';
+
+  passthru.tests = {
+    nixos-grub = nixosTests.grub;
+    nixos-install-simple = nixosTests.installer.simple;
+    nixos-install-grub1 = nixosTests.installer.grub1;
+    nixos-install-grub-uefi = nixosTests.installer.simpleUefiGrub;
+    nixos-install-grub-uefi-spec = nixosTests.installer.simpleUefiGrubSpecialisation;
+  };
 
   meta = with lib; {
     description = "GNU GRUB, the Grand Unified Boot Loader (2.x beta)";


### PR DESCRIPTION
* gettext is used for native binaries, not hosted libs
* grub2 expects `BUILD_CC` to point to a native C compiler
* add `strictDeps = true` to prevent regressions

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes e.g. `pkgsCross.aarch64-multiplatform.grub2`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (nixos/tests/grub.nix)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
