### PR TITLE
qemu-ga: add statedir option

### DIFF
--- a/nixos/modules/virtualisation/qemu-guest-agent.nix
+++ b/nixos/modules/virtualisation/qemu-guest-agent.nix
@@ -17,6 +17,11 @@ in {
         default = pkgs.qemu.ga;
         description = "The QEMU guest agent package.";
       };
+      stateDir = mkOption {
+        type = types.path;
+        default = "/var/run";
+        description = "Absolute path where qemu-ga stores state information";
+      };
   };
 
   config = mkIf cfg.enable (
@@ -30,7 +35,7 @@ in {
       systemd.services.qemu-guest-agent = {
         description = "Run the QEMU Guest Agent";
         serviceConfig = {
-          ExecStart = "${cfg.package}/bin/qemu-ga";
+          ExecStart = "${cfg.package}/bin/qemu-ga --statedir ${cfg.stateDir}";
           Restart = "always";
           RestartSec = 0;
         };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Presently, starting qemu guest agent fails with the following error:
```
Feb 12 14:07:50 desktop systemd[1]: Started Run the QEMU Guest Agent.
Feb 12 14:07:50 desktop qemu-ga[21931]: 1613119070.843292: critical: failed to write persistent state to /nix/store/p9nsjv5yw25h2bys7dqxzrcs9hsj21nh-qemu-5.1.0-ga/bin/../var/run/qga.state: Failed to create file “/nix/store/p9nsjv5yw25h2bys7dqxzrcs9hsj21nh-qemu-5.1.0-ga/bin/../var/run/qga.state.N6IVY0”: No such file or directory
Feb 12 14:07:50 desktop qemu-ga[21931]: 1613119070.843309: critical: unable to create state file at path /nix/store/p9nsjv5yw25h2bys7dqxzrcs9hsj21nh-qemu-5.1.0-ga/bin/../var/run/qga.state
Feb 12 14:07:50 desktop qemu-ga[21931]: 1613119070.843314: critical: failed to load persistent state
Feb 12 14:07:50 desktop qemu-ga[21931]: 1613119070.843318: critical: error initializing guest agent
```

`qemu-ga --help` shows the reason for this
```
-t, --statedir    specify dir to store state information (absolute paths only, default is /nix/store/p9nsjv5yw25h2bys7dqxzrcs9hsj21nh-qemu-5.1.0-ga/bin/../var/run)
```

Adding a writable path as `--statedir` to the ExecStart command solves this issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
