### PR TITLE
nixos/dbus: support dbus-broker

### DIFF
--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -278,7 +278,7 @@ in
       };
     };
 
-    services.dbus.enable = true;
+    services.dbus.enable = mkDefault true;
     services.dbus.packages = [ pkgs.avahi ];
 
     networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall [ 5353 ];

--- a/nixos/modules/services/networking/wicd.nix
+++ b/nixos/modules/services/networking/wicd.nix
@@ -34,7 +34,7 @@ with lib;
       script = "${pkgs.wicd}/sbin/wicd -f";
     };
 
-    services.dbus.enable = true;
+    services.dbus.enable = mkDefault true;
     services.dbus.packages = [pkgs.wicd];
   };
 }

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -8,6 +8,8 @@ let
 
   cfg = config.services.dbus;
 
+  brokerCfg = config.services.dbus-broker;
+
   homeDir = "/run/dbus";
 
   configDir = pkgs.makeDBusConf {
@@ -22,6 +24,17 @@ in
   ###### interface
 
   options = {
+
+    services.dbus-broker.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable dbus-broker, implementation of a message bus
+        as defined by the D-Bus specification. Its aim is to provide high
+        performance and reliability, while keeping compatibility to the D-Bus
+        reference implementation. You must disable services.dbus.enable to use this.
+      '';
+    };
 
     services.dbus = {
 
@@ -79,61 +92,111 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
-    warnings = optional (cfg.socketActivated != null) (
-      let
-        files = showFiles options.services.dbus.socketActivated.files;
-      in
-        "The option 'services.dbus.socketActivated' in ${files} no longer has"
-        + " any effect and can be safely removed: the user D-Bus session is"
-        + " now always socket activated."
-    );
+  config = mkMerge [
+    # You still need the dbus reference implementation installed to use dbus-broker
+    (mkIf (cfg.enable || brokerCfg.enable) {
+      warnings = optional (cfg.socketActivated != null) (
+        let
+          files = showFiles options.services.dbus.socketActivated.files;
+        in
+          "The option 'services.dbus.socketActivated' in ${files} no longer has"
+          + " any effect and can be safely removed: the user D-Bus session is"
+          + " now always socket activated."
+      );
 
-    environment.systemPackages = [ pkgs.dbus.daemon pkgs.dbus ];
+      assertions = [
+        { assertion = brokerCfg.enable -> !cfg.enable;
+          message = ''
+            You cannot use services.dbus.enable with services.dbus-broker.enable. Please disable DBus.
+          '';
+        }
+      ];
 
-    environment.etc."dbus-1".source = configDir;
+      environment.etc."dbus-1".source = configDir;
 
-    users.users.messagebus = {
-      uid = config.ids.uids.messagebus;
-      description = "D-Bus system message bus daemon user";
-      home = homeDir;
-      group = "messagebus";
-    };
+      users.users.messagebus = {
+        uid = config.ids.uids.messagebus;
+        description = "D-Bus system message bus daemon user";
+        home = homeDir;
+        group = "messagebus";
+      };
 
-    users.groups.messagebus.gid = config.ids.gids.messagebus;
+      users.groups.messagebus.gid = config.ids.gids.messagebus;
 
-    systemd.packages = [ pkgs.dbus.daemon ];
+      systemd.packages = [
+        pkgs.dbus.daemon
+      ];
 
-    security.wrappers.dbus-daemon-launch-helper = {
-      source = "${pkgs.dbus.daemon}/libexec/dbus-daemon-launch-helper";
-      owner = "root";
-      group = "messagebus";
-      setuid = true;
-      setgid = false;
-      permissions = "u+rx,g+rx,o-rx";
-    };
+      services.dbus.packages = [
+        pkgs.dbus.out
+        config.system.path
+      ];
 
-    services.dbus.packages = [
-      pkgs.dbus.out
-      config.system.path
-    ];
-
-    systemd.services.dbus = {
-      # Don't restart dbus-daemon. Bad things tend to happen if we do.
-      reloadIfChanged = true;
-      restartTriggers = [ configDir ];
-      environment = { LD_LIBRARY_PATH = config.system.nssModules.path; };
-    };
-
-    systemd.user = {
-      services.dbus = {
+      systemd.services.dbus = {
         # Don't restart dbus-daemon. Bad things tend to happen if we do.
         reloadIfChanged = true;
-        restartTriggers = [ configDir ];
+        restartTriggers = [
+          configDir
+        ];
+        environment = {
+          LD_LIBRARY_PATH = config.system.nssModules.path;
+        };
       };
-      sockets.dbus.wantedBy = [ "sockets.target" ];
-    };
 
-    environment.pathsToLink = [ "/etc/dbus-1" "/share/dbus-1" ];
-  };
+      systemd.user = {
+        services.dbus = {
+          # Don't restart dbus-daemon. Bad things tend to happen if we do.
+          reloadIfChanged = true;
+          restartTriggers = [
+            configDir
+          ];
+        };
+        sockets.dbus.wantedBy = [
+          "sockets.target"
+        ];
+      };
+
+      environment.pathsToLink = [
+        "/etc/dbus-1"
+        "/share/dbus-1"
+      ];
+    })
+
+    (mkIf cfg.enable {
+      environment.systemPackages = [
+        pkgs.dbus
+        pkgs.dbus.daemon
+      ];
+
+      security.wrappers.dbus-daemon-launch-helper = {
+        source = "${pkgs.dbus.daemon}/libexec/dbus-daemon-launch-helper";
+        owner = "root";
+        group = "messagebus";
+        setuid = true;
+        setgid = false;
+        permissions = "u+rx,g+rx,o-rx";
+      };
+    })
+
+    (mkIf brokerCfg.enable {
+      environment.systemPackages = [
+        pkgs.dbus-broker
+      ];
+
+      systemd.packages = [
+        pkgs.dbus-broker
+      ];
+
+      # NixOS Systemd Module doesn't respect 'Install'
+      # https://github.com/NixOS/nixpkgs/issues/108643
+      systemd.services.dbus-broker.aliases = [
+        "dbus.service"
+      ];
+
+      systemd.user.services.dbus-broker.aliases = [
+        "dbus.service"
+      ];
+    })
+
+  ];
 }

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -258,7 +258,7 @@ in
     environment.etc."lightdm/lightdm.conf".source = lightdmConf;
     environment.etc."lightdm/users.conf".source = usersConf;
 
-    services.dbus.enable = true;
+    services.dbus.enable = mkDefault true;
     services.dbus.packages = [ lightdm ];
 
     # lightdm uses the accounts daemon to remember language/window-manager per user

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1046,7 +1046,7 @@ in
       "systemd/system-shutdown" = { source = hooks "shutdown" cfg.shutdown; };
     });
 
-    services.dbus.enable = true;
+    services.dbus.enable = mkDefault true;
 
     users.users.systemd-network.uid = config.ids.uids.systemd-network;
     users.groups.systemd-network.gid = config.ids.gids.systemd-network;

--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -1,21 +1,50 @@
-{ lib, stdenv, fetchFromGitHub, docutils, meson, ninja, pkg-config
-, dbus, linuxHeaders, systemd }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, docutils
+, meson
+, ninja
+, pkg-config
+, dbus
+, linuxHeaders
+, systemd
+}:
 
 stdenv.mkDerivation rec {
   pname = "dbus-broker";
-  version = "22";
+  version = "26";
 
   src = fetchFromGitHub {
-    owner  = "bus1";
-    repo   = "dbus-broker";
-    rev    = "v${version}";
-    sha256 = "0vxr73afix5wjxy8g4cckwhl242rrlazm52673iwmdyfz5nskj2x";
+    owner = "bus1";
+    repo = "dbus-broker";
+    rev = "v${version}";
+    sha256 = "QjYjAvnLgMRL/4Jj1XBXl9z47zVHclOqZrAF2khC424=";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ docutils meson ninja pkg-config ];
+  patches = [
+    # Make launcher.c use nixos dbus configuration paths
+    # In the future the buildsystem should allow us to configure the **default**
+    # (as there is a --config-file cmdline)
+    ./fix-paths.patch
+  ];
 
-  buildInputs = [ dbus linuxHeaders systemd ];
+  mesonFlags = [
+    "-D=system-console-users=gdm,sddm,lightdm"
+  ];
+
+  nativeBuildInputs = [
+    docutils
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+    linuxHeaders
+    systemd
+  ];
 
   PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
   PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
@@ -32,9 +61,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Linux D-Bus Message Broker";
-    homepage    = "https://github.com/bus1/dbus-broker/wiki";
-    license     = licenses.asl20;
-    platforms   = platforms.linux;
-    maintainers = with maintainers; [ peterhoeg ];
+    homepage = "https://github.com/bus1/dbus-broker/wiki";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ peterhoeg worldofpeace ];
   };
 }

--- a/pkgs/os-specific/linux/dbus-broker/fix-paths.patch
+++ b/pkgs/os-specific/linux/dbus-broker/fix-paths.patch
@@ -1,0 +1,16 @@
+diff --git a/src/launch/launcher.c b/src/launch/launcher.c
+index 5ba9b77..e338d92 100644
+--- a/src/launch/launcher.c
++++ b/src/launch/launcher.c
+@@ -1007,9 +1007,9 @@ static int launcher_parse_config(Launcher *launcher, ConfigRoot **rootp, NSSCach
+         if (launcher->configfile)
+                 configfile = launcher->configfile;
+         else if (launcher->user_scope)
+-                configfile = "/usr/share/dbus-1/session.conf";
++                configfile = "/etc/dbus-1/session.conf";
+         else
+-                configfile = "/usr/share/dbus-1/system.conf";
++                configfile = "/etc/dbus-1/system.conf";
+ 
+         config_parser_init(&parser);
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The dbus-broker project tries to improve on what was dbus-daemon, and provide a better alternative.
This PR adds support for dbus-broker, which I hope could be the default dbus daemon for NixOS.
For more information about dbus-broker see https://dvdhrm.github.io/rethinking-the-dbus-message-bus/ or this short description from [Fedora]( https://fedoraproject.org/wiki/Changes/DbusBrokerAsTheDefaultDbusImplementation#Detailed_Description). They've used dbus-broker since F30 (was released on April 30, 2019,) which should help to make this an easy switch for us.

###### Things done
* I've logged into a root console and checked if `dbus-broker` was running
* Inspected `/etc/systemd` for the units being setup in the way I expected
* Ran a Pantheon VM , launched a terminal, and checked the status of `dbus-broker`


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
