### PR TITLE
emacs.pkgs.jam-mode: init at 0.3

### DIFF
--- a/pkgs/applications/editors/emacs-modes/jam-mode/default.nix
+++ b/pkgs/applications/editors/emacs-modes/jam-mode/default.nix
@@ -1,0 +1,22 @@
+{ trivialBuild, lib, fetchurl }:
+
+trivialBuild rec {
+  pname = "jam-mode";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "https://dev.gentoo.org/~ulm/distfiles/jam-mode-${version}.el.xz";
+    sha256 = "1jchgiy2rgvnb3swr6ar72yas6pj4inpgpcq78q01q6snflmi2fh";
+  };
+
+  unpackPhase = ''
+    xz -cd $src > jam-mode.el
+  '';
+
+  meta = with lib; {
+    description = "An Emacs major mode for editing Jam files";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ qyliss ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -111,6 +111,8 @@
 
   helm-words = callPackage ./helm-words { };
 
+  jam-mode = callPackage ./jam-mode { };
+
   org-mac-link =
     callPackage ./org-mac-link { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
