### PR TITLE
weechatScripts.weechat-matrix: make patchable

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
@@ -53,11 +53,11 @@ in buildPythonPackage {
 
   installPhase = ''
     mkdir -p $out/share $out/bin
-    cp $src/main.py $out/share/matrix.py
+    cp main.py $out/share/matrix.py
 
-    cp $src/contrib/matrix_upload.py $out/bin/matrix_upload
-    cp $src/contrib/matrix_decrypt.py $out/bin/matrix_decrypt
-    cp $src/contrib/matrix_sso_helper.py $out/bin/matrix_sso_helper
+    cp contrib/matrix_upload.py $out/bin/matrix_upload
+    cp contrib/matrix_decrypt.py $out/bin/matrix_decrypt
+    cp contrib/matrix_sso_helper.py $out/bin/matrix_sso_helper
     substituteInPlace $out/bin/matrix_upload \
       --replace '/usr/bin/env -S python3' '${scriptPython}/bin/python'
     substituteInPlace $out/bin/matrix_sso_helper \
@@ -66,7 +66,7 @@ in buildPythonPackage {
       --replace '/usr/bin/env python3' '${scriptPython}/bin/python'
 
     mkdir -p $out/${python.sitePackages}
-    cp -r $src/matrix $out/${python.sitePackages}/matrix
+    cp -r matrix $out/${python.sitePackages}/matrix
   '';
 
   dontPatchShebangs = true;


### PR DESCRIPTION
If an overlay adds patches, they wouldn't be applied because we were
copying from directory out of src.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
