### PR TITLE
nrfutil: python37Packages -> python3Packages

### DIFF
--- a/pkgs/development/tools/misc/nrfutil/default.nix
+++ b/pkgs/development/tools/misc/nrfutil/default.nix
@@ -1,6 +1,6 @@
-{ lib, python37Packages, fetchFromGitHub }:
+{ lib, python3Packages, fetchFromGitHub }:
 
-with python37Packages; buildPythonApplication rec {
+with python3Packages; buildPythonApplication rec {
   pname = "nrfutil";
   version = "6.1";
 


### PR DESCRIPTION
Clean up build so it tracks latest python3Packages,
instead of being pinned to python37Packages.

Nrfutil builds and works fine with python38 on Darwin and Linux.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>