### PR TITLE
lice: 0.4 -> 0.6

### DIFF
--- a/pkgs/tools/misc/lice/default.nix
+++ b/pkgs/tools/misc/lice/default.nix
@@ -1,17 +1,19 @@
-{ lib, fetchFromGitHub, python3Packages }:
+{ lib, buildPythonPackage, fetchPypi , setuptools, pytestCheckHook }:
 
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
 
-  version = "0.4";
-  name = "lice-${version}";
+  pname = "lice";
+  version = "0.6";
 
-  src = fetchFromGitHub {
-    owner = "licenses";
-    repo = "lice";
-    rev = version;
-    sha256 = "0yxf70fi8ds3hmwjply2815k466r99k8n22r0ppfhwjvp3rn60qx";
-    fetchSubmodules = true;
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0skyyirbidknfdzdvsjga8zb4ar6xpd5ilvz11dfm2a9yxh3d59d";
   };
+
+  propagatedBuildInputs = [ setuptools ];
+
+  checkInputs = [ pytestCheckHook ];
+
 
   meta = with lib; {
     description = "Print license based on selection and user options";

--- a/pkgs/tools/misc/lice/default.nix
+++ b/pkgs/tools/misc/lice/default.nix
@@ -1,7 +1,6 @@
 { lib, buildPythonPackage, fetchPypi , setuptools, pytestCheckHook }:
 
 buildPythonPackage rec {
-
   pname = "lice";
   version = "0.6";
 
@@ -13,8 +12,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ setuptools ];
 
   checkInputs = [ pytestCheckHook ];
-
-
   meta = with lib; {
     description = "Print license based on selection and user options";
     homepage = "https://github.com/licenses/lice";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29032,7 +29032,7 @@ in
 
   lkproof = callPackage ../tools/typesetting/tex/lkproof { };
 
-  lice = callPackage ../tools/misc/lice {};
+  lice = python3Packages.callPackage ../tools/misc/lice {};
 
   m33-linux = callPackage ../misc/drivers/m33-linux { };
 


### PR DESCRIPTION
Credits to @mat8913 (https://github.com/NixOS/nixpkgs/issues/75521#issuecomment-566013855).

###### Motivation for this change

lice 0.4 is old and in nixpkgs broken: fixes #75521

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) **+3.6 MB**
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
