### PR TITLE
flashbench: 2012-06-06 -> 2020-01-23

### DIFF
--- a/pkgs/os-specific/linux/flashbench/default.nix
+++ b/pkgs/os-specific/linux/flashbench/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "flashbench";
-  version = "2012-06-06";
+  version = "2020-01-23";
 
   src = fetchFromGitHub {
     owner = "bradfa";
     repo = "flashbench";
-    rev = "2e30b1968a66147412f21002ea844122a0d5e2f0";
-    sha256 = "037rhd2alwfip9qk78cy8fwwnc2kdyzccsyc7v2zpmvl4vvpvnhg";
+    rev = "d783b1bd2443812c6deadc31b081f043e43e4c1a";
+    sha256 = "045j1kpay6x2ikz8x54ph862ymfy1nzpbmmqpf3nkapiv32fjqw5";
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/flashbench/default.nix
+++ b/pkgs/os-specific/linux/flashbench/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "flashbench";
-  version = "2020-01-23";
+  version = "unstable-2020-01-23";
 
   src = fetchFromGitHub {
     owner = "bradfa";

--- a/pkgs/os-specific/linux/flashbench/default.nix
+++ b/pkgs/os-specific/linux/flashbench/default.nix
@@ -12,10 +12,14 @@ stdenv.mkDerivation {
   };
 
   installPhase = ''
+    runHook preInstall
+
     install -d -m755 $out/bin $out/share/doc/flashbench
     install -v -m755 flashbench $out/bin
     install -v -m755 erase $out/bin/flashbench-erase
     install -v -m644 README $out/share/doc/flashbench
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/flashbench/default.nix
+++ b/pkgs/os-specific/linux/flashbench/default.nix
@@ -1,11 +1,12 @@
-{ lib, stdenv, fetchgit }:
+{ lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
   pname = "flashbench";
   version = "2012-06-06";
 
-  src = fetchgit {
-    url = "https://github.com/bradfa/flashbench.git";
+  src = fetchFromGitHub {
+    owner = "bradfa";
+    repo = "flashbench";
     rev = "2e30b1968a66147412f21002ea844122a0d5e2f0";
     sha256 = "037rhd2alwfip9qk78cy8fwwnc2kdyzccsyc7v2zpmvl4vvpvnhg";
   };

--- a/pkgs/os-specific/linux/flashbench/default.nix
+++ b/pkgs/os-specific/linux/flashbench/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     description = "Testing tool for flash based memory devices";
     homepage = "https://github.com/bradfa/flashbench";
     platforms = platforms.linux;
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.rycee ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The current version of flashbench is quite old. I updated it to use the latest commit from about a year ago. There have only been four new commits with small changes since 2012, so I don't expect any regressions.
I also switched from fetchgit to fetchGitHub.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).