### PR TITLE
clpm: 0.3.5 -> 0.3.6

### DIFF
--- a/pkgs/development/tools/clpm/default.nix
+++ b/pkgs/development/tools/clpm/default.nix
@@ -23,13 +23,21 @@ stdenv.mkDerivation rec {
   ];
 
   buildPhase = ''
+    runHook preBuild
+
     ln -s ${openssl.out}/lib/libcrypto.so.* .
     ln -s ${openssl.out}/lib/libssl.so.* .
     common-lisp.sh --script scripts/build.lisp
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     INSTALL_ROOT=$out sh install.sh
+
+    runHook postInstall
   '';
 
   # fixupPhase results in fatal error in SBCL, `Can't find sbcl.core`

--- a/pkgs/development/tools/clpm/default.nix
+++ b/pkgs/development/tools/clpm/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchgit
 , wrapLisp
 , sbcl
@@ -7,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "clpm";
-  version = "0.3.5";
+  version = "0.3.6";
 
   src = fetchgit {
     url = "https://gitlab.common-lisp.net/clpm/clpm";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0jivnnp3z148yf4c2nzzr5whz76w5kjhsb97z2vs5maiwf79y2if";
+    sha256 = "04w46yhv31p4cfb84b6qvyfw7x5nx6lzyd4yzhd9x6qvb7p5kmfh";
   };
 
   buildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update CLPM. 

###### Things done

Update CLPM to 0.3.6

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
