### PR TITLE
python3Packages.pytest-click: 0.3 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/pytest-click/default.nix
+++ b/pkgs/development/python-modules/pytest-click/default.nix
@@ -1,40 +1,36 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
 , pytest
 , click
-, pytestcov
-, isPy27
-, mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pytest-click";
-  version = "0.3";
+  version = "1.0.2";
+  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "Stranger6667";
     repo = "pytest-click";
-    rev = version;
-    sha256 = "1cd15anw8d4rq6qs03j6ag38199rqw7vp0w0w0fm41mvdzr0lwvz";
+    rev = "v${version}";
+    sha256 = "197nvlqlyfrqpy5lrkmfh1ywpr6j9zipxl9d7syg2a2n7jz3a8rj";
   };
-
-  postConfigure = ''
-    substituteInPlace setup.py \
-      --replace "mock==1.0.1" "mock"
-  '';
 
   propagatedBuildInputs = [
     pytest
     click
   ];
 
-  checkInputs = [ pytestcov ] ++ lib.optionals isPy27 [ mock ];
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "pytest plugin for click";
     homepage = "https://github.com/Stranger6667/pytest-click";
+    changelog = "https://github.com/Stranger6667/pytest-click/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

When I found this package, noticed the Nix version was out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
