### PR TITLE
python3Packages.astroid: 2.4.2 -> 2.5.0

### DIFF
--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "An abstract syntax tree for Python with inference support";
     homepage = "https://github.com/PyCQA/astroid";
-    license = licenses.lgpl2;
+    license = licenses.lgpl21Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ nand0p ];
   };

--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -1,29 +1,34 @@
-{ lib, fetchPypi, buildPythonPackage, pythonOlder, isPyPy, pythonAtLeast
-, lazy-object-proxy, six, wrapt, typing, typed-ast
-, pytestrunner, pytest
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, isPyPy
+, lazy-object-proxy
+, wrapt
+, typed-ast
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "astroid";
-  version = "2.4.2";
+  version = "2.5";
 
-  disabled = pythonOlder "3.4" || pythonAtLeast "3.9";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703";
+    sha256 = "03dzhjrsc5d2whyjngfrwvxn42058k0cjjr85x2wqzai8psr475k";
   };
 
-  postPatch = ''
-    substituteInPlace astroid/__pkginfo__.py --replace "lazy_object_proxy==1.4.*" "lazy_object_proxy"
-  '';
-
   # From astroid/__pkginfo__.py
-  propagatedBuildInputs = [ lazy-object-proxy six wrapt ]
-    ++ lib.optional (pythonOlder "3.5") typing
-    ++ lib.optional (!isPyPy) typed-ast;
+  propagatedBuildInputs = [
+    lazy-object-proxy
+    wrapt
+  ] ++ lib.optional (!isPyPy && pythonOlder "3.8") typed-ast;
 
-  checkInputs = [ pytestrunner pytest ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "An abstract syntax tree for Python with inference support";

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -1,50 +1,69 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, pythonOlder, astroid, installShellFiles,
-  isort, mccabe, pytestCheckHook, pytest-benchmark, pytestrunner, toml }:
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, installShellFiles
+, astroid
+, isort
+, mccabe
+, toml
+, pytest-benchmark
+, pytest-xdist
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pylint";
-  version = "2.6.2";
+  version = "2.7.1";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-cYt0eG6n7QeqDFi/VyFU1Geflg0m6WQcwd4gSjC4f8k=";
+    sha256 = "10nrvzk1naf5ryawmi59wp99k31053sz37q3x9li2hj2cf7i1kl1";
   };
 
-  nativeBuildInputs = [ pytestrunner installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
-  checkInputs = [ pytestCheckHook pytest-benchmark ];
+  propagatedBuildInputs = [
+    astroid
+    isort
+    mccabe
+    toml
+  ];
 
-  propagatedBuildInputs = [ astroid isort mccabe toml ];
-
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    # Remove broken darwin test
-    rm -vf pylint/test/test_functional.py
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp
+    cp -v "elisp/"*.el $out/share/emacs/site-lisp/
+    installManPage man/*.1
   '';
 
-  disabledTests = [
-    # https://github.com/PyCQA/pylint/issues/3198
-    "test_by_module_statement_value"
-    # has issues with local directories
-    "test_version"
-   ] ++ lib.optionals stdenv.isDarwin [
-      "test_parallel_execution"
-      "test_py3k_jobs_option"
-   ];
+  checkInputs = [
+    pytest-benchmark
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  dontUseSetuptoolsCheck = true;
 
   # calls executable in one of the tests
   preCheck = ''
     export PATH=$PATH:$out/bin
   '';
 
-  dontUseSetuptoolsCheck = true;
+  pytestFlagsArray = [
+    "-n auto"
+  ];
 
-  postInstall = ''
-    mkdir -p $out/share/emacs/site-lisp
-    cp "elisp/"*.el $out/share/emacs/site-lisp/
-    installManPage man/*.1
-  '';
+  disabledTests = lib.optionals stdenv.isDarwin [
+    "test_parallel_execution"
+    "test_py3k_jobs_option"
+  ];
+
+  disabledTestPaths = lib.optional stdenv.isDarwin "pylint/test/test_functional.py";
 
   meta = with lib; {
     homepage = "https://pylint.pycqa.org/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Python 3.9 :heart: 

Updates to 2.5.0 which was released today (2020-02-16).
https://github.com/PyCQA/astroid/releases/tag/astroid-2.5

<s>Applies patches that fix Python 3.9 support in the testsuite:
- https://github.com/PyCQA/astroid/pull/829
- https://github.com/PyCQA/astroid/pull/858
</s>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
