### PR TITLE
nixos/mastodon: set environment for mastodon-init-dirs

### DIFF
--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -367,6 +367,7 @@ in {
       '' else "") + ''
         EOF
       '';
+      environment = env;
       serviceConfig = {
         Type = "oneshot";
         User = cfg.user;


### PR DESCRIPTION


###### Motivation for this change

mastodon-init-dirs should have the same environment as the other services, as it also calls rake. Especially RAILS_ENV was missing.



###### Things done

