### PR TITLE
trezor-suite: init at 21.2.2

### DIFF
--- a/pkgs/applications/blockchains/trezor-suite/default.nix
+++ b/pkgs/applications/blockchains/trezor-suite/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, fetchurl
+, appimageTools
+, tor
+, trezord
+}:
+
+let
+  pname = "trezor-suite";
+  version = "21.2.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/trezor/${pname}/releases/download/v${version}/Trezor-Suite-${version}-linux-x86_64.AppImage";
+    sha256 = "0dj3azx9jvxchrpm02w6nkcis6wlnc6df04z7xc6f66fwn6r3kkw";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in
+
+appimageTools.wrapType2 rec {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    mkdir -p $out/bin $out/share/${pname} $out/share/${pname}/resources
+
+    cp -a ${appimageContents}/locales/ $out/share/${pname}
+    cp -a ${appimageContents}/resources/app*.* $out/share/${pname}/resources
+    cp -a ${appimageContents}/resources/images/ $out/share/${pname}/resources
+
+    install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
+    install -m 444 -D ${appimageContents}/${pname}.png $out/share/icons/hicolor/512x512/apps/${pname}.png
+    install -m 444 -D ${appimageContents}/resources/images/icons/512x512.png $out/share/icons/hicolor/512x512/apps/${pname}.png
+    substituteInPlace $out/share/applications/trezor-suite.desktop --replace 'Exec=AppRun' 'Exec=${pname}'
+
+    # symlink system binaries instead bundled ones
+    mkdir -p $out/share/${pname}/resources/bin/{bridge,tor}
+    ln -sf ${trezord}/bin/trezord-go $out/share/${pname}/resources/bin/bridge/trezord
+    ln -sf ${tor}/bin/tor $out/share/${pname}/resources/bin/tor/tor
+  '';
+
+  meta = with lib; {
+    description = "Trezor Suite - Desktop App for managing crypto";
+    homepage = "https://suite.trezor.io";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ prusnak ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8429,6 +8429,8 @@ in
 
   trezor_agent = with python3Packages; toPythonApplication trezor_agent;
 
+  trezor-suite = callPackage ../applications/blockchains/trezor-suite { };
+
   tthsum = callPackage ../applications/misc/tthsum { };
 
   chaps = callPackage ../tools/security/chaps { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- package Trezor Suite - https://suite.trezor.io

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
