### PR TITLE
python3Packages.pyzerproc: init at 0.4.6

### DIFF
--- a/pkgs/development/python-modules/pyzerproc/default.nix
+++ b/pkgs/development/python-modules/pyzerproc/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, asynctest
+, bleak
+, click
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytest-cov
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyzerproc";
+  version = "0.4.6";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "emlove";
+    repo = pname;
+    rev = version;
+    sha256 = "1qlxvvy9fyff56dvc46nsd5ngkxqhdi7s4gwfndj7dn76j81srpq";
+  };
+
+  # Remove pytest-runner, https://github.com/emlove/pyzerproc/pull/1
+  patchPhase = ''
+    substituteInPlace setup.py --replace "'pytest-runner'," ""
+  '';
+
+  propagatedBuildInputs = [
+    bleak
+    click
+  ];
+
+  checkInputs = [
+    asynctest
+    pytest-asyncio
+    pytest-cov
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pyzerproc" ];
+
+  meta = with lib; {
+    description = "Python library to control Zerproc Bluetooth LED smart string lights";
+    homepage = "https://github.com/emlove/pyzerproc";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -965,7 +965,7 @@
     "zamg" = ps: with ps; [ ];
     "zengge" = ps: with ps; [ ]; # missing inputs: zengge
     "zeroconf" = ps: with ps; [ aiohttp-cors zeroconf ];
-    "zerproc" = ps: with ps; [ ]; # missing inputs: pyzerproc
+    "zerproc" = ps: with ps; [ pyzerproc ];
     "zestimate" = ps: with ps; [ xmltodict ];
     "zha" = ps: with ps; [ bellows pyserial-asyncio pyserial zha-quirks zigpy-cc zigpy-deconz zigpy-xbee zigpy-zigate zigpy-znp zigpy ];
     "zhong_hong" = ps: with ps; [ ]; # missing inputs: zhong_hong_hvac

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6598,6 +6598,8 @@ in {
 
   pyyaml = callPackage ../development/python-modules/pyyaml { };
 
+  pyzerproc = callPackage ../development/python-modules/pyzerproc { };
+
   pyzmq = callPackage ../development/python-modules/pyzmq { };
 
   pyzufall = callPackage ../development/python-modules/pyzufall { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to control Zerproc Bluetooth LED smart string lights

https://github.com/emlove/pyzerproc

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
