### PR TITLE
apfs-fuse: 2019-07-23 -> 2020-09-28

### DIFF
--- a/pkgs/tools/filesystems/apfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/apfs-fuse/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage    = "https://github.com/sgan81/apfs-fuse";
     description = "FUSE driver for APFS (Apple File System)";
-    license     = licenses.gpl2;
+    license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ ealasu ];
     platforms   = platforms.linux;
   };

--- a/pkgs/tools/filesystems/apfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/apfs-fuse/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "apfs-fuse-unstable";
-  version = "2019-07-23";
+  version = "2020-09-28";
 
   src = fetchFromGitHub {
     owner  = "sgan81";
     repo   = "apfs-fuse";
-    rev    = "309ecb030f38edac4c10fa741a004c5eb7a23e15";
-    sha256 = "0wq6rlqi00m5dp5gbzy65i1plm40j6nsm7938zvfgx5laal4wzr2";
+    rev    = "ee71aa5c87c0831c1ae17048951fe9cd7579c3db";
+    sha256 = "0wvsx708km1lnhghny5y69k694x0zy8vlbndswkb7sq81j1r6kwx";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Update apfs-fuse to the latest commit.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).