### PR TITLE
pkgsCross.musl32: fix a few basic package

### DIFF
--- a/pkgs/applications/misc/audio/sox/0001-musl-rewind-pipe-workaround.patch
+++ b/pkgs/applications/misc/audio/sox/0001-musl-rewind-pipe-workaround.patch
@@ -1,0 +1,24 @@
+From e7446c9bcb47674c9d0ee3b5bab129e9b86eb1c9 Mon Sep 17 00:00:00 2001
+From: Walter Franzini <walter.franzini@gmail.com>
+Date: Fri, 7 Jun 2019 17:57:11 +0200
+Subject: [PATCH] musl does not support rewind pipe, make it build anyway
+
+---
+ src/formats.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/formats.c b/src/formats.c
+index f3efe764..477bf451 100644
+--- a/src/formats.c
++++ b/src/formats.c
+@@ -424,7 +424,6 @@ static void UNUSED rewind_pipe(FILE * fp)
+   /* To fix this #error, either simply remove the #error line and live without
+    * file-type detection with pipes, or add support for your compiler in the
+    * lines above.  Test with cat monkey.wav | ./sox --info - */
+-  #error FIX NEEDED HERE
+   #define NO_REWIND_PIPE
+   (void)fp;
+ #endif
+-- 
+2.19.2
+

--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
   # configure.ac uses pkg-config only to locate libopusfile
   nativeBuildInputs = optional enableOpusfile pkg-config;
 
+  patches = [ ./0001-musl-rewind-pipe-workaround.patch ];
+
   buildInputs =
     optional (enableAlsa && stdenv.isLinux) alsaLib ++
     optional enableLibao libao ++

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -451,7 +451,9 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" stackprotector pic"
     '' + optionalString (targetPlatform.libc == "newlib") ''
       hardening_unsupported_flags+=" stackprotector fortify pie pic"
-    '' + optionalString targetPlatform.isNetBSD ''
+      '' + optionalString (targetPlatform.libc == "musl" && targetPlatform.isi686) ''
+      hardening_unsupported_flags+=" stackprotector"
+      '' + optionalString targetPlatform.isNetBSD ''
       hardening_unsupported_flags+=" stackprotector fortify"
     '' + optionalString cc.langAda or false ''
       hardening_unsupported_flags+=" format stackprotector strictoverflow"

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -451,9 +451,9 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" stackprotector pic"
     '' + optionalString (targetPlatform.libc == "newlib") ''
       hardening_unsupported_flags+=" stackprotector fortify pie pic"
-      '' + optionalString (targetPlatform.libc == "musl" && targetPlatform.isi686) ''
+    '' + optionalString (targetPlatform.libc == "musl" && targetPlatform.isx86_32) ''
       hardening_unsupported_flags+=" stackprotector"
-      '' + optionalString targetPlatform.isNetBSD ''
+    '' + optionalString targetPlatform.isNetBSD ''
       hardening_unsupported_flags+=" stackprotector fortify"
     '' + optionalString cc.langAda or false ''
       hardening_unsupported_flags+=" format stackprotector strictoverflow"

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -78,7 +78,11 @@ let majorVersion = "6";
       ++ optional (targetPlatform.libc == "musl") ../libgomp-dont-force-initial-exec.patch
 
       # Obtain latest patch with ../update-mcfgthread-patches.sh
-      ++ optional (!crossStageStatic && targetPlatform.isMinGW) ./Added-mcf-thread-model-support-from-mcfgthread.patch;
+      ++ optional (!crossStageStatic && targetPlatform.isMinGW) ./Added-mcf-thread-model-support-from-mcfgthread.patch
+      ++ optional (targetPlatform.libc == "musl" && targetPlatform.isx86_32) (fetchpatch {
+        url = "https://git.alpinelinux.org/aports/plain/main/gcc/gcc-6.1-musl-libssp.patch?id=5e4b96e23871ee28ef593b439f8c07ca7c7eb5bb";
+        sha256 = "1jf1ciz4gr49lwyh8knfhw6l5gvfkwzjy90m7qiwkcbsf4a3fqn2";
+      });
 
     javaEcj = fetchurl {
       # The `$(top_srcdir)/ecj.jar' file is automatically picked up at

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -72,6 +72,10 @@ let majorVersion = "7";
       })
       ++ optional langFortran ../gfortran-driving.patch
       ++ optional (targetPlatform.libc == "musl" && targetPlatform.isPower) ../ppc-musl.patch
+      ++ optional (targetPlatform.libc == "musl" && targetPlatform.isx86_32) (fetchpatch {
+        url = "https://git.alpinelinux.org/aports/plain/main/gcc/gcc-6.1-musl-libssp.patch";
+        sha256 = "1jf1ciz4gr49lwyh8knfhw6l5gvfkwzjy90m7qiwkcbsf4a3fqn2";
+      })
       ++ optional (targetPlatform.libc == "musl") ../libgomp-dont-force-initial-exec.patch
 
       # Obtain latest patch with ../update-mcfgthread-patches.sh

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -73,7 +73,7 @@ let majorVersion = "7";
       ++ optional langFortran ../gfortran-driving.patch
       ++ optional (targetPlatform.libc == "musl" && targetPlatform.isPower) ../ppc-musl.patch
       ++ optional (targetPlatform.libc == "musl" && targetPlatform.isx86_32) (fetchpatch {
-        url = "https://git.alpinelinux.org/aports/plain/main/gcc/gcc-6.1-musl-libssp.patch";
+        url = "https://git.alpinelinux.org/aports/plain/main/gcc/gcc-6.1-musl-libssp.patch?id=5e4b96e23871ee28ef593b439f8c07ca7c7eb5bb";
         sha256 = "1jf1ciz4gr49lwyh8knfhw6l5gvfkwzjy90m7qiwkcbsf4a3fqn2";
       })
       ++ optional (targetPlatform.libc == "musl") ../libgomp-dont-force-initial-exec.patch

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -94,9 +94,6 @@ let
       # In uclibc cases, libgomp needs an additional '-ldl'
       # and as I don't know how to pass it, I disable libgomp.
       "--disable-libgomp"
-    ] ++ lib.optionals (targetPlatform.libc == "musl") [
-      # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-      "--disable-libmpx"
     ] ++ lib.optional (targetPlatform.libc == "newlib") "--with-newlib"
       ++ lib.optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
     );
@@ -181,6 +178,9 @@ let
       # On Illumos/Solaris GNU as is preferred
       "--with-gnu-as" "--without-gnu-ld"
     ]
+    ++ lib.optional (targetPlatform.libc == "musl")
+      # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
+      "--disable-libmpx"
     ++ lib.optionals (targetPlatform == hostPlatform && targetPlatform.libc == "musl") [
       "--disable-libsanitizer"
       "--disable-symvers"

--- a/pkgs/development/libraries/libexecinfo/30-linux-makefile.patch
+++ b/pkgs/development/libraries/libexecinfo/30-linux-makefile.patch
@@ -1,0 +1,44 @@
+--- Makefile.orig
++++ Makefile
+@@ -23,24 +23,25 @@
+ # SUCH DAMAGE.
+ #
+ # $Id: Makefile,v 1.3 2004/07/19 05:19:55 sobomax Exp $
++#
++# Linux Makefile by Matt Smith <mcs@darkregion.net>, 2011/01/04
+ 
+-LIB=	execinfo
++CC=cc
++AR=ar
++EXECINFO_CFLAGS=$(CFLAGS) -O2 -pipe -fno-strict-aliasing -std=gnu99 -c
++EXECINFO_LDFLAGS=$(LDFLAGS)
+ 
+-SRCS=	stacktraverse.c stacktraverse.h execinfo.c execinfo.h
++all: static dynamic
+ 
+-INCS=	execinfo.h
++static:
++	$(CC) $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) stacktraverse.c
++	$(CC) $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) execinfo.c
++	$(AR) rcs libexecinfo.a stacktraverse.o execinfo.o
+ 
+-SHLIB_MAJOR=	1
+-SHLIB_MINOR=	0
++dynamic:
++	$(CC) -fpic -DPIC $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) stacktraverse.c -o stacktraverse.So
++	$(CC) -fpic -DPIC $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) execinfo.c -o execinfo.So
++	$(CC) -shared -Wl,-soname,libexecinfo.so.1 -o libexecinfo.so.1 stacktraverse.So execinfo.So
+ 
+-NOPROFILE=	yes
+-
+-DPADD=		${LIBM}
+-LDADD=		-lm
+-
+-#WARNS?=	4
+-
+-#stacktraverse.c: gen.py
+-#	./gen.py > stacktraverse.c
+-
+-.include <bsd.lib.mk>
++clean:
++	rm -rf *.o *.So *.a *.so

--- a/pkgs/development/libraries/libexecinfo/default.nix
+++ b/pkgs/development/libraries/libexecinfo/default.nix
@@ -23,14 +23,11 @@ stdenv.mkDerivation rec {
       url = "https://git.alpinelinux.org/aports/plain/main/libexecinfo/20-define-gnu-source.patch?id=730cdcef6901750f4029d4c3b8639ce02ee3ead1";
       sha256 = "1mp8mc639b0h2s69m5z6s2h3q3n1zl298j9j0plzj7f979j76302";
     })
-    (fetchpatch {
-      name = "30-linux-makefile.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/libexecinfo/30-linux-makefile.patch?id=730cdcef6901750f4029d4c3b8639ce02ee3ead1";
-      sha256 = "1jwjz22z5cjy5h2bfghn62yl9ar8jiqhdvbwrcfavv17ihbhwcaf";
-    })
+    ./30-linux-makefile.patch
   ];
 
   makeFlags = [ "CC:=$(CC)" "AR:=$(AR)" ];
+  hardeningEnable = [ "stackprotector" ];
 
   buildFlags =
       lib.optional enableStatic "static"

--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, gettext, libgpgerror, enableCapabilities ? false, libcap
-, buildPackages
+, buildPackages, fetchpatch
 }:
 
 assert enableCapabilities -> stdenv.isLinux;
@@ -12,6 +12,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnupg/libgcrypt/${pname}-${version}.tar.bz2";
     sha256 = "1nb50bgzp83q6r5cz4v40y1mcbhpqwqyxlay87xp1lrbkf5pm9n5";
   };
+
+  patches = [
+    # fix build on 32bit musl
+    (fetchpatch {
+      name = "fix_building_with_disable-asm_on_x86.patch";
+      url = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commitdiff_plain;h=af23ab5c5482d625ff52e60606cf044e2b0106c8";
+      sha256 = "1m8apm8wra6fk89ggha4d0bba5absihm38zvb2khklqh9q5hj9jw";
+    })
+  ];
 
   outputs = [ "out" "dev" "info" ];
   outputBin = "dev";
@@ -26,6 +35,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ libgpgerror ]
     ++ lib.optional stdenv.isDarwin gettext
     ++ lib.optional enableCapabilities libcap;
+
+  strictDeps = true;
 
   configureFlags = [ "--with-libgpg-error-prefix=${libgpgerror.dev}" ]
    ++ lib.optional stdenv.hostPlatform.isMusl "--disable-asm";

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
   separateDebugInfo = stdenv.isLinux && stdenv.hostPlatform.libc != "musl";
 
   enableParallelBuilding = true;
+  hardeningDisable = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isi686) "stackprotector";
+
+  # FIXME: the hardeingDisable attr above does not seems effective, so
+  # the need to disable stackprotector via configureFlags
+  configureFlags = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isi686) "--disable-ssp";
 
   doCheck = true;
 

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -12,11 +12,11 @@ stdenv.mkDerivation rec {
   separateDebugInfo = stdenv.isLinux && stdenv.hostPlatform.libc != "musl";
 
   enableParallelBuilding = true;
-  hardeningDisable = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isi686) "stackprotector";
+  hardeningDisable = lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isx86_32) "stackprotector";
 
   # FIXME: the hardeingDisable attr above does not seems effective, so
   # the need to disable stackprotector via configureFlags
-  configureFlags = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isi686) "--disable-ssp";
+  configureFlags = lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isx86_32) "--disable-ssp";
 
   doCheck = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9827,6 +9827,9 @@ in
     libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then libcCross else null;
     threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else null;
 
+    # gcc 10 is too strict to cross compile gcc <= 8
+    stdenv = if (stdenv.targetPlatform != stdenv.buildPlatform) && stdenv.cc.isGNU then gcc7Stdenv else stdenv;
+
     isl = if stdenv.isDarwin
             then null
           else if stdenv.targetPlatform.isRedox
@@ -9843,6 +9846,9 @@ in
     libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then libcCross else null;
     threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else null;
 
+    # gcc 10 is too strict to cross compile gcc <= 8
+    stdenv = if (stdenv.targetPlatform != stdenv.buildPlatform) && stdenv.cc.isGNU then gcc7Stdenv else stdenv;
+
     isl = if !stdenv.isDarwin then isl_0_17 else null;
   }));
 
@@ -9854,6 +9860,9 @@ in
 
     libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then libcCross else null;
     threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else null;
+
+    # gcc 10 is too strict to cross compile gcc <= 8
+    stdenv = if (stdenv.targetPlatform != stdenv.buildPlatform) && stdenv.cc.isGNU then gcc7Stdenv else stdenv;
 
     isl = if !stdenv.isDarwin then isl_0_17 else null;
   }));


### PR DESCRIPTION
A rebase of https://github.com/NixOS/nixpkgs/pull/89471 on current staging, fixing some patches.

Fixes https://github.com/NixOS/nixpkgs/issues/88554 for gcc6 7 8.

cc @wfranzini @matthewbauer  @nagisa @NixOS/exotic-platform-maintainers 

Tested by building
```
nix-build . -A pkgsCross.musl32.libsodium -A pkgsCross.musl32.libgcrypt -A pkgsCross.musl32.openssl -A pkgsCross.musl32.audit -A pkgsCross.musl64.openssl -A pkgsCross.musl32.gcc7 -A gcc7
```


###### Motivation for this change


I occasionally use `pkgsCross.musl32`.


Note: I don't fully understand the stackprotector patches, I only rebased them without much thought.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
