### PR TITLE
python3Packages.py-cid: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/py-cid/default.nix
+++ b/pkgs/development/python-modules/py-cid/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, base58
+, py-multibase
+, py-multicodec
+, morphys
+, py-multihash
+, hypothesis
+}:
+
+buildPythonPackage rec {
+  pname = "py-cid";
+  version = "0.3.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "ipld";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-aN7ee25ghKKa90+FoMDCdGauToePc5AzDLV3tONvh4U=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "base58>=1.0.2,<2.0" "base58>=1.0.2" \
+      --replace "py-multihash>=0.2.0,<1.0.0" "py-multihash>=0.2.0" \
+      --replace "'pytest-runner'," ""
+  '';
+
+  propagatedBuildInputs = [
+    base58
+    py-multibase
+    py-multicodec
+    morphys
+    py-multihash
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    hypothesis
+  ];
+
+  pythonImportsCheck = [ "cid" ];
+
+  meta = with lib; {
+    description = "Self-describing content-addressed identifiers for distributed systems implementation in Python";
+    homepage = "https://github.com/ipld/py-cid";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5315,6 +5315,8 @@ in {
 
   pycparser = callPackage ../development/python-modules/pycparser { };
 
+  py-cid = callPackage ../development/python-modules/py-cid { };
+
   py-cpuinfo = callPackage ../development/python-modules/py-cpuinfo { };
 
   pycrc = callPackage ../development/python-modules/pycrc { };


### PR DESCRIPTION
###### Motivation for this change
This adds py-cid from https://github.com/ipld/py-cid.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).