### PR TITLE
stockfish: darwin build support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9433,6 +9433,12 @@
       fingerprint = "556A 403F B0A2 D423 F656  3424 8489 B911 F9ED 617B";
     }];
   };
+  tmountain = {
+    email = "tinymountain@gmail.com";
+    github = "tmountain";
+    githubId = 135297;
+    name = "Travis Whitton";
+  };
   tmplt = {
     email = "tmplt@dragons.rocks";
     github = "tmplt";

--- a/pkgs/games/stockfish/default.nix
+++ b/pkgs/games/stockfish/default.nix
@@ -1,15 +1,22 @@
 { lib, stdenv, fetchurl }:
 
-let arch = if stdenv.isx86_64 then "x86-64" else
+with lib;
+
+let
+    # The x86-64-modern may need to be refined further in the future
+    # but stdenv.hostPlatform CPU flags do not currently work on Darwin
+    # https://discourse.nixos.org/t/darwin-system-and-stdenv-hostplatform-features/9745
+    archDarwin = if stdenv.isx86_64 then "x86-64-modern" else "x86-64";
+    arch = if stdenv.isDarwin then archDarwin else
+           if stdenv.isx86_64 then "x86-64" else
            if stdenv.isi686 then "x86-32" else
            "unknown";
-
     version = "12";
 
     nnueFile = "nn-82215d0fd0df.nnue";
     nnue = fetchurl {
       name = nnueFile;
-        url = "https://tests.stockfishchess.org/api/nn/${nnueFile}";
+      url = "https://tests.stockfishchess.org/api/nn/${nnueFile}";
       sha256 = "1r4yqrh4di05syyhl84hqcz84djpbd605b27zhbxwg6zs07ms8c2";
     };
 in
@@ -23,18 +30,24 @@ stdenv.mkDerivation {
     sha256 = "16980aicm5i6i9252239q4f9bcxg1gnqkv6nphrmpz4drg8i3v6i";
   };
 
+  # This addresses a linker issue with Darwin
+  # https://github.com/NixOS/nixpkgs/issues/19098
+  preBuild = optionalString stdenv.isDarwin ''
+    sed -i.orig '/^\#\#\# 3.*Link Time Optimization/,/^\#\#\# 3/d' Makefile
+  '';
+
   postUnpack = ''
     sourceRoot+=/src
     echo ${nnue}
     cp "${nnue}" "$sourceRoot/${nnueFile}"
   '';
 
-  makeFlags = [ "PREFIX=$(out)" "ARCH=${arch}" ];
+  makeFlags = [ "PREFIX=$(out)" "ARCH=${arch}" "CXX=${stdenv.cc.targetPrefix}c++" ];
   buildFlags = [ "build" ];
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://stockfishchess.org/";
     description = "Strong open source chess engine";
     longDescription = ''
@@ -42,7 +55,7 @@ stdenv.mkDerivation {
       much stronger than the best human chess grandmasters.
       '';
     maintainers = with maintainers; [ luispedro peti ];
-    platforms = ["x86_64-linux" "i686-linux"];
+    platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
     license = licenses.gpl2;
   };
 


### PR DESCRIPTION
###### Motivation for this change

This PR allows stockfish to build successfully for Darwin/x86. Does not add support for apple-silicon, as Nix still seems to be solidifying its approach to the new chipset.

Note: I had to modify the makeFlags, as the Stockfish Makefile hardcodes g++, and this doesn't work with clang.

###### Things done

- Built on platform(s)
   - [X ] macOS
   - [ X] other Linux distributions
- [ X] Tested execution of all binary files (usually in `./result/bin/`)
- [X ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
