### PR TITLE
ssh-tools: init at 1.6

### DIFF
--- a/pkgs/applications/misc/ssh-tools/default.nix
+++ b/pkgs/applications/misc/ssh-tools/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "ssh-tools";
+  version = "1.6";
+
+  src = fetchFromGitHub {
+    owner = "vaporup";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0m0x9383p9ab4hdirncmrfha130iasa0v4cbif2y5nbxnxgh101r";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ssh-* $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Collection of various tools using ssh";
+    homepage = "https://github.com/vaporup/ssh-tools/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29389,6 +29389,8 @@ in
 
   ssh-audit = callPackage ../tools/security/ssh-audit { };
 
+  ssh-tools = callPackage ../applications/misc/ssh-tools { };
+
   auto-cpufreq = callPackage ../tools/system/auto-cpufreq {  };
 
   thermald = callPackage ../tools/system/thermald { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
