### PR TITLE
codespell: enable tests

### DIFF
--- a/pkgs/development/python-modules/aspell-python/default.nix
+++ b/pkgs/development/python-modules/aspell-python/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, aspell, aspellDicts, python }:
+
+buildPythonPackage rec {
+  pname = "aspell-python";
+  version = "1.15";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "aspell-python-py3";
+    extension = "tar.bz2";
+    sha256 = "13dk3jrvqmfvf2w9b8afj37d8bh32kcx295lyn3z7r8qch792hi0";
+  };
+
+  buildInputs = [ aspell ];
+
+  checkPhase = ''
+    export ASPELL_CONF="dict-dir ${aspellDicts.en}/lib/aspell"
+    export HOME=$(mktemp -d)
+    ${python.interpreter} test/unittests.py
+  '';
+
+  pythonImportsCheck = [ "aspell" ];
+
+  meta = with lib; {
+    description = "Python wrapper for aspell (C extension and python version)";
+    homepage = "https://github.com/WojciechMula/aspell-python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/development/python-modules/codespell/default.nix
+++ b/pkgs/development/python-modules/codespell/default.nix
@@ -1,31 +1,31 @@
-{ lib, buildPythonApplication, fetchPypi, pytest, chardet }:
+{ lib, buildPythonApplication, fetchFromGitHub, pytestCheckHook, pytest-cov, pytest-dependency, aspell-python, aspellDicts, chardet }:
 
 buildPythonApplication rec {
   pname = "codespell";
   version = "2.0.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "dd9983e096b9f7ba89dd2d2466d1fc37231d060f19066331b9571341363c77b8";
+  src = fetchFromGitHub {
+    owner = "codespell-project";
+    repo = "codespell";
+    rev = "v${version}";
+    sha256 = "187g26s3wzjmvdx9vjabbnajpbg0s9klixyv6baymmgz9lrcv4ln";
   };
 
-  # no tests in pypi tarball
-  doCheck = false;
-  checkInputs = [ pytest chardet ];
-  checkPhase = ''
-    # We don't want to be affected by the presence of these
-    rm -r codespell_lib setup.cfg
-    # test_command assumes too much about the execution environment
-    pytest --pyargs codespell_lib.tests -k "not test_command"
+  checkInputs = [ aspell-python chardet pytestCheckHook pytest-cov pytest-dependency ];
+
+  preCheck = ''
+    export ASPELL_CONF="dict-dir ${aspellDicts.en}/lib/aspell"
   '';
+
+  # tries to run not rully installed script
+  disabledTests = [ "test_command" ];
 
   pythonImportsCheck = [ "codespell_lib" ];
 
-  meta = {
+  meta = with lib; {
     description = "Fix common misspellings in source code";
     homepage = "https://github.com/codespell-project/codespell";
-    license = with lib.licenses; [ gpl2 cc-by-sa-30 ];
-    maintainers = with lib.maintainers; [ johnazoidberg ];
-    platforms = lib.platforms.all;
+    license = with licenses; [ gpl2Only cc-by-sa-30 ];
+    maintainers = with maintainers; [ johnazoidberg SuperSandro2000 ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -461,6 +461,8 @@ in {
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };
 
+  aspell-python = callPackage ../development/python-modules/aspell-python { };
+
   aspy-yaml = callPackage ../development/python-modules/aspy.yaml { };
 
   asteval = callPackage ../development/python-modules/asteval { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
