### PR TITLE
e2fsprogs,yosys,verilog: mark broken on darwin; ranger: cleanup stale substituteInPlace; pythonPackages.img2pdf: Disable tests; thefuck: Fix tests

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -32,18 +32,12 @@ python3Packages.buildPythonApplication rec {
         ranger/data/scope.sh
     ''}
 
-    substituteInPlace ranger/data/scope.sh \
-      --replace "/bin/echo" "echo"
-
     substituteInPlace ranger/__init__.py \
       --replace "DEFAULT_PAGER = 'less'" "DEFAULT_PAGER = '${lib.getBin less}/bin/less'"
 
-    for i in ranger/config/rc.conf doc/config/rc.conf ; do
-      substituteInPlace $i --replace /usr/share $out/share
-    done
-
     # give file previews out of the box
     substituteInPlace ranger/config/rc.conf \
+      --replace /usr/share $out/share \
       --replace "#set preview_script ~/.config/ranger/scope.sh" "set preview_script $out/share/doc/ranger/config/scope.sh"
   '' + optionalString imagePreviewSupport ''
     substituteInPlace ranger/ext/img_display.py \

--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -38,7 +38,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
+  # tests try to access /proc/ which does not exist on darwin
+  # Cannot locate IVL modules : couldn't get command path from OS.
+  doCheck = !stdenv.isDarwin;
 
   installCheckInputs = [ perl ];
 

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -103,5 +103,12 @@ stdenv.mkDerivation rec {
     license     = licenses.isc;
     platforms   = platforms.all;
     maintainers = with maintainers; [ shell thoughtpolice emily ];
+    #In file included from kernel/driver.cc:20:
+    #./kernel/yosys.h:42:10: fatal error: 'map' file not found
+    ##include <map>
+
+    #https://github.com/YosysHQ/yosys/issues/681
+    #https://github.com/YosysHQ/yosys/issues/2011
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, setuptools, swig, verilog }:
+{ lib, stdenv, buildPythonPackage, fetchFromGitHub, setuptools, swig, verilog }:
 
 buildPythonPackage rec {
   pname = "cocotb";
@@ -25,9 +25,6 @@ buildPythonPackage rec {
     do
       substituteInPlace $f --replace 'shell which' 'shell command -v'
     done
-
-    # This can perhaps be removed in the next update after 1.3.2?
-    substituteInPlace cocotb/share/makefiles/Makefile.inc --replace "-Werror" ""
   '';
 
   checkInputs = [ swig verilog ];
@@ -36,8 +33,7 @@ buildPythonPackage rec {
     # test expected failures actually pass because of a fix in our icarus version
     # https://github.com/cocotb/cocotb/issues/1952
     substituteInPlace tests/test_cases/test_discovery/test_discovery.py \
-      --replace 'def access_single_bit' $'def foo(x): pass\ndef foo' \
-      --replace 'def access_single_bit_assignment' $'def foo(x): pass\ndef foo'
+      --replace 'def access_single_bit' $'def foo(x): pass\ndef foo'
 
     export PATH=$out/bin:$PATH
     make test
@@ -48,5 +44,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/cocotb/cocotb";
     license = licenses.bsd3;
     maintainers = with maintainers; [ matthuszagh ];
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -15,6 +15,9 @@ buildPythonPackage rec {
     pillow
   ];
 
+  # no tests exectuted
+  doCheck = false;
+
   meta = with lib; {
     description = "Convert images to PDF via direct JPEG inclusion";
     homepage = "https://gitlab.mister-muffin.de/josch/img2pdf";

--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -71,5 +71,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = [ maintainers.eelco ];
+    # imager.c:70:2: error: unknown type name 'loff_t'; did you mean 'off_t'?
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/tools/misc/smenu/default.nix
+++ b/pkgs/tools/misc/smenu/default.nix
@@ -5,25 +5,24 @@ stdenv.mkDerivation rec {
   pname = "smenu";
 
   src = fetchFromGitHub {
-    owner  = "p-gen";
-    repo   = "smenu";
-    rev    = "v${version}";
+    owner = "p-gen";
+    repo = "smenu";
+    rev = "v${version}";
     sha256 = "1p8y1fgrfb7jxmv5ycvvnqaz7ghdi50paisgzk71169fqwp1crfa";
   };
 
   buildInputs = [ ncurses ];
 
   meta = with lib; {
-    homepage        = "https://github.com/p-gen/smenu";
-    description     = "Terminal selection utility";
+    homepage = "https://github.com/p-gen/smenu";
+    description = "Terminal selection utility";
     longDescription = ''
       Terminal utility that allows you to use words coming from the standard
       input to create a nice selection window just below the cursor. Once done,
       your selection will be sent to standard output.
     '';
-    license     = licenses.gpl2;
-    maintainers = [ maintainers.matthiasbeyer ];
-    platforms   = platforms.unix;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ matthiasbeyer SuperSandro2000 ];
+    platforms = platforms.unix;
   };
 }
-

--- a/pkgs/tools/misc/thefuck/default.nix
+++ b/pkgs/tools/misc/thefuck/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, buildPythonApplication
 , colorama, decorator, psutil, pyte, six
-, pytest, pytest-mock
+, go, mock, pytestCheckHook, pytest-mock
 }:
 
 buildPythonApplication rec {
@@ -16,22 +16,12 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [ colorama decorator psutil pyte six ];
 
-  checkInputs = [ pytest pytest-mock ];
-
-  checkPhase = ''
-    export HOME=$TMPDIR
-    export LANG=en_US.UTF-8
-    export XDG_CACHE_HOME=$TMPDIR/cache
-    export XDG_CONFIG_HOME=$TMPDIR/config
-    py.test
-  '';
-
-  doCheck = false; # The above is only enough for tests to pass outside the sandbox.
+  checkInputs = [ go mock pytestCheckHook pytest-mock ];
 
   meta = with lib; {
     homepage = "https://github.com/nvbn/thefuck";
     description = "Magnificent app which corrects your previous console command";
     license = licenses.mit;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ma27 SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
