### PR TITLE
zsjed: init at 0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10686,6 +10686,16 @@
     github = "pulsation";
     githubId = 1838397;
   };
+  zseri = {
+    name = "Erik K. A. Zscheile";
+    email = "zseri.devel@ytrizja.de";
+    github = "zserik";
+    githubId = 1618343;
+    keys = [{
+      longkeyid = "rsa4096/0x229E63AE5644A96D";
+      fingerprint = "7AFB C595 0D3A 77BD B00F  947B 229E 63AE 5644 A96D";
+    }];
+  };
   zupo = {
     name = "Nejc Zupan";
     email = "nejczupan+nix@gmail.com";

--- a/pkgs/tools/misc/zsjed/default.nix
+++ b/pkgs/tools/misc/zsjed/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  installFlags = "DESTDIR=$out";
+  installFlags = [ "DESTDIR=${placeholder "out"}" ];
 
   # zsjed-mkls uses: sort find awk
   postInstall = ''

--- a/pkgs/tools/misc/zsjed/default.nix
+++ b/pkgs/tools/misc/zsjed/default.nix
@@ -3,7 +3,6 @@
 , fetchurl
 , findutils
 , gawk
-, gcc
 , lib
 , makeWrapper
 , stdenv
@@ -18,9 +17,12 @@ stdenv.mkDerivation rec {
     sha256 = "1rcrvrqjsv80ldz7cscqbrf98jb0yd2in97irrzlpask699z5k29";
   };
 
+  patches = [
+    ./zsjed-0.3-Makefile.patch
+  ];
+
   nativeBuildInputs = [
     diffutils
-    gcc
     makeWrapper
   ];
 
@@ -47,15 +49,11 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  # can't reuse the Makefile 'install' target, as it assumes the wrong prefix
+  installFlags = "DESTDIR=$out";
+
   # zsjed-mkls uses: sort find awk
-  installPhase = ''
-    runHook preInstall
-
-    install -D -t $out/bin zsjed-collect zsjed-clear zsjed-spread zsjed-mkls
+  postInstall = ''
     wrapProgram $out/bin/zsjed-mkls --prefix PATH ":" "${lib.makeBinPath [coreutils findutils gawk]}"
-
-    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/zsjed/default.nix
+++ b/pkgs/tools/misc/zsjed/default.nix
@@ -1,0 +1,72 @@
+{ coreutils
+, diffutils
+, fetchurl
+, findutils
+, gawk
+, gcc
+, lib
+, makeWrapper
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zsjed";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "https://ytrizja.de/distfiles/zsjed-${version}.tar.gz";
+    sha256 = "1rcrvrqjsv80ldz7cscqbrf98jb0yd2in97irrzlpask699z5k29";
+  };
+
+  nativeBuildInputs = [
+    diffutils
+    gcc
+    makeWrapper
+  ];
+
+  doCheck = true;
+  enableParallelBuilding = true;
+
+  # doesn't test zsjed-mkls
+  checkPhase = ''
+    runHook preCheck
+
+    dst="$(realpath .)"
+    tmp="$(mktemp -d)"
+    cd "$tmp"
+    touch f1 f2
+    echo f1 > l
+    echo f2 >> l
+    "$dst"/zsjed-clear l
+    echo "a b c d e f g h i j k" > i
+    "$dst"/zsjed-spread i l
+    "$dst"/zsjed-collect j l
+    cmp i j
+    cd "$dst"
+
+    runHook postCheck
+  '';
+
+  # can't reuse the Makefile 'install' target, as it assumes the wrong prefix
+  # zsjed-mkls uses: sort find awk
+  installPhase = ''
+    runHook preInstall
+
+    install -D -t $out/bin zsjed-collect zsjed-clear zsjed-spread zsjed-mkls
+    wrapProgram $out/bin/zsjed-mkls --prefix PATH ":" "${lib.makeBinPath [coreutils findutils gawk]}"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Zscheile data split semi-steganography tool";
+    longDescription = ''
+      zsjed is a data split semi-steganography tool.
+      It splits a file and pastes these parts
+      at the end of many other files, recoverable.
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.zseri ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/zsjed/zsjed-0.3-Makefile.patch
+++ b/pkgs/tools/misc/zsjed/zsjed-0.3-Makefile.patch
@@ -1,0 +1,19 @@
+diff -u zsjed-0.3/Makefile zsjed-0.3.new/Makefile
+--- zsjed-0.3/Makefile	2018-01-01 17:21:55.000000000 +0100
++++ zsjed-0.3.new/Makefile	2021-02-20 12:48:25.988807315 +0100
+@@ -4,13 +4,12 @@
+ .PHONY: all
+ 
+ zsjed-%: %.cxx zsjed_seek.hpp
+-	g++ -std=c++14 -Wall $(CXXFLAGS) -o $@ $<
++	$(CXX) -std=c++14 -Wall $(CXXFLAGS) -o $@ $<
+ 
+ clean:
+ 	@rm -f $(TARGETS)
+ .PHONY: clean
+ 
+ install: $(TARGETS)
+-	mkdir -p $(DESTDIR)/usr/bin
+-	install -t $(DESTDIR)/usr/bin $^ zsjed-mkls
++	install -D -t $(DESTDIR)/bin $^ zsjed-mkls
+ .PHONY: install

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9263,6 +9263,8 @@ in
 
   zsh-autoenv = callPackage ../tools/misc/zsh-autoenv { };
 
+  zsjed = callPackage ../tools/misc/zsjed { };
+
   zsh-autopair = callPackage ../shells/zsh/zsh-autopair { };
 
   zsh-bd = callPackage ../shells/zsh/zsh-bd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Packaging my semi-stenography tool (hiding file snippets at the end of other files).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux) (enabled by default)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
