### PR TITLE
wakeonlan: init at 0.41

### DIFF
--- a/pkgs/tools/networking/wakeonlan/default.nix
+++ b/pkgs/tools/networking/wakeonlan/default.nix
@@ -1,0 +1,29 @@
+{ lib, perlPackages, fetchFromGitHub, installShellFiles }:
+
+perlPackages.buildPerlPackage rec {
+  pname = "wakeonlan";
+  version = "0.41";
+
+  src = fetchFromGitHub {
+    owner = "jpoliv";
+    repo = pname;
+    rev = "wakeonlan-${version}";
+    sha256 = "0m48b39lz0yc5ckx2jx8y2p4c8npjngxl9wy86k43xgsd8mq1g3c";
+  };
+
+  outputs = [ "out" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    install -Dt $out/bin wakeonlan
+    installManPage blib/man1/wakeonlan.1
+  '';
+
+  meta = with lib; {
+    description = "Perl script for waking up computers via Wake-On-LAN magic packets";
+    homepage = "https://github.com/jpoliv/wakeonlan";
+    license = licenses.artistic1;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3835,6 +3835,8 @@ in
 
   utahfs = callPackage ../applications/networking/utahfs { };
 
+  wakeonlan = callPackage ../tools/networking/wakeonlan { };
+
   wallutils = callPackage ../tools/graphics/wallutils { };
 
   wayland-utils = callPackage ../tools/wayland/wayland-utils { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
