### PR TITLE
pipewire: 0.3.18 -> 0.3.21

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -39,7 +39,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "pipewire";
-  version = "0.3.18";
+  version = "0.3.21";
 
   outputs = [
     "out"
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     owner = "pipewire";
     repo = "pipewire";
     rev = version;
-    sha256 = "1yghhgs18yqrnd0b2r75l5n8yng962r1wszbsi01v6i9zib3jc9g";
+    sha256 = "sha256-2YJzPTMPIoQQeNja3F53SD4gtpdSlbD/i77hBWiQfuQ=";
   };
 
   patches = [

--- a/pkgs/development/libraries/pipewire/installed-tests-path.patch
+++ b/pkgs/development/libraries/pipewire/installed-tests-path.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index ffee41b4..bab6f019 100644
+index 429ac249..b973b2d3 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -318,8 +318,8 @@ alsa_dep = (get_option('pipewire-alsa')
+@@ -358,8 +358,8 @@ alsa_dep = (get_option('pipewire-alsa')
      ? dependency('alsa', version : '>=1.1.7')
      : dependency('', required: false))
  
@@ -14,7 +14,7 @@ index ffee41b4..bab6f019 100644
  installed_tests_template = files('template.test.in')
  
 diff --git a/meson_options.txt b/meson_options.txt
-index f03033c3..32df6c53 100644
+index 200a8fa2..b205a4f6 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -18,6 +18,9 @@ option('installed_tests',

--- a/pkgs/development/libraries/pipewire/pipewire-pulse-path.patch
+++ b/pkgs/development/libraries/pipewire/pipewire-pulse-path.patch
@@ -1,19 +1,19 @@
 diff --git a/meson_options.txt b/meson_options.txt
-index 4b9e46b8..9d73ed06 100644
+index 200a8fa2..45c27ec7 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -147,3 +147,6 @@ option('pw-cat',
- option('udevrulesdir',
+@@ -151,3 +151,6 @@ option('udevrulesdir',
+ option('systemd-user-unit-dir',
         type : 'string',
-        description : 'Directory for udev rules (defaults to /lib/udev/rules.d)')
+        description : 'Directory for user systemd units (defaults to /usr/lib/systemd/user)')
 +option('pipewire_pulse_prefix',
 +       type : 'string',
 +       description : 'Install directory for the pipewire-pulse daemon')
 diff --git a/src/daemon/systemd/user/meson.build b/src/daemon/systemd/user/meson.build
-index 29fc93d4..f78946f2 100644
+index 46dfbbc8..0d975cec 100644
 --- a/src/daemon/systemd/user/meson.build
 +++ b/src/daemon/systemd/user/meson.build
-@@ -6,7 +6,7 @@ install_data(
+@@ -9,7 +9,7 @@ install_data(
  
  systemd_config = configuration_data()
  systemd_config.set('PW_BINARY', join_paths(pipewire_bindir, 'pipewire'))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
