### PR TITLE
roon-bridge: init at 1.8-795

### DIFF
--- a/nixos/modules/services/audio/roon-bridge.nix
+++ b/nixos/modules/services/audio/roon-bridge.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  name = "roon-bridge";
+  cfg = config.services.roon-bridge;
+in {
+  options = {
+    services.roon-bridge = {
+      enable = mkEnableOption "Roon Bridge";
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Open ports in the firewall for the bridge.
+
+          UDP: 9003
+          TCP: 9100 - 9200
+        '';
+      };
+      user = mkOption {
+        type = types.str;
+        default = "roon-bridge";
+        description = ''
+          User to run the Roon bridge as.
+        '';
+      };
+      group = mkOption {
+        type = types.str;
+        default = "roon-bridge";
+        description = ''
+          Group to run the Roon Bridge as.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.roon-bridge = {
+      after = [ "network.target" ];
+      description = "Roon Bridge";
+      wantedBy = [ "multi-user.target" ];
+
+      environment.ROON_DATAROOT = "/var/lib/${name}";
+
+      serviceConfig = {
+        ExecStart = "${pkgs.roon-bridge}/start.sh";
+        LimitNOFILE = 8192;
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = name;
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPortRanges = [
+        { from = 9100; to = 9200; }
+      ];
+      allowedUDPPorts = [ 9003 ];
+    };
+
+
+    users.groups.${cfg.group} = {};
+    users.users.${cfg.user} =
+      if cfg.user == "roon-bridge" then {
+        isSystemUser = true;
+        description = "Roon Bridge user";
+        group = cfg.group;
+        extraGroups = [ "audio" ];
+      }
+      else {};
+  };
+}

--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -1,5 +1,5 @@
-{ alsaLib
-, alsaUtils
+{ alsa-lib
+, alsa-utils
 , autoPatchelfHook
 , fetchurl
 , lib
@@ -10,20 +10,20 @@
 
 stdenv.mkDerivation rec {
   pname = "roon-bridge";
-  version = "100800753";
+  version = "1.8-795";
 
   # N.B. The URL is unstable. I've asked for them to provide a stable URL but
   # they have ignored me. If this package fails to build for you, you may need
   # to update the version and sha256.
   # c.f. https://community.roonlabs.com/t/latest-roon-server-is-not-available-for-download-on-nixos/118129
   src = fetchurl {
-    url = "https://web.archive.org/web/20201221152142/http://download.roonlabs.com/builds/RoonBridge_linuxx64.tar.bz2";
+    url = "https://web.archive.org/web/20210610172810/http://download.roonlabs.com/builds/RoonBridge_linuxx64.tar.bz2";
     sha256 = "sha256-ahdy0/TBOyMfCt4VTkcDTZGAFmwQJT2KvZuMtFcAY3w=";
   };
 
   buildInputs = [
-    alsaLib
-    alsaUtils
+    alsa-lib
+    alsa-utils
     zlib
   ];
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
         ln -sf $out/RoonMono/bin/mono-sgen $out/RoonMono/bin/${builtins.baseNameOf bin}
       '';
       wrapFix = bin: ''
-        wrapProgram ${bin} --prefix PATH : ${lib.makeBinPath [ alsaUtils ]}
+        wrapProgram ${bin} --prefix PATH : ${lib.makeBinPath [ alsa-utils ]}
       '';
     in
     ''

--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -1,0 +1,66 @@
+{ alsaLib
+, alsaUtils
+, autoPatchelfHook
+, fetchurl
+, lib
+, makeWrapper
+, stdenv
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "roon-bridge";
+  version = "100800753";
+
+  # N.B. The URL is unstable. I've asked for them to provide a stable URL but
+  # they have ignored me. If this package fails to build for you, you may need
+  # to update the version and sha256.
+  # c.f. https://community.roonlabs.com/t/latest-roon-server-is-not-available-for-download-on-nixos/118129
+  src = fetchurl {
+    url = "https://web.archive.org/web/20201221152142/http://download.roonlabs.com/builds/RoonBridge_linuxx64.tar.bz2";
+    sha256 = "sha256-ahdy0/TBOyMfCt4VTkcDTZGAFmwQJT2KvZuMtFcAY3w=";
+  };
+
+  buildInputs = [
+    alsaLib
+    alsaUtils
+    zlib
+  ];
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    mv * $out
+    runHook postInstall
+  '';
+
+  postFixup =
+    let
+      linkFix = bin: ''
+        sed -i '/ulimit/d' ${bin}
+        sed -i '/ln -sf/d' ${bin}
+        ln -sf $out/RoonMono/bin/mono-sgen $out/RoonMono/bin/${builtins.baseNameOf bin}
+      '';
+      wrapFix = bin: ''
+        wrapProgram ${bin} --prefix PATH : ${lib.makeBinPath [ alsaUtils ]}
+      '';
+    in
+    ''
+      ${linkFix "$out/Bridge/RAATServer"}
+      ${linkFix "$out/Bridge/RoonBridge"}
+      ${linkFix "$out/Bridge/RoonBridgeHelper"}
+
+      ${wrapFix "$out/check.sh"}
+      ${wrapFix "$out/start.sh"}
+    '';
+
+  meta = with lib; {
+    description = "The music player for music lovers";
+    homepage = "https://roonlabs.com";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ lovesegfault ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19845,6 +19845,8 @@ in
     boost = boost17x;
   };
 
+  roon-bridge = callPackage ../servers/roon-bridge { };
+
   roon-server = callPackage ../servers/roon-server { };
 
   s6 = skawarePackages.s6;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The implementation was mostly copied from `roon-server` as the packages are very
similar.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
