### PR TITLE
boundary: 0.1.5 -> 0.1.6

### DIFF
--- a/pkgs/tools/networking/boundary/default.nix
+++ b/pkgs/tools/networking/boundary/default.nix
@@ -14,12 +14,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "boundary";
-  version = "0.1.5";
+  version = "0.1.6";
 
   src = fetchsrc version {
-    x86_64-linux = "sha256-A8dfmFjvOHDwotCyRq9QQ9uHJIkq1JkIwtHsqDqTSNo=";
-    aarch64-linux = "sha256-i2qc4bmoSzUwNCQmnXLFQ+W4VZjVwXzEBSF3NeTju3M=";
-    x86_64-darwin = "sha256-lKGTpS2TmgxFdjUsBXKg8Mu6oJA0VidHc/noWWEuUVo=";
+    x86_64-linux = "sha256-6Pwl8smp6ZX57hzPc7e8gVSqnPHse+RvhU2xprG/2dg=";
+    aarch64-linux = "sha256-/ZhLZ/Sj0h4HvOJthe83Y5Hqpz1UYiaQZxuyR8loI44=";
+    x86_64-darwin = "sha256-s+XoEmup/jvIf+jGI3OPIGFDwsWbgE1yuySLWsC3jJE=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump boundary to `0.1.6`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
