### PR TITLE
python3Packages.tellduslive: init at 0.10.11

### DIFF
--- a/pkgs/development/python-modules/tellduslive/default.nix
+++ b/pkgs/development/python-modules/tellduslive/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, docopt
+, fetchFromGitHub
+, requests
+, requests_oauthlib
+}:
+
+buildPythonPackage rec {
+  pname = "tellduslive";
+  version = "0.10.11";
+
+  src = fetchFromGitHub {
+    owner = "molobrakos";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0aqhj6fq2z2qb4jyk23ygjicf5nlj8lkya7blkyqb7jra5k1gyg0";
+  };
+
+  propagatedBuildInputs = [
+    docopt
+    requests
+    requests_oauthlib
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "tellduslive" ];
+
+  meta = with lib; {
+    description = "Python module to communicate with Telldus Live";
+    homepage = "https://github.com/molobrakos/tellduslive";
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -825,7 +825,7 @@
     "ted5000" = ps: with ps; [ xmltodict ];
     "telegram" = ps: with ps; [ pysocks aiohttp-cors python-telegram-bot ];
     "telegram_bot" = ps: with ps; [ pysocks aiohttp-cors python-telegram-bot ];
-    "tellduslive" = ps: with ps; [ ]; # missing inputs: tellduslive
+    "tellduslive" = ps: with ps; [ tellduslive ];
     "tellstick" = ps: with ps; [ ]; # missing inputs: tellcore-net tellcore-py
     "telnet" = ps: with ps; [ ];
     "temper" = ps: with ps; [ ]; # missing inputs: temperusb

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7742,6 +7742,8 @@ in {
 
   tensorly = callPackage ../development/python-modules/tensorly { };
 
+  tellduslive = callPackage ../development/python-modules/tellduslive { };
+
   termcolor = callPackage ../development/python-modules/termcolor { };
 
   terminado = callPackage ../development/python-modules/terminado { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to communicate with Telldus Live

https://github.com/molobrakos/tellduslive

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
