### PR TITLE
hcxtools: 6.0.3 -> 6.1.5

### DIFF
--- a/pkgs/tools/security/hcxtools/default.nix
+++ b/pkgs/tools/security/hcxtools/default.nix
@@ -1,16 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, curl, openssl, zlib }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, curl, openssl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "hcxtools";
-  version = "6.0.3";
+  version = "6.1.5";
 
   src = fetchFromGitHub {
     owner = "ZerBea";
     repo = pname;
     rev = version;
-    sha256 = "0s9l5mvzcv6hnj7h28piabnm66b09hk2l57vb85ny35w99hzpkc0";
+    sha256 = "1xvr89r6287788bx5qbw9sr8jvmajps0rpc7fvh9bfzb6zw2rq6w";
   };
 
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ curl openssl zlib ];
 
   makeFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

--------

closes #94504 closes #106913
