### PR TITLE
python3Packages.surepy: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/surepy/default.nix
+++ b/pkgs/development/python-modules/surepy/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, aiodns
+, aiohttp
+, async-timeout
+, brotlipy
+, buildPythonPackage
+, cchardet
+, click
+, colorama
+, fetchFromGitHub
+, halo
+, poetry-core
+, pythonOlder
+, requests
+, rich
+}:
+
+buildPythonPackage rec {
+  pname = "surepy";
+  version = "0.5.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "benleb";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1adsnjya142bxdhfxqsi2qa35ylvdcibigs1wafjlxazlxs3mg0j";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    aiodns
+    aiohttp
+    async-timeout
+    brotlipy
+    cchardet
+    click
+    colorama
+    halo
+    requests
+    rich
+  ];
+
+  postPatch = ''
+    # halo is out-dated, https://github.com/benleb/surepy/pull/7
+    substituteInPlace pyproject.toml --replace "^0.0.30" "^0.0.31"
+  '';
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "surepy" ];
+
+  meta = with lib; {
+    description = "Python library to interact with the Sure Petcare API";
+    homepage = "https://github.com/benleb/surepy";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -796,7 +796,7 @@
     "sun" = ps: with ps; [ ];
     "supervisord" = ps: with ps; [ ];
     "supla" = ps: with ps; [ ]; # missing inputs: asyncpysupla
-    "surepetcare" = ps: with ps; [ ]; # missing inputs: surepy
+    "surepetcare" = ps: with ps; [ surepy ];
     "swiss_hydrological_data" = ps: with ps; [ swisshydrodata ];
     "swiss_public_transport" = ps: with ps; [ python-opendata-transport ];
     "swisscom" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7573,6 +7573,8 @@ in {
 
   sure = callPackage ../development/python-modules/sure { };
 
+  surepy = callPackage ../development/python-modules/surepy { };
+
   survey = callPackage ../development/python-modules/survey { };
 
   suseapi = callPackage ../development/python-modules/suseapi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to interact with the Sure Petcare API

https://github.com/benleb/surepy

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
