### PR TITLE
python3Packages.aioambient: init 1.2.3

### DIFF
--- a/pkgs/development/python-modules/aioambient/default.nix
+++ b/pkgs/development/python-modules/aioambient/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, aiohttp
+, aresponses
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytest-asyncio
+, pytest-cov
+, pytestCheckHook
+, python-engineio
+, python-socketio
+, pythonOlder
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "aioambient";
+  version = "1.2.3";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "bachya";
+    repo = pname;
+    rev = version;
+    sha256 = "1jg93rjn1gxc66qmipw4z1c09l8hgfsydacjgkfjq7vg547lragp";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    python-engineio
+    python-socketio
+    websockets
+  ];
+
+  checkInputs = [
+    aresponses
+    asynctest
+    pytest-asyncio
+    pytest-cov
+    pytestCheckHook
+  ];
+
+  # Ignore the examples directory as the files are prefixed with test_
+  pytestFlagsArray = [ "--ignore examples/" ];
+  pythonImportsCheck = [ "aioambient" ];
+
+  meta = with lib; {
+    description = "Python library for the Ambient Weather API";
+    homepage = "https://github.com/bachya/aioambient";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -27,7 +27,7 @@
     "alpha_vantage" = ps: with ps; [ ]; # missing inputs: alpha_vantage
     "amazon_polly" = ps: with ps; [ boto3 ];
     "ambiclimate" = ps: with ps; [ aiohttp-cors ambiclimate ];
-    "ambient_station" = ps: with ps; [ ]; # missing inputs: aioambient
+    "ambient_station" = ps: with ps; [ aioambient ];
     "amcrest" = ps: with ps; [ amcrest ha-ffmpeg ];
     "ampio" = ps: with ps; [ ]; # missing inputs: asmog
     "android_ip_webcam" = ps: with ps; [ ]; # missing inputs: pydroid-ipcam

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -202,6 +202,8 @@ in {
 
   agent-py = callPackage ../development/python-modules/agent-py { };
 
+  aioambient = callPackage ../development/python-modules/aioambient { };
+
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
   ailment = callPackage ../development/python-modules/ailment { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for the Ambient Weather API

https://github.com/bachya/aioambient

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
