### PR TITLE
python3Packages.pydaikin: init at 2.4.1

### DIFF
--- a/pkgs/development/python-modules/pydaikin/default.nix
+++ b/pkgs/development/python-modules/pydaikin/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromBitbucket
+, freezegun
+, netifaces
+, pytest-aiohttp
+, pytestCheckHook
+, pythonOlder
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "pydaikin";
+  version = "2.4.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromBitbucket {
+    owner = "mustang51";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1624adp4lqd1n9flnf0wqrcibml2nd19ga3fmxzjg4x5z6767bs3";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    netifaces
+    urllib3
+  ];
+
+  checkInputs = [
+    freezegun
+    pytest-aiohttp
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pydaikin" ];
+
+  meta = with lib; {
+    description = "Python Daikin HVAC appliances interface";
+    homepage = "https://bitbucket.org/mustang51/pydaikin";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -145,7 +145,7 @@
     "crimereports" = ps: with ps; [ ]; # missing inputs: crimereports
     "cups" = ps: with ps; [ pycups ];
     "currencylayer" = ps: with ps; [ ];
-    "daikin" = ps: with ps; [ ]; # missing inputs: pydaikin
+    "daikin" = ps: with ps; [ pydaikin ];
     "danfoss_air" = ps: with ps; [ ]; # missing inputs: pydanfossair
     "darksky" = ps: with ps; [ python-forecastio ];
     "datadog" = ps: with ps; [ datadog ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5342,6 +5342,8 @@ in {
 
   pycxx = callPackage ../development/python-modules/pycxx { };
 
+  pydaikin = callPackage ../development/python-modules/pydaikin { };
+
   pydantic = callPackage ../development/python-modules/pydantic { };
 
   pydbus = callPackage ../development/python-modules/pydbus { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python Daikin HVAC appliances interface

https://bitbucket.org/mustang51/pydaikin

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
