### PR TITLE
python3Packages.skybellpy: init at 0.6.3

### DIFF
--- a/pkgs/development/python-modules/skybellpy/default.nix
+++ b/pkgs/development/python-modules/skybellpy/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, colorlog
+, fetchFromGitHub
+, pytest-sugar
+, pytest-timeout
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-mock
+}:
+
+buildPythonPackage rec {
+  pname = "skybellpy";
+  version = "0.6.3";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "MisterWil";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ghvm0pcdyhq6xfjc2dkldd701x77w07077sx09xsk6q2milmvzz";
+  };
+
+  propagatedBuildInputs = [
+    colorlog
+    requests
+  ];
+
+  checkInputs = [
+    pytest-sugar
+    pytest-timeout
+    pytestCheckHook
+    requests-mock
+  ];
+
+  pythonImportsCheck = [ "skybellpy" ];
+
+  meta = with lib; {
+    description = "Python wrapper for the Skybell alarm API";
+    homepage = "https://github.com/MisterWil/skybellpy";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -740,7 +740,7 @@
     "sisyphus" = ps: with ps; [ ]; # missing inputs: sisyphus-control
     "sky_hub" = ps: with ps; [ ]; # missing inputs: pyskyqhub
     "skybeacon" = ps: with ps; [ ]; # missing inputs: pygatt[GATTTOOL]
-    "skybell" = ps: with ps; [ ]; # missing inputs: skybellpy
+    "skybell" = ps: with ps; [ skybellpy ];
     "slack" = ps: with ps; [ ]; # missing inputs: slackclient
     "sleepiq" = ps: with ps; [ ]; # missing inputs: sleepyq
     "slide" = ps: with ps; [ ]; # missing inputs: goslide-api

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7286,6 +7286,8 @@ in {
 
   skorch = callPackage ../development/python-modules/skorch { };
 
+  skybellpy = callPackage ../development/python-modules/skybellpy { };
+
   slack-sdk = callPackage ../development/python-modules/slack-sdk { };
 
   slackclient = callPackage ../development/python-modules/slackclient { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python wrapper for the Skybell alarm API

https://github.com/MisterWil/skybellpy

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
