### PR TITLE
proxychains: 4.2.0 -> 4.4.0

### DIFF
--- a/pkgs/tools/networking/proxychains/default.nix
+++ b/pkgs/tools/networking/proxychains/default.nix
@@ -1,27 +1,33 @@
-{ lib, stdenv, fetchFromGitHub } :
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
 stdenv.mkDerivation rec {
   pname = "proxychains";
-  version = "4.2.0";
+  version = "4.4.0";
 
   src = fetchFromGitHub {
     owner = "haad";
-    repo = "proxychains";
+    repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "015skh3z1jmm8kxbm3nkqv1w56kcvabdmcbmpwzywxr4xnh3x3pc";
+    sha256 = "083xdg6fsn8c2ns93lvy794rixxq8va6jdf99w1z0xi4j7f1nyjw";
   };
 
   postPatch = ''
-    # Temporary work-around; most likely fixed by next upstream release
-    sed -i Makefile -e '/-lpthread/a LDFLAGS+=-ldl'
+    # Suppress compiler warning. Remove it when upstream fix arrives
+    substituteInPlace Makefile --replace "-Werror" "-Werror -Wno-stringop-truncation"
   '';
+
   postInstall = ''
     cp src/proxychains.conf $out/etc
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Proxifier for SOCKS proxies";
     homepage = "http://proxychains.sourceforge.net";
-    license = lib.licenses.gpl2Plus;
-    platforms = lib.platforms.linux;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fab ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 4.4.0

Change log: https://github.com/haad/proxychains/blob/master/ChangeLog (outdated)

Fixes #112929

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
