### PR TITLE
python3Packages.pytrafikverket: init at 0.1.6.2

### DIFF
--- a/pkgs/development/python-modules/pytrafikverket/default.nix
+++ b/pkgs/development/python-modules/pytrafikverket/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, async-timeout
+, lxml
+}:
+
+buildPythonPackage rec {
+  pname = "pytrafikverket";
+  version = "0.1.6.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hrjsw53ixgmhsiszdrzzh0wma705nrhq8npzacsyaf43r29zvqy";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    lxml
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pytrafikverket" ];
+
+  meta = with lib; {
+    description = "Python library to manage Etekcity Devices and Levoit Air Purifier";
+    homepage = "https://github.com/endor-force/pytrafikverket";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -858,8 +858,8 @@
     "traccar" = ps: with ps; [ aiohttp-cors stringcase ]; # missing inputs: pytraccar
     "trackr" = ps: with ps; [ ]; # missing inputs: pytrackr
     "tradfri" = ps: with ps; [ ]; # missing inputs: pytradfri[async]
-    "trafikverket_train" = ps: with ps; [ ]; # missing inputs: pytrafikverket
-    "trafikverket_weatherstation" = ps: with ps; [ ]; # missing inputs: pytrafikverket
+    "trafikverket_train" = ps: with ps; [ pytrafikverket ];
+    "trafikverket_weatherstation" = ps: with ps; [ pytrafikverket ];
     "transmission" = ps: with ps; [ transmissionrpc ];
     "transport_nsw" = ps: with ps; [ ]; # missing inputs: PyTransportNSW
     "travisci" = ps: with ps; [ ]; # missing inputs: TravisPy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6489,6 +6489,8 @@ in {
 
   pytorchWithoutCuda = self.pytorch.override { cudaSupport = false; };
 
+  pytrafikverket = callPackage ../development/python-modules/pytrafikverket { };
+
   pytrends = callPackage ../development/python-modules/pytrends { };
 
   pytricia = callPackage ../development/python-modules/pytricia { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to manage Etekcity Devices and Levoit Air Purifier

https://github.com/endor-force/pytrafikverket

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
