### PR TITLE
podman: Remove unconfigured runtime warnings

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     owner = "containers";
     repo = "podman";
     rev = "v${version}";
-    sha256 = "141ii271w2azvhl8ragrgzmir9iq9npl8wmh5dr31kvq4z4syxw1";
+    sha256 = "1dsriw2vjzjaddxdhl3wbj2ppnsyi29f4bjwc8lzyz20wfwx4ay4";
   };
 
   patches = [

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -25,6 +25,10 @@ buildGoModule rec {
     sha256 = "141ii271w2azvhl8ragrgzmir9iq9npl8wmh5dr31kvq4z4syxw1";
   };
 
+  patches = [
+    ./remove-unconfigured-runtime-warn.patch
+  ];
+
   vendorSha256 = null;
 
   doCheck = false;

--- a/pkgs/applications/virtualization/podman/remove-unconfigured-runtime-warn.patch
+++ b/pkgs/applications/virtualization/podman/remove-unconfigured-runtime-warn.patch
@@ -1,0 +1,23 @@
+Remove warning "WARN[0000] Found default OCIruntime /nix/store/.../bin/crun path which is missing from [engine.runtimes] in containers.conf
+
+It doesn't make sense as we promote using the podman wrapper where runtime paths will vary because they are nix store paths.
+---
+ vendor/github.com/containers/common/pkg/config/config.go | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/vendor/github.com/containers/common/pkg/config/config.go b/vendor/github.com/containers/common/pkg/config/config.go
+index 4a98c7e92..4a95a2a49 100644
+--- a/vendor/github.com/containers/common/pkg/config/config.go
++++ b/vendor/github.com/containers/common/pkg/config/config.go
+@@ -605,8 +605,7 @@ func (c *EngineConfig) findRuntime() string {
+ 				return name
+ 			}
+ 		}
+-		if path, err := exec.LookPath(name); err == nil {
+-			logrus.Warningf("Found default OCIruntime %s path which is missing from [engine.runtimes] in containers.conf", path)
++		if _, err := exec.LookPath(name); err == nil {
+ 			return name
+ 		}
+ 	}
+--
+2.30.0

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -31,6 +31,8 @@ in runCommand podman.name {
   name = "${podman.pname}-wrapper-${podman.version}";
   inherit (podman) pname version passthru;
 
+  preferLocalBuild = true;
+
   meta = builtins.removeAttrs podman.meta [ "outputsToInstall" ];
 
   outputs = [


### PR DESCRIPTION
It doesn't make sense as we promote using the podman wrapper where runtime paths will vary because they are nix store paths.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @NixOS/podman 