### PR TITLE
python3Packages.proxmoxer: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/proxmoxer/default.nix
+++ b/pkgs/development/python-modules/proxmoxer/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, nose
+, paramiko
+, pytestCheckHook
+, pythonOlder
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "proxmoxer";
+  version = "1.1.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "09fz8zbxjaly9zqksvq6cqp66plbsyjsmndy4g25ryys45siz1ny";
+  };
+
+  propagatedBuildInputs = [
+    paramiko
+    requests
+  ];
+
+  checkInputs = [
+    mock
+    nose
+    pytestCheckHook
+  ];
+
+  # Tests require openssh_wrapper which is outdated and not available
+  pytestFlagsArray = [ "tests/paramiko_tests.py" ];
+  pythonImportsCheck = [ "proxmoxer" ];
+
+  meta = with lib; {
+    description = "Python wrapper for Proxmox API v2";
+    homepage = "https://github.com/proxmoxer/proxmoxer";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -637,7 +637,7 @@
     "prometheus" = ps: with ps; [ aiohttp-cors prometheus_client ];
     "prowl" = ps: with ps; [ ];
     "proximity" = ps: with ps; [ ];
-    "proxmoxve" = ps: with ps; [ ]; # missing inputs: proxmoxer
+    "proxmoxve" = ps: with ps; [ proxmoxer ];
     "proxy" = ps: with ps; [ pillow ];
     "ps4" = ps: with ps; [ ]; # missing inputs: pyps4-2ndscreen
     "pulseaudio_loopback" = ps: with ps; [ pulsectl ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5117,6 +5117,8 @@ in {
 
   prox-tv = callPackage ../development/python-modules/prox-tv { };
 
+  proxmoxer = callPackage ../development/python-modules/proxmoxer { };
+
   psautohint = callPackage ../development/python-modules/psautohint { };
 
   psd-tools = callPackage ../development/python-modules/psd-tools { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python wrapper for Proxmox API v2

https://github.com/proxmoxer/proxmoxer

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
