### PR TITLE
python3Packages.pyzerproc: 0.4.6 -> 0.4.8

### DIFF
--- a/pkgs/development/python-modules/pyzerproc/default.nix
+++ b/pkgs/development/python-modules/pyzerproc/default.nix
@@ -5,7 +5,6 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytest-asyncio
-, pytest-cov
 , pytest-mock
 , pytestCheckHook
 , pythonOlder
@@ -13,19 +12,18 @@
 
 buildPythonPackage rec {
   pname = "pyzerproc";
-  version = "0.4.6";
+  version = "0.4.8";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "emlove";
     repo = pname;
     rev = version;
-    sha256 = "1qlxvvy9fyff56dvc46nsd5ngkxqhdi7s4gwfndj7dn76j81srpq";
+    sha256 = "sha256-PNvkgjPcBbnETjWpVF3De9O9IprdpCke0nWvJ9Tju1M=";
   };
 
-  # Remove pytest-runner, https://github.com/emlove/pyzerproc/pull/1
-  patchPhase = ''
-    substituteInPlace setup.py --replace "'pytest-runner'," ""
+  postPatch = ''
+    sed -i "/--cov/d" setup.cfg
   '';
 
   propagatedBuildInputs = [
@@ -34,11 +32,11 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    asynctest
     pytest-asyncio
-    pytest-cov
     pytest-mock
     pytestCheckHook
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    asynctest
   ];
 
   pythonImportsCheck = [ "pyzerproc" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.4.8

Change log: https://github.com/emlove/pyzerproc#048-2021-02-12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
