### PR TITLE
lapack: enable tests & remove python dependency

### DIFF
--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   gfortran,
   cmake,
-  python2,
   shared ? true
 }:
 let
@@ -22,12 +21,13 @@ stdenv.mkDerivation {
     sha256 = "0sxnc97z67i7phdmcnq8f8lmxgw10wdwvr8ami0w3pb179cgrbpb";
   };
 
-  nativeBuildInputs = [ gfortran python2 cmake ];
+  nativeBuildInputs = [ gfortran cmake ];
 
   cmakeFlags = [
     "-DCMAKE_Fortran_FLAGS=-fPIC"
     "-DLAPACKE=ON"
     "-DCBLAS=ON"
+    "-DBUILD_TESTING=ON"
   ]
   ++ optional shared "-DBUILD_SHARED_LIBS=ON";
 


### PR DESCRIPTION
###### Motivation for this change
90326ba624ddfbd3b7f9eb3995994644cee804fb mentions enabling them and did set doCheck = true, but that doesn't actually work, because ~~the cmake generated Makefiles do not have the right targets~~ it was missing the flag to enable them.

As the python dependency is only needed for tests (edit: in the Makefiles, but not in cmake), ~~but they do not work,~~
we can just remove it.

~~It would obviously be better to enable them instead, but ~~ lapack seems to
have 3 semi-incompatible build systems, ~~and the tests seem to only work
with the Makefiles, which we do not and probably also do not want to
use.~~

See https://github.com/Reference-LAPACK/lapack/issues/488 as for why we wouldn't want to use the Makefiles.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
