### PR TITLE
python3Packages.httplib2: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -1,27 +1,53 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, isPy27
+, mock
 , pyparsing
+, pytest-forked
+, pytest-randomly
+, pytest-timeout
+, pytest-xdist
+, pytestCheckHook
+, six
 }:
 
 buildPythonPackage rec {
   pname = "httplib2";
   version = "0.19.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-4NQo2tQ8ctvOfRY7d1P/x6OcCX5niO8Q9BmNtpuS8I4=";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04y2bc2yv3q84llxnafqrciqxjqpxbrd8glbnvvr16c20fwc3r4q";
   };
+
+  postPatch = ''
+    sed -i "/--cov/d" setup.cfg
+  '';
 
   propagatedBuildInputs = [ pyparsing ];
 
-  # Needs setting up
-  doCheck = false;
+  checkInputs = [
+    mock
+    pytest-forked
+    pytest-randomly
+    pytest-timeout
+    pytest-xdist
+    six
+    pytestCheckHook
+  ];
+
+  # Don't run tests for Python 2.7
+  doCheck = !isPy27;
+  pytestFlagsArray = [ "--ignore python2" ];
+  pythonImportsCheck = [ "httplib2" ];
 
   meta = with lib; {
-    homepage = "https://github.com/httplib2/httplib2";
     description = "A comprehensive HTTP client library";
+    homepage = "https://httplib2.readthedocs.io";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -1,13 +1,19 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyparsing
+}:
 
 buildPythonPackage rec {
   pname = "httplib2";
-  version = "0.18.1";
+  version = "0.19.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8af66c1c52c7ffe1aa5dc4bcd7c769885254b0756e6e69f953c7f0ab49a70ba3";
+    sha256 = "sha256-4NQo2tQ8ctvOfRY7d1P/x6OcCX5niO8Q9BmNtpuS8I4=";
   };
+
+  propagatedBuildInputs = [ pyparsing ];
 
   # Needs setting up
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.19.0

Change log: https://github.com/httplib2/httplib2/blob/master/CHANGELOG

Tests are now enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
