### PR TITLE
python3Packages.importlib-metadata: 1.7.0 -> 3.4.0

### DIFF
--- a/pkgs/development/python-modules/importlib-metadata/2.nix
+++ b/pkgs/development/python-modules/importlib-metadata/2.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, zipp
+, pathlib2
+, contextlib2
+, configparser
+, isPy3k
+, importlib-resources
+, packaging
+}:
+
+buildPythonPackage rec {
+  pname = "importlib-metadata";
+  version = "2.1.1";
+
+  src = fetchPypi {
+    pname = "importlib_metadata";
+    inherit version;
+    sha256 = "1pdmsmwagimn0lsl4x7sg3skcr2fvzqpv2pjd1rh7yrm5gzrxpmq";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [ zipp ]
+    ++ lib.optionals (!isPy3k) [ pathlib2 contextlib2 configparser ];
+
+  # Cyclic dependencies
+  doCheck = false;
+
+  pythonImportsCheck = [ "importlib_metadata" ];
+
+  meta = with lib; {
+    description = "Read metadata from Python packages";
+    homepage = "https://importlib-metadata.readthedocs.io/";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/importlib-metadata/default.nix
+++ b/pkgs/development/python-modules/importlib-metadata/default.nix
@@ -1,42 +1,35 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, setuptools_scm
+, pythonOlder
+, setuptools-scm
+, toml
 , zipp
-, pathlib2
-, contextlib2
-, configparser
-, isPy3k
-, importlib-resources
-, packaging
 }:
 
 buildPythonPackage rec {
   pname = "importlib-metadata";
-  version = "1.7.0";
+  version = "3.7.2";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     pname = "importlib_metadata";
     inherit version;
-    sha256 = "10vz0ydrzspdhdbxrzwr9vhs693hzh4ff71lnqsifvdzvf66bfwh";
+    sha256 = "1pmci5r6hgl3vj558mawclfq2d4aq584nsjvc1fqvyb921hgzm8q";
   };
 
-  nativeBuildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
 
-  propagatedBuildInputs = [ zipp ]
-    ++ lib.optionals (!isPy3k) [ pathlib2 contextlib2 configparser ];
+  propagatedBuildInputs = [ toml zipp ];
 
-  doCheck = false; # Cyclic dependencies.
-
-  # removing test_main.py - it requires 'pyflakefs'
-  # and adding `pyflakefs` to `checkInputs` causes infinite recursion.
-  preCheck = ''
-    rm importlib_metadata/tests/test_main.py
-  '';
+  # Cyclic dependencies due to pyflakefs
+  doCheck = false;
+  pythonImportsCheck = [ "importlib_metadata" ];
 
   meta = with lib; {
     description = "Read metadata from Python packages";
     homepage = "https://importlib-metadata.readthedocs.io/";
     license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/pyfakefs/default.nix
+++ b/pkgs/development/python-modules/pyfakefs/default.nix
@@ -7,13 +7,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "4.3.3";
+  version = "4.4.0";
   pname = "pyfakefs";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-/7KrJkoLg69Uii2wxQl5jiCDYd85YBuomK5lzs+1nLs=";
+    sha256 = "0k69n9cq8vl33ffyahjr0pjih7m957ih993xd4gkax1a1qz8cb88";
   };
 
   postPatch = ''
@@ -30,8 +30,10 @@ buildPythonPackage rec {
   '');
 
   checkInputs = [ pytestCheckHook ];
+
   # https://github.com/jmcgeheeiv/pyfakefs/issues/581 (OSError: [Errno 9] Bad file descriptor)
   disabledTests = [ "test_open_existing_pipe" ];
+
   pythonImportsCheck = [ "pyfakefs" ];
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3217,7 +3217,10 @@ in {
 
   impacket = callPackage ../development/python-modules/impacket { };
 
-  importlib-metadata = callPackage ../development/python-modules/importlib-metadata { };
+  importlib-metadata = if pythonOlder "3.6" then
+    callPackage ../development/python-modules/importlib-metadata/2.nix { }
+  else
+    callPackage ../development/python-modules/importlib-metadata { };
 
   importlib-resources = callPackage ../development/python-modules/importlib-resources { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.4.0

Change log: https://importlib-metadata.readthedocs.io/en/latest/history.html#v3-4-0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
