### PR TITLE
bombadillo: add man page

### DIFF
--- a/pkgs/applications/networking/browsers/bombadillo/default.nix
+++ b/pkgs/applications/networking/browsers/bombadillo/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchgit, buildGoModule }:
+{ lib, fetchgit, buildGoModule, installShellFiles }:
 
 buildGoModule rec {
   pname = "bombadillo";
@@ -10,7 +10,15 @@ buildGoModule rec {
     sha256 = "02w6h44sxzmk3bkdidl8xla0i9rwwpdqljnvcbydx5kyixycmg0q";
   };
 
+  nativeBuildInputs = [ installShellFiles ];
+
   vendorSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+
+  outputs = [ "out" "man" ];
+
+  postInstall = ''
+    installManPage bombadillo.1
+  '';
 
   meta = with lib; {
     description = "Non-web client for the terminal, supporting Gopher, Gemini and more";


### PR DESCRIPTION
###### Motivation for this change

cc: @ehmry 
###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
