### PR TITLE
nixos/mastodon: update service configuration

### DIFF
--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -25,6 +25,8 @@ let
     ES_ENABLED = if (cfg.elasticsearch.host != null) then "true" else "false";
     ES_HOST = cfg.elasticsearch.host;
     ES_PORT = toString(cfg.elasticsearch.port);
+
+    TRUSTED_PROXY_IP = cfg.trustedProxy;
   }
   // (if cfg.smtp.authenticate then { SMTP_LOGIN  = cfg.smtp.user; } else {})
   // cfg.extraConfig;
@@ -177,6 +179,16 @@ in {
         '';
         default = "/var/lib/mastodon/secrets/vapid-private-key";
         type = lib.types.str;
+      };
+
+      trustedProxy = lib.mkOption {
+        description = ''
+          You need to set it to the IP from which your reverse proxy sends requests to Mastodon's web process,
+          otherwise Mastodon will record the reverse proxy's own IP as the IP of all requests, which would be
+          bad because IP addresses are used for important rate limits and security functions.
+        '';
+        type = lib.types.str;
+        default = "127.0.0.1";
       };
 
       redis = {

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -417,7 +417,7 @@ in {
 
     systemd.services.mastodon-init-db = lib.mkIf cfg.automaticMigrations {
       script = ''
-        if [ `psql mastodon -c \
+        if [ `psql ${cfg.database.name} -c \
                 "select count(*) from pg_class c \
                 join pg_namespace s on s.oid = c.relnamespace \
                 where s.nspname not in ('pg_catalog', 'pg_toast', 'information_schema') \


### PR DESCRIPTION
###### Motivation for this change
Changes:
 - Added trusted proxy to correct view session ip.
 - Now mastodon uses unix connections by default.
 - optimize permissions - only a of mastodon group is allowed access.
 - fixed mastodon-init-db script
```
ев 14 20:55:22 tech mastodon-init-db-start[77967]: psql: FATAL:  database "mastodon" does not exist
фев 14 20:55:22 tech mastodon-init-db-start[77965]: /nix/store/rb6r505d9saxff81sjmnlh12sxsp8874-unit-script-mastodon-init-db-start/bin/mastodon-init-db-start: line 6: [: -eq: unary operator expected
фев 14 20:55:30 tech mastodon-init-db-start[77970]: Your database collation is susceptible to index corruption.
фев 14 20:55:30 tech mastodon-init-db-start[77970]:   (This warning does not indicate that index corruption has occured and can be ignored)
фев 14 20:55:30 tech mastodon-init-db-start[77970]:   (To learn more, visit: https://docs.joinmastodon.org/admin/troubleshooting/index-corruption/)
```
 - runnnig mastodon in sandboxing mode

cc @erictapen @happy-river 
~@adisbladis~ (note from adisbladis: I'm not maintaining mastodon, please don't CC me on reviews for this package)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
