### PR TITLE
python3.pkgs.osmpythontools: 0.2.9 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/osmpythontools/default.nix
+++ b/pkgs/development/python-modules/osmpythontools/default.nix
@@ -13,15 +13,17 @@
 
 buildPythonPackage rec {
   pname = "osmpythontools";
-  version = "0.2.9";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "mocnik-science";
     repo = "osm-python-tools";
     rev = "v${version}";
-    sha256 = "1qpj03fgn8rmrg9a9vk7bw32k9hdy15g5p2q3a6q52ykpb78jdz5";
+    sha256 = "0r72z7f7kmvvbd9zvgci8rwmfj85xj34mb3x5dj3jcv5ij5j72yh";
   };
 
+  # Upstream setup.py has test dependencies in `install_requires` argument.
+  # Remove them, as we don't run the tests.
   patches = [ ./remove-test-only-dependencies.patch ];
 
   propagatedBuildInputs = [
@@ -55,7 +57,7 @@ buildPythonPackage rec {
       Nominatim, and the OpenStreetMap editing API.
     '';
     homepage = "https://github.com/mocnik-science/osm-python-tools";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ das-g ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream release 0.3.0 ([PyPI](https://pypi.org/project/OSMPythonTools/0.3.0/), [Git tag](https://github.com/mocnik-science/osm-python-tools/releases/tag/v0.3.0))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix run nixpkgs.nixpkgs-review -c nixpkgs-review wip`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (there are no executable files, as this is a library)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
