### PR TITLE
pythonPackages.transitions: 0.8.6 -> 0.8.7

### DIFF
--- a/pkgs/development/python-modules/transitions/default.nix
+++ b/pkgs/development/python-modules/transitions/default.nix
@@ -1,21 +1,39 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, six, pytestCheckHook, mock, dill, pycodestyle }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, pygraphviz
+, pytestCheckHook
+, mock
+, graphviz
+, pycodestyle
+}:
 
 buildPythonPackage rec {
   pname = "transitions";
-  version = "0.8.6";
+  version = "0.8.7";
 
-  # test_codestyle.py fails in PyPI sdist
-  src = fetchFromGitHub {
-    owner = "pytransitions";
-    repo = "transitions";
-    rev = version;
-    sha256 = "1d913hzzyqhdhhbkbvjw65dqkajrw50a4sxhyxk0jlg8pcs7bs7v";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8c60ec0828cd037820726283cad5d4d77a5e31514e058b51250420e9873e9bc7";
   };
 
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [
+    six
+    pygraphviz # optional
+  ];
 
-  checkInputs = [ pytestCheckHook mock dill pycodestyle ];
+  checkInputs = [
+    pytestCheckHook
+    mock
+    graphviz
+    pycodestyle
+  ];
+
+  disabledTests = [
+    # Fontconfig error: Cannot load default config file
+    "test_diagram"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/pytransitions/transitions";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Consequences of this change
Support for Python 2 is dropped. We could add pygraphviz to checkInputs only on Python 3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
