### PR TITLE
python3Packages.libnacl: 1.7.1 -> 1.7.2

### DIFF
--- a/pkgs/development/python-modules/libnacl/default.nix
+++ b/pkgs/development/python-modules/libnacl/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "sha256-nttR9PQimhqd2pByJ5IJzJ4RmSI4y7lcX7a7jcK+vqc=";
   };
 
-  propagatedBuildInputs = [ libsodium ];
+  buildInputs = [ libsodium ];
 
   postPatch =
     let soext = stdenv.hostPlatform.extensions.sharedLibrary; in

--- a/pkgs/development/python-modules/libnacl/default.nix
+++ b/pkgs/development/python-modules/libnacl/default.nix
@@ -1,33 +1,41 @@
-{ lib, stdenv, buildPythonPackage, fetchFromGitHub, pytest, libsodium }:
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, libsodium
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "libnacl";
-  version = "1.7.1";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
     owner = "saltstack";
     repo = pname;
     rev = "v${version}";
-    sha256 = "10rpim9lf0qd861a3miq8iqg8w87slqwqni7nq66h72jdk130axg";
+    sha256 = "sha256-nttR9PQimhqd2pByJ5IJzJ4RmSI4y7lcX7a7jcK+vqc=";
   };
 
-  checkInputs = [ pytest ];
   propagatedBuildInputs = [ libsodium ];
 
   postPatch =
-    let soext = stdenv.hostPlatform.extensions.sharedLibrary; in ''
-    substituteInPlace "./libnacl/__init__.py" --replace "ctypes.cdll.LoadLibrary('libsodium${soext}')" "ctypes.cdll.LoadLibrary('${libsodium}/lib/libsodium${soext}')"
-  '';
+    let soext = stdenv.hostPlatform.extensions.sharedLibrary; in
+    ''
+      substituteInPlace "./libnacl/__init__.py" --replace \
+        "ctypes.cdll.LoadLibrary('libsodium${soext}')" \
+        "ctypes.cdll.LoadLibrary('${libsodium}/lib/libsodium${soext}')"
+    '';
 
-  checkPhase = ''
-    py.test
-  '';
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "libnacl" ];
 
   meta = with lib; {
-    maintainers = with maintainers; [ xvapx ];
     description = "Python bindings for libsodium based on ctypes";
-    homepage = "https://pypi.python.org/pypi/libnacl";
+    homepage = "https://libnacl.readthedocs.io/";
     license = licenses.asl20;
     platforms = platforms.unix;
+    maintainers = with maintainers; [ xvapx ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.7.2

Change log: not available (https://libnacl.readthedocs.io/en/latest/topics/releases/index.html#)

- switch to `pytestCheckHook`
- incl. `nixpkgs-fmt`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
