### PR TITLE
buildRustPackage: add assert for verifyCargoDeps

### DIFF
--- a/pkgs/applications/audio/netease-music-tui/default.nix
+++ b/pkgs/applications/audio/netease-music-tui/default.nix
@@ -17,7 +17,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ alsaLib openssl ];
 
   cargoSha256 = "1kfbnwy3lkbhz0ggxwr5n6qd1plipkr1ycr3z2r7c0amrzzbkc7l";
-  verifyCargoDeps = true;
 
   meta = with lib; {
     homepage = "https://github.com/betta-cyber/netease-music-tui";

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -51,10 +51,14 @@
 # case for `rustfmt`/etc from the `rust-sources).
 # Otherwise, everything from the tarball would've been built/tested.
 , buildAndTestSubdir ? null
+
+, verifyCargoDeps ? ""
 , ... } @ args:
 
 assert cargoVendorDir == null -> !(cargoSha256 == "" && cargoHash == "");
 assert buildType == "release" || buildType == "debug";
+
+assert verifyCargoDeps != "" -> throw "`verifyCargoDeps` is not needed as it is the default";
 
 let
 

--- a/pkgs/tools/inputmethods/evscript/default.nix
+++ b/pkgs/tools/inputmethods/evscript/default.nix
@@ -12,7 +12,6 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "1dcyhxfyq0nrjl05g1s9pjkg7vqw63wbdhlskrdcvxncmci3s7rp";
-  verifyCargoDeps = true;
 
   meta = with lib; {
     homepage = "https://github.com/myfreeweb/${pname}";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @bhipple @Mic92 