### PR TITLE
taskwarrior: 2.5.2 -> 2.5.3

### DIFF
--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -1,15 +1,36 @@
-{ lib, stdenv, fetchurl, cmake, libuuid, gnutls }:
+{ lib, stdenv, fetchurl, cmake, libuuid, gnutls, python3, bash }:
 
 stdenv.mkDerivation rec {
   pname = "taskwarrior";
   version = "2.5.3";
 
-  src = fetchurl {
-    url = "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/task-${version}.tar.gz";
-    sha256 = "0fwnxshhlha21hlgg5z1ad01w13zm1hlmncs274y5n8i15gdfhvj";
-  };
+  srcs = [
+    (fetchurl {
+      url = " https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/${sourceRoot}.tar.gz";
+      sha256 = "0fwnxshhlha21hlgg5z1ad01w13zm1hlmncs274y5n8i15gdfhvj";
+    })
+    (fetchurl {
+      url = "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/tests-${version}.tar.gz";
+      sha256 = "165xmf9h6rb7l6l9nlyygj0mx9bi1zyd78z0lrl3nadhmgzggv0b";
+    })
+  ];
+
+  sourceRoot = "task-${version}";
+
+  postUnpack = ''
+    mv test ${sourceRoot}
+  '';
 
   nativeBuildInputs = [ cmake libuuid gnutls ];
+
+  doCheck = true;
+  preCheck = ''
+    find test -type f -exec sed -i \
+      -e "s|/usr/bin/env python3|${python3.interpreter}|" \
+      -e "s|/usr/bin/env bash|${bash}/bin/bash|" \
+      {} +
+  '';
+  checkTarget = "test";
 
   postInstall = ''
     mkdir -p "$out/share/bash-completion/completions"

--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     homepage = "https://taskwarrior.org";
     license = licenses.mit;
     maintainers = with maintainers; [ marcweber ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -1,15 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libuuid, gnutls }:
+{ lib, stdenv, fetchurl, cmake, libuuid, gnutls }:
 
 stdenv.mkDerivation rec {
   pname = "taskwarrior";
   version = "2.5.2";
 
-  src = fetchFromGitHub {
-    owner = "GothenburgBitFactory";
-    repo = "taskwarrior";
-    rev = "v${version}";
-    sha256 = "0jv5b56v75qhdqbrfsddfwizmbizcsv3mn8gp92nckwlx9hrk5id";
-    fetchSubmodules = true;
+  src = fetchurl {
+    url = "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/task-${version}.tar.gz";
+    sha256 = "0ipfl9k4l9vls07v64idfvffw68ca1hpv0dv01plmgdryb54bzk3";
   };
 
   nativeBuildInputs = [ cmake libuuid gnutls ];

--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "taskwarrior";
-  version = "2.5.2";
+  version = "2.5.3";
 
   src = fetchurl {
     url = "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/task-${version}.tar.gz";
-    sha256 = "0ipfl9k4l9vls07v64idfvffw68ca1hpv0dv01plmgdryb54bzk3";
+    sha256 = "0fwnxshhlha21hlgg5z1ad01w13zm1hlmncs274y5n8i15gdfhvj";
   };
 
   nativeBuildInputs = [ cmake libuuid gnutls ];


### PR DESCRIPTION
###### Motivation for this change

- updated to new version
- run test suite in check phase
- enable for bsd, etc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) (2k decrease)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
