### PR TITLE
python3Packages.asyncwhois: enable tests

### DIFF
--- a/pkgs/development/python-modules/asyncwhois/default.nix
+++ b/pkgs/development/python-modules/asyncwhois/default.nix
@@ -1,20 +1,23 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-, pythonOlder
 , aiodns
-, tldextract
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
 , pytestCheckHook
+, pythonOlder
+, tldextract
 }:
 
 buildPythonPackage rec {
   pname = "asyncwhois";
   version = "0.2.4";
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "84677e90bc2d2975788e905ae9841bc91a732a452bc870991105b0a6cc3cd22f";
+  src = fetchFromGitHub {
+    owner = "pogzyb";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "17w007hjnpggj6jvkv8wxwllxk6mir1q2nhw0dqg7glm4lfbx8kr";
   };
 
   propagatedBuildInputs = [
@@ -22,9 +25,24 @@ buildPythonPackage rec {
     tldextract
   ];
 
-  # tests are only present at GitHub but not the released source tarballs
-  # https://github.com/pogzyb/asyncwhois/issues/10
-  doCheck = false;
+  checkInputs = [
+    asynctest
+    pytestCheckHook
+  ];
+
+  # Disable tests that require network access
+  disabledTests = [
+    "test_pywhois_aio_get_hostname_from_ip"
+    "test_pywhois_get_hostname_from_ip"
+    "test_pywhois_aio_lookup_ipv4"
+    "test_not_found"
+    "test_aio_from_whois_cmd"
+    "test_aio_get_hostname_from_ip"
+    "test_from_whois_cmd"
+    "test_get_hostname_from_ip"
+    "test_whois_query_run"
+  ];
+
   pythonImportsCheck = [ "asyncwhois" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
