### PR TITLE
Emacs package updates 2021-02-13

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-generated.nix
@@ -223,10 +223,10 @@
       elpaBuild {
         pname = "auctex";
         ename = "auctex";
-        version = "13.0.3";
+        version = "13.0.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/auctex-13.0.3.tar";
-          sha256 = "1ljpkr0z15fyh907jbgky238dvci5vqi3xhvslyhblhp8sg9cbsi";
+          url = "https://elpa.gnu.org/packages/auctex-13.0.4.tar";
+          sha256 = "1362dqb8mcaddda9849gqsj6rzlfq18xprddb74j02884xl7hq65";
         };
         packageRequires = [ cl-lib emacs ];
         meta = {
@@ -955,10 +955,10 @@
       elpaBuild {
         pname = "ebdb";
         ename = "ebdb";
-        version = "0.6.21";
+        version = "0.6.22";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-0.6.21.tar";
-          sha256 = "0pp190wr6z98kggmw9ls486f9vxfimdjdbqsp263qiyi21ws98if";
+          url = "https://elpa.gnu.org/packages/ebdb-0.6.22.tar";
+          sha256 = "0dljl21n6508c7ash7l6zgxhpn2wdfzga0va63d4k9nwnqmkvsgz";
         };
         packageRequires = [ cl-lib emacs seq ];
         meta = {
@@ -985,10 +985,10 @@
       elpaBuild {
         pname = "ebdb-i18n-chn";
         ename = "ebdb-i18n-chn";
-        version = "1.3.1";
+        version = "1.3.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-i18n-chn-1.3.1.el";
-          sha256 = "02drr89i4kzjm1rs22sj0nv9sj95dmqk40xvxd75qzfn8y33k9vl";
+          url = "https://elpa.gnu.org/packages/ebdb-i18n-chn-1.3.2.tar";
+          sha256 = "06ii9xi2y157vfbhx75mn80ash22d1xgcyp9kzz1s0lkxwlv74zj";
         };
         packageRequires = [ ebdb pyim ];
         meta = {
@@ -1205,10 +1205,10 @@
       elpaBuild {
         pname = "excorporate";
         ename = "excorporate";
-        version = "0.9.1";
+        version = "0.9.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/excorporate-0.9.1.tar";
-          sha256 = "15rk0br7dmvni10f3mm94ylybl3jbf2ps1sypis6hxbazxxr443j";
+          url = "https://elpa.gnu.org/packages/excorporate-0.9.3.tar";
+          sha256 = "1ybj0ww7x7l7ymykk6hs720whabavmwnrwq7x8dkn41wma181zzy";
         };
         packageRequires = [ emacs fsm nadvice soap-client url-http-ntlm ];
         meta = {
@@ -1585,6 +1585,21 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/heap.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    hiddenquote = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "hiddenquote";
+        ename = "hiddenquote";
+        version = "1.1";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/hiddenquote-1.1.tar";
+          sha256 = "1j692ka84z6k9c3bhcn28irym5fga4d1wvhmvzvixdbfwn58ivw5";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/hiddenquote.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -2598,10 +2613,10 @@
       elpaBuild {
         pname = "phps-mode";
         ename = "phps-mode";
-        version = "0.3.65";
+        version = "0.4.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/phps-mode-0.3.65.tar";
-          sha256 = "18pqxwfmciz9d2w808mvspkcifrja85y2qjwmb6pbdnkj9dr6yad";
+          url = "https://elpa.gnu.org/packages/phps-mode-0.4.1.tar";
+          sha256 = "11d1gsvvj26h9d7a28v87b022vbi3syzngn1x9v1d2g55iv01x38";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2643,10 +2658,10 @@
       elpaBuild {
         pname = "posframe";
         ename = "posframe";
-        version = "0.8.4";
+        version = "0.8.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/posframe-0.8.4.tar";
-          sha256 = "1sn35ibp5y4y80l1xm4b8i94ld953a9gbkk99zqd9mrq9bwjyhdp";
+          url = "https://elpa.gnu.org/packages/posframe-0.8.5.tar";
+          sha256 = "0rls0rsj9clx4wd0gbdi5jzwyslparlf7phib649637gq6gs90ds";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2778,10 +2793,10 @@
       elpaBuild {
         pname = "rcirc-color";
         ename = "rcirc-color";
-        version = "0.4.1";
+        version = "0.4.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/rcirc-color-0.4.1.el";
-          sha256 = "1zs3i3xr8zbjr8hzr1r1qx7mqb2wckpn25qh9444c9as2dnh9sn9";
+          url = "https://elpa.gnu.org/packages/rcirc-color-0.4.2.tar";
+          sha256 = "0pa9p018kwsy44cmkli7x6cz1abxkyi26ac7w3vh99qp7x97dia3";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2991,6 +3006,21 @@
         packageRequires = [ emacs xr ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/relint.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    repology = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "repology";
+        ename = "repology";
+        version = "1.1.0";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/repology-1.1.0.tar";
+          sha256 = "031245rrhazj53bk1csa6x3ygzvg74w2hwjf08ficwvmdn97li90";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/repology.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -3533,10 +3563,10 @@
       elpaBuild {
         pname = "tramp";
         ename = "tramp";
-        version = "2.5.0";
+        version = "2.5.0.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-2.5.0.tar";
-          sha256 = "1jpnqyk108nksaym2b9v243y5zkpr4px9d070wsb9cwm3xrcd8rh";
+          url = "https://elpa.gnu.org/packages/tramp-2.5.0.1.tar";
+          sha256 = "0kqlc03bbsdywp0m3mf0m62hqyam8vg81phh7nqmpdjzskrdc1yy";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3677,10 +3707,10 @@
       elpaBuild {
         pname = "valign";
         ename = "valign";
-        version = "3.0.0";
+        version = "3.1.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/valign-3.0.0.el";
-          sha256 = "16f889x6yc1af2bmbly2lww4sy1s864ll75xdxp28i5m57gj25w8";
+          url = "https://elpa.gnu.org/packages/valign-3.1.0.tar";
+          sha256 = "0zx6p2nlvd4nkffj0myqv4hry8kgnhq45fcivfjzbfn62j2kp293";
         };
         packageRequires = [ emacs ];
         meta = {

--- a/pkgs/applications/editors/emacs-modes/org-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20210111";
+        version = "20210208";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-20210111.tar";
-          sha256 = "1hn3i583h3idmiv1plbp0p6qi3myl317vl43qyxjks2nvqfj5313";
+          url = "https://orgmode.org/elpa/org-20210208.tar";
+          sha256 = "1awqk2dk3sgglq6fqgaz8y8rqw3p5rcnkp7i6m15n7wlq9nx7njp";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20210111";
+        version = "20210208";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-plus-contrib-20210111.tar";
-          sha256 = "1qw44y4v4vg0vhz1i55x4fjiaxfaqcch0mqm98sc5f31fw3r4zga";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20210208.tar";
+          sha256 = "13yrzx7sdndf38hamm1m82kfgnqgm8752mjxmmqw1iqr3r33ihi3";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs-modes/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs-modes/recipes-archive-melpa.json
@@ -241,11 +241,11 @@
   "repo": "afroisalreadyinu/abl-mode",
   "unstable": {
    "version": [
-    20190403,
-    904
+    20210122,
+    1508
    ],
-   "commit": "44b7d946bc3a693f5a931c4a62c0a67d42e8d4dc",
-   "sha256": "070c408bq5pliq0xbd1861l6db4sbfpnj3r6aknbqh2vb7l4yimb"
+   "commit": "fdd83e732b2c870f4ddc0f62b5b261e03bfb212a",
+   "sha256": "1ny3386n5h3s3lg9235vj17vwsx6n1y99kln6vgqy6kk37q0ig42"
   }
  },
  {
@@ -1006,22 +1006,22 @@
     "auto-complete",
     "yasnippet"
    ],
-   "commit": "7d97ecc07e6b4ac772670e26583f11e77fdc69fd",
-   "sha256": "00jdn4dw975bb6fgf7wyxjbmvs31p8bav376d017kk56q9w6mv1f"
+   "commit": "33ed12bb2ec627a8a05360885f071e4a88fff399",
+   "sha256": "1ffayysbqh7vq65vhbmqg9yp03fqfnwj3drwyinr5ia81acp37nz"
   },
   "stable": {
    "version": [
     2,
-    3,
-    1
+    4,
+    0
    ],
    "deps": [
     "ac-php-core",
     "auto-complete",
     "yasnippet"
    ],
-   "commit": "1477a463e7b2fadf2542d9563b28424481d19bf3",
-   "sha256": "04163qnz5kq3cwmkm5yfvahq8d8ybmchlimzdp15p1izhfpvxnfn"
+   "commit": "33ed12bb2ec627a8a05360885f071e4a88fff399",
+   "sha256": "1ffayysbqh7vq65vhbmqg9yp03fqfnwj3drwyinr5ia81acp37nz"
   }
  },
  {
@@ -1032,8 +1032,8 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20201015,
-    903
+    20210129,
+    951
    ],
    "deps": [
     "dash",
@@ -1043,14 +1043,14 @@
     "s",
     "xcscope"
    ],
-   "commit": "7d97ecc07e6b4ac772670e26583f11e77fdc69fd",
-   "sha256": "00jdn4dw975bb6fgf7wyxjbmvs31p8bav376d017kk56q9w6mv1f"
+   "commit": "33ed12bb2ec627a8a05360885f071e4a88fff399",
+   "sha256": "1ffayysbqh7vq65vhbmqg9yp03fqfnwj3drwyinr5ia81acp37nz"
   },
   "stable": {
    "version": [
     2,
-    3,
-    1
+    4,
+    0
    ],
    "deps": [
     "dash",
@@ -1060,8 +1060,8 @@
     "s",
     "xcscope"
    ],
-   "commit": "1477a463e7b2fadf2542d9563b28424481d19bf3",
-   "sha256": "04163qnz5kq3cwmkm5yfvahq8d8ybmchlimzdp15p1izhfpvxnfn"
+   "commit": "33ed12bb2ec627a8a05360885f071e4a88fff399",
+   "sha256": "1ffayysbqh7vq65vhbmqg9yp03fqfnwj3drwyinr5ia81acp37nz"
   }
  },
  {
@@ -1110,8 +1110,8 @@
     "auto-complete",
     "rtags"
    ],
-   "commit": "39339388256df662d0084b4a094d03e52748f9e8",
-   "sha256": "0wp4mygsxzibra2p3m5rn9m0yd3fscd795k5xa0wxi5pwddv7dlg"
+   "commit": "aa4c827b417f5448c12401c33acdab1325917c13",
+   "sha256": "02jqcbrpxm4sv15l8kyvsw9pwkmamj065cgifj68x242fw2f0sam"
   },
   "stable": {
    "version": [
@@ -1401,14 +1401,14 @@
   "repo": "abo-abo/ace-link",
   "unstable": {
    "version": [
-    20200518,
-    957
+    20210121,
+    923
    ],
    "deps": [
     "avy"
    ],
-   "commit": "298f02f7dd117f9ec01f6aa2a2ddfecae0efb7f4",
-   "sha256": "1i243wfwrbxn00sh96248lpqfb7cvxqqwlc78nf8kim4ymylpp41"
+   "commit": "e1b1c91b280d85fce2194fea861a9ae29e8b03dd",
+   "sha256": "190m4ikm9580gmd0yf9k7a7q9l7087zdm9gm1hv12wg8g8g6pzca"
   },
   "stable": {
    "version": [
@@ -1756,6 +1756,30 @@
   }
  },
  {
+  "ename": "ado-mode",
+  "commit": "337f21eb8f4af233b4c0bc658cd82e8479b49aaa",
+  "sha256": "1gybsnj7s21vm1iakz4hy5d6skzcfi6455wnikv9dpwy1069rw32",
+  "fetcher": "github",
+  "repo": "louabill/ado-mode",
+  "unstable": {
+   "version": [
+    20210202,
+    2006
+   ],
+   "commit": "c9af0cac90b912ce0dd02fbf470f513dea2d4f43",
+   "sha256": "0z4vi4q6awss52afp4nnxxdhmhdchp8qn6hqyhdikr8lgvja4pq6"
+  },
+  "stable": {
+   "version": [
+    16,
+    1,
+    4
+   ],
+   "commit": "29d56532c7ab6f680c596add31fd80cd79186e89",
+   "sha256": "1hvxxjwbxw8ivj5399f745l3gcrgf2j0qpbli50pxz0h91pcvi5p"
+  }
+ },
+ {
   "ename": "adoc-mode",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "0jd3zr4zpb4qqn504azl0y02cryv7n9wphv64b0fbpipr7w5hm2c",
@@ -1871,18 +1895,18 @@
     "annotation",
     "eri"
    ],
-   "commit": "c5400349d7d9cb1e54af19bdb2046b52ecada5bc",
-   "sha256": "02kma8f6v6vxzbfzd2limwabp8a5hzjyg9kfabgp1j0dwvsl64pf"
+   "commit": "e6862ebe3e8f2f29325378d820f7fa94656be479",
+   "sha256": "1iwi8jm3mp77zmcvn813mcnih1sq56mpl66r2qlkl72paqli790i"
   },
   "stable": {
    "version": [
     2,
     6,
     1,
-    1
+    3
    ],
-   "commit": "fce01db8f9d2ceb9c3a4aa179330ea4aa7587a71",
-   "sha256": "0fzq9pfkvsdin04vzcz2vyjq3gx0lfhbpwpz0zyfa3b84dgffxq7"
+   "commit": "e5486b79cc78689e3fd07b6c924d0085063915ea",
+   "sha256": "1zl7c0rb5rg867a431apxlzj2flg3hjidamqa5prc1bzpmfaywyz"
   }
  },
  {
@@ -2331,11 +2355,11 @@
   "repo": "domtronn/all-the-icons.el",
   "unstable": {
    "version": [
-    20210114,
-    1520
+    20210208,
+    0
    ],
-   "commit": "ed978fa64fdefc817e8b1b826c87e8928a26f2ce",
-   "sha256": "0l5jc0f5q5p4i2c5s6vrryxkc0fapxffz8x1yvk32j151rz932rc"
+   "commit": "2f5ea7259ed104a0ef8727f640ee2525108038d5",
+   "sha256": "1lvnzjarnzjkrkmhbwgny64ym7s6m4if6lc2fpapcx9hh6bq9h6c"
   },
   "stable": {
    "version": [
@@ -2457,15 +2481,15 @@
   "repo": "seagle0128/all-the-icons-ivy-rich",
   "unstable": {
    "version": [
-    20201215,
-    1647
+    20210126,
+    1227
    ],
    "deps": [
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "6eb63a158cd5e1b47635704ebdd3e010e7b914f8",
-   "sha256": "1xvcgylx2h9mrpm56icqsflyxvy88mprgxrs6byhkvkm3p7jzin2"
+   "commit": "3cfc62cea6f26279e062d6056fa0fec7b6f7ac1c",
+   "sha256": "03xpsrdh2z1d7sax83a5dv1alb5kmnbfvxwvqib3f7bllggw4wpg"
   },
   "stable": {
    "version": [
@@ -2492,8 +2516,8 @@
     20200211,
     2126
    ],
-   "commit": "2f5935a1a9d042751c7135cac79875886edb2556",
-   "sha256": "1q1ry37rcpzwwl2bwf3j8nmhap7v72fg0hdzxlls89gm3jl3nb97"
+   "commit": "0b804c3ce21b9045d9b3093ef066d8269ac93990",
+   "sha256": "0bp38fwrgw5hr8vyn9shy1am2d224nbyjymdar6i2gh191y43rpm"
   }
  },
  {
@@ -2737,14 +2761,14 @@
  },
  {
   "ename": "anaconda-mode",
-  "commit": "c756ccbae044bc23131060355532261aa9a12409",
-  "sha256": "1cr4qyk2brm1kvm7i9cmvihid8799df7yhmmdizv3sj5l6qnsyfr",
+  "commit": "83b7dcc75e35d9527bce39c5dca3ade0b68ddeb7",
+  "sha256": "1p1bik1fh50hf6ylbhlszzwdah7gp3ay93j4a0xz49cksd1a4ksq",
   "fetcher": "github",
   "repo": "pythonic-emacs/anaconda-mode",
   "unstable": {
    "version": [
-    20210101,
-    833
+    20210210,
+    852
    ],
    "deps": [
     "dash",
@@ -2752,8 +2776,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "80afec20f91f13614647b192522fff460505db6f",
-   "sha256": "04f6kw4rd8k6waiyfbk7x8qdrqm411mdsdzjh2w9rvmv7y36ckh8"
+   "commit": "081f9d8f92f5b85b4f4ac01af7ee72582e689ce1",
+   "sha256": "01z4npw03rkpjl0gmxgryvpkndwn43bgmda398dyzfv00pl5cdar"
   },
   "stable": {
    "version": [
@@ -3061,11 +3085,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20210108,
-    1828
+    20210211,
+    1931
    ],
-   "commit": "d4eff870d9c1575731890acfdde89511d0322ec1",
-   "sha256": "11k5j7xgnxq4s5ar56f3qmbr8vnrhi231zv0iiv2p0nqryaaj354"
+   "commit": "3e0d5f39b24eeded849c1c4903f9a75976732d2b",
+   "sha256": "1l1xmb12qfs0rvgvqqnbjn0njdgxiprxx6fd0vzinlpfdfk1f39j"
   },
   "stable": {
    "version": [
@@ -3103,18 +3127,18 @@
     20200914,
     644
    ],
-   "commit": "c5400349d7d9cb1e54af19bdb2046b52ecada5bc",
-   "sha256": "02kma8f6v6vxzbfzd2limwabp8a5hzjyg9kfabgp1j0dwvsl64pf"
+   "commit": "e6862ebe3e8f2f29325378d820f7fa94656be479",
+   "sha256": "1iwi8jm3mp77zmcvn813mcnih1sq56mpl66r2qlkl72paqli790i"
   },
   "stable": {
    "version": [
     2,
     6,
     1,
-    1
+    3
    ],
-   "commit": "fce01db8f9d2ceb9c3a4aa179330ea4aa7587a71",
-   "sha256": "0fzq9pfkvsdin04vzcz2vyjq3gx0lfhbpwpz0zyfa3b84dgffxq7"
+   "commit": "e5486b79cc78689e3fd07b6c924d0085063915ea",
+   "sha256": "1zl7c0rb5rg867a431apxlzj2flg3hjidamqa5prc1bzpmfaywyz"
   }
  },
  {
@@ -3639,8 +3663,8 @@
     "let-alist",
     "request"
    ],
-   "commit": "5fe8b035b2b6bc165728444bb8e9792d14b7409d",
-   "sha256": "1wbpjz5jgpph6c6wk29dxz8r368ai6jx9cb4y2mdcpngig8kmazm"
+   "commit": "c107a2e21cd1ac6008d8baaeeedb3fab26583d45",
+   "sha256": "19xrm4nwwsf86ysqnqx7jfl78gbg66jj4yfw3h99y3nd82j2rdws"
   }
  },
  {
@@ -3724,11 +3748,11 @@
   "repo": "motform/arduino-cli-mode",
   "unstable": {
    "version": [
-    20201001,
-    1357
+    20210119,
+    1200
    ],
-   "commit": "00893089344cfeef387e6da1844fa49d14ff4fa9",
-   "sha256": "1p37c18ax1nki5175xz2c75pjbsg5wsd3m6qaln9x0mj5hdgz860"
+   "commit": "10d5cfa1563f314e5b24b151f63b9579992a7ba5",
+   "sha256": "0czbp56jg40y33p05l1wvrinjiz795zjk4gyxyvjbra11a8byf84"
   }
  },
  {
@@ -3980,11 +4004,11 @@
   "repo": "jwiegley/emacs-async",
   "unstable": {
    "version": [
-    20200809,
-    501
+    20210117,
+    718
    ],
-   "commit": "14f48de586b0977e3470f053b810d77b07ea427a",
-   "sha256": "16m67s2mpr2ak7vyc3dxzln3v5136b85dsirjkd2fm2n934q9h0r"
+   "commit": "d7e7f79ee42311a0187aa2ab4f4e2f8843fa28da",
+   "sha256": "11r6jzqyywgzxmpq2z97j3ni5b1sv6z5lrjmkqip396bxmw9zxm1"
   },
   "stable": {
    "version": [
@@ -4130,11 +4154,11 @@
   "repo": "jonathanchu/atom-one-dark-theme",
   "unstable": {
    "version": [
-    20200831,
-    342
+    20210128,
+    1640
    ],
-   "commit": "321739d50b8a3b9152972134e83e69a67e12ee81",
-   "sha256": "0a6lx2pav0a0k6lfq8ar03z33dis29diq1gvxfdqwa3sayn6fbab"
+   "commit": "b34b62e85593812b55ee552a1cb0eecfb04767bb",
+   "sha256": "1n98fxspx1qmm5p5s591jy2baviqy8b5hjn9hsrvqbmixc7arrhv"
   },
   "stable": {
    "version": [
@@ -4154,15 +4178,15 @@
   "repo": "alpha22jp/atomic-chrome",
   "unstable": {
    "version": [
-    20180617,
-    724
+    20210117,
+    408
    ],
    "deps": [
     "let-alist",
     "websocket"
    ],
-   "commit": "a505f638866f9e7b913784be0dc84f338e9ad449",
-   "sha256": "081465ahis2rvlklzn2vakbwn5dgr43ks4csp3arnlj11b43f3ai"
+   "commit": "ae2a6158a6a216dddbe281d0b0b00af7a2fdd558",
+   "sha256": "1wb770157p85nmsmqb2pspkw0jfrrlp43bp7cmdjv561gh0mbrak"
   },
   "stable": {
    "version": [
@@ -4186,8 +4210,8 @@
   "repo": "jyp/attrap",
   "unstable": {
    "version": [
-    20200908,
-    1252
+    20210205,
+    1027
    ],
    "deps": [
     "dash",
@@ -4195,8 +4219,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "9c881548debcf59b8aadda0ef4abca3c9a68dd80",
-   "sha256": "01x2nwqzrnngvmw6zynh6xhfg3jx7l22mv3gndi5xzxqngqh137s"
+   "commit": "c84d68846995dbfe15f1237bf4ce0bc83c37bc52",
+   "sha256": "14446mn96kmmn1l915jf54x3cvrmkjnzrgsp8091xicxfvmhmpyq"
   },
   "stable": {
    "version": [
@@ -4370,11 +4394,11 @@
   "repo": "DamienCassou/auth-source-pass",
   "unstable": {
    "version": [
-    20201108,
-    1043
+    20210210,
+    1908
    ],
-   "commit": "aa7f17116ec3f760eb414d655ba20016b11a4a0e",
-   "sha256": "08q1dicdj4fgmn47mslinrl7wfnpix98xdwvhz78cvqhclb1662s"
+   "commit": "468bba286fc20d739ed7724ec884357907ac8bda",
+   "sha256": "1pazl19rd4fvnfi9i2ssaygby5pw2a821aysy8jswsij57lw40dy"
   },
   "stable": {
    "version": [
@@ -4457,8 +4481,8 @@
    "deps": [
     "packed"
    ],
-   "commit": "f8619d1616b523918323914ec77bfbee2c559781",
-   "sha256": "1qcszjjqkq811p8pafjx0knm4giv7dls4x1xamhzbndjz0d022kz"
+   "commit": "4952a1a1cadf1bdf7018610a71f8c3acb67962c2",
+   "sha256": "17p7jmr8qd3hgx79iiljsi2kpy24g8v2ynxiz023wanasxr6bdc6"
   },
   "stable": {
    "version": [
@@ -4488,8 +4512,8 @@
     "cl-lib",
     "popup"
    ],
-   "commit": "6bbb6c7ab8e5aa2d389807fce65bbc5ce7065900",
-   "sha256": "0cxs9is3ifn9grqaw50dvpsjkkmwh398a6lqc93fny7p6d1hd9ja"
+   "commit": "aafd3f566a8002a1e9b3e197721a2660c0a835ff",
+   "sha256": "0ipa5kaprisrmyyqlgzi5giq0449hjflfm81i9a5vy82ikz5lsxg"
   },
   "stable": {
    "version": [
@@ -4795,11 +4819,11 @@
   "repo": "mina86/auto-dim-other-buffers.el",
   "unstable": {
    "version": [
-    20200801,
-    2029
+    20210210,
+    1744
    ],
-   "commit": "cad370fb6c9fc7186c2af221932e097af5900a2d",
-   "sha256": "0hjxadi8245zwwsp0kdz0c6i1j25drbky5cvksdnc8xw2l91kpbs"
+   "commit": "62c936d502f35d168b9e59a66c994d74a62ad2cf",
+   "sha256": "07ilprnidpg8wn28h8ra9ml6pxaixg734ybya0gj1ac6sc3ky52s"
   }
  },
  {
@@ -4894,14 +4918,14 @@
   "repo": "rranelli/auto-package-update.el",
   "unstable": {
    "version": [
-    20200826,
-    2227
+    20210211,
+    2036
    ],
    "deps": [
     "dash"
    ],
-   "commit": "c0df65ac9845ba2c7c9f53bbdbe013f1024f96f9",
-   "sha256": "0fy45psfsfsfrailiqv86bxsb3vxb36wyf7farb0zaxlrqay8qvd"
+   "commit": "22130fb17d00d79497253c94f3e88382cb40c3ac",
+   "sha256": "1z0yfhg44zsra1c29w05fa6gkqidmwjaszxvjhkx4n3mzy3vhqf2"
   },
   "stable": {
    "version": [
@@ -5259,8 +5283,8 @@
     20190331,
     2230
    ],
-   "commit": "c6ccdc83e85719a8bb07ef715cf5fd06866a479c",
-   "sha256": "0z8rykhhhwccy0zg6v3gnghfiawqw3afv4pvxr1hrympiyhyvhvp"
+   "commit": "19e2f1766b4a845ce5a4ccc87de62608f385bd11",
+   "sha256": "1gpzi092732chg0mvrwmr01c2njip1d2m15lj9fa1ii6sddfpand"
   }
  },
  {
@@ -5396,15 +5420,27 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210112,
-    2334
+    20210125,
+    2115
    ],
    "deps": [
     "avy",
     "embark"
    ],
-   "commit": "14dcc650d9339a6458bb0babfed35de13e76fa50",
-   "sha256": "15shi1i8071833mjzrwyy5iw818sxcqym0cb0zvi9bk5nvprp58b"
+   "commit": "3a9c581cb7518f738dce8d6a0f1d1eb6c78b6622",
+   "sha256": "1aik11mq5yqk9zwqqfizh9vsb8gglisrf02hlx28s32h2hybsd3n"
+  },
+  "stable": {
+   "version": [
+    0,
+    10
+   ],
+   "deps": [
+    "avy",
+    "embark"
+   ],
+   "commit": "47daded610b245caf01a97d74c940aff91fe14e2",
+   "sha256": "063hc0hganws11vjdk3ic0mxm9i0vpw6s7hzbgxvja0gjkdxjldz"
   }
  },
  {
@@ -5602,11 +5638,11 @@
   "url": "https://bitbucket.org/pdo/axiom-environment",
   "unstable": {
    "version": [
-    20201212,
-    1109
+    20210131,
+    2053
    ],
-   "commit": "47d6dffc29286badb2b1d7143b219e5c1be15bdb",
-   "sha256": "1dppyda9jkwh6fj8m4kziq84w0b5yzxrhq87jhkv54jjra6yxbb4"
+   "commit": "d9c1c85ea731a18f271bd003a5b1736e26fa172a",
+   "sha256": "1clcbgs5dk3jas6sclsfj6ibrb0n2508xapyp85lb0nm01i07jb9"
   }
  },
  {
@@ -5977,11 +6013,11 @@
   "repo": "belak/base16-emacs",
   "unstable": {
    "version": [
-    20200929,
-    2159
+    20210206,
+    1822
    ],
-   "commit": "93b1513a9994355492314e809cdbfb0d21f1e30d",
-   "sha256": "0sw483bzm5ax07cyvjbm6qaji5m0xw4mzcgrxi5ki81i0y79x59q"
+   "commit": "041e442b6ab2b85a254e17bfc776a508e1b66abf",
+   "sha256": "1rcw4jsla3fhrb6b5margiwk2i2m0rrf3vp8lxk8vdg9bsy5ikmc"
   },
   "stable": {
    "version": [
@@ -6157,8 +6193,8 @@
     20200627,
     1625
    ],
-   "commit": "2cf143b616df3de4b199538341d674c58386719e",
-   "sha256": "1p9pxxdx39jmf8sav660ps6mqwbsgcl4v1i9xb8xsd5qdxmwjqli"
+   "commit": "689f5df2c728129f288ed6eed82cde5df8c2ad1f",
+   "sha256": "09mj52wqdlysdqrs8mabm6373pqrab7zjbc4y5ll54a5iz7fv7yb"
   },
   "stable": {
    "version": [
@@ -6597,17 +6633,17 @@
  },
  {
   "ename": "better-defaults",
-  "commit": "7bb729c1ad8602a5c0c27e81c9442981a54a924a",
-  "sha256": "13bqcmx2gagm2ykg921ik3awp8zvw5d4lb69rr6gkpjlqp7nq2cm",
-  "fetcher": "github",
-  "repo": "technomancy/better-defaults",
+  "commit": "8bec8e696afde1b89502f312efc0054ca59502a6",
+  "sha256": "0vl6ivjjg4sy67ma18ya64r4wn64z2kqbxaa435s9ayszmbpmpa2",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~technomancy/better-defaults",
   "unstable": {
    "version": [
     20200717,
     2012
    ],
-   "commit": "293237a22a4f24171dd9910d6517a0eccf526fdf",
-   "sha256": "0f3alik361d81kdwpigcgkj9rxww23prqfhjfdh97fnycp3r1nyb"
+   "commit": "fd4346735d61be88e6eafabf1f62c4c16548f1b3",
+   "sha256": "1cnqwrkiml8jz4hbdv16pb97v6g528mvpqx1lg01v45h4mky82bn"
   },
   "stable": {
    "version": [
@@ -7027,8 +7063,8 @@
     "bind-key",
     "key-chord"
    ],
-   "commit": "365c73d2618dd0040a32c2601c5456ab5495b812",
-   "sha256": "10c0rmi5axypx0xy3fib739rjnakl32spwcirzxz1p5r0x9gya4a"
+   "commit": "a7422fb8ab1baee19adb2717b5b47b9c3812a84c",
+   "sha256": "1zz2gg475254hbbxw4y82b2m2iy8cvx0phh030daax315hdbsaqb"
   },
   "stable": {
    "version": [
@@ -7052,11 +7088,11 @@
   "repo": "jwiegley/use-package",
   "unstable": {
    "version": [
-    20200805,
-    1727
+    20210210,
+    1609
    ],
-   "commit": "365c73d2618dd0040a32c2601c5456ab5495b812",
-   "sha256": "10c0rmi5axypx0xy3fib739rjnakl32spwcirzxz1p5r0x9gya4a"
+   "commit": "a7422fb8ab1baee19adb2717b5b47b9c3812a84c",
+   "sha256": "1zz2gg475254hbbxw4y82b2m2iy8cvx0phh030daax315hdbsaqb"
   },
   "stable": {
    "version": [
@@ -7100,26 +7136,26 @@
   "repo": "rnkn/binder",
   "unstable": {
    "version": [
-    20201222,
-    1603
+    20210131,
+    1227
    ],
    "deps": [
     "seq"
    ],
-   "commit": "8a10a66116797e132b19f57026a1976753d332e9",
-   "sha256": "0qjrcvmmhirzw08r81jnxl79kmgiwwhjnvif16amkf1l8r8qiawq"
+   "commit": "9cec78c685dbca51ab9d1014eb535a541083effc",
+   "sha256": "065cqvdjdb5w60b7ga7q51920ib5vpz63zq9s68q0fjwb55q3k8z"
   },
   "stable": {
    "version": [
     0,
     4,
-    3
+    4
    ],
    "deps": [
     "seq"
    ],
-   "commit": "8d479f1ad0573008e7f60dad2f6549c7d2f96598",
-   "sha256": "1wfbm3z4irgh22lrfkdf05y9y3ayl1jcmf2iqgncrj12j5a5jwa7"
+   "commit": "3cf7c254703f5c3a90c2cd617b522d09e7913c7b",
+   "sha256": "01y9yd1rvi1ll3pp2i44g7ivkvz1cvc22207f8a3dbv90jw4c66m"
   }
  },
  {
@@ -7675,8 +7711,8 @@
   "repo": "boogie-org/boogie-friends",
   "unstable": {
    "version": [
-    20201108,
-    230
+    20210131,
+    8
    ],
    "deps": [
     "cl-lib",
@@ -7685,8 +7721,8 @@
     "flycheck",
     "yasnippet"
    ],
-   "commit": "462acddf8012c896a510f539fa3d16eb3c4dc71b",
-   "sha256": "0lz39j1alzzchfz67xp70cj1z6ckapdyqbl2gnax8xqyw7f3816f"
+   "commit": "8e906c41725bada06ff6e296af65cc463b028ea9",
+   "sha256": "1cf94hw1b50qkzjc88gxi5qhpf3pkaj2w3glr8dldnh0l5z8vfxg"
   }
  },
  {
@@ -7721,16 +7757,16 @@
   "repo": "jyp/boon",
   "unstable": {
    "version": [
-    20201118,
-    1521
+    20210212,
+    2136
    ],
    "deps": [
     "dash",
     "expand-region",
     "multiple-cursors"
    ],
-   "commit": "3dd9669d01e48860bb7ea12be8c764a4bc6808ea",
-   "sha256": "0j5v2mm6gd463x6jcbp5ly71g2qaiajrbc3ina2rzbmj0ccqr39l"
+   "commit": "d34d5cfc902702537e82df11d743fd0ac8ffe1d2",
+   "sha256": "0545alciqa51gi6rnw8mhb0xjab8f22dnb2vh238in3bxf2i349h"
   },
   "stable": {
    "version": [
@@ -7761,8 +7797,8 @@
     "epkg",
     "magit"
    ],
-   "commit": "5de2a7aa0c126f5b18506e187bca66079e68f51d",
-   "sha256": "18d845xpfp1dklqqghxxzy6zglm8w11lyi3ww44yfmrmxgi8xsvd"
+   "commit": "d0283edfaead36564ba4e64dcf8785f6d65f288c",
+   "sha256": "076n6jh084f6pra12cbl3fp1gv3229rj5nxbpcmr9rpp50x2c790"
   },
   "stable": {
    "version": [
@@ -8104,11 +8140,11 @@
   "repo": "topikettunen/brutal-emacs",
   "unstable": {
    "version": [
-    20200415,
-    602
+    20210206,
+    1
    ],
-   "commit": "ee63563b7cb07aeec342722ae684426cb0465a98",
-   "sha256": "1wx6771iv4psvlwhng0n09g0w3yml1pw3ga5lghjz9j6hba0bc6s"
+   "commit": "3959cf1737691d8eb41ec9c652d959f24c7de150",
+   "sha256": "1pq4iyl0z8wwzahjcdncmvwc4nz4zh9nmb54zjx7mrdcqvzh2x7v"
   }
  },
  {
@@ -8954,6 +8990,30 @@
   }
  },
  {
+  "ename": "ca65-mode",
+  "commit": "e479ed85d361e3439fb69e4b0cc0f0fd608f9c7a",
+  "sha256": "04s9z3brwc1zr5v2h7p1d129jg44j00x3qdd9md2cwiaxbr4c3ns",
+  "fetcher": "github",
+  "repo": "wendelscardua/ca65-mode",
+  "unstable": {
+   "version": [
+    20210202,
+    39
+   ],
+   "commit": "100e0f1ff7678733404a03b5a5eefb5daf2081c2",
+   "sha256": "0r66sw7scw0y1vfby7mcrf8kxhyvsaqhn9v2n098ih1x06ah0640"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    1
+   ],
+   "commit": "431e61b886611d1c5f08266b482c18fd03a61130",
+   "sha256": "0043v8a861714xalk3hf0gbpmx223432qbsgimizar59ysczagma"
+  }
+ },
+ {
   "ename": "cabledolphin",
   "commit": "0c8bd2715aec4793abc37d6899adabd568955a08",
   "sha256": "04slrx0vkcm66q59158limn0cpxn18ghlqyx7z8nrn7frrc03z03",
@@ -9491,15 +9551,15 @@
   "repo": "kwrooijen/cargo.el",
   "unstable": {
    "version": [
-    20210103,
-    2111
+    20210124,
+    1516
    ],
    "deps": [
     "markdown-mode",
     "rust-mode"
    ],
-   "commit": "9c7d885562c7d5935ec2e97585acf95813a084be",
-   "sha256": "0j1ls97m4rc9mkjp57k4ba1ljvzlhmpn31z7drkqhx9yff0q0fan"
+   "commit": "e66beb9b2f1f8dce48aa31f42cb5c384328554c6",
+   "sha256": "0hf7ij307nndxs96a3xqzcgpn8fblpx4px817ib08kfqzi6ph99j"
   },
   "stable": {
    "version": [
@@ -9571,8 +9631,8 @@
   "repo": "cask/cask",
   "unstable": {
    "version": [
-    20201206,
-    1419
+    20210211,
+    727
    ],
    "deps": [
     "ansi",
@@ -9584,8 +9644,8 @@
     "s",
     "shut-up"
    ],
-   "commit": "b0afdf94c0a2424db86b264bcac175b75c4395b3",
-   "sha256": "0hjc2pig7chhvb94qyccmnndy16xlyzwq37x4pm2s44yl1vra02k"
+   "commit": "5ac82efeea812a83c636d5273ddf5b99bb72f8a2",
+   "sha256": "19dg2z9mmqzpvjs5xnyj0yh2j212cakvkaf660ha6j03c203nbw4"
   },
   "stable": {
    "version": [
@@ -10102,8 +10162,8 @@
     20171115,
     2108
    ],
-   "commit": "a1f30acc05097d9def5925e8b48de3df4237610b",
-   "sha256": "18ixkfz41wa3h4041rlj6zxg30m3afhn1vfvcf6dz2vnj1z22h2z"
+   "commit": "711f389a527d65b39c91f5c10fc24cededb62ccf",
+   "sha256": "1q134lk70qkm3cw0m2cn024bvahfwlyvpap50f150rfpkz1v4v5v"
   },
   "stable": {
    "version": [
@@ -10187,16 +10247,16 @@
   "repo": "Alexander-Miller/cfrs",
   "unstable": {
    "version": [
-    20210108,
-    1152
+    20210121,
+    2007
    ],
    "deps": [
     "dash",
     "posframe",
     "s"
    ],
-   "commit": "d4cee9074b31b283b1475bfc8fe3c63ab51dbb61",
-   "sha256": "122gls0zwxl3km5h0gw5ykccxxdfy8svvr7s7lm78ylmp6prpx2p"
+   "commit": "fdcb5031ca364770475fc432b36599b7d34be502",
+   "sha256": "1ffdxyw3f791s11hw0qlybxqhg9q0994hc8w21n9vg856by9h7yq"
   },
   "stable": {
    "version": [
@@ -10236,11 +10296,11 @@
   "repo": "challenger-deep-theme/emacs",
   "unstable": {
    "version": [
-    20201214,
-    1705
+    20210120,
+    941
    ],
-   "commit": "b0d5f103db8ee846580617cc3a2f44f89edd5a6d",
-   "sha256": "03k4bvidvhcfqvk3hqni546pfz6lb8jwhxynsyacq1vcmvx1j8xw"
+   "commit": "2a799259406a8b96a688873093ffab6630a3ad3b",
+   "sha256": "1rl3rkrbms96wv51mwxih9b4zg1dzh3jcmx4ylgamg77abd03sg3"
   }
  },
  {
@@ -10251,14 +10311,14 @@
   "repo": "magnars/change-inner.el",
   "unstable": {
    "version": [
-    20150707,
-    1544
+    20210126,
+    1456
    ],
    "deps": [
     "expand-region"
    ],
-   "commit": "52c543a4b9808c0d15b565fcdf646c9779de33e8",
-   "sha256": "1m9sq93bwajbld3lnlzkjbsby5zlm9sxjzqynryyvsb9zr1d0a9z"
+   "commit": "42cad58aed2caec260f8e8ff61f78a7d3db72d1b",
+   "sha256": "0hs5hw36yagchpihx18059gi8b85hrccm82ynh89y7dkk1pw3wy1"
   }
  },
  {
@@ -10519,21 +10579,6 @@
   }
  },
  {
-  "ename": "chicken-scheme",
-  "commit": "03f4992471185bf41720ff6fc725fd5fa1291a41",
-  "sha256": "0ns49p7nsifpi7wrzr02ljrr0p6hxanrg54zaixakvjkxwcgfabr",
-  "fetcher": "github",
-  "repo": "dleslie/chicken-scheme.el",
-  "unstable": {
-   "version": [
-    20141116,
-    1939
-   ],
-   "commit": "19b0b08b5592063e852cae094b394c7d1f923639",
-   "sha256": "0j61lvr99viaharg4553whcppp7lxhimkk5lps0izz9mnd8y2wm5"
-  }
- },
- {
   "ename": "chinese-conv",
   "commit": "a798158829f8fd84dd3e5e3ec5987d98ff54e641",
   "sha256": "1lqpq7pg0nqqqj29f8is6c724vl75wscmm1v08j480pfks3l8cnr",
@@ -10638,14 +10683,14 @@
   "repo": "SavchenkoValeriy/emacs-chocolate-theme",
   "unstable": {
    "version": [
-    20191021,
-    1346
+    20210128,
+    1647
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "1c6cd8d2fdc939bd4d26117d61e57c11cfe26512",
-   "sha256": "1knnj1kzjccr7hg5zbj4qfnkgjkf221bf7wv83km9hs7zs7brj5x"
+   "commit": "ccc05f7ad96d3d1332727689bf6250443adc7ec0",
+   "sha256": "1d8a9jwv9y0sncw24k840c8yyrig30f2d6q2zqlc09f05yzq9p9p"
   }
  },
  {
@@ -10700,8 +10745,8 @@
   "repo": "contrapunctus-1/chronometrist",
   "unstable": {
    "version": [
-    20210106,
-    2147
+    20210211,
+    601
    ],
    "deps": [
     "anaphora",
@@ -10710,14 +10755,14 @@
     "seq",
     "ts"
    ],
-   "commit": "cef185de5ce47236c6ba70a7613f7aa51365e5ec",
-   "sha256": "10jc1xw3rz18h1an8psbmrp9a1y11xcf53j0hi7vvch85w75hfc6"
+   "commit": "d1b42bbf0d134ee6ed6f423956a355ba0a7ac968",
+   "sha256": "1k7r5rc6vzrnhp9j5bkv45yzqz7zbqrkiry4fzc8w6f36pcw862f"
   },
   "stable": {
    "version": [
     0,
     6,
-    2
+    5
    ],
    "deps": [
     "anaphora",
@@ -10726,8 +10771,8 @@
     "seq",
     "ts"
    ],
-   "commit": "cef185de5ce47236c6ba70a7613f7aa51365e5ec",
-   "sha256": "10jc1xw3rz18h1an8psbmrp9a1y11xcf53j0hi7vvch85w75hfc6"
+   "commit": "d1b42bbf0d134ee6ed6f423956a355ba0a7ac968",
+   "sha256": "1k7r5rc6vzrnhp9j5bkv45yzqz7zbqrkiry4fzc8w6f36pcw862f"
   }
  },
  {
@@ -10818,8 +10863,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20210104,
-    915
+    20210209,
+    632
    ],
    "deps": [
     "clojure-mode",
@@ -10830,8 +10875,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "3fac28541e03812990c771bd774bf8ea65c228c9",
-   "sha256": "1216nws4mcvmrlkdvpb83slqqwkqiwdyw0fxp2b1nkm2lmrcq7bs"
+   "commit": "6b397733f7ebe5dbd4d9c717c0acb13a69f88d7d",
+   "sha256": "1mqws9386fph96ypr516i9dlm15nxyiwfsvqpgnzi366sdpx9bid"
   },
   "stable": {
    "version": [
@@ -11424,14 +11469,14 @@
   "repo": "redguardtoo/cliphist",
   "unstable": {
    "version": [
-    20190920,
-    149
+    20210129,
+    313
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "3105e5c4b4d2d0338edb6effd9329426854b80b1",
-   "sha256": "0jbn2nczhsv9adhkc6mnrmxyjbpkbqq475gry0khhqlmzm49y618"
+   "commit": "3682a114e7651fc53155451afef0026f25f01f64",
+   "sha256": "08ih6n6xmnv179z8lfvplgss3xvl9bxppcbj1qiqbvgnf2rqfpb3"
   },
   "stable": {
    "version": [
@@ -11947,8 +11992,8 @@
    "deps": [
     "emacsql-sqlite"
    ],
-   "commit": "c864c1fadfea4a05fff29cb60891b7a32ac88c78",
-   "sha256": "06j0sc6dx8f34wc8i7dzkp8jwvwnrpnl8i93vpc1qw0ih0jwa2zh"
+   "commit": "1d5e9cbb69bc2992eaafa1bc084343efbd3e0c4c",
+   "sha256": "1s3pb8zn3ypc2pvkp7g7wvml02m06lk9d7c29pq1yqn9f5sisrcg"
   },
   "stable": {
    "version": [
@@ -12124,17 +12169,17 @@
     20210104,
     1831
    ],
-   "commit": "e6b6e457a0e8d33402bc7d64d85b20a8ca0546a0",
-   "sha256": "1p5vd3dmp7q0nw5px2gplrrdi6zgd3qlvmc3ql7xclgaxbp0zrs2"
+   "commit": "99e9167caa8fa65e72553fa38adb24071b51fd71",
+   "sha256": "0c0cxskd7nrswv3ihmkm9hgldfhw4grrsl2ihkw1idz5hj05y3rg"
   },
   "stable": {
    "version": [
     3,
     19,
-    3
+    4
    ],
-   "commit": "19ff734e76a35d59eb0f973197cadb1c271c766c",
-   "sha256": "0yzwnb1vikbhqzrqq6ngzqv45dcngajjc3b2f4cc002ry3bnn1mv"
+   "commit": "0c86d15459eeef2ddd15644b7bb3d7854f226334",
+   "sha256": "1m56r4glwzvy92hafb8kh16x4qa0dhp0v464p7n1hb18bb53xl8h"
   }
  },
  {
@@ -12276,6 +12321,21 @@
    ],
    "commit": "1ad9af6679d0294c3056eab9cad673f29c562721",
    "sha256": "0s0zakrmbx9gr7ippnyqngc09xj9f7bsv0mv11p062a8pkilg219"
+  }
+ },
+ {
+  "ename": "code-cells",
+  "commit": "75600cc888a717d300c6ca05b629fa7acba9390b",
+  "sha256": "1z8cf6bkpv21r42d10kvih5pb31k0iw4r18i8l96wfizad8bva93",
+  "fetcher": "github",
+  "repo": "astoff/code-cells.el",
+  "unstable": {
+   "version": [
+    20210111,
+    744
+   ],
+   "commit": "d03621b1033cc33054e30169517c57d020c13050",
+   "sha256": "0c2agyg28lqsmkkjcnhx8wdn531lh0zsy37q939wf231lpl4asvj"
   }
  },
  {
@@ -13078,11 +13138,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20210114,
-    35
+    20210122,
+    2314
    ],
-   "commit": "288a7617c4c3e5f22a887a17a697ac2bfe4e567d",
-   "sha256": "1h5wkgv7gny7dp01mq35fj9g18v62813gx6qvw7812rypaj068yw"
+   "commit": "5c25e114c3ac1bee3671abd47f46592a3151d549",
+   "sha256": "0y6gqc9w4zw1048hlyx0l46gcngbyrmdvzk30flwfphg1ancmcrj"
   },
   "stable": {
    "version": [
@@ -13220,8 +13280,8 @@
     "axiom-environment",
     "company"
    ],
-   "commit": "47d6dffc29286badb2b1d7143b219e5c1be15bdb",
-   "sha256": "1dppyda9jkwh6fj8m4kziq84w0b5yzxrhq87jhkv54jjra6yxbb4"
+   "commit": "d9c1c85ea731a18f271bd003a5b1736e26fa172a",
+   "sha256": "1clcbgs5dk3jas6sclsfj6ibrb0n2508xapyp85lb0nm01i07jb9"
   }
  },
  {
@@ -13599,62 +13659,30 @@
   "repo": "jcs-elpa/company-fuzzy",
   "unstable": {
    "version": [
-    20201119,
-    315
+    20210123,
+    1814
    ],
    "deps": [
     "company",
+    "ht",
     "s"
    ],
-   "commit": "ae004dc234b2cd2e4a0fd8a35aa8c966a15074c7",
-   "sha256": "1073hf1ximvhaf5vaxmz5arfph51ywqld52fkwjna6bf2djmchrf"
+   "commit": "4d6d56a8b92af72aa3b1e0af1a7e7add965bf468",
+   "sha256": "1yr050zgygjvhwjmm2yd5p889y24vars90cr4pyqc4zhmgzrdkw5"
   },
   "stable": {
    "version": [
     1,
-    0,
+    2,
     1
    ],
    "deps": [
     "company",
+    "ht",
     "s"
    ],
-   "commit": "ae004dc234b2cd2e4a0fd8a35aa8c966a15074c7",
-   "sha256": "1073hf1ximvhaf5vaxmz5arfph51ywqld52fkwjna6bf2djmchrf"
-  }
- },
- {
-  "ename": "company-ghc",
-  "commit": "28f6a983444f796c81df7e5ee94d74c480b21298",
-  "sha256": "07adykza4dqs64bk8vjmgryr54khxmcy28hms5z8i1qpsk9vmvnn",
-  "fetcher": "github",
-  "repo": "iquiw/company-ghc",
-  "unstable": {
-   "version": [
-    20170918,
-    833
-   ],
-   "deps": [
-    "cl-lib",
-    "company",
-    "ghc"
-   ],
-   "commit": "8b264b5c3c0e42c0d0c4e9315559896c9b0edfdc",
-   "sha256": "0cmyrz251ls6ygyas455mj4pnmzfdqag1sp8v5zggw74wsl5wm23"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    0
-   ],
-   "deps": [
-    "cl-lib",
-    "company",
-    "ghc"
-   ],
-   "commit": "64e4f9d0cf9377138a8dee34c69e7d578fd71090",
-   "sha256": "0y9i0q37xjbnlnlxq7xjvnpn6ykzbd55g6nbw10z1wg0m2v7f96r"
+   "commit": "4d6d56a8b92af72aa3b1e0af1a7e7add965bf468",
+   "sha256": "1yr050zgygjvhwjmm2yd5p889y24vars90cr4pyqc4zhmgzrdkw5"
   }
  },
  {
@@ -13863,8 +13891,8 @@
     "lean-mode",
     "s"
    ],
-   "commit": "cc1f5fadf8e9ae08aa25828985edc97df04d94a7",
-   "sha256": "0v03bisr0ljk1ypbicgh9izxwazz8ry5xcd7r1lqb339xqb0bzqb"
+   "commit": "15bee87dc4080b87c543964375b7ce162317ab6f",
+   "sha256": "127b7ny5mr1y14yg54gy7an3lk3928w4y9a22295i4v4zgj704j4"
   }
  },
  {
@@ -14021,8 +14049,8 @@
     "maxima",
     "seq"
    ],
-   "commit": "1600cfc059a80ed8fa0d381b88f29ba658811cc5",
-   "sha256": "030sg31xh46vrmsafvn04sdvyv4vzqf8rf5ghrlina1gav6kybfd"
+   "commit": "5e80033e6fa9089d5cd6fa93f6484b544f2ba059",
+   "sha256": "0qh19a3yi5cccj01wxrlyaw1zcaxvpjhxc5qk3mf4f1l8gm1sfi2"
   },
   "stable": {
    "version": [
@@ -14093,8 +14121,8 @@
     "cl-lib",
     "company"
    ],
-   "commit": "3ef9aa76c43347694d355db4c75cfd3d049cdbe1",
-   "sha256": "0kvxmpwf206grfirkpf8rwnkprb96lhna4bgaixf71g160dm3770"
+   "commit": "82bdb730ad5971c594d9c99c069f3c7bb067897d",
+   "sha256": "0qrlqir7fa2zf97yfsg8phj5dqgjz2rzn5zspfk9qlys3j8i483d"
   }
  },
  {
@@ -14164,38 +14192,6 @@
   }
  },
  {
-  "ename": "company-org-roam",
-  "commit": "aeb95e34be27dd78a237c0bfe1da94802fa68eae",
-  "sha256": "0k4w9g1rl94rpcvbcdmvsy47vzs53wz4b4hy9khj4yjn023nbsj7",
-  "fetcher": "github",
-  "repo": "org-roam/company-org-roam",
-  "unstable": {
-   "version": [
-    20200711,
-    355
-   ],
-   "deps": [
-    "company",
-    "dash",
-    "org-roam"
-   ],
-   "commit": "1132663bd68022aa7ea005ff53c7c7571890769d",
-   "sha256": "1xk53lyf5sn16cs2gv874sajs5jlsxbxpksbjx9nk8glzrq7r6r3"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "deps": [
-    "company",
-    "org-roam"
-   ],
-   "commit": "a4c3f60883de783b190d4eb8bcc85f5912d9393a",
-   "sha256": "087z699i7y0q72s5qc7ks09bzin9cl3gm3aqs4ka99lzg676lrl8"
-  }
- },
- {
   "ename": "company-php",
   "commit": "ac283f1b65c3ba6278e9d3236e5a19734e42b123",
   "sha256": "1gnhklfkg17vxfx7fw65lr4nr07jx71y84mhs9zszwcr9p840hh5",
@@ -14211,22 +14207,22 @@
     "cl-lib",
     "company"
    ],
-   "commit": "7d97ecc07e6b4ac772670e26583f11e77fdc69fd",
-   "sha256": "00jdn4dw975bb6fgf7wyxjbmvs31p8bav376d017kk56q9w6mv1f"
+   "commit": "33ed12bb2ec627a8a05360885f071e4a88fff399",
+   "sha256": "1ffayysbqh7vq65vhbmqg9yp03fqfnwj3drwyinr5ia81acp37nz"
   },
   "stable": {
    "version": [
     2,
-    3,
-    1
+    4,
+    0
    ],
    "deps": [
     "ac-php-core",
     "cl-lib",
     "company"
    ],
-   "commit": "1477a463e7b2fadf2542d9563b28424481d19bf3",
-   "sha256": "04163qnz5kq3cwmkm5yfvahq8d8ybmchlimzdp15p1izhfpvxnfn"
+   "commit": "33ed12bb2ec627a8a05360885f071e4a88fff399",
+   "sha256": "1ffayysbqh7vq65vhbmqg9yp03fqfnwj3drwyinr5ia81acp37nz"
   }
  },
  {
@@ -14333,8 +14329,8 @@
     "company",
     "pollen-mode"
    ],
-   "commit": "d0a33591498013886c2c4676e204cd684954e82a",
-   "sha256": "0lg65hzdjwbc3dav79f3jm7251yyq8ghcbccvkb32vwz281xhjnh"
+   "commit": "09a9dc48c468dcd385982b9629f325e70d569faf",
+   "sha256": "15z6sdkg9vygczr1imk3c5v6cbpqgsvnkydzkcmxnbwnqlx1agpc"
   }
  },
  {
@@ -14573,8 +14569,8 @@
     "company",
     "rtags"
    ],
-   "commit": "39339388256df662d0084b4a094d03e52748f9e8",
-   "sha256": "0wp4mygsxzibra2p3m5rn9m0yd3fscd795k5xa0wxi5pwddv7dlg"
+   "commit": "aa4c827b417f5448c12401c33acdab1325917c13",
+   "sha256": "02jqcbrpxm4sv15l8kyvsw9pwkmamj065cgifj68x242fw2f0sam"
   },
   "stable": {
    "version": [
@@ -14639,8 +14635,8 @@
     "company",
     "solidity-mode"
    ],
-   "commit": "d166a86b83907e0cfd64c191e9dfce4b44a9843e",
-   "sha256": "19hgvsrqch2vp49ag6m76bi5qxd20v95z0ib838rib9as15b17wq"
+   "commit": "b4fd719715be098921b6cbfb2ff9da31f3bd0d05",
+   "sha256": "0gsgj5485k7415wzq73xbj3ax9hh2l1j46ma5d0xkww3md3c3kca"
   },
   "stable": {
    "version": [
@@ -14701,15 +14697,15 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20200221,
-    2025
+    20210130,
+    1325
    ],
    "deps": [
     "company",
     "stan-mode"
    ],
-   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
-   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
+   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
+   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
   },
   "stable": {
    "version": [
@@ -14781,8 +14777,8 @@
   "repo": "TommyX12/company-tabnine",
   "unstable": {
    "version": [
-    20210111,
-    347
+    20210208,
+    1808
    ],
    "deps": [
     "cl-lib",
@@ -14791,8 +14787,8 @@
     "s",
     "unicode-escape"
    ],
-   "commit": "a6edb64cd1087f0453d08a72c3c0169cebcd9f4c",
-   "sha256": "069zzs80zwxhhnwnvybyvhd0qrwdd60r7ihffn5bmngmxf5nmi8i"
+   "commit": "235c99dc9fe629a42e6432d54d46310e2b5b426d",
+   "sha256": "1w8y9sv0k6r9q2d7a06bh6ackxckijyb9qd4w9s3lnbryrx1n6rk"
   }
  },
  {
@@ -14878,6 +14874,36 @@
    ],
    "commit": "f0cc9187c9c34f72ad71f5649a69c74f996bae9a",
    "sha256": "1xcwwcy2866vzaqgn7hrl7j8k48mk74i4shm40v7ybacws47s9nr"
+  }
+ },
+ {
+  "ename": "company-wordfreq",
+  "commit": "8df1cb0929505984e9fe739a01c196715f065b1e",
+  "sha256": "0980iay8d10xwx5i05zwyz85d8pcbj8y7kamyxfh47mxkaczip2i",
+  "fetcher": "github",
+  "repo": "johannes-mueller/company-wordfreq.el",
+  "unstable": {
+   "version": [
+    20210201,
+    1839
+   ],
+   "deps": [
+    "company"
+   ],
+   "commit": "3787785af2135c42af7b22562da554628141afdb",
+   "sha256": "0iwhi1pw14finc9n9avlv79wnyl8628cmdka5j83hjv1bs2fnysw"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "deps": [
+    "company"
+   ],
+   "commit": "3787785af2135c42af7b22562da554628141afdb",
+   "sha256": "0iwhi1pw14finc9n9avlv79wnyl8628cmdka5j83hjv1bs2fnysw"
   }
  },
  {
@@ -14982,6 +15008,36 @@
    ],
    "commit": "b0245fcbabf035d89b80150add5d6a47859ab555",
    "sha256": "07l495vv3by6r62i48jbfyr5pp1p6896cz25gkc7p3xqwrhi2min"
+  }
+ },
+ {
+  "ename": "compiler-explorer",
+  "commit": "28f8011009f8e92c020fe7599d9ede24b532e998",
+  "sha256": "1kqgdld32pfbxhxyrcjshj8ip06r8kxd7znvpsba39fp9s2k0pjh",
+  "fetcher": "github",
+  "repo": "mkcms/compiler-explorer.el",
+  "unstable": {
+   "version": [
+    20210212,
+    2218
+   ],
+   "deps": [
+    "request"
+   ],
+   "commit": "13dd0d44590dbf513aa0d70b518a3d2b1644179c",
+   "sha256": "0qwsajgwl28r4kpfxr5vzqwzspcjg0bb0n7cln8fp55bbq8wprq7"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "request"
+   ],
+   "commit": "0195db82b767e9defa36a2e298e6ac4aa4b47e69",
+   "sha256": "1ky63d2szw4sfgjd8xyfxswg2x7b8vnqnly6h1yisxc17994vl4v"
   }
  },
  {
@@ -15297,11 +15353,19 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20210115,
-    618
+    20210212,
+    2204
    ],
-   "commit": "6e7fd01c217b2ee6cc5e02dd74d7e687c2ccf267",
-   "sha256": "0vzbv51q6ax824kcrr7hv4l93s91ii583lsx2wc0nvi0vklbq50i"
+   "commit": "3bb31bd5f23a2c5fbc3b9d314e60f85b6f9e11c2",
+   "sha256": "1g6zgnbff6yqzz5wh4nqkbwzkrm96dmynfg0ak50lsy7brfyi1yh"
+  },
+  "stable": {
+   "version": [
+    0,
+    5
+   ],
+   "commit": "947fa7067cb9a171251972f74b608d58df88faf5",
+   "sha256": "0840hm6nk6yzz8yp8xqzdrycf7wwklxaxp10q0d30wpxwcrsw5c2"
   }
  },
  {
@@ -15312,15 +15376,27 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20210112,
-    1845
+    20210210,
+    1821
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "6e7fd01c217b2ee6cc5e02dd74d7e687c2ccf267",
-   "sha256": "0vzbv51q6ax824kcrr7hv4l93s91ii583lsx2wc0nvi0vklbq50i"
+   "commit": "3bb31bd5f23a2c5fbc3b9d314e60f85b6f9e11c2",
+   "sha256": "1g6zgnbff6yqzz5wh4nqkbwzkrm96dmynfg0ak50lsy7brfyi1yh"
+  },
+  "stable": {
+   "version": [
+    0,
+    5
+   ],
+   "deps": [
+    "consult",
+    "flycheck"
+   ],
+   "commit": "947fa7067cb9a171251972f74b608d58df88faf5",
+   "sha256": "0840hm6nk6yzz8yp8xqzdrycf7wwklxaxp10q0d30wpxwcrsw5c2"
   }
  },
  {
@@ -15636,14 +15712,14 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210109,
-    1641
+    20210129,
+    1143
    ],
    "deps": [
     "swiper"
    ],
-   "commit": "cbce9ce71429c98c67bd76ef15d049ecced042f7",
-   "sha256": "08lgvpvkhp2i9q73bnr2v17w864rwp6wjnrl3b7qg06dacfs2rvl"
+   "commit": "e0374dc0bbcd8ab0ec24baf308d331251d4f9c49",
+   "sha256": "1zvcp35vnnz5iybihrw0r21pvkghn73ni2m9jkgf352n8zza7z9g"
   },
   "stable": {
    "version": [
@@ -15666,15 +15742,15 @@
   "repo": "gexplorer/counsel-ag-popup",
   "unstable": {
    "version": [
-    20210114,
-    1548
+    20210121,
+    805
    ],
    "deps": [
     "counsel",
     "transient"
    ],
-   "commit": "cf0ee4f5bdb43a576f5cde00d52744ddb49177d5",
-   "sha256": "1k9d0581imp65d6w9vmc8bx6phyx0pvl7mas56p06hgnwg1i9cyk"
+   "commit": "41d85fe36edd72da68f5009ad9cf9013cd19960d",
+   "sha256": "1gfppiwx0cilg97bfb2cpdk7j10rdm473kklrkvb6wlwwg3j9w3q"
   }
  },
  {
@@ -15795,6 +15871,40 @@
   }
  },
  {
+  "ename": "counsel-edit-mode",
+  "commit": "73f84ab4a5b2cc5625968961601bad2a50ecc1f1",
+  "sha256": "0hlg10a7vg8lk08l439z0ldfidccgk6ngsjs1p384s24nqzrds9b",
+  "fetcher": "github",
+  "repo": "tyler-dodge/counsel-edit-mode",
+  "unstable": {
+   "version": [
+    20210103,
+    1508
+   ],
+   "deps": [
+    "counsel",
+    "ht",
+    "s"
+   ],
+   "commit": "82234306562f47ec50db212888dbcf21ef0b70f8",
+   "sha256": "0jfl33npvw6rqk734ml87bfvnjrsgzim0z397j1bg7klva60j7q6"
+  },
+  "stable": {
+   "version": [
+    0,
+    6,
+    1
+   ],
+   "deps": [
+    "counsel",
+    "ht",
+    "s"
+   ],
+   "commit": "75563c48135a4f52230d08e818e35d72fd55c2a4",
+   "sha256": "05ryph35ynzq7r5wp8m1q9vhnjv60x24sphzvbp8is0dp0fgwr0d"
+  }
+ },
+ {
   "ename": "counsel-etags",
   "commit": "87528349a3ab305bfe98f30c5404913272817a38",
   "sha256": "1h3dlczm1m21d4h41vz9ngg5fi02g6f95qalfxdnsvz0d4w4yxk0",
@@ -15802,14 +15912,14 @@
   "repo": "redguardtoo/counsel-etags",
   "unstable": {
    "version": [
-    20201228,
-    741
+    20210131,
+    824
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "c10951946d6dd935e4ab5d18db5da228e1c22806",
-   "sha256": "09n0mpp0pchb85f7qkizd686rpkfagmr7sd0sxsh81xhzdavam47"
+   "commit": "305eaa4a1ad6487e22eaa7ad36c33fa0d4a9456d",
+   "sha256": "1649yhmiimi2fm8av22b7h1nlb7lm1j1g9wgbsb6fk9wpvndazfx"
   },
   "stable": {
    "version": [
@@ -15975,8 +16085,8 @@
     "dash",
     "ivy"
    ],
-   "commit": "c5f781f241f8b16b7c3b6fb3e56e2938ba1dd87a",
-   "sha256": "10img15z5lfn8ml8d6v5mjf1nr73i8mjn9xy23ydp16n2idshh3d"
+   "commit": "6ba0f2ac7e4e5b8c1baec90296d9f24407d8d632",
+   "sha256": "1kp83cql4gn9g3d8g5mw3mrmpfj407kzpsi5wmwl1jr1pmw3v3jc"
   }
  },
  {
@@ -16186,8 +16296,8 @@
     "f",
     "s"
    ],
-   "commit": "5efa13e7d3e06f206b29879d8f66afd6b0d26f52",
-   "sha256": "01d7kgsdv09lllmhi2dvywb61n2aj3j665xcxqjidwfl03vsw16g"
+   "commit": "2f25d645448d64f2516f8f1181429c35cd214639",
+   "sha256": "0prhapqan96hha92sjfkhx3dv7zgxbrc7fcm8kk63z38psnx92zx"
   }
  },
  {
@@ -16576,6 +16686,21 @@
   }
  },
  {
+  "ename": "crossword",
+  "commit": "d74c680a2eada669fa092d05fa5c16ac81b9ad13",
+  "sha256": "11kpsdzpr4cv49xvzh49qfn77if397y6p2bxh7ql772mbhhb2h1m",
+  "fetcher": "github",
+  "repo": "Boruch-Baum/emacs-crossword",
+  "unstable": {
+   "version": [
+    20210212,
+    1602
+   ],
+   "commit": "8da505a40d077f06afefb8c6de507a62f5b3ad9a",
+   "sha256": "0j7qzdxssp35n642caa5vdy4bs9p1sbhara21ncbsln09aisg78d"
+  }
+ },
+ {
   "ename": "crux",
   "commit": "575e3442a925500a5806e0b900208c1e6bfd11ae",
   "sha256": "10lim1sngqbdqqwyq6ksqjjqpkm97aj1jk550sgwj28338lnw73c",
@@ -16694,11 +16819,16 @@
   "repo": "emacs-csharp/csharp-mode",
   "unstable": {
    "version": [
-    20210114,
-    2018
+    20210128,
+    841
    ],
-   "commit": "1d02a54f71b0c6ae0b5be9f764271ac31b1b0167",
-   "sha256": "02mbxqf4y04ancz89jkb8dmpmx3pmzxnxm5vc4fc6d828nzv56fx"
+   "deps": [
+    "tree-sitter",
+    "tree-sitter-indent",
+    "tree-sitter-langs"
+   ],
+   "commit": "09b4d57d020a97e1696e89baa6d9855ff5c86014",
+   "sha256": "1k8qz7fivwr8jli5xid156m0cb00mszfxskblylh2rs2fswpg3la"
   },
   "stable": {
    "version": [
@@ -16844,6 +16974,26 @@
   }
  },
  {
+  "ename": "ct",
+  "commit": "a216297f766f14428c689a184bf1ba0a03f02a29",
+  "sha256": "01p6jz0kdsr3h033nwg7xbyp55w3pszdg6bkkhdygiyhsaqlw4y1",
+  "fetcher": "github",
+  "repo": "neeasade/ct.el",
+  "unstable": {
+   "version": [
+    20210205,
+    1249
+   ],
+   "deps": [
+    "dash",
+    "dash-functional",
+    "hsluv"
+   ],
+   "commit": "356f6c765773b90e538f7801cb7281345cdbe4aa",
+   "sha256": "1m0mifqjsfr3487n1hypcxb5f0895y4xwkri7djwi3brv3nx52rv"
+  }
+ },
+ {
   "ename": "ctable",
   "commit": "8bc29a8d518ce7a584277089bd4654f52ac0f358",
   "sha256": "040qmlgfvjc1f908n52m5ll2fizbrhjzbd0kgrsw37bvm3029rx1",
@@ -16851,11 +17001,14 @@
   "repo": "kiwanami/emacs-ctable",
   "unstable": {
    "version": [
-    20171006,
-    11
+    20210128,
+    629
    ],
-   "commit": "b8830d1ca95abb100a81bc32011bd17d5ecba000",
-   "sha256": "0pg303pnqscrsbx9579hc815angszsgf9vpd2z2f8p4f4ka6a00h"
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "48b73742757a3ae5736d825fe49e00034cc453b5",
+   "sha256": "16yrx1z44xs24z2a0gwzf1xhhks1wrzafc5ihf6lbw843rq2jar0"
   },
   "stable": {
    "version": [
@@ -16913,11 +17066,11 @@
   "repo": "raxod502/ctrlf",
   "unstable": {
    "version": [
-    20201020,
-    1353
+    20210118,
+    132
    ],
-   "commit": "5acefdc9a6f8e35febf6f71b6a34a0d4fc499269",
-   "sha256": "0h707npbc4n9zx3pzla8cwaij48f80gg8fyjrdha4wb4y8ld6llq"
+   "commit": "928f98da5fdb8ca50c0957015f964dea8cde8b5f",
+   "sha256": "0sp09rk63dfvc1h40rmzwhac0dzp19w6zqzqigdsn6zrpk8g9vjg"
   },
   "stable": {
    "version": [
@@ -16951,11 +17104,11 @@
   "repo": "maurooaranda/ctune",
   "unstable": {
    "version": [
-    20190914,
-    1305
+    20210205,
+    1428
    ],
-   "commit": "d7643461f5aa33cc04e4d808123e4ed1d85500ee",
-   "sha256": "03gby644xqah7q9sjba9w6c7askc1s7ka4bx814x6vrlla6089h4"
+   "commit": "3f7abc6e74d4e5954b476ba9a1dc652f96b10c05",
+   "sha256": "1lcgkh0hhgx4rvc84kgbg3sczqp53gz6859c30hq1agn1zhbwrvy"
   },
   "stable": {
    "version": [
@@ -17306,8 +17459,8 @@
     20190111,
     2150
    ],
-   "commit": "30fc474830b4a5beb88cdc53a31797ed794cddb8",
-   "sha256": "08wb26skxw4gh1gzpbxxgi63x44zbb50xd6mi5nbsg538fqb9arj"
+   "commit": "c2fea5bf4a6e011a039f8764862bb6338a2ae546",
+   "sha256": "114c7ilcim908664wp8llnnnf496l39bm7y0fprydh2zwn7cqdng"
   },
   "stable": {
    "version": [
@@ -17342,11 +17495,11 @@
   "repo": "Emacs-D-Mode-Maintainers/Emacs-D-Mode",
   "unstable": {
    "version": [
-    20201201,
-    1136
+    20210119,
+    1853
    ],
-   "commit": "1931ec9ee7af6767883452a822914ad3fd98ddad",
-   "sha256": "0sf7bn11hfcmmlx3vrp0aix2g1nvng7wfwbkbvj682prr9zld3c3"
+   "commit": "80fad305784b21a818683010bc27d48302ec7110",
+   "sha256": "0xz29ac8mpqkzgzdvhdv98aa4mrd6br4sr5fxwpb3kpidmqpa9h8"
   },
   "stable": {
    "version": [
@@ -17514,8 +17667,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20201118,
-    1304
+    20210207,
+    1923
    ],
    "deps": [
     "bui",
@@ -17527,8 +17680,8 @@
     "posframe",
     "s"
    ],
-   "commit": "612388d0b85e77972a9c28391bac6224a63408c7",
-   "sha256": "1z1vimfwjb5bfqdijh38cii222sw07l2mgbw4bwhwp93kasczw9a"
+   "commit": "5450af5c1cc7c46b1ecd47e9ba1ec2de9f62f9d9",
+   "sha256": "1mk5prfx0nsi1528ar3yw0sgkgyk60697w9i14ljq6lhbnz6cx8n"
   },
   "stable": {
    "version": [
@@ -17781,11 +17934,11 @@
   "repo": "magnars/dash.el",
   "unstable": {
    "version": [
-    20210114,
-    2017
+    20210210,
+    1427
    ],
-   "commit": "6f5888c77523c2373c5252ef2113612beac7e78f",
-   "sha256": "1kg6c0jv44wlc0pidphg0cpmxfkn72r9391x0jgl1w22bhsvy4cz"
+   "commit": "be4e939b8982fa9a6ac5286027ea8ae1ff9b9b19",
+   "sha256": "1b0wpvwivzsym6hiaxybhfy8mvq8cbxi97dcm1ci2sc33fv6vq74"
   },
   "stable": {
    "version": [
@@ -17854,14 +18007,14 @@
   "repo": "magnars/dash.el",
   "unstable": {
    "version": [
-    20210103,
-    1524
+    20210206,
+    1519
    ],
    "deps": [
     "dash"
    ],
-   "commit": "6f5888c77523c2373c5252ef2113612beac7e78f",
-   "sha256": "1kg6c0jv44wlc0pidphg0cpmxfkn72r9391x0jgl1w22bhsvy4cz"
+   "commit": "be4e939b8982fa9a6ac5286027ea8ae1ff9b9b19",
+   "sha256": "1b0wpvwivzsym6hiaxybhfy8mvq8cbxi97dcm1ci2sc33fv6vq74"
   },
   "stable": {
    "version": [
@@ -17884,14 +18037,14 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20210113,
-    922
+    20210125,
+    909
    ],
    "deps": [
     "page-break-lines"
    ],
-   "commit": "fb5e47576a1c91374b008221277f0a45b2491085",
-   "sha256": "0c4rj8lm7dikjbnr2ynzhmzchg7mjirawp0hqxd5jgdv0lbn267n"
+   "commit": "18b38b49b60c005909f91f047c0507f47cc75fd3",
+   "sha256": "0ajw2wr02j0avjr5zdjllqhm7f1y27p6xjc6grgv90mmka926486"
   },
   "stable": {
    "version": [
@@ -18282,8 +18435,8 @@
     "s",
     "spinner"
    ],
-   "commit": "bb374c625939ac2dd9e2408c2cc180b1c9f4aa20",
-   "sha256": "0galdbka4dmlrryn5pbyd7frc676hb91y0zf6di8p9j2v3r7gzqv"
+   "commit": "3ea915f0c4f3b37a482cbf6faa070845d7ab1876",
+   "sha256": "1w922p46i3bf7mq5jj0i27b3ndiip2x46b1qy924y9874sc5ifxk"
   },
   "stable": {
    "version": [
@@ -18806,20 +18959,20 @@
   "repo": "DamienCassou/desktop-environment",
   "unstable": {
    "version": [
-    20201229,
-    1107
+    20210129,
+    2018
    ],
-   "commit": "9ece03e3e687ff97d79eb2a9f6cc506a932f89ca",
-   "sha256": "1hsjzwwlhqxqgp5ii8a23wq2fc7a8dzfnqhjyakn39wp7dm925sz"
+   "commit": "2c3e0750c11485931f447ea82f80bc90ae07aeba",
+   "sha256": "0ciha9q6j0fp0197ga0ifi4j527sp2pk6862mm70skpfv6bm8dx2"
   },
   "stable": {
    "version": [
     0,
-    4,
+    5,
     0
    ],
-   "commit": "c7507bfb10464b0527b3e2c5287a256cf3bf7ba3",
-   "sha256": "0s33jncjg8c2xlr90qjk1ishwmwxm9yg0z6n3kzilawcilpxidsh"
+   "commit": "9da8f4bddb78668085a7fc367f9021549f9e5f70",
+   "sha256": "03rl1z860jmirjrrg0xsjx0bqk73k043c8bz6049zhndh7pidri7"
   }
  },
  {
@@ -19086,14 +19239,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20210113,
-    1930
+    20210213,
+    41
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "dc3e12f14f5fddff3811310cd48640e2c9e626da",
-   "sha256": "1ackhs5rajydwfjgm4a9mwqhc75dk1jsby4yxkqbji495kwq4rsq"
+   "commit": "4c46b3b9851c85d15bff1e3ec92e5fc6043322bc",
+   "sha256": "1na2daa3d6hclj9hr8f9l029716c3pzky9ybwq08iv68msf3lvhn"
   },
   "stable": {
    "version": [
@@ -19188,20 +19341,20 @@
   "repo": "retroj/digistar-mode",
   "unstable": {
    "version": [
-    20200827,
-    9
+    20210129,
+    1719
    ],
-   "commit": "f46d58ea690c7c9ff9aca19441dff23284bab7cf",
-   "sha256": "0x29502mn9cpbsfiqsdaa90j2566zfai5lbv2c49w5wxxm904b7j"
+   "commit": "e12b128023b7696a23545f812877e8c6531d261c",
+   "sha256": "17ja51xcwmiy66000k08z8c7za4rivsi1w8w650s8byd4v9nkc75"
   },
   "stable": {
    "version": [
     0,
     9,
-    1
+    2
    ],
-   "commit": "f46d58ea690c7c9ff9aca19441dff23284bab7cf",
-   "sha256": "0x29502mn9cpbsfiqsdaa90j2566zfai5lbv2c49w5wxxm904b7j"
+   "commit": "e12b128023b7696a23545f812877e8c6531d261c",
+   "sha256": "17ja51xcwmiy66000k08z8c7za4rivsi1w8w650s8byd4v9nkc75"
   }
  },
  {
@@ -20014,8 +20167,8 @@
     "dash",
     "s"
    ],
-   "commit": "947a008387a939f466ca122bda2ea98bb17710e3",
-   "sha256": "19za6i96xrmczdh928n5ixd7j7pvy175sz1msaiwvdjwysjr8k51"
+   "commit": "fb0f161ac3cce1b224f52547f5bc7e1dcd283191",
+   "sha256": "0c92cqdsllly2dqrgfa9x8nmdyia1p9gkzyaf4427m1wd08dnfra"
   },
   "stable": {
    "version": [
@@ -20161,6 +20314,14 @@
     20210113,
     1
    ],
+   "commit": "491308566832a38c0c49a894f7b12b8ff62e7aa6",
+   "sha256": "1pa9k4y74rihh8d4ij6pdnpybs0ib2vcxvjp7ldlndxqpfzxaxxd"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
    "commit": "887434054c2cfc521ceb990266cc7bbc12c4a72a",
    "sha256": "16rwxv2mrn79m8hqg79kq7z6fz2l8amh17kny4y3qnsvakpi0hch"
   }
@@ -20219,14 +20380,14 @@
   "repo": "wbolster/emacs-direnv",
   "unstable": {
    "version": [
-    20200529,
-    1305
+    20210117,
+    1213
    ],
    "deps": [
     "dash"
    ],
-   "commit": "f5484b0fc33d4e5116612626294efb362ff9ecd4",
-   "sha256": "0772z4v2jjinqlqhrdcsvk912gdi0dkxag7q5nm0rnkx2pyk7ynw"
+   "commit": "381176f301dea8414a5a395c0d6546507838f6ce",
+   "sha256": "0hmj5m3wiqwdmjzxbzkf4sg8gaswdv5rv6jqgqvz3h9sm17fnps7"
   },
   "stable": {
    "version": [
@@ -20744,10 +20905,10 @@
  },
  {
   "ename": "django-mode",
-  "commit": "bdc46811612ff96cb1e09552b9f095d68528dcb3",
-  "sha256": "1rdkzqvicjpfh9k66m31ky6jshx9fqw7pza7add36bk6xg8lbara",
+  "commit": "bb974042c92a37403f855c0b3fb3cfdc8807ed19",
+  "sha256": "1wydqd3pbwshmd2a52hczbq3vfj2dsv9dgs7ivqkawryigdj3qfc",
   "fetcher": "github",
-  "repo": "myfreeweb/django-mode",
+  "repo": "unrelentingtech/django-mode",
   "unstable": {
    "version": [
     20170522,
@@ -20764,10 +20925,10 @@
  },
  {
   "ename": "django-snippets",
-  "commit": "bdc46811612ff96cb1e09552b9f095d68528dcb3",
-  "sha256": "1qs9fw104kidbr5zbxc1q71yy033nq3wxh98vvzk4z4fppnd29sw",
+  "commit": "bb974042c92a37403f855c0b3fb3cfdc8807ed19",
+  "sha256": "0fz9jywfxwhh9kq5w12jyizvxxhfjzybfl3gxrhg5sj0qakfpll8",
   "fetcher": "github",
-  "repo": "myfreeweb/django-mode",
+  "repo": "unrelentingtech/django-mode",
   "unstable": {
    "version": [
     20131229,
@@ -20994,8 +21155,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20200610,
-    715
+    20210208,
+    1500
    ],
    "deps": [
     "dash",
@@ -21005,8 +21166,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "3773112eea3fc99704b5ca50c1e9a3db2cb8e4f3",
-   "sha256": "0gi86ggjyfmfas7pswj7wirn5n7zs6rvb5b95nchnf4xf0nzwia1"
+   "commit": "0ca910badf86ff2e2dbfdf3f18819dd72a3198fc",
+   "sha256": "0n21nv79z356wmz2sryq1r0f68ds2kwkgivi8z82lqrv9ndni2xv"
   },
   "stable": {
    "version": [
@@ -21203,11 +21364,11 @@
   "repo": "progfolio/doct",
   "unstable": {
    "version": [
-    20210113,
-    1646
+    20210126,
+    310
    ],
-   "commit": "a795fa4eafd42e016b6c9fed93d2f370c4f5eef5",
-   "sha256": "1z8yzphckcbykz5nxz75vbc75zigv3f5lwwpnk35ipzb20xnm563"
+   "commit": "8ac08633ae413a6605b6506d2739eece7475272e",
+   "sha256": "09nmxq66cmwpbqc4l8p9f76pn6dmckfvpkj9fk99zsnhan4d8870"
   }
  },
  {
@@ -21322,16 +21483,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20210107,
-    1407
+    20210124,
+    1610
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "4956606a5455a3968ca10cbdb8de3889e6bd1d85",
-   "sha256": "1agv0jdfqvyw227mr3c4wnpjby48ccggfjglbidnfl7knd9i982d"
+   "commit": "116c733fd580f729e275d3b6b3954667d5dfdd5a",
+   "sha256": "0jx6ha2dg32mk5gy4p86ij61xssmd3q2za0xla9nfb23nrfm7g93"
   },
   "stable": {
    "version": [
@@ -21349,6 +21510,25 @@
   }
  },
  {
+  "ename": "doom-modeline-now-playing",
+  "commit": "de6f7f4030bc93babc3907a96d07029dd75caec4",
+  "sha256": "14wl5zr5g2bwzwly27wc6vpgk11cz1asx7xwx9mqwjf8nygr7bpq",
+  "fetcher": "github",
+  "repo": "elken/doom-modeline-now-playing",
+  "unstable": {
+   "version": [
+    20210202,
+    1948
+   ],
+   "deps": [
+    "async",
+    "doom-modeline"
+   ],
+   "commit": "bed9e4da626ede148c7d362188b2e7729e2a8a4f",
+   "sha256": "1rz50wyinj9nmz37wam4rsdi5igmvdfp6pwn3rmzqsrdp3j81smv"
+  }
+ },
+ {
   "ename": "doom-themes",
   "commit": "c5084bc2c3fe378af6ff39d65e40649c6359b7b5",
   "sha256": "0plqhis9ki3ck1pbv4hiqk4x428fps8qsfx72mamdayyx2nncdrs",
@@ -21356,14 +21536,14 @@
   "repo": "hlissner/emacs-doom-themes",
   "unstable": {
    "version": [
-    20210113,
-    1858
+    20210212,
+    1921
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "18cddefb3c8b9da63086496142ad6756f0bc9167",
-   "sha256": "0ix7kfxhs45w763ajzi2qxr7f94rd4g4xfi6szv3c75q6y5mb3y3"
+   "commit": "80cc62813bcb4e1f28b256a09d1e3d00a4b50b55",
+   "sha256": "1q2mv4w6bw8caaq25hzj5z45firll2h7cd0gxzsy53xm199sdi4g"
   },
   "stable": {
    "version": [
@@ -21834,8 +22014,8 @@
   "repo": "dtk01/dtk",
   "unstable": {
    "version": [
-    20201006,
-    1835
+    20210209,
+    1841
    ],
    "deps": [
     "cl-lib",
@@ -21843,8 +22023,8 @@
     "s",
     "seq"
    ],
-   "commit": "86d1558711cc6e843a1a5470113ff9cb1ad608d8",
-   "sha256": "03k96gr7hxw76dpykbzjfvrpkl2m1ifm4y0jc9skf2p448fd1ssw"
+   "commit": "270320f5a31dbef543f95b15608526629d613366",
+   "sha256": "1w6ylljrdrrp0087gkz83rf0fr1qnpqsm3lsg6k681wnvxz916gv"
   }
  },
  {
@@ -21870,11 +22050,11 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20201208,
-    1925
+    20210205,
+    1727
    ],
-   "commit": "854b9a1ce93d9926018a0eb18e6e552769c5407d",
-   "sha256": "0hw8md2qp8r89ndgz82yf4iydm5yc9cj2s3g75h6hm940mp4fgxm"
+   "commit": "4a30d8edac7fbc5936fc07050e3ebfb94f97c1e7",
+   "sha256": "1k0kwg4yqa29pcn5zzkp16qm8i0zwlxsazng1hnb5nvvqirsxv7c"
   },
   "stable": {
    "version": [
@@ -22002,20 +22182,20 @@
   "repo": "ocaml/dune",
   "unstable": {
    "version": [
-    20191016,
-    1241
+    20210213,
+    757
    ],
-   "commit": "13642e22a405de7c4361e94dd9aaa35ad1b09847",
-   "sha256": "0liha8qf1f4w5x8kklxc30yrn9krcrs9wvvj7chmgrg3m4mk3172"
+   "commit": "e1564823e86b797d41b2bb833c1f877f165df8d8",
+   "sha256": "05yl7p8f7l3gfyvxyjks2jcl9p6ghpxsia29903009ry5jiprjcr"
   },
   "stable": {
    "version": [
     2,
     8,
-    1
+    2
    ],
-   "commit": "b796156167490e777131403f651e83779e954000",
-   "sha256": "118fc0bwqp4yn4b6sfir53y3b7acgmpd2n0d7dc2cdjcv72bv0bm"
+   "commit": "6c471da57bea666267a8a63034aed57962f378b0",
+   "sha256": "0b7mqcns4n614fq3p9kisffks3j2wzawxp4xccka7wgyn1q2pgr8"
   }
  },
  {
@@ -22683,8 +22863,8 @@
    "deps": [
     "parsebib"
    ],
-   "commit": "a0c1cd12f2a635c89f4ecad1f3ec5701a78ebd00",
-   "sha256": "03np9b9xkd2h7c6il2a6vvlpcm80vnaf16ryark9cv9wraa5q4d1"
+   "commit": "8a6e7ec3773ad0d87716bc0766eb1b4ff548f856",
+   "sha256": "012v001dy49cspak16cr90fwz0y6r2l01r3j25h0gdd5gm91dggv"
   },
   "stable": {
    "version": [
@@ -22790,8 +22970,8 @@
   "repo": "ecukes/ecukes",
   "unstable": {
    "version": [
-    20201010,
-    1529
+    20210202,
+    1241
    ],
    "deps": [
     "ansi",
@@ -22801,8 +22981,8 @@
     "f",
     "s"
    ],
-   "commit": "f13723e0d7c2abbcb7a870091201ec80103bf202",
-   "sha256": "187zbmk1k14y7lwnbgycsk7g42c55bmp8vmyrvwylkz2lq65n0b2"
+   "commit": "d173cdf487bc2c62305e2232db96290bc021950f",
+   "sha256": "182qgddfv8nd89y1l55rs5vm5i61ayc8cxbplb8zx0alnid9xrw1"
   },
   "stable": {
    "version": [
@@ -22966,6 +23146,21 @@
    ],
    "commit": "6b62ffa7a69f52aab79067eaed80b2720f7e3fc2",
    "sha256": "001yhxngr6h7v1sjz0wskd5dv6fiby7m1mbc8vdz1h93150wzahp"
+  }
+ },
+ {
+  "ename": "edebug-inline-result",
+  "commit": "235b422e95ecce5671a16d44bc648379b6859bed",
+  "sha256": "036fpy7f748c8z7di94ya1dwz2ckri3qm6bsl809myr5wsghp2w1",
+  "fetcher": "github",
+  "repo": "stardiviner/edebug-inline-result",
+  "unstable": {
+   "version": [
+    20210213,
+    25
+   ],
+   "commit": "86a9ed9e4f58c2e9870b8918dc898ccd78d2d3f8",
+   "sha256": "1zf09s03xkhpbhkj99ilzp679lhkyiaaa5kmyj4lb380di1nrw2w"
   }
  },
  {
@@ -23150,14 +23345,14 @@
   "repo": "editorconfig/editorconfig-emacs",
   "unstable": {
    "version": [
-    20210112,
-    901
+    20210209,
+    947
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "9dd9789b77521eb9d128f9ebd4cfc7ef45072d0f",
-   "sha256": "1fi3mn16pw7iflhwsnhvdgzyghzgmv1kxdiw4ycnc7rb4q162an5"
+   "commit": "f830b86316338fcc5b26a07eaeab6c34104b9ddc",
+   "sha256": "092cc8dgf1z1cxgjmkysca76z93xw1a1bjb5k4y0jiw6jsr4d1h0"
   },
   "stable": {
    "version": [
@@ -23299,8 +23494,8 @@
     20201122,
     25
    ],
-   "commit": "84c49302e9d6d5f9b2b110e61a7a1774d79f111f",
-   "sha256": "12dqavx3d665drwsdzh2g81xzf5iaa4i76d2q37yihb1xx7ibk3q"
+   "commit": "507a694fb778754f3967bf95d9e1c4e446725835",
+   "sha256": "1hvir0bxlh9jbd3781pdx72hkrrnai6qg56mskl30vdbjv0byhhh"
   }
  },
  {
@@ -23487,8 +23682,8 @@
     20200107,
     2333
    ],
-   "commit": "a874f97af30b59daefaf08e1b4b6846b2214d1a5",
-   "sha256": "1vqllbkiwjcq3y68cbrvh7xq4r4xsm04qh628sbc95l09gwrsk2x"
+   "commit": "6a83f224a3cbe2d97c1641d49e443c503e54ddb6",
+   "sha256": "0r0ncy89h0gg8ah842rpmmkpn10xfgihh5bj3vswxi4g6b5mqqsz"
   },
   "stable": {
    "version": [
@@ -23508,8 +23703,8 @@
   "repo": "joaotavora/eglot",
   "unstable": {
    "version": [
-    20210113,
-    1843
+    20210203,
+    1041
    ],
    "deps": [
     "eldoc",
@@ -23518,8 +23713,8 @@
     "project",
     "xref"
    ],
-   "commit": "e5a9648beec6e83f5b4471261b07e1da6630da1d",
-   "sha256": "1ny2myy1yxz9xqd0cs3hciasyc6gfvr2gshgza3pry7w5z481yy3"
+   "commit": "398b81eeec44b35b39480a38f1b1357bc8550a1c",
+   "sha256": "1w0ndyzdnjldpwgyb8dgfiyhxk2ks6vmxkk2v6y4kn7ch3qwbg8z"
   },
   "stable": {
    "version": [
@@ -23535,6 +23730,37 @@
    ],
    "commit": "4edd4782f1c16c0516533b52e16b02b772812d16",
    "sha256": "17aamcda6h92rrg23vjllwr9qirb4fyxz9x7wcddzi1cawkhsh8k"
+  }
+ },
+ {
+  "ename": "eglot-fsharp",
+  "commit": "e03ae15749da9aab38ce2bc615d863f47fc23341",
+  "sha256": "197bqbkjb128a9p14rrrwcqf64962655krl052pqswns9is4bvf3",
+  "fetcher": "github",
+  "repo": "fsharp/emacs-fsharp-mode",
+  "unstable": {
+   "version": [
+    20210126,
+    454
+   ],
+   "deps": [
+    "eglot",
+    "fsharp-mode",
+    "jsonrpc"
+   ],
+   "commit": "78898a1535878394d83643c383f4320e7b5fcefd",
+   "sha256": "0d60jfaf8av0b7vx44lbqzb7v70dszvr2w1yjh1cxn71dnjphp4j"
+  },
+  "stable": {
+   "version": [
+    1,
+    10
+   ],
+   "deps": [
+    "eglot"
+   ],
+   "commit": "4a1df3342931f09edc933cb481da70cc5a5ef268",
+   "sha256": "0dkfd4nlc0hxikvby1271y6zppsvcc0jr12m2w1zrng1pqx666di"
   }
  },
  {
@@ -23638,8 +23864,8 @@
   "repo": "millejoh/emacs-ipython-notebook",
   "unstable": {
    "version": [
-    20210115,
-    120
+    20210211,
+    1542
    ],
    "deps": [
     "anaphora",
@@ -23650,8 +23876,8 @@
     "websocket",
     "with-editor"
    ],
-   "commit": "fbf1f71f52881dc23580053a6e188badb541388c",
-   "sha256": "1jnwl5yvw6bvj2hw0bnlzs4mz6xsv610ll1pk1rw3kricrnbmh1b"
+   "commit": "069e54cc1270ff4957699e5e9481b56b7b4bef8b",
+   "sha256": "0scl5lxl5dzcxbpw2xmqxcqpajfvvzl9zgmhl96i1q52f08mplhf"
   },
   "stable": {
    "version": [
@@ -23817,8 +24043,8 @@
     20200912,
     1653
    ],
-   "commit": "215ff5e56cedcc18866aba6e451b61c06a050e74",
-   "sha256": "0qnyzvvpvzy3cvnq07yfi1v13i91qwa6xfb4p9j9yr2r3gsgdc1g"
+   "commit": "84dd1837f9ac80a329ab0c2de6859777f445f8ff",
+   "sha256": "098x17hg9dc28s7g50mxhv6m6fgch1xp1di7rplkg7w1dfphpc5a"
   },
   "stable": {
    "version": [
@@ -24197,20 +24423,19 @@
   "repo": "doublep/eldev",
   "unstable": {
    "version": [
-    20201223,
-    2049
+    20210124,
+    1814
    ],
-   "commit": "9ca9abb3edca233ab52ada40531bec4ce3a8e642",
-   "sha256": "1nz2y9nqyxlb7bsg9chgdjkqmsfklh39shlvqhwl15im144ww9f7"
+   "commit": "dc8e1ebf0af386eee46097ee20c20b193d1d6a2d",
+   "sha256": "1rvnpysd0cwpg1n6fvg94a5s5psav6vn76v10pv8a2y1nqirjjc9"
   },
   "stable": {
    "version": [
     0,
-    7,
-    2
+    8
    ],
-   "commit": "a25ea7a9f6c15c18457e737ef61a0ff81970c5cc",
-   "sha256": "1xxcxgycn0a03irjcdq2pcb4p1bddhfjspni7lliwpv6zjqgkyhb"
+   "commit": "0cd211d21628ab35b21cd9ab0f16b0fc8438cac8",
+   "sha256": "1dfqajcghh9mww5c0hp9qya2nss87xd5x096bb17vgg5dpx5px3s"
   }
  },
  {
@@ -24302,14 +24527,14 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20200830,
-    1032
+    20210130,
+    1325
    ],
    "deps": [
     "stan-mode"
    ],
-   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
-   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
+   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
+   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
   },
   "stable": {
    "version": [
@@ -24416,6 +24641,39 @@
   }
  },
  {
+  "ename": "elescope",
+  "commit": "62debdf1f79d96c98b3957a11b203cfef289ac9c",
+  "sha256": "120ll2fgkyxxnlk84y1s5v05i08qi8055fjj8k3v2qyyz6z7w87b",
+  "fetcher": "github",
+  "repo": "freesteph/elescope",
+  "unstable": {
+   "version": [
+    20210128,
+    1509
+   ],
+   "deps": [
+    "ivy",
+    "request",
+    "seq"
+   ],
+   "commit": "cd3ce082e47c0c13cfce34e6f6957c2275f9416b",
+   "sha256": "1pk8avmvvcxmv2gsl5n8g66jjwi92py1r9f5h9c0wjq0nrazapy1"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
+   ],
+   "deps": [
+    "ivy",
+    "request",
+    "seq"
+   ],
+   "commit": "7711f7e34d04ea52a258f69ee0c94ef1240c5655",
+   "sha256": "0y2cv5af05mjcr5qba88q7ga6w04yxpymn4s28g2c4591lmbkhsj"
+  }
+ },
+ {
   "ename": "elf-mode",
   "commit": "368d1ff91f310e5ffe68f872ab0a91584a41a66e",
   "sha256": "0xwpaqg4mc0a0d8a4dxbd1sqzvi01gfhwr75f7i3sjzx0fj8vcwd",
@@ -24447,20 +24705,20 @@
   "repo": "skeeto/elfeed",
   "unstable": {
    "version": [
-    20201220,
-    1359
+    20210212,
+    1601
    ],
-   "commit": "de4b64b3f5d9fd41d9dc72023632ae535dc912e2",
-   "sha256": "04x3589jc39j3q2la82cidw3zpph10p5sj57m1kfz3ajyvh7rlm0"
+   "commit": "0b44362cb93ce49c36a94289d5fa5da8279c5f52",
+   "sha256": "1j96sq266511z9mfqqv3n50f8i1nqaxkwcy7jg7vg6sqhsf40sdd"
   },
   "stable": {
    "version": [
     3,
-    3,
+    4,
     0
    ],
-   "commit": "9b5a0ce648cdaa59f7c96414ee868038e08ea29d",
-   "sha256": "0j8a94val4ml7g1vcjgzk1w89h55sxfdrwnncmz6qbh1y2xsz8c5"
+   "commit": "362bbe5b38353d033c5299f621fea39e2c75a5e0",
+   "sha256": "1y95410hrcp23zc84sn79bxla9xr2fqh7wwagza05iaprv7zbbw0"
   }
  },
  {
@@ -24566,26 +24824,26 @@
   "repo": "sp1ff/elfeed-score",
   "unstable": {
    "version": [
-    20201219,
-    2359
+    20210130,
+    159
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "5fff4152bdb2a5f38ab83f7fa6b2943647935f94",
-   "sha256": "18jwg4a2ssswvbw50z9b84ca76i3q6vmv0ab90p432pjywpkwh73"
+   "commit": "43609d6fdf388caac91e848dc50d368f0bf83296",
+   "sha256": "075955i995d7xzd9cfyrpzyz0mfdvw95s0i00q85nb9wmxyijcb2"
   },
   "stable": {
    "version": [
     0,
-    6,
-    4
+    7,
+    1
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "5fff4152bdb2a5f38ab83f7fa6b2943647935f94",
-   "sha256": "18jwg4a2ssswvbw50z9b84ca76i3q6vmv0ab90p432pjywpkwh73"
+   "commit": "795954c8afda6da0196267c3324290841fcc4647",
+   "sha256": "0mmfzn1ims4w7nqa65r2cm7vbx8v9269h3n4scmjgjhrzmxh41dj"
   }
  },
  {
@@ -24596,28 +24854,28 @@
   "repo": "skeeto/elfeed",
   "unstable": {
    "version": [
-    20191123,
-    1738
+    20210131,
+    143
    ],
    "deps": [
     "elfeed",
     "simple-httpd"
    ],
-   "commit": "de4b64b3f5d9fd41d9dc72023632ae535dc912e2",
-   "sha256": "04x3589jc39j3q2la82cidw3zpph10p5sj57m1kfz3ajyvh7rlm0"
+   "commit": "0b44362cb93ce49c36a94289d5fa5da8279c5f52",
+   "sha256": "1j96sq266511z9mfqqv3n50f8i1nqaxkwcy7jg7vg6sqhsf40sdd"
   },
   "stable": {
    "version": [
     3,
-    3,
+    4,
     0
    ],
    "deps": [
     "elfeed",
     "simple-httpd"
    ],
-   "commit": "9b5a0ce648cdaa59f7c96414ee868038e08ea29d",
-   "sha256": "0j8a94val4ml7g1vcjgzk1w89h55sxfdrwnncmz6qbh1y2xsz8c5"
+   "commit": "362bbe5b38353d033c5299f621fea39e2c75a5e0",
+   "sha256": "1y95410hrcp23zc84sn79bxla9xr2fqh7wwagza05iaprv7zbbw0"
   }
  },
  {
@@ -24628,14 +24886,14 @@
   "repo": "TobiasZawada/elgrep",
   "unstable": {
    "version": [
-    20191203,
-    1227
+    20210205,
+    733
    ],
    "deps": [
     "async"
    ],
-   "commit": "c475cee98bc607746901318ef9da463c96d5e04e",
-   "sha256": "02jfpi8bvjxw5jnjjpzq87xf1xjly745k8s74jc9lpginip3kj95"
+   "commit": "b627cc0f307161e580e9450ad5334687b9406a16",
+   "sha256": "17nbjr5dll5n0m52p3isw8gkkza5iqxlhamhv7x61vjd8w72gl3d"
   },
   "stable": {
    "version": [
@@ -24673,16 +24931,16 @@
   "repo": "Wilfred/elisp-def",
   "unstable": {
    "version": [
-    20201215,
-    706
+    20210126,
+    750
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "679fa7d2d702263b6a55f30a1b8cfbb2fd817549",
-   "sha256": "0xzb89zk13db34kis68xc2b0b649335hxlnvjr4q1inf3yyzmiav"
+   "commit": "dfca043ec0cbead67bd9c526cb009daf771d0fa2",
+   "sha256": "16ryl9idrfpf8whx7srd6a0b3j50qhvc8brkk7iq42p7srr79ly0"
   },
   "stable": {
    "version": [
@@ -25279,20 +25537,20 @@
   "repo": "redguardtoo/elpa-mirror",
   "unstable": {
    "version": [
-    20210107,
-    219
+    20210210,
+    339
    ],
-   "commit": "49088c9bcdd66316a133252cf657187c4064488a",
-   "sha256": "15n1gbr6h6nm856drss8d1yrc6a3x191bsikhw64zkf7bdlqnxaw"
+   "commit": "164b2034111535c727a9e5d2b7e12884c565923d",
+   "sha256": "0gidcdfm792513pz3mbydrm36zpjlcji88hlfhkvvxwvrzh7flxx"
   },
   "stable": {
    "version": [
     2,
     1,
-    3
+    4
    ],
-   "commit": "49088c9bcdd66316a133252cf657187c4064488a",
-   "sha256": "15n1gbr6h6nm856drss8d1yrc6a3x191bsikhw64zkf7bdlqnxaw"
+   "commit": "47f194c77830946c66bc6ffecdecadc5a3191402",
+   "sha256": "00c33b0k5rw66xbzv1ggz1ai1yaqa705vqb25b54sirwr0s37wly"
   }
  },
  {
@@ -25658,8 +25916,8 @@
     20200728,
     819
    ],
-   "commit": "f9f810ffcd3cce7ed15848c72ce299609ec09414",
-   "sha256": "1p3zpg4p4a1cn13sg3hsa33gs1bdra1mlmxkagx883p3808i5qha"
+   "commit": "01ad699c562887dfe135f21dbf65d72cfe7d9cd9",
+   "sha256": "05r6y0sqfmxw6d8ngy3l3rz7v015v8hil834py1ghysnqq8farn3"
   },
   "stable": {
    "version": [
@@ -25958,19 +26216,19 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210115,
-    613
+    20210212,
+    1743
    ],
-   "commit": "14dcc650d9339a6458bb0babfed35de13e76fa50",
-   "sha256": "15shi1i8071833mjzrwyy5iw818sxcqym0cb0zvi9bk5nvprp58b"
+   "commit": "3a9c581cb7518f738dce8d6a0f1d1eb6c78b6622",
+   "sha256": "1aik11mq5yqk9zwqqfizh9vsb8gglisrf02hlx28s32h2hybsd3n"
   },
   "stable": {
    "version": [
     0,
-    9
+    10
    ],
-   "commit": "8b1291dfd6187815158299d25dc32b0bbc5af71d",
-   "sha256": "0b1p3pmdy21bix3fh57c2kb5mp0bmrwdc5q9vfdb9pni9sxw3n6v"
+   "commit": "47daded610b245caf01a97d74c940aff91fe14e2",
+   "sha256": "063hc0hganws11vjdk3ic0mxm9i0vpw6s7hzbgxvja0gjkdxjldz"
   }
  },
  {
@@ -25981,15 +26239,27 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210113,
-    1434
+    20210212,
+    228
    ],
    "deps": [
     "consult",
     "embark"
    ],
-   "commit": "14dcc650d9339a6458bb0babfed35de13e76fa50",
-   "sha256": "15shi1i8071833mjzrwyy5iw818sxcqym0cb0zvi9bk5nvprp58b"
+   "commit": "3a9c581cb7518f738dce8d6a0f1d1eb6c78b6622",
+   "sha256": "1aik11mq5yqk9zwqqfizh9vsb8gglisrf02hlx28s32h2hybsd3n"
+  },
+  "stable": {
+   "version": [
+    0,
+    10
+   ],
+   "deps": [
+    "consult",
+    "embark"
+   ],
+   "commit": "47daded610b245caf01a97d74c940aff91fe14e2",
+   "sha256": "063hc0hganws11vjdk3ic0mxm9i0vpw6s7hzbgxvja0gjkdxjldz"
   }
  },
  {
@@ -26144,15 +26414,15 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20210113,
-    2138
+    20210120,
+    1745
    ],
    "deps": [
     "cl-lib",
     "seq"
    ],
-   "commit": "50bdbcc619e376ac2d7472b7097b3a5ba2d1f64e",
-   "sha256": "1mbfdvh0fs824zvlw3vcy5rdbqdrq4dcx8031yyiq9qpxziswicd"
+   "commit": "ba16ff6dedf2de5dda219cf38b1d6d092b542de6",
+   "sha256": "0hvdd4mqghllnir88sszq54y8hss8dhkgc1p8082627bnqx4sbjb"
   },
   "stable": {
    "version": [
@@ -26644,11 +26914,11 @@
   "repo": "zenspider/enhanced-ruby-mode",
   "unstable": {
    "version": [
-    20201222,
-    858
+    20210120,
+    201
    ],
-   "commit": "28f30c056cfe2fd7135a71576c183d242dff3b52",
-   "sha256": "1jslhi3nzn6b16481fkmq1mqrg7f8p5mqi4hqdkywpprqcygrwn1"
+   "commit": "e960bf941d9fa9d92eabf7c03a8bbb51ba1ac453",
+   "sha256": "0qmklr7d6g98ijd4l4j65x7cx18aafngppvynr4jvlinzsnr263q"
   },
   "stable": {
    "version": [
@@ -26733,25 +27003,26 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20210106,
-    2359
+    20210207,
+    810
+   ],
+   "deps": [
+    "inheritenv",
+    "seq"
+   ],
+   "commit": "a7c6ca84a2b0617c94594a23a0c05246f14fa4ee",
+   "sha256": "1dpwb5plymb13jv44rdxkg0lrc180076rcvricac6xk33pklsmbz"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
    ],
    "deps": [
     "seq"
    ],
    "commit": "d1b991f19a4c4781e73bbc3badd368727fae942c",
    "sha256": "0ssf9i6iym2rb530k2w5aj392qa73i6p5y0vwrs5qhkv9lagqq7p"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "deps": [
-    "seq"
-   ],
-   "commit": "a15003d6b540b1b07847310d5ed4c39046336a7d",
-   "sha256": "1sspy227b733dxx6czml5lmx9g7nsxwgnazk1b9ip81q0cm0dv55"
   }
  },
  {
@@ -26854,8 +27125,8 @@
    "deps": [
     "closql"
    ],
-   "commit": "94c8389a8b660a68ae7e5458583b06b30ba0edb9",
-   "sha256": "0r2lvcrs34ixk5xx81b20m0s8x795l7plmry394lgh28gwr437jj"
+   "commit": "b9040a91412824d04134286f31fe287f19496184",
+   "sha256": "1ml6gyd1ad5n9fq5szrzjysa4nnapvszz5dd5qx68jrn1djg00jy"
   },
   "stable": {
    "version": [
@@ -27489,18 +27760,18 @@
     20200914,
     644
    ],
-   "commit": "c5400349d7d9cb1e54af19bdb2046b52ecada5bc",
-   "sha256": "02kma8f6v6vxzbfzd2limwabp8a5hzjyg9kfabgp1j0dwvsl64pf"
+   "commit": "e6862ebe3e8f2f29325378d820f7fa94656be479",
+   "sha256": "1iwi8jm3mp77zmcvn813mcnih1sq56mpl66r2qlkl72paqli790i"
   },
   "stable": {
    "version": [
     2,
     6,
     1,
-    1
+    3
    ],
-   "commit": "fce01db8f9d2ceb9c3a4aa179330ea4aa7587a71",
-   "sha256": "0fzq9pfkvsdin04vzcz2vyjq3gx0lfhbpwpz0zyfa3b84dgffxq7"
+   "commit": "e5486b79cc78689e3fd07b6c924d0085063915ea",
+   "sha256": "1zl7c0rb5rg867a431apxlzj2flg3hjidamqa5prc1bzpmfaywyz"
   }
  },
  {
@@ -27514,17 +27785,17 @@
     20201215,
     830
    ],
-   "commit": "ed4bc369fe6724083bd0decac961fb7b3462d202",
-   "sha256": "1bsf9y6rxwndafvi1lh2vgawjd9k469rhbqb42p6wjc4872lbb0q"
+   "commit": "26150b438fa1587506a020642ab9335ef7cd3fe2",
+   "sha256": "0m2csjqviqd219mg99wgb19whq12842hq9mpjc4nhg9bd5n9zrf9"
   },
   "stable": {
    "version": [
     23,
     2,
-    1
+    4
    ],
-   "commit": "2c89431fa867d5b1cc56f26a9282bcfb6fcdec58",
-   "sha256": "1xya7rv9j2528w7x0kivb3zl0rdzdwv82xp22yh7bw22vhfyrk4y"
+   "commit": "74d045d62e283948247e03a93d22171802997804",
+   "sha256": "0567gk8by1l4bfwk2j4l4s0z8xw2qz62km9anw0vkfbshlabhmp3"
   }
  },
  {
@@ -28093,11 +28364,11 @@
   "repo": "akreisher/eshell-syntax-highlighting",
   "unstable": {
    "version": [
-    20201013,
-    623
+    20210117,
+    357
    ],
-   "commit": "6cc32ee59d79d965e40269c764d90aa898252f0a",
-   "sha256": "09yjiamz3gvpchhzf424419q4gx7wybm2bcm5j2bw688qswd9rrc"
+   "commit": "172c9fb80ba2bee37fbb067a69583a6428dcc0a4",
+   "sha256": "10f3sz0hlqfihq60zz3m3lxqz5xncjiyd8qdcslfxzl2rlwlgx77"
   },
   "stable": {
    "version": [
@@ -28361,11 +28632,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20210113,
-    915
+    20210210,
+    1202
    ],
-   "commit": "19de88d2b3b2436955ce0f7e6cf8544d4ffaf8ac",
-   "sha256": "048b0274cj6hkri6hzsmp7r8g9vkx2vxxjljx24vvzxyqfwmn445"
+   "commit": "6dc683130466df1d2b437c6956ce26a910e47156",
+   "sha256": "0zsrwkr7zma8cb2v98wr1i7lxi2yqzhz3mm8jgb63hmq4042z2w3"
   },
   "stable": {
    "version": [
@@ -28614,14 +28885,15 @@
   "repo": "zcaudate/eta",
   "unstable": {
    "version": [
-    20210103,
-    645
+    20210115,
+    1655
    ],
    "deps": [
+    "dash",
     "ht"
    ],
-   "commit": "850c3aff1d7999348aea30530e722e561b672f9c",
-   "sha256": "1ridnn2b1sp8rp3z9x3igavaq40d66chq25lhfimb6yw84544l0b"
+   "commit": "c7540ac50163f368fec1918dfc334304d9b36c51",
+   "sha256": "02xkrcrf62z303axy4jxr9d2xy6sbxgp6x5dj917xd04hygiqwj0"
   }
  },
  {
@@ -28757,15 +29029,15 @@
   "repo": "zzkt/ethermacs",
   "unstable": {
    "version": [
-    20201017,
-    2006
+    20210124,
+    1110
    ],
    "deps": [
     "let-alist",
     "request"
    ],
-   "commit": "36956db9fa65ff88f3213a80b11f1fad0765d972",
-   "sha256": "1aqwnfdp3cb7zc38iy37hyvzr0qii182c6w6z7k9rq1arjg1vs2b"
+   "commit": "6d9c86dac6ab569d1842fcfa8bbe63ee9de8cd71",
+   "sha256": "0pawqmwv3cmr2fw5w0nvq36ms882k68w61nyb1d0bvzbjvrbbc03"
   }
  },
  {
@@ -29089,10 +29361,10 @@
  },
  {
   "ename": "evil-colemak-basics",
-  "commit": "945417d19faf492fb678aee3ba692d14e7518d85",
-  "sha256": "1sbbli0hdmpc23f3g5n95svqfdg3rlvf71plyvpv1a6va9jhi83k",
+  "commit": "fcc76e080a9b16879980beca5ae71afd9d6a6486",
+  "sha256": "0crvmlyrvia5bfa4nq5h5y5pg0nkgds5rmjmhrga3627m0na0dyv",
   "fetcher": "github",
-  "repo": "wbolster/evil-colemak-basics",
+  "repo": "wbolster/emacs-evil-colemak-basics",
   "unstable": {
    "version": [
     20200630,
@@ -29102,8 +29374,8 @@
     "evil",
     "evil-snipe"
    ],
-   "commit": "2354c9fa3d396fa5b1de8608e6920420b89ee323",
-   "sha256": "1cb7dv8wgixrfyx0mnc82i0ydg5bz7snn2643xi261kbrwhg51yj"
+   "commit": "584f8f9496bf5250a439c9c9fee1d94f3b4883f0",
+   "sha256": "0hv8068yaiqwswzhiikrlyl53w43yqi35m9xypvq6v9dwisrqg00"
   },
   "stable": {
    "version": [
@@ -29145,28 +29417,28 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20210115,
-    641
+    20210209,
+    629
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "a67450ff537b9681a5fed25010ce28d4128e6db2",
-   "sha256": "0iyp72pp5db5pg7nrw81ij7r7gkzsl11d5hcvllcm7qwpj99az8q"
+   "commit": "334670e29d964c5f591f75ccbf52b7b5faf4daba",
+   "sha256": "0drjcdclzy27ja95q9wp25p798nr2xwix2br50pp0s73rpfvv2sy"
   },
   "stable": {
    "version": [
     0,
     0,
-    4
+    5
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "04df79eadc952eaa9469094426b008426d3c5bee",
-   "sha256": "0ydr06krlj6v1r7hq3m5iy875mhmjr9amcfjjgqglfnzhic29g18"
+   "commit": "a615e4a7f642e0c3acd8628111624355380aa18f",
+   "sha256": "0dxrwcf5dnww0a9mvwjkcgm8ry3y282v9l85jh0645zk71nz1in3"
   }
  },
  {
@@ -29177,26 +29449,26 @@
   "repo": "linktohack/evil-commentary",
   "unstable": {
    "version": [
-    20170413,
-    1451
+    20210210,
+    1702
    ],
    "deps": [
     "evil"
    ],
-   "commit": "395f91014b69844b81660c155f42eb9b1b3d199d",
-   "sha256": "0zjs9zyqfygnpxapvf0ymmiid40i06cxbhjzd81zw33nafgkf6r4"
+   "commit": "2dab6ac34d1617971768ad219d73af48f7473fec",
+   "sha256": "0zgigbfn0h1snls4d5xdjcg6mksaz6si0xm4827jyh5s8r0brc6w"
   },
   "stable": {
    "version": [
     2,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "evil"
    ],
-   "commit": "395f91014b69844b81660c155f42eb9b1b3d199d",
-   "sha256": "0zjs9zyqfygnpxapvf0ymmiid40i06cxbhjzd81zw33nafgkf6r4"
+   "commit": "ca182e27156198db533bf6d48b7e5f6f54081397",
+   "sha256": "1l8zi9wlg1f7ffm8gh92qwk3q7h6cdl8b8zkd9hcda53mq6klpjr"
   }
  },
  {
@@ -29674,38 +29946,6 @@
   }
  },
  {
-  "ename": "evil-magit",
-  "commit": "50315ec837d2951bf5b2bb75809a35dd7ffc8fe8",
-  "sha256": "02ncki7qrl22804576h76xl4d5lvvk32lzn9gvxn63hb19r0s980",
-  "fetcher": "github",
-  "repo": "emacs-evil/evil-magit",
-  "unstable": {
-   "version": [
-    20201107,
-    1529
-   ],
-   "deps": [
-    "evil",
-    "magit"
-   ],
-   "commit": "f4a8c8d3a5a699baea9356be7c1c5fd8867f610c",
-   "sha256": "1a14n8nl6470vbzw1a2y9rw5l7pw21qnnhxrw963gy063jyl9m8i"
-  },
-  "stable": {
-   "version": [
-    0,
-    4,
-    2
-   ],
-   "deps": [
-    "evil",
-    "magit"
-   ],
-   "commit": "a24186be7cc2cdab24b56f6dcc4665eeb8349c1a",
-   "sha256": "12hr2w5r2hgagb3hqbi59v73rxpjml5prc3m7dw3wzsm0rf1rwh3"
-  }
- },
- {
   "ename": "evil-mark-replace",
   "commit": "e608f40d00a3b2a80a6997da00e7d04f76d8ef0d",
   "sha256": "14j2d46288shlixb57nh5vlqdi3aiv20djvcbhiw1cm9ar2c3y4v",
@@ -29743,14 +29983,14 @@
   "repo": "redguardtoo/evil-matchit",
   "unstable": {
    "version": [
-    20210110,
-    1011
+    20210201,
+    522
    ],
    "deps": [
     "evil"
    ],
-   "commit": "9cdaddd55d28b50d1319baee8038972796e8b178",
-   "sha256": "15j6li3fnj4q6l54c6r31ng3hrcb703c06c3wk5w4spc4nsgzfvc"
+   "commit": "cdb9b90381ac0a225b01fb99472f5b23b612eb6e",
+   "sha256": "0qf3583w082787hsp5ihj84w8k2d0pwpci6a9ig8qk9f4sk66v04"
   },
   "stable": {
    "version": [
@@ -29773,15 +30013,15 @@
   "repo": "gabesoft/evil-mc",
   "unstable": {
    "version": [
-    20200228,
-    1535
+    20210206,
+    1941
    ],
    "deps": [
     "cl-lib",
     "evil"
    ],
-   "commit": "7dfb2ca5ac00c249cb2f55cd6fa91fb2bfb1117e",
-   "sha256": "18a4xcxadchyh9vrg9pqjmby40d5d0j78y1298kpflx78m5c9rgx"
+   "commit": "f04fb17f35f2722f2ac93c862b4450bb8e5b739a",
+   "sha256": "1d7mdqw4bx6p8y3c843n40g21099pmvras3bf9il5nhg4i3b12z8"
   },
   "stable": {
    "version": [
@@ -29878,20 +30118,20 @@
   "repo": "redguardtoo/evil-nerd-commenter",
   "unstable": {
    "version": [
-    20201017,
-    1148
+    20210208,
+    530
    ],
-   "commit": "563cdc154b1f29d181b883563dd37be7eafafdee",
-   "sha256": "0q3m6i2hin6sb3aqng37nfvz97bj099c3727srxcw2m4gw7z4cp2"
+   "commit": "2730820b9ccedf758c8a0428ee2c994c9fc415dd",
+   "sha256": "1y5pn3rkqj8dxp5c7dsci621vnv6hsia74w2c1hybkkrjbka851q"
   },
   "stable": {
    "version": [
     3,
     5,
-    1
+    3
    ],
-   "commit": "fa40dab8d2f010db17e1e62dfd245c1504d0542f",
-   "sha256": "0dn712k54qsxy82jqbqip77k5i3zv8m7afj2yi39zqx28iqvic0z"
+   "commit": "2730820b9ccedf758c8a0428ee2c994c9fc415dd",
+   "sha256": "1y5pn3rkqj8dxp5c7dsci621vnv6hsia74w2c1hybkkrjbka851q"
   }
  },
  {
@@ -30476,14 +30716,14 @@
   "repo": "7696122/evil-terminal-cursor-changer",
   "unstable": {
    "version": [
-    20170401,
-    842
+    20210130,
+    1855
    ],
    "deps": [
     "evil"
    ],
-   "commit": "b49ca4393d2f3cc6014174950059b36a5cb22949",
-   "sha256": "1zra2h0x20whshbc4sfyj6w73jv6ak435mr9n6r6s7brqqqgpa36"
+   "commit": "a88c680c631676ff8f6c5156b529f86d6b9f0841",
+   "sha256": "1b9y21p56a000z62mknbnr22ypkv1j58r24i8bg9836n23y8l717"
   }
  },
  {
@@ -31351,15 +31591,15 @@
   "repo": "ananthakumaran/exunit.el",
   "unstable": {
    "version": [
-    20190919,
-    1238
+    20210207,
+    1214
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "c77b0397b80d772c98fcc34c9ab131a8350fbf40",
-   "sha256": "08lhsjmibgvd4cjrvyxhwn7cqrpd83bgsvh2xqppi9mnw1xwgzd5"
+   "commit": "b341d3972af167ff82ad3dd41899c9367e12a7f7",
+   "sha256": "05nbjkj968gdgpphqn7pjqwv11vmvl30947yq2z024wkvm3vpfmj"
   }
  },
  {
@@ -31413,6 +31653,26 @@
    ],
    "commit": "14643ee53a506ddcb5d2e06cb9f1be7310cd00b1",
    "sha256": "12rhsy5f662maip1sma0vi364xb8swb7g59r4dmafjv3b52gxik8"
+  }
+ },
+ {
+  "ename": "exwm-float",
+  "commit": "0da450683bfd7c2da29ebfa0ffad7d66b268aae4",
+  "sha256": "1w4l8z3p55zrjjawg09ih0wnxdbzvhcpvazgz5z20dxfbj3cvryr",
+  "fetcher": "gitlab",
+  "repo": "mtekman/exwm-float.el",
+  "unstable": {
+   "version": [
+    20210207,
+    2035
+   ],
+   "deps": [
+    "exwm",
+    "popwin",
+    "xelb"
+   ],
+   "commit": "eb1b60b4a65e1ca5e323ef68a284ec6af72e637a",
+   "sha256": "1bwnw6qacdrm54lx4hc36f9lnidfw1wl399n7wasa24n9wrbr8z0"
   }
  },
  {
@@ -31771,11 +32031,11 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20210108,
-    1527
+    20210128,
+    2108
    ],
-   "commit": "e475a0805cd9f4bb0f7397e4d37b868f42d96c00",
-   "sha256": "1djgrjnqapxjpnjly3mk9xna27fgl53rj257slz2dm3svhyghk2n"
+   "commit": "14a755f2f85e4db00978de76e1b7f404bfaa5e67",
+   "sha256": "0nxijsqwq3kvszv3f3r4z0vskxp9f0zjq5mx0c6gzfc4q82lvqkr"
   },
   "stable": {
    "version": [
@@ -32538,18 +32798,41 @@
   }
  },
  {
-  "ename": "find-file-in-project",
-  "commit": "cae2ac3513e371a256be0f1a7468e38e686c2487",
-  "sha256": "0aznnv82xhnilc9j4cdmcgh6ksv7bhjjm3pa76hynnyrfn7kq7wy",
+  "ename": "find-dupes-dired",
+  "commit": "f119ddd30a27e63e01d2be7928534a0708c8b8c6",
+  "sha256": "1ps1rhc1aa64gdx2dxhkkzjdricsqqljyzm1p6yzqy5a0jvicglg",
   "fetcher": "github",
-  "repo": "technomancy/find-file-in-project",
+  "repo": "ShuguangSun/find-dupes-dired",
   "unstable": {
    "version": [
-    20210112,
-    532
+    20210204,
+    49
    ],
-   "commit": "c4c7ec595c54c3006299717b1fd83e357864b2d5",
-   "sha256": "0mhp70h7n6h5s4dls5pslp45xxlrg6bbs7hkpbl3p1jhxx414fwr"
+   "commit": "3c9783589e43717b682c9e37dd229839735402e8",
+   "sha256": "1wd7n08cf1mnd7czca3mcsfyh4nlkl36arhc3lnh7lzi98nyd0zv"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "f39e2afbc33e02a6bf62116f6ce71b8368068698",
+   "sha256": "1i86dqiw5b8wcqy4gc6nk3xk9narc3b40xl0bqyp0n6a1mckx9kh"
+  }
+ },
+ {
+  "ename": "find-file-in-project",
+  "commit": "3bd8d837d8fe1712df6f62f825985d9e12d97fc6",
+  "sha256": "06kp64zxc9br4vsdl419fz68igqzmkzglhzzcb643vszi9dd5djq",
+  "fetcher": "github",
+  "repo": "redguardtoo/find-file-in-project",
+  "unstable": {
+   "version": [
+    20210212,
+    231
+   ],
+   "commit": "5bc4db49e9bfe33292d225e98ff2d7c31ac6d39c",
+   "sha256": "0grm9q224jmd2vbxfgv5h4nrfbj3arrym1pi6xxwgx13415z1ddz"
   },
   "stable": {
    "version": [
@@ -32569,11 +32852,11 @@
   "repo": "h/find-file-in-repository",
   "unstable": {
    "version": [
-    20190404,
-    828
+    20210128,
+    2102
    ],
-   "commit": "b44d78682082270dc6b59cdc911333d0d3e7edaa",
-   "sha256": "1icsxp2b3grvdbv6bh9hpxz1hrqa7vvjzajjwi2knvjbq41d99bn"
+   "commit": "2dba14e8175b1107dc9d2860d26de628b7548dbf",
+   "sha256": "0gfrpqdhipa8xmp29f8yqik4vh83mkj5j9kccyq3g9rb0xwjhf0b"
   },
   "stable": {
    "version": [
@@ -34424,6 +34707,36 @@
   }
  },
  {
+  "ename": "flycheck-google-cpplint",
+  "commit": "d8aae034af2142a1bcec47414e00083b2afc7e4f",
+  "sha256": "17jm3r5mrn7hnk53cd9hahqgyqnc7jb4zh8ghg7i1zcg3k7wlbav",
+  "fetcher": "github",
+  "repo": "flycheck/flycheck-google-cpplint",
+  "unstable": {
+   "version": [
+    20210210,
+    300
+   ],
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "6e2bc77da6e2a8812246b4717d97b68675ed84f1",
+   "sha256": "02m22d9y152aj7aba736j5gxpniqr0rc2k8iyq9cgbgavfhbr3ac"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    2
+   ],
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "95f2038831d1e04a4ea6f91f0a846a4f989606b7",
+   "sha256": "1nlyv81pyqmyz18dlzw5h23prhkvyzb0aasjxba8mm33avx0fvvb"
+  }
+ },
+ {
   "ename": "flycheck-gradle",
   "commit": "382d9afd2bbb0c137719c308a67d185b86d84331",
   "sha256": "0zd92lx0mqjqwzclvvhfwwahq80qspyv9k7qcxjc0bl3avjk6a47",
@@ -34598,6 +34911,36 @@
    ],
    "commit": "fbf90b9a7d2d90f69ac55b57d18f0f4a47afed61",
    "sha256": "136mdg21a8sqxhijsjsvpli7r7sb40nmf80p6gmgb1ghwmhlm8k3"
+  }
+ },
+ {
+  "ename": "flycheck-hledger",
+  "commit": "502709e2195bf0001891e438081e274fa3824af3",
+  "sha256": "1sdglh0s00af8qiqvi583gksi2yl8z47r1hry2dbm9vs0p0sf1z8",
+  "fetcher": "github",
+  "repo": "DamienCassou/flycheck-hledger",
+  "unstable": {
+   "version": [
+    20210119,
+    1000
+   ],
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "0eeaa707b74f96761404daa2f807fbd7af904b75",
+   "sha256": "15xwnxvda3kj81q2rm8cz2qj17l9cwjqak4y6v02cv37nax0jmfh"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "9e45dd3f6b6cf51acf7312939aa437ae156be2e7",
+   "sha256": "0q6b0vyd55x71kv4k7jp8xzgy5zf9md8mgy3y6pwmpga9dmv149j"
   }
  },
  {
@@ -34834,8 +35177,8 @@
     "flycheck",
     "keg"
    ],
-   "commit": "18c675aa2ff1749eb42f081f0549398b82cd4540",
-   "sha256": "1mz5rfzyv4varn09pza5yb851vmsbicsz4zgc0y7zni2bhlj9250"
+   "commit": "10c70dba667752c3612e69a190e097677fef268d",
+   "sha256": "137xjq1ky9d9ddklzfmfnd5bz75bw0bkqr4ajq3m8al28wpld3k5"
   }
  },
  {
@@ -35064,8 +35407,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "cf45af2a71f6e7a21e01c556613c5b5cdc983ac9",
-   "sha256": "1qhix0i8d9qrc0jg3r17v6fmrz07pjw5kk04fm72i8n4c16vb6r1"
+   "commit": "5e74a5a796e73fca7f3fd15986fefa56529b8e98",
+   "sha256": "11sdxlqwk4wa3pgbfyxjq100yra11iya61wnx6c01n2fxmf82iih"
   },
   "stable": {
    "version": [
@@ -35292,26 +35635,26 @@
   "repo": "ponylang/flycheck-pony",
   "unstable": {
    "version": [
-    20190227,
-    235
+    20210118,
+    1326
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "43421fb43ab4fec759061a11e9d9166bb7da013d",
-   "sha256": "03byayxvhrkm88s7157cfzi91ziggs872yis9ys04ndk1pdf940f"
+   "commit": "039a6c9d0324208d4f4b006693c16248fcf5519b",
+   "sha256": "1sr1n7gv5n22w018z5nxfnknjqmk2lc8h2flv4d2f23aihlss9h3"
   },
   "stable": {
    "version": [
     0,
-    2,
-    2
+    3,
+    0
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "9356cbcd404eaf381ab0c4b0f9c47232f723fa7e",
-   "sha256": "1rzz3cl0pxn3hhrkxcdiy17wl4dzbn8kxm3hq90zmhag1gbfy4zz"
+   "commit": "22787cf8223ca9ec309e30a42c20a8e706d8bfbe",
+   "sha256": "1dpxhljgw0k6y7973ssqfnmc7vp4fv87ajsq1bm8g4m04vj4127q"
   }
  },
  {
@@ -35590,8 +35933,8 @@
     "flycheck",
     "rtags"
    ],
-   "commit": "39339388256df662d0084b4a094d03e52748f9e8",
-   "sha256": "0wp4mygsxzibra2p3m5rn9m0yd3fscd795k5xa0wxi5pwddv7dlg"
+   "commit": "aa4c827b417f5448c12401c33acdab1325917c13",
+   "sha256": "02jqcbrpxm4sv15l8kyvsw9pwkmamj065cgifj68x242fw2f0sam"
   },
   "stable": {
    "version": [
@@ -35649,15 +35992,15 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20200830,
-    1032
+    20210130,
+    1325
    ],
    "deps": [
     "flycheck",
     "stan-mode"
    ],
-   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
-   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
+   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
+   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
   },
   "stable": {
    "version": [
@@ -35749,8 +36092,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "77a000095b321ac5d2378cf03ccf2377ccc37f59",
-   "sha256": "1rp0v681kvdsi84lk4m1lj8bfllwqw1ivl53q3zy34ja186xviww"
+   "commit": "f83b2bb7086e54beb2bd2df406a498927a7b2fba",
+   "sha256": "04rdc8jsb8gx2bhrf7rwpyrw4pw04638j574g6614f9h1whpw9jw"
   },
   "stable": {
    "version": [
@@ -36079,24 +36422,6 @@
   }
  },
  {
-  "ename": "flymake-cppcheck",
-  "commit": "2a83d56c6e150de5d4fdbd89f271f18e5304afd8",
-  "sha256": "11brzgq2zl32a8a2dgj2imsldjqaqvxwk2jypf4bmfwa3mkcqh3d",
-  "fetcher": "github",
-  "repo": "senda-akiha/flymake-cppcheck",
-  "unstable": {
-   "version": [
-    20140415,
-    1257
-   ],
-   "deps": [
-    "flymake-easy"
-   ],
-   "commit": "7eac8c7b9c74ebb5e600686f1f3891767dc87bb2",
-   "sha256": "1xwpznllgz47f6h7mzwy601179sxdj6i8qvnfa6fn4cx4dz5z3iv"
-  }
- },
- {
   "ename": "flymake-css",
   "commit": "cae2ac3513e371a256be0f1a7468e38e686c2487",
   "sha256": "0kqm3wn9symqc9ivnh11gqgq8ql2bhpqvxfm86d8vwm082hd92c5",
@@ -36133,14 +36458,14 @@
   "repo": "flymake/emacs-flymake-cursor",
   "unstable": {
    "version": [
-    20120322,
-    1757
+    20210126,
+    1733
    ],
    "deps": [
     "flymake"
    ],
-   "commit": "ecc539082c3fc9e91bba33d72c26989217411593",
-   "sha256": "0cdf5m3rfwsim505qjyyml0r5zzqx7jrlc8ayfvix70f3bmxnibs"
+   "commit": "afd458daf88f475cfacdd22375635e43a5017564",
+   "sha256": "17fzs4r22nlf27xcdfj9qs337879xkk9hgq121dgxd93xy3n0ky7"
   },
   "stable": {
    "version": [
@@ -36320,24 +36645,6 @@
   }
  },
  {
-  "ename": "flymake-google-cpplint",
-  "commit": "01f8e5c2b63e80f0411860fde38bf694df3bfc8f",
-  "sha256": "0q7v70xbprh03f1yabq216q4q82a58s2c1ykr6ig49cg1jdgzkf3",
-  "fetcher": "github",
-  "repo": "senda-akiha/flymake-google-cpplint",
-  "unstable": {
-   "version": [
-    20140205,
-    1325
-   ],
-   "deps": [
-    "flymake-easy"
-   ],
-   "commit": "426e56ae1278d7a078c368e9d495003825ada0bd",
-   "sha256": "1gckz68050pj9pg7yn3wwn13x2nrv6y4ggswkgcyijxi7x0sqana"
-  }
- },
- {
   "ename": "flymake-gradle",
   "commit": "7cccc8537324e0faf7fd35325e3ccd3b2e05771a",
   "sha256": "00wpymzw2j2zx37nq8qf77pk04r0hxlmlwykcj6yzq9bfgi75wnf",
@@ -36354,20 +36661,20 @@
  },
  {
   "ename": "flymake-grammarly",
-  "commit": "a8a5e3f1d6b2976b0544ca23189f58486f2065f1",
-  "sha256": "08gqywxms7mn4xihj3sqm7kw02zjcfhxm0ldcvwaihjnkxmfrll4",
+  "commit": "1365aa5edc900493e930429eca4748bb8e6aaf69",
+  "sha256": "0ipap3vz40v90qlh1a3iiqm5934bsx5xk897m5r5q5ab63k5yq75",
   "fetcher": "github",
-  "repo": "jcs-elpa/flymake-grammarly",
+  "repo": "flymake/flymake-grammarly",
   "unstable": {
    "version": [
-    20201028,
-    647
+    20210127,
+    834
    ],
    "deps": [
     "grammarly"
    ],
-   "commit": "28efe445c91daa9a604d518f00cae6b1375179df",
-   "sha256": "05icajswb649g3d3qhj96dzz5zc9faf1hr93ni0039gqk312p48a"
+   "commit": "c86109387e277251ba3d9aee4a71f0f452e9b401",
+   "sha256": "1bz0vs2l59ga7x1gqrywl1dhfs1ihbcsflaznmrvg7p7v9vdrmrc"
   },
   "stable": {
    "version": [
@@ -36651,6 +36958,24 @@
   }
  },
  {
+  "ename": "flymake-nasm",
+  "commit": "003b8973f810f771da88e30b4aa7457967f21364",
+  "sha256": "1i12dz0xzvbyajnlb64scv894zj2nbsz354mv9rjhkgvc9zw2hnl",
+  "fetcher": "github",
+  "repo": "juergenhoetzel/flymake-nasm",
+  "unstable": {
+   "version": [
+    20210107,
+    524
+   ],
+   "deps": [
+    "flymake-quickdef"
+   ],
+   "commit": "92b96ca659e88d25e21e711038332a5b4c199e61",
+   "sha256": "1s76s5y5lwdw84bkcbx3xawc748hm9p9g2sfpn33mmz1mc227kz5"
+  }
+ },
+ {
   "ename": "flymake-perlcritic",
   "commit": "3416586d4d782cdd61a56159c5f80a0ca9b3ddf4",
   "sha256": "1i0bc81cby2nsala2mhghzv7clhbf1gpp54vdxiq2wdanqy25vmk",
@@ -36664,8 +36989,8 @@
    "deps": [
     "flymake"
    ],
-   "commit": "edfaa86500ddfa8a6a6f51f5581a81a821277df6",
-   "sha256": "1f4l2r4gp03s18255jawc7s5abpjjrw54937wzygmvzvqvmaiikj"
+   "commit": "c70eb881d4fb27aeb72c0bf8de6707b9de49bd51",
+   "sha256": "1w7msjg4sa0h0a4ycl9382agv1bhzcr9z0i6hmhcg7333rd31ilh"
   },
   "stable": {
    "version": [
@@ -36753,8 +37078,19 @@
    "deps": [
     "flymake-easy"
    ],
-   "commit": "bba25dbda15955b609ceae0893cf3be74ec67230",
-   "sha256": "1z6m3bggd3gmxvx92j16jmqm5h9jjxnmsd7adyf12ziy5n5rqcbc"
+   "commit": "8e5ab5103c8f40a2ab6c86def6327e480ae93657",
+   "sha256": "19cggpaj14w3j3q6dgv7ybjqbr2pqbwhingz4yi7wkrr0w6s0lsa"
+  },
+  "stable": {
+   "version": [
+    1,
+    1
+   ],
+   "deps": [
+    "flymake-easy"
+   ],
+   "commit": "f947ba3066c1fa903d2ec69d67bf84413f51eb3f",
+   "sha256": "10qaw7dhklxqzimfsj87clb297y7rnd3bpn061bh04cwnayjn2hr"
   }
  },
  {
@@ -37121,11 +37457,11 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20200904,
-    526
+    20210124,
+    1143
    ],
-   "commit": "0d5076f93b4c903a69a5f9ed19bab45d107acd10",
-   "sha256": "0zx45lm292mvq6q1i9288qg7nfy0xnxvvaa7qgv3yfi5zdsjq619"
+   "commit": "d19a090b978a249fc8f6d8b14309a5705a6bb483",
+   "sha256": "1p9s1qcqk834r0lkqzch8gb7c8qrpvbhxfyb44bgjd9qcw0kzr3s"
   },
   "stable": {
    "version": [
@@ -37145,15 +37481,15 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20200215,
-    1337
+    20210124,
+    1143
    ],
    "deps": [
     "avy-menu",
     "flyspell-correct"
    ],
-   "commit": "0d5076f93b4c903a69a5f9ed19bab45d107acd10",
-   "sha256": "0zx45lm292mvq6q1i9288qg7nfy0xnxvvaa7qgv3yfi5zdsjq619"
+   "commit": "d19a090b978a249fc8f6d8b14309a5705a6bb483",
+   "sha256": "1p9s1qcqk834r0lkqzch8gb7c8qrpvbhxfyb44bgjd9qcw0kzr3s"
   },
   "stable": {
    "version": [
@@ -37177,15 +37513,15 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20200215,
-    1337
+    20210124,
+    1143
    ],
    "deps": [
     "flyspell-correct",
     "helm"
    ],
-   "commit": "0d5076f93b4c903a69a5f9ed19bab45d107acd10",
-   "sha256": "0zx45lm292mvq6q1i9288qg7nfy0xnxvvaa7qgv3yfi5zdsjq619"
+   "commit": "d19a090b978a249fc8f6d8b14309a5705a6bb483",
+   "sha256": "1p9s1qcqk834r0lkqzch8gb7c8qrpvbhxfyb44bgjd9qcw0kzr3s"
   },
   "stable": {
    "version": [
@@ -37209,15 +37545,15 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20201202,
-    636
+    20210124,
+    1143
    ],
    "deps": [
     "flyspell-correct",
     "ivy"
    ],
-   "commit": "0d5076f93b4c903a69a5f9ed19bab45d107acd10",
-   "sha256": "0zx45lm292mvq6q1i9288qg7nfy0xnxvvaa7qgv3yfi5zdsjq619"
+   "commit": "d19a090b978a249fc8f6d8b14309a5705a6bb483",
+   "sha256": "1p9s1qcqk834r0lkqzch8gb7c8qrpvbhxfyb44bgjd9qcw0kzr3s"
   },
   "stable": {
    "version": [
@@ -37241,15 +37577,15 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20200828,
-    629
+    20210124,
+    1143
    ],
    "deps": [
     "flyspell-correct",
     "popup"
    ],
-   "commit": "0d5076f93b4c903a69a5f9ed19bab45d107acd10",
-   "sha256": "0zx45lm292mvq6q1i9288qg7nfy0xnxvvaa7qgv3yfi5zdsjq619"
+   "commit": "d19a090b978a249fc8f6d8b14309a5705a6bb483",
+   "sha256": "1p9s1qcqk834r0lkqzch8gb7c8qrpvbhxfyb44bgjd9qcw0kzr3s"
   },
   "stable": {
    "version": [
@@ -37559,15 +37895,15 @@
   "repo": "rolandwalker/font-utils",
   "unstable": {
    "version": [
-    20150806,
-    1751
+    20210124,
+    43
    ],
    "deps": [
     "pcache",
     "persistent-soft"
    ],
-   "commit": "9192d3f8ee6a4e75f34c3fed10378674cc2b11d3",
-   "sha256": "1k90w8v5rpswqb8fn1cc8sq5w12gf4sn6say5dhvqd63512b0055"
+   "commit": "88fb9b046e7094303e4f5b43e84b0f5d5283c508",
+   "sha256": "1qhrvmx8pcjb2hg3y3ra07nv3bcga3ckqxd9i89wrgay5kk7avcy"
   },
   "stable": {
    "version": [
@@ -37722,8 +38058,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20210112,
-    1148
+    20210128,
+    812
    ],
    "deps": [
     "closql",
@@ -37735,8 +38071,8 @@
     "markdown-mode",
     "transient"
    ],
-   "commit": "47be4eebfa34f87e502aad30f59907ad09552979",
-   "sha256": "0fbj6css456abzslr09vxr46xikxydjh78kmd0kqfidsp1rx6xsj"
+   "commit": "8683b148d3ce1413aeb4b6dde1b6f55610b5aaf5",
+   "sha256": "1wgznm6qynz0vgylksgimlqawdv6cd8hi5zxw6cgxii2dgajpr1b"
   },
   "stable": {
    "version": [
@@ -37791,14 +38127,15 @@
   "repo": "lassik/emacs-format-all-the-code",
   "unstable": {
    "version": [
-    20210107,
-    1425
+    20210213,
+    804
    ],
    "deps": [
+    "inheritenv",
     "language-id"
    ],
-   "commit": "05bd6d0b4aa3d8b22291de5827da64b7be155590",
-   "sha256": "0fgc0kj9zb0f08i2mcm8ny9f8cqlk9v8185qmc6wmq1i7kaczsvr"
+   "commit": "d64b8afc6dd91f7a990fe12799319c0f72534009",
+   "sha256": "0wsp0awq237xngmp8glakljdlrv8y107icwmz70avnn97vhikj9b"
   },
   "stable": {
    "version": [
@@ -37875,11 +38212,11 @@
   "repo": "larsbrinkhoff/forth-mode",
   "unstable": {
    "version": [
-    20170527,
-    1930
+    20210123,
+    900
    ],
-   "commit": "522256d98d1a909983bcfd3ae20c65226d5929b6",
-   "sha256": "110ycl8zkimy2818rhp3hk3mn2y25m695shdsy6dwxnrv90agss6"
+   "commit": "f44fa6481ffe2b4321d462c3fab78a858f2a8ae9",
+   "sha256": "08p9ddxs3ya7an2p485wrw5ywimbgnqrihriyc4aaq963zpssk2c"
   }
  },
  {
@@ -37935,26 +38272,26 @@
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20201226,
-    1636
+    20210131,
+    1220
    ],
    "deps": [
     "seq"
    ],
-   "commit": "c7ac77fef71fc20c4c7bee73516ec3c0f656a91a",
-   "sha256": "00m4x3nylvwsaki6m7gvk1grcaap96rnx10mpsxlapkpbrydhpk0"
+   "commit": "b855c916bfe988246572d9982435c7c9837c983c",
+   "sha256": "15m7dihnnys9r2185bpdqd0iazdbccyrnkrdl7a067hygc3iilal"
   },
   "stable": {
    "version": [
     3,
     4,
-    0
+    1
    ],
    "deps": [
     "seq"
    ],
-   "commit": "3e7ef35fae455f77abb63c34e926c2d0e3070d7f",
-   "sha256": "161wn66gc2z7fd4f89827dpww6hjmnassbi15yis5rqbklj1h2z6"
+   "commit": "707b8fdc9a0e1de1a911ca312c23c0c1672f3ec3",
+   "sha256": "14zhbcfqyp093kd1bxl7f2hf5l5995qmgpmnxfgw9qcc781crj73"
   }
  },
  {
@@ -38157,15 +38494,16 @@
   "url": "https://git.launchpad.net/frecentf.el",
   "unstable": {
    "version": [
-    20201217,
-    2150
+    20210211,
+    1630
    ],
    "deps": [
+    "async",
     "frecency",
     "persist"
    ],
-   "commit": "23a41b8d06b1e345e6b99d1efd38a219f376faff",
-   "sha256": "1sgsi7kdk3r1lh0iilpyz241qpzj46xp4ifhbszjxs6p2gcwi5y9"
+   "commit": "b385061a3103890df2d4b2e46a8b3ac775aeec00",
+   "sha256": "09s6fkshkd3mfhf0zynl50p70cnpx67qigi55is2byvhh5950fx5"
   }
  },
  {
@@ -38221,20 +38559,20 @@
   "repo": "rnkn/freeze-it",
   "unstable": {
    "version": [
-    20200416,
-    1605
+    20210201,
+    731
    ],
-   "commit": "968cb4580bbd7d23ee78e53152e30e0cdf0f5e41",
-   "sha256": "0v9yriw45rg12mz72gmhwi2mz19h6svh3dsw1fpbww4qcx4mnjvd"
+   "commit": "752fe042ba3153473cd149875388c8dd9b4a8a26",
+   "sha256": "0x4sp6n6dksa8vps465i8sqvdzacr7hrxd4jlxj9gqkcspalrjgy"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
-   "commit": "b93af18633bc783c2cb8443808aeeaaca33e1146",
-   "sha256": "0gljal6hmchx5zyd268kwlqn8pqq206y8a89ff7kq6qaql88mngn"
+   "commit": "1f252a922612e0d6ee62a683b7cdab8956460f11",
+   "sha256": "0bwd3hw5qdijmvbfm69iyhijjx12yqvsa8n08cawxfa26cs6hi1g"
   }
  },
  {
@@ -38430,6 +38768,31 @@
   }
  },
  {
+  "ename": "frontside-javascript",
+  "commit": "73ac023ee296b2b890265832d68d1d1d9f59fe33",
+  "sha256": "1yqp9zpahd808q5c2cpb2sb7xh8z75vqbrb5jxxrng4n4dxqj3yj",
+  "fetcher": "github",
+  "repo": "thefrontside/frontmacs",
+  "unstable": {
+   "version": [
+    20210206,
+    2008
+   ],
+   "deps": [
+    "add-node-modules-path",
+    "company",
+    "flycheck",
+    "js2-mode",
+    "js2-refactor",
+    "rjsx-mode",
+    "tide",
+    "web-mode"
+   ],
+   "commit": "2b0e27a2f5fa18079b00753b3bf9635818e11f71",
+   "sha256": "0cv0vrz8mv7b8hm3ac8l7zjscavsxix0wiv646n5vx03282zfgpk"
+  }
+ },
+ {
   "ename": "fsbot-data-browser",
   "commit": "35763febad20f29320d459394f810668db6c3353",
   "sha256": "14d4d8lasvgj520rmqgnzk6mi16znzcdvja9p8164fr9l41wnzgd",
@@ -38454,21 +38817,20 @@
  },
  {
   "ename": "fsharp-mode",
-  "commit": "7a41e8a101b1b76870402eb8f60130be9e9f189d",
-  "sha256": "1bcgy40z5d1663rafh4vhbm8d24yxnbw23sagki4427sywinl11x",
+  "commit": "fb0dd36a02a45ae31a21da0fd5551843243f597b",
+  "sha256": "0kl8hwm7101i3pc949xj22d85mxmqhk86qbwjzbgxdh64lwp5hnc",
   "fetcher": "github",
   "repo": "fsharp/emacs-fsharp-mode",
   "unstable": {
    "version": [
-    20210106,
-    1632
+    20210131,
+    1150
    ],
    "deps": [
-    "eglot",
     "s"
    ],
-   "commit": "e3dccd65a16a1675722b1eed7aca1a729a2fc8ed",
-   "sha256": "1wyc3lzvjl01cy18cyzq1xms4kid9iqkm31fxrv87awmzpxsvqi5"
+   "commit": "78898a1535878394d83643c383f4320e7b5fcefd",
+   "sha256": "0d60jfaf8av0b7vx44lbqzb7v70dszvr2w1yjh1cxn71dnjphp4j"
   },
   "stable": {
    "version": [
@@ -38534,8 +38896,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "527567aa9f668e9fa63df7d258b82004473dd7e4",
-   "sha256": "1w1k193hc2ihi2wh9gbsp9wcwl2gxqia21868ad7v3xadyik0a6i"
+   "commit": "3654ddbd8b3d54258edcc0f4e30ec482cfa8a255",
+   "sha256": "0xk7n93m1qsp68jxva9sjaafr98rqhw2swa1d76yg01dbq5fk9pw"
   },
   "stable": {
    "version": [
@@ -39033,11 +39395,11 @@
   "repo": "godotengine/emacs-gdscript-mode",
   "unstable": {
    "version": [
-    20210104,
-    1919
+    20210131,
+    1551
    ],
-   "commit": "b53d56e467a77dfd6c26eec5b78e2241083b1408",
-   "sha256": "120yjlwf8pyrv5n0bdzxnr2lbppwgir4l8c128jq0cx3mbfamjlz"
+   "commit": "16c631cd6f2f2eeb11730442c9897008e1e10f7a",
+   "sha256": "1ygwvavwrhpjrgw58psawcwp01y8j0xhsvc2bywiz8a1d2pngn1q"
   },
   "stable": {
    "version": [
@@ -39205,11 +39567,11 @@
   "url": "https://git.carcosa.net/jmcbray/gemini.el.git",
   "unstable": {
    "version": [
-    20201120,
-    2054
+    20210124,
+    1755
    ],
-   "commit": "3b4bcc568ca9e537118f3b803f4218b0d57fee0b",
-   "sha256": "1lc2pgqjyanfwfykrg8a9d5kra4zihdvr612z9x927r16cj470ac"
+   "commit": "b4f2be4eec55f0c779311cf97ffd69122b161ac3",
+   "sha256": "1qvnr591vyd85gm8m0y0r88s3ik163lq55phs0kf0vr2k5xq10p7"
   }
  },
  {
@@ -39345,8 +39707,8 @@
   "repo": "thisch/gerrit.el",
   "unstable": {
    "version": [
-    20201216,
-    2245
+    20210211,
+    1542
    ],
    "deps": [
     "dash",
@@ -39354,8 +39716,8 @@
     "magit",
     "s"
    ],
-   "commit": "00b0201cef4fd2ade108289a8444e1b354a882f6",
-   "sha256": "0k9bwxqd2zs3bbikqgfnshk7snycfxkzlipih4m0pcnpk1fdp6sv"
+   "commit": "b1029914d6078e1883674d2f1e1af511202641d9",
+   "sha256": "0s69a83y629an7fj05gkf3qvzx7hwd6wyx62sw9h021d6xdlk5ap"
   }
  },
  {
@@ -39507,37 +39869,6 @@
   }
  },
  {
-  "ename": "ghc",
-  "commit": "7fabdb05de9b8ec18a3a566f99688b50443b6b44",
-  "sha256": "02nc7a9khqpd4ca2snam8dq72m53q8x7v5awx56bjq31z6vcmav5",
-  "fetcher": "github",
-  "repo": "DanielG/ghc-mod",
-  "unstable": {
-   "version": [
-    20180121,
-    1218
-   ],
-   "deps": [
-    "haskell-mode"
-   ],
-   "commit": "391e187a5dfef4421aab2508fa6ff7875cc8259d",
-   "sha256": "1z142vgv72yfly7nyknzlcpm51sx5zqi26by3c7g68dbb4dxhq57"
-  },
-  "stable": {
-   "version": [
-    5,
-    8,
-    0,
-    0
-   ],
-   "deps": [
-    "haskell-mode"
-   ],
-   "commit": "35690941aadbe44d9401102ab44a39753e0bb2b5",
-   "sha256": "0fcaxj2lhkhkm2h91d9fdqas2b99wblwl74l2y6ckpf05hrc4w1q"
-  }
- },
- {
   "ename": "ghc-imported-from",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "063kbymk4r1yrg5ks660d2byrnia6gs6nimjzrvqfi2ib1psc7jc",
@@ -39651,8 +39982,8 @@
     "let-alist",
     "treepy"
    ],
-   "commit": "5fae5e31586a11a2025168030e0eb3876502611c",
-   "sha256": "0i19h9zl8wky1296f0d7dcx9dpfmfixinnaf4l1w1bf4p2xmyfiw"
+   "commit": "c46de21b8db1f17df126d5f5a361ed90cdd26f99",
+   "sha256": "0yiccv9813bxix60jx39jflx6vvrgxs8gfs7l8amlmy0h0kssp8g"
   },
   "stable": {
    "version": [
@@ -39843,6 +40174,21 @@
   }
  },
  {
+  "ename": "git-assembler-mode",
+  "commit": "5f909805296a0959a6317ac6714784854108cfde",
+  "sha256": "1i894n7vhd1r86sbrkf3yr4fv6nc8y5wgqvx42csc0441988cp38",
+  "fetcher": "gitlab",
+  "repo": "wavexx/git-assembler-mode.el",
+  "unstable": {
+   "version": [
+    20210207,
+    1545
+   ],
+   "commit": "1243bdc1a9cdc79802ece05c90731ee14e4f92c9",
+   "sha256": "1rc8z2r8lxzx836j7nk61snps8r0szzifg0inzfv3nb2z8bsiw0b"
+  }
+ },
+ {
   "ename": "git-attr",
   "commit": "3417e4bc586df60b5e6239b1f7683b87953f5b7c",
   "sha256": "084l3zdcgy1ka2wq1fz9d6ryhg38gxvr52njlv43gwibzvbqniyi",
@@ -39995,16 +40341,16 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210102,
-    1242
+    20210206,
+    2245
    ],
    "deps": [
     "dash",
     "transient",
     "with-editor"
    ],
-   "commit": "25f432551347468ce97b8b03987e59092e91f8f0",
-   "sha256": "0vxsh75xynpfkfvmyyz8x3rppbwr9rgk7zjfil2af2kzba3p27vl"
+   "commit": "47c57839b80c05f792de288da050fabac90639d6",
+   "sha256": "0bpcy6vxbqx50p2cqskpfrk2chnjp3025zmnx33kvq22860f7qi2"
   },
   "stable": {
    "version": [
@@ -40097,11 +40443,11 @@
   "repo": "emacsorphanage/git-gutter",
   "unstable": {
    "version": [
-    20210109,
-    640
+    20210127,
+    1100
    ],
-   "commit": "5c2ae01562b3ff2def870ed822fd0869326977d6",
-   "sha256": "0bf12nfyhpvdbxajbwna2z19ii42ih8h4p8jrvgqvh0r3lhavdiw"
+   "commit": "cca61a1c6b0c0fd6ecb1b0366711c618581eabb6",
+   "sha256": "1q6qrrxa3mf3pkkqr8piaij3yrgqh48xrrn3a442wn2i427q63kc"
   },
   "stable": {
    "version": [
@@ -40287,20 +40633,20 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20201214,
-    2330
+    20210121,
+    235
    ],
-   "commit": "9a3e893751791b17db85d691444e50e346cb2bd3",
-   "sha256": "1jdgkjiv6pn2whim71fsyfady8lv180y56j9z6bfx3gg3pp2dcbd"
+   "commit": "f76bffd42fb4ed8ffe09d48c084f6577b0b99fa6",
+   "sha256": "0l7xmvmj5s93hc39wjjv75f22zbhahnmcxpmvx3dfvsbig9pmk75"
   },
   "stable": {
    "version": [
     0,
     8,
-    2
+    3
    ],
-   "commit": "9a3e893751791b17db85d691444e50e346cb2bd3",
-   "sha256": "1jdgkjiv6pn2whim71fsyfady8lv180y56j9z6bfx3gg3pp2dcbd"
+   "commit": "f76bffd42fb4ed8ffe09d48c084f6577b0b99fa6",
+   "sha256": "0l7xmvmj5s93hc39wjjv75f22zbhahnmcxpmvx3dfvsbig9pmk75"
   }
  },
  {
@@ -40491,8 +40837,8 @@
     20180318,
     1956
    ],
-   "commit": "55468314a5f6b77d2c96be62c7005ac94545e217",
-   "sha256": "08hy7rbfazs6grkpk54i82bz0i0c74zcjk96cip8970h6jn3mj72"
+   "commit": "14adca24eb6b0b4e311ad144c5d41972c6b044b2",
+   "sha256": "1z3xyjlbxni98hqdnd46lg89dcmcaqjsv73wv16ia4z6lrkhv5dp"
   },
   "stable": {
    "version": [
@@ -40539,8 +40885,8 @@
     20180318,
     1956
    ],
-   "commit": "55468314a5f6b77d2c96be62c7005ac94545e217",
-   "sha256": "08hy7rbfazs6grkpk54i82bz0i0c74zcjk96cip8970h6jn3mj72"
+   "commit": "14adca24eb6b0b4e311ad144c5d41972c6b044b2",
+   "sha256": "1z3xyjlbxni98hqdnd46lg89dcmcaqjsv73wv16ia4z6lrkhv5dp"
   },
   "stable": {
    "version": [
@@ -40672,21 +41018,6 @@
   }
  },
  {
-  "ename": "github-issues",
-  "commit": "f761e76236e9372d5fae6b5c5dcb1992c5d64d37",
-  "sha256": "12c6yb3v7xwkzc51binfgl4jb3sm3al5nlrklbsxhn44alazsvb0",
-  "fetcher": "github",
-  "repo": "inkel/github-issues.el",
-  "unstable": {
-   "version": [
-    20160616,
-    1841
-   ],
-   "commit": "816f7712b0eb05bffec0add3507302862d2629c4",
-   "sha256": "1x6jbnx9lwgy64nl9lpp01xcj9cbx5fq435iwhiarjdsm4kvixb5"
-  }
- },
- {
   "ename": "github-modern-theme",
   "commit": "35763febad20f29320d459394f810668db6c3353",
   "sha256": "07xv4psw34mrpb1f5fsvj8vcm9k3xlm43zxr6qmj00p46b35z25r",
@@ -40762,8 +41093,8 @@
     "ghub",
     "s"
    ],
-   "commit": "db723740e02348c0760407e532ad667ef89210ec",
-   "sha256": "16d09z1p9ljpc6h2kj30qk6hrs5zgixxj7qrgi3i3kc5djcy2km0"
+   "commit": "d0c8234cf523818513f892f30153210606abb6be",
+   "sha256": "1d0g79mp14ngx5x0f8sc4lri40m3gh0ql6gzyqrl4c94lhq59cn7"
   }
  },
  {
@@ -40842,8 +41173,8 @@
     20180318,
     1956
    ],
-   "commit": "55468314a5f6b77d2c96be62c7005ac94545e217",
-   "sha256": "08hy7rbfazs6grkpk54i82bz0i0c74zcjk96cip8970h6jn3mj72"
+   "commit": "14adca24eb6b0b4e311ad144c5d41972c6b044b2",
+   "sha256": "1z3xyjlbxni98hqdnd46lg89dcmcaqjsv73wv16ia4z6lrkhv5dp"
   },
   "stable": {
    "version": [
@@ -41190,15 +41521,15 @@
   "url": "https://git.launchpad.net/global-tags.el",
   "unstable": {
    "version": [
-    20201215,
-    1900
+    20210122,
+    1606
    ],
    "deps": [
     "async",
     "project"
    ],
-   "commit": "8f46692749e05113d4d14870dd67c6efa06626c7",
-   "sha256": "1sjv3ydqv1gv2nqbdwywj52xc2b2ix9f8sjb14022v0bwywk3v2j"
+   "commit": "03bf9d9f92886bcc7b1b8dc45e3213d6e1be9df5",
+   "sha256": "13qczr2z83ggc2rw2rkzmsj1xgn4rqmg9mvfkp7wf7232d3hwpg8"
   }
  },
  {
@@ -41346,11 +41677,11 @@
   "repo": "juergenhoetzel/emacs-gnome-screencast",
   "unstable": {
    "version": [
-    20200115,
-    2230
+    20210125,
+    2001
    ],
-   "commit": "8c5e787230b2b8a51520ab970d5b505cbbc8f32f",
-   "sha256": "1zalx97b92vxjczm798arxyxhl29hla9c9j4da9ykpyspf3wry4d"
+   "commit": "6450ee470e84ff14a15c5c3c0489c79ff593f165",
+   "sha256": "0809psw8jz344hm4vzhapdr79l325dz57p88x509f8kq3fsvv44f"
   },
   "stable": {
    "version": [
@@ -41510,8 +41841,8 @@
   "repo": "deusmax/gnus-notes",
   "unstable": {
    "version": [
-    20210103,
-    2050
+    20210207,
+    1010
    ],
    "deps": [
     "async",
@@ -41522,8 +41853,8 @@
     "org",
     "s"
    ],
-   "commit": "8cacba653f8912355d45847c5e5376eb83e6898f",
-   "sha256": "11d98vasn74p7ifyw8qnyzm4na8l0pnbh7a04cr2znnwqjbnzd7s"
+   "commit": "1457bba34b40d5197aa14dbf0856925f83025ae1",
+   "sha256": "01jm2maa8q0zjpqa95c84k9b9jx5rgwvvhaqbwvw8ccz883mcdjm"
   },
   "stable": {
    "version": [
@@ -41552,11 +41883,11 @@
   "repo": "unhammer/gnus-recent",
   "unstable": {
    "version": [
-    20210107,
-    1346
+    20210115,
+    1107
    ],
-   "commit": "6f13a00c5736c269ed850094cfbc9ea474e24dfe",
-   "sha256": "1x91da1vb48hn2qqdn144gj9n2sas252llcf5jlqqkl8w5wk6z3i"
+   "commit": "52f05e7431b5ce5487e8a990eb2ad01cade973bc",
+   "sha256": "178b8l2f5ykrq1yllg9rmn1vsyp3aqslrga1gxx1rc4grx22x31z"
   },
   "stable": {
    "version": [
@@ -41972,8 +42303,8 @@
     "cl-lib",
     "go-mode"
    ],
-   "commit": "fdf46fe0e110a8e0dddb5aac4ab20a93ee9c5d88",
-   "sha256": "00986s42kfyyxzvlwd2wvllxqkmiq0iajj1wahpdnsbajrrk14sc"
+   "commit": "49a538028e63dbe20f428c52d91f09b70b564626",
+   "sha256": "1zmpbna0picp8iyscrqgvxz5pbkbpapzij0vprkqzfznvihn926n"
   },
   "stable": {
    "version": [
@@ -42065,11 +42396,11 @@
   "repo": "dominikh/go-mode.el",
   "unstable": {
    "version": [
-    20201204,
-    1652
+    20210201,
+    1458
    ],
-   "commit": "fdf46fe0e110a8e0dddb5aac4ab20a93ee9c5d88",
-   "sha256": "00986s42kfyyxzvlwd2wvllxqkmiq0iajj1wahpdnsbajrrk14sc"
+   "commit": "49a538028e63dbe20f428c52d91f09b70b564626",
+   "sha256": "1zmpbna0picp8iyscrqgvxz5pbkbpapzij0vprkqzfznvihn926n"
   },
   "stable": {
    "version": [
@@ -42188,8 +42519,8 @@
    "deps": [
     "go-mode"
    ],
-   "commit": "fdf46fe0e110a8e0dddb5aac4ab20a93ee9c5d88",
-   "sha256": "00986s42kfyyxzvlwd2wvllxqkmiq0iajj1wahpdnsbajrrk14sc"
+   "commit": "49a538028e63dbe20f428c52d91f09b70b564626",
+   "sha256": "1zmpbna0picp8iyscrqgvxz5pbkbpapzij0vprkqzfznvihn926n"
   },
   "stable": {
    "version": [
@@ -42391,11 +42722,11 @@
   "repo": "minad/goggles",
   "unstable": {
    "version": [
-    20210113,
-    1945
+    20210208,
+    124
    ],
-   "commit": "8b7d223eca9b26acb0e3eca4b58d39a3b933bf08",
-   "sha256": "1s0smkprlnmml4a2rqhzb81mz7dlxswnvqsn3wra4brbrs3almhi"
+   "commit": "b014b2414fad8bb3a9a7b6a7e765822887c28fe8",
+   "sha256": "1p3pagldf17mpyv0qmks5hq8y4q59bim0zh42p3b7c4y89nv7qw7"
   }
  },
  {
@@ -42528,11 +42859,11 @@
   "repo": "io12/good-scroll.el",
   "unstable": {
    "version": [
-    20210105,
-    903
+    20210123,
+    159
    ],
-   "commit": "beac144c37227d23e5ceefb8ce1f45aa484ca5c9",
-   "sha256": "1yv07vpgqla7nk0imn7dlzsv392jvhk3w63frvhcmijq5ciafc45"
+   "commit": "5d0479e5a0fe1589fe549f2fc1966f80a4718a4f",
+   "sha256": "046iimmkljbfcz66cj73cnizxn15hw7bzi3glls2h6vh8sxak7d7"
   },
   "stable": {
    "version": [
@@ -42570,8 +42901,8 @@
     20180130,
     1736
    ],
-   "commit": "d5b510476350b9ba99a83a7ceee114012f515394",
-   "sha256": "169aijgk0viyyq3s6sw6fl61ajw6gan9kwv2igawwki5ljfc2rkr"
+   "commit": "6e239d7f906ee456b926be229f3e4ee6bad53e42",
+   "sha256": "04mz13p5n6az94mq0mhd1zw7jdpf26sm4mk0p2r92vfy2xqnjqnd"
   }
  },
  {
@@ -42930,8 +43261,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "c43a1c86c89e6e30e54d4a21b2d95c03c6ed0c4d",
-   "sha256": "0d43gkppk06w58xsawbnil83170k6h387jr5a4v48zy2amdq7rp2"
+   "commit": "3f73f7597473434ef0b68fa7aa1d1b3ad775eb5a",
+   "sha256": "1zkpjf7kja4qpfzxz9l6kyzdmzn0w6xnbq2ks2d1szl7czmfvm12"
   },
   "stable": {
    "version": [
@@ -43435,11 +43766,11 @@
   "repo": "fredcamps/green-is-the-new-black-emacs",
   "unstable": {
    "version": [
-    20200529,
-    242
+    20210203,
+    1511
    ],
-   "commit": "9b682c0000bc732e4c55e876ac968877eada0402",
-   "sha256": "0yilp68qw2a4z8b8mmr2yl2lmwkd3ibk6j5ix6x3vlcmfmrfl3bj"
+   "commit": "09f6908064dd1854379a072d7cdd706959256299",
+   "sha256": "1ad676aiyj0p8jxpmkb0mhfznd6hzpdliji56ix6sbj5jdyxm8jv"
   },
   "stable": {
    "version": [
@@ -43678,20 +44009,20 @@
   "repo": "ROCKTAKEY/grugru",
   "unstable": {
    "version": [
-    20210115,
-    646
+    20210127,
+    432
    ],
-   "commit": "7a3437feb777996dcb8f484b79e898cfdb714bfe",
-   "sha256": "0jfz54phg3db8cgp9sj1grvj3sf10jaq359024j72l71s5cqwmlx"
+   "commit": "4ac2bf3877e3af7d23ace3165b9c8ed536ff4832",
+   "sha256": "05nw45hgbygfvbymghsp425474d4nrgl8pjii8jwd1ym155bf13k"
   },
   "stable": {
    "version": [
     1,
-    17,
+    20,
     0
    ],
-   "commit": "6820ae3aa9203f5e23e0cd80f51b410aaf1d32f3",
-   "sha256": "0sf3lkdvqb55bin8bx5jd06ncqiy9lkx7mx5i8q27r8wmi58q7v6"
+   "commit": "e7f0fca4bfd4815e5ed794f13f89b1e28ce57d26",
+   "sha256": "15h1h5gg369h2dm9yp97ac6l5qajm7f9c0s2cgpymv21gyx2ikr5"
   }
  },
  {
@@ -43803,16 +44134,16 @@
   "repo": "wbolster/emacs-gsettings",
   "unstable": {
    "version": [
-    20190513,
-    1003
+    20210208,
+    2042
    ],
    "deps": [
     "dash",
     "gvariant",
     "s"
    ],
-   "commit": "3009335a077636347defd08d24fb092495d16d3e",
-   "sha256": "0xvj0p533laxvhv9jvgdzw5pix6zlai3jp43n2bi0kwmq21clwgz"
+   "commit": "1bd1909a22121a8200cca678302f1533856b9008",
+   "sha256": "1g195dg359iff4cq5ywwd5jjxwhvwd4qj6j8631g7wkjz1rx7bxb"
   },
   "stable": {
    "version": [
@@ -43908,14 +44239,14 @@
   "repo": "tmalsburg/guess-language.el",
   "unstable": {
    "version": [
-    20201229,
-    1021
+    20210131,
+    1100
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "afbc3456ebdfe4bb5f8754a91c8398f8b5b7636c",
-   "sha256": "1x0f3v98p6lxb31rgkv2a9kr5jqrmvpsa7nqr960s41rkyx4wvi6"
+   "commit": "e423be90a4c517f8fb032ba4ea6d776a72db03f9",
+   "sha256": "12calq514nxd2vkskj497r38v887sz4bg2m4gp2lllw929wj4wpn"
   }
  },
  {
@@ -44220,20 +44551,20 @@
   "repo": "clarete/hackernews.el",
   "unstable": {
    "version": [
-    20201019,
-    5
+    20210117,
+    1834
    ],
-   "commit": "c793275565372f63bf9dc1229d5b893a5bd0278e",
-   "sha256": "1fld3q2j58ka130v7gqm24ngw5ghy9vk63141y7bkjs5zb8mahpl"
+   "commit": "c9c2bb0f13f5bd64c74dbdf945d9613192c0e454",
+   "sha256": "17lkjcka6ydd6khhz5jbjlybfpx05153z0d8s1rxaxcwl7z2y6cf"
   },
   "stable": {
    "version": [
     0,
     6,
-    0
+    1
    ],
-   "commit": "aec997970f2c2f8e0077c1f6584e4d1996ae3864",
-   "sha256": "15asarr271p582xbmhvhh9q0lgka25h6k65xh82rqvig4mirhn1l"
+   "commit": "c9c2bb0f13f5bd64c74dbdf945d9613192c0e454",
+   "sha256": "17lkjcka6ydd6khhz5jbjlybfpx05153z0d8s1rxaxcwl7z2y6cf"
   }
  },
  {
@@ -44695,8 +45026,8 @@
     20181110,
     1859
    ],
-   "commit": "f33ba22a6e5060fb14c9fd3dda728d6724f2f9dd",
-   "sha256": "1lmr8j2g7v3jn2q9h65c7qhzzk4asz0mlqarnl2h0g7xjk0wmi6z"
+   "commit": "57e8ac22bd499b632ab94657b855c7c43b166dda",
+   "sha256": "11792hjxfsnkfwj3q2v6d090x6klf5g257dd75casnsadrlbka2b"
   }
  },
  {
@@ -44949,16 +45280,16 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210114,
-    1521
+    20210212,
+    659
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "d0073fd556e5e2296b4fea824929dfab9b1895b8",
-   "sha256": "0wz12f190vsp71bcwygvagksqfihm85rj80bc4a3sx96wyrdjbqm"
+   "commit": "df4f34bc1d6d6478ad8ee543c358314da040fbe1",
+   "sha256": "17i50b87ycqvb8x69qxbk9zq44k2q7d308dm06ny774mafcprrj9"
   },
   "stable": {
    "version": [
@@ -45042,26 +45373,6 @@
    ],
    "commit": "8ac044705d8620ee354a9cfa8cc1b865e83c0d55",
    "sha256": "0hxfgdn56c7qr64r59g9hvxxwa4mw0ad9c9m0z5cj85bsdd7rlx4"
-  }
- },
- {
-  "ename": "helm-addressbook",
-  "commit": "4bb805b0f2d2055aa4e88bd41239d75ec34f5785",
-  "sha256": "1d8byi6sr5gz1rx3kglnkp47sn9dqdd83s12d84wyay06ix3cqqi",
-  "fetcher": "github",
-  "repo": "emacs-helm/helm-addressbook",
-  "unstable": {
-   "version": [
-    20170903,
-    728
-   ],
-   "deps": [
-    "addressbook-bookmark",
-    "cl-lib",
-    "helm"
-   ],
-   "commit": "62497f72d46afd3a9f9f94b27d062a82fb232de4",
-   "sha256": "1lmq7j19qv3pabs5arapx3lv2xhf0sgn4b2hl0l0kzph52fvics7"
   }
  },
  {
@@ -45877,14 +46188,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210105,
-    504
+    20210211,
+    1417
    ],
    "deps": [
     "async"
    ],
-   "commit": "d0073fd556e5e2296b4fea824929dfab9b1895b8",
-   "sha256": "0wz12f190vsp71bcwygvagksqfihm85rj80bc4a3sx96wyrdjbqm"
+   "commit": "df4f34bc1d6d6478ad8ee543c358314da040fbe1",
+   "sha256": "17i50b87ycqvb8x69qxbk9zq44k2q7d308dm06ny774mafcprrj9"
   },
   "stable": {
    "version": [
@@ -46168,26 +46479,6 @@
    ],
    "commit": "eb30810cd26e1ee73d84a863e6b2667700e9aead",
    "sha256": "183vj5yi575aqkak19hl8k4mw38r0ki9p1fnpa8nny2srjyy34yb"
-  }
- },
- {
-  "ename": "helm-elscreen",
-  "commit": "dfe42a7fe2dc051c6c49aa75bce89bfe1b5fdbbb",
-  "sha256": "186k66kf2ak2ihha39989cz1aarqrvbgp213y1fwh9qsn1kxclnd",
-  "fetcher": "github",
-  "repo": "emacs-helm/helm-elscreen",
-  "unstable": {
-   "version": [
-    20170709,
-    914
-   ],
-   "deps": [
-    "cl-lib",
-    "elscreen",
-    "helm"
-   ],
-   "commit": "b8212866939dc4a1e1dc23ad572407b688e130e3",
-   "sha256": "0gy6lbdngiwfl9vfw32clagbmv70f93slc9zkm3dz3mca37435kz"
   }
  },
  {
@@ -46743,40 +47034,6 @@
   }
  },
  {
-  "ename": "helm-ghc",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "0bv0sfpya1jyay9p80lv0w6h9kdp96r8lnp6nj15w660p1b51c0d",
-  "fetcher": "github",
-  "repo": "david-christiansen/helm-ghc",
-  "unstable": {
-   "version": [
-    20141105,
-    1459
-   ],
-   "deps": [
-    "cl-lib",
-    "ghc",
-    "helm"
-   ],
-   "commit": "e5ee7b8d3b745d162553aecfbd41381c4de85f35",
-   "sha256": "16p1gisbza48qircsvrwx020n96ss1c6s68d7cgqqfc0bf2467is"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    0
-   ],
-   "deps": [
-    "cl-lib",
-    "ghc",
-    "helm"
-   ],
-   "commit": "d3603ee18299b789be255297dc42af16dd431869",
-   "sha256": "00ls9v3jdpz3wka90crd193z3ipwnf1b0slmldn4vb9ivrndh6wn"
-  }
- },
- {
   "ename": "helm-ghq",
   "commit": "e94eec646def7c77b15f6a6ac1841200848e62c7",
   "sha256": "14f3cbsj7jhlhrp561d8pasllnx1cmi7jk6v2fja7ghzj76dnvq6",
@@ -47230,16 +47487,16 @@
   "repo": "yyoncho/helm-icons",
   "unstable": {
    "version": [
-    20200719,
-    1359
+    20210125,
+    1913
    ],
    "deps": [
     "dash",
     "f",
     "treemacs"
    ],
-   "commit": "d8c15dc61c1f321686b447e83abb17e14bc6f1c6",
-   "sha256": "0na4nks6l7917r64rc49b38lwsdj7wvslnnikms92882z5c8c6nn"
+   "commit": "14df05527e1c629d8eb8e5937de97fa13aeedbe8",
+   "sha256": "1ia72l8n9n59ikq4gcjqpc9asnyyykkg4nzs5bzw2wf6i41pn4dl"
   }
  },
  {
@@ -47474,8 +47731,8 @@
     "helm",
     "lean-mode"
    ],
-   "commit": "cc1f5fadf8e9ae08aa25828985edc97df04d94a7",
-   "sha256": "0v03bisr0ljk1ypbicgh9izxwazz8ry5xcd7r1lqb339xqb0bzqb"
+   "commit": "15bee87dc4080b87c543964375b7ce162317ab6f",
+   "sha256": "127b7ny5mr1y14yg54gy7an3lk3928w4y9a22295i4v4zgj704j4"
   }
  },
  {
@@ -47974,18 +48231,19 @@
   "repo": "akirak/org-multi-wiki",
   "unstable": {
    "version": [
-    20210111,
-    1022
+    20210210,
+    1119
    ],
    "deps": [
     "dash",
     "helm",
     "helm-org-ql",
+    "org",
     "org-multi-wiki",
     "org-ql"
    ],
-   "commit": "c9005cbe4077cce3743b680dec97c11fa179bb36",
-   "sha256": "1428lky09cvlqdb8b9zf0x49cxmigrkhvhi391b2mj2qzgmjzcvm"
+   "commit": "3b97aa047233d521e937b6040cf9085e77507f28",
+   "sha256": "0rq37k0ydksc2wsavy4g6wydr2hxcclbipab14qdldvrif35sr24"
   },
   "stable": {
    "version": [
@@ -48771,8 +49029,8 @@
     "helm",
     "rtags"
    ],
-   "commit": "39339388256df662d0084b4a094d03e52748f9e8",
-   "sha256": "0wp4mygsxzibra2p3m5rn9m0yd3fscd795k5xa0wxi5pwddv7dlg"
+   "commit": "aa4c827b417f5448c12401c33acdab1325917c13",
+   "sha256": "02jqcbrpxm4sv15l8kyvsw9pwkmamj065cgifj68x242fw2f0sam"
   },
   "stable": {
    "version": [
@@ -48897,8 +49155,8 @@
   "repo": "emacs-helm/helm-searcher",
   "unstable": {
    "version": [
-    20210108,
-    1818
+    20210124,
+    1648
    ],
    "deps": [
     "f",
@@ -48906,14 +49164,14 @@
     "s",
     "searcher"
    ],
-   "commit": "d27c7cafc79b6e5e11881014eee9817e3897762f",
-   "sha256": "117m2c8ms66gqwsxgdwywx166bif2i2y5dgq1w0yw5j4h02q3ji7"
+   "commit": "3c0e4997126b5e7ba2db2dba8f1dbc5cb92d2459",
+   "sha256": "1fcinlxrvzmlrn17gfpv3n2wf9si084p6yi3jg0jzagnprris8lx"
   },
   "stable": {
    "version": [
     0,
     2,
-    4
+    5
    ],
    "deps": [
     "f",
@@ -48921,8 +49179,8 @@
     "s",
     "searcher"
    ],
-   "commit": "7b3016faeca201843d849c00d11665a90c1709fb",
-   "sha256": "07whjqsi7jq4i3fypzasq2iivsj025x3701wfgsj2f02xyvgfk4p"
+   "commit": "3c0e4997126b5e7ba2db2dba8f1dbc5cb92d2459",
+   "sha256": "1fcinlxrvzmlrn17gfpv3n2wf9si084p6yi3jg0jzagnprris8lx"
   }
  },
  {
@@ -48952,25 +49210,26 @@
   "repo": "emacs-helm/helm-selector",
   "unstable": {
    "version": [
-    20201219,
-    1639
+    20210125,
+    857
    ],
    "deps": [
     "helm"
    ],
-   "commit": "6a943b9952c749c2a83c284cfcf5b56f5f6622ad",
-   "sha256": "0msc8byspjd0ygpbnxkiv2g9qv5kxpcp2vh2sjg7yxrfbishj8hq"
+   "commit": "4da4711c4cfd14527abe20d66787beeb49171b26",
+   "sha256": "01lh1df0bnas1p7xlqc4i1jd67f8lxgq0q2zsvx10z8828i76j3v"
   },
   "stable": {
    "version": [
     0,
-    5
+    6,
+    1
    ],
    "deps": [
     "helm"
    ],
-   "commit": "7542a6dffe338db8109b0233e4d4c8f4b22354a0",
-   "sha256": "1cv659sqmrvk316fp7mjc58vvbcg1j6s2q4rwgqrpbyszrxl3i63"
+   "commit": "4da4711c4cfd14527abe20d66787beeb49171b26",
+   "sha256": "01lh1df0bnas1p7xlqc4i1jd67f8lxgq0q2zsvx10z8828i76j3v"
   }
  },
  {
@@ -49033,30 +49292,30 @@
   "repo": "emacs-helm/helm-sly",
   "unstable": {
    "version": [
-    20210114,
-    1928
+    20210205,
+    1424
    ],
    "deps": [
     "cl-lib",
     "helm",
     "sly"
    ],
-   "commit": "7fbd6544511d8669c8122b6a9128fd09e835c3fe",
-   "sha256": "061qihf8fwka7jpcvn1z76rcjbipfri41xfkn17i7pg4nzmqhaaw"
+   "commit": "3691626c80620e992a338c3222283d9149f1ecb5",
+   "sha256": "06x8wyx1r0s7askkvlbklgz1cszv34qsvv3gryndw350smk1v8kx"
   },
   "stable": {
    "version": [
     0,
-    5,
-    1
+    7,
+    2
    ],
    "deps": [
     "cl-lib",
     "helm",
     "sly"
    ],
-   "commit": "ccf8e83644bc1b2113eab46693e64d3f0c56198f",
-   "sha256": "13s2dj09mcdwlibjlahyyq2dxjkjlpxs88dbdyvcd64249jmahsx"
+   "commit": "3691626c80620e992a338c3222283d9149f1ecb5",
+   "sha256": "06x8wyx1r0s7askkvlbklgz1cszv34qsvv3gryndw350smk1v8kx"
   }
  },
  {
@@ -49203,26 +49462,26 @@
   "repo": "emacs-helm/helm-switch-to-repl",
   "unstable": {
    "version": [
-    20201214,
-    1216
+    20210206,
+    844
    ],
    "deps": [
     "helm"
    ],
-   "commit": "e6cae905c9d224bcca02437696afae7d6633c4a9",
-   "sha256": "1zwzpar34b98p0fiwy9q1bxrb67nv79pv9cz4kmyypclrmrhgqa2"
+   "commit": "f0e732e7217fc0373b0805245fa15920cf676619",
+   "sha256": "0n8qa549c5syvgqw1h2zrakjjbygddpxzaifaq5irscgdcajrads"
   },
   "stable": {
    "version": [
     0,
     1,
-    1
+    2
    ],
    "deps": [
     "helm"
    ],
-   "commit": "e6cae905c9d224bcca02437696afae7d6633c4a9",
-   "sha256": "1zwzpar34b98p0fiwy9q1bxrb67nv79pv9cz4kmyypclrmrhgqa2"
+   "commit": "f0e732e7217fc0373b0805245fa15920cf676619",
+   "sha256": "0n8qa549c5syvgqw1h2zrakjjbygddpxzaifaq5irscgdcajrads"
   }
  },
  {
@@ -49897,6 +50156,30 @@
   }
  },
  {
+  "ename": "hiccup-cli",
+  "commit": "524a84be8692bd29b93e4897467e2e798be5fa53",
+  "sha256": "0xv6bq2ryz71lqqm1z6wg0lf1qmqwydg17zi614dsajsa5xhrjkb",
+  "fetcher": "github",
+  "repo": "kwrooijen/hiccup-cli",
+  "unstable": {
+   "version": [
+    20210208,
+    652
+   ],
+   "commit": "b56ae0d5cd5ce3ef24ed13be5103e231c91ef4e2",
+   "sha256": "0cl84mlgrjwjxgk2kx4930rarxyc6n07lvy54gmb907i4l6flw61"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "cfbb957a1f86bc1d28e778bfdffdeaaa2ae79286",
+   "sha256": "0f3b7wsq9b0xswvj4073ykkcc36kybz16bz4q068qziig22d9szb"
+  }
+ },
+ {
   "ename": "hide-lines",
   "commit": "ae489be43b1aee93614e40f492ebdf0b98a3fbc1",
   "sha256": "18h5ygi6idpb5wjlmjjvjmwcw7xiljkfxdvq7pm8wnw75p705x4d",
@@ -50392,26 +50675,26 @@
   "repo": "mihaimaruseac/hindent",
   "unstable": {
    "version": [
-    20200904,
-    2236
+    20210201,
+    148
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1917b7b9ac2cb3dcb152f4435de61d1858a4064b",
-   "sha256": "0rpmmzwjqij5v8k33qlpq323za96447pdwrwzwk4474n4v5xsp50"
+   "commit": "e146d672ea4c00fe17018e7e76e49d59570eeb2b",
+   "sha256": "0bcrlw76nihbffm7p5jh9vf3r1756p6vwa7hbwp933r4caaiyqid"
   },
   "stable": {
    "version": [
     5,
     3,
-    1
+    2
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1583be4a8a01b765841f7306284528ae713abb7b",
-   "sha256": "1l8v3vq3yw7zr1yxyscfw8lggcf0klnyszhv18505c6myybp2dkp"
+   "commit": "e146d672ea4c00fe17018e7e76e49d59570eeb2b",
+   "sha256": "0bcrlw76nihbffm7p5jh9vf3r1756p6vwa7hbwp933r4caaiyqid"
   }
  },
  {
@@ -50677,11 +50960,11 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20210105,
-    744
+    20210117,
+    1140
    ],
-   "commit": "9661a462d86b22293caaa4c3d94f971a15dbf1d5",
-   "sha256": "0w0l990wqdv9fdxf8a02fx0aj6ffp83jp3zh81jf3j5i0l75xfkr"
+   "commit": "4d18ccde596aef84ef278aa60144390ab41f0046",
+   "sha256": "0r9yz485g393yh4nh1a8nqhk1yxjapq2dzjs3l13ld34hql776yc"
   },
   "stable": {
    "version": [
@@ -50709,8 +50992,8 @@
     "htmlize",
     "popup"
    ],
-   "commit": "bad680b33c2ca20a6088986a10735a5df3cb9996",
-   "sha256": "0vd2fn011l5iqi1ja8j3l0wq90wr70b8dk75mh3xrrl8jp55xwxl"
+   "commit": "f1deebb0cbe9ca040856d3cc99942335250d9566",
+   "sha256": "0hnmia3c052php3i2g1sbsp402fgi17yv6as044ck617p7avz971"
   }
  },
  {
@@ -50850,6 +51133,26 @@
   }
  },
  {
+  "ename": "holy-books",
+  "commit": "6b74662e2f4bee4b7c06be029bfa75eca35d5d86",
+  "sha256": "1s9kkjnbmm7vxh767asmnv4h040ksyqzhn3h7x5h0iszhrp6nmp2",
+  "fetcher": "github",
+  "repo": "alhassy/holy-books",
+  "unstable": {
+   "version": [
+    20210114,
+    1607
+   ],
+   "deps": [
+    "dash",
+    "org",
+    "s"
+   ],
+   "commit": "3a31424fcf889e594067de314acb4fec238d510b",
+   "sha256": "1n69j4yx2dyyhvs649n17lqb1b5nwdrsfrj0a3vhyvd3q56j3fkl"
+  }
+ },
+ {
   "ename": "home-end",
   "commit": "f67c9cf33e0f11a9bd6e1521af86d180177111c4",
   "sha256": "0xnpb0n4kd7b0m80g2a88ylfk5gbvkcgwb78nig98dmgjg48z2ly",
@@ -50859,6 +51162,17 @@
    "version": [
     20180817,
     855
+   ],
+   "deps": [
+    "keypress-multi-event"
+   ],
+   "commit": "fbddad2c1268720ce17662a232b48f666e489526",
+   "sha256": "0wabzpah1vkg8ns21agvrs9s7rm1r0cxghmfv6c2zq71886glv1y"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
    ],
    "deps": [
     "keypress-multi-event"
@@ -51064,16 +51378,16 @@
   "repo": "thanhvg/emacs-howdoyou",
   "unstable": {
    "version": [
-    20201002,
-    1901
+    20210205,
+    1720
    ],
    "deps": [
     "org",
     "promise",
     "request"
    ],
-   "commit": "e7c2e75a0365bca16e8910e295f330c35fa016ae",
-   "sha256": "1wsbd4rjfh27w5qzrzd1h6xpqp7s5amw33wdaa2cfp7c67pnm4kc"
+   "commit": "63addedefcad86fe3cd64b29d87a500849124d4b",
+   "sha256": "162sqbvxxh19fyg6is1hnqzck01mglw2cahs07lsxmfh58gw2lx6"
   }
  },
  {
@@ -51120,25 +51434,25 @@
   "repo": "Wilfred/ht.el",
   "unstable": {
    "version": [
-    20210113,
-    822
+    20210119,
+    741
    ],
    "deps": [
     "dash"
    ],
-   "commit": "5876209c9712bd1acbbf1d31f6e3293e5ab88971",
-   "sha256": "03cn43vd2zq67hzb1hy82b7lshzslxzndjj1z1liv1kspww2hkch"
+   "commit": "c4c1be487d6ecb353d07881526db05d7fc90ea87",
+   "sha256": "1i3ps5zrr719nrcrsyhlmfdazzcz1agrmx424mbyca5vra8cc35i"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
     "dash"
    ],
-   "commit": "a23a72342fda1eb3cc8d792f86efabe45eb0d1fd",
-   "sha256": "1p3qa7g0wa0wbviv2f8bda39cjys3naayk5xjm3nxxmqsyy8papx"
+   "commit": "2eddb85a66508ad607e94fd8384b18feb07a2449",
+   "sha256": "0can9v336lgnq0q2ha3js0565jzp3dlwwqxhcbx5swk5kp148f07"
   }
  },
  {
@@ -51704,6 +52018,24 @@
   }
  },
  {
+  "ename": "i-ching",
+  "commit": "28b05f2e04d286f3115e33e9d3e717caef8a0a46",
+  "sha256": "14g095dd8gzp64xwnnha1smd5jqgswzfaw9vfz4ihyglsjvl23m1",
+  "fetcher": "github",
+  "repo": "zzkt/i-ching",
+  "unstable": {
+   "version": [
+    20210208,
+    1251
+   ],
+   "deps": [
+    "request"
+   ],
+   "commit": "706052ba196797fd32e6d6d05e059b1f5dd4f2c9",
+   "sha256": "16kkdzd49b91dvby4mfghpq4phwilzyqaciar8jvk5sfiilyw7yi"
+  }
+ },
+ {
   "ename": "i2b2-mode",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "1jnlisdnp9sz54p444vlq00y3080i4ljcvclri9fy382g1s5ags5",
@@ -51810,19 +52142,19 @@
   "repo": "muffinmad/emacs-ibuffer-project",
   "unstable": {
    "version": [
-    20200210,
-    2252
+    20210205,
+    1940
    ],
-   "commit": "8cc8c96cb15874dd55cdbfce759f528de0046f9f",
-   "sha256": "0ysjyirw9gkrs8wivvvxfgdq8radpkl6nhh2a0ac3s42vrwbf9g1"
+   "commit": "2483d2dbd715c4bd892d1fbc968a17a01888cb2d",
+   "sha256": "165g2lsg8apdpn7i36h0x5j80clpjpf3d1d1l8g8ahf5280flcfw"
   },
   "stable": {
    "version": [
     2,
-    0
+    1
    ],
-   "commit": "8cc8c96cb15874dd55cdbfce759f528de0046f9f",
-   "sha256": "0ysjyirw9gkrs8wivvvxfgdq8radpkl6nhh2a0ac3s42vrwbf9g1"
+   "commit": "2483d2dbd715c4bd892d1fbc968a17a01888cb2d",
+   "sha256": "165g2lsg8apdpn7i36h0x5j80clpjpf3d1d1l8g8ahf5280flcfw"
   }
  },
  {
@@ -51978,11 +52310,11 @@
   "repo": "oantolin/icomplete-vertical",
   "unstable": {
    "version": [
-    20210105,
-    500
+    20210212,
+    1737
    ],
-   "commit": "288166784de29db2f5f61722cc11151deca3f34a",
-   "sha256": "0if14qqixkkg8nfikfzhqqnsclhkbx4n8885gm9w0zlibkcj65pk"
+   "commit": "708d2b673f5e993c8894817b083dd08eef66cebe",
+   "sha256": "0hxsmk97cis6k34a0iq2pz97nkhpljkbf8x306ra2y5sf6a82rcf"
   },
   "stable": {
    "version": [
@@ -52182,17 +52514,17 @@
  },
  {
   "ename": "ido-complete-space-or-hyphen",
-  "commit": "59e11094068d3a0c0e4edc1f82158c43d3b15e0e",
-  "sha256": "1wk0cq5gjnprmpyvhh80ksz3fash42hckvmx8m95crbzjg9j0gbc",
+  "commit": "af424a73243aabec86c5bcd688a0cf29ad57199c",
+  "sha256": "084lgxjq2wfvhp1pv0dcn3ac8hy6jhjpyv1bxan6pdr2v5bc0lz2",
   "fetcher": "github",
-  "repo": "doitian/ido-complete-space-or-hyphen",
+  "repo": "DarwinAwardWinner/ido-complete-space-or-hyphen",
   "unstable": {
    "version": [
-    20180929,
-    150
+    20210206,
+    1505
    ],
-   "commit": "ed60ebed113e4e1552efeab0c416f7c88428268e",
-   "sha256": "15h0alwi7qfqyi7w7gdl06ykxvafbx1p4614rg81kmzgs4dpqgy3"
+   "commit": "d1244243e042b8d5b6b991db752a17a44ea169bc",
+   "sha256": "1gl646lj1i2yxmgrgwd0sz9abq3zqf9z4qkl6ilp49ijk4cks63g"
   },
   "stable": {
    "version": [
@@ -52211,16 +52543,16 @@
   "repo": "DarwinAwardWinner/ido-completing-read-plus",
   "unstable": {
    "version": [
-    20210103,
-    1621
+    20210206,
+    1750
    ],
    "deps": [
     "cl-lib",
     "memoize",
     "seq"
    ],
-   "commit": "f91e5a1d696c13db029fd62806fe9bcb9702be26",
-   "sha256": "0yhl6wa3fkvkfx87vhjl8dhn3igzrilby2vxhllgysb5kbd9adzc"
+   "commit": "36a8bb93a59a16c8d5a5163c8cfde3770a1052df",
+   "sha256": "03v0d93fwp5k2n8mmkj3szqm80ilbzkqqdaz5v1v2ar0p4sajl8v"
   },
   "stable": {
    "version": [
@@ -52463,11 +52795,11 @@
   "repo": "creichert/ido-vertical-mode.el",
   "unstable": {
    "version": [
-    20201012,
-    1514
+    20210205,
+    436
    ],
-   "commit": "5a6e17048528c328c129db6dccfe605f301ddef2",
-   "sha256": "19mwbz6a67a76pm9820w3rvz0mb54gx09nq5fzz4lkwn94578kyn"
+   "commit": "b1659e967da0687abceca733b389ace24004fa66",
+   "sha256": "0wihhkbcfsfy3drqhg443vlz931c0nvpr9rdmp8l8m33ca1bbx5i"
   },
   "stable": {
    "version": [
@@ -52585,11 +52917,11 @@
   "repo": "victorhge/iedit",
   "unstable": {
    "version": [
-    20210114,
-    1621
+    20210203,
+    23
    ],
-   "commit": "dc3b419f1b945bd806bf40b7a478e7a2144c2077",
-   "sha256": "1xqq0hl8wcxa64pfn11pxcb7gcfgczaw166h0qksczwib2v4racc"
+   "commit": "0d6d2387188763a88cdf84f749e6f32d5a72bbd6",
+   "sha256": "0v34zqbfr7z3mr5c9nyksxkdgmnyvvsr9zaq202hhq25lwlhrkpq"
   },
   "stable": {
    "version": [
@@ -52681,10 +53013,10 @@
  },
  {
   "ename": "image+",
-  "commit": "02d7400477a993b7a3cae327501dbf8db97dfa28",
-  "sha256": "1a9dxswnqn6cvx28180kclpjc0vc6fimzp7n91gpdwnmy123x6hg",
+  "commit": "98ecbfb97550c3dfffaab63fcfe27786f3574bff",
+  "sha256": "14xcb0a5ihq16amri3n8avbg1jjx4hg3dnynxd4903gig72kywbx",
   "fetcher": "github",
-  "repo": "mhayashi1120/Emacs-imagex",
+  "repo": "emacsorphanage/image-plus",
   "unstable": {
    "version": [
     20150707,
@@ -52840,11 +53172,11 @@
   "repo": "QiangF/imbot",
   "unstable": {
    "version": [
-    20201204,
-    801
+    20210210,
+    909
    ],
-   "commit": "17b586307065f868a999e58fab30749d1b722aa2",
-   "sha256": "14c48zgdi54i9yz8ya6vgclafzqpfnjxsxf4dvzxcn74p4sb246z"
+   "commit": "4083ad2e5a840467668a7c2fb809177726a7c519",
+   "sha256": "1hcfhlvnqbfkym96bl9qpvcarijbqva2q80ld8vi3hmr2ghrq30y"
   }
  },
  {
@@ -52855,26 +53187,26 @@
   "repo": "vspinu/imenu-anywhere",
   "unstable": {
    "version": [
-    20190512,
-    1939
+    20210201,
+    1704
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "88b0e120284058b32252e4b0ed1a07c9fe44092f",
-   "sha256": "1w0n4hx29zc6n06qfq3ryc4dcfmk7wx3lw083yv7fi12hjj255vm"
+   "commit": "06ec33d79e33edf01b9118aead1eabeae8ee08b1",
+   "sha256": "0lbwfhcl40ayxskvmsvdrg8p63qp086xpzw61bqk4b3fxndxl04h"
   },
   "stable": {
    "version": [
     1,
     1,
-    4
+    6
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "fc7f0fd2f19e5ebee70156a99bf87393123893e3",
-   "sha256": "0g2gb7jrys81kphmhlvhvzwl8l75j36y6pqjawh9wmzzwad876q5"
+   "commit": "06ec33d79e33edf01b9118aead1eabeae8ee08b1",
+   "sha256": "0lbwfhcl40ayxskvmsvdrg8p63qp086xpzw61bqk4b3fxndxl04h"
   }
  },
  {
@@ -52985,11 +53317,11 @@
   "repo": "petergardfjall/emacs-immaterial-theme",
   "unstable": {
    "version": [
-    20210109,
-    1653
+    20210126,
+    1127
    ],
-   "commit": "288b367ea0efccd5e98efbdf925591ffc989a654",
-   "sha256": "1y62yfg67lnbc89l6k4gw5fibahnlpn23g415a6zdk2vz89n6y0k"
+   "commit": "c5684a17c78e6e05ea0bdb63e44373b064db935a",
+   "sha256": "09fw0bgqr7fhwhm7vgdd12iw9nbgn19qna7k6vv1ljsdfcmwg5s5"
   },
   "stable": {
    "version": [
@@ -53190,6 +53522,30 @@
    ],
    "commit": "c0360a8146ca65565a7fa66c6d72986edd916dd5",
    "sha256": "0s6hp62kmhvmgj3m5jr3cfqc8yv3p8jfxk0piq8xbf2chr1hp6l5"
+  }
+ },
+ {
+  "ename": "indent-control",
+  "commit": "c2c3a73f54091f5347877d51a68b0e009253583b",
+  "sha256": "0nd7crp6k1mklhz0y1zypc3jmjfydy6d1ksx24sm9zj83i3fp339",
+  "fetcher": "github",
+  "repo": "jcs-elpa/indent-control",
+  "unstable": {
+   "version": [
+    20210117,
+    356
+   ],
+   "commit": "ec9238bb204875d0d789e077c84c1d2ffe4e8173",
+   "sha256": "1r61jvbx57gqlfq2kkbxwz4rsidj6dig4czkxjnb01nigzp0y58c"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    4
+   ],
+   "commit": "2594740d8e8b324722d133a2db051ba4941eb170",
+   "sha256": "0v42lv5ig5hpnc02saqqmrjcvy8n216s7jnlc4f9jjyl7bl7lfsx"
   }
  },
  {
@@ -53670,6 +54026,29 @@
   }
  },
  {
+  "ename": "inheritenv",
+  "commit": "40b820a8d2f250b2bc67082049bafe712c329da3",
+  "sha256": "13ah98c141lvrm4yq6mryk2ji2fl3vnac6vp8lgri8rpvwkk46nz",
+  "fetcher": "github",
+  "repo": "purcell/inheritenv",
+  "unstable": {
+   "version": [
+    20210204,
+    354
+   ],
+   "commit": "13c0135ddd96519ddeb993ee21163d6e11b4f464",
+   "sha256": "1zwj26mxc4md4ar79pfdi8i4v2qr9bdrqjb8ykal524gqm79xsb9"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "bc680a2670156cd482edba83d8c81142282174ba",
+   "sha256": "0ygzf70vfb7qwpsllcq5i3brprsnx3sxy2zng02mzwrr5jkx4ypc"
+  }
+ },
+ {
   "ename": "ini-mode",
   "commit": "000cca577d000bafe7bf5711d0bfe7593fb6975a",
   "sha256": "0f6fbmg4wmlzghcibfbcx3z124b2017rhsasi5smgx9i2vkydzrm",
@@ -54074,40 +54453,6 @@
   }
  },
  {
-  "ename": "intero",
-  "commit": "a3c6e6adb1a63534275f9d3d3d0fe0f5e85c549b",
-  "sha256": "1a25lsm1psjvn9az3vd0an46p9qwrrmn09r16dqnhsjcaiabinxi",
-  "fetcher": "github",
-  "repo": "chrisdone/intero",
-  "unstable": {
-   "version": [
-    20200125,
-    848
-   ],
-   "deps": [
-    "company",
-    "flycheck",
-    "haskell-mode"
-   ],
-   "commit": "fdb0550a2ddb5692d470336aa4a057717d572695",
-   "sha256": "0myjhj416cbvlfv2x9h624nygfis94jaw9gqf75sjv6y4inkzy73"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    40
-   ],
-   "deps": [
-    "company",
-    "flycheck",
-    "haskell-mode"
-   ],
-   "commit": "107640cc3a3ea12db24ae674ff7a820f6073f3d5",
-   "sha256": "0yr6g2f35rmym6nkdgm6wdczirc5b9f7sza2sad0mx02b81qmaci"
-  }
- },
- {
   "ename": "interval-list",
   "commit": "afee0fed80f4fa444116b12653c034d760f5f1fb",
   "sha256": "0926z3lxkmpxalpq7hj355cjzbgpdiw7z4s8xdrpa1pi818d35zf",
@@ -54152,15 +54497,15 @@
   "repo": "dcjohnson/inverse-acme-theme",
   "unstable": {
    "version": [
-    20170823,
-    254
+    20210204,
+    1640
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "74d6f3e2f6534371509dd2d77006435156c276d6",
-   "sha256": "15fk60ky8kbj665yjylmgc4nn4qsk57fvarqzwv3fns64yfshkv3"
+   "commit": "79008920ce7923312ada6f95a3ec1f96ce513c0b",
+   "sha256": "169zsp8kd8dq8mcfzm228wm8c97rv56clsg6z8dp8aaz7nw1kxgf"
   }
  },
  {
@@ -54394,6 +54739,21 @@
   }
  },
  {
+  "ename": "iscroll",
+  "commit": "1a654105396633a1018cddb459a46630071455b3",
+  "sha256": "06nzfza043n2ypjp0kc009n3ax4avafvgfqdhkzr7x6bzgxvkx6d",
+  "fetcher": "github",
+  "repo": "casouri/iscroll",
+  "unstable": {
+   "version": [
+    20210128,
+    1938
+   ],
+   "commit": "d6e11066169d232fe23c2867d44c012722ddfc5a",
+   "sha256": "0pbcr5bwmw2ikwg266q2fpxaf0z5h5cl1rp3rhhn9i9yn7hlfc78"
+  }
+ },
+ {
   "ename": "isearch-dabbrev",
   "commit": "b9dfc7c1112bac8744910c58f77a98a901fd8065",
   "sha256": "1hl7zl5vjcsk3z452874g4nfcnmna8m2242dc9cgpl5jddzwqa7x",
@@ -54492,29 +54852,6 @@
    ],
    "commit": "764306dadd5a9213799081a48aba22f7c75cca9a",
    "sha256": "09hx28lmldm7z3x22a0qx34id09fdp3z61pdr61flgny213q1ach"
-  }
- },
- {
-  "ename": "isolate",
-  "commit": "c8091f8d72c24a103f6dcaadc18bbec745c1c3d3",
-  "sha256": "1ldyvw01nq2ynxaaqmw9ihk9kwfss9rqpaydn9f41bqj15xrypjc",
-  "fetcher": "github",
-  "repo": "casouri/isolate",
-  "unstable": {
-   "version": [
-    20190808,
-    731
-   ],
-   "commit": "e93cb652f150705347480a2ee13b63fa625b1edf",
-   "sha256": "0fa4z1mm62s1x4fd6d4pwl6zvksx1xiv6id9fy7rdbs0vznsjgqb"
-  },
-  "stable": {
-   "version": [
-    1,
-    2
-   ],
-   "commit": "700aa3c7945580c876d29c3c064282c33ebb365c",
-   "sha256": "0j96rzfabn6lgv9xxyndpq3d2nys5z1brrrd7bga786zzwlp78a9"
   }
  },
  {
@@ -54681,11 +55018,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210114,
-    1859
+    20210202,
+    1423
    ],
-   "commit": "cbce9ce71429c98c67bd76ef15d049ecced042f7",
-   "sha256": "08lgvpvkhp2i9q73bnr2v17w864rwp6wjnrl3b7qg06dacfs2rvl"
+   "commit": "e0374dc0bbcd8ab0ec24baf308d331251d4f9c49",
+   "sha256": "1zvcp35vnnz5iybihrw0r21pvkghn73ni2m9jkgf352n8zza7z9g"
   },
   "stable": {
    "version": [
@@ -54712,8 +55049,8 @@
     "avy",
     "ivy"
    ],
-   "commit": "cbce9ce71429c98c67bd76ef15d049ecced042f7",
-   "sha256": "08lgvpvkhp2i9q73bnr2v17w864rwp6wjnrl3b7qg06dacfs2rvl"
+   "commit": "e0374dc0bbcd8ab0ec24baf308d331251d4f9c49",
+   "sha256": "1zvcp35vnnz5iybihrw0r21pvkghn73ni2m9jkgf352n8zza7z9g"
   }
  },
  {
@@ -54938,30 +55275,30 @@
   "repo": "jcs-elpa/ivy-file-preview",
   "unstable": {
    "version": [
-    20201127,
-    629
+    20210124,
+    1639
    ],
    "deps": [
     "f",
     "ivy",
     "s"
    ],
-   "commit": "402b4b915bc7daa14d16a48b47a2e453ce80dcd3",
-   "sha256": "0z1czcqdkdxn1c92fa640idacc8c1b9ykfk8r94d2174ki93jd9j"
+   "commit": "b237ee8e9fd2fd1b52254ef84cd06a0bb6c10a24",
+   "sha256": "0bimn8j3md579sg7bypsynmjnq1mlmmslci1k98sc8kfnky8260c"
   },
   "stable": {
    "version": [
     0,
     4,
-    3
+    5
    ],
    "deps": [
     "f",
     "ivy",
     "s"
    ],
-   "commit": "4727ac0dd7906807c830e2abdd3e081812105ad6",
-   "sha256": "0ia0a38f3dfiqz96fc405ax472zyj92yn61qs9mpdz8ql3pv2dwb"
+   "commit": "b237ee8e9fd2fd1b52254ef84cd06a0bb6c10a24",
+   "sha256": "0bimn8j3md579sg7bypsynmjnq1mlmmslci1k98sc8kfnky8260c"
   }
  },
  {
@@ -55067,8 +55404,8 @@
     "hydra",
     "ivy"
    ],
-   "commit": "cbce9ce71429c98c67bd76ef15d049ecced042f7",
-   "sha256": "08lgvpvkhp2i9q73bnr2v17w864rwp6wjnrl3b7qg06dacfs2rvl"
+   "commit": "e0374dc0bbcd8ab0ec24baf308d331251d4f9c49",
+   "sha256": "1zvcp35vnnz5iybihrw0r21pvkghn73ni2m9jkgf352n8zza7z9g"
   },
   "stable": {
    "version": [
@@ -55111,15 +55448,15 @@
   "repo": "ROCKTAKEY/ivy-migemo",
   "unstable": {
    "version": [
-    20201214,
-    307
+    20210206,
+    919
    ],
    "deps": [
     "ivy",
     "migemo"
    ],
-   "commit": "0f34245dae2f890c685be767e3dc2c24c65dfe28",
-   "sha256": "1d013v8nb83g1hkfc5vxf5y7m67fi8346xm912hyyy03871kb469"
+   "commit": "9cdf3823b3303d69c0c77dfee91136817da12aea",
+   "sha256": "0nxk1i208zm6p666920gh1nmrfhfqglhgs07b5ir4b7mz3m5caab"
   },
   "stable": {
    "version": [
@@ -55234,15 +55571,15 @@
   "repo": "tumashu/ivy-posframe",
   "unstable": {
    "version": [
-    20201215,
-    39
+    20210122,
+    45
    ],
    "deps": [
     "ivy",
     "posframe"
    ],
-   "commit": "83047d440ff132d5a45acde5955f71853edeefb9",
-   "sha256": "03n1a9qzc53i3lx0ywayc2v8p0n4ydl7ly6niaj9dj15ik0nzxsp"
+   "commit": "3132719a9a7c04431fe65f1dced8acafe789bdf6",
+   "sha256": "133l0rd3iwphj9xcgww5m54mmyfd7icr46s792awlpc1ch7748c3"
   },
   "stable": {
    "version": [
@@ -55328,14 +55665,14 @@
   "repo": "Yevgnen/ivy-rich",
   "unstable": {
    "version": [
-    20201224,
-    4
+    20210212,
+    1441
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "f8a1f5c90d2a113b597ef5903634c089fce3365b",
-   "sha256": "1bwp26b7m3zxl00ywav7qfwlszxms3z00w41k7nvb47a4s0cvffl"
+   "commit": "7b9b7b20c3ead81da90232cd6707dfad3c1f1eb3",
+   "sha256": "03p13z609ighdq4axls93alqfl7pclx12g4vdd7lwpcy0r0cgyf8"
   },
   "stable": {
    "version": [
@@ -55365,8 +55702,8 @@
     "ivy",
     "rtags"
    ],
-   "commit": "39339388256df662d0084b4a094d03e52748f9e8",
-   "sha256": "0wp4mygsxzibra2p3m5rn9m0yd3fscd795k5xa0wxi5pwddv7dlg"
+   "commit": "aa4c827b417f5448c12401c33acdab1325917c13",
+   "sha256": "02jqcbrpxm4sv15l8kyvsw9pwkmamj065cgifj68x242fw2f0sam"
   },
   "stable": {
    "version": [
@@ -55389,8 +55726,8 @@
   "repo": "jcs-elpa/ivy-searcher",
   "unstable": {
    "version": [
-    20201001,
-    834
+    20210124,
+    1641
    ],
    "deps": [
     "f",
@@ -55398,14 +55735,14 @@
     "s",
     "searcher"
    ],
-   "commit": "8eb55ff22b4b833094232acb35ec46261f069fa3",
-   "sha256": "0in9xihr2v6xn7iqlj5zz0h127bg4yf9hmrfvgxn53pcivzj9vw9"
+   "commit": "46a461eb873083bc53d7fd3a15b266c52b3cbfb4",
+   "sha256": "1qsbbpmk3211lm29mks7r3dfphyikbkkj94028748y6ngwqk1vb4"
   },
   "stable": {
    "version": [
     0,
     3,
-    8
+    10
    ],
    "deps": [
     "f",
@@ -55413,8 +55750,8 @@
     "s",
     "searcher"
    ],
-   "commit": "8eb55ff22b4b833094232acb35ec46261f069fa3",
-   "sha256": "0in9xihr2v6xn7iqlj5zz0h127bg4yf9hmrfvgxn53pcivzj9vw9"
+   "commit": "46a461eb873083bc53d7fd3a15b266c52b3cbfb4",
+   "sha256": "1qsbbpmk3211lm29mks7r3dfphyikbkkj94028748y6ngwqk1vb4"
   }
  },
  {
@@ -55995,8 +56332,8 @@
     "auto-complete",
     "jedi-core"
    ],
-   "commit": "9d5f29116c4d42cae561a9d69e6fba2b61e2cf43",
-   "sha256": "1bckxppfzd5gwn0aw4h86igb7igal9axqncq7j8zmflg7zppncf1"
+   "commit": "3a9c503c35359d6bca6ff90c384c104c8743cdab",
+   "sha256": "1rx3qiicgg9p0chbfx8v1aypk93p6r5wlkia0b2sqr796r7xdn35"
   },
   "stable": {
    "version": [
@@ -56020,16 +56357,16 @@
   "repo": "tkf/emacs-jedi",
   "unstable": {
    "version": [
-    20191011,
-    1750
+    20210202,
+    856
    ],
    "deps": [
     "cl-lib",
     "epc",
     "python-environment"
    ],
-   "commit": "9d5f29116c4d42cae561a9d69e6fba2b61e2cf43",
-   "sha256": "1bckxppfzd5gwn0aw4h86igb7igal9axqncq7j8zmflg7zppncf1"
+   "commit": "3a9c503c35359d6bca6ff90c384c104c8743cdab",
+   "sha256": "1rx3qiicgg9p0chbfx8v1aypk93p6r5wlkia0b2sqr796r7xdn35"
   },
   "stable": {
    "version": [
@@ -56396,11 +56733,11 @@
   "repo": "Michael-Allan/Java_Mode_Tamed",
   "unstable": {
    "version": [
-    20210114,
-    900
+    20210206,
+    1851
    ],
-   "commit": "6a307c7ee17d44f1b0fe3dfba2bc34e0ca055818",
-   "sha256": "0q8y512l91r32igdksc6i2gwv0csl35xqlnx1cw41fwdpnbvdx4m"
+   "commit": "fd9be900549bb0c0a373d6fd1552295f1e8a1d08",
+   "sha256": "0g9bihlmq6bwbyzk9zr3gig5w0vaysz1gsdqacq604jls34ks491"
   }
  },
  {
@@ -57239,23 +57576,26 @@
   "repo": "tpapp/julia-repl",
   "unstable": {
    "version": [
-    20210114,
-    1549
+    20210124,
+    923
    ],
    "deps": [
     "s"
    ],
-   "commit": "0774d3b5b954e82e5bbcbe5123c689341297b01e",
-   "sha256": "056zv48nbqvnadca4q2hh0aal2bz00f9ayzqpwnsxl482p8bi93k"
+   "commit": "7ce38a9caf2a9c105afe66f464a2f30e816d69f3",
+   "sha256": "11vpqqnxqj9nxh8kccj4y6h3f8lib6jxnsk6vxc2j2fqw6alnafm"
   },
   "stable": {
    "version": [
     1,
-    2,
+    3,
     0
    ],
-   "commit": "b8155b8a1e23e1ad740fd7bd49b5d841b1365c7d",
-   "sha256": "0qdn70h6k03l3xmv4xmbvrs1lx632jihhmkvjxk5hp4nk5phh9rk"
+   "deps": [
+    "s"
+   ],
+   "commit": "7ce38a9caf2a9c105afe66f464a2f30e816d69f3",
+   "sha256": "11vpqqnxqj9nxh8kccj4y6h3f8lib6jxnsk6vxc2j2fqw6alnafm"
   }
  },
  {
@@ -57330,8 +57670,8 @@
    "deps": [
     "vterm"
    ],
-   "commit": "06ee45bffb6e711278a7af5207899d2b4316706c",
-   "sha256": "1zwhbwm285gqy9bfhlaaa9wp3lz959i3d1s41msl70jxbrnjz7pw"
+   "commit": "c051cdc4ba574039b622fce37a5f61685dcc6d89",
+   "sha256": "0ixlh640106cdvdnnmr7p6n0c5bg5qzyk9mspylsnlgiws4gz1ff"
   },
   "stable": {
    "version": [
@@ -57477,8 +57817,8 @@
   "repo": "nnicandro/emacs-jupyter",
   "unstable": {
    "version": [
-    20200417,
-    1907
+    20210116,
+    255
    ],
    "deps": [
     "cl-lib",
@@ -57486,8 +57826,8 @@
     "websocket",
     "zmq"
    ],
-   "commit": "360cae2c70ab28c7a7848c0c56473d984f0243e5",
-   "sha256": "1bn0jwpigpl5n45vpz73vv12g078151vyhkkhkwy5xqx627swxf9"
+   "commit": "6ce8d01e3a550a3268b415bf9d9b635d4dba5940",
+   "sha256": "1l0a6abyshrr6wb9xhgwgkdcarnhxj929rg52zf63xix351dlqi9"
   },
   "stable": {
    "version": [
@@ -57694,16 +58034,16 @@
   "repo": "jmorag/kakoune.el",
   "unstable": {
    "version": [
-    20201111,
-    2159
+    20210212,
+    2031
    ],
    "deps": [
     "expand-region",
     "multiple-cursors",
     "ryo-modal"
    ],
-   "commit": "fa27e48b49d42ed6d8b4492d7c734b0f1e647fc1",
-   "sha256": "1qg6crhqraj78frdqbqr260j9l0h8cdp96bqzwjwai8ia16zskn7"
+   "commit": "34af1bc1225b044d9a15d8c276b7e33b12cb8720",
+   "sha256": "08b1r4yz7ikzwxn4hlip75vmd77hc8nsmiphdw46a9h6w9aw0v30"
   }
  },
  {
@@ -57834,15 +58174,15 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20201216,
-    717
+    20210206,
+    1553
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "5694f27f6e17bf2d840fa04728d392b5df77e20c",
-   "sha256": "1c5hdr654f012lj3ssxsavbnij0i109nykwcsgl2c2pb9yxqr5rw"
+   "commit": "097ffb434feb149bce548dfe4daf99d604abb1bd",
+   "sha256": "00svj1w9iyf7qh1s49d955j1q7ja8fcs5kwd6prjmg61whlqnyik"
   },
   "stable": {
    "version": [
@@ -57984,14 +58324,14 @@
   "repo": "conao3/keg.el",
   "unstable": {
    "version": [
-    20201204,
-    406
+    20210201,
+    821
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "18c675aa2ff1749eb42f081f0549398b82cd4540",
-   "sha256": "1mz5rfzyv4varn09pza5yb851vmsbicsz4zgc0y7zni2bhlj9250"
+   "commit": "10c70dba667752c3612e69a190e097677fef268d",
+   "sha256": "137xjq1ky9d9ddklzfmfnd5bz75bw0bkqr4ajq3m8al28wpld3k5"
   }
  },
  {
@@ -58005,8 +58345,8 @@
     20200601,
     333
    ],
-   "commit": "18c675aa2ff1749eb42f081f0549398b82cd4540",
-   "sha256": "1mz5rfzyv4varn09pza5yb851vmsbicsz4zgc0y7zni2bhlj9250"
+   "commit": "10c70dba667752c3612e69a190e097677fef268d",
+   "sha256": "137xjq1ky9d9ddklzfmfnd5bz75bw0bkqr4ajq3m8al28wpld3k5"
   }
  },
  {
@@ -58034,6 +58374,14 @@
    "version": [
     20201109,
     1358
+   ],
+   "commit": "7fd89c306c975a1fa3ab16ba7a4d3b102130a868",
+   "sha256": "1m1p3iydn5s3dlmjv751ligbwxkg472rhcbk80q2y1lnwjsnbhdy"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
    ],
    "commit": "dda02615b45a86c806d61e0484e08aa51343f8d8",
    "sha256": "08zxn25jbd3sqwd2bsbnh9kj8jf5jygyf8x4i8i6k89jw2fd7mds"
@@ -58168,11 +58516,11 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20201229,
-    1006
+    20210123,
+    1149
    ],
-   "commit": "b02892ec77ef8b83c957652c7859422d6f46e051",
-   "sha256": "1ggl3k2h9y7nwhawpddl0mk9smm5bpq42fyp1pq64z67zrb4217l"
+   "commit": "a3a0798349adf3e33277091fa8dee63173b68edf",
+   "sha256": "08n4lfd6zb0qwpaw48q7p1mi6rn5rzja02113fphz7ra2kapbpva"
   },
   "stable": {
    "version": [
@@ -58265,26 +58613,26 @@
   "repo": "tarsius/keymap-utils",
   "unstable": {
    "version": [
-    20201125,
-    1434
+    20210125,
+    823
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "6cefdf42d95a20565d51974d73ad38749c46cddd",
-   "sha256": "0qlp9hfb3kzp36c03zjxv7sxgsikqmfjm0ynvgqch3bccwqbsz1v"
+   "commit": "0b282e19ac3d23b9a74f656b137b9eebeb2aaa39",
+   "sha256": "0ni03xnakai9ncq07gwzqy4walgijd04bnxslk3b4xnnk60i8m2h"
   },
   "stable": {
    "version": [
     3,
-    0,
-    3
+    1,
+    0
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "195e0ca5b1b9967faf94a3e5a634d8975b796705",
-   "sha256": "0ckv9mbqb1f2lp17sv3nxjwww4ph9v3bhlxwvchvkkdlbcg87i5n"
+   "commit": "0b282e19ac3d23b9a74f656b137b9eebeb2aaa39",
+   "sha256": "0ni03xnakai9ncq07gwzqy4walgijd04bnxslk3b4xnnk60i8m2h"
   }
  },
  {
@@ -58297,6 +58645,14 @@
    "version": [
     20190109,
     530
+   ],
+   "commit": "f7041deccd9d03066c2fe41c3443c42a4713ac02",
+   "sha256": "1pj621z2ywwx6kybhyifm9grp9bkhk6f3fwancn0x53c33zp2daq"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
    ],
    "commit": "9de65a27e10d8ae47aa6d28c02c3eb82ee8c0b2e",
    "sha256": "1ybbayxfix63rwc8p5kl4wxxlk6vg53abw40fqrlkbc6qrr7nm5c"
@@ -58603,8 +58959,8 @@
     20180702,
     2029
    ],
-   "commit": "554e98fb7c439d182a48dce7276932139a325f02",
-   "sha256": "1afw0ak9wbf63d23sfp78a9ial4vscw002p0b47rlsq895j683cb"
+   "commit": "7f8a887e153e9924d260069c0184958c0b53e57b",
+   "sha256": "0hzmsr911y2r701l92hjx0nh1w58407jfkn8ky8mymvszb0qggy3"
   },
   "stable": {
    "version": [
@@ -58888,8 +59244,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20201223,
-    1730
+    20210212,
+    2154
    ],
    "deps": [
     "dash",
@@ -58897,8 +59253,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "9b1aa4830a4470ff8f11ecc0bc80b5cdaee473fd",
-   "sha256": "1n1z8w2n7raxfmd4la2knzvs9vnprcdhxjlp21k6r757k75na3qn"
+   "commit": "5d5639cac5d98bca74cad44b5a1e128df77050bd",
+   "sha256": "059yqvr36gycqdbnls2nbsd34q16wxyi2paxqlh7wc053h2y7zp3"
   },
   "stable": {
    "version": [
@@ -58930,8 +59286,8 @@
     "evil",
     "kubel"
    ],
-   "commit": "9b1aa4830a4470ff8f11ecc0bc80b5cdaee473fd",
-   "sha256": "1n1z8w2n7raxfmd4la2knzvs9vnprcdhxjlp21k6r757k75na3qn"
+   "commit": "5d5639cac5d98bca74cad44b5a1e128df77050bd",
+   "sha256": "059yqvr36gycqdbnls2nbsd34q16wxyi2paxqlh7wc053h2y7zp3"
   },
   "stable": {
    "version": [
@@ -59185,16 +59541,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20210115,
-    651
+    20210208,
+    908
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "e4205c5da3a0c99f0b29677736711ee069e2c175",
-   "sha256": "0kxdli25dbzq7mjinnvfxy2x9zy79062l45kafpayywa1ipwgfkp"
+   "commit": "c05332eb20f98fd1dba05279a5a02a7c819aa342",
+   "sha256": "0fyrzpphs7lahzqgcljbfd4lgcj566f3wyc4ym8x5jl6vd6kdr0g"
   }
  },
  {
@@ -59301,25 +59657,25 @@
   "repo": "lassik/emacs-language-id",
   "unstable": {
    "version": [
-    20201217,
-    1633
+    20210207,
+    1829
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3f0ad28202207c266bd8fc7904b224db69ceccf6",
-   "sha256": "0rc6hggdqpfvcq1kx6ghnzqzn7842331b0qfng42vmqn44mk9skx"
+   "commit": "2c99ce29b86fc635649f4e89723912dc1cc4f36c",
+   "sha256": "12fzzdc4jns440gb71iydsicni646gciaxv50p0wrfk9mbppidck"
   },
   "stable": {
    "version": [
     0,
-    10
+    12
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3f0ad28202207c266bd8fc7904b224db69ceccf6",
-   "sha256": "0rc6hggdqpfvcq1kx6ghnzqzn7842331b0qfng42vmqn44mk9skx"
+   "commit": "2c99ce29b86fc635649f4e89723912dc1cc4f36c",
+   "sha256": "12fzzdc4jns440gb71iydsicni646gciaxv50p0wrfk9mbppidck"
   }
  },
  {
@@ -59817,8 +60173,8 @@
   "repo": "leanprover/lean-mode",
   "unstable": {
    "version": [
-    20200930,
-    604
+    20210209,
+    1734
    ],
    "deps": [
     "dash",
@@ -59827,8 +60183,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "cc1f5fadf8e9ae08aa25828985edc97df04d94a7",
-   "sha256": "0v03bisr0ljk1ypbicgh9izxwazz8ry5xcd7r1lqb339xqb0bzqb"
+   "commit": "15bee87dc4080b87c543964375b7ce162317ab6f",
+   "sha256": "127b7ny5mr1y14yg54gy7an3lk3928w4y9a22295i4v4zgj704j4"
   }
  },
  {
@@ -59879,11 +60235,11 @@
   "repo": "pfitaxel/learn-ocaml.el",
   "unstable": {
    "version": [
-    20200224,
-    2229
+    20210209,
+    4
    ],
-   "commit": "86505672be0aabc9fa1048bc453ab2fc855b27e1",
-   "sha256": "00j6j2n0z616r9p78wp8hk62d9s2dpzlmflfm7ilrx40dnd4nlgj"
+   "commit": "ac7e2887baebedd51afbadc9e4c6f7b59351b0bb",
+   "sha256": "0v6nw2yqy8lhwssq2myx91jjlsg8d97f60yhrpjk3qc62037q60b"
   }
  },
  {
@@ -59924,11 +60280,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20210106,
-    227
+    20210118,
+    2040
    ],
-   "commit": "bcd8cefb720702db88986a52bb66e08e2e451c05",
-   "sha256": "1l2lhz45lc7njdv3kl5g8z5ig6vykxlp446raaif14k2flhw24a0"
+   "commit": "643f29cd618db5366fa8ff442548d124528355c6",
+   "sha256": "1vip1yc4vf4213kjxal1bff7bw776b8mhk8f3h56rnp7siah2m1n"
   },
   "stable": {
    "version": [
@@ -59963,8 +60319,8 @@
   "repo": "kaiwk/leetcode.el",
   "unstable": {
    "version": [
-    20200730,
-    1433
+    20210121,
+    1600
    ],
    "deps": [
     "aio",
@@ -59973,8 +60329,8 @@
     "log4e",
     "spinner"
    ],
-   "commit": "153a3a6a9ffb64ffce37b3d203c13a85cc1884ab",
-   "sha256": "0600njpn3dvd8xrj21r5p69mc1r76ri1bjcxy2krp53dnsy3nvfb"
+   "commit": "5b17bc254e225b880e94ff5dad5caa60b270eecc",
+   "sha256": "18qnzgysdzadwy97s6fcfmcjs8gnrqkgqxfgq1130r1b36gjixqg"
   },
   "stable": {
    "version": [
@@ -60208,6 +60564,25 @@
   }
  },
  {
+  "ename": "lexic",
+  "commit": "d7c4ddd3b6eb8243e6a4bdb9188e95ad24bfcf5e",
+  "sha256": "1im7x26gkhk3lkfx8r36q9aa0wayhi1dvbsrighn3pg86bl1k5cs",
+  "fetcher": "github",
+  "repo": "tecosaur/lexic",
+  "unstable": {
+   "version": [
+    20210203,
+    358
+   ],
+   "deps": [
+    "dash",
+    "visual-fill-column"
+   ],
+   "commit": "e59224cd5808af50e8b9ba8cce0a687cf09aacc1",
+   "sha256": "1si5ndfs8xbk96iiwcwlhi57k914jnsq3zdgvlb7xm3y8zjy2l6x"
+  }
+ },
+ {
   "ename": "lfe-mode",
   "commit": "c44bdb00707c9ef90160e0a44f7148b480635132",
   "sha256": "0smncyby53ipm8yqslz88sqjafk0x6r8d0qwk4wzk0pbgfyklhgs",
@@ -60218,8 +60593,8 @@
     20201007,
     2214
    ],
-   "commit": "e5f20c459a13b35ed1e71b1d2667363af168e958",
-   "sha256": "0fapq9b14lxx5qm55yhcj2f1ym0kfrh6796ffb2i032bprh8n3m6"
+   "commit": "89683794014cab79d2cb7362f901d03c6d3b8c00",
+   "sha256": "09cflqn4g9s6hz91882w9vnkwzpbba796jhcyvxr23qbv14q7257"
   },
   "stable": {
    "version": [
@@ -60495,8 +60870,8 @@
     20180219,
     1024
    ],
-   "commit": "30cc83af69216ceced310c058ffae48bbe67fed1",
-   "sha256": "143l1fb3i0z7dxd39lw5qds62kv5ii9wy4gbqy3jg11swva0xkcd"
+   "commit": "3f42011e08dd4c15f20b620cdd5008cc1d9ef65f",
+   "sha256": "0fdl4prvhn905y8js8hd6dysxisrrvz51g5dqd22cs8w06zk6zis"
   },
   "stable": {
    "version": [
@@ -60807,8 +61182,8 @@
   "repo": "abo-abo/lispy",
   "unstable": {
    "version": [
-    20201226,
-    1746
+    20210121,
+    926
    ],
    "deps": [
     "ace-window",
@@ -60817,8 +61192,8 @@
     "iedit",
     "zoutline"
    ],
-   "commit": "1ad128be0afc04b58967c1158439d99931becef4",
-   "sha256": "15an4nbpri49imvkbhhynsmczkzhl4i037r8hcg4mam3w5nw14y8"
+   "commit": "38a7df4cbb16cfe3d62dc8ea98b50e2d9a572e58",
+   "sha256": "1q3sgk8ffwajmh8l7c4p4fz36xw4fqds8yqblbi5kardaa8bs8cs"
   },
   "stable": {
    "version": [
@@ -60853,8 +61228,8 @@
     "evil",
     "lispy"
    ],
-   "commit": "0f13f26cd6aa71f9fd852186ad4a00c4294661cd",
-   "sha256": "0ah59s9c24addlx1rxgm11jihn7w45xrf0wrmrb7mbmqf3rj3izc"
+   "commit": "89316f01822b2135e52ca27fd308d207ef618052",
+   "sha256": "10k3hxxpx2v2k4dyad7j1bzmr1q7rzvv4y6c67pa9zcqyaw8m91v"
   }
  },
  {
@@ -61131,14 +61506,11 @@
   "repo": "jingtaozf/literate-elisp",
   "unstable": {
    "version": [
-    20200708,
-    803
+    20210130,
+    107
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "722b7b3988336642167e0e0db12800a23410ab07",
-   "sha256": "19fckshqp1dxf7msjjk6cd506i0ydzqb1fqz879pfbbvhg6iclva"
+   "commit": "de73de9e8060574cb0c85be4ec3b5d8ff8a92b7b",
+   "sha256": "19kyrvpkmbgiygcxr3hyrba9smz33y0adz5fwh1kb5qhcyrq8jw7"
   },
   "stable": {
    "version": [
@@ -61335,6 +61707,36 @@
    ],
    "commit": "f551a7e1d5ecd64608db744d0f0e24aa0b8645fe",
    "sha256": "1d8m7pbfny0bkbaq609k1m8y5cd2lm0w1dnl53lls9ahyz60hdk4"
+  }
+ },
+ {
+  "ename": "llama",
+  "commit": "773b273063715a9b4373f23c583880948d812826",
+  "sha256": "13i2s5aqgk3hb3b3rvm597dhapajbsybr3vrkjswq5p36mda66fq",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~tarsius/llama",
+  "unstable": {
+   "version": [
+    20210201,
+    837
+   ],
+   "deps": [
+    "seq"
+   ],
+   "commit": "fa28bed90b77487e275e3908c3bd0f00f94ab88b",
+   "sha256": "1f58d1y44m3ac2db8yddhrxjpv2503di08p0v46103pnlm7a245q"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "seq"
+   ],
+   "commit": "2027ce79165bf40314ad838c282920c53b5d7eae",
+   "sha256": "1jnll9xaxfwwvs0xjpdz8y6xlrsckm3a8ri5ml8k3fp81yby9as5"
   }
  },
  {
@@ -61622,11 +62024,11 @@
   "repo": "Wilfred/logstash-conf.el",
   "unstable": {
    "version": [
-    20200725,
-    1843
+    20210123,
+    1949
    ],
-   "commit": "131565042f8f12b9b88bd477959246dd034fa7d6",
-   "sha256": "1cyrmhnc38piw8q6d8j8xwyk0vl0a00mzjhmswkwd76w06adr9md"
+   "commit": "ebc4731c45709ad1e0526f4f4164020ae83cbeff",
+   "sha256": "1bjmd1xy45p4v2307sxd6mna9iqxvvz82sx5jbdf3hz5d71w5vfn"
   },
   "stable": {
    "version": [
@@ -61785,35 +62187,6 @@
   }
  },
  {
-  "ename": "love-minor-mode",
-  "commit": "0f224c4c7519b3668b1270c957227e486896b7b6",
-  "sha256": "1skg039h2hn8dh47ww6n9l776s2yda8ariab4v9f56kb21bncr4m",
-  "fetcher": "github",
-  "repo": "ejmr/love-minor-mode",
-  "unstable": {
-   "version": [
-    20170727,
-    536
-   ],
-   "deps": [
-    "lua-mode"
-   ],
-   "commit": "3ca8f3405338f2d6f4fbcdd5e89342a46378543a",
-   "sha256": "1hwm7yxbwvb27pa35cgcxyjfjdjhk2a33i417q2akc7vppdbcmzh"
-  },
-  "stable": {
-   "version": [
-    1,
-    2
-   ],
-   "deps": [
-    "lua-mode"
-   ],
-   "commit": "3ca8f3405338f2d6f4fbcdd5e89342a46378543a",
-   "sha256": "1hwm7yxbwvb27pa35cgcxyjfjdjhk2a33i417q2akc7vppdbcmzh"
-  }
- },
- {
   "ename": "lox-mode",
   "commit": "8a4f385fd128097781b563ad91d4aa8301167f5e",
   "sha256": "14mqn4r2jmz661gyvzm48s9qb98w75sjflmrgqg6sslaca98jrpi",
@@ -61850,8 +62223,8 @@
    "deps": [
     "lispy"
    ],
-   "commit": "c3da907fdc1c7da8b0c19721605bf63d9d1be404",
-   "sha256": "1znjl9v72sy87ir6ia1qkgrfnxdgh9fk5pdl4k002labmsi2aw93"
+   "commit": "076ce9acb68f6ac1b39127b634a91ffd865d13d8",
+   "sha256": "10sab50wmr3zn7jgzx93201ymhmacqacn3m2qllsqkfw2gpsi6dn"
   }
  },
  {
@@ -61874,8 +62247,8 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "be9f979fa9cb098d064c3ab26d1f7ea7c65cbd23",
-   "sha256": "03g97sm3y5y1y8crwlc8kvpgrrljyym5yq6qz9llpwy8cg9srchw"
+   "commit": "69e36b6c824c165527a25b9e6e754eea659a878e",
+   "sha256": "1k4dxi1yv0w0k99qlpaz2wsvnb31p33ypqvbh9x3fqj6kp720biq"
   },
   "stable": {
    "version": [
@@ -61955,15 +62328,15 @@
   "repo": "emacs-lsp/lsp-haskell",
   "unstable": {
    "version": [
-    20210108,
-    1332
+    20210209,
+    2150
    ],
    "deps": [
     "haskell-mode",
     "lsp-mode"
    ],
-   "commit": "5d3f4814f6ac44547a62551472cc76fbaebcccf7",
-   "sha256": "0qak0vl9jicx9sv4sa2ash5agxxsx8qycp4jk3wxs96q5kjshf62"
+   "commit": "7efbef3d206989faa8b691a4230a3ed872542187",
+   "sha256": "15xp3gjj9zdvxbhcgw21108s9y99rfmih5sqlk7f0m9hw5mqw4zm"
   }
  },
  {
@@ -62025,8 +62398,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20210105,
-    1625
+    20210122,
+    2024
    ],
    "deps": [
     "dap-mode",
@@ -62039,8 +62412,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "33364a268a61366f1a07596e9fe7bd0f6d73fd90",
-   "sha256": "0ii26773cm945z1s4vyfqgzjsizv1a9wiadgg3klnfz9748y93a4"
+   "commit": "e56fb65bf17af46fa13d4527530c491dd798edcd",
+   "sha256": "0gp31yj65rs30a1a9wjidm6r6qkhpf5azpisdl2dvh4f2jypc2ll"
   },
   "stable": {
    "version": [
@@ -62157,8 +62530,8 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "2140e65fc5d759cdf163128ef6ab15c246d6039b",
-   "sha256": "10qf62c6raqhikhmfrav6qhc1mj229mrabzs1swyc06sx1sgkiwf"
+   "commit": "5fc536f24dc659f998bc673129d9e7c4b20d297c",
+   "sha256": "1k34zpg6f3i1pb68zh6fc7azd4hmbclnjpad1893q2zhqwxqdwz8"
   },
   "stable": {
    "version": [
@@ -62224,8 +62597,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20210114,
-    1955
+    20210213,
+    910
    ],
    "deps": [
     "dash",
@@ -62236,8 +62609,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "0062a7cd4ab674390287e6b20d93ac42ed1f5512",
-   "sha256": "16awnan07b6ayf0rnxs8hal468bc7i24gw0l849s04v41y2i35cg"
+   "commit": "83334f62b58feed06c0438671bfc550efcbebe63",
+   "sha256": "1vkc2ffl08d36cgr69g3fl1lmkpr33qzzsxmm7zzaa0b6hzba58d"
   },
   "stable": {
    "version": [
@@ -62288,15 +62661,15 @@
   "repo": "emacs-lsp/lsp-origami",
   "unstable": {
    "version": [
-    20200914,
-    1846
+    20210126,
+    843
    ],
    "deps": [
     "lsp-mode",
     "origami"
    ],
-   "commit": "aa309589668d32a8b4bb23c8f41163f6ae208f7b",
-   "sha256": "1l5n01icyp00ljcs5sfk3wbp74gn53p0mj1l4fqdpi70c1wahwmv"
+   "commit": "bedea3d25552d6969e917a15a0acc3d333ddc742",
+   "sha256": "0sbqplrchfz7d662xk1xjrgxvijd3dzwpvphaksv6agv4bjikbad"
   },
   "stable": {
    "version": [
@@ -62405,14 +62778,14 @@
   "repo": "emacs-lsp/lsp-python-ms",
   "unstable": {
    "version": [
-    20201023,
-    1750
+    20210123,
+    1748
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "c4ebc7a11398733055a1dc07f9cffacd04d1c2dc",
-   "sha256": "0sdvqnk598gdzjrzrgwqg2m8fzs9dpbbzsp70hqnrkp14x9jklmi"
+   "commit": "5470ada6cde6e68fe6ce13ff1146c89c3bae0cc8",
+   "sha256": "1m9nwnwyabbl7gxkyf43mvi76i6qnkqbpy7f5hvx84674pcjnh06"
   },
   "stable": {
    "version": [
@@ -62475,8 +62848,26 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "948c3a35fd05496a77af2d8935e754db112cb4c3",
-   "sha256": "1n9jfaq1w2vxhv2gpvmj3qyc8bwacyj6kdyw62hlgbl7xnhhhc6d"
+   "commit": "ff204ed820df8c3035ebdc4b5a583640d52caeeb",
+   "sha256": "1q9ml3r827am27fhs9vlrgsxnq43k3zjb3h5mi999da1nhqwcs49"
+  }
+ },
+ {
+  "ename": "lsp-tailwindcss",
+  "commit": "c837c3b97d7e833d22a1605dcf3c2ebc35c19e0c",
+  "sha256": "0cnkj1ahp48i8zx1qh0fbxf40cnv6d1i9c579kmkfmfbnvxpp080",
+  "fetcher": "github",
+  "repo": "merrickluo/lsp-tailwindcss",
+  "unstable": {
+   "version": [
+    20210208,
+    1458
+   ],
+   "deps": [
+    "lsp-mode"
+   ],
+   "commit": "0558fd1cdbc31c48ca02308bee1b65c77f3fce3a",
+   "sha256": "0lbpwcf6vnk99rk3mzq3mbh4nxgl6prjrrak2aq9c789n7qainfr"
   }
  },
  {
@@ -62487,8 +62878,8 @@
   "repo": "emacs-lsp/lsp-treemacs",
   "unstable": {
    "version": [
-    20201230,
-    2214
+    20210131,
+    911
    ],
    "deps": [
     "dash",
@@ -62498,8 +62889,8 @@
     "lsp-mode",
     "treemacs"
    ],
-   "commit": "64e375fcc700d4d47cf52ad912e6863d479e3bfa",
-   "sha256": "19wy4xk0ll8pxdyq74a0zjlqkssc6ww21ac79zihndv90604c5km"
+   "commit": "10c34fc213f9aff29b5fe86b26bfc216b14c631e",
+   "sha256": "0l5473fa880993k02rz1bxwcp701q874bv1bx5caa4vygvm0rhiw"
   },
   "stable": {
    "version": [
@@ -62520,14 +62911,14 @@
  },
  {
   "ename": "lsp-ui",
-  "commit": "883d739e46c32c95adcf41835078ba3604188eda",
-  "sha256": "0n4z7gmpkbz9azbk8pi4f368396y4s9bpqvkdykzq6ykqyswk4bm",
+  "commit": "c4b521f55483fd176f4a3f4fc5e0799fe4506580",
+  "sha256": "0g6pkdr05yihw6fl651yih5fa51kv2l1xy4sr4487z2m4azb223b",
   "fetcher": "github",
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20210110,
-    1507
+    20210202,
+    551
    ],
    "deps": [
     "dash",
@@ -62535,8 +62926,8 @@
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "fbe9a859f0b50097270ccf1314952de2d2039c12",
-   "sha256": "01xw3jpwffk5gg86s5n2i1jwn0xslc9bdbacfxy0iyrn6qp5jr1i"
+   "commit": "732992aa41bb78b7341e28c980817de488b7a317",
+   "sha256": "1cmsyql92ldb0c4phdk8pws2whb6slhy3r52nf10v45bqh9n167m"
   },
   "stable": {
    "version": [
@@ -62565,8 +62956,8 @@
     20201110,
     1250
    ],
-   "commit": "9454aeeb665df360543b47e162f03276a16b01a5",
-   "sha256": "0ssqqhvc08g5917i4lmsr698zr57v9hpnbw67l1lx48ra4vr6fcr"
+   "commit": "2d9a468b94acd8480299d47449b53136060b7b23",
+   "sha256": "1586k3friamcyfg1xszhkh1vaddrfxji1mn7rd7s8id8f7sp8mnv"
   },
   "stable": {
    "version": [
@@ -62781,8 +63172,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "703ee41303dc251b7672b7cba5aeb6aa54a76c90",
-   "sha256": "0cplbz7mc2zrxfk8g349ahb7gzli2hn5kda9155nbk8dw74xmj7d"
+   "commit": "94240ebb716f11af8427b6295c3f44c0c43419d3",
+   "sha256": "0c3l50qpdzracjncsbjv5chpvjdphhzwqk4jwv31fw6p62i1zvlb"
   },
   "stable": {
    "version": [
@@ -62980,18 +63371,17 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210105,
-    1030
+    20210212,
+    1313
    ],
    "deps": [
-    "async",
     "dash",
     "git-commit",
     "transient",
     "with-editor"
    ],
-   "commit": "25f432551347468ce97b8b03987e59092e91f8f0",
-   "sha256": "0vxsh75xynpfkfvmyyz8x3rppbwr9rgk7zjfil2af2kzba3p27vl"
+   "commit": "47c57839b80c05f792de288da050fabac90639d6",
+   "sha256": "0bpcy6vxbqx50p2cqskpfrk2chnjp3025zmnx33kvq22860f7qi2"
   },
   "stable": {
    "version": [
@@ -63019,15 +63409,15 @@
   "repo": "magit/magit-annex",
   "unstable": {
    "version": [
-    20200516,
-    2028
+    20210210,
+    2312
    ],
    "deps": [
     "cl-lib",
     "magit"
    ],
-   "commit": "c5ecb4b53ea2461e737ea00242ef1e69e35da398",
-   "sha256": "0f1psh03hsb57h3r66zfa0jmwkky12121lhvpynlgj330ryxl5bj"
+   "commit": "71b1522a2d681ab5653f48c7a13ad73330e7914f",
+   "sha256": "152sk0bm33i37ijvnr0427dvfwdzr0jl8s6bjhs9f3ii393k7mwn"
   },
   "stable": {
    "version": [
@@ -63059,8 +63449,8 @@
     "magit",
     "transient"
    ],
-   "commit": "3425ad5b16cb48d6802b7e9ed044b4cd7a99c785",
-   "sha256": "10iinizl99aivrf9zihykabb5lyg62kxbmydwaf7swzxf4dgxn2k"
+   "commit": "2d4bdacf498ed3ff7d2c3574d346b2d24cbb12da",
+   "sha256": "0rbbprjax6af0np1m5prilh2ndbhhlzfrq8sb8mn5vi3is2w1mgs"
   }
  },
  {
@@ -63330,15 +63720,15 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210103,
-    1554
+    20210124,
+    1829
    ],
    "deps": [
     "libgit",
     "magit"
    ],
-   "commit": "25f432551347468ce97b8b03987e59092e91f8f0",
-   "sha256": "0vxsh75xynpfkfvmyyz8x3rppbwr9rgk7zjfil2af2kzba3p27vl"
+   "commit": "47c57839b80c05f792de288da050fabac90639d6",
+   "sha256": "0bpcy6vxbqx50p2cqskpfrk2chnjp3025zmnx33kvq22860f7qi2"
   }
  },
  {
@@ -63486,14 +63876,14 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210103,
-    1631
+    20210124,
+    1824
    ],
    "deps": [
     "dash"
    ],
-   "commit": "25f432551347468ce97b8b03987e59092e91f8f0",
-   "sha256": "0vxsh75xynpfkfvmyyz8x3rppbwr9rgk7zjfil2af2kzba3p27vl"
+   "commit": "47c57839b80c05f792de288da050fabac90639d6",
+   "sha256": "0bpcy6vxbqx50p2cqskpfrk2chnjp3025zmnx33kvq22860f7qi2"
   },
   "stable": {
    "version": [
@@ -63550,13 +63940,13 @@
    "version": [
     2,
     2,
-    1
+    2
    ],
    "deps": [
     "magit"
    ],
-   "commit": "c833903732a14478f5c4cfc561bae7c50671b36c",
-   "sha256": "01kcsc53q3mbhgjssjpby7ypnhqsr48rkl1xz3ahaypmlp929gl9"
+   "commit": "99601f47f47a421576809595ca7463fd010760b1",
+   "sha256": "00lsfkmsz26pz1paqn73skgx747250vc2pa0n8n0h7ywxj9dkzvb"
   }
  },
  {
@@ -64282,11 +64672,19 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20210114,
-    1652
+    20210210,
+    112
    ],
-   "commit": "327ad58bd69a372dc10dbb5b5d3d47f246e28020",
-   "sha256": "0nx5322278vr44aq27kaj5nr0rcq4d3wcbfyb3fpl80asj672m09"
+   "commit": "51f750994aaa0b6798d97366acfb0d397639af66",
+   "sha256": "0d6vif3ymwlddk3f8pg02h3s62kx9zzsbgyvc7cb76g6fk3b46kd"
+  },
+  "stable": {
+   "version": [
+    0,
+    3
+   ],
+   "commit": "62ed158ff588900b9d3e56f3f05f659763c8c2ba",
+   "sha256": "1qihw1vq9sysrl6ha23ggycp0n2n1dx1ajkaqfm5vmv8480al07i"
   }
  },
  {
@@ -64394,11 +64792,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20210112,
-    1557
+    20210210,
+    636
    ],
-   "commit": "3e380572a5177d0fa527c15efd15e340f53a923b",
-   "sha256": "1zhxw0cp95zy3qy9ai9k81zja5m31964nyyrjqzlywxx7zjk4x9g"
+   "commit": "d8267c17eb14d3db2ebd079094df524b547607b1",
+   "sha256": "0h8jpgg0dn8l56kq13gs3dlzr1b6d614gravwjqaywvswiiwnjzn"
   },
   "stable": {
    "version": [
@@ -64461,8 +64859,8 @@
   "repo": "ancane/markdown-preview-mode",
   "unstable": {
    "version": [
-    20181213,
-    1339
+    20210207,
+    2114
    ],
    "deps": [
     "cl-lib",
@@ -64470,8 +64868,8 @@
     "web-server",
     "websocket"
    ],
-   "commit": "f98d9114ca87e3e8e5ce70e601d13061eda15415",
-   "sha256": "1d1id99gagymvzdfa1mwqh8y3szm8ii47rpijkfi1qnifjg5jaq9"
+   "commit": "01af98ac1adcc9cb247fbc6c80fb159c30360ee6",
+   "sha256": "0n6ywxq12jqacdpah350ha6gqryxsh0iix93m0xnyy34dq2by4rc"
   },
   "stable": {
    "version": [
@@ -64907,15 +65305,15 @@
   "repo": "sasanidas/maxima",
   "unstable": {
    "version": [
-    20201226,
-    1538
+    20210124,
+    2005
    ],
    "deps": [
     "s",
     "test-simple"
    ],
-   "commit": "1600cfc059a80ed8fa0d381b88f29ba658811cc5",
-   "sha256": "030sg31xh46vrmsafvn04sdvyv4vzqf8rf5ghrlina1gav6kybfd"
+   "commit": "5e80033e6fa9089d5cd6fa93f6484b544f2ba059",
+   "sha256": "0qh19a3yi5cccj01wxrlyaw1zcaxvpjhxc5qk3mf4f1l8gm1sfi2"
   },
   "stable": {
    "version": [
@@ -65345,16 +65743,16 @@
   "repo": "DogLooksGood/meow",
   "unstable": {
    "version": [
-    20210114,
-    1624
+    20210213,
+    654
    ],
    "deps": [
     "cl-lib",
     "dash",
     "s"
    ],
-   "commit": "d012944ac149358d0e978b10ff0e8a090921e044",
-   "sha256": "0i89v52damd9jhg9sdqghxrcbdybix2cw8hzx6lawg847wc09j06"
+   "commit": "cfcb0d457dd92afb511b9376c9f928f20ab96b89",
+   "sha256": "03sa5bh8ackmbc2gg4nwnc34ij0g4mcmizn7sf1z54lg0d585fdz"
   }
  },
  {
@@ -65365,20 +65763,19 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20191025,
-    851
+    20210129,
+    1443
    ],
-   "commit": "a1a6e02756426f58a885846cbe56c4704b2a79e1",
-   "sha256": "1drx20bj1bb45n6wan0ys04qp4ccqjapi4056qn0ry6fdzx3c35d"
+   "commit": "ecde6900bb9d6dee3683c214993375f65bb39c7c",
+   "sha256": "1fambd8n4hzbmizc04p5m8an84qklc4gpnhz957dpwd3x4prcx2s"
   },
   "stable": {
    "version": [
-    3,
     4,
-    2
+    0
    ],
-   "commit": "c9761a552380838e9f530b5c47c0ea3c47c33565",
-   "sha256": "0i2nwkdh6cfzmnsdsr8aw86vs8j1k5jkjzrs61b9384wnffdbbmj"
+   "commit": "4b7c642c92ea6e6906709bb4656f6cf02ff35289",
+   "sha256": "0ylfp0750k79ylzwjd4f36hfh2jwxsvvi39v4bhc8xy9skl9b88q"
   }
  },
  {
@@ -65626,14 +66023,14 @@
   "repo": "ianxm/emacs-tracker",
   "unstable": {
    "version": [
-    20200602,
-    1032
+    20210207,
+    1100
    ],
    "deps": [
     "seq"
    ],
-   "commit": "6283e1fc5ddb65323513eb77638181551bda967b",
-   "sha256": "12sw627rhvqldbg8cvgg4fim91h3r9qlki5ni1fi0y5sa9iqh20j"
+   "commit": "e0ddd7a17da899fa85b1d49f1260042f8caa0612",
+   "sha256": "0k9lk2z8rnc2pa4wb2afj9byfryqlnw5hg1vs3bx6f0hs8rwa8yh"
   }
  },
  {
@@ -65659,11 +66056,11 @@
   "repo": "kazu-yamamoto/Mew",
   "unstable": {
    "version": [
-    20210113,
-    11
+    20210131,
+    740
    ],
-   "commit": "1dabdcd19ac93223ebc1a488666958e8c224449f",
-   "sha256": "0p5wwxfxds5h5v6jp4z2f423lzz3b3y84da8gw593byqzxd0sbf3"
+   "commit": "8c6bc6bf9562beb74b3b4fda47b2fe473139eb1c",
+   "sha256": "0bf30kkrmi0qw8i0viv1dnvrd52a66rp6vcklidrnv4dh5b782n8"
   },
   "stable": {
    "version": [
@@ -65697,18 +66094,19 @@
   "repo": "danielsz/meyvn-el",
   "unstable": {
    "version": [
-    20200311,
-    2209
+    20210130,
+    2016
    ],
    "deps": [
     "cider",
     "dash",
+    "geiser",
     "parseedn",
     "projectile",
     "s"
    ],
-   "commit": "36166b9bffeb1b5f967be2ab6f3a504632c33a65",
-   "sha256": "1w16sx15fk2m04gl6ahkw2scw6bvpl6bf4g0gf7532rxg339xgjg"
+   "commit": "a49731f39020b7c7626ba12e4c7b2f1c17a69341",
+   "sha256": "13m1qym94qvy197ngd8lyn8nzfsbxbr5ss29mkbvaidhi13jdrwa"
   },
   "stable": {
    "version": [
@@ -65934,11 +66332,11 @@
   "repo": "muffinmad/emacs-mini-frame",
   "unstable": {
    "version": [
-    20201223,
-    1013
+    20210212,
+    2041
    ],
-   "commit": "0912cf4f500403be32735bc50e331fd06910471f",
-   "sha256": "1hnhgx1nyhj814dlcg8mgijnfh30a5vzzinivh2ywgr151wv3b9w"
+   "commit": "41afb3d79cd269726e955ef0896dc077562de0f5",
+   "sha256": "0yghz9pdjsm9v6lbjckm6c5h9ak7iylx8sqgyjwl6nihkpvv4jyp"
   }
  },
  {
@@ -66277,20 +66675,20 @@
   "repo": "jabranham/mixed-pitch",
   "unstable": {
    "version": [
-    20210103,
-    7
+    20210203,
+    2211
    ],
-   "commit": "beb22e85f6073a930f7338a78bd186e3090abdd7",
-   "sha256": "1dhljrh44dsnixd8hbb11k6dgap8r8n7jknhfy2afdzq889fih74"
+   "commit": "d5f64b967d831ea776f07aa2c80cc5fa88a3e869",
+   "sha256": "0gs5pmpkfm4skycmq6agy1hdxjwzw6wvfdkvczdygzvn8hjq2inn"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
-   "commit": "734fbdf2d2c17beee151faf39bd10174a87eea5d",
-   "sha256": "1i0yd7akkyqhkd8g2g793n6syiy0mbnlq9apg7p1s4xycmwxx684"
+   "commit": "beb22e85f6073a930f7338a78bd186e3090abdd7",
+   "sha256": "1dhljrh44dsnixd8hbb11k6dgap8r8n7jknhfy2afdzq889fih74"
   }
  },
  {
@@ -66534,8 +66932,8 @@
     20210115,
     157
    ],
-   "commit": "cc538e5702274ad9e8c6c41c807f890ca38f427f",
-   "sha256": "0ai424aggmavj3yjqpzi8a7cxxz96bm3wdbs7vy4g68xxb88ll7n"
+   "commit": "5b01b3cc51388faf1ba823683c3600790099c84c",
+   "sha256": "0nmi6bsbbgcxihjb865bmm2zrirnzi1lq02d6cl1df57k47md4ny"
   },
   "stable": {
    "version": [
@@ -66752,20 +67150,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20210114,
-    1245
+    20210213,
+    550
    ],
-   "commit": "cefa14959c9118c279adccd151ac77e05b8beb3e",
-   "sha256": "1zqyvqkgy9w0ay0i61gq0mz5dwjdymcq4c2cbypq0adph4dlhkjq"
+   "commit": "2f80b40710d13017a0756830c9e314cf8e3dd82c",
+   "sha256": "0xd4w2aqil4dhv37d2a0h1jb2jsh8rz4zidsq2wznvvz4cylb8ay"
   },
   "stable": {
    "version": [
     1,
-    0,
-    2
+    1,
+    1
    ],
-   "commit": "ab0f558397bb674342176c37c22190c0c1e54cc1",
-   "sha256": "1v82payjgx8z0qdklsrkim7xkb6hqrbs34d5qpq0sii43jwhiy5j"
+   "commit": "585659d36ac41dcc97ab335daa5bde566f088d4b",
+   "sha256": "1n716nasa1pccz7983kicagc9sqnxlyfmflvifqk4kza2ks0rh9m"
   }
  },
  {
@@ -66958,11 +67356,11 @@
   "repo": "belak/emacs-monokai-pro-theme",
   "unstable": {
    "version": [
-    20200525,
-    1430
+    20210206,
+    1820
    ],
-   "commit": "d1bc669200bf5753cf1963e5e65269e0d60648d5",
-   "sha256": "0zqrn1pvlrgbf0yc34bycahvrl8sl67jmc0436yx3lgjwpkvhf0f"
+   "commit": "d0489741a80d818713c290a1a4bdd985877228bb",
+   "sha256": "1nmnmijqfxdxz0cxyfq9fn34cy5bbf6cdg0qvg5mjxrjcfsl57dc"
   }
  },
  {
@@ -67108,20 +67506,20 @@
   "repo": "takaxp/moom",
   "unstable": {
    "version": [
-    20201122,
-    528
+    20210213,
+    721
    ],
-   "commit": "56a6a11b612aa295ef250e5a9879dc5df3b3234d",
-   "sha256": "0smddm5x5m5mv15wdfm04y8hxfzvxh4gkmjr1h8dlp686jg5mvl3"
+   "commit": "2d7ca0b0ad76da4d11f8925e72904f03fd1c869e",
+   "sha256": "0cp8hm9vfb453h47vjxk549km51p06zzw6wjjag42ldj9hnba1v3"
   },
   "stable": {
    "version": [
     1,
-    3,
+    4,
     0
    ],
-   "commit": "1d8344cec018a417cb5845c0717c7400c281caa1",
-   "sha256": "0ig5j4dzb0vxx145yv4ly93hndc2hkbx6dfng2zy7agf124ygh37"
+   "commit": "42d809ed57ad6ed63dde61f75e4b535b2700aaca",
+   "sha256": "0ln8qa51v1r5m2z4cjz7kfdmvq48lwgsdf7z43zmb1nzvn10gcvg"
   }
  },
  {
@@ -67315,20 +67713,20 @@
   "repo": "wyuenho/move-dup",
   "unstable": {
    "version": [
-    20200819,
-    940
+    20210127,
+    1938
    ],
-   "commit": "c5a346d3058011b8152cceeb45858f9b4cef1b69",
-   "sha256": "1dfsfxy7v85qc2gl14gxhngnvkcdbq9gadnsabs1fq56qdgmq814"
+   "commit": "5906503e0b9b832b1d5062c9cd27cf72a2ce4817",
+   "sha256": "138h20zlhqdyacs6563naxlcbksbp9r4ck2jliikix5gaq950chg"
   },
   "stable": {
    "version": [
-    1,
-    1,
-    2
+    2,
+    0,
+    0
    ],
-   "commit": "c5a346d3058011b8152cceeb45858f9b4cef1b69",
-   "sha256": "1dfsfxy7v85qc2gl14gxhngnvkcdbq9gadnsabs1fq56qdgmq814"
+   "commit": "bf2e578b89d7e7bf0b5500d9afcf49ac6ec2dcd1",
+   "sha256": "1hl7sddhs6wzn3z4h55znbix8n7jl9b85sd1b5s6x5n8wxj28gvz"
   }
  },
  {
@@ -67440,11 +67838,11 @@
   "repo": "google/mozc",
   "unstable": {
    "version": [
-    20200822,
-    1229
+    20210109,
+    642
    ],
-   "commit": "1f4fa17372bd196e87042738a16ab08bf904bcbf",
-   "sha256": "180glmkk6wnq5pc02543phih1f71vpvykqkwxs2qv7s7dyf2qg58"
+   "commit": "6ac62d2e888cabb138c8427e6173c04e07bb60e0",
+   "sha256": "1zrhpiwfsxva5v7vdwilf50d8q8gl6kw1nydaika4f1a5321a35i"
   },
   "stable": {
    "version": [
@@ -67661,16 +68059,16 @@
   "repo": "kljohann/mpv.el",
   "unstable": {
    "version": [
-    20200315,
-    2158
+    20210207,
+    1140
    ],
    "deps": [
     "cl-lib",
     "json",
     "org"
    ],
-   "commit": "2d40c4550558eb1bf35a69446777c4e9cae7a623",
-   "sha256": "0f9iq83dfj73gbx7zndvh32b102582lzv4xb8gvqjs26k5bywdxj"
+   "commit": "2d24187f7bdb0495c90d5109a730742e735636ba",
+   "sha256": "1siwl0pjmklpzywn5jmq7jgnsynpa6qafm6mqg9h8gxxbswd5xbi"
   },
   "stable": {
    "version": [
@@ -67931,6 +68329,24 @@
   }
  },
  {
+  "ename": "mu4e-marker-icons",
+  "commit": "52f7c75f26eb02a58ed023a9d709fdcc09e11587",
+  "sha256": "1lyxcw7a842z4ss47sa8gzyh84p886d3qsszz9vl6978gy77i4al",
+  "fetcher": "github",
+  "repo": "stardiviner/mu4e-marker-icons",
+  "unstable": {
+   "version": [
+    20210124,
+    514
+   ],
+   "deps": [
+    "all-the-icons"
+   ],
+   "commit": "e5c4f9b14eab69a0a28f108c6fee3390e19bd080",
+   "sha256": "1a3cinvi0j92j65qfgzmnx6z0xvq4l2jkvw9wydhm3bkmi3v6ni4"
+  }
+ },
+ {
   "ename": "mu4e-overview",
   "commit": "ec240f0f9bc43c5abca557607b0b89a24696744e",
   "sha256": "076lpfj6zrg2ivgbslg9whm4mci278kg45a3km7iadilwipiaxsk",
@@ -68025,6 +68441,18 @@
    "version": [
     20200831,
     702
+   ],
+   "deps": [
+    "anaphora",
+    "s"
+   ],
+   "commit": "34dfba027bf11e4cca2c547ce80b73d7324c7ba6",
+   "sha256": "011qr9jc90arg3y8y49hjmv94968ym81a36db0dvxyf08hspz006"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
    ],
    "deps": [
     "anaphora",
@@ -68289,15 +68717,14 @@
   "repo": "matsievskiysv/multistate",
   "unstable": {
    "version": [
-    20200514,
-    2206
+    20210124,
+    2014
    ],
    "deps": [
-    "cl-lib",
     "ht"
    ],
-   "commit": "eadd0df2745bf10500a9ad4ee8f66f3cb470bef0",
-   "sha256": "081rangw4iqk1lcahk01skh518ljdp6g4ww7zydjr813x7jzv2kv"
+   "commit": "a7ab9dc7aac0b6d6d2f872de4e0d1b8550834a9b",
+   "sha256": "1r4l0s8401yfm3dl83yqffim5m1gsqzqz9pv3dvq3v8rb94m9n9s"
   }
  },
  {
@@ -68338,16 +68765,16 @@
   "repo": "Wilfred/mustache.el",
   "unstable": {
    "version": [
-    20201119,
-    529
+    20210210,
+    643
    ],
    "deps": [
     "dash",
     "ht",
     "s"
    ],
-   "commit": "7f4b1cf0483366a77539081fde94fa6079b514a0",
-   "sha256": "0yg726jdcvkfxss1sw261rz1df3zv9g95rx3b3g8g5xncxi0cqvh"
+   "commit": "ebecf704d1431e03f1be6df9e45e07944b359a56",
+   "sha256": "0bwdm1sx3r8fmc3hp278wqx3x9hxa5gjwywgsym4vfkg2jp3g7zn"
   },
   "stable": {
    "version": [
@@ -68749,8 +69176,8 @@
     20181120,
     2224
    ],
-   "commit": "670b81e3eddef2e7353a4eedc9553a85306445db",
-   "sha256": "1inbizxlfgndwxsn8cwnpf4vm42rby7pkjqxyzl7ldq4qln7q8v1"
+   "commit": "d8baeada19b56176c66aed5fa220751e3de11cb8",
+   "sha256": "0xa44mks90xhwkjvrgxll0hzwhkf317i3gxqlajl9cx8v3bhczz1"
   }
  },
  {
@@ -69435,8 +69862,8 @@
   "repo": "felko/neuron-mode",
   "unstable": {
    "version": [
-    20201229,
-    1005
+    20210208,
+    1455
    ],
    "deps": [
     "company",
@@ -69444,8 +69871,8 @@
     "markdown-mode",
     "s"
    ],
-   "commit": "81ed1f3288eab9aed2cb0b1eb11af69f988b7d0b",
-   "sha256": "1dgvlk0apd7ddzzg5jcpsrdhps37my59jyvkv1sqp31km0nby6qk"
+   "commit": "02fbfca98b5dfb09f09159914682efea6d6afb5a",
+   "sha256": "18xj8a5h9rrz134hac9qz8cpqswz79h3h24wb3bf89xvq2kyvq10"
   }
  },
  {
@@ -69676,11 +70103,11 @@
   "repo": "m-cat/nimbus-theme",
   "unstable": {
    "version": [
-    20201222,
-    1503
+    20210115,
+    2034
    ],
-   "commit": "5ff56a6a68cde7cd0a67fc60e3e993be52604a6d",
-   "sha256": "1073x878gdg97xym31mx3l7zpbc51pkspigpxqlpq48q62llcigj"
+   "commit": "ca504e4387641b648e7bc6037fe515b03a90b801",
+   "sha256": "0gz2qrkr4gvy5wh44wiy7mhqwlxgfa8fyg0bincnba89161fnymk"
   }
  },
  {
@@ -69694,8 +70121,8 @@
     20181024,
     1439
    ],
-   "commit": "68f09b03c090840162d1852f1e92afa8e117cc4e",
-   "sha256": "1ampghm9laigs0frqfw2yjsm0whh2vff5gqp96i4d88n9ar0wj5n"
+   "commit": "9c66e698466ed29a493df8746b767558684205b2",
+   "sha256": "0lpzicxaj2nf4926j50x29sijgarkrj2wvsmnp1xfj1s38v9pyqd"
   },
   "stable": {
    "version": [
@@ -69793,11 +70220,11 @@
   "repo": "NixOS/nix-mode",
   "unstable": {
    "version": [
-    20210115,
-    340
+    20210124,
+    204
    ],
-   "commit": "e8e5211f6e083cf0ba9aac52acb6657818a32972",
-   "sha256": "1zhvj1j5pvsfa0xzky819fc1xlhy3a4snkyyp1dczbfdnk34kan9"
+   "commit": "0023fc5b100ec0c939ffe699d1a7d1afcf1f417a",
+   "sha256": "1fjf16dah95i3vlxk63rlixskgq18kn69fyg6dgpiw7pm98kjviy"
   },
   "stable": {
    "version": [
@@ -69999,8 +70426,8 @@
   "repo": "dickmao/nnhackernews",
   "unstable": {
    "version": [
-    20200730,
-    1052
+    20210203,
+    240
    ],
    "deps": [
     "anaphora",
@@ -70008,8 +70435,8 @@
     "dash-functional",
     "request"
    ],
-   "commit": "baeb84dd0be0e7631d1f49da30a53eb61863b04c",
-   "sha256": "15r5hph17pdy5c5jyxh5sia5yqd81ckki185m9jqg9yls749hy55"
+   "commit": "008d4a475dcf9432318d0baed53a0a196453ee75",
+   "sha256": "0s9wgq1k1f3dlx6rna67p2bpnpd6cn3x9wvi8dlg3wfckg652fjy"
   }
  },
  {
@@ -70092,14 +70519,14 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20210108,
-    1350
+    20210124,
+    1559
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "6e8950ad296c0f57d80d034eb0b7adf538c02906",
-   "sha256": "10zjxc6ipm9330awx7k9hzjf28qpnaw2rcz67dc0jbdgxkn16gl8"
+   "commit": "57357e15643158b4e0d9b3b4f70a82f5fc73178a",
+   "sha256": "1kbbbx1agzcxc5n1b6cavdx3wjxz6mgi9rafja8mk8cyaaiz0rkd"
   },
   "stable": {
    "version": [
@@ -70398,11 +70825,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20210113,
-    1123
+    20210205,
+    1412
    ],
-   "commit": "1bbbde4a0c3153f6caa30724bd173397be43144f",
-   "sha256": "0lawmpg52yc7fsh2rrmwajds2yhx9jr3h8g04ikf4cma95v4d8s2"
+   "commit": "8fb42948a209c54e3dcf832119d7f54e9cc0665a",
+   "sha256": "017fqgwvvrbb8i6bfaappimz8fv41b01ia06xq9fn0a2vzn1pf4r"
   },
   "stable": {
    "version": [
@@ -70487,8 +70914,8 @@
    "deps": [
     "notmuch"
    ],
-   "commit": "bac7b56e1a758670e7e6d57d233b45f45961d321",
-   "sha256": "0wx064c2njjq32dqbv68hysds5bm43921vsr34xb4lk748lk2qhv"
+   "commit": "9f3e8bbce4c8c6cd80fb71b92d315d4f3334b450",
+   "sha256": "1rrd3ymc7k8irq1w4496h4whks7lnfam7ibfwgcra074ligfrs4p"
   },
   "stable": {
    "version": [
@@ -70732,20 +71159,20 @@
   "repo": "joostkremers/nswbuff",
   "unstable": {
    "version": [
-    20201207,
-    805
+    20210129,
+    850
    ],
-   "commit": "76e5d96f31368a74121076df679255e1ea97f5d9",
-   "sha256": "08yf7cdmq6nqn4bhm4asj3yavcifwjgkyzhdcr3dm9a9jv1b3w0m"
+   "commit": "72fac3d4b7a1c42a71cb396d20cc22fca8a52ed5",
+   "sha256": "17ks8cmnwc313q9vcxbrsv9xmji2hdnw18jczc3xrgl441vkzds1"
   },
   "stable": {
    "version": [
     1,
-    1,
+    2,
     1
    ],
-   "commit": "76e5d96f31368a74121076df679255e1ea97f5d9",
-   "sha256": "08yf7cdmq6nqn4bhm4asj3yavcifwjgkyzhdcr3dm9a9jv1b3w0m"
+   "commit": "71e241763ca0a4a1d1b432e172d46bed4f44dbe7",
+   "sha256": "1sswhr52rp8c4v4fv30sww1gadbdrlk3l35j8xmqfw6hbgzxb5dn"
   }
  },
  {
@@ -71066,8 +71493,8 @@
    "deps": [
     "axiom-environment"
    ],
-   "commit": "47d6dffc29286badb2b1d7143b219e5c1be15bdb",
-   "sha256": "1dppyda9jkwh6fj8m4kziq84w0b5yzxrhq87jhkv54jjra6yxbb4"
+   "commit": "d9c1c85ea731a18f271bd003a5b1736e26fa172a",
+   "sha256": "1clcbgs5dk3jas6sclsfj6ibrb0n2508xapyp85lb0nm01i07jb9"
   }
  },
  {
@@ -71728,11 +72155,11 @@
   "repo": "micanzhang/ob-rust",
   "unstable": {
    "version": [
-    20180911,
-    1535
+    20210204,
+    244
    ],
-   "commit": "6a82587598cd097e9642be916243c31f1231b24a",
-   "sha256": "041mvlwnkxa93fjbln0yc6pgykh6k7fwg1nigr6njgaxlfnssmlm"
+   "commit": "30fe7e7181f44443d02e905dda77f83ec4944e76",
+   "sha256": "103j84iblzw87p12w1vjinfsq6zif47lvmjzs0456d8kwli0hpkp"
   }
  },
  {
@@ -72073,8 +72500,8 @@
     20201204,
     945
    ],
-   "commit": "7c6e115c38e447e7cfd4d1d128bed363d3d10c4b",
-   "sha256": "0jik0j3mjyd8fxdlcdkxp0znlw29fm3knqa7i4fgwz6cvzkl9fa0"
+   "commit": "60678b05f75d660fcde4c1b991758af9620dcea8",
+   "sha256": "07xszr8405lcakzdl6c99x73a6zdfc43dr30rw9qpq4mrs6q5npz"
   },
   "stable": {
    "version": [
@@ -72109,11 +72536,11 @@
   "repo": "dgtized/occur-context-resize.el",
   "unstable": {
    "version": [
-    20170904,
-    2309
+    20210121,
+    50
    ],
-   "commit": "cdee5a631ceed9337579d4090e0acf8140747f80",
-   "sha256": "0h7ypw45h5rcbwx4c4mn2ps9hp84dpjp3iay2nc9zaavv05n7ysa"
+   "commit": "9d62a5b5c39ab7921dfc12dd0ab139b38dd16582",
+   "sha256": "1s2j0205sp40nz1ljwa2nf2zm5mlkvsp95xfrra6rzbdrvbsfxyi"
   }
  },
  {
@@ -72391,20 +72818,20 @@
   "repo": "rnkn/olivetti",
   "unstable": {
    "version": [
-    20201029,
-    922
+    20210202,
+    709
    ],
-   "commit": "b76a020aedb57a6a7d0ae61cde13434f5c802a44",
-   "sha256": "1qq0lx0wrflx1r2m7gidnvcv7cipc6dzh1clf5mp50mm2cp88n50"
+   "commit": "61d26644fd9dd2d45b80b9b82f5f930ed17530d0",
+   "sha256": "1nvnahwjqs9i2cinkpwg689lg134wp7l6f9f1k1jwn0dh1amqmvp"
   },
   "stable": {
    "version": [
     1,
     11,
-    2
+    3
    ],
-   "commit": "b76a020aedb57a6a7d0ae61cde13434f5c802a44",
-   "sha256": "1qq0lx0wrflx1r2m7gidnvcv7cipc6dzh1clf5mp50mm2cp88n50"
+   "commit": "a2dbd3dc4e7000fec29febbd089cd4558a7322b9",
+   "sha256": "0zcph7l0hxisbvsyzb1dw3paq5a5sjp5lrq5nq9zggvgc6zvx7sh"
   }
  },
  {
@@ -72959,11 +73386,11 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20210105,
-    448
+    20210212,
+    1645
    ],
-   "commit": "cbc0109eac542ef4fe0be027af1c62c4bbf846ee",
-   "sha256": "0cp8yspghfbgy2nhcqw8irqyhphw4jdr36864m45ralzzxc6lqac"
+   "commit": "edce950fe1353c2284516f7b01bd37bc2d7fa136",
+   "sha256": "0dgw51f5cp2yxvpq11xkbavbykkr9c275pizcj8d81zw8jrnbs79"
   },
   "stable": {
    "version": [
@@ -73155,6 +73582,36 @@
   }
  },
  {
+  "ename": "org-auto-tangle",
+  "commit": "8cdae87606068b7b47530e0744e91aead86d288e",
+  "sha256": "1cr34yjr43ah9bqvrghlyx2vag7xnamgfijb417k5m70cbk8vcb8",
+  "fetcher": "github",
+  "repo": "yilkalargaw/org-auto-tangle",
+  "unstable": {
+   "version": [
+    20210208,
+    847
+   ],
+   "deps": [
+    "async"
+   ],
+   "commit": "5da721fff97a44a38a650b23bdf73b74f17d4a36",
+   "sha256": "0iydrx38ih8vrj7p3sn861ckn52sh8pvwjvl7s3287j3x81affnh"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    10
+   ],
+   "deps": [
+    "async"
+   ],
+   "commit": "7bd6e9c934bc659b026b0d1497b2013da44597d8",
+   "sha256": "04wc7yc47csz1amzm7990f46pr89avcxrpf2kyiw02i1lc50cfpq"
+  }
+ },
+ {
   "ename": "org-autolist",
   "commit": "ca8e2cdb282674b20881bf6b4fc49af42a5d09a7",
   "sha256": "1jvspxhxlvd7h1srk9dbk1v5dykmf8jsjaqicpll7ial6i0qgikj",
@@ -73337,8 +73794,8 @@
    "deps": [
     "org"
    ],
-   "commit": "f7939ef5071895930eebccf490ea7cb25cc54b2c",
-   "sha256": "0lplrdy5432ckif94vl9phh07c6qfm8cxa1mjyn1dypn2sh8p9gi"
+   "commit": "e9b9b3e5bb3c63cecb1367df49205c346d9c050a",
+   "sha256": "0j1f75p40p033acnkds2mxhqx5wilmlhak8cgn196x6y8j1ra7d8"
   }
  },
  {
@@ -73611,29 +74068,29 @@
   "url": "https://git.spwhitton.name/org-d20",
   "unstable": {
    "version": [
-    20201113,
-    453
+    20210212,
+    139
    ],
    "deps": [
     "dash",
     "s",
     "seq"
    ],
-   "commit": "bab77ede4b1aaf879e7c24e0522da624ee23bf2e",
-   "sha256": "1bcvdl5h4nz2x1zvrq700vf2mbkyhvrslfkabmirhs7hd2q0n41n"
+   "commit": "e6149dcfbb6302d10109dd792fd0ffae7bfe2595",
+   "sha256": "129zdnz97h6px0yz0f0if4gw96zxmsg24xc8vg51crsazqqz8l3b"
   },
   "stable": {
    "version": [
     0,
-    4
+    5
    ],
    "deps": [
     "dash",
     "s",
     "seq"
    ],
-   "commit": "bab77ede4b1aaf879e7c24e0522da624ee23bf2e",
-   "sha256": "1bcvdl5h4nz2x1zvrq700vf2mbkyhvrslfkabmirhs7hd2q0n41n"
+   "commit": "e6149dcfbb6302d10109dd792fd0ffae7bfe2595",
+   "sha256": "129zdnz97h6px0yz0f0if4gw96zxmsg24xc8vg51crsazqqz8l3b"
   }
  },
  {
@@ -73704,14 +74161,14 @@
   "repo": "abo-abo/org-download",
   "unstable": {
    "version": [
-    20210105,
-    1758
+    20210118,
+    958
    ],
    "deps": [
     "async"
    ],
-   "commit": "97bec7412e1a4d6e9031c7a0568d0f065cd9fd00",
-   "sha256": "0jb49q2ayhw1s2dnd323lqc7fy9k3sznxn4dv73s4945j8w2lqcc"
+   "commit": "947ca223643d28e189480e607df68449c15786cb",
+   "sha256": "1yzv4r2820pbdpx09rdrrb9lk1dv4axhxif22f1svf8pggisrsd8"
   },
   "stable": {
    "version": [
@@ -73921,6 +74378,29 @@
    ],
    "commit": "3e33ab1a2933dd7f2782ef91d667a37f12d633ab",
    "sha256": "088pbafz1x4z7qi70cjbrvfrcdrjp4zy0yl115klbidshqhxycmj"
+  }
+ },
+ {
+  "ename": "org-elp",
+  "commit": "36d4b3e08482f4c51a3d43fc961fd7d1408c5cfe",
+  "sha256": "1px2q2sxx4624aj09ibmqhjcmx8s0fvvmg42pvyx9gblkayl3nbf",
+  "fetcher": "github",
+  "repo": "guanyilun/org-elp",
+  "unstable": {
+   "version": [
+    20210201,
+    1544
+   ],
+   "commit": "983fd7af4244835601be090211344ed92c36d360",
+   "sha256": "0v2cgw360sigl0jm8fm1hld71xbcjw9j8xjlr176cn4g308zw1sa"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "f9d48042eed49b9936d162cecb4188456a9cc19b",
+   "sha256": "0spwyrxirmnf8182xsjrvpl8zf2662434zzhnw4qs7fz7wld2f11"
   }
  },
  {
@@ -74181,28 +74661,28 @@
   "repo": "marcIhm/org-id-cleanup",
   "unstable": {
    "version": [
-    20201127,
-    1712
+    20210212,
+    1158
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "1654be88f5a5e1c57e5d204f060f9a07ff4242cc",
-   "sha256": "0gzrdrr0b8rs2lb96j0zczmfvsy37fwri3dxzdpyvddb4x5a1rl2"
+   "commit": "87752d5b4811f94d0e5b2cc220aa30147a89a7ea",
+   "sha256": "03c29app8n1a8grv2a7qlqgq7f90ql1raxfnm9slfwk1al3s8j8k"
   },
   "stable": {
    "version": [
     1,
     5,
-    2
+    5
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "a5c5ff8f2d3ae1fd3ef81511bd4b0226f6764935",
-   "sha256": "17r36k2gdk8n1433a84c490js1x22yjwr21ihcjj13mnfcglmzhp"
+   "commit": "87752d5b4811f94d0e5b2cc220aa30147a89a7ea",
+   "sha256": "03c29app8n1a8grv2a7qlqgq7f90ql1raxfnm9slfwk1al3s8j8k"
   }
  },
  {
@@ -74237,30 +74717,30 @@
   "repo": "marcIhm/org-index",
   "unstable": {
    "version": [
-    20201117,
-    1211
+    20210208,
+    1405
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "0863397ba2782e229fa6216beb074dd44eb0c031",
-   "sha256": "062dm9famamziqjczyk6w6ynk0qw6dp4k6a5k81iscz0gdlv6cfm"
+   "commit": "b0a4892ca4f2f9791ebc78b472680465f5785fc6",
+   "sha256": "14xhbsar219kbgzg59ynynxx21723f7f0qr39p2ardi16b00pzvs"
   },
   "stable": {
    "version": [
     7,
-    0,
-    0
+    1,
+    2
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "3ada80bca278bb0fb791f7498cced6e8c9752064",
-   "sha256": "1y1nrw39bc1ng6p4asy4lv3y20vdvx1cqa03s5jf9nccddn5j924"
+   "commit": "b0a4892ca4f2f9791ebc78b472680465f5785fc6",
+   "sha256": "14xhbsar219kbgzg59ynynxx21723f7f0qr39p2ardi16b00pzvs"
   }
  },
  {
@@ -74271,14 +74751,14 @@
   "repo": "shg/org-inline-pdf.el",
   "unstable": {
    "version": [
-    20210107,
-    940
+    20210119,
+    529
    ],
    "deps": [
     "org"
    ],
-   "commit": "a449c614d63712cd55e8c38d4679667117c132c1",
-   "sha256": "0grsmhif0pmdsvc6lifxip1jh57h5him6ipzkr1rvbs5l47qndk7"
+   "commit": "f9a3321712626d2f43a8849203ceb089cf8233b1",
+   "sha256": "195bzlfqf91f7prv4xh1x1p5xnyygr0mzwqxbsw2apc0haaz6ajk"
   },
   "stable": {
    "version": [
@@ -74354,26 +74834,26 @@
   "repo": "bastibe/org-journal",
   "unstable": {
    "version": [
-    20210109,
-    913
+    20210204,
+    820
    ],
    "deps": [
     "org"
    ],
-   "commit": "08d5fce95023c015372678d353388ad0dae8952b",
-   "sha256": "0f1826xi9z895a1wgnvvv5nqpi2r0l6f8h761zk8ng9j1rhkz865"
+   "commit": "f4b15499135d43e98244dda4606a5b97462b3f39",
+   "sha256": "140wfvj2cygpip75w60difg9gwvh5c53ds6zbysnj5zqsjm4zica"
   },
   "stable": {
    "version": [
     2,
     1,
-    1
+    2
    ],
    "deps": [
     "org"
    ],
-   "commit": "25ebb8f1c8cd8993fb75a15e2bb8144fb6f9e006",
-   "sha256": "1p9i6v3bwi1ab576vc9qg1ki91197d6nkkg857s52zsan1zlkzzw"
+   "commit": "c26e73a017963f6638044f1f63354c453f2db54a",
+   "sha256": "0s82sh2svc0mzr1ak414n5r2j0dmwvvyx4swk2c61zivc2gjd778"
   }
  },
  {
@@ -74473,14 +74953,14 @@
   "repo": "stardiviner/org-link-beautify",
   "unstable": {
    "version": [
-    20210114,
-    1508
+    20210210,
+    1421
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "e20c116f7a7a42f0cd6af580ef6e53e006c5b538",
-   "sha256": "1321z866ahs07kil4yzqvsnjcdldapg1gvfx9k9rdx11x3awja2q"
+   "commit": "bbf6257951cfcee7cb7850eca6af17d797555c86",
+   "sha256": "1sps2j096rhk0sfvl98lvvcqv8i9886xav7r9r7fw0qa1sc5337z"
   }
  },
  {
@@ -74551,15 +75031,15 @@
   "repo": "dfeich/org-listcruncher",
   "unstable": {
    "version": [
-    20180815,
-    603
+    20210130,
+    1405
    ],
    "deps": [
     "cl-lib",
     "seq"
    ],
-   "commit": "65c09c5deba065752eb88875c54dc26abcdfaffb",
-   "sha256": "11chlfvil0wbvzaplzdymn4ajz85956hcs8bh3zds6ij806mqa4y"
+   "commit": "291a824d8da1c14a883e21281b596ce9dcd11e1b",
+   "sha256": "0bz57dvydz67bk704q2daxkfpdygxmz9jf6ilycjip2v16lx37i1"
   }
  },
  {
@@ -74652,30 +75132,30 @@
   "repo": "ndwarshuis/org-ml",
   "unstable": {
    "version": [
-    20201229,
-    418
+    20210203,
+    1452
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "d856ac6f0afed0299a47ed77830c676fd0fa9e55",
-   "sha256": "1rydmbjzq24vzfpfrb93ad4wibhpc4rnk7crqbx1p11sdby85h95"
+   "commit": "5faf2bd099c51b51af241132578c1a4e06f73d57",
+   "sha256": "0f1ldhsjnfh1jn3zlgnmw22fml0y1dhvn7gsbf4x2szkcw1i9hfs"
   },
   "stable": {
    "version": [
     5,
     5,
-    3
+    4
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "a396e4a11394b5e00aef1450488b61aeddbd9b55",
-   "sha256": "1rydmbjzq24vzfpfrb93ad4wibhpc4rnk7crqbx1p11sdby85h95"
+   "commit": "1c7ace3d536f6f1b63410a63e52975dc37871b77",
+   "sha256": "0f1ldhsjnfh1jn3zlgnmw22fml0y1dhvn7gsbf4x2szkcw1i9hfs"
   }
  },
  {
@@ -74704,11 +75184,11 @@
   "repo": "unhammer/org-mru-clock",
   "unstable": {
    "version": [
-    20210113,
-    1416
+    20210127,
+    1400
    ],
-   "commit": "e08e2ab2b71763f53f2029471057d58f96085a69",
-   "sha256": "10v1ric4xppx92vv722d50as350pw14cqkjlswi0nqssgihxrk11"
+   "commit": "75d4f32c2526f752bd121aa807ee9256e0e64441",
+   "sha256": "026p6sk02lk6cc4mrhpjqrfksfxfa1mmn0k68ipa3wgg1rizdhhi"
   },
   "stable": {
    "version": [
@@ -74728,14 +75208,14 @@
   "repo": "jeremy-compostella/org-msg",
   "unstable": {
    "version": [
-    20210111,
-    2224
+    20210209,
+    2056
    ],
    "deps": [
     "htmlize"
    ],
-   "commit": "c19f54beebe268833c44a015861bf02531591011",
-   "sha256": "06c8hlj3zpsx9xsw7xr06db8c61iczyvn3kkwpg54p03sjzmpsnx"
+   "commit": "89e746c0a864031eef940758230bc7263a6f2289",
+   "sha256": "15gd5zbxvdallyra9lmpb9i1r2mmwz0j0i0ra7j9imnbfiz3ln9r"
   }
  },
  {
@@ -74746,8 +75226,8 @@
   "repo": "akirak/org-multi-wiki",
   "unstable": {
    "version": [
-    20210111,
-    1022
+    20210122,
+    552
    ],
    "deps": [
     "dash",
@@ -74755,8 +75235,8 @@
     "org-ql",
     "s"
    ],
-   "commit": "c9005cbe4077cce3743b680dec97c11fa179bb36",
-   "sha256": "1428lky09cvlqdb8b9zf0x49cxmigrkhvhi391b2mj2qzgmjzcvm"
+   "commit": "3b97aa047233d521e937b6040cf9085e77507f28",
+   "sha256": "0rq37k0ydksc2wsavy4g6wydr2hxcclbipab14qdldvrif35sr24"
   },
   "stable": {
    "version": [
@@ -74864,8 +75344,8 @@
   "repo": "fuxialexander/org-pdftools",
   "unstable": {
    "version": [
-    20210110,
-    2132
+    20210118,
+    1611
    ],
    "deps": [
     "org",
@@ -74873,8 +75353,8 @@
     "org-pdftools",
     "pdf-tools"
    ],
-   "commit": "812bbff3212097bb9f8d2acc4b25826ed45dde92",
-   "sha256": "1iaswir2fwbhnwlyi2a1h9azgfdsa8m5ydgyckf67a2y5ykwkwv7"
+   "commit": "a5b61bca3f8c91b0859bb0df1a929f9a31a57b99",
+   "sha256": "18iy03hc7jb7qsfj25f6hmrwli6fyjbf14c1p5bhp5gwk49rm9p1"
   }
  },
  {
@@ -75019,39 +75499,6 @@
   }
  },
  {
-  "ename": "org-password-manager",
-  "commit": "38249f32d150d10b6ed86679361d99ace2375a02",
-  "sha256": "148rv5kzmnqlfn8z2474wn0bxir49d4mb40mjrv76kvyzyj7nly9",
-  "fetcher": "github",
-  "repo": "leafac/org-password-manager",
-  "unstable": {
-   "version": [
-    20180227,
-    1810
-   ],
-   "deps": [
-    "dash",
-    "org",
-    "s"
-   ],
-   "commit": "4b30a36e71182553a02e4dd415369290d98ec03a",
-   "sha256": "1a6i3g032c5xzsnaf7rprn22kk68y1ay3w21p3q52p3lvlzhnfis"
-  },
-  "stable": {
-   "version": [
-    0,
-    0,
-    1
-   ],
-   "deps": [
-    "org",
-    "s"
-   ],
-   "commit": "d3a33ddfe583180bdb76cfb8bbd772e0078b24a3",
-   "sha256": "0pqmnhd3qdg06agj6h8v8lm4m5q8px0qmd7a1bfn6i5g2bq9zrck"
-  }
- },
- {
   "ename": "org-pdftools",
   "commit": "d52346a042a72b76729d259c7f12f45d38ac27cd",
   "sha256": "1pgfx0zgdp9kg8mxqxm5qac7vnd0j1ghfwq04rvqi9r1d51zpynl",
@@ -75059,16 +75506,16 @@
   "repo": "fuxialexander/org-pdftools",
   "unstable": {
    "version": [
-    20210110,
-    2052
+    20210118,
+    1611
    ],
    "deps": [
     "org",
     "org-noter",
     "pdf-tools"
    ],
-   "commit": "812bbff3212097bb9f8d2acc4b25826ed45dde92",
-   "sha256": "1iaswir2fwbhnwlyi2a1h9azgfdsa8m5ydgyckf67a2y5ykwkwv7"
+   "commit": "a5b61bca3f8c91b0859bb0df1a929f9a31a57b99",
+   "sha256": "18iy03hc7jb7qsfj25f6hmrwli6fyjbf14c1p5bhp5gwk49rm9p1"
   }
  },
  {
@@ -75079,11 +75526,11 @@
   "repo": "tumashu/org-picklink",
   "unstable": {
    "version": [
-    20191203,
-    59
+    20210210,
+    516
    ],
-   "commit": "f79040ed988bdeec63b098b187e00f2b80d3d570",
-   "sha256": "0a0dzg8w617sn079mshihfv5sm74xphab81kmvi1dqcc5iyi15kh"
+   "commit": "bfdc22b436482752be41c5d6f6f37dca76b1c7c3",
+   "sha256": "1asq336rff0f1zh5crsj3xwyx4xiwdypzy6dlqrxzszkxx8sd4dd"
   }
  },
  {
@@ -75437,28 +75884,28 @@
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20210111,
-    1807
+    20210121,
+    1011
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "7b536b497edc46e6231f33d2c1eea9cd9a7eabbb",
-   "sha256": "16kpprrcylrysbpqsz2k47q0qb1yjz9y7az71aik1nskinnml83v"
+   "commit": "18a2456befcfda5f681b2b4041f3262f93e52cba",
+   "sha256": "1274zq6qhzl8l7hpbh2spgmf9hqrilcm31m3mbybj6gm085g17dz"
   },
   "stable": {
    "version": [
     3,
-    6,
+    7,
     0
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "7b536b497edc46e6231f33d2c1eea9cd9a7eabbb",
-   "sha256": "16kpprrcylrysbpqsz2k47q0qb1yjz9y7az71aik1nskinnml83v"
+   "commit": "d404eb13d9e34354c081870ebdd69711937682b3",
+   "sha256": "1vzn0l8ig4rzh5h8j7kxn8kslqrij97qqv98fbnlwmrw4z87v8dr"
   }
  },
  {
@@ -75569,8 +76016,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20210113,
-    1549
+    20210210,
+    1810
    ],
    "deps": [
     "bibtex-completion",
@@ -75585,8 +76032,8 @@
     "pdf-tools",
     "s"
    ],
-   "commit": "cd0b4997fad3a050a0092d1458d34286ef5122d2",
-   "sha256": "1rn9x5p4kmm83smg7c9xalbziliqq02fwfl4v1cgczqyb7vir7nz"
+   "commit": "32803203cc4b01e1d4436f0f65138bf569dad8ad",
+   "sha256": "09g9zblhkfcaks5m4h418v85cwbz308r7sh1qj2v8yxay1360v03"
   },
   "stable": {
    "version": [
@@ -75712,8 +76159,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20210111,
-    1138
+    20210128,
+    1341
    ],
    "deps": [
     "dash",
@@ -75723,8 +76170,8 @@
     "org",
     "s"
    ],
-   "commit": "05a9bc44f2d158cc355c904382f2c7b079aeee15",
-   "sha256": "18s3qp671g28qy1qllnm4lay7mvyar8qcqqjn8yd3417gxwndqhh"
+   "commit": "b0fd12647b94ba6e3cf82a2a5b1ee7655ac07760",
+   "sha256": "0blpfwiff0sn39hfsk2zznmkj8ad0f4a65vcbgdqmmc9i56yahv1"
   },
   "stable": {
    "version": [
@@ -75752,15 +76199,15 @@
   "repo": "org-roam/org-roam-bibtex",
   "unstable": {
    "version": [
-    20201220,
-    1653
+    20210129,
+    954
    ],
    "deps": [
     "bibtex-completion",
     "org-roam"
    ],
-   "commit": "9ba15069c3f7ecd1080873cd3a7d587eb7c72d08",
-   "sha256": "0nfsrrca1p5xlildcbjisfhhrwiwgd6jv0nfn4a2gdpxd77v39d6"
+   "commit": "c2b097e982108f53bb995c74dde3b1a9dd28cb5b",
+   "sha256": "0gv5a4bk333vg1xy9pys9j52ikp9n1y17x5mgm4w2gnf2q0s1sc8"
   },
   "stable": {
    "version": [
@@ -75784,8 +76231,8 @@
   "repo": "org-roam/org-roam-server",
   "unstable": {
    "version": [
-    20210109,
-    935
+    20210201,
+    1122
    ],
    "deps": [
     "dash",
@@ -75795,24 +76242,25 @@
     "s",
     "simple-httpd"
    ],
-   "commit": "c7793202e9929dc2a415482779141e7b429421ce",
-   "sha256": "1z29xngyxmq0pd8kfx6z8n8hps4apnffnsi8qc0hvmyhp197hkqc"
+   "commit": "2093ea5a1a1f2d128dd377778472a481913717b4",
+   "sha256": "1jp8mkqx1l3w166b16l2d5zsqjcc836bkclplgjk4laysb6msry8"
   },
   "stable": {
    "version": [
     1,
-    0,
-    4
+    1,
+    2
    ],
    "deps": [
     "dash",
+    "f",
     "org",
     "org-roam",
     "s",
     "simple-httpd"
    ],
-   "commit": "fe0364ef63928337f442c1d987d17cfe9619df2d",
-   "sha256": "0a5b625i7gv467xm8p92nvrh2wzgmldm8gzcbrc15al1gvnwpbqm"
+   "commit": "2093ea5a1a1f2d128dd377778472a481913717b4",
+   "sha256": "1jp8mkqx1l3w166b16l2d5zsqjcc836bkclplgjk4laysb6msry8"
   }
  },
  {
@@ -75999,8 +76447,8 @@
   "repo": "alhassy/org-special-block-extras",
   "unstable": {
    "version": [
-    20210114,
-    2006
+    20210208,
+    103
    ],
    "deps": [
     "dash",
@@ -76008,8 +76456,8 @@
     "org",
     "s"
    ],
-   "commit": "0c5a7b97be4e5e11093276af310442ab5776ab90",
-   "sha256": "1311yxmsdb9gms0v20dd7ak0vdkkgda5p89zrp21v4dazjh7rl9a"
+   "commit": "7b94dcb8daa2495348da0c4177af77e911e0fb3c",
+   "sha256": "0yvna55zl74q92hzrlmychmi0h1gzsz9kaciy517vgzc3ma8w348"
   },
   "stable": {
    "version": [
@@ -76033,30 +76481,32 @@
   "repo": "ndwarshuis/org-sql",
   "unstable": {
    "version": [
-    20201222,
-    206
+    20210121,
+    1746
    ],
    "deps": [
     "dash",
+    "f",
     "org-ml",
     "s"
    ],
-   "commit": "ddbab360a49d4c0cab964cd1fdb80d2135a10272",
-   "sha256": "0rhc5sb6drzndxay52qb3f1kbxfnwvz99i1jpjs4adsmyhx35xai"
+   "commit": "9a2a753b41685b241fb3ba6cf5c01073b4648e0f",
+   "sha256": "1iy25j0qqqic6jzzppg0vq4990r97n9glikrmwzq6hwj9y901bj4"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "dash",
+    "f",
     "org-ml",
     "s"
    ],
-   "commit": "6160de13bcef3ad91c706d8a7b1601703b424616",
-   "sha256": "0rhc5sb6drzndxay52qb3f1kbxfnwvz99i1jpjs4adsmyhx35xai"
+   "commit": "9a2a753b41685b241fb3ba6cf5c01073b4648e0f",
+   "sha256": "1iy25j0qqqic6jzzppg0vq4990r97n9glikrmwzq6hwj9y901bj4"
   }
  },
  {
@@ -76131,11 +76581,11 @@
   "repo": "bastibe/org-static-blog",
   "unstable": {
    "version": [
-    20210113,
-    731
+    20210211,
+    933
    ],
-   "commit": "0da4f8cc3a09bdd107da18ab381a4cabb461430d",
-   "sha256": "1684cxa1qj3b90zckhph7vawwxwa0djpaqwps0vh9p8yngy794z2"
+   "commit": "a66d1e43882978a9da82c033a809765061c71052",
+   "sha256": "1xpwpfwbxblybj8h9dqd6d9s0xy95hpkfviviwzprcsrm9i7b971"
   },
   "stable": {
    "version": [
@@ -76221,14 +76671,14 @@
   "repo": "integral-dw/org-superstar-mode",
   "unstable": {
    "version": [
-    20200818,
-    2257
+    20210212,
+    1458
    ],
    "deps": [
     "org"
    ],
-   "commit": "7f83636db215bf5a10edbfdf11d12a132864a914",
-   "sha256": "086h7fj7k0199m3i01whmqzi4kb4h6ncikdmv6skxs41hzpnjvk4"
+   "commit": "84362aeccb7e1022f534e7face6aa5456ec9a787",
+   "sha256": "1700n0zxk58d9akkdhgjhdi9xya1b4x0cchdw42gxbwycrzsjnf3"
   },
   "stable": {
    "version": [
@@ -76349,6 +76799,25 @@
   }
  },
  {
+  "ename": "org-tag-beautify",
+  "commit": "faa48723cbc4486c2d8262d00aa9967bfad81738",
+  "sha256": "1dn164z53c38bfzx8m22dynfx2wlw8cgcm63q6kvz5xsxqqwwsmp",
+  "fetcher": "github",
+  "repo": "stardiviner/org-tag-beautify",
+  "unstable": {
+   "version": [
+    20210202,
+    628
+   ],
+   "deps": [
+    "all-the-icons",
+    "org-pretty-tags"
+   ],
+   "commit": "4a6de709ee0d4ee719c83df6dce86f38f9db1f75",
+   "sha256": "02qw4b750p4rav9kw3qwcvmril8wxkgdfqklbrfbws6wz2sjjv3l"
+  }
+ },
+ {
   "ename": "org-tanglesync",
   "commit": "2db07414d2d39b2d40a2ae91491032844b82d801",
   "sha256": "11h97qihb3n82jan08fhg5zjh8jqcwjrhf6b933gy6b4h1nwlmdj",
@@ -76465,26 +76934,26 @@
   "repo": "Fuco1/org-timeline",
   "unstable": {
    "version": [
-    20190612,
-    1759
+    20210210,
+    2306
    ],
    "deps": [
     "dash"
    ],
-   "commit": "f628519a12ce3d534b9aa5043b0273880cf29790",
-   "sha256": "16qjbw5l39j3kc4lfpm18ba81w9bhy9cdd3fii1n7dwyx76av73i"
+   "commit": "af1b44e18048278a116da89faf138310f09c74c6",
+   "sha256": "05gp5hqfwx668a0qvpx1wn8957qgn6g9jhrhiwgscnnxch2dp0c0"
   },
   "stable": {
    "version": [
     0,
-    3,
+    4,
     0
    ],
    "deps": [
     "dash"
    ],
-   "commit": "aed995c1db6c8bfd9db0a75a978f5e261aab38e5",
-   "sha256": "1jz44lag1j4rawqjpcgb9zrs88vfi7vjgdh756hs2ln7i1cnvgh5"
+   "commit": "55cafb5512a174c3898aaacd71ab58832b9fe321",
+   "sha256": "106603835m3dy3bzjiasq2w574faxnn5kb72gr0y0mdkd0iwh8qa"
   }
  },
  {
@@ -76731,11 +77200,11 @@
   "repo": "flexibeast/org-vcard",
   "unstable": {
    "version": [
-    20200720,
-    638
+    20210208,
+    305
    ],
-   "commit": "1ae97371b207dabfecaf6b4f7118abafe6cc5e2b",
-   "sha256": "0k9slz20gxcdpvpz8kgvvwff6cif74wybpqgg9x03wqqqda3f37v"
+   "commit": "f4b7445550deb30e170a25fc42541e99730e21d0",
+   "sha256": "07dwxxwvahl153w6nsgfwrxgiw0s6c12kmvqvni19n6aiv3zavaj"
   },
   "stable": {
    "version": [
@@ -76844,30 +77313,30 @@
   "repo": "marcIhm/org-working-set",
   "unstable": {
    "version": [
-    20201118,
-    810
+    20210212,
+    1204
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "cf4bd2bfb11d0e0ed8c9228c07df8eb8150504f4",
-   "sha256": "10ailnbq2hhn8cnw1lcibhm8vgvy1437h48gbwxkk2kf25wpm73p"
+   "commit": "8e22ffe59d241a0f43395f2cd88589ffb0c7db23",
+   "sha256": "0vcawnrj5ap3h0cy5h1nsiki41scgdhxf83adnvv3lj6gwif1l9a"
   },
   "stable": {
    "version": [
     2,
     4,
-    0
+    3
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "cf4bd2bfb11d0e0ed8c9228c07df8eb8150504f4",
-   "sha256": "10ailnbq2hhn8cnw1lcibhm8vgvy1437h48gbwxkk2kf25wpm73p"
+   "commit": "8e22ffe59d241a0f43395f2cd88589ffb0c7db23",
+   "sha256": "0vcawnrj5ap3h0cy5h1nsiki41scgdhxf83adnvv3lj6gwif1l9a"
   }
  },
  {
@@ -77022,8 +77491,8 @@
   "repo": "tumashu/org2web",
   "unstable": {
    "version": [
-    20171005,
-    2317
+    20210203,
+    324
    ],
    "deps": [
     "cl-lib",
@@ -77035,8 +77504,8 @@
     "org",
     "simple-httpd"
    ],
-   "commit": "5243b399927a4c474bb3b8d1c8a00799df1f27d7",
-   "sha256": "0wsvfn409a2ivbich8b8zqza78sprirg4bl7igx536ydqclmi0n7"
+   "commit": "6f5c5f0cc5c877ac3a383782bbe8751264d807b6",
+   "sha256": "12rgrmcp91y27zcq8kcqvndb38n6ix4amf13cc2gjhi6aayxxx7k"
   },
   "stable": {
    "version": [
@@ -77081,8 +77550,8 @@
   "repo": "jcs-elpa/organize-imports-java",
   "unstable": {
    "version": [
-    20210113,
-    1838
+    20210121,
+    606
    ],
    "deps": [
     "dash",
@@ -77090,8 +77559,8 @@
     "ht",
     "s"
    ],
-   "commit": "6e0b1d094bc624a895d198874a8a423dfc033247",
-   "sha256": "0fhnlzg0gh9bkb471kxgsx69zqk1xybnii4lyv2lshylxac918a6"
+   "commit": "50c11af264505b026aed77d6b67a132f7d4f7e6b",
+   "sha256": "0q5qz7bm8k17v9mzixb4fbdcn9czcskkrrlnk38sgj390d2pyc7c"
   },
   "stable": {
    "version": [
@@ -77190,8 +77659,8 @@
     "org",
     "orgit"
    ],
-   "commit": "63a19d1df1434e583aac1329ba4dcfa2ee59d7c1",
-   "sha256": "1vd7wnas53z0985if22sv0wpww2dp0g8b0z9hwlzdhlcrsjay5fz"
+   "commit": "051d92661ef12b67ffadb231324806d87d1e6a54",
+   "sha256": "0x8wmqp9x2c7qv0ipj2rvjf7bc7z0pn8s253gjxpxmakz3l8wnyk"
   },
   "stable": {
    "version": [
@@ -77291,8 +77760,8 @@
     20201129,
     604
    ],
-   "commit": "c63c1682de9a10c6d6946978c154f09bb6fa7284",
-   "sha256": "0vp4s8m1rg0q3pd8vdk8ys03dzsibglpkx30hfw10z847fbif85w"
+   "commit": "69b2b5c3c6e581c3da56ec3ca4e2cd6c2e141c51",
+   "sha256": "0a87izghc9kjjbxylaqiy5ln6hzf4kjsn8fk7s4dpx0mqv5ps7y6"
   },
   "stable": {
    "version": [
@@ -77648,8 +78117,8 @@
     20200215,
     513
    ],
-   "commit": "703ee41303dc251b7672b7cba5aeb6aa54a76c90",
-   "sha256": "0cplbz7mc2zrxfk8g349ahb7gzli2hn5kda9155nbk8dw74xmj7d"
+   "commit": "94240ebb716f11af8427b6295c3f44c0c43419d3",
+   "sha256": "0c3l50qpdzracjncsbjv5chpvjdphhzwqk4jwv31fw6p62i1zvlb"
   },
   "stable": {
    "version": [
@@ -78067,15 +78536,15 @@
   "repo": "jkitchin/ox-clip",
   "unstable": {
    "version": [
-    20210113,
-    1749
+    20210115,
+    2234
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "bae9075745f21da2dfce311ae3ca8ad12d75046c",
-   "sha256": "04hnl7w6hf2jwd788p3p633bdfcziwll8638mlmslpws84iwx905"
+   "commit": "38b83ac6a70e9f1bc5cefb79a3b4e5397d11e467",
+   "sha256": "140yj6z9bz7i6ap7m9b465ambsczmx43zjp7887qjf77zbnf152b"
   }
  },
  {
@@ -78200,14 +78669,14 @@
   "repo": "kaushalmodi/ox-hugo",
   "unstable": {
    "version": [
-    20201111,
-    1638
+    20210129,
+    2241
    ],
    "deps": [
     "org"
    ],
-   "commit": "6bc8ee08023695fa167ac0ddf1fc61e1975fa1ce",
-   "sha256": "0sb4ms9wd6085g6c6kfjm4bk9z1z02l8dbn15xs9axzksk4zcq6x"
+   "commit": "be1d5ddd8622d369cb5196b7f9e7d4b21a71a8f1",
+   "sha256": "0zs7izss7kpqwv5a7crbwbis9w71vkz9qwgbbzhs2my6wmcdyjxi"
   },
   "stable": {
    "version": [
@@ -78352,8 +78821,8 @@
    "deps": [
     "org"
    ],
-   "commit": "be0a0dde62fde8cdf8d72b6968344906aa8c6f54",
-   "sha256": "1afikv50ii4xk9pkg4m6dx246bjnwka37lccif8i5r48hfy5w4bq"
+   "commit": "c4487689309dddff3228603754b69ab381cfa5dc",
+   "sha256": "17p42zv2slnfahrh9ln3rrh3fjnh2bk4j4fxljn589cgv0wblwqc"
   },
   "stable": {
    "version": [
@@ -78722,6 +79191,21 @@
   }
  },
  {
+  "ename": "ox-timeline",
+  "commit": "da58cd5a678314a359f6bdec404574b473ff361b",
+  "sha256": "0b0jb8n38rrllv4w2kcdh33k3vpjl0dyy7v4lpczsy23880pyfbq",
+  "fetcher": "github",
+  "repo": "jjuliano/org-simple-timeline",
+  "unstable": {
+   "version": [
+    20210118,
+    536
+   ],
+   "commit": "238e05b01dde37fa27a3a8943cc04dcc9b9b83b2",
+   "sha256": "0949gabr0wfsrzzaf217jsaawkc3gj1lxkrzwp3bigmxngsn4ykn"
+  }
+ },
+ {
   "ename": "ox-trac",
   "commit": "4b73753ef9229d0fdfbe237acc63126f1786a494",
   "sha256": "0f8b3i83vzxzfa91p4ahlqz6njql18xy5nk265sjxpy9zr898rsa",
@@ -78946,26 +79430,26 @@
  },
  {
   "ename": "package+",
-  "commit": "49cfbbc4535aa7e175aa819d67b8aa52a6f94384",
-  "sha256": "1mbsxr4llz8ny7n7w3lykld9yvbaywlfqnvr9l0aiv9rvmdv03bn",
+  "commit": "e6af50f8f11d89eca83f96f312fd9a143edae6d9",
+  "sha256": "1gyhy0jgqj9vv7ddm4xi5x5jaqdhkkc4mqcyr7134v2355nbpqlj",
   "fetcher": "github",
   "repo": "zenspider/package",
   "unstable": {
    "version": [
-    20201222,
-    255
+    20210124,
+    640
    ],
-   "commit": "59b0f6daf219a2e0a0a0389d56471eb2a876f21d",
-   "sha256": "139ffhhjv45fbxqjasv46v0057sjbynqi9x6g7vikrph0js7bnja"
+   "commit": "06fbc904e09d3349b669c2624a587fee5accf5ef",
+   "sha256": "0mmziyswrfj1a43cy6qn1d8b1a302z4w3xk4z5yi5frdr22j684c"
   },
   "stable": {
    "version": [
     1,
-    3,
+    4,
     0
    ],
-   "commit": "59b0f6daf219a2e0a0a0389d56471eb2a876f21d",
-   "sha256": "139ffhhjv45fbxqjasv46v0057sjbynqi9x6g7vikrph0js7bnja"
+   "commit": "2729bfd012c53733d3e00267d81d849ce5aa8e2d",
+   "sha256": "1ky1zm1rwkl0cphvdhg5vhzfg7syp8dhq774dq526nlrbfsvmiph"
   }
  },
  {
@@ -78976,14 +79460,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20210113,
-    329
+    20210209,
+    1639
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "71484efbf5f5df74c0db9936019c2e08f5ef3789",
-   "sha256": "08w97l0xycnm2z43n51bmgkf38cgaj4jq8p3qxyw3gx76605i8ck"
+   "commit": "d8ec8ddf5e39b61e9338de9a778633b7e01854cd",
+   "sha256": "1wdii6hlvd4pbgf7bp9d8ay0kd34nyxz2w7gyq2kx43hlcgxhyp1"
   },
   "stable": {
    "version": [
@@ -79020,15 +79504,15 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20210111,
-    341
+    20210127,
+    158
    ],
    "deps": [
     "cl-lib",
     "let-alist"
    ],
-   "commit": "348b15a1da1d62dee378b33971e39758b96c6575",
-   "sha256": "0zj7qxb3b0yrrfwa8n9hhzrnsyh9msf38glmn8r087p27x0ifwzr"
+   "commit": "1dd52c65cf1431aec5b3dbbb16408f25559c5112",
+   "sha256": "0pq4ksipnli2798c7rvv2wlnk1nkd8j92vz7kpld8y0bgfr62mbr"
   },
   "stable": {
    "version": [
@@ -79057,8 +79541,8 @@
    "deps": [
     "package-lint"
    ],
-   "commit": "348b15a1da1d62dee378b33971e39758b96c6575",
-   "sha256": "0zj7qxb3b0yrrfwa8n9hhzrnsyh9msf38glmn8r087p27x0ifwzr"
+   "commit": "1dd52c65cf1431aec5b3dbbb16408f25559c5112",
+   "sha256": "0pq4ksipnli2798c7rvv2wlnk1nkd8j92vz7kpld8y0bgfr62mbr"
   },
   "stable": {
    "version": [
@@ -79143,8 +79627,8 @@
     20201120,
     2047
    ],
-   "commit": "3b96dedb404f614479c1b321fac3e4bf11ba0782",
-   "sha256": "0fbv8ryxjz1ndfv4ximmr5m1rd9xkmi8dp0x14r8g5wiy9959asb"
+   "commit": "47437da7839394b079699eb4cfcc00627ab2df8e",
+   "sha256": "0hp80n3mxnkssq431h9b9xlz21dqkyzjsajylrnbfvqqwqh293qk"
   },
   "stable": {
    "version": [
@@ -79270,6 +79754,24 @@
    ],
    "commit": "dbbd49c2ac5906d1dabf9e9c832bfebc1ab405b3",
    "sha256": "11msqs8v9wn8sj45dw1fl0ldi3sw33v0xclynbxgmawyabfq3bqm"
+  }
+ },
+ {
+  "ename": "pair-tree",
+  "commit": "ca9422233229d8703641d87d9250ad3f38c11fd7",
+  "sha256": "0rv6yp2vzcvnjkrlihm2a2a62879rcqwnzw7ph535drvwfl0inws",
+  "fetcher": "github",
+  "repo": "zainab-ali/pair-tree.el",
+  "unstable": {
+   "version": [
+    20210205,
+    1018
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "f45418560dfc7773ea896e34fb216f68b90c764d",
+   "sha256": "10bhwq7g16cvib8s4lg9skskbwp1bjyqrw8h0mip3sgvvjlhckfh"
   }
  },
  {
@@ -79413,15 +79915,15 @@
   "repo": "joostkremers/pandoc-mode",
   "unstable": {
    "version": [
-    20201120,
-    2241
+    20210201,
+    1150
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "0630a112ae7d3eab1a4c47c7ef380915560a6bb2",
-   "sha256": "1k31pkvd9m798i6phcr0y3wd34fgq6ii41hx3lszmikvxb1yvm2y"
+   "commit": "69ec31fc4da30dca2d223ac9ed1bcb5f9d3801ba",
+   "sha256": "0c4j95c2axbhw0jnqsj9qxc62cdqwk2w3g4a2zgi64m2qlf3q4c9"
   },
   "stable": {
    "version": [
@@ -79653,20 +80155,20 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20200103,
-    1238
+    20210127,
+    1749
    ],
-   "commit": "eb4a51b8ef455e0914108105e7c0008d675457cc",
-   "sha256": "17bdcxah216z928387yx6z9lmp4jsi461n8fwiqaibn2qy5fagas"
+   "commit": "6790c7fdec490a69e7d460c0bea36ad343776f9b",
+   "sha256": "1zyrrrr8rmksr3rfsv96psk1z15wbbx1bvcfp3hf5ciyc2n79000"
   },
   "stable": {
    "version": [
     1,
     0,
-    6
+    7
    ],
-   "commit": "eb4a51b8ef455e0914108105e7c0008d675457cc",
-   "sha256": "17bdcxah216z928387yx6z9lmp4jsi461n8fwiqaibn2qy5fagas"
+   "commit": "6790c7fdec490a69e7d460c0bea36ad343776f9b",
+   "sha256": "1zyrrrr8rmksr3rfsv96psk1z15wbbx1bvcfp3hf5ciyc2n79000"
   }
  },
  {
@@ -79707,8 +80209,8 @@
     "cl-lib",
     "dash"
    ],
-   "commit": "91856b9c5817ead97aa034fe108c4a6e884802b2",
-   "sha256": "0l16x34af9y60n6502iihl9nz1w4kq8hx1dipi6xa16kr5gs8ba6"
+   "commit": "8659c99a9475ee34af683fdf8f272728c6bebb3a",
+   "sha256": "06pz7ady4l05y56w3nr7bknv277jr949p9p9yy0dh8slii2acl77"
   },
   "stable": {
    "version": [
@@ -79735,8 +80237,8 @@
     20201124,
     616
    ],
-   "commit": "ca9e7b6f8c3c70daf6a933952955b6931a24af83",
-   "sha256": "17gf7ahvplgr7x3afpdm5zh8w8y45vzjcyb4jg8vn67grq3kij74"
+   "commit": "67eed38129c28f087c0b5dffe8a790978d41a8c1",
+   "sha256": "074mx8dx4ja0bylsrf05d8n03a7ivix65iz3377h4p3ikmvppc3f"
   },
   "stable": {
    "version": [
@@ -79795,14 +80297,14 @@
   "repo": "jcs-elpa/parse-it",
   "unstable": {
    "version": [
-    20201103,
-    1107
+    20210128,
+    1345
    ],
    "deps": [
     "s"
    ],
-   "commit": "580713c0c578f6c91f6851ae2120e8a9b7871bb0",
-   "sha256": "0c61gyks581xx47a4lrdjx64d1x1py7qmzsxklvwlcx0gq6pzalm"
+   "commit": "27a7b6ac6e92644160358958602aeae596ba8bad",
+   "sha256": "13hh3rfpfcmg6avakgb7rg4nrrifsj8s3yp359933axv2f622gbx"
   },
   "stable": {
    "version": [
@@ -79956,16 +80458,16 @@
   "repo": "NicolasPetton/pass",
   "unstable": {
    "version": [
-    20201230,
-    1556
+    20210203,
+    810
    ],
    "deps": [
     "f",
     "password-store",
     "password-store-otp"
    ],
-   "commit": "a095d24cf06a7b0fbc3add480c101304a91cf788",
-   "sha256": "1nv6xs90zkv3qd0jxjwxlx132cz0ias0i7n2kvih6fp5gfkrzdci"
+   "commit": "5651da53137db9adcb125b4897c2fe27eeb4368d",
+   "sha256": "0xrdi06m55mzm14fw0ly0xbfyh2g43k3np2fm771nwzdw5kmin4v"
   },
   "stable": {
    "version": [
@@ -80013,10 +80515,10 @@
  },
  {
   "ename": "password-generator",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "1ziiz4x4slfadlm7fjpmwvq4a9fi3ird74b6v5na499ylqnzrl59",
+  "commit": "fd591276073bf87fd9debdffc396f650790d566a",
+  "sha256": "0kb424axcik38a9zn2a6mabs3ya6bs8zh06d26jzyaa4d2q75246",
   "fetcher": "github",
-  "repo": "zargener/emacs-password-genarator",
+  "repo": "vandrlexay/emacs-password-genarator",
   "unstable": {
    "version": [
     20201123,
@@ -80631,11 +81133,11 @@
   "repo": "jeremy-compostella/pdfgrep",
   "unstable": {
    "version": [
-    20200306,
-    209
+    20210203,
+    1730
    ],
-   "commit": "1576fc98754d3bdaa40573a037a80f1973110756",
-   "sha256": "1c3p3vdhy6wibxwpc76bvvm0583zmjmxs9pa453z3msbq33kc7j8"
+   "commit": "a4ca0a1e6521de93f28bb6736a5344b4974d144c",
+   "sha256": "093sm3ywa338lhhz2ib3ylcgklsbxcsqck2qsaq26i2qxr0r7lq2"
   }
  },
  {
@@ -80987,8 +81489,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "2f2b59e693f08b8d9c81062fca25e6076b6e7f8d",
-   "sha256": "04r5h5zs5r6s22p5ynhpr860r2r552z9pyf4kbabfg1gz9jag7yp"
+   "commit": "d46082ca2adb8df3f6a7a422cff4af095878c2b6",
+   "sha256": "1vxnp6bzs1vlvh3cn56g64pb5zsy0ww1f50hlz7sklabc1mpp6sy"
   },
   "stable": {
    "version": [
@@ -81355,38 +81857,6 @@
   }
  },
  {
-  "ename": "php-auto-yasnippets",
-  "commit": "28b2d8802f98e339ff01ecf9733b71b6c631123e",
-  "sha256": "047i51ks2nn7ydrx2hjx9qvsh3lxnyxp8a6c3h3nb1acy84f5bd1",
-  "fetcher": "github",
-  "repo": "emacs-php/php-auto-yasnippets",
-  "unstable": {
-   "version": [
-    20170331,
-    114
-   ],
-   "deps": [
-    "php-mode",
-    "yasnippet"
-   ],
-   "commit": "03e1f0899c081813901ac15c2f7a675a37cca9f5",
-   "sha256": "0d7y6njsd1s2r5df2k8wvvwgxpwwyaqkhdd2b3p1php8rrbj3mg8"
-  },
-  "stable": {
-   "version": [
-    2,
-    3,
-    1
-   ],
-   "deps": [
-    "php-mode",
-    "yasnippet"
-   ],
-   "commit": "1950d83cbcc5c5d62cd3bc432e1595870fe8cabf",
-   "sha256": "0zs11811kx6x1zgc1icd8gw420saa7z6zshpzmrddnbznya4qql6"
-  }
- },
- {
   "ename": "php-boris",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "0kklwk8b98czsg567vgzzdfnv76yn1id3ah2q2qqdhaky1yzw7ak",
@@ -81612,36 +82082,6 @@
    ],
    "commit": "61e4eab638168b7034eef0f11e35a89223fa7687",
    "sha256": "0dsa1mygb96nlz5gppf0sny3lxaacvmvnkg84c0cs6x223s6zfx8"
-  }
- },
- {
-  "ename": "phpcbf",
-  "commit": "77ef54e3fb2715a081786dc54f99ae74def5c77c",
-  "sha256": "1hf88ys4grffpqgavrbc72dn3m7crafgid2ygzx9c5j55syh8mfv",
-  "fetcher": "github",
-  "repo": "nishimaki10/emacs-phpcbf",
-  "unstable": {
-   "version": [
-    20181228,
-    423
-   ],
-   "deps": [
-    "s"
-   ],
-   "commit": "fb0bc6073a57126cf1a8404723aa0a715dd761aa",
-   "sha256": "0k2wl137nippcfx3g35kfprz2fiv8rbbi7dcpxciwnbqmn6ry7rf"
-  },
-  "stable": {
-   "version": [
-    0,
-    9,
-    2
-   ],
-   "deps": [
-    "s"
-   ],
-   "commit": "b556b548ceb061b002389d6165d2cc63d8bddb5d",
-   "sha256": "09rinyx0621d7613xmbyvrrlav6d4ia332wkgg0m9dn265g3h56z"
   }
  },
  {
@@ -82099,16 +82539,15 @@
   "repo": "pwalsh/pipenv.el",
   "unstable": {
    "version": [
-    20201206,
-    1408
+    20210127,
+    1444
    ],
    "deps": [
-    "f",
     "pyvenv",
     "s"
    ],
-   "commit": "f516a1a8677a6a1ce9683056e9f77b1e785e8431",
-   "sha256": "0ksjshvv8vnx2v91bfykajjnlcc5i0by0lrg0a34f8f3zjyaqcab"
+   "commit": "8f50c68d415307a2cbc65cc4df20df18e1776e9b",
+   "sha256": "0l81vbwp7gmcg1n7i8cwa01rpwc24db7gxqvmhln8piy1r2ymh6x"
   }
  },
  {
@@ -82210,11 +82649,11 @@
   "repo": "juergenhoetzel/pkgbuild-mode",
   "unstable": {
    "version": [
-    20210114,
-    1506
+    20210123,
+    1507
    ],
-   "commit": "e4f0067bdce3e071a7d9316a6e142e1c61215169",
-   "sha256": "1mvn4w3k1wf8yls0mjl667yzlir1qyvxamlzdx62yhqpr9y55sip"
+   "commit": "8a5e95c8514315cb40c47f1acdb68a4ace921497",
+   "sha256": "1p903a3jbw1jp5l6d6mb50dq5zd8951qxh2b97vy30p3nnl8i0lj"
   },
   "stable": {
    "version": [
@@ -82990,14 +83429,14 @@
   "repo": "lijunsong/pollen-mode",
   "unstable": {
    "version": [
-    20191223,
-    1920
+    20210120,
+    422
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d0a33591498013886c2c4676e204cd684954e82a",
-   "sha256": "0lg65hzdjwbc3dav79f3jm7251yyq8ghcbccvkb32vwz281xhjnh"
+   "commit": "09a9dc48c468dcd385982b9629f325e70d569faf",
+   "sha256": "15z6sdkg9vygczr1imk3c5v6cbpqgsvnkydzkcmxnbwnqlx1agpc"
   }
  },
  {
@@ -83008,16 +83447,16 @@
   "repo": "polymode/poly-R",
   "unstable": {
    "version": [
-    20200316,
-    1315
+    20210210,
+    1053
    ],
    "deps": [
     "poly-markdown",
     "poly-noweb",
     "polymode"
    ],
-   "commit": "51ffeb6ec45dd44eafa4d22ad2d6150cc4b248fc",
-   "sha256": "0a4wx73jkngw5nbq1fa4jfhba6bsmyn6vnsf887x3xhb5v3ykhsg"
+   "commit": "c42ff3a4d0da96ccb7f826dca5c6b2eb558a2ab5",
+   "sha256": "0sazc0vnks2jnrmgz9p2r821l4m9wrggr6mgcwh6v7lzwj76x3f7"
   },
   "stable": {
    "version": [
@@ -83316,8 +83755,8 @@
     20200606,
     1106
    ],
-   "commit": "3284ff10017d280ba82f27dc20fe5223b0df709c",
-   "sha256": "0756c0fi5msqdsks95bcs0ghhk90b340y4zrkijhaz4b2cnm07h4"
+   "commit": "b3871e946d278a256d95a3bd4615b1df234ad75a",
+   "sha256": "08xn2my8n5m9mqr7zd1956vybakys17kldb6dijax1651fdjy772"
   },
   "stable": {
    "version": [
@@ -83425,8 +83864,8 @@
   "repo": "ponylang/ponylang-mode",
   "unstable": {
    "version": [
-    20201113,
-    1633
+    20210118,
+    1325
    ],
    "deps": [
     "company-ctags",
@@ -83438,8 +83877,8 @@
     "yafolding",
     "yasnippet"
    ],
-   "commit": "ef3ce7122e2fd112bde0e49a529934be1fea0ad5",
-   "sha256": "0kh9p66lhv4fs778cy4dysnvlvwj7zaa1f9ivw2hnqjycqf2bz53"
+   "commit": "a1583287cbafce053d4345a1531c6358ce970a77",
+   "sha256": "0pdimil370rilynz437xw7s1a323g00hmcinzpsfbnvq4k4ajk8s"
   },
   "stable": {
    "version": [
@@ -83762,20 +84201,20 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20210113,
-    314
+    20210208,
+    229
    ],
-   "commit": "efd7ea490defc53a5b78e7469a3a35d225b766cc",
-   "sha256": "1in1w9h1hal1qbcqxlk3mqn3q5qpcpni8a2c05dxqaqavbvz2y4j"
+   "commit": "3454a4cb9d218c38f9c5b88798dfb2f7f85ad936",
+   "sha256": "039a84gwb0phjm7jcklmji1pcpbxmp4s40djhac8sbzmwdv39zi4"
   },
   "stable": {
    "version": [
     0,
     8,
-    4
+    5
    ],
-   "commit": "efd7ea490defc53a5b78e7469a3a35d225b766cc",
-   "sha256": "1in1w9h1hal1qbcqxlk3mqn3q5qpcpni8a2c05dxqaqavbvz2y4j"
+   "commit": "3454a4cb9d218c38f9c5b88798dfb2f7f85ad936",
+   "sha256": "039a84gwb0phjm7jcklmji1pcpbxmp4s40djhac8sbzmwdv39zi4"
   }
  },
  {
@@ -84113,28 +84552,28 @@
   "repo": "jscheid/prettier.el",
   "unstable": {
    "version": [
-    20201222,
-    953
+    20210129,
+    826
    ],
    "deps": [
     "iter2",
     "nvm"
    ],
-   "commit": "5b584f21b8dd9a53ceb7745c2d91c513358892e7",
-   "sha256": "1m5298i60s1rdy2r8wnyialkfbafd99wp9q0bzsbr7grq3cdp2ic"
+   "commit": "61f135a82156712b9226d9bf23156c0cce9d5c98",
+   "sha256": "0z0nrhajx4xs6miaixhb0syzp7ilbbm71qcbvqqdk1fr9819nhgl"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "iter2",
     "nvm"
    ],
-   "commit": "d5ccedc7a8ed84aff292bce688c73648dc8f567f",
-   "sha256": "1rk2hwpxvnc1hadvdg86jnzz4nh5kmkwp18iwvsbkgmx47cnyni3"
+   "commit": "8b38172bb6644b71b718c0732e5b9f1cd32e587a",
+   "sha256": "0zkicnfj1y2zpwbwm4ccrpvzr5z6rpkk82mdzaszkx0sksd3hzxm"
   }
  },
  {
@@ -84417,16 +84856,16 @@
   "repo": "rejeep/prodigy.el",
   "unstable": {
    "version": [
-    20191212,
-    1242
+    20210116,
+    816
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "6ae71f27b09b172f03fb55b9eeef001206baacd3",
-   "sha256": "16w1xidfbqlbdxq45ff6am9j1hzlxz3pwqvimwk4432prrvnf8zg"
+   "commit": "168f5ace1671876d8c3bd350c0853bd0196bddda",
+   "sha256": "15rshpq0h5i252xamxh70acdz9jddn5xwgswzk5h2b24kxsbfnli"
   },
   "stable": {
    "version": [
@@ -84679,14 +85118,14 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20210104,
-    1216
+    20210125,
+    726
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "c31bd41c0b9d6fba8837ebfd3a31dec0b3cd73c6",
-   "sha256": "10pibv07mb3mwmz6r2kmd7xdz5rly7hfbxvhmxd536zbr2s9rr1j"
+   "commit": "fd5994762a90c2311e8aa40c37373f24e1743a55",
+   "sha256": "1vlry2pa45v0l3g0lrhi6sp24cf8i0s76nz1pm92iwgk6hpdz560"
   },
   "stable": {
    "version": [
@@ -84718,26 +85157,6 @@
    ],
    "commit": "f6eb96f034a925444412cfa03e45e0ccbbafe3f2",
    "sha256": "1xdkm1f04z1h3ivd6zm8hckf3n3fbi5rwybg4dwi5mim6w84i7j9"
-  }
- },
- {
-  "ename": "projectile-direnv",
-  "commit": "602485c251bc573e855dfd33e4e94052afbab93f",
-  "sha256": "1s5dapdcblcbcqyv8df26v8wxl8bhrs9ybl5h5qbzz49gigd8nqh",
-  "fetcher": "github",
-  "repo": "christianromney/projectile-direnv",
-  "unstable": {
-   "version": [
-    20160306,
-    138
-   ],
-   "deps": [
-    "dash",
-    "projectile",
-    "s"
-   ],
-   "commit": "d5d29e5228f840b7a25358a2fd50353ef2dc9b16",
-   "sha256": "1bq47a6lckgin93cqy5wj277rlrw2cgfywgmbdpxvmbhygpg5hqr"
   }
  },
  {
@@ -85110,11 +85529,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20210110,
-    1959
+    20210131,
+    2042
    ],
-   "commit": "0d731606bee81b2d73895a23b69e84796ea7e4e7",
-   "sha256": "1j0fhd5cmhx6h3hnk2xb30hn6sxfp1js3zgldqpvk4qrws5vs25h"
+   "commit": "89300b579aea2471448b8871b94c0e5982c7c059",
+   "sha256": "0097gkhb9lw8rl1pqk0fchpgkvfynvgvkz7rgwp4dqifn63krq1j"
   },
   "stable": {
    "version": [
@@ -85217,8 +85636,8 @@
     20200619,
     1742
    ],
-   "commit": "48234f5f012582843bb476ee3afef36cda94cb66",
-   "sha256": "1rn10w72a98k2r98lv3vaq6k8vwasdkc6c1r8lix441hd1jl60gj"
+   "commit": "aee143afe8c17a3d2c7e88b70ffa6e08a73e2683",
+   "sha256": "184fg4x1v2yyzh5z47mj0shmq45v1cb8d8pdqbrx7ffxr4lmyn74"
   },
   "stable": {
    "version": [
@@ -85373,15 +85792,15 @@
   "repo": "thierryvolpiatto/psession",
   "unstable": {
    "version": [
-    20210102,
-    1856
+    20210203,
+    828
    ],
    "deps": [
     "async",
     "cl-lib"
    ],
-   "commit": "a3fbcbb94a41450c9a5fdbea3b4ac2134c2aa082",
-   "sha256": "1w0ifzmd35c9rrc1vwas63hz7f1l8w0dlzwikmiiza6jy51qn9dd"
+   "commit": "ed53362af4dfc813505c30ca40227072df16fdfc",
+   "sha256": "0crq5ynhqi6lbq471nskcnjplyj6i80rxl3z00iyisc9184r7wwb"
   },
   "stable": {
    "version": [
@@ -85461,14 +85880,14 @@
   "repo": "nbfalcon/ptemplate",
   "unstable": {
    "version": [
-    20201213,
-    1355
+    20210204,
+    1306
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "7caca3ed9f2c1bce77943d8ef3db6721e2b027e5",
-   "sha256": "0p23rlhv7xqwhzd0a2ybvn799xpr2n7jdinx5r07sdxmsjrmgzv9"
+   "commit": "0d03fe3b2c608ab31bda309ef8e7a7d076bb0069",
+   "sha256": "18lb3an90py39lmxk05fw5ppxa3xqrhck2qz27a0zaxvd6y3hqmx"
   }
  },
  {
@@ -85479,14 +85898,14 @@
   "repo": "nbfalcon/ptemplate-templates",
   "unstable": {
    "version": [
-    20210109,
-    2155
+    20210204,
+    1308
    ],
    "deps": [
     "ptemplate"
    ],
-   "commit": "26f1e4d40ac0e89e82c3210591064770f86490bf",
-   "sha256": "1yjigz22laz0f5m10kcslhg184lsqsfr72samk59l13jpnr676qg"
+   "commit": "66bcd5d16289809ac771a7f25bd62b6eaa1ab022",
+   "sha256": "0bz1ipf7spch9fh1dwgnypka0199yfl07avrsg19y2lpbwi7mg0k"
   }
  },
  {
@@ -86230,8 +86649,8 @@
     20200503,
     1624
    ],
-   "commit": "168bee7f23d9956c12b419b18aa9f5974151e3d7",
-   "sha256": "00y3klba3m1j43mfggh7pvy93khk1ga1lyb98r5mlfffrymvr209"
+   "commit": "d825c21e18de5618cfcacea0fd818efa80a6b0fe",
+   "sha256": "0riipssdnhys8qijayz1syk1haw1z915c0pplv50qi9nf7lli95j"
   }
  },
  {
@@ -86596,30 +87015,28 @@
   "repo": "pythonic-emacs/pythonic",
   "unstable": {
    "version": [
-    20200806,
-    434
+    20210122,
+    1247
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "51233ec7ec9fbafd13e2b0479c7b2ee0930ccca5",
-   "sha256": "1v4n6wx0qff2ndlxy11acm21jq5yflk28axs6jc6yh7mdj44js9x"
+   "commit": "e0e5cc882f2f1316268ec461a34d4be8abc313b7",
+   "sha256": "0hbvy8wdi5dgxn86j8z54y2fhcvm605xxm6xv054nl6fw2hh2h5h"
   },
   "stable": {
    "version": [
     0,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
-    "cl-lib",
-    "dash",
     "f",
     "s"
    ],
-   "commit": "c59a158942634d3c07e506b2376d96e8d5d1466f",
-   "sha256": "0219s900kdpi3cxllvmwm8hb2lwqzikplq578f7pyxhzljjh2lma"
+   "commit": "e0e5cc882f2f1316268ec461a34d4be8abc313b7",
+   "sha256": "0hbvy8wdi5dgxn86j8z54y2fhcvm605xxm6xv054nl6fw2hh2h5h"
   }
  },
  {
@@ -86656,8 +87073,8 @@
     20201231,
     140
    ],
-   "commit": "e4499e7fcdfafd8d1825eb705c34a7748ca5ee64",
-   "sha256": "1bb9w75rxvsx024y0yx41rrskkmhpyfslw3xi414d2w5wmh82zbm"
+   "commit": "3fef8d74bb45ec82f3c317d904a570c3b3318ce2",
+   "sha256": "03n6cyg1qkn2hglvv0iynlmq1gwhxgd59jil9rc1qka60pislpgz"
   }
  },
  {
@@ -86791,11 +87208,11 @@
   "repo": "quelpa/quelpa",
   "unstable": {
    "version": [
-    20210101,
-    937
+    20210208,
+    716
    ],
-   "commit": "42835119977a6512274d8337e866479af4f26dec",
-   "sha256": "1qqzkk3ym4p3q8b33szmww4ixp1sjmirihnvkgmvfpv0rrc15icc"
+   "commit": "8c25a40d07c08a6a9754b3ae12174664e8ed7871",
+   "sha256": "05yl7ivr6rq6gry0ik4qg2pxsw07byqwz9sn58hpsx8v7blxwxln"
   },
   "stable": {
    "version": [
@@ -86804,6 +87221,38 @@
    ],
    "commit": "f1fc228f217be692eaae2d53f51966ce922d6a32",
    "sha256": "03h30qcixq54q212381cf7mahi2k9q4590vm44pqy9widpigmxz7"
+  }
+ },
+ {
+  "ename": "quelpa-leaf",
+  "commit": "2c6b25a8bde336bef7d0bd0ef0261b2b2c08abb1",
+  "sha256": "1gn0g4w6qas62fq1dgxa5vplpq4qry6fz98xva1rl44yv1miigjp",
+  "fetcher": "github",
+  "repo": "quelpa/quelpa-leaf",
+  "unstable": {
+   "version": [
+    20210124,
+    348
+   ],
+   "deps": [
+    "leaf",
+    "quelpa"
+   ],
+   "commit": "eacc544b93f6fdc3be69a6ffbf960380a63fc715",
+   "sha256": "0ka2qk1y7byrq4rbmyhr06kfgc76afpmpdcxk3nf4g3krgi778dw"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    1
+   ],
+   "deps": [
+    "leaf",
+    "quelpa"
+   ],
+   "commit": "d367e3cd54d9ac949569f4cb7c0ff092a76391ab",
+   "sha256": "048216i1kn65d0ckzy1j08lg1lq2169jg7a4mchvcw3z7rmhx8f5"
   }
  },
  {
@@ -87051,8 +87500,8 @@
   "repo": "racer-rust/emacs-racer",
   "unstable": {
    "version": [
-    20191001,
-    2344
+    20210119,
+    225
    ],
    "deps": [
     "dash",
@@ -87061,8 +87510,8 @@
     "rust-mode",
     "s"
    ],
-   "commit": "a0bdf778f01e8c4b8a92591447257422ac0b455b",
-   "sha256": "1dzp2l6lcdrcss5xp32yvil4c1din09awnxg0f71fls6kh2g2fcq"
+   "commit": "f17f9d73c74ac86001a19d08735e6b966d6c5609",
+   "sha256": "1hi0ackw5pfqak5yl4z804z2vajhg7wkvzz20w9kbzcighz6vccq"
   },
   "stable": {
    "version": [
@@ -87087,15 +87536,15 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20210110,
-    1607
+    20210213,
+    24
    ],
    "deps": [
     "faceup",
     "pos-tip"
    ],
-   "commit": "871aff8dc5a4bbc6f1d760fdbceb1f71fcf70b1f",
-   "sha256": "1z8lxaj24ykpa27y6v5zjwmdnaxhd7m8my5q7yxr4inlzyhhgckp"
+   "commit": "c73c3fcbe135f6cda7abc246e01bc5dc6b310462",
+   "sha256": "0crzdaqr1yjziv3dswxa9nn1dirq4pa8rhd0mda09bipvxfjirhp"
   }
  },
  {
@@ -87208,14 +87657,14 @@
   "repo": "stardiviner/emacs-rainbow-fart",
   "unstable": {
    "version": [
-    20201228,
-    6
+    20210202,
+    846
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "63b6a77a38235e7917d200886922156506853c42",
-   "sha256": "1pfpinplhkn5d91rlbgh359w4d7hp399vpximipj69bnx3nizic6"
+   "commit": "61acc77535720f7ed3b8f680fa9d9a1871832f11",
+   "sha256": "063a76lvyx83h7smplghcg5zxkncx017kjc25y74diwsda16sn0z"
   }
  },
  {
@@ -87365,11 +87814,11 @@
   "repo": "ralesi/ranger.el",
   "unstable": {
    "version": [
-    20200607,
-    2002
+    20210125,
+    330
    ],
-   "commit": "caf75f0060e503af078c7e5bb50d9aaa508e6f3e",
-   "sha256": "0xfg38ginrd0sdn194gpapi67q6i81csddgsf0rqmwihazpgs060"
+   "commit": "2498519cb21dcd5791d240607a72a204d1761668",
+   "sha256": "1wzshhg6dchny9drm8lf8sw4s24icgyb4my58xvhm55dp4zl5p3b"
   },
   "stable": {
    "version": [
@@ -88319,8 +88768,8 @@
     20201219,
     1739
    ],
-   "commit": "54d9914b270975e92fec56bcb3911c7335aeed7d",
-   "sha256": "1v2maw9jpvvfv6a6qkh3nasshf3pjzbqpyxsarhk2054d982qy5c"
+   "commit": "348030d5d65524b4f6a2dfad1d53f2ca92dbd49c",
+   "sha256": "1h96qy2741vsnrsnq5klxf2swm2kib7lfr3ni1rwsygib10hkqb5"
   }
  },
  {
@@ -88641,11 +89090,11 @@
   "repo": "YangZhao11/register-channel",
   "unstable": {
    "version": [
-    20180926,
-    2349
+    20210120,
+    1618
    ],
-   "commit": "9272923757402d177a0b2deab1d9c3c74601c48e",
-   "sha256": "0k9qgrbzbxx4sjffnr02qx5wm71i3m61w7mh2j4hq9jf8k6nbkq4"
+   "commit": "ed7f563e92170b758dc878fcb5df88d46d5d44cc",
+   "sha256": "1ih1s274004faq78fgdxw3gy7i58nbanbp39ax2wi8zz6ivm9lqa"
   }
  },
  {
@@ -88998,11 +89447,11 @@
   "repo": "tkf/emacs-request",
   "unstable": {
    "version": [
-    20201026,
-    2324
+    20210212,
+    505
    ],
-   "commit": "0183da84cb45eb94da996cd2eab714ef0d7504cc",
-   "sha256": "16q2mb0ir3a6kpgbkv6ag0zs10pj4gr2j1qdizzfqx7m4piyfj0n"
+   "commit": "c5a10680f38cd9b60057a7d213eb9bc7dcec918b",
+   "sha256": "16vs9ifnsa76kikz64jawwkpfck15xm8cdd3ndi4hl4g6ff8a92s"
   },
   "stable": {
    "version": [
@@ -89029,8 +89478,8 @@
     "deferred",
     "request"
    ],
-   "commit": "0183da84cb45eb94da996cd2eab714ef0d7504cc",
-   "sha256": "16q2mb0ir3a6kpgbkv6ag0zs10pj4gr2j1qdizzfqx7m4piyfj0n"
+   "commit": "c5a10680f38cd9b60057a7d213eb9bc7dcec918b",
+   "sha256": "16vs9ifnsa76kikz64jawwkpfck15xm8cdd3ndi4hl4g6ff8a92s"
   },
   "stable": {
    "version": [
@@ -89259,28 +89708,28 @@
   "repo": "jcs-elpa/reveal-in-folder",
   "unstable": {
    "version": [
-    20201224,
-    1242
+    20210129,
+    1921
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "5143c92c806fd3a80e6729a42167be9caea88f45",
-   "sha256": "1kpnk1fhzgiv2dc3y6fk27ina7j11s6siagqpi5fckbbi18hd84i"
+   "commit": "f62be2d11c8a9182cf84f0efe7ed054cc304262d",
+   "sha256": "0ksw9s96mmb1qlypz9mc9br9139ha5jmahi42x4i8qppcn6zs5ja"
   },
   "stable": {
    "version": [
     0,
     1,
-    1
+    2
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "29240e4845a44d10134652b427580301318f1288",
-   "sha256": "0ckaq8z38mj17abzarvq0awsqvwnff22mxa6pgsl7ks67hzq5kb4"
+   "commit": "f62be2d11c8a9182cf84f0efe7ed054cc304262d",
+   "sha256": "0ksw9s96mmb1qlypz9mc9br9139ha5jmahi42x4i8qppcn6zs5ja"
   }
  },
  {
@@ -89410,15 +89859,15 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20210113,
-    1559
+    20210209,
+    1953
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "c34266646951618af916684e954c33a9b1f86085",
-   "sha256": "12v7x427rwg8q9i7c81bzd4r4jpqwsv0442dahjxiivlrxqdb18h"
+   "commit": "a1bc7036dc662b8c38aaac0b4e2ea3bb5934a688",
+   "sha256": "1q8z71b9vwq1v1n36byr1qqb3h7sjrvkds2yzbs3vvm1mzzl3qa3"
   },
   "stable": {
    "version": [
@@ -89567,8 +90016,8 @@
   "repo": "DogLooksGood/emacs-rime",
   "unstable": {
    "version": [
-    20210113,
-    742
+    20210207,
+    1432
    ],
    "deps": [
     "cl-lib",
@@ -89576,8 +90025,8 @@
     "popup",
     "posframe"
    ],
-   "commit": "8012c6a09195d940c2ba24d7c63974fb5b3b0e51",
-   "sha256": "0wnx4saydjy6h97hg9277sqykxs2qh7731qs27n5nhxq2rbyw01p"
+   "commit": "edcb6278b1a864d28ed96375e18ff77def09feb0",
+   "sha256": "1g8ns518yn30838by7nd13k73nz8k6wk580jcsfjqpwjig8vr5as"
   },
   "stable": {
    "version": [
@@ -89782,14 +90231,14 @@
   "repo": "dgutov/robe",
   "unstable": {
    "version": [
-    20201214,
-    2255
+    20210202,
+    111
    ],
    "deps": [
     "inf-ruby"
    ],
-   "commit": "596d27e37440cad6cd65dcf83d03c502efc01eb4",
-   "sha256": "09gc6yy2d5z75s37zw1xiv0qh44nvf4j24w8qd15270wkaczfixa"
+   "commit": "3ef165c5c99aebfd811a0f18ea7f8c983d4ab152",
+   "sha256": "1vwwchgd45a0lin4n04ffwz021889ps4vcj787iy5ijw34pi8zrj"
   },
   "stable": {
    "version": [
@@ -89935,11 +90384,11 @@
   "repo": "daichirata/emacs-rotate",
   "unstable": {
    "version": [
-    20160909,
-    836
+    20210126,
+    637
    ],
-   "commit": "091b5ac4fc310773253efb317e3dbe8e46959ba6",
-   "sha256": "0msjn7ays71mcw6qmdk0mpjp1rvd7fwz917vmvlcd7cpmvkyfbds"
+   "commit": "4e9ac3ff800880bd9b705794ef0f7c99d72900a6",
+   "sha256": "1v4xaqfh3madrc8jcr16xzs40vvmk2ml1qwgsxkcm11l6pglmnnk"
   }
  },
  {
@@ -89991,29 +90440,6 @@
   }
  },
  {
-  "ename": "rsense",
-  "commit": "e2149ce3baef9ac01d5b2e8b1a933a3e1206015f",
-  "sha256": "1901xqlpc8fg4sl9j58jn40i2djs8s0cdcqcrzrq02lvk8ssfdf5",
-  "fetcher": "github",
-  "repo": "m2ym/rsense",
-  "unstable": {
-   "version": [
-    20100511,
-    405
-   ],
-   "commit": "8b5ee58318747ca1dde84ee41d48c4f50175cf35",
-   "sha256": "0xkr1qn8fm3kv5c11janq5acp1q02abvxc463zijvm2qk735yl4d"
-  },
-  "stable": {
-   "version": [
-    0,
-    3
-   ],
-   "commit": "e4297052ef32d06237e8bd1534a0caf70a34ad28",
-   "sha256": "0mfkq8n28lal4lqwp6v0ilz8wrwgg61sbm0jggznwisjqqy3lzrh"
-  }
- },
- {
   "ename": "rspec-mode",
   "commit": "cd83e61b10da20198de990aa081b47d3b0b44d43",
   "sha256": "0nyib9rx9w9cbsgkcjx9n8fp77xkzxg923z0rdm3f9kc7njcn0zx",
@@ -90055,8 +90481,8 @@
     20201218,
     1821
    ],
-   "commit": "39339388256df662d0084b4a094d03e52748f9e8",
-   "sha256": "0wp4mygsxzibra2p3m5rn9m0yd3fscd795k5xa0wxi5pwddv7dlg"
+   "commit": "aa4c827b417f5448c12401c33acdab1325917c13",
+   "sha256": "02jqcbrpxm4sv15l8kyvsw9pwkmamj065cgifj68x242fw2f0sam"
   },
   "stable": {
    "version": [
@@ -90081,8 +90507,8 @@
    "deps": [
     "rtags"
    ],
-   "commit": "39339388256df662d0084b4a094d03e52748f9e8",
-   "sha256": "0wp4mygsxzibra2p3m5rn9m0yd3fscd795k5xa0wxi5pwddv7dlg"
+   "commit": "aa4c827b417f5448c12401c33acdab1325917c13",
+   "sha256": "02jqcbrpxm4sv15l8kyvsw9pwkmamj065cgifj68x242fw2f0sam"
   },
   "stable": {
    "version": [
@@ -90372,15 +90798,15 @@
   "repo": "ruby-test-mode/ruby-test-mode",
   "unstable": {
    "version": [
-    20201027,
-    905
+    20210205,
+    1107
    ],
    "deps": [
     "pcre2el",
     "ruby-mode"
    ],
-   "commit": "4af8a51483e5ed3104693a0052c2aebf8361c52c",
-   "sha256": "178dbacbhs7j74ia4ay1h84k9cx6jacyw82q6g0hnm2kgzg4x85k"
+   "commit": "d66db4aca6e6a246f65f7195ecfbc7581d35fb7a",
+   "sha256": "0rwq5g6p8n45vqf35dklkzdrhbp9i9gx03v7s1b4s4h83hlhlh51"
   },
   "stable": {
    "version": [
@@ -90452,6 +90878,21 @@
    ],
    "commit": "b69a3866e0299cae8c9c805d644e69b2c17b64de",
    "sha256": "13sm2v7al9658n17dka6dclzsprccrm3zycx6nwsgl99i14cnn99"
+  }
+ },
+ {
+  "ename": "run-command",
+  "commit": "55089aac37c8934be2882c33bf96cc61322fec23",
+  "sha256": "1bcm39sy09h16j06rvshchlbzgvm12qa8snvfs99fdz3riikb2v2",
+  "fetcher": "github",
+  "repo": "bard/emacs-run-command",
+  "unstable": {
+   "version": [
+    20210207,
+    1145
+   ],
+   "commit": "a504d6d5f978e9e133daa901eda6c1420e19f307",
+   "sha256": "02md9ayraclj97jyjs5pz9xnw32j5wr86zjbaly1dwm87avs27g6"
   }
  },
  {
@@ -90600,8 +91041,8 @@
   "repo": "brotzeit/rustic",
   "unstable": {
    "version": [
-    20210103,
-    1235
+    20210201,
+    1846
    ],
    "deps": [
     "dash",
@@ -90614,8 +91055,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "4570312648cb8d4788f4fe749d67c0fce2de42e4",
-   "sha256": "1l6b0ljr6xwpjq46qgna2brprj81ppxwzhaj5s1xbwffzi67dc1z"
+   "commit": "61d600e5598a37034b8b539bd50966c3eb557f10",
+   "sha256": "0d5z6wab62g5xyb2bpmpprny22gy7rm11vsgij0phhnsqb8fqiig"
   }
  },
  {
@@ -91088,8 +91529,8 @@
     20200830,
     301
    ],
-   "commit": "85f1e8f2dabb94fb1c853a7c60c1dda07163ac8e",
-   "sha256": "16cnp54gvkx7kc6kr74mahvjwhkpc7y60c8v16m8n7si6h77lfqd"
+   "commit": "1a814450162a2a8d0dde107f5a72d6152efbb63a",
+   "sha256": "0zpmsga0y1sgdm22w9k790mm44y4xc1hjcnlf6byhm1raf7yairg"
   }
  },
  {
@@ -91118,11 +91559,11 @@
   "repo": "hvesalai/emacs-scala-mode",
   "unstable": {
    "version": [
-    20201106,
-    2057
+    20210205,
+    851
    ],
-   "commit": "2bf56219924e0cbc0325547799144b02d4085935",
-   "sha256": "1cs5d9x69q2akzf7a64awapjxljbqggxv391k885ld3zqglqkzks"
+   "commit": "402d6df56457e9c512c3d77c7bcb0d04c77715f1",
+   "sha256": "018c668i1cv6a22gvvbzgn8111wh9zbk6yr41cj9xb1pwg0y373d"
   },
   "stable": {
    "version": [
@@ -91277,20 +91718,20 @@
  },
  {
   "ename": "scpaste",
-  "commit": "9007fb32097bc63731c3615dae9342fcef2558a2",
-  "sha256": "02dqmx6v3jxdn5yz1z74624sc6sz2bm4qjyi78w9akhp2jplwlk1",
-  "fetcher": "github",
-  "repo": "technomancy/scpaste",
+  "commit": "8bec8e696afde1b89502f312efc0054ca59502a6",
+  "sha256": "1x2ikbb1k34yfrr45pk4a8171l3azbgl0mrd4pb44qz7z1rpn57m",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~technomancy/scpaste",
   "unstable": {
    "version": [
-    20200717,
-    2007
+    20200731,
+    1520
    ],
    "deps": [
     "htmlize"
    ],
-   "commit": "2aa1513fa0a402f03b993c0a6929daf39820b02b",
-   "sha256": "1cvkqb5v0v790nmhg4wi6kv6mbzfkfcgvn2xh9bmny37dcv0i2gk"
+   "commit": "779b94d1159bba8dbcf2b1081df7c54a15577066",
+   "sha256": "02zsknby258l62vga5p7gzbx12aj6cs4ypmrf7acv5pvliwd9wl6"
   },
   "stable": {
    "version": [
@@ -91647,15 +92088,15 @@
   "repo": "jcs-elpa/searcher",
   "unstable": {
    "version": [
-    20201010,
-    641
+    20210124,
+    1524
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "432d2ea9f7d0ab7274ff2927d26e7adca85be169",
-   "sha256": "07kwcyg8v5svqq2v24qn4rd43r590gr9nmv3270aqad8lqjlrrn8"
+   "commit": "447b6f0c3b4429e70a474a325151913100bc6417",
+   "sha256": "1w0l0r4n0w99523klia1pfyh0y3jvskhk2wrwzdx09mad0bdfj1b"
   },
   "stable": {
    "version": [
@@ -91877,11 +92318,11 @@
   "repo": "raxod502/selectrum",
   "unstable": {
    "version": [
-    20210114,
-    2154
+    20210212,
+    1714
    ],
-   "commit": "3abbfd9bc7d8991cce20202942a5b59a6c8d8dab",
-   "sha256": "05g0cwyv77ajbbq3ja4bsgh84m1829mqrp5mxg5gbwhjp9xr974r"
+   "commit": "a2ba6333e59ddc853318ece229f34016400ca033",
+   "sha256": "1agpcazga6gxl6k28bdski1sx046699cici8a9hz0nj7s8rkx1zm"
   },
   "stable": {
    "version": [
@@ -92085,16 +92526,16 @@
   "repo": "twlz0ne/separedit.el",
   "unstable": {
    "version": [
-    20200827,
-    725
+    20210210,
+    1411
    ],
    "deps": [
     "dash",
     "dash-functional",
     "edit-indirect"
    ],
-   "commit": "dc0b3448f3d9738f5233c34c5c8fc172eda26323",
-   "sha256": "0qjfhal2pjw1lk7qyb89lwibabpycibf5vsadinvqnn77m25sx04"
+   "commit": "cc1145bde8b1868322ea799a90e38a1295089ada",
+   "sha256": "0m429i3zy5aik0q91r6sbr5xpqh4fgx984szp01p8fmbyb7wsh67"
   }
  },
  {
@@ -92852,8 +93293,8 @@
     20201021,
     552
    ],
-   "commit": "f29aadae07bd58689720271b1f6538edfec5c476",
-   "sha256": "130ydwzpzw4s4h3jhh5h066iib7s9c8xa43imvlvcqs3vghp7p1x"
+   "commit": "54c3ccd9b3fa9becc4b108046b117ccd6384449d",
+   "sha256": "024drmvh1qv2sbl5nxvyrqbwlk4wk8bfsa08rn21rhlbnwknb5ip"
   }
  },
  {
@@ -93039,26 +93480,27 @@
   "repo": "chenyanming/shrface",
   "unstable": {
    "version": [
-    20201108,
-    640
+    20210213,
+    531
    ],
    "deps": [
+    "language-detection",
     "org"
    ],
-   "commit": "da8acfb347c14e82a9c56cfd65e57b8adb8eb5d2",
-   "sha256": "1gc5w4svkfvd4a0sqyaq4570iabql4w6yayamcpf20n7i8wvlpws"
+   "commit": "46573b3823be1f5ea57603a0e4855279848ad037",
+   "sha256": "12v1snjw4adrnbz6d0f4xkbr8k2kxa4xfkx32zwqp4bvsgi80arv"
   },
   "stable": {
    "version": [
     2,
     6,
-    1
+    3
    ],
    "deps": [
     "org"
    ],
-   "commit": "716b8a51ab331952f5b617152055799e32efb77e",
-   "sha256": "10yrkza38ylvahgq5ga78brkzi5c2ms2v9800a0y8ld019zxkr7r"
+   "commit": "3dc6b980a4235b084abeae500a377e60026c28ef",
+   "sha256": "1gg0z15a4rygi0dxabnlpjh56sa7kwxw3fji6ibk70l1jwgd7ydc"
   }
  },
  {
@@ -93248,20 +93690,20 @@
   "repo": "rnkn/side-notes",
   "unstable": {
    "version": [
-    20200926,
-    1404
+    20210201,
+    724
    ],
-   "commit": "f5135f652d2b21f55b4809151143845c6807de01",
-   "sha256": "1jnh4djxp4k0c1r6yq0n0zi9vadsj9daqnajs33g2npvhmyav0sr"
+   "commit": "3993e8de44c141420efbec3cdb4c5620b862a200",
+   "sha256": "1ivm2xr7mc8hp7g1l6l3a4mm5byn2cp7m6bv2g222997xbpk0il5"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
-   "commit": "27c964334b8e30fa88e4278ae58dc3d00df34f1f",
-   "sha256": "1xl2ykdscrwpxm02ypnf68mkxf9dkp64cj465b69s874x10bxfc3"
+   "commit": "d41255fc2b8cadfc7882c617c7d1aff71524ed46",
+   "sha256": "0jsfa5dfs0kl9c7pjxi1niq1mknsxnqm9gs18l0lb9ipbzb949sr"
   }
  },
  {
@@ -93470,14 +93912,14 @@
   "repo": "andreas-roehler/simple-paren",
   "unstable": {
    "version": [
-    20200120,
-    2036
+    20210206,
+    2015
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "2a4ba8f99f39abf17976db8118e32b80eff0798b",
-   "sha256": "0897i5ggdivi2knblcbkyv9lpnwgdlr8ql9brd09bkdsbzhsqb6y"
+   "commit": "7b17fcc467e485dce5550be901d26223b8ad3f23",
+   "sha256": "1ksckai0hr2345vpjsahv0kzk8h52vrg2wki290v5aj64iy2nw76"
   }
  },
  {
@@ -93639,8 +94081,8 @@
   "repo": "chrisbarrett/skeletor.el",
   "unstable": {
    "version": [
-    20191129,
-    841
+    20210129,
+    239
    ],
    "deps": [
     "cl-lib",
@@ -93649,8 +94091,8 @@
     "let-alist",
     "s"
    ],
-   "commit": "eb21383a9c9e7cf7ae2bbb85cb6d4f42aa3cb37f",
-   "sha256": "1vq4g8kpq9q4zyybw4k4hgvn13avxz653gdfrx4x5wvfqcr91mbx"
+   "commit": "f6e560a0bfe459e0b8a268047920ce1148f2ebf6",
+   "sha256": "0xal5m59z8whrsr6id52gb6f22jy6dp349xvs6xxjdfamj1083r7"
   },
   "stable": {
    "version": [
@@ -93873,15 +94315,15 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20210105,
-    2148
+    20210202,
+    1426
    ],
    "deps": [
     "cl-lib",
     "macrostep"
    ],
-   "commit": "48bfe6cccfdf879cd7137b00eb2ca160665a92f8",
-   "sha256": "1b3kjxjx30lan77vgiskvh9g5cqz4j44xa221vnh9ccixqwqhhim"
+   "commit": "f135f69c5c97bb1f2456d05ee1e84ad6b4495ca3",
+   "sha256": "0xx4zm0anp9vvhl5j1xvq039jyhs96fbbq21pap0c4h1rfv5mgin"
   },
   "stable": {
    "version": [
@@ -93905,60 +94347,59 @@
   "repo": "anwyn/slime-company",
   "unstable": {
    "version": [
-    20200424,
-    1045
+    20210124,
+    1627
    ],
    "deps": [
     "company",
     "slime"
    ],
-   "commit": "cec203c45ebd678b05341d1cdbe420ad07a1b8e0",
-   "sha256": "0dwj6kv8laivhisd9jrzdn1lxynqqxmimvyz3z0zz6qf0ijsl0wm"
+   "commit": "f20ecc4104d4c35052696e7e760109fb02060e72",
+   "sha256": "05dnnc4ms5c9yp9h65k2gbkg3pw9k38nx5wzlwdlfr4shqmw54w0"
   },
   "stable": {
    "version": [
     1,
-    3
+    6
    ],
    "deps": [
     "company",
     "slime"
    ],
-   "commit": "cec203c45ebd678b05341d1cdbe420ad07a1b8e0",
-   "sha256": "0dwj6kv8laivhisd9jrzdn1lxynqqxmimvyz3z0zz6qf0ijsl0wm"
+   "commit": "f20ecc4104d4c35052696e7e760109fb02060e72",
+   "sha256": "05dnnc4ms5c9yp9h65k2gbkg3pw9k38nx5wzlwdlfr4shqmw54w0"
   }
  },
  {
   "ename": "slime-docker",
-  "commit": "15ec3f7208287161571c8fc3b29369ceabb44e5f",
-  "sha256": "13zkkrpww51ndsblpyz2msiwrjnaz6yrk61jbzrwp0r7a2v0djsa",
+  "commit": "19cafb22be7286f56391dc98b362fb2aa55a9a80",
+  "sha256": "1vrns4fys01chk2cq10wb8w559lc7899s9dhwysg6818nvqj9my1",
   "fetcher": "github",
-  "repo": "daewok/slime-docker",
+  "repo": "cl-docker-images/slime-docker",
   "unstable": {
    "version": [
-    20190430,
-    157
+    20210124,
+    2145
    ],
    "deps": [
-    "cl-lib",
     "docker-tramp",
     "slime"
    ],
-   "commit": "151cec4a11965cdc00d231900a50f2c9f455fce2",
-   "sha256": "1sp6qi2i1cl41ga9y6fwf7q855y0b59fcbxdiggdhigwd5zslzcv"
+   "commit": "903470fe3860402794a4f268c1efffd44a30f273",
+   "sha256": "089yskdbkr7k25sns5vms7f0hqdbpnjg3ih95nhia1nghxcqj482"
   },
   "stable": {
    "version": [
     0,
-    7
+    8,
+    2
    ],
    "deps": [
-    "cl-lib",
     "docker-tramp",
     "slime"
    ],
-   "commit": "1ba41c2d86540a84b47466b0b6957f8063f23aa8",
-   "sha256": "168s5xsf7l6s8x5hcmzmk5j9d8a3wpr4s3dlm697dg2n1717gl2z"
+   "commit": "903470fe3860402794a4f268c1efffd44a30f273",
+   "sha256": "089yskdbkr7k25sns5vms7f0hqdbpnjg3ih95nhia1nghxcqj482"
   }
  },
  {
@@ -94099,11 +94540,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20210114,
-    912
+    20210207,
+    940
    ],
-   "commit": "eb67be9698794ba66a09f46b7cfffab742863a91",
-   "sha256": "11yclc8i6gpy26m1yj6bid6da22639zpil1qzj87m5gfvxiv4zg6"
+   "commit": "3278819ddf71d16444e6cea293dd41ca83ea9bae",
+   "sha256": "1acq2jsk3hbk3lq5klwf825kykyvqrrzicawy5wvssmbvxcgpy8s"
   },
   "stable": {
    "version": [
@@ -95065,6 +95506,30 @@
   }
  },
  {
+  "ename": "snitch",
+  "commit": "8d08307e483c328075bbf933b2ea0c03bffe8b7c",
+  "sha256": "1zck9r251jj3q6q1glxj20812yhkv630qnd2y7q1kkjgp68gby7g",
+  "fetcher": "github",
+  "repo": "mrmekon/snitch-el",
+  "unstable": {
+   "version": [
+    20210202,
+    1730
+   ],
+   "commit": "3b3e7f1bf612c4624764d1ec4b1a96e4d2850b05",
+   "sha256": "00r36xjglp7d1gkxkqlymqjkd8pmr5g0bg468xq9s5hp7g5md4ig"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "commit": "14e91336fb04c23d7b23836642eef3f2edef03bf",
+   "sha256": "1l06biw2af8yqivhmpwb6dxnslvm0xw4wr1ckmjq3yn7zx542viw"
+  }
+ },
+ {
   "ename": "snoopy",
   "commit": "4a882cd92964ac195a09469006c9a44dc202f000",
   "sha256": "1wa8jykqyj6rxqfhwbiyli6yh8s7n0pqv7fc9sfaymarda93zbgi",
@@ -95243,14 +95708,14 @@
   "repo": "bbatsov/solarized-emacs",
   "unstable": {
    "version": [
-    20210112,
-    1050
+    20210202,
+    1730
    ],
    "deps": [
     "dash"
    ],
-   "commit": "93d124962106f4cec72e9c8ab8cb243c581d9d46",
-   "sha256": "11gsxakwmkymlmm8jjbkxi6ryhvfri06n2g8kh4s6abm15pnq6sh"
+   "commit": "4d4b004460271e310ca45606d24a60e95ca3151d",
+   "sha256": "1fjvi10asfz5qya91swma2k9w7a79kh7a3lik23gdqzxs0swmn4g"
   },
   "stable": {
    "version": [
@@ -95274,15 +95739,15 @@
   "repo": "ethereum/emacs-solidity",
   "unstable": {
    "version": [
-    20200113,
-    1721
+    20210122,
+    1746
    ],
    "deps": [
     "flycheck",
     "solidity-mode"
    ],
-   "commit": "d166a86b83907e0cfd64c191e9dfce4b44a9843e",
-   "sha256": "19hgvsrqch2vp49ag6m76bi5qxd20v95z0ib838rib9as15b17wq"
+   "commit": "b4fd719715be098921b6cbfb2ff9da31f3bd0d05",
+   "sha256": "0gsgj5485k7415wzq73xbj3ax9hh2l1j46ma5d0xkww3md3c3kca"
   },
   "stable": {
    "version": [
@@ -95309,8 +95774,8 @@
     20200529,
     1924
    ],
-   "commit": "d166a86b83907e0cfd64c191e9dfce4b44a9843e",
-   "sha256": "19hgvsrqch2vp49ag6m76bi5qxd20v95z0ib838rib9as15b17wq"
+   "commit": "b4fd719715be098921b6cbfb2ff9da31f3bd0d05",
+   "sha256": "0gsgj5485k7415wzq73xbj3ax9hh2l1j46ma5d0xkww3md3c3kca"
   },
   "stable": {
    "version": [
@@ -95428,20 +95893,20 @@
   "repo": "mssola/soria",
   "unstable": {
    "version": [
-    20200803,
-    1402
+    20210201,
+    1830
    ],
-   "commit": "d5274cc4a8e19ed0f1393a09192def951d025a11",
-   "sha256": "1zdcwccndgmn83xmlxqlx6azd03g7dxd2ldc3dj6yxbjasfx00x5"
+   "commit": "f765f193ccaf4ad438e1d9be842efd2f4394efa4",
+   "sha256": "1p6kzsci8hgccpjcy6swwa6yk741l6ay48rb35gmf03j04abszm0"
   },
   "stable": {
    "version": [
     0,
-    3,
-    3
+    4,
+    0
    ],
-   "commit": "d5274cc4a8e19ed0f1393a09192def951d025a11",
-   "sha256": "1zdcwccndgmn83xmlxqlx6azd03g7dxd2ldc3dj6yxbjasfx00x5"
+   "commit": "bca7a42db1245543d81373e67d71278a0e3135a2",
+   "sha256": "1i1hb5xg97frkhpmv608dlqs8wclwf78sq9q3sy9776m5zfdhcxl"
   }
  },
  {
@@ -95836,11 +96301,11 @@
   "repo": "nashamri/spacemacs-theme",
   "unstable": {
    "version": [
-    20200825,
-    1818
+    20210206,
+    1428
    ],
-   "commit": "1f5b03254de6bfa9645711f2b79781f5cca8d203",
-   "sha256": "04x8x557va2nsl1wginvaq9ha9wfk8l45dgs88sxm60jyrci802x"
+   "commit": "c8c468580048e2464f012d171b2101bfb208e33d",
+   "sha256": "1rbv04smfyhm5qm3ghn9vsl0sm4lv20gkpw2zdzrf0l3nkb7dx45"
   }
  },
  {
@@ -95917,8 +96382,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "62f198256453265af48bef3a0207e80143fbff1e",
-   "sha256": "0a49678yaq2vc04w4xp0i9lpb7bdf1fwhjkg0xnzssvnjcnk368k"
+   "commit": "e8c9345e2e2427282b3dc9cd1e297e3c76d34f7f",
+   "sha256": "1i799cq0dydq7jdhc1b2ridlsmmkk85286g9r6nj6kif3177l171"
   },
   "stable": {
    "version": [
@@ -95956,11 +96421,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20210109,
-    1842
+    20210206,
+    728
    ],
-   "commit": "e451b29f2702c60b664ad1e3e3ae253cfb969fa0",
-   "sha256": "0am4da6j5mianjj6ib5hf87z5v2q3wc8xlmgmna4mi70rx4bkz3x"
+   "commit": "7cb1809498442b1e52f586bcde36b387777ec316",
+   "sha256": "0zqczxnrjwl9y0q54gsxz906cds8q9bk7mhlplsgnlm7w9aipr2l"
   }
  },
  {
@@ -96625,11 +97090,11 @@
   "repo": "srcery-colors/srcery-emacs",
   "unstable": {
    "version": [
-    20200813,
-    1430
+    20210201,
+    1444
    ],
-   "commit": "c10f71465a416050ee4b9633aeabaee823ff3ba9",
-   "sha256": "1a5bblc5sfd0akrvjs2hysjs7a9fz4p6y44l00nmk43yl7bh0678"
+   "commit": "760dc6cb854383ab087d9b924de7273deddefe6a",
+   "sha256": "15anfzsfgddrlskppk068dzlz4zkg7xyk9727a7hwg4845126q6w"
   },
   "stable": {
    "version": [
@@ -96672,11 +97137,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20210113,
-    2052
+    20210212,
+    2231
    ],
-   "commit": "1fe8720e2e1e8884eac512d28257d655306a9686",
-   "sha256": "1s99ynhkak2qpfy448yi1iwxss4zwz1p61279xv1771jx7aclcd3"
+   "commit": "537b4c350e562660aa406b99660f80275254714e",
+   "sha256": "1ihyrdpsqf06d4s91hnd9lgwsas5r2pajdinj1jydqdy6z7g0bba"
   },
   "stable": {
    "version": [
@@ -96789,11 +97254,11 @@
   "repo": "jhgorrell/ssh-config-mode-el",
   "unstable": {
    "version": [
-    20201223,
+    20210127,
     1051
    ],
-   "commit": "a236e04f2950bd9d7f7c79ad992d1f8b57df950d",
-   "sha256": "0d5vx8k18avnja6mlhzrsj3z5brs70fj3s7151zgjq5i12n6aqm2"
+   "commit": "7539916b1eb4f44b2a682111424f3aca1233c482",
+   "sha256": "04hmf8haqpvd0vjrmr65rnh6xd3pginpg7330r1gsbhkbhpy3p53"
   }
  },
  {
@@ -96865,11 +97330,11 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20200830,
-    1032
+    20210130,
+    1325
    ],
-   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
-   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
+   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
+   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
   },
   "stable": {
    "version": [
@@ -96889,15 +97354,15 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20200830,
-    1032
+    20210130,
+    1325
    ],
    "deps": [
     "stan-mode",
     "yasnippet"
    ],
-   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
-   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
+   "commit": "9bb858b9f1314dcf1a5df23e39f9af522098276b",
+   "sha256": "031418nkp9qwlxda8i3ankp3lq94sv8a8ijwrbcwb4w3ssr9j3ds"
   },
   "stable": {
    "version": [
@@ -97100,16 +97565,16 @@
     20200606,
     1308
    ],
-   "commit": "417b344e3c97beb2e50c2c919b0d01cb0d4ed9a5",
-   "sha256": "105va5nb5wgqkw25rdc2d591c6fcd9wa3dzsyvg3y83fcxhqgi7g"
+   "commit": "11aa5944459e464a96f41d934e23da5320c13333",
+   "sha256": "0nc388hi362rks9q60yvs2gbbf9v6qp031c0linv29wdqvavwva1"
   },
   "stable": {
    "version": [
-    0,
-    23
+    1,
+    0
    ],
-   "commit": "e6dd7eff206a6515aefced2ad701beaf625d7b7d",
-   "sha256": "157vdhdjzxsf7077916ibn0jbsxw9d71m8mwm4kn0i0ip7sj9xdg"
+   "commit": "11aa5944459e464a96f41d934e23da5320c13333",
+   "sha256": "0nc388hi362rks9q60yvs2gbbf9v6qp031c0linv29wdqvavwva1"
   }
  },
  {
@@ -97616,6 +98081,30 @@
    ],
    "commit": "9d4580f304121ce7b8104bd4bd3b64e4dfa3c9b3",
    "sha256": "1m9srlxavqg6yxmz6rz61saz1lj5hh029314dic8kh6g3bqdnh2w"
+  }
+ },
+ {
+  "ename": "sudo-utils",
+  "commit": "20960a5caad9e3f51160fa1786ba422f0e01dc99",
+  "sha256": "1jlzw4bl8mdr7yijsb93d32cqnn7rphbdsf9cnkzrlr7dkcrnwyg",
+  "fetcher": "github",
+  "repo": "alpha-catharsis/sudo-utils",
+  "unstable": {
+   "version": [
+    20210119,
+    1930
+   ],
+   "commit": "089f7833fa256f293284a6286bf9cb2b78eff40d",
+   "sha256": "03kks8sqw1j8ywzk3bvcb8i6v3px5zr05c4pnrwmls724m79sagd"
+  },
+  "stable": {
+   "version": [
+    3,
+    0,
+    1
+   ],
+   "commit": "089f7833fa256f293284a6286bf9cb2b78eff40d",
+   "sha256": "03kks8sqw1j8ywzk3bvcb8i6v3px5zr05c4pnrwmls724m79sagd"
   }
  },
  {
@@ -98144,14 +98633,14 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20201208,
-    1419
+    20210202,
+    2312
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "cbce9ce71429c98c67bd76ef15d049ecced042f7",
-   "sha256": "08lgvpvkhp2i9q73bnr2v17w864rwp6wjnrl3b7qg06dacfs2rvl"
+   "commit": "e0374dc0bbcd8ab0ec24baf308d331251d4f9c49",
+   "sha256": "1zvcp35vnnz5iybihrw0r21pvkghn73ni2m9jkgf352n8zza7z9g"
   },
   "stable": {
    "version": [
@@ -98411,13 +98900,13 @@
   "repo": "wolray/symbol-overlay",
   "unstable": {
    "version": [
-    20200828,
-    425
+    20210118,
+    807
    ],
    "deps": [
     "seq"
    ],
-   "commit": "39f772b531117edba596e7a1210b3dbb87d56adb",
+   "commit": "5bcd6d7e3f3b6501ccec3e6c378f33f7e7488c99",
    "sha256": "10n0871xzycifyqp73xnbqmrgy60imlb26yhm3p6vfj3d84mg1b2"
   },
   "stable": {
@@ -98795,11 +99284,11 @@
   "repo": "holomorph/systemd-mode",
   "unstable": {
    "version": [
-    20191219,
-    2304
+    20210209,
+    2052
    ],
-   "commit": "51c148e09a129ddf33d95276aa0e89d4ef6f8dd2",
-   "sha256": "0mikrj91qip5f0sj62c4gamvw7h6wc0yz8cfyzj9h3gxrllkp87k"
+   "commit": "b6ae63a236605b1c5e1069f7d3afe06ae32a7bae",
+   "sha256": "0q1f5mnx6npr6c94x93lyza87kxjy08v7x4by13wp23fxaqxgzaf"
   },
   "stable": {
    "version": [
@@ -99107,11 +99596,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20210104,
-    1044
+    20210120,
+    2015
    ],
-   "commit": "fe4030a3b44a283dc3e1062d40f2bb7ab08db542",
-   "sha256": "0y9c40dw9fcrjf9pdqiva12fha6d3yww6yip1g7dadi648hzr0ip"
+   "commit": "6ef30c69be9da77f0750880da27bab5d81006c6a",
+   "sha256": "0wfrmp3rix3jxiiq1aijl0k73l8qxi9fp41faxyabr2cqx2pzzsv"
   },
   "stable": {
    "version": [
@@ -99298,28 +99787,28 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20210114,
-    1122
+    20210212,
+    1021
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "d72bd42f57c0a09c2e91ecb69516b2eaab1991bd",
-   "sha256": "05czr9wwvqbhrvvslv2nsgip78ayfx4p6lfbdxnq44qjmfvamx0y"
+   "commit": "f1bb443ce1d24f00203c67b7ebca536832286704",
+   "sha256": "14ghyvpiwqlrxn76zq6jbwwh3lmp542kaixncwm26ljvmgq22b6p"
   },
   "stable": {
    "version": [
     0,
     7,
-    9
+    20
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "f87858583ca7c0e4328f3373aa57d715fd25bbb7",
-   "sha256": "14954lpkd22p3q66lykbl0fvapdly9cll313jrag5qzbcccrxq5j"
+   "commit": "0ed5173a2eaf1c049f3393c1518bb534a3a9ac94",
+   "sha256": "0g0ffxd9p0l772p6bc3s2sr3rlvgmds5jvr0fn6fnv9sypvzplfq"
   }
  },
  {
@@ -99353,16 +99842,16 @@
   "repo": "dbordak/telephone-line",
   "unstable": {
    "version": [
-    20200516,
-    2102
+    20210211,
+    117
    ],
    "deps": [
     "cl-generic",
     "cl-lib",
     "seq"
    ],
-   "commit": "110c578ccf6c0421cfd9eec7aa3e960b6fd49fb4",
-   "sha256": "157df4h9hr5mmwp0q5w0rdv7ndrjk3014r5xwwblszvx33s70gbk"
+   "commit": "2fbcdb44a9dfa608c44b19e731d15438b4b03d87",
+   "sha256": "0y7zak23cri9glysdmx035fvzrcpzr0fzsvjx9vcanlivq94v7fq"
   },
   "stable": {
    "version": [
@@ -99437,20 +99926,20 @@
   "repo": "clarete/templatel",
   "unstable": {
    "version": [
-    20210111,
-    521
+    20210210,
+    1359
    ],
-   "commit": "6dd630e5786e500441b5acbfe5868d7172a2dbcf",
-   "sha256": "1kqxmainf31d1s2qbwanwzp9dij0i6zj9pp3833clnybf4l90cr6"
+   "commit": "a3458234b8e0e83c46c6aca11a757c1134752c09",
+   "sha256": "0l5j2a44sslq1qm0sjaqcnca0y89faxw6ic19zzv5z836m83hl9d"
   },
   "stable": {
    "version": [
     0,
     1,
-    3
+    4
    ],
-   "commit": "8c4ba0d5db5280a78d94bb1cc3dbd2f1abd37e9e",
-   "sha256": "177m72c2gdmp2jq55z1sgff8izpv39n1s7qsin2bfl4p9ccwywmr"
+   "commit": "1a7784e5ec9a5e43adae56674aa63e8b3cf7a2cd",
+   "sha256": "1k33h503038l2bcr8gs020z2cjxfs94lamkdgv52cvd9i20d0kqq"
   }
  },
  {
@@ -100374,18 +100863,18 @@
     20200212,
     1903
    ],
-   "commit": "442466ab9411594350d4f9ef012f9892d4034773",
-   "sha256": "0srj6fnk7damyh6snwnvl599iad4ys7dw944vp0d4wpay0sxqvcl"
+   "commit": "a983a4a27a9e49f9ea7f990e260214a3d2473b61",
+   "sha256": "0cnasic4xk9x5s81i36dprmg93csmil5p8fadfpmdsfpi83cb9i9"
   },
   "stable": {
    "version": [
     2021,
-    1,
-    11,
+    2,
+    8,
     0
    ],
-   "commit": "c72b2fa29856d45c91f5ed6c98fca6d723246977",
-   "sha256": "1y2hjw2a0dq6vzyfg7hcn09dbw00rfyblzibf5i7s08jbvp2zzin"
+   "commit": "38468becbbda1488b2b204b209a4dac3352d1791",
+   "sha256": "1z2s12rqgzi4cx77mmim25rh9xgna9i10vv7wljkkfwncnf1xlin"
   }
  },
  {
@@ -100435,26 +100924,26 @@
   "repo": "tidalcycles/Tidal",
   "unstable": {
    "version": [
-    20210107,
-    1831
+    20210211,
+    1531
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "0a3a5f9d0aad689ad87649647944d6dca6c16bb5",
-   "sha256": "1lrwjxx0a3lalwbpndf751b1wn2yv3j2x58xa5kby63dxnxf77ph"
+   "commit": "8cf18c6a8b1b4c825bdacbdd913d1c355c15bf11",
+   "sha256": "05ffyh4a9cmv14a64xxscp303wddhi1264xgsiyvllfasz14vjj1"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     1
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "7377b6c8ddc23d197018af203456063864df1457",
-   "sha256": "0vj55135h0mw093b9rlnq8hka9sj4kmhnv8xj46z2kcqj0qcq7q8"
+   "commit": "8cf18c6a8b1b4c825bdacbdd913d1c355c15bf11",
+   "sha256": "05ffyh4a9cmv14a64xxscp303wddhi1264xgsiyvllfasz14vjj1"
   }
  },
  {
@@ -100465,8 +100954,8 @@
   "repo": "ananthakumaran/tide",
   "unstable": {
    "version": [
-    20210105,
-    812
+    20210211,
+    1055
    ],
    "deps": [
     "cl-lib",
@@ -100475,8 +100964,8 @@
     "s",
     "typescript-mode"
    ],
-   "commit": "e622d4d879d8b1de2517962b243146ec18b6cfff",
-   "sha256": "1963yf9nzx4hgp16c9vyn3drx9ypyni4xrrz1kylkb3mcm10y97v"
+   "commit": "7f7334b42a40dd3093b830e887c36cdb4ef40858",
+   "sha256": "0krixylc58lglpi6kgwlxfd47c90vmck3cml0h3awplbyyr8b5vg"
   },
   "stable": {
    "version": [
@@ -100951,8 +101440,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "c6ccdc83e85719a8bb07ef715cf5fd06866a479c",
-   "sha256": "0z8rykhhhwccy0zg6v3gnghfiawqw3afv4pvxr1hrympiyhyvhvp"
+   "commit": "19e2f1766b4a845ce5a4ccc87de62608f385bd11",
+   "sha256": "1gpzi092732chg0mvrwmr01c2njip1d2m15lj9fa1ii6sddfpand"
   }
  },
  {
@@ -101245,14 +101734,14 @@
   "repo": "trueroad/tr-emacs-ime-module",
   "unstable": {
    "version": [
-    20201128,
-    928
+    20210202,
+    1057
    ],
    "deps": [
     "w32-ime"
    ],
-   "commit": "9406b498e6a256a5928f03cd089fdd2823b03876",
-   "sha256": "0q4f7c1nrvz58ycbjgfih1m3xyb0x4wn405yz4gm1172j0phcmlj"
+   "commit": "077dfb87054a20a1bbec8d6d0f282f64c6722999",
+   "sha256": "066vl2qvz14ds66vvyj6cabmf4fbc8x4p12ph340kj4yjncpqcqs"
   },
   "stable": {
    "version": [
@@ -101424,11 +101913,11 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20210103,
-    1546
+    20210117,
+    2008
    ],
-   "commit": "7811dcff825210c17bd15525fb6a98854501af99",
-   "sha256": "1nwpwviica8fv8q8pfgx0r4888giq48x0phgl2mkvbz8rr6nyn50"
+   "commit": "94582a3fd96450072ab1b7a4e65802dbdb00aebc",
+   "sha256": "0p96vsva9y6w8fa69vhzzakb9c2sfzihlk9789z3gs5nw88qwkly"
   },
   "stable": {
    "version": [
@@ -101485,14 +101974,14 @@
   "repo": "holomorph/transmission",
   "unstable": {
    "version": [
-    20210106,
-    2057
+    20210203,
+    2107
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "7cf0d739a8a7834d6c3896b62122a0fc6953d371",
-   "sha256": "1gy4fmjpymabs4z5k3j07di6hqpx6w592w4qvq1iccapy1kqxbj1"
+   "commit": "e3c1fb176c6d91a8378426e3ea5e6c036f321746",
+   "sha256": "1dlm3hi22cyw6d0c7i36wkr186v7ll840s1dm4zpd12k11m9sbks"
   },
   "stable": {
    "version": [
@@ -101631,6 +102120,24 @@
   }
  },
  {
+  "ename": "tray",
+  "commit": "26905a583fa78d1cf23e34ed983bbc132f5d71a4",
+  "sha256": "1c5rjyi7y5bni8mviafyfiwzrd6af3s82n87298d4356sjrggf2b",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~tarsius/tray",
+  "unstable": {
+   "version": [
+    20210209,
+    1655
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "ba04344c90094910cfa4f2f5e56b0b33934cebf7",
+   "sha256": "1bgshgqwidkk14vq0jmi42wfa81y0bd9rq1r6gzqw024g8syhv47"
+  }
+ },
+ {
   "ename": "tree-mode",
   "commit": "84f836338818946a6bb31d35d6ae959571128ed5",
   "sha256": "1b15xgh96j4qas1kh4ghczcn7hb1ri86wnjgn9wz2d6bw3c6077b",
@@ -101653,26 +102160,26 @@
   "repo": "ubolonton/emacs-tree-sitter",
   "unstable": {
    "version": [
-    20201229,
-    1403
+    20210116,
+    621
    ],
    "deps": [
     "tsc"
    ],
-   "commit": "e7f2f625c1b9a2dce4f6b16a5affbb4f57337ae0",
-   "sha256": "0175mr8wqkrv83lyx7q9vbb6j90abqfbd3h1qc1kqb80p03l5vcr"
+   "commit": "04994785c4ca865bcd4b841d39f40664458b1ec1",
+   "sha256": "0hyk12s336snwxiz6ca64d3nfyjf70s626rir61ly42m2cyb6ql2"
   },
   "stable": {
    "version": [
     0,
     13,
-    0
+    1
    ],
    "deps": [
     "tsc"
    ],
-   "commit": "a3aef9113365032d55fedbbe08ab7b04f5268d14",
-   "sha256": "1n8mxd7fhs2brblrfr5892j5xqgh247d8ngnkhwq6acn8hfxn7qf"
+   "commit": "d569763c143fdf4ba8480befbb4b8ce1e49df5e2",
+   "sha256": "1rw21nc78m4xngl3i3dmlzrzlqb8rgvlpal6d4f50zdlfbn4pa4v"
   }
  },
  {
@@ -101683,15 +102190,15 @@
   "url": "https://codeberg.org/FelipeLema/tree-sitter-indent.el.git",
   "unstable": {
    "version": [
-    20201231,
-    1842
+    20210116,
+    1930
    ],
    "deps": [
     "seq",
     "tree-sitter"
    ],
-   "commit": "a11aa84a768cff2d40db7ef0c6029742b7ce46a1",
-   "sha256": "1zxzmqdyw681vzxwhs7bi4xylqy99v0jajsv03mppsslxl4l2fwm"
+   "commit": "7ce723730993ca7879c8660f5ae78c69193a1451",
+   "sha256": "069851611i4ra8kjknn9nyzrj2xy9qax4f69jxnf99cimw2xd8gr"
   }
  },
  {
@@ -101702,26 +102209,26 @@
   "repo": "ubolonton/emacs-tree-sitter",
   "unstable": {
    "version": [
-    20210113,
-    1755
+    20210212,
+    1035
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "e7f2f625c1b9a2dce4f6b16a5affbb4f57337ae0",
-   "sha256": "0175mr8wqkrv83lyx7q9vbb6j90abqfbd3h1qc1kqb80p03l5vcr"
+   "commit": "04994785c4ca865bcd4b841d39f40664458b1ec1",
+   "sha256": "0hyk12s336snwxiz6ca64d3nfyjf70s626rir61ly42m2cyb6ql2"
   },
   "stable": {
    "version": [
     0,
     13,
-    0
+    1
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "a3aef9113365032d55fedbbe08ab7b04f5268d14",
-   "sha256": "1n8mxd7fhs2brblrfr5892j5xqgh247d8ngnkhwq6acn8hfxn7qf"
+   "commit": "d569763c143fdf4ba8480befbb4b8ce1e49df5e2",
+   "sha256": "1rw21nc78m4xngl3i3dmlzrzlqb8rgvlpal6d4f50zdlfbn4pa4v"
   }
  },
  {
@@ -101768,8 +102275,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210110,
-    2030
+    20210201,
+    1800
    ],
    "deps": [
     "ace-window",
@@ -101782,8 +102289,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "16d757fc697a73cbf7920caf2f598e839e7e0e56",
-   "sha256": "036chafmgx0zdqa00yb5y0y6lq6mfimlvwhzkdy1n982jgqvk12f"
+   "commit": "332d4e0f1f606c472dd083c9cdd4f143ee23020a",
+   "sha256": "1bgkw8yrjhdpwsjs87yi3hldpvjkl6rpqfd8bpcs6q6anx5dcxxd"
   },
   "stable": {
    "version": [
@@ -101812,15 +102319,15 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210107,
-    1251
+    20210118,
+    1808
    ],
    "deps": [
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "16d757fc697a73cbf7920caf2f598e839e7e0e56",
-   "sha256": "036chafmgx0zdqa00yb5y0y6lq6mfimlvwhzkdy1n982jgqvk12f"
+   "commit": "332d4e0f1f606c472dd083c9cdd4f143ee23020a",
+   "sha256": "1bgkw8yrjhdpwsjs87yi3hldpvjkl6rpqfd8bpcs6q6anx5dcxxd"
   }
  },
  {
@@ -101838,8 +102345,8 @@
     "evil",
     "treemacs"
    ],
-   "commit": "16d757fc697a73cbf7920caf2f598e839e7e0e56",
-   "sha256": "036chafmgx0zdqa00yb5y0y6lq6mfimlvwhzkdy1n982jgqvk12f"
+   "commit": "332d4e0f1f606c472dd083c9cdd4f143ee23020a",
+   "sha256": "1bgkw8yrjhdpwsjs87yi3hldpvjkl6rpqfd8bpcs6q6anx5dcxxd"
   },
   "stable": {
    "version": [
@@ -101868,8 +102375,8 @@
    "deps": [
     "treemacs"
    ],
-   "commit": "16d757fc697a73cbf7920caf2f598e839e7e0e56",
-   "sha256": "036chafmgx0zdqa00yb5y0y6lq6mfimlvwhzkdy1n982jgqvk12f"
+   "commit": "332d4e0f1f606c472dd083c9cdd4f143ee23020a",
+   "sha256": "1bgkw8yrjhdpwsjs87yi3hldpvjkl6rpqfd8bpcs6q6anx5dcxxd"
   },
   "stable": {
    "version": [
@@ -101900,8 +102407,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "16d757fc697a73cbf7920caf2f598e839e7e0e56",
-   "sha256": "036chafmgx0zdqa00yb5y0y6lq6mfimlvwhzkdy1n982jgqvk12f"
+   "commit": "332d4e0f1f606c472dd083c9cdd4f143ee23020a",
+   "sha256": "1bgkw8yrjhdpwsjs87yi3hldpvjkl6rpqfd8bpcs6q6anx5dcxxd"
   },
   "stable": {
    "version": [
@@ -101933,8 +102440,8 @@
     "persp-mode",
     "treemacs"
    ],
-   "commit": "16d757fc697a73cbf7920caf2f598e839e7e0e56",
-   "sha256": "036chafmgx0zdqa00yb5y0y6lq6mfimlvwhzkdy1n982jgqvk12f"
+   "commit": "332d4e0f1f606c472dd083c9cdd4f143ee23020a",
+   "sha256": "1bgkw8yrjhdpwsjs87yi3hldpvjkl6rpqfd8bpcs6q6anx5dcxxd"
   },
   "stable": {
    "version": [
@@ -101958,16 +102465,16 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210114,
-    2135
+    20210116,
+    1155
    ],
    "deps": [
     "dash",
     "perspective",
     "treemacs"
    ],
-   "commit": "16d757fc697a73cbf7920caf2f598e839e7e0e56",
-   "sha256": "036chafmgx0zdqa00yb5y0y6lq6mfimlvwhzkdy1n982jgqvk12f"
+   "commit": "332d4e0f1f606c472dd083c9cdd4f143ee23020a",
+   "sha256": "1bgkw8yrjhdpwsjs87yi3hldpvjkl6rpqfd8bpcs6q6anx5dcxxd"
   }
  },
  {
@@ -101985,8 +102492,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "16d757fc697a73cbf7920caf2f598e839e7e0e56",
-   "sha256": "036chafmgx0zdqa00yb5y0y6lq6mfimlvwhzkdy1n982jgqvk12f"
+   "commit": "332d4e0f1f606c472dd083c9cdd4f143ee23020a",
+   "sha256": "1bgkw8yrjhdpwsjs87yi3hldpvjkl6rpqfd8bpcs6q6anx5dcxxd"
   },
   "stable": {
    "version": [
@@ -102240,20 +102747,20 @@
   "repo": "ubolonton/emacs-tree-sitter",
   "unstable": {
    "version": [
-    20201229,
-    1403
+    20210116,
+    621
    ],
-   "commit": "e7f2f625c1b9a2dce4f6b16a5affbb4f57337ae0",
-   "sha256": "0175mr8wqkrv83lyx7q9vbb6j90abqfbd3h1qc1kqb80p03l5vcr"
+   "commit": "04994785c4ca865bcd4b841d39f40664458b1ec1",
+   "sha256": "0hyk12s336snwxiz6ca64d3nfyjf70s626rir61ly42m2cyb6ql2"
   },
   "stable": {
    "version": [
     0,
     13,
-    0
+    1
    ],
-   "commit": "a3aef9113365032d55fedbbe08ab7b04f5268d14",
-   "sha256": "1n8mxd7fhs2brblrfr5892j5xqgh247d8ngnkhwq6acn8hfxn7qf"
+   "commit": "d569763c143fdf4ba8480befbb4b8ce1e49df5e2",
+   "sha256": "1rw21nc78m4xngl3i3dmlzrzlqb8rgvlpal6d4f50zdlfbn4pa4v"
   }
  },
  {
@@ -102881,28 +103388,28 @@
   "repo": "undercover-el/undercover.el",
   "unstable": {
    "version": [
-    20200830,
-    1638
+    20210123,
+    2157
    ],
    "deps": [
     "dash",
     "shut-up"
    ],
-   "commit": "a73c50aedbca0416d0e4d4fbeee27131bdd117aa",
-   "sha256": "0jkbwj8qb10nsl7imcnjlhrp1c9skw088cirrvn7380hlq07w346"
+   "commit": "c36a7366aa080558125fa651ed6a28d5df735b37",
+   "sha256": "0qji4738q0yx2n0xrpk12q2akx8rgsvpfgnnfxrnk8xiywjfrqwz"
   },
   "stable": {
    "version": [
     0,
-    7,
+    8,
     0
    ],
    "deps": [
     "dash",
     "shut-up"
    ],
-   "commit": "9515b247649d05219bf96b1843eed7c4d02a332e",
-   "sha256": "1dh4cpn1l1shchr0gg6jyld1qbjn3fy12s43pksfww4sm4rjn9rn"
+   "commit": "0bc3583065e49647db47d8a595fec13cb517d12f",
+   "sha256": "19d3373fy635vbfwr1yhxirwqn68qzny9byv74smxws4ly04mr02"
   }
  },
  {
@@ -103014,11 +103521,11 @@
   "repo": "jackkamm/undo-propose-el",
   "unstable": {
    "version": [
-    20200204,
-    1612
+    20210207,
+    45
    ],
-   "commit": "5a9eb34ed945a4d62362528cc7557b9c4e81a12b",
-   "sha256": "10ybvgdrw9hzqwbzvsr3hmzci4yp9rxi5nbcm6iafrsn7p1vv1wj"
+   "commit": "91a1dfe516d90dab69c368f6669bacb2458ec5e9",
+   "sha256": "15rmg7gl4yz3kfb1096fq20y0fnfc35jmppg7nl4vi71xv4db35d"
   }
  },
  {
@@ -103652,14 +104159,14 @@
   "repo": "jwiegley/use-package",
   "unstable": {
    "version": [
-    20210106,
-    2145
+    20210207,
+    1926
    ],
    "deps": [
     "bind-key"
    ],
-   "commit": "365c73d2618dd0040a32c2601c5456ab5495b812",
-   "sha256": "10c0rmi5axypx0xy3fib739rjnakl32spwcirzxz1p5r0x9gya4a"
+   "commit": "a7422fb8ab1baee19adb2717b5b47b9c3812a84c",
+   "sha256": "1zz2gg475254hbbxw4y82b2m2iy8cvx0phh030daax315hdbsaqb"
   },
   "stable": {
    "version": [
@@ -103691,8 +104198,8 @@
     "key-chord",
     "use-package"
    ],
-   "commit": "365c73d2618dd0040a32c2601c5456ab5495b812",
-   "sha256": "10c0rmi5axypx0xy3fib739rjnakl32spwcirzxz1p5r0x9gya4a"
+   "commit": "a7422fb8ab1baee19adb2717b5b47b9c3812a84c",
+   "sha256": "1zz2gg475254hbbxw4y82b2m2iy8cvx0phh030daax315hdbsaqb"
   },
   "stable": {
    "version": [
@@ -103754,8 +104261,8 @@
     "system-packages",
     "use-package"
    ],
-   "commit": "365c73d2618dd0040a32c2601c5456ab5495b812",
-   "sha256": "10c0rmi5axypx0xy3fib739rjnakl32spwcirzxz1p5r0x9gya4a"
+   "commit": "a7422fb8ab1baee19adb2717b5b47b9c3812a84c",
+   "sha256": "1zz2gg475254hbbxw4y82b2m2iy8cvx0phh030daax315hdbsaqb"
   },
   "stable": {
    "version": [
@@ -103868,11 +104375,11 @@
   "repo": "ideasman42/emacs-utimeclock",
   "unstable": {
    "version": [
-    20201213,
-    438
+    20210124,
+    138
    ],
-   "commit": "cd3ab3a419ed50f51a7746849c80cb69910b89ca",
-   "sha256": "0anmmy46cbph9sjngcz3hbyzir8glzb6fqzl36wzfnxj54rzcf7l"
+   "commit": "727aa7809b2e3ea09a36c61740d04e316ee21070",
+   "sha256": "1c83gialj6ydm1h4075fk70yr84199s6235jfzc9c7h44jf88gvn"
   }
  },
  {
@@ -104087,11 +104594,11 @@
   "repo": "arthurgleckler/validate-html",
   "unstable": {
    "version": [
-    20200913,
-    2002
+    20210131,
+    1704
    ],
-   "commit": "04321596380c7a87ed85762b6764e98b2ef31bf8",
-   "sha256": "09c24i4b5yg21qzlyss4si607d1n63sj5dr2pysikkzzd81b9hki"
+   "commit": "39890f7d00579954a660fc3b1c0195231325efd6",
+   "sha256": "0xb1gnf0f408z9p6iscb9g5c5xj2d460gyzk1mr0wjm847b9cs42"
   }
  },
  {
@@ -104196,11 +104703,11 @@
   "repo": "venks1/emacs-fossil",
   "unstable": {
    "version": [
-    20201121,
-    1726
+    20210124,
+    812
    ],
-   "commit": "31b0ee6285cca98d376eb5b6e1bc832c419c9fd0",
-   "sha256": "1jva2vnpz97mrzpix5z2y8z9qph7p1r39ajyvdzjfx6vlvwgsv0i"
+   "commit": "5d66231e25f34aaedb4befa0fcd80a9c30d7e607",
+   "sha256": "01r8j7a8b3icfgyxpgxh3pimzwig0xbhmggahzllgn96w5fafgpv"
   }
  },
  {
@@ -104964,6 +105471,21 @@
   }
  },
  {
+  "ename": "virtual-comment",
+  "commit": "fe865358d240a8797d08010cc22d1451d6a8be46",
+  "sha256": "16ykignpbrd4i31wp25fj74mz6c5sakk6sd1lxib408f980zf6j5",
+  "fetcher": "github",
+  "repo": "thanhvg/emacs-virtual-comment",
+  "unstable": {
+   "version": [
+    20210210,
+    255
+   ],
+   "commit": "dadf36158c7ff89291bea4695999860cca2d094e",
+   "sha256": "10vnw6p5zg3azn1hf74014497qyxbxh6rr27lba45nrnxiz6wfmp"
+  }
+ },
+ {
   "ename": "virtualenv",
   "commit": "923e4fcf29423ad55b13132d53759bc436466ef9",
   "sha256": "1djqzzlbwsp9xyjqjbjwdck73wzikbpq19irzamybk90nc98wirl",
@@ -105361,11 +105883,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20210111,
-    522
+    20210209,
+    356
    ],
-   "commit": "9d2ef5e535e79781a0c1d2523f82d096eb48765f",
-   "sha256": "03nslg391cagq9kdxkgyjcw3abfd5xswza5bq8rl8mrp9f8v7i17"
+   "commit": "a3fadd28370aa43f03d4f7b197be8fa074f311f5",
+   "sha256": "02vy7kxpv3k1viyf977apk0nmr53wb988h8zv19w1llp9lwa578f"
   }
  },
  {
@@ -105376,14 +105898,14 @@
   "repo": "jixiuf/vterm-toggle",
   "unstable": {
    "version": [
-    20201204,
-    1537
+    20210130,
+    1149
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "61cb072af997aa961e2aebe0125b883ff3bd6f43",
-   "sha256": "082gcdb3lnjn361hnsc1pzxx8dma7pm4iv03kd284fszs032amp2"
+   "commit": "277a2071426562c385f87ef265dfafaf5051afb3",
+   "sha256": "10y2qxz3rz746sbfmkff0rh1vcjjdlkc9dw5gy5k1qnj8b3mi8pg"
   }
  },
  {
@@ -105467,8 +105989,8 @@
   "repo": "mihaiolteanu/vuiet",
   "unstable": {
    "version": [
-    20200616,
-    1136
+    20210208,
+    827
    ],
    "deps": [
     "bind-key",
@@ -105477,8 +105999,8 @@
     "s",
     "versuri"
    ],
-   "commit": "3dab1ea2253d5bc2974a1a064d2b1af3bd6b24f6",
-   "sha256": "1q1rcnsda1392kqh944hdj30d79300ycl46ck1bzx4szx3m3p801"
+   "commit": "7063ccde4269925827283553f794bfe48866ffda",
+   "sha256": "1bkwlwa95v967bpafzkgjv0ac4h8nknjlwdsgslvanfxz046py15"
   },
   "stable": {
    "version": [
@@ -105563,11 +106085,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210105,
-    2310
+    20210201,
+    2305
    ],
-   "commit": "f29aadae07bd58689720271b1f6538edfec5c476",
-   "sha256": "130ydwzpzw4s4h3jhh5h066iib7s9c8xa43imvlvcqs3vghp7p1x"
+   "commit": "54c3ccd9b3fa9becc4b108046b117ccd6384449d",
+   "sha256": "024drmvh1qv2sbl5nxvyrqbwlk4wk8bfsa08rn21rhlbnwknb5ip"
   }
  },
  {
@@ -105788,16 +106310,16 @@
   "repo": "wanderlust/wanderlust",
   "unstable": {
    "version": [
-    20210105,
-    1556
+    20210209,
+    1125
    ],
    "deps": [
     "apel",
     "flim",
     "semi"
    ],
-   "commit": "cf16d1272cd04ccc845476a1db9fb2ab690b0f55",
-   "sha256": "05mx1g5gqrbzl4p41kxsk2hl15vrfx8nf97xf2zn9c9s8nq0qj0n"
+   "commit": "3a3530b1c4e2a2aa02d683d166cf123e9cc16a0a",
+   "sha256": "09px7ns1k03frxx02gvkhjzbygz9sp214xq5qnain5mnz4vglcih"
   }
  },
  {
@@ -106033,11 +106555,11 @@
   "repo": "fxbois/web-mode",
   "unstable": {
    "version": [
-    20201227,
-    1048
+    20210131,
+    1758
    ],
-   "commit": "a3ce21f795e03c7a5489a24b2b3c4fce2d7a2f59",
-   "sha256": "1234cr8hd25z181vg64r10l4gmdc1nr7dij2qnp4xs9ag3zkdf1y"
+   "commit": "8ef47935d638902ba35a557cae5edd6ab6ab1346",
+   "sha256": "1csskh7wyyjjpn81if2ss29vaz8vqzszb9yg99ffkgkyx2fr57y1"
   },
   "stable": {
    "version": [
@@ -106171,32 +106693,32 @@
  },
  {
   "ename": "weblorg",
-  "commit": "8c9f6e5452a31772f90c1b5a5fa34b5a833073bb",
-  "sha256": "0gcxksn353zl0kzi387dm3fyy9n4gpjsjy5qlbr7iq4pcby4zbjb",
+  "commit": "61f6ede846bbf5e364c626524c567d4e3e99b906",
+  "sha256": "13snxyxfpjp7aznqwvkikkdpgn0vnar51mqxl2zbiwr8iksh9hpz",
   "fetcher": "github",
   "repo": "emacs-love/weblorg",
   "unstable": {
    "version": [
-    20210111,
-    526
+    20210211,
+    255
    ],
    "deps": [
     "templatel"
    ],
-   "commit": "1d0b5b9bc640a7147e1aa42867c7794fb5d039cc",
-   "sha256": "1fanpp3a40fkwdxc3ixvz6ykvkxh61mq2jxl1dgf0rrxc82mzhms"
+   "commit": "95ee894dea36ac1f0d39266169123ee1ba7674ed",
+   "sha256": "1ap1nk9f560qvggvpknnk33xjbk7n4hisiv98xin20s60vjwspx3"
   },
   "stable": {
    "version": [
     0,
     1,
-    0
+    1
    ],
    "deps": [
     "templatel"
    ],
-   "commit": "5ef2daff8498be07ea9b0f50a92d84c8d21d3a49",
-   "sha256": "14797vv2i3b5dgzdazacw2g9r3i5zam4xr3554xzpq1l8ran0g2p"
+   "commit": "3c860c7b52ccee2f8d0b96e8a9e65e9695eb6e0a",
+   "sha256": "1lia9g9dpmn7l7valyw7mvh7ipy2nanhjbd60gha1k4p4ypx3sla"
   }
  },
  {
@@ -106363,11 +106885,11 @@
   "repo": "jstaursky/weyland-yutani-theme",
   "unstable": {
    "version": [
-    20201209,
-    1505
+    20210212,
+    1514
    ],
-   "commit": "86c72ef8e3d25bee94c35254ad03b5d3e4836994",
-   "sha256": "148p1c6cwxcri2732ngbbmd27g1m61gsxbgs0f1qbpqhsy0pplz2"
+   "commit": "2c0ade85ef96ce311dcf10f915af5c3696c333bf",
+   "sha256": "173csa3pv5230q9r9iz5j3nf34m8kd9jcrcvc17yv5bp7njmak4d"
   }
  },
  {
@@ -106537,20 +107059,20 @@
   "repo": "justbur/emacs-which-key",
   "unstable": {
    "version": [
-    20201216,
-    1720
+    20210131,
+    1837
    ],
-   "commit": "428aedfce0157920814fbb2ae5d00b4aea89df88",
-   "sha256": "116c3krgi7iyv708jwzqjz72wf1j1aczgv5cvkdscrn7zgpyvm8c"
+   "commit": "c0608e812a8d1bc7aefeacdfaeb56a7272eabf44",
+   "sha256": "1g07i6hyv9glhk6xq1z9vn81vi2f0byy7dp3rg4gw22sm6f6d1al"
   },
   "stable": {
    "version": [
     3,
     5,
-    0
+    1
    ],
-   "commit": "ae59b7edb0d82aa0251803fdfbde6b865083c8b8",
-   "sha256": "13lgjsm9pwgjsxg7lzc1c9sw2bzssxikfj6grnshqfll8kz8yr4r"
+   "commit": "c0608e812a8d1bc7aefeacdfaeb56a7272eabf44",
+   "sha256": "1g07i6hyv9glhk6xq1z9vn81vi2f0byy7dp3rg4gw22sm6f6d1al"
   }
  },
  {
@@ -106593,14 +107115,11 @@
   "repo": "Fuco1/whitaker",
   "unstable": {
    "version": [
-    20150814,
-    1122
+    20210203,
+    1149
    ],
-   "deps": [
-    "dash"
-   ],
-   "commit": "eaf26ea647b729ca705b73ea70312d5ffdf89448",
-   "sha256": "1y75cylvqgn54h8yqahz4wi1qj5yhbs66i7x23jmbmah3q0rycab"
+   "commit": "a6fda24ccb69a18c0706633326d5cc4fcfaed83a",
+   "sha256": "00s7cljadn4f713kvwgvlapzh208fpqwyxlv4sxbsw6ba3gdllrd"
   },
   "stable": {
    "version": [
@@ -106622,11 +107141,11 @@
   "repo": "mswift42/white-sand-theme",
   "unstable": {
    "version": [
-    20151117,
-    1648
+    20210131,
+    813
    ],
-   "commit": "97621edd69267dd143760d94393db2c2558c9ea4",
-   "sha256": "0sh92g5vd518f80klvljqkjpw4ji909439dpc3sfaccf5jiwn9xn"
+   "commit": "729dd52cc1936250183d6761eed406c4be514a71",
+   "sha256": "0vlq6wywhc08z4ivyahpagcxbxfww6ipbmvgw4sgc8c6h3vb8v9s"
   }
  },
  {
@@ -106858,11 +107377,11 @@
   "repo": "progfolio/wikinfo",
   "unstable": {
    "version": [
-    20210112,
-    324
+    20210121,
+    1642
    ],
-   "commit": "b3c2824ab7cd653741b2b905f5c3279e312857cc",
-   "sha256": "01l3qwaqrcgrwlvfhxw2db06svcqhiahp6jbn8x8k5fmq7mk5hr3"
+   "commit": "afa32f2b3c23e6d1565698faf9697fa445059bb9",
+   "sha256": "1wxdb34xsvqydr54w44b84hbins8ay1md49vphp6jqbj99q992dg"
   }
  },
  {
@@ -106873,15 +107392,15 @@
   "repo": "progfolio/wikinforg",
   "unstable": {
    "version": [
-    20201227,
-    1454
+    20210126,
+    405
    ],
    "deps": [
     "org",
     "wikinfo"
    ],
-   "commit": "8496c243f8d98ba2787b63f7d19fbae3831832d2",
-   "sha256": "1w7q3badp6r653grsblmnambv99r52c34gmnpdz0f5ybmw83002p"
+   "commit": "d1a95a62e90cff70d83a6a2ce611aa895adb9a58",
+   "sha256": "196hhbqpx233av4zfcz0ig5r0rbp6annr8w88j5i6bqrk0yzm2ws"
   }
  },
  {
@@ -107051,15 +107570,15 @@
   "repo": "bmag/emacs-purpose",
   "unstable": {
    "version": [
-    20190628,
-    1827
+    20210211,
+    1713
    ],
    "deps": [
     "imenu-list",
     "let-alist"
    ],
-   "commit": "f6421966761ad911fe8861aba2b110c5dd60d1ea",
-   "sha256": "1p0y5gnrw7q65py2wjdf1hrdpiw5c2zbgvfbfmb13257jq5mga38"
+   "commit": "76b2298c27e69941ed5200363fbcac7487875f83",
+   "sha256": "0slbhn09vbv10mxmgym0fmk4yf28q9aj2bnmkf2fh3p766ps9n1a"
   },
   "stable": {
    "version": [
@@ -107277,14 +107796,11 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20210110,
-    1545
+    20210117,
+    2008
    ],
-   "deps": [
-    "async"
-   ],
-   "commit": "139ef3933ea7aa3fe67b87450a6a1ac0895e5c81",
-   "sha256": "1zdgn2ajpbdxnc7qf98z7590w8y1s0iqj27fv7m8ndkrn8c1cx0x"
+   "commit": "2848a90addae086b657605b84a7fbecf2c4c1c65",
+   "sha256": "0pcy9w0q4jlwcf4hhcdm2cjgpj9ca4b04cydwlv5pnm0qrnlrzpc"
   },
   "stable": {
    "version": [
@@ -107389,8 +107905,8 @@
     20200509,
     2010
    ],
-   "commit": "0d5e910f19657ab376f72e5848be50d13d3b8e50",
-   "sha256": "1ksm11k8gxkjn9byacy08xrz91gvzyf7fjnxv7j5ffpsccbh0wg3"
+   "commit": "228732caf5272dd25e5c8acb2c6c86b0ac29ece8",
+   "sha256": "08j0ab7i0fk3d9d805mzwszlc82afr1sjw7isnx8k35d90cnmf3d"
   },
   "stable": {
    "version": [
@@ -107607,8 +108123,8 @@
   "repo": "abo-abo/worf",
   "unstable": {
    "version": [
-    20201226,
-    1859
+    20210128,
+    1005
    ],
    "deps": [
     "ace-link",
@@ -107616,8 +108132,8 @@
     "swiper",
     "zoutline"
    ],
-   "commit": "7ddd86aa3c62955714c2d60decd7a78c06b4771a",
-   "sha256": "02ci6hnjv80n3gjl04lxkcjvc2bzvn34w0z721qira1g7m2ysa8a"
+   "commit": "718ad44ff340e0298ee843130067f42d799350a4",
+   "sha256": "16nqx4ridk6asibxhp9l8pw33kc862i42wkjm14m8r5y6gi67k7d"
   },
   "stable": {
    "version": [
@@ -107897,11 +108413,11 @@
   "repo": "redguardtoo/wucuo",
   "unstable": {
    "version": [
-    20201208,
-    811
+    20210129,
+    407
    ],
-   "commit": "609bab2d72690c2eb1562e87dfa468b927eb1295",
-   "sha256": "0h14af90zcbinrn8q5csjc7px4yag20as995mvcn0ik8h9xk6jc7"
+   "commit": "4f1a63bf990c06942c5c290d5d146f8545f43b95",
+   "sha256": "0awa2zhnmm49sdvxwzhbnzcynk4qsbpsrmqmh9xi9rw20711iwjr"
   },
   "stable": {
    "version": [
@@ -108036,11 +108552,11 @@
   "repo": "xahlee/xah-elisp-mode",
   "unstable": {
    "version": [
-    20210112,
-    109
+    20210208,
+    2056
    ],
-   "commit": "134f9d259b68f5c3644dbed203d0d4142e2f3ce9",
-   "sha256": "15x15dzk67xif8ybnv9jid5xzmwimxx086ysdhryqqzrlxc3igiq"
+   "commit": "3ae341944297d59bf33f5580364af2858198781e",
+   "sha256": "09w44nmxdvc7pxyz959qj59dfqxplj22qqdal7206bb12r1l88zr"
   }
  },
  {
@@ -108066,11 +108582,11 @@
   "repo": "xahlee/xah-fly-keys",
   "unstable": {
    "version": [
-    20210114,
-    751
+    20210212,
+    2334
    ],
-   "commit": "015ec792050b4df00bb640602903258431ca6a44",
-   "sha256": "0h8sr9ig5ww2dwg5d22dfndyq68fv5mm1lf99k76wy5dxkqs5w5c"
+   "commit": "3e5c9db36b9a01b485fffd12219a1685ea1e1fc6",
+   "sha256": "03496m1vs7kkh2rwymj5nbr2cv07s3vdlic9mm30rim0cpw3gax6"
   }
  },
  {
@@ -108978,11 +109494,11 @@
   "repo": "Kungsgeten/yankpad",
   "unstable": {
    "version": [
-    20201228,
-    1208
+    20210205,
+    1318
    ],
-   "commit": "06d85f04133fbd49a6469174032f4c10a0abe98d",
-   "sha256": "16a4qfliym93rj7bsjijzwlv8r8h9kbxrd53wdk9fb6vgdk2vv9h"
+   "commit": "fb9cb7753af971701dcd96a51efb4d70e2b2a18f",
+   "sha256": "1xaal77cqics6fdm51j7pm12k61v0qxg68krgb7yi1fd90fm2iy3"
   },
   "stable": {
    "version": [
@@ -109465,11 +109981,11 @@
   "repo": "ryuslash/yoshi-theme",
   "unstable": {
    "version": [
-    20200909,
-    513
+    20210201,
+    605
    ],
-   "commit": "1ca48766209d941f0300d725ce9bec5a8bc2d642",
-   "sha256": "1abzv19aghgjkzc15wcii3fvapjx221imap48gfn2d3ckbppy8lb"
+   "commit": "77036b1067c16451cbc9fdca254f31b6725b795b",
+   "sha256": "0dm9rd0dr1dv6adq4rmj3z9l94y2jq1kd8p1d2r3qw6jqz8w035d"
   },
   "stable": {
    "version": [
@@ -109513,6 +110029,21 @@
    ],
    "commit": "a6e44e4fb93cc1b9f1067f10cf854b0bfc3fe732",
    "sha256": "1m4zri7kiw70062w2sp4fdqmmx2vmjisamjwmjdg6669dzvnpawq"
+  }
+ },
+ {
+  "ename": "ytdious",
+  "commit": "946fc7cf4d5e6cd346c331bec7af519ab93f53c4",
+  "sha256": "1yg5kfr0kbr55ral50m56njkfl3lz2shlp2fs4cgmwrbp9pvzb9p",
+  "fetcher": "github",
+  "repo": "spiderbit/ytdious",
+  "unstable": {
+   "version": [
+    20210207,
+    1841
+   ],
+   "commit": "6005ff920b7df97724094b1afa2a6a3d0fcc6a60",
+   "sha256": "17dp67awxpv8zi961rbhzgzkyxvnj2498p6ld0bjh3v7nqg0zfwg"
   }
  },
  {
@@ -109829,14 +110360,14 @@
   "repo": "NicolasPetton/zerodark-theme",
   "unstable": {
    "version": [
-    20190528,
-    923
+    20210212,
+    956
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "df22536a244293591575e56970bf83814faa7c14",
-   "sha256": "0pfyd1iqs7l2ngwgvj9n0r9k1px7yl16h8n502xdyf0pprxcs4p6"
+   "commit": "744c1a5b06277f0f9b70abb30a93b35818773532",
+   "sha256": "1v5by5kq7ifqz172x80y3ddlkywl3dccvqvz6skxq7rz8w4gx5d3"
   },
   "stable": {
    "version": [
@@ -109865,8 +110396,8 @@
     "ace-window",
     "deft"
    ],
-   "commit": "ca3793959669b577296e1787aa029effa29a15c5",
-   "sha256": "1rxp0nwnjpwz3j44yj7afjj04hx4y3157a7vrgy0dlivhjzmdgag"
+   "commit": "09d31b083e0d08bd4dda3e60af44711c090140b0",
+   "sha256": "14hawr28rcr4scjchjx71g6wvvnym9ai20iz615a751iilg4mw7a"
   },
   "stable": {
    "version": [
@@ -110371,14 +110902,14 @@
   "repo": "fourier/ztree",
   "unstable": {
    "version": [
-    20191108,
-    2234
+    20210210,
+    2022
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "0a5b25f364490a58ef7371534a39c75d11f54132",
-   "sha256": "0a0p9srdkc79isw99al3vba50vc435654wix07r9jcgdh856zbsr"
+   "commit": "6eee81d2691009ce60b2edf7c298b227caf1b0d6",
+   "sha256": "1xmimjflylssx63g1kpd5n34gdlpivgg9ih8nwplad57bxiy2yqb"
   }
  },
  {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
