### PR TITLE
.github/workflows/labels.yml: label PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,149 @@
+"6.topic: agda":
+  - doc/languages-frameworks/agda.section.md
+  - nixos/tests/agda.nix
+  - pkgs/build-support/agda/**/*
+  - pkgs/development/libraries/agda/**/*
+  - pkgs/top-level/agda-packages.nix
+
+"6.topic: emacs":
+  - nixos/modules/services/editors/emacs.nix
+  - nixos/modules/services/editors/emacs.xml
+  - nixos/tests/emacs-daemon.nix
+  - pkgs/applications/editors/emacs-modes/**/*
+  - pkgs/applications/editors/emacs/**/*
+  - pkgs/build-support/emacs/**/*
+  - pkgs/top-level/emacs-packages.nix
+
+"6.topic: erlang":
+  - doc/languages-frameworks/beam.xml
+  - pkgs/development/beam-modules/**/*
+  - pkgs/development/interpreters/elixir/**/*
+  - pkgs/development/interpreters/erlang/**/*
+  - pkgs/development/tools/build-managers/rebar/**/*
+  - pkgs/development/tools/build-managers/rebar3/**/*
+  - pkgs/development/tools/erlang/**/*
+  - pkgs/development/tools/elixir/**/*
+  - pkgs/top-level/beam-packages.nix
+
+"6.topic: fetch":
+  - pkgs/build-support/fetch/**/*
+
+"6.topic: GNOME":
+  - pkgs/desktops/gnome-3/**/*
+  - nixos/modules/services/x11/desktop-managers/gnome3.nix
+  - nixos/tests/gnome3.nix
+  - nixos/tests/gnome3-xorg.nix
+  - nixos/modules/services/desktops/gnome3/**/*
+  - doc/languages-frameworks/gnome.xml
+
+"6.topic: golang":
+  - pkgs/development/compilers/go/**/*
+  - pkgs/development/go-modules/**/*
+  - doc/languages-frameworks/go.xml
+
+"6.topic: haskell":
+  - pkgs/development/compilers/ghc/**/*
+  - pkgs/development/tools/haskell/**/*
+  - pkgs/development/haskell-modules/**/*
+  - pkgs/top-level/haskell-packages.nix
+  - doc/languages-frameworks/haskell.md
+
+"6.topic: kernel":
+  - pkgs/build-support/linux/kernel/**/*
+
+"6.topic: lua":
+  - pkgs/development/lua-modules/**/*
+  - pkgs/top-level/lua-packages.nix
+  - pkgs/development/interpreters/lua-5/**/*
+  - pkgs/development/interpreters/luajit/**/*
+
+"6.topic: nixos":
+  - nixos/**/*
+
+"6.topic: ocaml":
+  - doc/languages-frameworks/ocaml.section.md
+  - pkgs/top-level/ocaml-packages.nix
+  - pkgs/development/ocaml-modules/**/*
+  - pkgs/development/compilers/ocaml/**/*
+  - pkgs/development/tools/ocaml/**/*
+  - pkgs/development/compilers/reason/**/*
+
+"6.topic: pantheon":
+  - pkgs/desktops/pantheon/**/*
+  - nixos/tests/pantheon.nix
+  - nixos/modules/services/x11/desktop-managers/pantheon.nix
+  - nixos/modules/services/x11/display-managers/lightdm-greeters/pantheon.nix
+  - nixos/modules/services/desktops/pantheon/**/*
+
+"6.topic: policy discussion":
+  - .github/**/*
+
+"6.topic: printing":
+  - pkgs/misc/cups/**/*
+  - nixos/modules/services/printing/cupsd.nix
+
+"6.topic: python":
+  - pkgs/top-level/python-packages.nix
+  - pkgs/development/interpreters/python/**/*
+  - pkgs/development/python-modules/**/*
+  - doc/languages-frameworks/python.md
+
+"6.topic: qt/kde":
+  - pkgs/applications/kde/**/*
+  - pkgs/desktops/plasma-5/**/*
+  - pkgs/development/libraries/kde-frameworks/**/*
+  - pkgs/development/libraries/qt-5/**/*
+  - doc/languages-frameworks/qt.xml
+  - nixos/modules/services/x11/desktop-managers/plasma5.nix
+  - nixos/tests/plasma5.nix
+
+"6.topic: ruby":
+  - pkgs/development/interpreters/ruby/**/*
+  - pkgs/development/ruby-modules/**/*
+  - doc/languages-frameworks/ruby.xml
+
+"6.topic: rust":
+  - pkgs/development/compilers/rust/**/*
+  - pkgs/build-support/rust/**/*
+  - doc/languages-frameworks/rust.md
+
+"6.topic: stdenv":
+  - pkgs/stdenv/**/*
+
+"6.topic: steam":
+  - pkgs/games/steam/**/*
+
+"6.topic: systemd":
+  - pkgs/os-specific/linux/systemd/**/*
+  - nixos/modules/system/boot/systemd/**/*
+
+"6.topic: TeX":
+  - pkgs/tools/typesetting/tex/**/*
+  - doc/languages-frameworks/texlive.xml
+
+"6.topic: vim":
+  - pkgs/applications/editors/vim/**/*
+  - pkgs/misc/vim-plugins/**/*
+  - doc/languages-frameworks/vim.md
+
+"6.topic: xfce":
+  - pkgs/desktops/xfce/**/*
+  - pkgs/destkops/xfce4-14/**/*
+  - nixos/doc/manual/configuration/xfce.xml
+  - nixos/modules/services/x11/desktop-managers/xfce4-14.nix
+  - nixos/modules/services/x11/desktop-managers/xfce.nix
+  - nixos/tests/xfce.nix
+  - nixos/tests/xfce4-14.nix
+
+"6.topic: cinnamon":
+  - pkgs/desktops/cinnamon/**/*
+
+"8.has: changelog":
+  - doc/manual/release-notes/**/*
+
+"8.has: documentation":
+  - doc/**/*
+  - nixos/doc/**/*
+
+"8.has: module (update)":
+  - nixos/modules/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,9 @@
   - pkgs/development/libraries/agda/**/*
   - pkgs/top-level/agda-packages.nix
 
+"6.topic: cinnamon":
+  - pkgs/desktops/cinnamon/**/*
+
 "6.topic: emacs":
   - nixos/modules/services/editors/emacs.nix
   - nixos/modules/services/editors/emacs.xml
@@ -15,97 +18,97 @@
   - pkgs/top-level/emacs-packages.nix
 
 "6.topic: erlang":
-  - doc/languages-frameworks/beam.xml
+  - doc/languages-frameworks/beam.section.md
   - pkgs/development/beam-modules/**/*
   - pkgs/development/interpreters/elixir/**/*
   - pkgs/development/interpreters/erlang/**/*
   - pkgs/development/tools/build-managers/rebar/**/*
   - pkgs/development/tools/build-managers/rebar3/**/*
   - pkgs/development/tools/erlang/**/*
-  - pkgs/development/tools/elixir/**/*
   - pkgs/top-level/beam-packages.nix
 
 "6.topic: fetch":
-  - pkgs/build-support/fetch/**/*
+  - pkgs/build-support/fetch*/**/*
 
 "6.topic: GNOME":
-  - pkgs/desktops/gnome-3/**/*
-  - nixos/modules/services/x11/desktop-managers/gnome3.nix
-  - nixos/tests/gnome3.nix
-  - nixos/tests/gnome3-xorg.nix
+  - doc/languages-frameworks/gnome.section.md
   - nixos/modules/services/desktops/gnome3/**/*
-  - doc/languages-frameworks/gnome.xml
+  - nixos/modules/services/x11/desktop-managers/gnome3.nix
+  - nixos/tests/gnome3-xorg.nix
+  - nixos/tests/gnome3.nix
+  - pkgs/desktops/gnome-3/**/*
 
 "6.topic: golang":
+  - doc/languages-frameworks/go.section.md
   - pkgs/development/compilers/go/**/*
   - pkgs/development/go-modules/**/*
-  - doc/languages-frameworks/go.xml
+  - pkgs/development/go-packages/**/*
 
 "6.topic: haskell":
+  - doc/languages-frameworks/haskell.section.md
   - pkgs/development/compilers/ghc/**/*
-  - pkgs/development/tools/haskell/**/*
   - pkgs/development/haskell-modules/**/*
+  - pkgs/development/tools/haskell/**/*
   - pkgs/top-level/haskell-packages.nix
-  - doc/languages-frameworks/haskell.md
 
 "6.topic: kernel":
-  - pkgs/build-support/linux/kernel/**/*
+  - pkgs/build-support/kernel/**/*
 
 "6.topic: lua":
-  - pkgs/development/lua-modules/**/*
-  - pkgs/top-level/lua-packages.nix
   - pkgs/development/interpreters/lua-5/**/*
   - pkgs/development/interpreters/luajit/**/*
+  - pkgs/development/lua-modules/**/*
+  - pkgs/top-level/lua-packages.nix
 
 "6.topic: nixos":
   - nixos/**/*
 
 "6.topic: ocaml":
   - doc/languages-frameworks/ocaml.section.md
-  - pkgs/top-level/ocaml-packages.nix
-  - pkgs/development/ocaml-modules/**/*
   - pkgs/development/compilers/ocaml/**/*
-  - pkgs/development/tools/ocaml/**/*
   - pkgs/development/compilers/reason/**/*
+  - pkgs/development/ocaml-modules/**/*
+  - pkgs/development/tools/ocaml/**/*
+  - pkgs/top-level/ocaml-packages.nix
 
 "6.topic: pantheon":
-  - pkgs/desktops/pantheon/**/*
-  - nixos/tests/pantheon.nix
+  - nixos/modules/services/desktops/pantheon/**/*
   - nixos/modules/services/x11/desktop-managers/pantheon.nix
   - nixos/modules/services/x11/display-managers/lightdm-greeters/pantheon.nix
-  - nixos/modules/services/desktops/pantheon/**/*
+  - nixos/tests/pantheon.nix
+  - pkgs/desktops/pantheon/**/*
 
 "6.topic: policy discussion":
   - .github/**/*
 
 "6.topic: printing":
-  - pkgs/misc/cups/**/*
   - nixos/modules/services/printing/cupsd.nix
+  - pkgs/misc/cups/**/*
 
 "6.topic: python":
-  - pkgs/top-level/python-packages.nix
+  - doc/languages-frameworks/python.section.md
   - pkgs/development/interpreters/python/**/*
   - pkgs/development/python-modules/**/*
-  - doc/languages-frameworks/python.md
+  - pkgs/top-level/python-packages.nix
 
 "6.topic: qt/kde":
+  - doc/languages-frameworks/qt.section.md
+  - nixos/modules/services/x11/desktop-managers/plasma5.nix
+  - nixos/tests/plasma5.nix
   - pkgs/applications/kde/**/*
   - pkgs/desktops/plasma-5/**/*
   - pkgs/development/libraries/kde-frameworks/**/*
   - pkgs/development/libraries/qt-5/**/*
-  - doc/languages-frameworks/qt.xml
-  - nixos/modules/services/x11/desktop-managers/plasma5.nix
-  - nixos/tests/plasma5.nix
 
 "6.topic: ruby":
+  - doc/languages-frameworks/ruby.section.md
   - pkgs/development/interpreters/ruby/**/*
   - pkgs/development/ruby-modules/**/*
-  - doc/languages-frameworks/ruby.xml
 
 "6.topic: rust":
-  - pkgs/development/compilers/rust/**/*
+  - doc/languages-frameworks/rust.section.md
   - pkgs/build-support/rust/**/*
-  - doc/languages-frameworks/rust.md
+  - pkgs/development/compilers/rust/**/*
 
 "6.topic: stdenv":
   - pkgs/stdenv/**/*
@@ -115,31 +118,25 @@
 
 "6.topic: systemd":
   - pkgs/os-specific/linux/systemd/**/*
-  - nixos/modules/system/boot/systemd/**/*
+  - nixos/modules/system/boot/systemd*/**/*
 
 "6.topic: TeX":
+  - doc/languages-frameworks/texlive.section.md
   - pkgs/tools/typesetting/tex/**/*
-  - doc/languages-frameworks/texlive.xml
 
 "6.topic: vim":
+  - doc/languages-frameworks/vim.section.md
   - pkgs/applications/editors/vim/**/*
   - pkgs/misc/vim-plugins/**/*
-  - doc/languages-frameworks/vim.md
 
 "6.topic: xfce":
-  - pkgs/desktops/xfce/**/*
-  - pkgs/destkops/xfce4-14/**/*
   - nixos/doc/manual/configuration/xfce.xml
-  - nixos/modules/services/x11/desktop-managers/xfce4-14.nix
   - nixos/modules/services/x11/desktop-managers/xfce.nix
   - nixos/tests/xfce.nix
-  - nixos/tests/xfce4-14.nix
-
-"6.topic: cinnamon":
-  - pkgs/desktops/cinnamon/**/*
+  - pkgs/desktops/xfce/**/*
 
 "8.has: changelog":
-  - doc/manual/release-notes/**/*
+  - nixos/doc/manual/release-notes/**/*
 
 "8.has: documentation":
   - doc/**/*

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,14 @@
+name: "Label PR"
+
+on:
+  pull_request_target:
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'NixOS'
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        sync-labels: true


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Easier to update when it's in the same repo.
- Labels will be accurate, e.g. `docker` won't be labelled with `documentation`.
- Doesn't require a redeploy of ofborg to pick up changes.

This will need to be merged after the labels are removed from `config.public.json` in ofborg and it is redeployed, I'll open a PR to do that if this one is accepted.

This will only affect labels that are listed here so the behaviour of manual and other `ofborg` labels (e.g. `rebuilds`, `security`, etc) will remain the same as it is currently. 