### PR TITLE
lavalauncher: init at 2.0.0

### DIFF
--- a/pkgs/applications/misc/lavalauncher/default.nix
+++ b/pkgs/applications/misc/lavalauncher/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchgit
+, meson
+, ninja
+, pkg-config
+, scdoc
+, cairo
+, librsvg
+, wayland
+, wayland-protocols
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lavalauncher";
+  version = "2.0.0";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~leon_plickat/lavalauncher";
+    rev = "v${version}";
+    sha256 = "MXREycR4ZetTe71ZwEqyozMJN9OLTDvU0W4J8qkTQAs=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config scdoc ];
+  buildInputs = [
+    cairo
+    librsvg
+    wayland
+    wayland-protocols
+  ];
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~leon_plickat/lavalauncher";
+    description = "A simple launcher panel for Wayland desktops";
+    longDescription = ''
+      LavaLauncher is a simple launcher panel for Wayland desktops.
+
+      It displays a dynamically sized bar with user defined buttons. Buttons
+      consist of an image, which is displayed as the button icon on the bar, and
+      at least one shell command, which is executed when the user activates the
+      button.
+
+      Buttons can be activated with pointer and touch events.
+
+      A single LavaLauncher instance can provide multiple such bars, across
+      multiple outputs.
+
+      The Wayland compositor must implement the Layer-Shell and XDG-Output for
+      LavaLauncher to work.
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25364,6 +25364,8 @@ in
 
   testssl = callPackage ../applications/networking/testssl { };
 
+  lavalauncher = callPackage ../applications/misc/lavalauncher { };
+
   ulauncher = callPackage ../applications/misc/ulauncher { };
 
   twinkle = qt5.callPackage ../applications/networking/instant-messengers/twinkle { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
