### PR TITLE
pythonPackages.libcst: 0.3.13 -> 0.3.17

### DIFF
--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -1,7 +1,14 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, isPy3k, attrs, coverage, enum34, pexpect
-, doCheck ? true, pytest, pytest_xdist, flaky, mock
+{ lib
+, buildPythonPackage
+, pythonAtLeast
+, fetchFromGitHub
+, attrs
+, pexpect
+, doCheck ? true
+, pytestCheckHook
+, pytest-xdist
 , sortedcontainers
+, tzdata
 }:
 buildPythonPackage rec {
   # https://hypothesis.readthedocs.org/en/latest/packaging.html
@@ -10,36 +17,40 @@ buildPythonPackage rec {
   # pytz fake_factory django numpy pytest
   # If you need these, you can just add them to your environment.
 
-  version = "5.30.0";
   pname = "hypothesis";
+  version = "5.49.0";
 
   # Use github tarballs that includes tests
   src = fetchFromGitHub {
     owner = "HypothesisWorks";
     repo = "hypothesis-python";
     rev = "hypothesis-python-${version}";
-    sha256 = "0fmc4jfaksr285fjhp18ibj2rr8cxmbd0pwx370r5wf8jnhm6jb3";
+    sha256 = "1lr9a93vdx70s9i1zazazif5hy8fbqhvwqq402ygpf53yw4lgi2w";
   };
 
   postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";
 
   propagatedBuildInputs = [
     attrs
-    coverage
     sortedcontainers
-  ] ++ lib.optional (!isPy3k) enum34;
+  ];
 
-  checkInputs = [ pytest pytest_xdist flaky mock pexpect ];
+  checkInputs = [ pytestCheckHook pytest-xdist pexpect ]
+    ++ lib.optional (pythonAtLeast "3.9") tzdata;
+
   inherit doCheck;
 
-  checkPhase = ''
-    rm tox.ini # This file changes how py.test runs and breaks it
-    py.test tests/cover
+  # This file changes how pytest runs and breaks it
+  preCheck = ''
+    rm tox.ini
   '';
+
+  pytestFlagsArray = [ "tests/cover" ];
 
   meta = with lib; {
     description = "A Python library for property based testing";
     homepage = "https://github.com/HypothesisWorks/hypothesis";
     license = licenses.mpl20;
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/development/python-modules/hypothesmith/default.nix
+++ b/pkgs/development/python-modules/hypothesmith/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, hypothesis, lark-parser, libcst, black, parso, pytestCheckHook, pytest-cov, pytest-xdist }:
+
+buildPythonPackage rec {
+  pname = "hypothesmith";
+  version = "0.1.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-+f8EexXE7TEs49pX6idXD4bWtTzhKvnyXlnmV2oAQQo=";
+  };
+
+  propagatedBuildInputs = [ hypothesis lark-parser libcst ];
+
+  checkInputs = [ black parso pytestCheckHook pytest-cov pytest-xdist ];
+
+  pythonImportsCheck = [ "hypothesmith" ];
+
+  meta = with lib; {
+    description = "Hypothesis strategies for generating Python programs, something like CSmith";
+    homepage = "https://github.com/Zac-HD/hypothesmith";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/development/python-modules/libcst/default.nix
+++ b/pkgs/development/python-modules/libcst/default.nix
@@ -1,9 +1,22 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, black, isort
-, pytestCheckHook, pyyaml, typing-extensions, typing-inspect, dataclasses }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, hypothesis
+, doCheck ? true
+, dataclasses
+, hypothesmith
+, pytestCheckHook
+, pyyaml
+, typing-extensions
+, typing-inspect
+, black
+, isort
+}:
 
 buildPythonPackage rec {
   pname = "libcst";
-  version = "0.3.13";
+  version = "0.3.17";
 
   # Some files for tests missing from PyPi
   # https://github.com/Instagram/LibCST/issues/331
@@ -11,25 +24,21 @@ buildPythonPackage rec {
     owner = "instagram";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0pbddjrsqj641mr6zijk2phfn15dampbx268zcws4bhhhnrxlj65";
+    sha256 = "sha256-mlSeB9OjCiUVYwcPYNrQdlfcj9DV/+wqVWt91uFsQsU=";
   };
 
   disabled = pythonOlder "3.6";
 
-  propagatedBuildInputs = [ pyyaml typing-inspect ]
+  propagatedBuildInputs = [ hypothesis typing-inspect pyyaml ]
     ++ lib.optional (pythonOlder "3.7") dataclasses;
 
-  checkInputs = [ black isort pytestCheckHook ];
+  checkInputs = [ black hypothesmith isort pytestCheckHook ];
 
-  # https://github.com/Instagram/LibCST/issues/346
-  # https://github.com/Instagram/LibCST/issues/347
+  inherit doCheck;
+
   preCheck = ''
     python -m libcst.codegen.generate visitors
     python -m libcst.codegen.generate return_types
-    rm libcst/tests/test_fuzz.py
-    rm libcst/tests/test_pyre_integration.py
-    rm libcst/metadata/tests/test_full_repo_manager.py
-    rm libcst/metadata/tests/test_type_inference_provider.py
   '';
 
   pythonImportsCheck = [ "libcst" ];
@@ -39,6 +48,6 @@ buildPythonPackage rec {
       "A Concrete Syntax Tree (CST) parser and serializer library for Python.";
     homepage = "https://github.com/Instagram/libcst";
     license = with licenses; [ mit asl20 psfl ];
-    maintainers = with maintainers; [ maintainers.ruuda ];
+    maintainers = with maintainers; [ ruuda SuperSandro2000 ];
   };
 }

--- a/pkgs/development/python-modules/tzdata/default.nix
+++ b/pkgs/development/python-modules/tzdata/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "tzdata";
+  version = "2021.1";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-4ZxzUfiHUioaxznSEEHlkt3ebdG3ZP3vqPeys1UdPTg=";
+  };
+
+  pythonImportsCheck = [ "tzdata" ];
+
+  meta = with lib; {
+    description = "Provider of IANA time zone data";
+    homepage = "https://github.com/python/tzdata";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3065,6 +3065,10 @@ in {
 
   hypothesis = if isPy3k then callPackage ../development/python-modules/hypothesis { } else self.hypothesis_4;
 
+  hypothesmith = callPackage ../development/python-modules/hypothesmith {
+    libcst = self.libcst.override { doCheck = false; };
+  };
+
   hyppo = callPackage ../development/python-modules/hyppo { };
 
   i3ipc = callPackage ../development/python-modules/i3ipc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7985,6 +7985,8 @@ in {
 
   typogrify = callPackage ../development/python-modules/typogrify { };
 
+  tzdata = callPackage ../development/python-modules/tzdata { };
+
   tzlocal = callPackage ../development/python-modules/tzlocal { };
 
   uamqp = callPackage ../development/python-modules/uamqp {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I just wanted to update libcst which now requires hypothesmith which itself also requires libcst. hypothesmith also required a newer version of hypothesis so I fetched the latest 5.X.X version. On python 3.9 hypothesis now required tzdata for tests.

The hypothesis successfully build all dependencies required by those packages so the update should be save. 

The PR is based on master and staging so base can easily be changed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
