### PR TITLE
mbp2018-bridge-drv: init at 0.01

### DIFF
--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "mbp2018-bridge-drv";
-  version = "b43fcc069da73e051072fde24af4014c9c487286";
+  version = "0.01";
 
   src = fetchFromGitHub {
     owner = "MCMrARM";

--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, kernel, fetchFromGitHub, }:
+
+stdenv.mkDerivation rec {
+  name = "mbp2018-bridge-drv";
+  version = "b43fcc069da73e051072fde24af4014c9c487286";
+
+  src = fetchFromGitHub {
+    owner = "MCMrARM";
+    repo = "mbp2018-bridge-drv";
+    rev = "0.01";
+    sha256 = "0ac2l51ybfrvg8m36x67rsvgjqs1vwp7c89ssvbjkrcq3y4qdb53";
+  };
+
+  buildPhase = ''
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \
+      M=$(pwd) modules
+  '';
+
+  installPhase = ''
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build  \
+      INSTALL_MOD_PATH=$out M=$(pwd) modules_install
+  '';
+
+  meta = with lib; {
+    description = "A driver for MacBook models 2018 and newer, which makes the keyboard, mouse and audio output work.";
+    longDescription = ''
+      A driver for MacBook models 2018 and newer, implementing the VHCI (required for mouse/keyboard/etc.) and audio functionality.
+    '';
+    homepage = "https://github.com/MCMrARM/mbp2018-bridge-drv";
+    license = lib.licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "MCMrARM";
     repo = "mbp2018-bridge-drv";
-    rev = "0.01";
+    rev = "${version}";
     sha256 = "0ac2l51ybfrvg8m36x67rsvgjqs1vwp7c89ssvbjkrcq3y4qdb53";
   };
 

--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       A driver for MacBook models 2018 and newer, implementing the VHCI (required for mouse/keyboard/etc.) and audio functionality.
     '';
     homepage = "https://github.com/MCMrARM/mbp2018-bridge-drv";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = [ lib.maintainers.hlolli ];
   };

--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, kernel, fetchFromGitHub, }:
 
 stdenv.mkDerivation rec {
-  name = "mbp2018-bridge-drv";
+  pname = "mbp2018-bridge-drv";
   version = "b43fcc069da73e051072fde24af4014c9c487286";
 
   src = fetchFromGitHub {

--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \
-      M=$(pwd) modules
+      -j$NIX_BUILD_CORES M=$(pwd) modules
   '';
 
   installPhase = ''
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/MCMrARM/mbp2018-bridge-drv";
     license = lib.licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.hlolli ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19245,6 +19245,8 @@ in
 
     tbs = callPackage ../os-specific/linux/tbs { };
 
+    mbp2018-bridge-drv = callPackage ../os-specific/linux/mbp-modules/mbp2018-bridge-drv { inherit kernel; };
+
     nvidiabl = callPackage ../os-specific/linux/nvidiabl { };
 
     nvidiaPackages = dontRecurseIntoAttrs (callPackage ../os-specific/linux/nvidia-x11 { });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19245,7 +19245,7 @@ in
 
     tbs = callPackage ../os-specific/linux/tbs { };
 
-    mbp2018-bridge-drv = callPackage ../os-specific/linux/mbp-modules/mbp2018-bridge-drv { inherit kernel; };
+    mbp2018-bridge-drv = callPackage ../os-specific/linux/mbp-modules/mbp2018-bridge-drv { };
 
     nvidiabl = callPackage ../os-specific/linux/nvidiabl { };
 


### PR DESCRIPTION
###### Motivation for this change

This kernel-module is part of macbook pro 15+ hardware support https://github.com/NixOS/nixos-hardware/pull/231

###### Things done

Adding this kernel-module under mbp-modules, as I intend to add at least 1 more macbook pro kernel module. But this nesting is perhaps debateable. Also the author hasn't made any releases but I did find some metadata in the c file https://github.com/MCMrARM/mbp2018-bridge-drv/blob/master/pci.c#L431-L434 so I'm assuming gpl2 license.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
