### PR TITLE
sbcl: add 2.1.1

### DIFF
--- a/pkgs/development/compilers/sbcl/2.1.1.nix
+++ b/pkgs/development/compilers/sbcl/2.1.1.nix
@@ -1,0 +1,114 @@
+{ lib, stdenv, fetchurl, writeText, sbclBootstrap
+, sbclBootstrapHost ? "${sbclBootstrap}/bin/sbcl --disable-debugger --no-userinit --no-sysinit"
+, threadSupport ? (stdenv.isi686 || stdenv.isx86_64 || "aarch64-linux" == stdenv.hostPlatform.system)
+, disableImmobileSpace ? false
+  # Meant for sbcl used for creating binaries portable to non-NixOS via save-lisp-and-die.
+  # Note that the created binaries still need `patchelf --set-interpreter ...`
+  # to get rid of ${glibc} dependency.
+, purgeNixReferences ? false
+, texinfo
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sbcl";
+  version = "2.1.1";
+
+  src = fetchurl {
+    url    = "mirror://sourceforge/project/sbcl/sbcl/${version}/${pname}-${version}-source.tar.bz2";
+    sha256 = "sha256:15wa66sachhzgvg5n35vihmkpasg100lh561c1d1bdrql0p8kbd9";
+  };
+
+  buildInputs = [texinfo];
+
+  patchPhase = ''
+    echo '"${version}.nixos"' > version.lisp-expr
+
+    pwd
+
+    # SBCL checks whether files are up-to-date in many places..
+    # Unfortunately, same timestamp is not good enough
+    sed -e 's@> x y@>= x y@' -i contrib/sb-aclrepl/repl.lisp
+    #sed -e '/(date)/i((= date 2208988801) 2208988800)' -i contrib/asdf/asdf.lisp
+    sed -i src/cold/slam.lisp -e \
+      '/file-write-date input/a)'
+    sed -i src/cold/slam.lisp -e \
+      '/file-write-date output/i(or (and (= 2208988801 (file-write-date output)) (= 2208988801 (file-write-date input)))'
+    sed -i src/code/target-load.lisp -e \
+      '/date defaulted-fasl/a)'
+    sed -i src/code/target-load.lisp -e \
+      '/date defaulted-source/i(or (and (= 2208988801 (file-write-date defaulted-source-truename)) (= 2208988801 (file-write-date defaulted-fasl-truename)))'
+
+    # Fix the tests
+    sed -e '5,$d' -i contrib/sb-bsd-sockets/tests.lisp
+    sed -e '5,$d' -i contrib/sb-simple-streams/*test*.lisp
+
+    # Use whatever `cc` the stdenv provides
+    substituteInPlace src/runtime/Config.x86-64-darwin --replace gcc cc
+
+    substituteInPlace src/runtime/Config.x86-64-darwin \
+      --replace mmacosx-version-min=10.4 mmacosx-version-min=10.5
+  ''
+  + (if purgeNixReferences
+    then
+      # This is the default location to look for the core; by default in $out/lib/sbcl
+      ''
+        sed 's@^\(#define SBCL_HOME\) .*$@\1 "/no-such-path"@' \
+          -i src/runtime/runtime.c
+      ''
+    else
+      # Fix software version retrieval
+      ''
+        sed -e "s@/bin/uname@$(command -v uname)@g" -i src/code/*-os.lisp \
+          src/code/run-program.lisp
+      ''
+    );
+
+
+  preBuild = ''
+    export INSTALL_ROOT=$out
+    mkdir -p test-home
+    export HOME=$PWD/test-home
+  '';
+
+  enableFeatures = with lib;
+    optional threadSupport "sb-thread" ++
+    optional stdenv.isAarch32 "arm";
+
+  disableFeatures = with lib;
+    optional (!threadSupport) "sb-thread" ++
+    optionals disableImmobileSpace [ "immobile-space" "immobile-code" "compact-instance-header" ];
+
+  buildPhase = ''
+    sh make.sh --prefix=$out --xc-host="${sbclBootstrapHost}" ${
+                  lib.concatStringsSep " "
+                    (builtins.map (x: "--with-${x}") enableFeatures ++
+                     builtins.map (x: "--without-${x}") disableFeatures)
+                }
+    (cd doc/manual ; make info)
+  '';
+
+  installPhase = ''
+    INSTALL_ROOT=$out sh install.sh
+  ''
+  + lib.optionalString (!purgeNixReferences) ''
+    cp -r src $out/lib/sbcl
+    cp -r contrib $out/lib/sbcl
+    cat >$out/lib/sbcl/sbclrc <<EOF
+     (setf (logical-pathname-translations "SYS")
+       '(("SYS:SRC;**;*.*.*" #P"$out/lib/sbcl/src/**/*.*")
+         ("SYS:CONTRIB;**;*.*.*" #P"$out/lib/sbcl/contrib/**/*.*")))
+    EOF
+  '';
+
+  setupHook = lib.optional purgeNixReferences (writeText "setupHook.sh" ''
+    addEnvHooks "$targetOffset" _setSbclHome
+    _setSbclHome() {
+      export SBCL_HOME='@out@/lib/sbcl/'
+    }
+  '');
+
+  meta = sbclBootstrap.meta // {
+    inherit version;
+    updateWalker = true;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10886,6 +10886,7 @@ in
 
   sbclBootstrap = callPackage ../development/compilers/sbcl/bootstrap.nix {};
   sbcl_2_0_9 = callPackage ../development/compilers/sbcl/2.0.9.nix {};
+  sbcl_2_1_1 = callPackage ../development/compilers/sbcl/2.1.1.nix {};
   sbcl = callPackage ../development/compilers/sbcl {};
 
   scala_2_10 = callPackage ../development/compilers/scala/2.x.nix { majorVersion = "2.10"; jre = jdk8; };


### PR DESCRIPTION
###### Motivation for this change

Provide the latest version of the compiler, which provides many bugfixes as well as a few optimisations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ * ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
    - `/etc/nix/nix.conf` contains `sandbox = true`
    - tested via `nix-build -A sbcl_2_1_1` and comparing behaviour of `result/bin/sbcl` against that from sbcl_2_0_9 and default.
- Built on platform(s)
   - [ * ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - No test for sbcl
- [ * ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ * ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
   - Haven't spotted any
- [ * ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
   - IMO, anyway. This is my first PR, so YMMV. I'd like for this not to be my last PR, so feedback is welcome.