### PR TITLE
cudnn_cudatookit_11: add $ORIGIN/ to library RPATHs

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -25,9 +25,12 @@ stdenv.mkDerivation {
   installPhase = ''
     function fixRunPath {
       p=$(patchelf --print-rpath $1)
-      patchelf --set-rpath "$p:${lib.makeLibraryPath [ stdenv.cc.cc ]}" $1
+      patchelf --set-rpath "''${p:+$p:}${lib.makeLibraryPath [ stdenv.cc.cc ]}:\$ORIGIN/" $1
     }
-    fixRunPath lib64/libcudnn.so
+
+    for lib in lib64/lib*.so; do
+      fixRunPath $lib
+    done
 
     mkdir -p $out
     cp -a include $out/include

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -38,13 +38,7 @@ stdenv.mkDerivation {
   # See the explanation in addOpenGLRunpath.
   postFixup = ''
     for lib in $out/lib/lib*.so; do
-      # patchelf fails on libcudnn_cnn_infer due to it being too big.
-      # Most programs will still get the RPATH since they link to
-      # other things.
-      # (https://github.com/NixOS/patchelf/issues/222)
-      if [ "$(basename $lib)" != libcudnn_cnn_infer.so ]; then
-        addOpenGLRunpath $lib
-      fi
+      addOpenGLRunpath $lib
     done
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Starting with version 8, CuDNN consists of multiple libraries.
Libraries (except libcudnn.so) are dlopen()ed on demand.

Since the CuDNN library path itself was not added to the rpath of the
libraries, use of CuDNN often fails with the following error:

Could not load library libcudnn_cnn_train.so.8.
Error: libcudnn_ops_train.so.8: cannot open shared object file: No such file or directory
Please make sure libcudnn_cnn_train.so.8 is in your library path!

This change fixes this by adding $ORIGIN/ to the rpath of all CuDNN
libraries.

Tested using the CuDNN examples provided by NVIDIA.

**Additional change**

With the update to CuDNN 8.1, we do not get the "maximum file size
exceeded" error anymore when patchelf'ing libcudnn_cnn_infer.so. This
change removes the exception for that library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
