### PR TITLE
pritunl-ssh: init at 1.0.1674.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9363,6 +9363,16 @@
     githubId = 1391883;
     name = "Tom Hall";
   };
+  Thunderbottom = {
+    email = "chinmaydpai@gmail.com";
+    github = "Thunderbottom";
+    githubId = 11243138;
+    name = "Chinmay D. Pai";
+    keys = [{
+      longkeyid = "rsa4096/0x75507BE256F40CED";
+      fingerprint = "7F3E EEAA EE66 93CC 8782  042A 7550 7BE2 56F4 0CED";
+    }];
+  };
   tiagolobocastro = {
     email = "tiagolobocastro@gmail.com";
     github = "tiagolobocastro";

--- a/pkgs/tools/networking/pritunl-ssh/default.nix
+++ b/pkgs/tools/networking/pritunl-ssh/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, python3 }:
+
+stdenv.mkDerivation rec {
+  pname   = "pritunl-ssh";
+  version = "1.0.1674.4";
+
+  src = fetchFromGitHub {
+    owner = "pritunl";
+    repo = "pritunl-zero-client";
+    rev = version;
+    sha256 = "07z60lipbwm0p7s2bxcij21jid8w4nyh6xk2qq5qdm4acq4k1i88";
+  };
+
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install ssh_client.py $out/bin/pritunl-ssh
+    install ssh_host_client.py $out/bin/pritunl-ssh-host
+  '';
+
+  meta = with lib; {
+    description = "Pritunl Zero SSH client";
+    homepage = "https://github.com/pritunl/pritunl-zero-client";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ Thunderbottom ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7213,6 +7213,8 @@ in
 
   prettyping = callPackage ../tools/networking/prettyping { };
 
+  pritunl-ssh = callPackage ../tools/networking/pritunl-ssh { };
+
   profile-cleaner = callPackage ../tools/misc/profile-cleaner { };
 
   profile-sync-daemon = callPackage ../tools/misc/profile-sync-daemon { };


### PR DESCRIPTION
pritunl-ssh is a small Python script used to retrieve the SSH certificate from the Pritunl Zero server.

Homepage: https://zero.pritunl.com/
GitHub: https://github.com/pritunl/pritunl-zero-client

Signed-off-by: Chinmay D. Pai <chinmaydpai@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
