### PR TITLE
py65: init at 1.1.0

### DIFF
--- a/pkgs/misc/emulators/py65/default.nix
+++ b/pkgs/misc/emulators/py65/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchPypi, buildPythonApplication }:
+
+buildPythonApplication rec {
+  pname = "py65";
+  version = "1.1.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "Q7rjiHJ/Ew985vut/8fVAf/wWYW5aBPSvNPm8A6g1zg=";
+  };
+
+  meta = with lib; {
+    homepage = "https://py65.readthedocs.io/";
+    description = "Emulate 6502-based microcomputer systems in Python";
+    longDescription = ''
+      Py65 includes a program called Py65Mon that functions as a machine
+      language monitor. This kind of program is sometimes also called a
+      debugger. Py65Mon provides a command line with many convenient commands
+      for interacting with the simulated 6502-based system.
+    '';
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1743,6 +1743,8 @@ in
 
   bsod = callPackage ../misc/emulators/bsod { };
 
+  py65 = python3Packages.callPackage ../misc/emulators/py65 { };
+
   simh = callPackage ../misc/emulators/simh { };
 
   btrfs-progs = callPackage ../tools/filesystems/btrfs-progs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
