### PR TITLE
skawarePackages: add man page documentation ports

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-man-pages.nix
+++ b/pkgs/build-support/skaware/build-skaware-man-pages.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+{
+  # : string
+  pname
+  # : string
+, version
+  # : string
+, sha256
+  # : list (int | string)
+, sections
+  # : string
+, description
+  # : list Maintainer
+, maintainers
+  # : license
+, license ? lib.licenses.isc
+  # : string
+, owner ? "flexibeast"
+  # : string
+, rev ? "v${version}"
+}:
+
+let
+  manDir = "${placeholder "out"}/share/man";
+
+  src = fetchFromGitHub {
+    inherit owner rev sha256;
+    repo = pname;
+  };
+in
+
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  makeFlags = [
+    "MANPATH=${manDir}"
+  ];
+
+  dontBuild = true;
+
+  preInstall = lib.concatMapStringsSep "\n"
+    (section: "mkdir -p \"${manDir}/man${builtins.toString section}\"")
+    sections;
+
+  meta = with lib; {
+    inherit description license maintainers;
+    inherit (src.meta) homepage;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/documentation/execline-man-pages/default.nix
+++ b/pkgs/data/documentation/execline-man-pages/default.nix
@@ -1,0 +1,10 @@
+{ lib, buildManPages }:
+
+buildManPages {
+  pname = "execline-man-pages";
+  version = "2.8.0.1.1";
+  sha256 = "0xv9v39na1qnd8cm4v7xb8wa4ap3djq20iws0lrqz7vn1w40i8b4";
+  description = "Port of the documentation for the execline suite to mdoc";
+  sections = [ 1 7 ];
+  maintainers = [ lib.maintainers.sternenseemann ];
+}

--- a/pkgs/data/documentation/s6-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-man-pages/default.nix
@@ -1,0 +1,10 @@
+{ lib, buildManPages }:
+
+buildManPages {
+  pname = "s6-man-pages";
+  version = "2.10.0.3.1";
+  sha256 = "0q9b6v7kbyjsh390s4bw80kjdp92kih609vlmnpl1qzyrr6kivsg";
+  description = "Port of the documentation for the s6 supervision suite to mdoc";
+  sections = [ 1 7 ];
+  maintainers = [ lib.maintainers.sternenseemann ];
+}

--- a/pkgs/data/documentation/s6-networking-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-networking-man-pages/default.nix
@@ -1,0 +1,10 @@
+{ lib, buildManPages }:
+
+buildManPages {
+  pname = "s6-networking-man-pages";
+  version = "2.4.1.1.1";
+  sha256 = "1qrqzm2r4rxf8hglz8k4laknjqcx1y0z1kjf636z91w1077qg0pn";
+  description = "Port of the documentation for the s6-networking suite to mdoc";
+  sections = [ 1 7 ];
+  maintainers = [ lib.maintainers.sternenseemann ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18597,6 +18597,7 @@ with pkgs;
     buildPackage = callPackage ../build-support/skaware/build-skaware-package.nix {
       inherit cleanPackaging;
     };
+    buildManPages = callPackage ../build-support/skaware/build-skaware-man-pages.nix { };
 
     skalibs = callPackage ../development/libraries/skalibs { };
     execline = callPackage ../tools/misc/execline { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18602,6 +18602,10 @@ with pkgs;
     skalibs = callPackage ../development/libraries/skalibs { };
     execline = callPackage ../tools/misc/execline { };
 
+    execline-man-pages = callPackage ../data/documentation/execline-man-pages {
+      inherit buildManPages;
+    };
+
     s6 = callPackage ../tools/system/s6 { };
     s6-dns = callPackage ../tools/networking/s6-dns { };
     s6-linux-init = callPackage ../os-specific/linux/s6-linux-init { };
@@ -22502,6 +22506,8 @@ with pkgs;
     { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
 
   envdir = callPackage ../tools/misc/envdir-go { };
+
+  execline-man-pages = skawarePackages.execline-man-pages;
 
   fantasque-sans-mono = callPackage ../data/fonts/fantasque-sans-mono {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18613,6 +18613,9 @@ with pkgs;
     s6-networking = callPackage ../tools/networking/s6-networking { };
     s6-portable-utils = callPackage ../tools/misc/s6-portable-utils { };
     s6-rc = callPackage ../tools/system/s6-rc { };
+    s6-man-pages = callPackage ../data/documentation/s6-man-pages {
+      inherit buildManPages;
+    };
 
     mdevd = callPackage ../os-specific/linux/mdevd { };
     nsss = callPackage ../development/libraries/nsss { };
@@ -23024,6 +23027,8 @@ with pkgs;
   inter = callPackage ../data/fonts/inter { };
 
   open-fonts = callPackage ../data/fonts/open-fonts { };
+
+  s6-man-pages = skawarePackages.s6-man-pages;
 
   scientifica = callPackage ../data/fonts/scientifica { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18616,6 +18616,9 @@ with pkgs;
     s6-man-pages = callPackage ../data/documentation/s6-man-pages {
       inherit buildManPages;
     };
+    s6-networking-man-pages = callPackage ../data/documentation/s6-networking-man-pages {
+      inherit buildManPages;
+    };
 
     mdevd = callPackage ../os-specific/linux/mdevd { };
     nsss = callPackage ../development/libraries/nsss { };
@@ -23029,6 +23032,8 @@ with pkgs;
   open-fonts = callPackage ../data/fonts/open-fonts { };
 
   s6-man-pages = skawarePackages.s6-man-pages;
+
+  s6-networking-man-pages = skawarePackages.s6-networking-man-pages;
 
   scientifica = callPackage ../data/fonts/scientifica { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[flexibeast](https://github.com/flexibeast) has recently ported some of the skaware documentation to mdoc, meaning we can provide man pages for some of `skawarePackages`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
