### PR TITLE
WIP: android: Fix prebuilt toolchain

### DIFF
--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -49,7 +49,7 @@ let
   targetInfo = ndkInfoFun stdenv.targetPlatform;
 
   sdkVer = stdenv.targetPlatform.sdkVer;
-  prefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config + "-");
+  prefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config);
 in
 
 rec {
@@ -78,6 +78,14 @@ rec {
       cp $out/sysroot/usr/lib/${targetInfo.triple}/${sdkVer}/*.o $out/lib/
 
       cp -r $out/${targetInfo.triple}/bin/* $out/bin
+      for f in $out/bin/${targetInfo.triple}*; do
+        cp $f ''${f/${targetInfo.triple}/${prefix}}
+      done
+      rm $out/bin/${prefix}-gcc $out/bin/${prefix}-g++
+
+      for f in $out/bin/clang*; do
+        cp $f ''${f/clang/${prefix}-clang}
+      done
       patchShebangs $out/
 
       rm -r $out/lib64
@@ -102,6 +110,7 @@ rec {
       echo "-target ${targetInfo.toolchain}" >> $out/nix-support/cc-cflags
       echo "-resource-dir=$(echo ${androidndk}/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/${hostInfo.double}/lib*/clang/*)" >> $out/nix-support/cc-cflags
       echo "--gcc-toolchain=${androidndk}/libexec/android-sdk/ndk-bundle/toolchains/${targetInfo.toolchain}-${targetInfo.gccVer}/prebuilt/${hostInfo.double}" >> $out/nix-support/cc-cflags
+      echo "-I${binaries}/include -I${binaries}/sysroot/include -I${binaries}/sysroot/usr/include -I${binaries}/sysroot/include/c++/v1" >> $out/nix-support/cc-cflags
       echo "-L${binaries}/lib" >> $out/nix-support/cc-ldflags
     '';
   };

--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -19,7 +19,7 @@
     import ./androidndk-pkgs.nix {
       inherit lib;
       inherit (buildPackages)
-        makeWrapper;
+        makeWrapper python autoPatchelfHook;
       inherit (pkgs)
         stdenv
         runCommand wrapBintoolsWith wrapCCWith;
@@ -49,7 +49,7 @@
     import ./androidndk-pkgs.nix {
       inherit lib;
       inherit (buildPackages)
-        makeWrapper;
+        makeWrapper python autoPatchelfHook;
       inherit (pkgs)
         stdenv
         runCommand wrapBintoolsWith wrapCCWith;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The prebuilt toolchain for android (e.g. for aarch64) was not working correctly. It was impossible to compile even simple programs due to missing C/C++ headers and libs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

depends on #115118