### PR TITLE
rippled-validator-keys-tool: 20180927-d7774bc → 0.3.2

### DIFF
--- a/pkgs/servers/rippled/validator-keys-tool.nix
+++ b/pkgs/servers/rippled/validator-keys-tool.nix
@@ -1,33 +1,35 @@
-{ stdenv, lib, fetchgit, cmake, openssl, boost, zlib, rippled }:
+{ stdenv, lib, fetchFromGitHub, cmake, openssl, boost, zlib, icu, rippled }:
 
 stdenv.mkDerivation rec {
-  name = "rippled-validator-keys-tool-20180927-${builtins.substring 0 7 rev}";
-  rev = "d7774bcc1dc9439c586ea1c175fcd5ff3960b15f";
+  pname = "rippled-validator-keys-tool";
+  version = "0.3.2";
 
-  src = fetchgit {
-    url = "https://github.com/ripple/validator-keys-tool.git";
-    inherit rev;
-    sha256 = "1hcbwwa21n692qpbm0vqy5jvvnf4aias309610m4kwdsnzfw0902";
+  src = fetchFromGitHub {
+    owner = "ripple";
+    repo = "validator-keys-tool";
+    rev = "5d7efcfeda3bdf6f5dda78056004a7c326321e9b";
+    sha256 = "1irm8asp6plk9xw3ksf4fqnim8h0vj3h96w638lx71pga1h4zvmy";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ openssl boost zlib rippled ];
+  buildInputs = [ openssl boost zlib icu rippled ];
 
   hardeningDisable = ["format"];
 
-  preConfigure = ''
-    export CXX="$(command -v $CXX)"
-    export CC="$(command -v $CC)"
-  '';
+  cmakeFlags = [
+    "-Dep_procs=1"
+  ];
 
   installPhase = ''
+    runHook preInstall
     install -D validator-keys $out/bin/validator-keys
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Generate master and ephemeral rippled validator keys";
     homepage = "https://github.com/ripple/validator-keys-tool";
-    maintainers = with maintainers; [ offline ];
+    maintainers = with maintainers; [ offline rmcgibbo ];
     license = licenses.isc;
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18420,13 +18420,11 @@ in
 
   # Fails to compile with boost >= 1.72
   rippled = callPackage ../servers/rippled {
-    boost = boost171;
+    boost = boost17x;
   };
 
   rippled-validator-keys-tool = callPackage ../servers/rippled/validator-keys-tool.nix {
-    boost = boost167.override {
-      enableStatic = true;
-    };
+    boost = boost17x;
   };
 
   roon-server = callPackage ../servers/roon-server { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build that's been broken on hydra since 2019 (https://hydra.nixos.org/build/136814227). Prior failure was noted here: https://github.com/NixOS/nixpkgs/pull/112951#issuecomment-778687799

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[mcgibbon@pn50:~/projects/nixpkgs]$  result/bin/validator-keys 
validator-keys [options] <command> [<argument> ...]
General Options:
  -h [ --help ]         Display this message.
  --keyfile arg         Specify the key file.
  -u [ --unittest ]     Perform unit tests.
  --version             Display the build version.

Commands: 
     create_keys                   Generate validator keys.
     create_token                  Generate validator token.
     revoke_keys                   Revoke validator keys.
     sign <data>                   Sign string with validator key.
     show_manifest [hex|base64]    Displays the last generated manifest
     set_domain <domain>           Associate a domain with the validator key.
     clear_domain                  Disassociate a domain from a validator key.
     attest_domain                 Produce the attestation string for a domain.

[mcgibbon@pn50:~/projects/nixpkgs]$  result/bin/validator-keys  --version
validator-keys version 0.3.2
```