### PR TITLE
cicero-tui: init at 0.1.4

### DIFF
--- a/pkgs/tools/misc/cicero-tui/default.nix
+++ b/pkgs/tools/misc/cicero-tui/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, cmake
+, pkg-config
+, expat
+, fontconfig
+, freetype
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cicero-tui";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "eyeplum";
+    repo = "cicero-tui";
+    rev = "v${version}";
+    sha256 = "1bz2y37qf9c3fxc73chb42rffdivp5krczhgd9rnwq5r6n6bdgq7";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    expat
+    fontconfig
+    freetype
+  ];
+
+  cargoSha256 = "04359gf9mirczqwh8jv3rf0cc4pp05r8ncqyz0n8r7x5qv77kgcp";
+
+  meta = with lib; {
+    description = "Unicode tool with a terminal user interface";
+    homepage = "https://github.com/eyeplum/cicero-tui";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3094,6 +3094,8 @@ in
 
   chunksync = callPackage ../tools/backup/chunksync { };
 
+  cicero-tui = callPackage ../tools/misc/cicero-tui { };
+
   cipherscan = callPackage ../tools/security/cipherscan {
     openssl = if stdenv.hostPlatform.system == "x86_64-linux"
       then openssl-chacha


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/112820

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
