### PR TITLE
sbcl 2.1.1: Remove debug output

### DIFF
--- a/pkgs/development/compilers/sbcl/2.1.1.nix
+++ b/pkgs/development/compilers/sbcl/2.1.1.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [texinfo];
 
-  patchPhase = ''
+  postpatch = ''
     # SBCL checks whether files are up-to-date in many places..
     # Unfortunately, same timestamp is not good enough
     sed -e 's@> x y@>= x y@' -i contrib/sb-aclrepl/repl.lisp

--- a/pkgs/development/compilers/sbcl/2.1.1.nix
+++ b/pkgs/development/compilers/sbcl/2.1.1.nix
@@ -75,16 +75,24 @@ stdenv.mkDerivation rec {
     optionals disableImmobileSpace [ "immobile-space" "immobile-code" "compact-instance-header" ];
 
   buildPhase = ''
+    runHook preBuild
+
     sh make.sh --prefix=$out --xc-host="${sbclBootstrapHost}" ${
                   lib.concatStringsSep " "
                     (builtins.map (x: "--with-${x}") enableFeatures ++
                      builtins.map (x: "--without-${x}") disableFeatures)
                 }
     (cd doc/manual ; make info)
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     INSTALL_ROOT=$out sh install.sh
+
+    runHook postInstall
   ''
   + lib.optionalString (!purgeNixReferences) ''
     cp -r src $out/lib/sbcl

--- a/pkgs/development/compilers/sbcl/2.1.1.nix
+++ b/pkgs/development/compilers/sbcl/2.1.1.nix
@@ -21,10 +21,6 @@ stdenv.mkDerivation rec {
   buildInputs = [texinfo];
 
   patchPhase = ''
-    echo '"${version}.nixos"' > version.lisp-expr
-
-    pwd
-
     # SBCL checks whether files are up-to-date in many places..
     # Unfortunately, same timestamp is not good enough
     sed -e 's@> x y@>= x y@' -i contrib/sb-aclrepl/repl.lisp


### PR DESCRIPTION
Remove some debug output from the `patchPhase` that seems to serve no
lasting purpose.

###### Motivation for this change

As suggested by @SuperSandro2000 when reviewing my commit adding sbcl-2.1.1, I've removed a few lines whose purpose only seemed to be to confirm that the right version was being compiled.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ * ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ * ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   - n/a - no tests for this
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ * ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
   - n/a - no relevant documentation
- [ * ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
