### PR TITLE
Fix pythonInterpreters.pypy27_prebuilt, pythonInterpreters.pypy36_prebuilt

### DIFF
--- a/pkgs/development/interpreters/python/pypy/prebuilt.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, stdenv
 , fetchurl
 , python-setup-hook
 , self

--- a/pkgs/development/interpreters/python/pypy/prebuilt.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt.nix
@@ -32,9 +32,15 @@ let
     implementation = "pypy";
     libPrefix = "pypy${pythonVersion}";
     executable = "pypy${if isPy3k then "3" else ""}";
-    pythonForBuild = self; # Not possible to cross-compile with.
     sitePackages = "site-packages";
     hasDistutilsCxxPatch = false;
+
+    # Not possible to cross-compile with.
+    pythonOnBuildForBuild = throw "${pname} does not support cross compilation";
+    pythonOnBuildForHost = self;
+    pythonOnBuildForTarget = throw "${pname} does not support cross compilation";
+    pythonOnHostForHost = throw "${pname} does not support cross compilation";
+    pythonOnTargetForTarget = throw "${pname} does not support cross compilation";
   };
   pname = "${passthru.executable}_prebuilt";
   version = with sourceVersion; "${major}.${minor}.${patch}";


### PR DESCRIPTION
###### Motivation for this change

`pythonInterpreters.pypy27_prebuilt` and `pythonInterpreters.pypy36_prebuilt` were broken by #105155 and #110591. Fix them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
