### PR TITLE
python3Packages.py-multiaddr: init at 0.0.9

### DIFF
--- a/pkgs/development/python-modules/py-multiaddr/default.nix
+++ b/pkgs/development/python-modules/py-multiaddr/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, varint
+, base58
+, netaddr
+, idna
+, py-cid
+, py-multicodec
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "py-multiaddr";
+  version = "0.0.9";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "multiformats";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-cGM7iYQPP+UOkbTxRhzuED0pkcydFCO8vpx9wTc0/HI=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "'pytest-runner'," ""
+  '';
+
+  propagatedBuildInputs = [
+    varint
+    base58
+    netaddr
+    idna
+    py-cid
+    py-multicodec
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "multiaddr" ];
+
+  meta = with lib; {
+    description = "Composable and future-proof network addresses";
+    homepage = "https://github.com/multiformats/py-multiaddr";
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5688,6 +5688,8 @@ in {
 
   pymsteams = callPackage ../development/python-modules/pymsteams { };
 
+  py-multiaddr = callPackage ../development/python-modules/py-multiaddr { };
+
   py-multibase = callPackage ../development/python-modules/py-multibase { };
 
   py-multicodec = callPackage ../development/python-modules/py-multicodec { };


### PR DESCRIPTION
###### Motivation for this change
This adds py-multiaddr from https://github.com/multiformats/py-multiaddr.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).