### PR TITLE
pqrs: init at 0.1.1

### DIFF
--- a/pkgs/development/tools/pqrs/default.nix
+++ b/pkgs/development/tools/pqrs/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pqrs";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "manojkarthick";
+    repo = "pqrs";
+    rev = "v${version}";
+    sha256 = "1vx952ki1rhwfmr3faxs363m9fh61b37b0bkbs57ggn9r44sk1z2";
+  };
+
+  cargoSha256 = "1c482y83gzpvazdsxsx5n509mkqmyz640s18y4yg928mmqbsz9c4";
+
+  meta = with lib; {
+    description = "CLI tool to inspect Parquet files";
+    homepage = "https://github.com/manojkarthick/pqrs";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = [ maintainers.manojkarthick ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12657,6 +12657,8 @@ in
 
   pprof = callPackage ../development/tools/profiling/pprof { };
 
+  pqrs = callPackage ../development/tools/pqrs { };
+
   pyprof2calltree = with python3Packages; toPythonApplication pyprof2calltree;
 
   prelink = callPackage ../development/tools/misc/prelink { };


### PR DESCRIPTION
Motivation: CLI tool to inspect Apache Parquet tools

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
