### PR TITLE
fontfor: init at 0.3.1

### DIFF
--- a/pkgs/tools/misc/fontfor/default.nix
+++ b/pkgs/tools/misc/fontfor/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, cmake
+, pkg-config
+, expat
+, fontconfig
+, freetype
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fontfor";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "7sDream";
+    repo = "fontfor";
+    rev = "v${version}";
+    sha256 = "1b07hd41blwsnb91vh2ax9zigm4lh8n0i5man0cjmxhavvbfy12b";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    expat
+    fontconfig
+    freetype
+  ];
+
+  cargoSha256 = "194c4knjfb3pnpvw3zl1srwx3q1jp6z78vzln0q2mk5nf0a35yy0";
+
+  meta = with lib; {
+    description = "Find fonts which can show a specified character and preview them in browser";
+    homepage = "https://github.com/7sDream/fontfor";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4228,6 +4228,8 @@ in
     python = python2;
   };
 
+  fontfor = callPackage ../tools/misc/fontfor { };
+
   fontforge = lowPrio (callPackage ../tools/misc/fontforge {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
     python = python3;


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/112818

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
