### PR TITLE
cargo-whatfeatures: init at 0.9.6

### DIFF
--- a/pkgs/development/tools/rust/cargo-whatfeatures/default.nix
+++ b/pkgs/development/tools/rust/cargo-whatfeatures/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, pkg-config, openssl, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-whatfeatures";
+  version = "0.9.6";
+
+  src = fetchFromGitHub {
+    owner = "museun";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vki37pxngg15za9c1z61dc6sqk0j59s0qhcf9hplnym4ib5kqx1";
+  };
+
+  cargoSha256 = "sha256-nNV7UXjKZNFmTqW4H0qsNuBW9XOP2V9nfotewtI9mYE";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  meta = with lib; {
+    description = "A simple cargo plugin to get a list of features for a specific crate";
+    homepage = "https://github.com/museun/cargo-whatfeatures";
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ ivan-babrou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10856,6 +10856,10 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  cargo-whatfeatures = callPackage ../development/tools/rust/cargo-whatfeatures {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   crate2nix = callPackage ../development/tools/rust/crate2nix { };
 
   convco = callPackage ../development/tools/convco {


### PR DESCRIPTION
###### Motivation for this change

I use it, so it seems natural to have it packaged in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
