### PR TITLE
secretscanner: init at 20210214-42a38f9

### DIFF
--- a/pkgs/tools/security/secretscanner/default.nix
+++ b/pkgs/tools/security/secretscanner/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, hyperscan
+, pkg-config
+}:
+
+buildGoModule rec {
+  pname = "secretscanner";
+  version = "20210214-${lib.strings.substring 0 7 rev}";
+  rev = "42a38f9351352bf6240016b5b93d971be35cad46";
+
+  src = fetchFromGitHub {
+    owner = "deepfence";
+    repo = "SecretScanner";
+    inherit rev;
+    sha256 = "0yga71f7bx5a3hj5agr88pd7j8jnxbwqm241fhrvv8ic4sx0mawg";
+  };
+
+  vendorSha256 = "0b7qa83iqnigihgwlqsxi28n7d9h0dk3wx1bqvhn4k01483cipsd";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ hyperscan ];
+
+  postInstall = ''
+    mv $out/bin/SecretScanner $out/bin/$pname
+  '';
+
+  meta = with lib; {
+    description = "Tool to find secrets and passwords in container images and file systems";
+    homepage = "https://github.com/deepfence/SecretScanner";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24776,6 +24776,8 @@ in
 
   seafile-client = libsForQt5.callPackage ../applications/networking/seafile-client { };
 
+  secretscanner = callPackage ../tools/security/secretscanner { };
+
   sent = callPackage ../applications/misc/sent { };
 
   seq24 = callPackage ../applications/audio/seq24 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Find secrets and passwords in container images and file systems

https://github.com/deepfence/SecretScanner

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
