### PR TITLE
winePackages: enable mingwSupport in base build

### DIFF
--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -27,6 +27,7 @@ rec {
     xineramaSupport = true;
     xmlSupport = true;
     sdlSupport = true;
+    mingwSupport = true;
   };
 
   full = base.override {


### PR DESCRIPTION
###### Motivation for this change
Closes #103102

With `mingwSupport` enabled, Wine uses MinGW builds of GCC (compiled for the `i686-w64-mingw32` & `x86_64-w64-mingw32` targets) to cross compile system DLLs as PE executables.

This is used to workaround some basic anticheat software.

Fedora & Arch Linux also have this enabled by default in their Wine builds:
- Fedora: https://src.fedoraproject.org/rpms/wine/blob/8e216ca407b6c0f78f65f36c5b068c6452701e55/f/wine.spec#_116
- Arch Linux: https://github.com/archlinux/svntogit-community/blob/2435e762eacd989c588200d7cf57d8f4fb2e0cf3/trunk/PKGBUILD#L44

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@avnik @bendlas @7c6f434c @Atemu @veprbl