### PR TITLE
ophis: init at 2019-04-13

### DIFF
--- a/pkgs/development/compilers/ophis/default.nix
+++ b/pkgs/development/compilers/ophis/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonApplication, fetchFromGitHub }:
+
+buildPythonApplication rec {
+  pname = "ophis";
+  version = "unstable-2019-04-13";
+
+  src = fetchFromGitHub {
+    owner = "michaelcmartin";
+    repo = "Ophis";
+    rev = "99f074da278d4ec80689c0e22e20c5552ea12512";
+    sha256 = "2x8vwLTSngqQqmVrVh/mM4peATgaRqOSwrfm5XCkg/g=";
+  };
+
+  sourceRoot = "./src";
+
+  meta = with lib; {
+    homepage = "http://michaelcmartin.github.io/Ophis/";
+    description = "A cross-assembler for the 6502 series of microprocessors";
+    longDescription = ''
+      Ophis is an assembler for the 6502 microprocessor - the famous chip used
+      in the vast majority of the classic 8-bit computers and consoles. Its
+      primary design goals are code readability and output flexibility - Ophis
+      has successfully been used to create programs for the Nintendo
+      Entertainment System, the Atari 2600, and the Commodore 64.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6757,6 +6757,8 @@ in
     opendylan-bootstrap = opendylan_bin;
   };
 
+  ophis = python3Packages.callPackage ../development/compilers/ophis { };
+
   opendylan_bin = callPackage ../development/compilers/opendylan/bin.nix { };
 
   open-ecard = callPackage ../tools/security/open-ecard { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
