### PR TITLE
pciutils: use database from hwinfo which is easier to update

### DIFF
--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/vcrhonek/hwdata";
     description = "Hardware Database, including Monitors, pci.ids, usb.ids, and video cards";
-    license = lib.licenses.gpl2;
-    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/system/pciutils/default.nix
+++ b/pkgs/tools/system/pciutils/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, zlib, kmod, which
+, hwdata
 , static ? stdenv.hostPlatform.isStatic
 , darwin ? null
 }:
@@ -30,8 +31,15 @@ stdenv.mkDerivation rec {
 
   installTargets = [ "install" "install-lib" ];
 
-  # Get rid of update-pciids as it won't work.
-  postInstall = "rm $out/sbin/update-pciids $out/man/man8/update-pciids.8";
+  postInstall = ''
+    # Remove update-pciids as it won't work on nixos
+    rm $out/sbin/update-pciids $out/man/man8/update-pciids.8
+
+    # use database from hwdata instead
+    # (we don't create a symbolic link because we do not want to pull in the
+    # full closure of hwdata)
+    cp --reflink=auto ${hwdata}/share/hwdata/pci.ids $out/share/pci.ids
+  '';
 
   meta = with lib; {
     homepage = "http://mj.ucw.cz/pciutils.html";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #112644

I foresee one problem with the pull request in its current form: pciutils has platforms set to unix, but hwdata, the new additional native build input, has platforms set to linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
