### PR TITLE
pytest-check-hook: Split disabledTestFiles on whitespace

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -37,6 +37,7 @@ function pytestCheckPhase() {
         disabledTestsString=$(_pytestComputeDisabledTestsString "${disabledTests[@]}")
       args+=" -k \""$disabledTestsString"\""
     fi
+    disabledTestFiles=($disabledTestFiles)
     for file in ${disabledTestFiles[@]}; do
       if [ ! -f "$file" ]; then
         echo "Disabled test file \"$file\" does not exist. Aborting"


### PR DESCRIPTION
I think there is a bug in pytestCheckHook's `disabledTestFiles` when you supply multiple files. They get concatenated into a single string with spaces, and the loop doesn't actually iterate over each file.

This is the same issue as @jtojnar describes here with `buildFlagsArray`, I believe https://github.com/jtojnar/nixpkgs-hammering/blob/master/explanations/no-flags-array.md. It's very subtle.

Not sure what the best way to fix it is. This particular line of bash is from @SuperSandro2000, but it won't work if any of the filenames contain whitespace, and it's not obvious to me if there's some other solution that would work for files that contain whitespace...