### PR TITLE
zap: 2.7.0 -> 2.10.0

### DIFF
--- a/pkgs/tools/networking/zap/default.nix
+++ b/pkgs/tools/networking/zap/default.nix
@@ -1,31 +1,38 @@
-{ lib, stdenv, fetchFromGitHub, jdk8, ant, runtimeShell }:
+{ lib, stdenv, fetchurl, jre, runtimeShell }:
 
-let jdk = jdk8; in
 stdenv.mkDerivation rec {
   pname = "zap";
-  version = "2.7.0";
-  src = fetchFromGitHub {
-    owner = "zaproxy";
-    repo = "zaproxy";
-    rev =version;
-    sha256 = "1bz4pgq66v6kxmgj99llacm1d85vj8z78jlgc2z9hv0ha5i57y32";
+  version = "2.10.0";
+  src = fetchurl {
+    url = "https://github.com/zaproxy/zaproxy/releases/download/v${version}/ZAP_${version}_Linux.tar.gz";
+    sha256 = "1mz9s56pbs62g4pnd1ml8y6jpf9ilisdwwvjv5kn6yxrcdi2zzqh";
   };
 
-  buildInputs = [ jdk ant ];
+  buildInputs = [ jre ];
 
-  buildPhase = ''
-    cd build
-    echo -n "${version}" > version.txt
-    ant -f build.xml setup init  compile dist copy-source-to-build package-linux
-  '';
+  # From https://github.com/zaproxy/zaproxy/blob/master/zap/src/main/java/org/parosproxy/paros/Constant.java
+  version_tag = "2010000";
 
+  # Copying config and adding version tag before first use to avoid permission
+  # issues if zap tries to copy config on it's own.
   installPhase = ''
-    mkdir -p "$out/share"
-    tar xvf  "ZAP_${version}_Linux.tar.gz" -C "$out/share/"
-    mkdir -p "$out/bin"
-    echo "#!${runtimeShell}" > "$out/bin/zap"
-    echo \"$out/share/ZAP_${version}/zap.sh\" >> "$out/bin/zap"
-    chmod +x "$out/bin/zap"
+    mkdir -p "$out/bin" "$out/share"
+    cp -pR . "$out/share/${pname}/"
+
+    cat >> "$out/bin/${pname}" << EOF
+    #!${runtimeShell}
+    export PATH="${lib.makeBinPath [ jre ]}:\$PATH"
+    export JAVA_HOME='${jre}'
+    if ! [ -f "~/.ZAP/config.xml" ];then
+      mkdir -p "\$HOME/.ZAP"
+      head -n 2 $out/share/${pname}/xml/config.xml > "\$HOME/.ZAP/config.xml"
+      echo "<version>${version_tag}</version>" >> "\$HOME/.ZAP/config.xml"
+      tail -n +3 $out/share/${pname}/xml/config.xml >> "\$HOME/.ZAP/config.xml"
+    fi
+    exec "$out/share/${pname}/zap.sh"  "\$@"
+    EOF
+
+    chmod u+x  "$out/bin/${pname}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Bump of owasp zap following : [Arch linux recipe](https://github.com/archlinux/svntogit-community/blob/packages/zaproxy/trunk/PKGBUILD)
Probably fixes https://github.com/NixOS/nixpkgs/issues/87106

It's my first nixpkgs PR, so I am glad to fix mistakes I might have introduced ;) 

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
