### PR TITLE
pytestCheckHook: add support for disabling arbitrary paths

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -611,7 +611,7 @@ Using the example above, the analagous pytestCheckHook usage would be:
     "update"
   ];
 
-  disabledTestFiles = [
+  disabledTestPaths = [
     "tests/test_failing.py"
   ];
 ```

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -2,7 +2,7 @@
 echo "Sourcing pytest-check-hook"
 
 declare -ar disabledTests
-declare -ar disabledTestFiles
+declare -ar disabledTestPaths
 
 function _concatSep {
     local result
@@ -37,12 +37,12 @@ function pytestCheckPhase() {
         disabledTestsString=$(_pytestComputeDisabledTestsString "${disabledTests[@]}")
       args+=" -k \""$disabledTestsString"\""
     fi
-    for file in ${disabledTestFiles[@]}; do
-      if [ ! -f "$file" ]; then
-        echo "Disabled test file \"$file\" does not exist. Aborting"
+    for path in ${disabledTestPaths[@]}; do
+      if [ ! -e "$path" ]; then
+        echo "Disabled tests path \"$path\" does not exist. Aborting"
         exit 1
       fi
-      args+=" --ignore=\"$file\""
+      args+=" --ignore=\"$path\""
     done
     args+=" ${pytestFlagsArray[@]}"
     eval "@pythonCheckInterpreter@ $args"

--- a/pkgs/development/python-modules/cheroot/default.nix
+++ b/pkgs/development/python-modules/cheroot/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     "bind_addr_unix"
   ];
 
-  disabledTestFiles = [
+  disabledTestPaths = [
     # avoid attempting to use 3 packages not available on nixpkgs
     # (jaraco.apt, jaraco.context, yg.lockfile)
     "cheroot/test/test_wsgi.py"

--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   checkInputs = [ pytestCheckHook ];
 
   # Exclude live tests
-  disabledTestFiles = [ "tests/live_test.py" ];
+  disabledTestPaths = [ "tests/live_test.py" ];
 
   pythonImportsCheck = [ "slixmpp" ];
 

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  disabledTestFiles = [ "tests/test_graphql.py" ];
+  disabledTestPaths = [ "tests/test_graphql.py" ];
   # https://github.com/encode/starlette/issues/1131
   disabledTests = [ "test_debug_html" ];
   pythonImportsCheck = [ "starlette" ];

--- a/pkgs/development/python-modules/typesystem/default.nix
+++ b/pkgs/development/python-modules/typesystem/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     # the default string formatting of regular expression flags which breaks test assertion
     "test_to_json_schema_complex_regular_expression"
   ];
-  disabledTestFiles = [
+  disabledTestPaths = [
     # for some reason jinja2 not picking up forms directory (1% of tests)
     "tests/test_forms.py"
   ];

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
   '';
 
   # Ignore tests which require network access
-  disabledTestFiles = [
+  disabledTestPaths = [
     "tests/unit/create/test_creator.py"
     "tests/unit/seed/embed/test_bootstrap_link_via_app_data.py"
   ];


### PR DESCRIPTION
Renames `disabledTestFiles` to the more genereric `disabledTestPaths` to
reflect that change.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In the home-assistant package we disable tests on a whole directory, the `disabledTestFiles` option did not support this, due to a check for file existence. I've generalized this option to work for arbitrary paths and subsequently renamed the option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
