### PR TITLE
nodePackages: fix generate.sh failure

### DIFF
--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -2,8 +2,13 @@
 set -eu -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-node2nix=$(nix-build ../../.. --no-out-link -A nodePackages.node2nix)
-
+node2nix=$(nix-build ../../.. -A nodePackages.node2nix)
 cd ${DIR}
 rm -f ./node-env.nix
 ${node2nix}/bin/node2nix -i node-packages.json -o node-packages.nix -c composition.nix
+# using --no-out-link in nix-build argument would cause the
+# gc to run before the script finishes
+# which would cause a failure
+# it's safer to just remove the link after the script finishes
+# see https://github.com/NixOS/nixpkgs/issues/112846 for more details
+rm ./result


### PR DESCRIPTION
when gc is automatically enabled

###### Motivation for this change

for more informations check https://github.com/NixOS/nixpkgs/issues/112846
To be clear.

running the generate.sh script for nodePackages will create a temporary version of node2nix. That version was created with the --no-out-link flag. The script generate.sh can take upward of 1 hour on my machine. The gc would run before the script finished and cause a failure.

The fix proposed is to just create a link but remove it after the script has run.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
