### PR TITLE
gnome-session: Fix 2 minute shutdown delay

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-session/default.nix
@@ -1,6 +1,7 @@
 { fetchurl, lib, stdenv, substituteAll, meson, ninja, pkg-config, gnome3, glib, gtk3, gsettings-desktop-schemas
 , gnome-desktop, dbus, json-glib, libICE, xmlto, docbook_xsl, docbook_xml_dtd_412, python3
-, libxslt, gettext, makeWrapper, systemd, xorg, epoxy, gnugrep, bash, gnome-session-ctl }:
+, libxslt, gettext, makeWrapper, systemd, xorg, epoxy, gnugrep, bash, gnome-session-ctl
+, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-session";
@@ -20,6 +21,12 @@ stdenv.mkDerivation rec {
       dbusLaunch = "${dbus.lib}/bin/dbus-launch";
       grep = "${gnugrep}/bin/grep";
       bash = "${bash}/bin/bash";
+    })
+    # Fixes 2 minute delay at poweroff.
+    # https://gitlab.gnome.org/GNOME/gnome-session/issues/74
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-session/-/commit/9de6e40f12e8878f524f8d429d85724c156a0517.diff";
+      sha256 = "19vrjdf7d6dfl7sqxvbc5h5lcgk1krgzg5rkssrdzd1h4ma6y8fz";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #113165, by pulling in the upstream patch for https://gitlab.gnome.org/GNOME/gnome-session/-/issues/74 “2 minutes delay at poweroff with systemd-247”.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
