### PR TITLE
fop: 2.1 -> 2.6

### DIFF
--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -2,22 +2,25 @@
 
 stdenv.mkDerivation rec {
   pname = "fop";
-  version = "2.1";
+  version = "2.6";
 
   src = fetchurl {
     url = "mirror://apache/xmlgraphics/fop/source/${pname}-${version}-src.tar.gz";
-    sha256 = "165rx13q47l6qc29ppr7sg1z26vw830s3rkklj5ap7wgvy0ivbz5";
+    sha256 = "145qph3c0m4bmb342qxq1hwsg594lndmfs9ga1v7pk53s34sckq8";
   };
 
   buildInputs = [ ant jdk ];
 
-  buildPhase = "ant";
+  # build only the "package" target, which generates the fop command.
+  buildPhase = ''
+     export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+     ant -f fop/build.xml package
+  '';
 
   installPhase = ''
     mkdir -p $out/bin $out/lib $out/share/doc/fop
-
-    cp build/*.jar lib/*.jar $out/lib/
-    cp -r README examples/ $out/share/doc/fop/
+    cp fop/build/*.jar fop/lib/*.jar $out/lib/
+    cp -r README fop/examples/ $out/share/doc/fop/
 
     # There is a fop script in the source archive, but it has many impurities.
     # Instead of patching out 90 % of the script, we write our own.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrade to the latest version of Apache FOP, 2.1 was released on 2016.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [  ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (debian)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that dupdate/fopepend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
