### PR TITLE
dirdiff: init at 2.1

### DIFF
--- a/pkgs/tools/text/dirdiff/default.nix
+++ b/pkgs/tools/text/dirdiff/default.nix
@@ -1,0 +1,59 @@
+{ copyDesktopItems, fetchurl, lib, makeDesktopItem, stdenv, tcl, tk }:
+
+stdenv.mkDerivation rec {
+  pname = "dirdiff";
+  version = "2.1";
+
+  src = fetchurl {
+    url = "https://www.samba.org/ftp/paulus/${pname}-${version}.tar.gz";
+    sha256 = "0lljd8av68j70733yshzzhxjr1lm0vgmbqsm8f02g03qsma3cdyb";
+  };
+
+  nativeBuildInputs = [ copyDesktopItems ];
+  buildInputs = [ tcl tk ];
+
+  # Some light path patching.
+  patches = [ ./dirdiff-2.1-vars.patch ];
+  postPatch = ''
+    for file in dirdiff Makefile; do
+      substituteInPlace "$file" \
+          --subst-var out \
+          --subst-var-by tcl ${tcl} \
+          --subst-var-by tk ${tk}
+    done
+  '';
+
+  # If we don't create the directories ourselves, then 'make install' creates
+  # files named 'bin' and 'lib'.
+  preInstall = ''
+    mkdir -p $out/bin $out/lib
+  '';
+
+  installFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "LIBDIR=${placeholder "out"}/lib"
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "dirdiff";
+      exec = "dirdiff";
+      desktopName = "Dirdiff";
+      genericName = "Directory Diff Viewer";
+      comment = "Diff and merge directory trees";
+      categories = "Development;";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Graphical directory tree diff and merge tool";
+    longDescription = ''
+      Dirdiff is a graphical tool for displaying the differences between
+      directory trees and for merging changes from one tree into another.
+    '';
+    homepage = "https://www.samba.org/ftp/paulus/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ khumba ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/text/dirdiff/dirdiff-2.1-vars.patch
+++ b/pkgs/tools/text/dirdiff/dirdiff-2.1-vars.patch
@@ -1,0 +1,32 @@
+diff '--color=auto' -ru dirdiff-2.1/dirdiff dirdiff-2.1-patched/dirdiff
+--- dirdiff-2.1/dirdiff	2005-04-20 03:09:53.000000000 -0700
++++ dirdiff-2.1-patched/dirdiff	2021-02-14 22:54:09.837692023 -0800
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+ # Tcl ignores the next line \
+-exec wish "$0" -- "${1+$@}"
++exec @tk@/bin/wish "$0" -- "${1+$@}"
+ 
+ # Copyright (C) 1999-2004 Paul Mackerras.  All rights reserved.
+ # This program is free software; it may be used, copied, modified
+@@ -17,7 +17,7 @@
+ set TclExe [info nameofexecutable]
+ set compound_ok [expr {$tcl_version >= 8.4}]
+ 
+-set nofilecmp [catch {load libfilecmp.so.0.0}]
++set nofilecmp [catch {load @out@/lib/libfilecmp.so.0.0}]
+ set rcsflag {}
+ set diffbflag {}
+ set diffBflag {}
+diff '--color=auto' -ru dirdiff-2.1/Makefile dirdiff-2.1-patched/Makefile
+--- dirdiff-2.1/Makefile	2005-04-19 03:22:01.000000000 -0700
++++ dirdiff-2.1-patched/Makefile	2021-02-14 22:54:58.575400923 -0800
+@@ -7,7 +7,7 @@
+ INSTALL=install
+ 
+ # You may need to change the -I arguments depending on your system
+-CFLAGS=-O3 -I/usr/include/tcl8.3/ -I/usr/include/tcl
++CFLAGS=-O3 -I@tcl@/include
+ 
+ all:	libfilecmp.so.0.0
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3604,6 +3604,11 @@ in
     inherit (pythonPackages) mutagen python wrapPython;
   };
 
+  dirdiff = callPackage ../tools/text/dirdiff {
+    tcl = tcl-8_5;
+    tk = tk-8_5;
+  };
+
   picotts = callPackage ../tools/audio/picotts { };
 
   wgetpaste = callPackage ../tools/text/wgetpaste { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a Tcl/Tk directory diff and merge tool that is simple to use, and is something I've been missing on NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - This new package takes 160K according to `du -sh`.  It's closure size is 49MiB.
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
