### PR TITLE
ripgrep: link PCRE2 dynamically

### DIFF
--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -4,6 +4,7 @@
 , rustPlatform
 , asciidoctor
 , installShellFiles
+, pkg-config
 , Security
 , withPCRE2 ? true
 , pcre2 ? null
@@ -24,9 +25,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = lib.optional withPCRE2 "--features pcre2";
 
-  nativeBuildInputs = [ asciidoctor installShellFiles ];
+  nativeBuildInputs = [ asciidoctor installShellFiles ]
+    ++ lib.optional withPCRE2 pkg-config;
   buildInputs = (lib.optional withPCRE2 pcre2)
-  ++ (lib.optional stdenv.isDarwin Security);
+    ++ (lib.optional stdenv.isDarwin Security);
 
   preFixup = ''
     installManPage $releaseDir/build/ripgrep-*/out/rg.1


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The pcre2 crate which is used by ripgrep uses pkg-config to find the
path of the PCRE2 dynamic library. If the pkg-config or the library is
not found, PCRE2 will be built/linked statically.

This change adds pkg-config to the nativeBuildInputs of ripgrep, so
that the PCRE2 library is detected and dynamically linked.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
