### PR TITLE
bambootracker: un-mark broken on darwin

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation
 , lib
-, stdenv
 , fetchFromGitHub
+, fetchpatch
 , qmake
 , pkg-config
 , qttools
@@ -21,10 +21,15 @@ mkDerivation rec {
     sha256 = "0iddqfw951dw9xpl4w7310sl4z544507ppb12i8g4fzvlxfw2ifc";
   };
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace BambooTracker/BambooTracker.pro \
-      --replace '# Temporary known-error downgrades here' 'CPP_WARNING_FLAGS += -Wno-missing-braces'
-  '';
+  # TODO Remove when updating past 0.4.6
+  # Fixes build failure on darwin
+  patches = [
+    (fetchpatch {
+      name = "bambootracker-Add_braces_in_initialization_of_std-array.patch";
+      url = "https://github.com/rerrahkr/BambooTracker/commit/0fc96c60c7ae6c2504ee696bb7dec979ac19717d.patch";
+      sha256 = "1z28af46mqrgnyrr4i8883gp3wablkk8rijnj0jvpq01s4m2sfjn";
+    })
+  ];
 
   nativeBuildInputs = [ qmake qttools pkg-config ];
 
@@ -40,6 +45,5 @@ mkDerivation rec {
     license = licenses.gpl2Only;
     platforms = platforms.all;
     maintainers = with maintainers; [ OPNA2608 ];
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
It really wasn't necessary to mark my package as broken without pinging me, I immediately opened a fix PR after the first one got merged without testing…

Replaced `substituteInPlace` with upstream commit that should fix the problem as well. Please `nixpkgs-review` on `x86_64-darwin` @SuperSandro2000.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
