### PR TITLE
buildRustPackage: factor out cargoCheckHook and cargoInstallHook

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -196,7 +196,7 @@ sometimes it may be necessary to disable this so the tests run consecutively.
 ```nix
 rustPlatform.buildRustPackage {
   /* ... */
-  cargoParallelTestThreads = false;
+  dontUseCargoParallelTests = true;
 }
 ```
 
@@ -293,6 +293,10 @@ attributes can also be used:
   variable `buildAndTestSubdir` can be used to build a crate in a
   Cargo workspace. Additional maturin flags can be passed through
   `maturinBuildFlags`.
+* `cargoCheckHook`: run tests using Cargo. Additional flags can be
+  passed to Cargo using `checkFlags` and `checkFlagsArray`. By
+  default, tests are run in parallel. This can be disabled by setting
+  `dontUseCargoParallelTests`.
 * `cargoInstallHook`: install binaries and static/shared libraries
   that were built using `cargoBuildHook`.
 

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -293,6 +293,8 @@ attributes can also be used:
   variable `buildAndTestSubdir` can be used to build a crate in a
   Cargo workspace. Additional maturin flags can be passed through
   `maturinBuildFlags`.
+* `cargoInstallHook`: install binaries and static/shared libraries
+  that were built using `cargoBuildHook`.
 
 ### Examples
 

--- a/pkgs/applications/networking/browsers/castor/default.nix
+++ b/pkgs/applications/networking/browsers/castor/default.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
   postInstall = "make PREFIX=$out copy-data";
 
   # Sometimes tests fail when run in parallel
-  cargoParallelTestThreads = false;
+  dontUseCargoParallelThreads = true;
 
   meta = with lib; {
     description = "A graphical client for plain-text protocols written in Rust with GTK. It currently supports the Gemini, Gopher and Finger protocols";

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -36,7 +36,6 @@
 , nativeBuildInputs ? []
 , cargoUpdateHook ? ""
 , cargoDepsHook ? ""
-, cargoBuildFlags ? []
 , buildType ? "release"
 , meta ? {}
 , cargoVendorDir ? null
@@ -97,8 +96,6 @@ stdenv.mkDerivation ((removeAttrs args ["depsExtraArgs"]) // lib.optionalAttrs u
   RUSTFLAGS = "--sysroot ${sysroot} " + (args.RUSTFLAGS or "");
 } // {
   inherit buildAndTestSubdir cargoDeps;
-
-  cargoBuildFlags = lib.concatStringsSep " " cargoBuildFlags;
 
   cargoBuildType = buildType;
 

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -17,15 +17,15 @@ cargoBuildHook() {
       cargo build -j $NIX_BUILD_CORES \
         --target @rustTargetPlatformSpec@ \
         --frozen \
-        ${cargoBuildType} \
+        --${cargoBuildType} \
         ${cargoBuildFlags}
     )
-
-    runHook postBuild
 
     if [ ! -z "${buildAndTestSubdir-}" ]; then
         popd
     fi
+
+    runHook postBuild
 
     echo "Finished cargoBuildHook"
 }

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -1,3 +1,5 @@
+declare -a cargoBuildFlags
+
 cargoBuildHook() {
     echo "Executing cargoBuildHook"
 

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -1,3 +1,5 @@
+declare -a checkFlags
+
 cargoCheckHook() {
     echo "Executing cargoCheckHook"
 
@@ -34,4 +36,6 @@ cargoCheckHook() {
     runHook postCheck
 }
 
-checkPhase=cargoCheckHook
+if [ -z "${checkPhase-}" ]; then
+  checkPhase=cargoCheckHook
+fi

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -1,0 +1,37 @@
+cargoCheckHook() {
+    echo "Executing cargoCheckHook"
+
+    runHook preCheck
+
+    if [[ -n "${buildAndTestSubdir-}" ]]; then
+        pushd "${buildAndTestSubdir}"
+    fi
+
+    if [[ -z ${dontUseCargoParallelTests-} ]]; then
+        threads=$NIX_BUILD_CORES
+    else
+        threads=1
+    fi
+
+    argstr="--${cargoBuildType} --target @rustTargetPlatformSpec@ --frozen";
+
+    (
+        set -x
+        cargo test \
+              -j $NIX_BUILD_CORES \
+              ${argstr} -- \
+              --test-threads=${threads} \
+              ${checkFlags} \
+              ${checkFlagsArray+"${checkFlagsArray[@]}"}
+    )
+
+    if [[ -n "${buildAndTestSubdir-}" ]]; then
+        popd
+    fi
+
+    echo "Finished cargoCheckHook"
+
+    runHook postCheck
+}
+
+checkPhase=cargoCheckHook

--- a/pkgs/build-support/rust/hooks/cargo-install-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-install-hook.sh
@@ -1,0 +1,49 @@
+cargoInstallPostBuildHook() {
+    echo "Executing cargoInstallPostBuildHook"
+
+    releaseDir=target/@shortTarget@/$cargoBuildType
+    tmpDir="${releaseDir}-tmp";
+
+    mkdir -p $tmpDir
+    cp -r ${releaseDir}/* $tmpDir/
+    bins=$(find $tmpDir \
+      -maxdepth 1 \
+      -type f \
+      -executable ! \( -regex ".*\.\(so.[0-9.]+\|so\|a\|dylib\)" \))
+
+    echo "Finished cargoInstallPostBuildHook"
+}
+
+cargoInstallHook() {
+    echo "Executing cargoInstallHook"
+
+    runHook preInstall
+
+    # rename the output dir to a architecture independent one
+
+    releaseDir=target/@shortTarget@/$cargoBuildType
+    tmpDir="${releaseDir}-tmp";
+
+    mapfile -t targets < <(find "$NIX_BUILD_TOP" -type d | grep "${tmpDir}$")
+    for target in "${targets[@]}"; do
+      rm -rf "$target/../../${cargoBuildType}"
+      ln -srf "$target" "$target/../../"
+    done
+    mkdir -p $out/bin $out/lib
+
+    xargs -r cp -t $out/bin <<< $bins
+    find $tmpDir \
+      -maxdepth 1 \
+      -regex ".*\.\(so.[0-9.]+\|so\|a\|dylib\)" \
+      -print0 | xargs -r -0 cp -t $out/lib
+    rmdir --ignore-fail-on-non-empty $out/lib $out/bin
+    runHook postInstall
+
+    echo "Finished cargoInstallHook"
+}
+
+
+if [ -z "${installPhase-}" ]; then
+  installPhase=cargoInstallHook
+  postBuildHooks+=(cargoInstallPostBuildHook)
+fi

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -36,6 +36,15 @@ in {
       };
     } ./cargo-build-hook.sh) {};
 
+  cargoCheckHook = callPackage ({ }:
+    makeSetupHook {
+      name = "cargo-check-hook.sh";
+      deps = [ cargo ];
+      substitutions = {
+        inherit rustTargetPlatformSpec;
+      };
+    } ./cargo-check-hook.sh) {};
+
   cargoInstallHook = callPackage ({ }:
     makeSetupHook {
       name = "cargo-install-hook.sh";

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -36,6 +36,15 @@ in {
       };
     } ./cargo-build-hook.sh) {};
 
+  cargoInstallHook = callPackage ({ }:
+    makeSetupHook {
+      name = "cargo-install-hook.sh";
+      deps = [ ];
+      substitutions = {
+        inherit shortTarget;
+      };
+    } ./cargo-install-hook.sh) {};
+
   cargoSetupHook = callPackage ({ }:
     makeSetupHook {
       name = "cargo-setup-hook.sh";

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -12,7 +12,7 @@ rec {
   };
 
   buildRustPackage = callPackage ../../../build-support/rust {
-    inherit rustc cargo cargoBuildHook cargoSetupHook fetchCargoTarball;
+    inherit rustc cargo cargoBuildHook cargoInstallHook cargoSetupHook fetchCargoTarball;
   };
 
   rustcSrc = callPackage ./rust-src.nix {
@@ -26,5 +26,5 @@ rec {
   # Hooks
   inherit (callPackage ../../../build-support/rust/hooks {
     inherit cargo;
-  }) cargoBuildHook cargoSetupHook maturinBuildHook;
+  }) cargoBuildHook cargoInstallHook cargoSetupHook maturinBuildHook;
 }

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -12,7 +12,8 @@ rec {
   };
 
   buildRustPackage = callPackage ../../../build-support/rust {
-    inherit rustc cargo cargoBuildHook cargoInstallHook cargoSetupHook fetchCargoTarball;
+    inherit cargoBuildHook cargoCheckHook cargoInstallHook cargoSetupHook
+      fetchCargoTarball rustc;
   };
 
   rustcSrc = callPackage ./rust-src.nix {
@@ -26,5 +27,5 @@ rec {
   # Hooks
   inherit (callPackage ../../../build-support/rust/hooks {
     inherit cargo;
-  }) cargoBuildHook cargoInstallHook cargoSetupHook maturinBuildHook;
+  }) cargoBuildHook cargoCheckHook cargoInstallHook cargoSetupHook maturinBuildHook;
 }

--- a/pkgs/development/compilers/rust/rls/default.nix
+++ b/pkgs/development/compilers/rust/rls/default.nix
@@ -2,7 +2,7 @@
 , openssh, openssl, pkg-config, cmake, zlib, curl, libiconv
 , CoreFoundation, Security }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "rls";
   inherit (rustPlatform.rust.rustc) src version;
 
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage {
 
   preBuild = ''
     # client tests are flaky
-    rm tests/client.rs
+    rm ${buildAndTestSubdir}/tests/client.rs
   '';
 
   # a nightly compiler is required unless we use this cheat code.

--- a/pkgs/development/interpreters/wasmer/default.nix
+++ b/pkgs/development/interpreters/wasmer/default.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   # using the [makefile](https://github.com/wasmerio/wasmer/blob/master/Makefile).
   # Enabling cranelift as this used to be the old default. At least one backend is
   # needed for the run subcommand to work.
-  cargoBuildFlags = [ "--features 'backend-cranelift'" ];
+  cargoBuildFlags = [ "--features" "backend-cranelift" ];
 
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 

--- a/pkgs/development/tools/the-way/default.nix
+++ b/pkgs/development/tools/the-way/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-jTZso61Lyt6jprBxBAhvchgOsgM9y1qBleTxUx1jCnE=";
   checkFlagsArray = lib.optionals stdenv.isDarwin [ "--skip=copy" ];
-  cargoParallelTestThreads = false;
+  dontUseCargoParallelTests = true;
 
   postInstall = ''
     $out/bin/the-way config default tmp.toml


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Converts the last parts of `buildRustPackage` to hooks. There is two APIs changes:

1. `cargoParallelTestThreads` suggests that this attribute sets the number of threads used during tests, while it is actually a boolean option (use 1 thread or NIX_BUILD_CORES threads). In the hook, this is replaced by a more canonical name `dontUseCargoParallelTests`.
2. `preBuild`/`postBuild` are run outside `pushd`/`popd` in `buildPhase`, to make it possible to hookify the binary/library collection.

Wrt. (2) I went over all derivations that use `buildRustPackage` and `preBuild`/`postBuild`. I could only find a problematic `preBuild` in `wasmer`, which is fixed in this PR.

I also checked `cargoBuildFlags` in all derivations that use them and fixed feature quotations in `diesel-cli` and  `wasmer`.

Related issues:

* #83614
* #112438

Follow-up to:

* #112500
* #112804

CC @FRidh @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
