### PR TITLE
python3Packages.robotframework-tools, python3Packages.zetup: fix build

### DIFF
--- a/pkgs/development/python-modules/modeled/default.nix
+++ b/pkgs/development/python-modules/modeled/default.nix
@@ -24,9 +24,11 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
 
+  pythonImportsCheck = [ "modeled" ];
+
   meta = with lib; {
     description = "Universal data modeling for Python";
-    homepage = "https://bitbucket.org/userzimmermann/python-modeled";
+    homepage = "https://github.com/modeled/modeled";
     license = licenses.lgpl3Only;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/robotframework-tools/default.nix
+++ b/pkgs/development/python-modules/robotframework-tools/default.nix
@@ -8,7 +8,7 @@
 , six
 , zetup
 , modeled
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -20,9 +20,7 @@ buildPythonPackage rec {
     sha256 = "0377ikajf6c3zcy3lc0kh4w9zmlqyplk2c2hb0yyc7h3jnfnya96";
   };
 
-  nativeBuildInputs = [
-    zetup
-  ];
+  nativeBuildInputs = [ zetup ];
 
   propagatedBuildInputs = [
     robotframework
@@ -32,19 +30,21 @@ buildPythonPackage rec {
     modeled
   ];
 
-  checkInputs = [
-    pytest
-  ];
-
-  checkPhase = ''
-    # tests require network
-    pytest test --ignore test/remote/test_remote.py
+  postPatch = ''
+    # Remove upstream's selfmade approach to collect the dependencies
+    # https://github.com/userzimmermann/robotframework-tools/issues/1
+    substituteInPlace setup.py --replace \
+      "setup_requires=SETUP_REQUIRES + (zfg.SETUP_REQUIRES or [])," ""
   '';
+
+  checkInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [ "test" ];
+  pythonImportsCheck = [ "robottools" ];
 
   meta = with lib; {
     description = "Python Tools for Robot Framework and Test Libraries";
-    homepage = "https://bitbucket.org/userzimmermann/robotframework-tools";
-    license = licenses.gpl3;
+    homepage = "https://github.com/userzimmermann/robotframework-tools";
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.costrouc ];
   };
 }

--- a/pkgs/development/python-modules/zetup/default.nix
+++ b/pkgs/development/python-modules/zetup/default.nix
@@ -1,6 +1,11 @@
-{ lib, buildPythonPackage, fetchPypi
-, setuptools_scm, pathpy, nbconvert
-, pytest }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nbconvert
+, pathpy
+, pytestCheckHook
+, setuptools-scm
+}:
 
 buildPythonPackage rec {
   pname = "zetup";
@@ -11,18 +16,25 @@ buildPythonPackage rec {
     sha256 = "b8a9bdcfa4b705d72b55b218658bc9403c157db7b57a14158253c98d03ab713d";
   };
 
-  # Python 3.8 compatibility
+  # Python > 3.7 compatibility
   postPatch = ''
     substituteInPlace zetup/zetup_config.py \
-      --replace "'3.7']" "'3.7', '3.8']"
+      --replace "'3.7']" "'3.7', '3.8', '3.9', '3.10']"
   '';
 
   checkPhase = ''
     py.test test -k "not TestObject" --deselect=test/test_zetup_config.py::test_classifiers
   '';
 
-  checkInputs = [ pytest pathpy nbconvert ];
-  propagatedBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ setuptools-scm ];
+
+  checkInputs = [
+    pathpy
+    nbconvert
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "zetup" ];
 
   meta = with lib; {
     description = "Zimmermann's Extensible Tools for Unified Project setups";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Allow to build on Python 3.9 and switch to `pytestCheckHook`

Issue affects #112687

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
