### PR TITLE
quickjs: 2019-12-21 -> 2020-11-08

### DIFF
--- a/pkgs/development/interpreters/quickjs/default.nix
+++ b/pkgs/development/interpreters/quickjs/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "quickjs";
-  version = "2019-12-21";
+  version = "2020-11-08";
 
   src = fetchurl {
     url = "https://bellard.org/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "13hlx6qwrrxmlvvqcr3irxba6zmf05cf54l32vj50wc66s1qd41p";
+    sha256 = "0yqqcjxi3cqagw184mqrxpvqg486x7c233r3cp9mxachngd6779f";
   };
 
   makeFlags = [ "prefix=${placeholder "out"}" ];
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
     # Programs exit with code 1 when testing help, so grep for a string
     set +o pipefail
     qjs     --help 2>&1 | grep "QuickJS version"
-    qjsbn   --help 2>&1 | grep "QuickJS version"
     qjscalc --help 2>&1 | grep "QuickJS version"
     set -o pipefail
 
@@ -27,9 +26,7 @@ stdenv.mkDerivation rec {
     echo "console.log('Output from compiled program');" > "$temp"
     set -o verbose
     out=$(mktemp) && qjsc         "$temp" -o "$out" && "$out" | grep -q "Output from compiled program"
-    out=$(mktemp) && qjsbnc       "$temp" -o "$out" && "$out" | grep -q "Output from compiled program"
     out=$(mktemp) && qjsc   -flto "$temp" -o "$out" && "$out" | grep -q "Output from compiled program"
-    out=$(mktemp) && qjsbnc -flto "$temp" -o "$out" && "$out" | grep -q "Output from compiled program"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Just a regular bump. The removed lines in the build script are because (apparently) qjsbn and qjsbnc have been removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
