### PR TITLE
maestral-gui: 1.3.1 -> 1.4.2

### DIFF
--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -6,18 +6,17 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maestral-qt";
-  version = "1.3.1";
+  version = "1.4.2";
   disabled = python3.pkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-qt";
     rev = "v${version}";
-    sha256 = "sha256-2S2sa2/HVt3IRsE98PT2XwpONjaYENBzYW+ezBFrJYI=";
+    sha256 = "sha256-cPH0wD7RL3OifDTD48x58I4qeaLALOMFnfWXjE2/lUQ=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
-    bugsnag
     click
     markdown2
     maestral

--- a/pkgs/development/python-modules/desktop-notifier/default.nix
+++ b/pkgs/development/python-modules/desktop-notifier/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, stdenv
+, packaging
+, importlib-resources
+, dbus-next
+}:
+
+buildPythonPackage rec {
+  pname = "desktop-notifier";
+  version = "3.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-D8/amC6SwXkm8Ao8G2Vn9FNpbqyFJFBUVcngkW5g8k0=";
+  };
+
+  propagatedBuildInputs = [
+    packaging
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    importlib-resources
+  ] ++ lib.optionals stdenv.isLinux [
+    dbus-next
+  ];
+
+  # no tests available, do the imports check instead
+  doCheck = false;
+  pythonImportsCheck = [ "desktop_notifier" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/samschott/desktop-notifier";
+    description = "A Python library for cross-platform desktop notifications";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sfrijters ];
+  };
+}

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -1,30 +1,29 @@
-{ lib, stdenv
+{ lib
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
 , python
-, alembic, bugsnag, click, dropbox, fasteners, keyring, keyrings-alt, packaging, pathspec, Pyro5, requests, setuptools, sdnotify, sqlalchemy, survey, watchdog
+, alembic, click, desktop-notifier, dropbox, fasteners, keyring, keyrings-alt, packaging, pathspec, Pyro5, requests, setuptools, sdnotify, sqlalchemy, survey, watchdog
 , importlib-metadata
 , importlib-resources
-, dbus-next
 }:
 
 buildPythonPackage rec {
   pname = "maestral";
-  version = "1.3.1";
+  version = "1.4.2";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral";
     rev = "v${version}";
-    sha256 = "sha256-SspyTdmAbbmWN3AqVp9bj/QfAKLVgU2bLiiHjZO0aCM=";
+    sha256 = "sha256-ibAYuaPSty275/aQ0DibyWe2LjPoEpdWgElTnR+MEs8=";
   };
 
   propagatedBuildInputs = [
     alembic
-    bugsnag
     click
+    desktop-notifier
     dropbox
     fasteners
     keyring
@@ -42,8 +41,6 @@ buildPythonPackage rec {
     importlib-metadata
   ] ++ lib.optionals (pythonOlder "3.9") [
     importlib-resources
-  ] ++ lib.optionals stdenv.isLinux [
-    dbus-next
   ];
 
   makeWrapperArgs = [

--- a/pkgs/development/python-modules/survey/default.nix
+++ b/pkgs/development/python-modules/survey/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "survey";
-  version = "3.1.1";
+  version = "3.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-R/PfXW/CnqYiOWbCxPAYwneg6j6CLvdIpITZ2eIXn+M=";
+    sha256 = "sha256-aF7ZS5oxeIOb7mJsrusdc3HefcPE+3OTXcJB/pjJxFY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "watchdog";
-  version = "1.0.2";
+  version = "2.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-N2y8KjXAOSsP5/8W+8GzA/2Z1N2ZEatVge6daa3IiYI=";
+    sha256 = "sha256-/UtWz74NDZxPxDGs7KdXAKfxLTc33C6csuwrpkloBCU=";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin

--- a/pkgs/development/python-modules/wrapio/default.nix
+++ b/pkgs/development/python-modules/wrapio/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "wrapio";
-  version = "0.3.8";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-jGupLh+xzwil+VBtAjIG+ZYT+dy+QaZOTIfipTQeyWo";
+    sha256 = "sha256-JWcPsqZy1wM6/mbU3H0W3EkpLg0wrEUUg3pT/QrL+rE=";
   };
 
   doCheck = false;

--- a/pkgs/tools/text/markdown-pp/default.nix
+++ b/pkgs/tools/text/markdown-pp/default.nix
@@ -1,13 +1,15 @@
-{ fetchFromGitHub, pythonPackages, lib }:
+{ lib
+, fetchFromGitHub
+, python3
+}:
 
-with pythonPackages;
-buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "MarkdownPP";
   version = "1.5.1";
-  propagatedBuildInputs = [ pillow watchdog ];
+  propagatedBuildInputs = with python3.pkgs; [ pillow watchdog ];
   checkPhase = ''
     cd test
-    PATH=$out/bin:$PATH ${python}/bin/${python.executable} test.py
+    PATH=$out/bin:$PATH ${python3}/bin/${python3.executable} test.py
   '';
   src = fetchFromGitHub {
     owner = "jreese";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1708,6 +1708,8 @@ in {
 
   deskcon = callPackage ../development/python-modules/deskcon { };
 
+  desktop-notifier = callPackage ../development/python-modules/desktop-notifier { };
+
   detox = throw "detox is no longer maintained, and was broken since may 2019"; # added 2020-07-04
 
   devolo-home-control-api = callPackage ../development/python-modules/devolo-home-control-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3872,20 +3872,11 @@ in {
   macropy = callPackage ../development/python-modules/macropy { };
 
   maestral = callPackage ../development/python-modules/maestral {
-
-    # https://github.com/SamSchott/maestral/issues/250#issuecomment-739510048
-    survey = self.survey.overridePythonAttrs (old: rec {
-      version = "2.2.1";
+    keyring = self.keyring.overridePythonAttrs (old: rec {
+      version = "22.0.1";
       src = old.src.override {
         inherit version;
-        sha256 = "sha256-7ubWkqk1vyaJDLMOuKwUx2Bjziyi3HqpaQq4pKp4Z+0=";
-      };
-    });
-    watchdog = self.watchdog.overridePythonAttrs (old: rec {
-      version = "0.10.3";
-      src = old.src.override {
-        inherit version;
-        sha256 = "4214e1379d128b0588021880ccaf40317ee156d4603ac388b9adcf29165e0c04";
+        sha256 = "sha256-mss+FFLtu3VEgisS/SVFkHh2nlYPpR9Bi20Ar6pheN8=";
       };
     });
   };


### PR DESCRIPTION
###### Motivation for this change

Upstream maestral update, with updated dependency bounds.

Most have been fixed by updating the package version in nixpkgs, but if I update `keyring` to `22.0.1`, I get issues with the `poetry` package which has a very nasty cascade effect, so I modified the existing overrides instead.

I've changed `markdown-pp` to Python3 because otherwise I get problems with the new watchdog version. It seems to work for me and as far as I can see Python3 is supported. @zgrannan

@peterhoeg Are you still using this / does it work for you?

```
$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev maestral-1.4"
[...]
97 packages updated:
archivy aws-sam-cli buildbot coconut coconut coconut coconut datasette devpi-client devpi-server hovercraft maestral (1.3.1 → 1.4.1) maestral-gui (1.3.1 → 1.4.0) MarkdownPP OctoPrint pympress python3.7-buildbot python3.7-cornice python3.7-datasette python3.7-deform python3.7-easywatch python3.7-hupper python3.7-labelbox python3.7-lektor python37Packages.maestral (1.3.1 → 1.4.1) python3.7-ndjson python3.7-Nikola python3.7-pypugjs python3.7-pyramid python3.7-pyramid_beaker python3.7-pyramid_chameleon python3.7-pyramid_exclog python3.7-pyramid_hawkauth python3.7-pyramid_jinja2 python3.7-pyramid_mako python3.7-pyramid_multiauth python3.7-pytest-watch python3.7-python3.7-buildbot python3.7-python3.7-buildbot python3.7-spyder python3.7-staticjinja python37Packages.survey (3.1.1 → 3.4.2) python37Packages.watchdog (1.0.2 → 2.0.0) python37Packages.wrapio (0.3.8 → 1.0.0) python3.8-buildbot python3.8-buildbot python3.8-buildbot python3.8-cornice python3.8-datasette python3.8-deform python3.8-easywatch python3.8-hupper python3.8-labelbox python3.8-lektor python38Packages.maestral (1.3.1 → 1.4.1) python3.8-ndjson python3.8-Nikola python3.8-pypugjs python3.8-pyramid python3.8-pyramid_beaker python3.8-pyramid_chameleon python3.8-pyramid_exclog python3.8-pyramid_hawkauth python3.8-pyramid_jinja2 python3.8-pyramid_mako python3.8-pyramid_multiauth python3.8-pytest-watch python3.8-python3.8-buildbot python3.8-python3.8-buildbot python3.8-spyder python3.8-staticjinja python38Packages.survey (3.1.1 → 3.4.2) python38Packages.watchdog (1.0.2 → 2.0.0) python38Packages.wrapio (0.3.8 → 1.0.0) python3.9-cornice python3.9-deform python3.9-easywatch python3.9-hupper python3.9-lektor python3.9-Nikola python3.9-pypugjs python3.9-pyramid python3.9-pyramid_beaker python3.9-pyramid_chameleon python3.9-pyramid_exclog python3.9-pyramid_hawkauth python3.9-pyramid_jinja2 python3.9-pyramid_mako python3.9-pyramid_multiauth python3.9-pytest-watch python39Packages.survey (3.1.1 → 3.4.2) python39Packages.watchdog (1.0.2 → 2.0.0) python39Packages.wrapio (0.3.8 → 1.0.0) spyder staticjinja streamlit topydo
[...]
92 packages built:
archivy aws-sam-cli buildbot buildbot-full buildbot-ui coconut datasette devpi-client devpi-server hovercraft maestral maestral-gui markdown-pp octoprint pympress python37Packages.Nikola python37Packages.buildbot python37Packages.buildbot-full python37Packages.buildbot-ui python37Packages.coconut python37Packages.cornice python37Packages.datasette python37Packages.deform python37Packages.desktop-notifier python37Packages.easywatch python37Packages.hupper python37Packages.labelbox python37Packages.lektor python37Packages.maestral python37Packages.ndjson python37Packages.pypugjs python37Packages.pyramid python37Packages.pyramid_beaker python37Packages.pyramid_chameleon python37Packages.pyramid_exclog python37Packages.pyramid_hawkauth python37Packages.pyramid_jinja2 python37Packages.pyramid_mako python37Packages.pyramid_multiauth python37Packages.pytest-watch python37Packages.spyder python37Packages.staticjinja python37Packages.survey python37Packages.watchdog python37Packages.wrapio python38Packages.Nikola python38Packages.cornice python38Packages.deform python38Packages.desktop-notifier python38Packages.easywatch python38Packages.hupper python38Packages.labelbox python38Packages.lektor python38Packages.ndjson python38Packages.pypugjs python38Packages.pyramid python38Packages.pyramid_beaker python38Packages.pyramid_chameleon python38Packages.pyramid_exclog python38Packages.pyramid_hawkauth python38Packages.pyramid_jinja2 python38Packages.pyramid_mako python38Packages.pyramid_multiauth python38Packages.pytest-watch spyder staticjinja python38Packages.survey python38Packages.watchdog python38Packages.wrapio python39Packages.Nikola python39Packages.coconut python39Packages.cornice python39Packages.deform python39Packages.desktop-notifier python39Packages.easywatch python39Packages.hupper python39Packages.lektor python39Packages.pypugjs python39Packages.pyramid python39Packages.pyramid_beaker python39Packages.pyramid_chameleon python39Packages.pyramid_exclog python39Packages.pyramid_hawkauth python39Packages.pyramid_jinja2 python39Packages.pyramid_mako python39Packages.pyramid_multiauth python39Packages.pytest-watch python39Packages.survey python39Packages.watchdog python39Packages.wrapio streamlit topydo
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
