### PR TITLE
lib/systems/platforms: remove TI_CPTS override

### DIFF
--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -303,7 +303,8 @@ rec {
       preferBuiltin = true;
       target = "zImage";
       extraConfig = ''
-        # Serial port for Raspberry Pi 3. Upstream forgot to add it to the ARMv7 defconfig.
+        # Serial port for Raspberry Pi 3. Wasn't included in ARMv7 defconfig
+        # until 4.17.
         SERIAL_8250_BCM2835AUX y
         SERIAL_8250_EXTENDED y
         SERIAL_8250_SHARE_IRQ y

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -309,9 +309,6 @@ rec {
         SERIAL_8250_EXTENDED y
         SERIAL_8250_SHARE_IRQ y
 
-        # Fix broken sunxi-sid nvmem driver.
-        TI_CPTS y
-
         # Hangs ODROID-XU4
         ARM_BIG_LITTLE_CPUIDLE n
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The kernel config fails to build on armv7l because the platform config tries to force the `TI_CPTS` option to `y`, but it depends on `PTP_1588_CLOCK`, which is being compiled as a module. This results in the following error:
```
QUESTION:       TI Common Platform Time Sync (CPTS) Support, NAME: TI_CPTS, ALTS: M/n/?, ANSWER: y
GOT: y
GOT: 
GOT: CONFIG_TI_CPTS:
GOT: 
GOT: This driver supports the Common Platform Time Sync unit of
GOT: the CPSW Ethernet Switch and Keystone 2 1g/10g Switch Subsystem.
GOT: The unit can time stamp PTP UDP/IPv4 and Layer 2 packets, and the
GOT: driver offers a PTP Hardware Clock.
GOT: 
GOT: Symbol: TI_CPTS [=m]
GOT: Type  : tristate
GOT: Defined at drivers/net/ethernet/ti/Kconfig:81
GOT:   Prompt: TI Common Platform Time Sync (CPTS) Support
GOT:   Depends on: NETDEVICES [=y] && ETHERNET [=y] && NET_VENDOR_TI [=y] && (ARCH_OMAP2PLUS [=y] || ARCH_KEYSTONE [=y] || COMPILE_TEST [=n]) && COMMON_CLK [=y] && PTP_1588_CLOCK [=m]
GOT:   Location:
GOT:     -> Device Drivers
GOT:       -> Network device support (NETDEVICES [=y])
GOT:         -> Ethernet driver support (ETHERNET [=y])
GOT:           -> Texas Instruments (TI) devices (NET_VENDOR_TI [=y])
GOT: 
GOT: 
GOT: 
QUESTION:       TI Common Platform Time Sync (CPTS) Support, NAME: TI_CPTS, ALTS: M/n/?, ANSWER: y
repeated question:       TI Common Platform Time Sync (CPTS) Support at /nix/store/lsby3mmn4imqcc2pymfkw9fqxwmqzpfx-generate-config.pl line 87.

Error in reading or end of file.

Error in reading or end of file.

Error in reading or end of file.
```

The override was added in https://github.com/NixOS/nixpkgs/pull/24229, and it looks as though it was done to fix a compile issue (rather than a runtime issue), but it's not clear. Perhaps @abbradar can remember.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
