### PR TITLE
macbook15-spi-driver: init at 0.1

### DIFF
--- a/pkgs/os-specific/linux/mbp-modules/macbook15-spi-driver/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/macbook15-spi-driver/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, kernel, fetchFromGitHub, }:
+
+stdenv.mkDerivation rec {
+  name = "macbook15-spi-driver";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "hlolli";
+    repo = "macbook15-spi-driver";
+    rev = "86a2f37ca0d2a4729a32b636dc48f39c522dd8ad";
+    sha256 = "1724s3y8ad14s8a0rag9jadb69j0j2vn566fzg6basx2bmfrj8gi";
+  };
+
+  buildPhase = ''
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \
+      -j$NIX_BUILD_CORES M=$(pwd) modules
+  '';
+
+  installPhase = ''
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build  \
+      INSTALL_MOD_PATH=$out M=$(pwd) modules_install
+  '';
+
+  meta = with lib; {
+    description = "Driver for the touchbar and ambient-light-sensor on 2019 MacBook Pro's.";
+    homepage = "https://github.com/hlolli/macbook15-spi-driver";
+    license = lib.licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = [ lib.maintainers.hlolli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19288,6 +19288,8 @@ in
 
     tbs = callPackage ../os-specific/linux/tbs { };
 
+    macbook15-spi-driver = callPackage ../os-specific/linux/mbp-modules/macbook15-spi-driver { };
+
     nvidiabl = callPackage ../os-specific/linux/nvidiabl { };
 
     nvidiaPackages = dontRecurseIntoAttrs (callPackage ../os-specific/linux/nvidia-x11 { });


### PR DESCRIPTION
###### Motivation for this change

This kernel-module is part of macbook pro 15+ hardware support NixOS/nixos-hardware#231

###### Things done

This module is fork of a fork https://github.com/roadrunner2/macbook12-spi-driver which includes a branch "mbp15" which as far as I know is the only way to get the touchbar working on macbooks 2018 and later (without which there aren't any F-keys available). The reason I forked it, is because I failed to be able to get the ambient light sensor nor keyboard backlight working, without using code from the contents from the "touchbar" branch (the main branch). So I merged together the changes on both branches to get all working. I'll make sure to maintain this module as changes come upstream.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
