### PR TITLE
pytestCheckHook: improve disabledTestFiles whitespace handling

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -2,7 +2,7 @@
 echo "Sourcing pytest-check-hook"
 
 declare -ar disabledTests
-declare -ar disabledTestPaths
+declare -a disabledTestPaths
 
 function _concatSep {
     local result
@@ -37,6 +37,11 @@ function pytestCheckPhase() {
         disabledTestsString=$(_pytestComputeDisabledTestsString "${disabledTests[@]}")
       args+=" -k \""$disabledTestsString"\""
     fi
+
+    if [ -n "${disabledTestPaths-}" ]; then
+        eval "disabledTestPaths=($disabledTestPaths)"
+    fi
+
     for path in ${disabledTestPaths[@]}; do
       if [ ! -e "$path" ]; then
         echo "Disabled tests path \"$path\" does not exist. Aborting"

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -93,6 +93,8 @@
 
 , doCheck ? config.doCheckByDefault or false
 
+, disabledTestPaths ? []
+
 , ... } @ attrs:
 
 
@@ -106,6 +108,7 @@ let
 
   self = toPythonModule (stdenv.mkDerivation ((builtins.removeAttrs attrs [
     "disabled" "checkPhase" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "format"
+    "disabledTestPaths"
   ]) // {
 
     name = namePrefix + name;
@@ -176,6 +179,8 @@ let
     # If given use the specified checkPhase, otherwise use the setup hook.
     # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
     installCheckPhase = attrs.checkPhase;
+  } //  lib.optionalAttrs (disabledTestPaths != []) {
+      disabledTestPaths = lib.escapeShellArgs disabledTestPaths;
   }));
 
   passthru.updateScript = let


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Attempt to improve handling of the situation in which pytestCheckHook's `disabledTestFiles` contains multiple elements each of which may contain spaces or special characters.

See: https://github.com/NixOS/nixpkgs/pull/113153#issuecomment-778926377

xref #113167, #110700 

cc @mweinelt, @jtojnar, @SuperSandro2000, @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


