### PR TITLE
deadd-notification-center: 1.7.3 -> 2021-03-10 and service files for dbus and systemd

### DIFF
--- a/pkgs/applications/misc/deadd-notification-center/default.nix
+++ b/pkgs/applications/misc/deadd-notification-center/default.nix
@@ -7,6 +7,7 @@
 , gtk3
 , gobject-introspection
 , libxml2
+, fetchpatch
 }:
 stdenv.mkDerivation rec {
   pname = "deadd-notification-center";
@@ -19,6 +20,12 @@ stdenv.mkDerivation rec {
     sha256 = "12ldr8vppylr90849g3mpjphmnr4lp0vsdkj01a5f4bv4ksx35fm";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/phuhl/linux_notification_center/commit/5244e1498574983322be97925e1ff7ebe456d974.patch";
+      sha256 = "sha256-hbqbgBmuewOhtx0na2tmFa5W128ZrBvDcyPme/mRzlI=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoPatchelfHook
@@ -32,15 +39,18 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme
   ];
 
-  installPhase = ''
-    mkdir -p $out/bin $out/share/dbus-1/services
+  buildFlags = [
+    # Exclude stack from `make all` to use the prebuilt binary from .out/
+    "service"
+  ];
 
-    cp $src/.out/${pname} $out/bin/
-    chmod +x $out/bin/${pname}
-
-    sed "s|##PREFIX##|$out|g" $src/${pname}.service.in > \
-      $out/share/dbus-1/services/com.ph-uhl.deadd.notification.service
-  '';
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "SERVICEDIR_SYSTEMD=${placeholder "out"}/etc/systemd/user"
+    "SERVICEDIR_DBUS=${placeholder "out"}/share/dbus-1/services"
+    # Override systemd auto-detection.
+    "SYSTEMD=1"
+  ];
 
   meta = with lib; {
     description = "A haskell-written notification center for users that like a desktop with style";

--- a/pkgs/applications/misc/deadd-notification-center/default.nix
+++ b/pkgs/applications/misc/deadd-notification-center/default.nix
@@ -10,16 +10,15 @@
 }:
 stdenv.mkDerivation rec {
   pname = "deadd-notification-center";
-  version = "1.7.3";
+  version = "2021-03-10";
 
   src = fetchFromGitHub {
     owner = "phuhl";
     repo = "linux_notification_center";
-    rev = version;
-    sha256 = "QaOLrtlhQyhMOirk6JO1yMGRrgycHmF9FAdKNbN2TRk=";
+    rev = "640ce0f";
+    sha256 = "12ldr8vppylr90849g3mpjphmnr4lp0vsdkj01a5f4bv4ksx35fm";
   };
 
-  dontUnpack = true;
 
   nativeBuildInputs = [
     autoPatchelfHook


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The service file for deadd-notification-center was mixed up. I use the systemd service file for dbus by mistake.

This adds both the systemd and dbus service files to the appropriate place and uses the right files from the source.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
