### PR TITLE
linux: improve cross compilation with clang

### DIFF
--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -40,7 +40,7 @@ close ANSWERS;
 sub runConfig {
 
     # Run `make config'.
-    my $pid = open2(\*IN, \*OUT, "make -C $ENV{SRC} O=$buildRoot config SHELL=bash ARCH=$ENV{ARCH}");
+    my $pid = open2(\*IN, \*OUT, "make -C $ENV{SRC} O=$buildRoot config SHELL=bash ARCH=$ENV{ARCH} CC=$ENV{CC} HOSTCC=$ENV{HOSTCC} HOSTCXX=$ENV{HOSTCXX}");
 
     # Parse the output, look for questions and then send an
     # appropriate answer.

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -131,12 +131,16 @@ let
 
     buildPhase = ''
       export buildRoot="''${buildRoot:-build}"
+      export HOSTCC=$CC_FOR_BUILD
+      export HOSTCXX=$CXX_FOR_BUILD
+      export HOSTAR=$AR_FOR_BUILD
+      export HOSTLD=$LD_FOR_BUILD
 
       # Get a basic config file for later refinement with $generateConfig.
-      make -C .  O="$buildRoot" $kernelBaseConfig \
+      make -C . O="$buildRoot" $kernelBaseConfig \
           ARCH=$kernelArch \
-          HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc \
-          HOSTCXX=${buildPackages.stdenv.cc.targetPrefix}g++
+          HOSTCC=$HOSTCC HOSTCXX=$HOSTCXX HOSTAR=$HOSTAR HOSTLD=$HOSTLD \
+          CC=$CC OBJCOPY=$OBJCOPY OBJDUMP=$OBJDUMP READELF=$READELF
 
       # Create the config file.
       echo "generating kernel configuration..."


### PR DESCRIPTION
I am pursuing to cross-compile a Linux kernel on Darwin. I have [succeeded locally](https://gist.github.com/mroi/de2adc196e5926ab6dae936042ae4b61), but some changes are required to make things work. This PR is one cornerstone of these changes.

The derivation which creates the Linux configuration file currently assumes that all compilers (build and host) are gcc-based. This is not true when cross-compiling on Darwin, where the host compiler is clang. I fixed this by setting the `CC`, `HOSTCC`, and `HOSTCXX` variables in a cross-friendly way. I also needed to pass along the variables to the `make` launched from within `generate-config.pl`.

The change has no impact for regular kernel builds on Linux, as the `cc` and `c++` executables are pointing to gcc. I have successfully tested building a kernel on Linux. Please advise if there is more I should test.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
