### PR TITLE
cqrlog: init at 2.5.2

### DIFF
--- a/pkgs/applications/radio/cqrlog/default.nix
+++ b/pkgs/applications/radio/cqrlog/default.nix
@@ -1,0 +1,101 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fpc
+, lazarus
+, atk
+, cairo
+, gdk-pixbuf
+, glib
+, gtk2-x11
+, libX11
+, pango
+, hamlib
+, mysql57
+, tqsl
+, xdg-utils
+, xplanet
+, autoPatchelfHook
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cqrlog";
+  version = "2.5.2";
+
+  src = fetchFromGitHub {
+    owner = "ok2cqr";
+    repo = "cqrlog";
+    rev = "v${version}";
+    sha256 = "0zzcg0bl6mq4wfifj998x9x09w8sigbh46synpqx034fpr0swyhb";
+  };
+
+  # Adds the possiblity to change the lazarus directory,
+  # otherwise, we would get error : "directory lcl not found"
+  patches = [ ./fix-makefile-lazarusdir.patch ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace @Lazarusdir@ "${lazarus}/share/lazarus" \
+      --replace /usr ""
+    substituteInPlace src/fTRXControl.pas \
+      --replace "/usr/bin/rigctld" "${hamlib}/bin/rigctld"
+    substituteInPlace src/fCallAttachment.pas \
+      --replace "/usr/bin/xdg-open" "${xdg-utils}/bin/xdg-open"
+    substituteInPlace src/fRotControl.pas \
+      --replace "/usr/bin/rotctld" "${hamlib}/bin/rotctld"
+    substituteInPlace src/fPreferences.pas \
+      --replace "/usr/bin/rigctld" "${hamlib}/bin/rigctld" \
+      --replace "/usr/bin/rotctld" "${hamlib}/bin/rotctld" \
+      --replace "/usr/bin/xplanet" "${xplanet}/bin/xplanet"
+    substituteInPlace src/fLoTWExport.pas \
+      --replace "/usr/bin/tqsl" "${tqsl}/bin/tqsl"
+    substituteInPlace src/dUtils.pas \
+      --replace "/usr/bin/xplanet" "${xplanet}/bin/xplanet" \
+      --replace "/usr/bin/rigctld" "${hamlib}/bin/rigctld"
+    # Order is important
+    substituteInPlace src/dData.pas \
+      --replace "/usr/bin/mysqld_safe" "${mysql57}/bin/mysqld_safe" \
+      --replace "/usr/bin/mysqld" "${mysql57}/bin/mysqld"
+
+    # To be fail when I need to patch a new hardcoded binary
+    ! grep -C src -RC0 "/usr"
+  '';
+
+  nativeBuildInputs = [ lazarus fpc autoPatchelfHook wrapGAppsHook ];
+  buildInputs = [
+    atk
+    cairo
+    gdk-pixbuf
+    glib
+    gtk2-x11
+    libX11
+    pango
+  ];
+  propagatedBuildInputs = [
+    hamlib
+    mysql57
+    tqsl
+    xdg-utils
+    xplanet
+  ];
+
+  makeFlags = [
+    "FPC=fpc"
+    "PP=fpc"
+    "DESTDIR=$(out)"
+  ];
+
+  postFixup = ''
+    libmysqlclient=$(find "${mysql57}/lib" -name "libmysqlclient.so.*" | tail -n1)
+    patchelf --add-needed "$libmysqlclient" "$out/bin/.cqrlog-wrapped"
+  '';
+
+  meta = with lib; {
+    description = "Linux logging program for amateur radio operators";
+    homepage = "https://www.cqrlog.com/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/radio/cqrlog/fix-makefile-lazarusdir.patch
+++ b/pkgs/applications/radio/cqrlog/fix-makefile-lazarusdir.patch
@@ -1,0 +1,13 @@
+Seulement dans b: logs
+diff --color -ur a/Makefile b/Makefile
+--- a/Makefile	2021-02-15 17:07:14.333810200 +0100
++++ b/Makefile	2021-02-15 17:19:18.599426984 +0100
+@@ -6,7 +6,7 @@
+ tmpdir   = /tmp
+ 
+ cqrlog: src/cqrlog.lpi
+-	$(CC) --ws=gtk2 --pcp=$(tmpdir)/.lazarus src/cqrlog.lpi
++	$(CC) --ws=gtk2 --pcp=$(tmpdir)/.lazarus --lazarusdir=@Lazarusdir@ src/cqrlog.lpi
+ 	$(ST) src/cqrlog
+ 	gzip tools/cqrlog.1 -c > tools/cqrlog.1.gz
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21516,6 +21516,8 @@ in
     python3Packages = python37Packages;
   };
 
+  cqrlog = callPackage ../applications/radio/cqrlog { };
+
   crun = callPackage ../applications/virtualization/crun {};
 
   csdp = callPackage ../applications/science/math/csdp { };


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/111164

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Need to configure the mysql db for further testing.