### PR TITLE
wrapFish: fix singleton expansion in shell init

### DIFF
--- a/pkgs/shells/fish/wrapper.nix
+++ b/pkgs/shells/fish/wrapper.nix
@@ -14,12 +14,12 @@ let
   complPath = completionDirs ++ map (vendorDir "completions") pluginPkgs;
   funcPath = functionDirs ++ map (vendorDir "functions") pluginPkgs;
   confPath = confDirs ++ map (vendorDir "conf") pluginPkgs;
-  safeConfPath = map escapeShellArg confPath;
 
 in writeShellScriptBin "fish" ''
   ${fish}/bin/fish --init-command "
     set --prepend fish_complete_path ${escapeShellArgs complPath}
     set --prepend fish_function_path ${escapeShellArgs funcPath}
-    for c in {${concatStringsSep "," safeConfPath}}/*; source $c; end
+    set --local fish_conf_source_path ${escapeShellArgs confPath}
+    for c in $fish_conf_source_path/*; source $c; end
   " "$@"
 '')


### PR DESCRIPTION
This fixes the expansion of the configuration path in the pathological
case of a singleton, which would otherwise be used verbatim with the
surrounding braces for lookup.

GitHub: see https://github.com/NixOS/nixpkgs/pull/108491#pullrequestreview-590072603

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
