### PR TITLE
python3Packages.ConfigArgParse: 1.2.3 -> 1.3

### DIFF
--- a/pkgs/development/python-modules/configargparse/default.nix
+++ b/pkgs/development/python-modules/configargparse/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "ConfigArgParse";
-  version = "1.2.3";
+  version = "1.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1p1pzpf5qpf80bfxsx1mbw9blyhhypjvhl3i60pbmhfmhvlpplgd";
+    sha256 = "sha256-BCi5datsSLsQHMtzLhtcthYpbigmjgMqqAbzK2R6HME=";
   };
 
   # no tests in tarball

--- a/pkgs/development/python-modules/configargparse/default.nix
+++ b/pkgs/development/python-modules/configargparse/default.nix
@@ -1,20 +1,31 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "ConfigArgParse";
   version = "1.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-BCi5datsSLsQHMtzLhtcthYpbigmjgMqqAbzK2R6HME=";
+  src = fetchFromGitHub {
+    owner = "bw2";
+    repo = pname;
+    rev = version;
+    sha256 = "147x781lgahn9r3gbhayhx1pf0iysf7q1hnr3kypy3p2k9v7a9mh";
   };
 
-  # no tests in tarball
-  doCheck = false;
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "configargparse" ];
 
   meta = with lib; {
     description = "A drop-in replacement for argparse";
-    homepage = "https://github.com/zorro3/ConfigArgParse";
+    homepage = "https://github.com/bw2/ConfigArgParse";
     license = licenses.mit;
     maintainers = [ maintainers.willibutz ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.3

Also, tests are now enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
