### PR TITLE
Add python-engineio_3 and python-socketio_4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3499,6 +3499,12 @@
     githubId = 6893840;
     name = "Yacine Hmito";
   };
+  graham33 = {
+    email = "graham@grahambennett.org";
+    github = "graham33";
+    githubId = 10908649;
+    name = "Graham Bennett";
+  };
   grahamc = {
     email = "graham@grahamc.com";
     github = "grahamc";

--- a/pkgs/development/python-modules/python-engineio/3.nix
+++ b/pkgs/development/python-modules/python-engineio/3.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, eventlet
+, iana-etc
+, libredirect
+, mock
+, requests
+, six
+, tornado
+, websocket_client
+, websockets
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "python-engineio";
+  version = "3.14.2";
+
+  src = fetchFromGitHub {
+    owner = "miguelgrinberg";
+    repo = "python-engineio";
+    rev = "v${version}";
+    sha256 = "1r3gvizrknbv036pvxid1l726wkb0l43bdaz5y879s7j3ipyb464";
+  };
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    aiohttp
+    eventlet
+    mock
+    requests
+    tornado
+    websocket_client
+    websockets
+    pytestCheckHook
+  ];
+
+  preCheck = lib.optionalString stdenv.isLinux ''
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf) \
+      LD_PRELOAD=${libredirect}/lib/libredirect.so
+  '';
+  postCheck = ''
+    unset NIX_REDIRECTS LD_PRELOAD
+  '';
+
+  # somehow effective log level does not change?
+  disabledTests = [ "test_logger" ];
+  pythonImportsCheck = [ "engineio" ];
+
+  meta = with lib; {
+    description = "Python based Engine.IO client and server v3.x";
+    longDescription = ''
+      Engine.IO is a lightweight transport protocol that enables real-time
+      bidirectional event-based communication between clients and a server.
+    '';
+    homepage = "https://github.com/miguelgrinberg/python-engineio/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ graham33 ];
+  };
+}

--- a/pkgs/development/python-modules/python-socketio/4.nix
+++ b/pkgs/development/python-modules/python-socketio/4.nix
@@ -1,0 +1,47 @@
+{ lib
+, bidict
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, python-engineio_3
+}:
+
+buildPythonPackage rec {
+  pname = "python-socketio";
+  version = "4.6.1";
+
+  src = fetchFromGitHub {
+    owner = "miguelgrinberg";
+    repo = "python-socketio";
+    rev = "v${version}";
+    sha256 = "14dijag17v84v0pp9qi89h5awb4h4i9rj0ppkixqv6is9z9lflw5";
+  };
+
+  propagatedBuildInputs = [
+    bidict
+    python-engineio_3
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "socketio" ];
+
+  # pytestCheckHook seems to change the default log level to WARNING, but the
+  # tests assert it is ERROR
+  disabledTests = [ "test_logger" ];
+
+  meta = with lib; {
+    description = "Python Socket.IO server and client 4.x";
+    longDescription = ''
+      Socket.IO is a lightweight transport protocol that enables real-time
+      bidirectional event-based communication between clients and a server.
+    '';
+    homepage = "https://github.com/miguelgrinberg/python-socketio/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ graham33 ];
+  };
+}

--- a/pkgs/development/python-modules/python-socketio/default.nix
+++ b/pkgs/development/python-modules/python-socketio/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
       Socket.IO is a lightweight transport protocol that enables real-time
       bidirectional event-based communication between clients and a server.
     '';
-    homepage = "https://github.com/miguelgrinberg/python-engineio/";
+    homepage = "https://github.com/miguelgrinberg/python-socketio/";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ mic92 ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6307,6 +6307,8 @@ in {
 
   python-engineio = callPackage ../development/python-modules/python-engineio { };
 
+  python-engineio_3 = callPackage ../development/python-modules/python-engineio/3.nix { };
+
   python-etcd = callPackage ../development/python-modules/python-etcd { };
 
   python_fedora = callPackage ../development/python-modules/python_fedora { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6449,6 +6449,8 @@ in {
 
   python-socketio = callPackage ../development/python-modules/python-socketio { };
 
+  python-socketio_4 = callPackage ../development/python-modules/python-socketio/4.nix { };
+
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python_statsd = callPackage ../development/python-modules/python_statsd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Socket.IO and Engine.IO protocols are not backwards-compatible and major versions of the client and server need to be coordinated.  It's therefore useful to have python-engineio 3.x and python-socketio 4.x available, but unstable has moved up to 4.x and 5.x respectively.  Happy to maintain these older versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
