### PR TITLE
ledger2beancount: 2.1 -> 2.5

### DIFF
--- a/pkgs/tools/text/ledger2beancount/default.nix
+++ b/pkgs/tools/text/ledger2beancount/default.nix
@@ -4,21 +4,26 @@ with lib;
 
 let
   perlDeps = with perlPackages; [
-    ConfigOnion DateCalc
-    FileBaseDir YAMLLibYAML
-    GetoptLongDescriptive DateTimeFormatStrptime
+    DateCalc
+    DateTimeFormatStrptime
+    enum
+    FileBaseDir
+    GetoptLongDescriptive
+    ListMoreUtils
+    RegexpCommon
     StringInterpolate
+    YAMLLibYAML
   ];
 
 in stdenv.mkDerivation rec {
   pname = "ledger2beancount";
-  version = "2.1";
+  version = "2.5";
 
   src = fetchFromGitHub {
-    owner = "zacchiro";
+    owner = "beancount";
     repo = "ledger2beancount";
     rev = version;
-    sha256 = "0w88jb1x0w02jwwf6ipx3cxr89kzffrrdqws3556zrvvs01bh84j";
+    sha256 = "0kimp8l9ax37grfv5r5iw0g0xnrpkak022fl10y3i7kc4nyi1s99";
   };
 
   phases = [
@@ -50,7 +55,7 @@ in stdenv.mkDerivation rec {
 
       Conversion is based on (concrete) syntax, so that information that is not meaningful for accounting reasons but still valuable (e.g., comments, formatting, etc.) can be preserved.
     '';
-    homepage = "https://github.com/zacchiro/ledger2beancount";
+    homepage = "https://github.com/beancount/ledger2beancount";
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ pablovsky ];


### PR DESCRIPTION
Also, move to fetch src off the official `beancount` github org and update
dependencies. I've run this on my ledger file and it seems to work without issue.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).