### PR TITLE
ocamlPackages.ppx_log: init at 0.14.0

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -533,6 +533,14 @@ rec {
     propagatedBuildInputs = [ ppxlib ];
   };
 
+  ppx_log = janePackage {
+    pname = "ppx_log";
+    hash = "10hnr5lpww3fw0bnidzngalbgy0j1wvz1g5ki9c9h558pnpvsazr";
+    minimumOCamlVersion = "4.08.0";
+    meta.description = "Ppx_sexp_message-like extension nodes for lazily rendering log messages";
+    propagatedBuildInputs = [ async_unix ppx_jane sexplib ];
+  };
+
   ppx_module_timer = janePackage {
     pname = "ppx_module_timer";
     hash = "163q1rpblwv82fxwyf0p4j9zpsj0jzvkfmzb03r0l49gqhn89mp6";


### PR DESCRIPTION
###### Motivation for this change

ppx_log is a syntax extension for lazily generating sexp log messages, depending on the current log verbosity level.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
