### PR TITLE
nixos/mastodon: use nodejs v12

### DIFF
--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -450,7 +450,7 @@ in {
         else { PORT = toString(cfg.streamingPort); }
       );
       serviceConfig = {
-        ExecStart = "${pkgs.nodejs-slim}/bin/node streaming";
+        ExecStart = "${cfg.package}/run-streaming.sh";
         Restart = "always";
         RestartSec = 20;
         EnvironmentFile = "/var/lib/mastodon/.secrets_env";

--- a/pkgs/servers/mastodon/default.nix
+++ b/pkgs/servers/mastodon/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, nodejs-slim, mkYarnPackage, fetchFromGitHub, bundlerEnv
-, yarn, callPackage, imagemagick, ffmpeg, file, ruby_2_7
+, yarn, callPackage, imagemagick, ffmpeg, file, ruby_2_7, writeShellScript
 
   # Allow building a fork or custom version of Mastodon:
 , pname ? "mastodon"
@@ -96,10 +96,18 @@ stdenv.mkDerivation rec {
     ln -s /var/log/mastodon log
     ln -s /tmp tmp
   '';
+
   propagatedBuildInputs = [ imagemagick ffmpeg file mastodon-gems.wrappedRuby ];
-  installPhase = ''
+
+  installPhase = let
+    run-streaming = writeShellScript "run-streaming.sh" ''
+      # NixOS helper script to consistently use the same NodeJS version the package was built with.
+      ${nodejs-slim}/bin/node ./streaming
+    '';
+  in ''
     mkdir -p $out
     cp -r * $out/
+    ln -s ${run-streaming} $out/run-streaming.sh
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17929,7 +17929,11 @@ in
 
   mailman-web = with python3.pkgs; toPythonApplication mailman-web;
 
-  mastodon = callPackage ../servers/mastodon { };
+  mastodon = callPackage ../servers/mastodon {
+    # With nodejs v14 the streaming endpoint breaks. Need migrate to uWebSockets.js or similar.
+    # https://github.com/tootsuite/mastodon/issues/15184
+    nodejs-slim = nodejs-slim-12_x;
+  };
 
   mattermost = callPackage ../servers/mattermost { };
   matterircd = callPackage ../servers/mattermost/matterircd.nix { };


### PR DESCRIPTION
###### Motivation for this change
This PR fixed streaming endpoint and this error:
```
[error] 12367#12367: *436 upstream timed out (110: Unknown error) while reading response header from upstream, client: 2a0d:..., server: my_server, request: "GET /api/v1/streaming/? HTTP/1.1", upstream: "http://unix:/run/mastodon-streaming/streaming.socket/api/v1/streaming/?", host: "my_server"
```
See https://github.com/tootsuite/mastodon/pull/15151 and https://github.com/tootsuite/mastodon/issues/15184
cc @erictapen @happy-river

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
