### PR TITLE
gopass-jsonapi: init at 1.11.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5848,6 +5848,12 @@
     githubId = 35892750;
     name = "Maxine Aubrey";
   };
+  maxhbr = {
+    email = "nixos@maxhbr.dev";
+    github = "maxhbr";
+    githubId = 1187050;
+    name = "Maximilian Huber";
+  };
   maxxk = {
     email = "maxim.krivchikov@gmail.com";
     github = "maxxk";

--- a/pkgs/tools/security/gopass/jsonapi.nix
+++ b/pkgs/tools/security/gopass/jsonapi.nix
@@ -1,0 +1,43 @@
+{ lib
+, makeWrapper
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, gopass
+}:
+
+buildGoModule rec {
+  pname = "gopass-jsonapi";
+  version = "1.11.1";
+
+  src = fetchFromGitHub {
+    owner = "gopasspw";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "03xhza7n92xg12z83as9qdvvc0yx1qy6q0c7i4njvng594f9a8x2";
+  };
+
+  vendorSha256 = "0d4fyppsdfzvmjb0qvpnfnw0vl6z256bly7hfb0whk6rldks60wr";
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  preBuild = ''
+    buildFlagsArray+=(
+      "-ldflags=-s -w -X main.version=${version} -X main.commit=${src.rev}"
+    )
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/gopass-jsonapi --prefix PATH : "${lib.makeBinPath [ gopass ]}"
+  '';
+
+  meta = with lib; {
+    description = "Enables communication with gopass via JSON messages";
+    homepage = "https://www.gopass.pw/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ maxhbr ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1397,6 +1397,8 @@ in
 
   gopass = callPackage ../tools/security/gopass { };
 
+  gopass-jsonapi = callPackage ../tools/security/gopass/jsonapi.nix { };
+
   gospider = callPackage ../tools/security/gospider { };
 
   browserpass = callPackage ../tools/security/browserpass { };


### PR DESCRIPTION
###### Motivation for this change

Gopass was split up into multiple packages extracting `gopass-jsonapi` (see https://github.com/gopasspw/gopass/blob/master/docs/setup.md#filling-in-passwords-from-browser). This adds the binary as an independent package. It is necessary for browser gopass integration via gopassbridge (see e.g. https://github.com/maxhbr/myconfig/blob/e3bab467f7f5c17eb9e70034c07445da6503739a/modules/services.xserver.programs.firefox.hm.nix#L12-L25) 

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
