### PR TITLE
skaffold: 1.17.2 -> 1.20.0

### DIFF
--- a/pkgs/development/tools/skaffold/default.nix
+++ b/pkgs/development/tools/skaffold/default.nix
@@ -1,13 +1,21 @@
-{ lib, buildGoPackage, fetchFromGitHub, installShellFiles }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "skaffold";
-  version = "1.17.2";
+  version = "1.20.0";
 
-  goPackagePath = "github.com/GoogleContainerTools/skaffold";
+  src = fetchFromGitHub {
+    owner = "GoogleContainerTools";
+    repo = "skaffold";
+    rev = "v${version}";
+    sha256 = "080zhksznwsyi0w1ban90vgh8y1q2703h3h4fvkwg695prd9ij66";
+  };
+
+  vendorSha256 = "1jvrk5jhjzg0dq0zg7p4hvjwda2289cmwh0ldz3269y8g3l113x8";
+
   subPackages = ["cmd/skaffold"];
 
-  buildFlagsArray = let t = "${goPackagePath}/pkg/skaffold"; in  ''
+  buildFlagsArray = let t = "github.com/GoogleContainerTools/skaffold/pkg/skaffold"; in  ''
     -ldflags=
       -s -w
       -X ${t}/version.version=v${version}
@@ -15,24 +23,24 @@ buildGoPackage rec {
       -X ${t}/version.buildDate=unknown
   '';
 
-  src = fetchFromGitHub {
-    owner = "GoogleContainerTools";
-    repo = "skaffold";
-    rev = "v${version}";
-    sha256 = "1sn4pmikap93kpdgcalgb3nam7zp60ck6wmynsv8dnzihrr7ycm3";
-  };
-
   nativeBuildInputs = [ installShellFiles ];
+
   postInstall = ''
-    for shell in bash zsh; do
-      $out/bin/skaffold completion $shell > skaffold.$shell
-      installShellCompletion skaffold.$shell
-    done
+    installShellCompletion --cmd skaffold \
+      --bash <($out/bin/skaffold completion bash) \
+      --zsh <($out/bin/skaffold completion zsh)
   '';
 
   meta = with lib; {
-    description = "Easy and Repeatable Kubernetes Development";
     homepage = "https://skaffold.dev/";
+    changelog = "https://github.com/GoogleContainerTools/skaffold/releases/tag/v${version}";
+    description = "Easy and Repeatable Kubernetes Development";
+    longDescription = ''
+      Skaffold is a command line tool that facilitates continuous development for Kubernetes applications.
+      You can iterate on your application source code locally then deploy to local or remote Kubernetes clusters.
+      Skaffold handles the workflow for building, pushing and deploying your application.
+      It also provides building blocks and describe customizations for a CI/CD pipeline.
+    '';
     license = licenses.asl20;
     maintainers = with maintainers; [ vdemeester ];
   };


### PR DESCRIPTION


###### Motivation for this change

I converted the `buildGoPackage` to a `buildGoModule` as described [here](https://nixos.org/manual/nixpkgs/stable/#ssec-go-modules).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
