### PR TITLE
haskellPackages.hadolint: fix build by disabling static linking

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -808,4 +808,6 @@ self: super: builtins.intersectAttrs super {
 
   # tests depend on a specific version of solc
   hevm = dontCheck (doJailbreak super.hevm);
+
+  hadolint = disableCabalFlag super.hadolint "static";
 }

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -809,5 +809,7 @@ self: super: builtins.intersectAttrs super {
   # tests depend on a specific version of solc
   hevm = dontCheck (doJailbreak super.hevm);
 
+  # hadolint enables static linking by default in the cabal file, so we have to explicitly disable it.
+  # https://github.com/hadolint/hadolint/commit/e1305042c62d52c2af4d77cdce5d62f6a0a3ce7b
   hadolint = disableCabalFlag super.hadolint "static";
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Right now `hadolint` build fails with linker errors:

```
hadolint> Linking dist/build/hadolint/hadolint ...
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lpthread
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lc
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lpthread
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lrt
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lutil
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -ldl
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lpthread
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lgmp
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lc
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lm
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lm
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lrt
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -ldl
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lffi
hadolint> /nix/store/rqfgki7ck1bxqhk3hd7wziqhahjadfbj-binutils-2.35.1/bin/ld.gold: error: cannot find -lpthread
hadolint> /nix/store/rdgyrdsijyjsc91gxjgg91ngiybl9a77-cryptonite-0.27/lib/ghc-8.10.4/x86_64-linux-ghc-8.10.4/cryptonite-0.27-A4EwJA9VB9sFur3TMsQfrm/libHScryptonite-0.27-A4EwJA9VB9sFur3TMsQfrm.a(Hash.o)(.text..Ls3jos_info+0x9a): error: undefined reference to 'memcpy'
hadolint> /nix/store/rdgyrdsijyjsc91gxjgg91ngiybl9a77-cryptonite-0.27/lib/ghc-8.10.4/x86_64-linux-ghc-8.10.4/cryptonite-0.27-A4EwJA9VB9sFur3TMsQfrm/libHScryptonite-0.27-A4EwJA9VB9sFur3TMsQfrm.a(Types.o):function cryptonitezm0zi27zmA4EwJA9VB9sFur3TMsQfrm_CryptoziHashziTypes_zdfByteArrayAccessDigest1_info: error: undefined reference to 'memcpy'
… and so on …
```

This is because the `static` flag was enabled by default for 1.22.1:

  https://github.com/hadolint/hadolint/commit/e1305042c62d52c2af4d77cdce5d62f6a0a3ce7b#diff-e0ee4e21f8811c1171864cc68ea4005347b1b0ca70626026f251bf4111c2aa6e

We need to disable it in nixpkgs.

Previous chapters in this story:
 - #69311 
 - #86161

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
