### PR TITLE
redis-desktop-manager: Fix 'missing plugin "xcb"'

### DIFF
--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchFromGitiles, pkg-config, libssh2
+{ mkDerivation, lib, fetchFromGitHub, fetchFromGitiles, pkg-config, libssh2
 , qtbase, qtdeclarative, qtgraphicaleffects, qtimageformats, qtquickcontrols
 , qtsvg, qttools, qtquick1, qtcharts
 , qmake
@@ -13,7 +13,7 @@ let
 
 in
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "redis-desktop-manager";
   version = "0.9.1";
 

--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, lib, fetchFromGitHub, fetchFromGitiles, pkg-config, libssh2
 , qtbase, qtdeclarative, qtgraphicaleffects, qtimageformats, qtquickcontrols
-, qtsvg, qttools, qtquick1, qtcharts
+, qtquickcontrols2, qtsvg, qttools, qtquick1, qtcharts
 , qmake
 }:
 
@@ -28,7 +28,7 @@ mkDerivation rec {
   nativeBuildInputs = [ pkg-config qmake ];
   buildInputs = [
     libssh2 qtbase qtdeclarative qtgraphicaleffects qtimageformats
-    qtquick1 qtquickcontrols qtsvg qttools qtcharts
+    qtquick1 qtquickcontrols qtquickcontrols2 qtsvg qttools qtcharts
   ];
 
   dontUseQmakeConfigure = true;

--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, lib, fetchFromGitHub, fetchFromGitiles, pkg-config, libssh2
-, qtbase, qtdeclarative, qtgraphicaleffects, qtimageformats, qtquickcontrols
-, qtquickcontrols2, qtsvg, qttools, qtquick1, qtcharts
+, qtbase, qtdeclarative, qtgraphicaleffects, qtimageformats, qtquickcontrols2
+, qtsvg, qttools, qtquick1, qtcharts
 , qmake
 }:
 
@@ -28,7 +28,7 @@ mkDerivation rec {
   nativeBuildInputs = [ pkg-config qmake ];
   buildInputs = [
     libssh2 qtbase qtdeclarative qtgraphicaleffects qtimageformats
-    qtquick1 qtquickcontrols qtquickcontrols2 qtsvg qttools qtcharts
+    qtquick1 qtquickcontrols2 qtsvg qttools qtcharts
   ];
 
   dontUseQmakeConfigure = true;

--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -76,7 +76,7 @@ EOF
   meta = with lib; {
     description = "Cross-platform open source Redis DB management tool";
     homepage = "https://redisdesktop.com/";
-    license = licenses.lgpl21;
+    license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The current redis desktop manager fails to start when installed with `nix-env`. The error is:

```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

This appears to be due to using stdenv.mkDerivation instead of the mkDerivation set by the `libsForQt5.callPackage`. Furthermore, after fixing this, another issue came up: The application would fail to start due to a missing dependency on qtquickcontrols2. This was fixed by adding the missing dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
