### PR TITLE
treewide: add targetPrefix to hardcoded references to CC=cc

### DIFF
--- a/pkgs/applications/editors/jed/default.nix
+++ b/pkgs/applications/editors/jed/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "CC=cc"
+    "CC=${stdenv.cc.targetPrefix}cc"
     "--with-slang=${slang}"
     "JED_ROOT=${placeholder "out"}/share/jed"
   ];

--- a/pkgs/applications/editors/viw/default.nix
+++ b/pkgs/applications/editors/viw/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses ];
 
-  makeFlags = [ "CC=cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
   checkFlags = [ "test-command" "test-buffer" "test-state" ];
 
   installPhase = ''

--- a/pkgs/applications/misc/gpscorrelate/default.nix
+++ b/pkgs/applications/misc/gpscorrelate/default.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "prefix=${placeholder "out"}"
-    "CC=cc"
-    "CXX=c++"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "CXX=${stdenv.cc.targetPrefix}c++"
     "CFLAGS=-DENABLE_NLS"
   ];
 

--- a/pkgs/applications/misc/tty-solitaire/default.nix
+++ b/pkgs/applications/misc/tty-solitaire/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = "sed -i -e '/^CFLAGS *?= *-g *$/d' Makefile";
 
-  makeFlags = [ "CC=cc" "PREFIX=${placeholder "out"}" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "PREFIX=${placeholder "out"}" ];
 
   meta = with lib; {
     description = "Klondike Solitaire in your ncurses terminal";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     "DATA_ROOT_DIR_PURPLE=${placeholder "out"}/share"
   ];
 
-  buildFlags = [ "CC=cc" ]; # fix build on darwin
+  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ]; # fix build on darwin
 
   meta = with lib; {
     homepage = "https://github.com/matrix-org/purple-matrix";

--- a/pkgs/applications/science/biology/bcftools/default.nix
+++ b/pkgs/applications/science/biology/bcftools/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "HSTDIR=${htslib}"
     "prefix=$(out)"
-    "CC=cc"
+    "CC=${stdenv.cc.targetPrefix}cc"
   ];
 
   preCheck = ''

--- a/pkgs/applications/science/biology/prodigal/default.nix
+++ b/pkgs/applications/science/biology/prodigal/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   makeFlags = [
-    "CC=cc"
+    "CC=${stdenv.cc.targetPrefix}cc"
     "INSTALLDIR=$(out)/bin"
   ];
 

--- a/pkgs/applications/science/math/gfan/default.nix
+++ b/pkgs/applications/science/math/gfan/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace "-fno-guess-branch-probability" ""
   '';
 
-  buildFlags = [ "CC=cc" "CXX=c++" ];
+  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "CXX=${stdenv.cc.targetPrefix}c++" ];
   installFlags = [ "PREFIX=$(out)" ];
   buildInputs = [ gmp mpir cddlib ];
 

--- a/pkgs/applications/science/math/msieve/default.nix
+++ b/pkgs/applications/science/math/msieve/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   ECM = if ecm == null then "0" else "1";
 
   # Doesn't hurt Linux but lets clang-based platforms like Darwin work fine too
-  makeFlags = [ "CC=cc" "all" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "all" ];
 
   installPhase = ''
     mkdir -p $out/bin/

--- a/pkgs/applications/science/math/ratpoints/default.nix
+++ b/pkgs/applications/science/math/ratpoints/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gmp ];
 
-  makeFlags = [ "CC=cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
   buildFlags = lib.optional stdenv.isDarwin ["CCFLAGS2=-lgmp -lc -lm" "CCFLAGS=-UUSE_SSE"];
   installFlags = [ "INSTALL_DIR=$(out)" ];
 

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -248,10 +248,10 @@ in stdenv.mkDerivation {
     # Need these tools on the build system when cross compiling,
     # hacky, but have found no other way.
     preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
-      CXX=c++ LD=ld make -C tools/depends/native/JsonSchemaBuilder
+      CXX=${stdenv.cc.targetPrefix}c++ LD=ld make -C tools/depends/native/JsonSchemaBuilder
       cmakeFlags+=" -DWITH_JSONSCHEMABUILDER=$PWD/tools/depends/native/JsonSchemaBuilder/bin"
 
-      CXX=c++ LD=ld make EXTRA_CONFIGURE= -C tools/depends/native/TexturePacker
+      CXX=${stdenv.cc.targetPrefix}c++ LD=ld make EXTRA_CONFIGURE= -C tools/depends/native/TexturePacker
       cmakeFlags+=" -DWITH_TEXTUREPACKER=$PWD/tools/depends/native/TexturePacker/bin"
     '';
 

--- a/pkgs/applications/window-managers/windowmaker/dockapps/wmsm-app.nix
+++ b/pkgs/applications/window-managers/windowmaker/dockapps/wmsm-app.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       --replace "/usr/bin/install" "install"
   '';
 
-  makeFlags = [ "CC=cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   preInstall = ''
     runHook preInstall

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   preInstall = ''
      mv zic.o zic.o.orig
      mv zic zic.orig
-     make $makeFlags cc=cc AR=ar zic
+     make $makeFlags cc=${stdenv.cc.targetPrefix}cc AR=${stdenv.cc.targetPrefix}ar zic
      mv zic zic-native
      mv zic.o.orig zic.o
      mv zic.orig zic

--- a/pkgs/development/compilers/mosml/default.nix
+++ b/pkgs/development/compilers/mosml/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gmp perl ];
 
-  makeFlags = [ "PREFIX=$(out)" ] ++ lib.optionals stdenv.isDarwin [ "CC=${stdenv.cc.targetPrefix}cc" ];
+  makeFlags = [ "PREFIX=$(out)" "CC=${stdenv.cc.targetPrefix}cc" ];
 
   src = fetchurl {
     url = "https://github.com/kfl/mosml/archive/ver-${version}.tar.gz";

--- a/pkgs/development/compilers/mosml/default.nix
+++ b/pkgs/development/compilers/mosml/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gmp perl ];
 
-  makeFlags = [ "PREFIX=$(out)" ] ++ lib.optionals stdenv.isDarwin [ "CC=cc" ];
+  makeFlags = [ "PREFIX=$(out)" ] ++ lib.optionals stdenv.isDarwin [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   src = fetchurl {
     url = "https://github.com/kfl/mosml/archive/ver-${version}.tar.gz";

--- a/pkgs/development/compilers/owl-lisp/default.nix
+++ b/pkgs/development/compilers/owl-lisp/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ which ];
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" "CC=cc" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" "CC=${stdenv.cc.targetPrefix}cc" ];
 
   # tests are run as part of the compilation process
   doCheck = false;

--- a/pkgs/development/libraries/java/junixsocket/default.nix
+++ b/pkgs/development/libraries/java/junixsocket/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ANT_ARGS =
     # Note that our OpenJDK on Darwin is currently 32-bit, so we have to build a 32-bit dylib.
     (if stdenv.is64bit then [ "-Dskip32=true" ] else [ "-Dskip64=true" ])
-    ++ [ "-Dgcc=cc" "-Dant.build.javac.source=1.6" ]
+    ++ [ "-Dgcc=${stdenv.cc.targetPrefix}cc" "-Dant.build.javac.source=1.6" ]
     ++ lib.optional stdenv.isDarwin "-DisMac=true";
 
   installPhase =

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -61,7 +61,7 @@ let
       "--enable-avplay"
       "--enable-shared"
       "--enable-runtime-cpudetect"
-      "--cc=cc"
+      "--cc=${stdenv.cc.targetPrefix}cc"
       (enableFeature enableGPL "gpl")
       (enableFeature enableGPL "swscale")
       (enableFeature mp3Support "libmp3lame")

--- a/pkgs/development/libraries/mysocketw/default.nix
+++ b/pkgs/development/libraries/mysocketw/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
         --replace -Wl,-soname, -Wl,-install_name,$out/lib/
   '';
 
-  makeFlags = [ "PREFIX=$(out)" "CXX=c++" ];
+  makeFlags = [ "PREFIX=$(out)" "CXX=${stdenv.cc.targetPrefix}c++" ];
 
   meta = {
     description = "Cross platform (Linux/FreeBSD/Unix/Win32) streaming socket C++";

--- a/pkgs/development/libraries/ntl/default.nix
+++ b/pkgs/development/libraries/ntl/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
       else
         "generic" # "chooses options that should be OK for most platforms"
     }"
-    "CXX=c++"
+    "CXX=${stdenv.cc.targetPrefix}c++"
   ] ++ lib.optionals withGf2x [
     "NTL_GF2X_LIB=on"
     "GF2X_PREFIX=${gf2x}"

--- a/pkgs/development/libraries/odpic/default.nix
+++ b/pkgs/development/libraries/odpic/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
     ++ lib.optionals stdenv.isLinux [ libaio ];
 
   dontPatchELF = true;
-  makeFlags = [ "PREFIX=$(out)" "CC=cc" "LD=cc"];
+  makeFlags = [ "PREFIX=$(out)" "CC=${stdenv.cc.targetPrefix}cc" "LD=${stdenv.cc.targetPrefix}cc"];
 
   postFixup = ''
     ${lib.optionalString (stdenv.isLinux) ''

--- a/pkgs/development/libraries/science/math/zn_poly/default.nix
+++ b/pkgs/development/libraries/science/math/zn_poly/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   libbasename = "libzn_poly";
   libext = stdenv.targetPlatform.extensions.sharedLibrary;
 
-  makeFlags = [ "CC=cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   # Tuning (either autotuning or with hand-written paramters) is possible
   # but not implemented here.

--- a/pkgs/development/libraries/sonic/default.nix
+++ b/pkgs/development/libraries/sonic/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0ah54nizb6iwcx277w104wsfnx05vrp4sh56d2pfxhf8xghg54m6";
   };
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" "CC=cc" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" "CC=${stdenv.cc.targetPrefix}cc" ];
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/development/tools/misc/elfkickers/default.nix
+++ b/pkgs/development/tools/misc/elfkickers/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "02354yn1lh1dxny35ky2d0b44iq302krsqpwk5grr4glma00hhq6";
   };
 
-  makeFlags = [ "CC=cc prefix=$(out)" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc prefix=$(out)" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/misc/micronucleus/default.nix
+++ b/pkgs/development/tools/misc/micronucleus/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libusb-compat-0_1 ];
-  makeFlags = lib.optionals stdenv.isDarwin [ "CC=cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/development/tools/misc/sloccount/default.nix
+++ b/pkgs/development/tools/misc/sloccount/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  makeFlags = [ "PREFIX=$(out)" "CC=cc" ];
+  makeFlags = [ "PREFIX=$(out)" "CC=${stdenv.cc.targetPrefix}cc" ];
 
   doCheck = true;
   checkPhase = ''HOME="$TMPDIR" PATH="$PWD:$PATH" make test'';

--- a/pkgs/development/tools/misc/stm32flash/default.nix
+++ b/pkgs/development/tools/misc/stm32flash/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "01p396daqw3zh6nijffbfbwyqza33bi2k4q3m5yjzs02xwi99alp";
   };
 
-  buildFlags = [ "CC=cc" ];
+  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     # Manually copy, make install copies to /usr/local/bin

--- a/pkgs/games/assaultcube/default.nix
+++ b/pkgs/games/assaultcube/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ file zlib ] ++ optionals client [ openal SDL SDL_image libogg libvorbis ];
 
   targets = (optionalString server "server") + (optionalString client " client");
-  makeFlags = [ "-C source/src" "CXX=c++" targets ];
+  makeFlags = [ "-C source/src" "CXX=${stdenv.cc.targetPrefix}c++" targets ];
 
   desktop = makeDesktopItem {
     name = "AssaultCube";

--- a/pkgs/games/crawl/default.nix
+++ b/pkgs/games/crawl/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, which, sqlite, lua5_1, perl, python3, zlib, pkg-config, ncurses
 , dejavu_fonts, libpng, SDL2, SDL2_image, SDL2_mixer, libGLU, libGL, freetype, pngcrush, advancecomp
-, tileMode ? false, enableSound ? tileMode
+, tileMode ? false, enableSound ? tileMode, buildPackages
 
 # MacOS / Darwin builds
 , darwin ? null
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   fontsPath = lib.optionalString tileMode dejavu_fonts;
 
-  makeFlags = [ "prefix=${placeholder "out"}" "FORCE_CC=${stdenv.cc.targetPrefix}cc" "FORCE_CXX=${stdenv.cc.targetPrefix}c++" "HOSTCXX=${stdenv.cc.targetPrefix}c++"
+  makeFlags = [ "prefix=${placeholder "out"}" "FORCE_CC=${stdenv.cc.targetPrefix}cc" "FORCE_CXX=${stdenv.cc.targetPrefix}c++" "HOSTCXX=${buildPackages.stdenv.cc.targetPrefix}c++"
                 "FORCE_PKGCONFIG=y"
                 "SAVEDIR=~/.crawl" "sqlite=${sqlite.dev}"
                 "DATADIR=${placeholder "out"}"

--- a/pkgs/games/crawl/default.nix
+++ b/pkgs/games/crawl/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   fontsPath = lib.optionalString tileMode dejavu_fonts;
 
-  makeFlags = [ "prefix=${placeholder "out"}" "FORCE_CC=cc" "FORCE_CXX=c++" "HOSTCXX=c++"
+  makeFlags = [ "prefix=${placeholder "out"}" "FORCE_CC=${stdenv.cc.targetPrefix}cc" "FORCE_CXX=${stdenv.cc.targetPrefix}c++" "HOSTCXX=${stdenv.cc.targetPrefix}c++"
                 "FORCE_PKGCONFIG=y"
                 "SAVEDIR=~/.crawl" "sqlite=${sqlite.dev}"
                 "DATADIR=${placeholder "out"}"

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -60,7 +60,7 @@ in stdenv.mkDerivation rec {
       -e 's,^WINTTYLIB=.*,WINTTYLIB=-lncurses,' \
       -i sys/unix/hints/linux
     sed \
-      -e 's,^CC=.*$,CC=cc,' \
+      -e 's,^CC=.*$,CC=${stdenv.cc.targetPrefix}cc,' \
       -e 's,^HACKDIR=.*$,HACKDIR=\$(PREFIX)/games/lib/\$(GAME)dir,' \
       -e 's,^SHELLDIR=.*$,SHELLDIR=\$(PREFIX)/games,' \
       -e 's,^CFLAGS=-g,CFLAGS=,' \

--- a/pkgs/games/zdoom/bcc-git.nix
+++ b/pkgs/games/zdoom/bcc-git.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
 
   enableParallelBuilding = true;
-  makeFlags = ["CC=cc"];
+  makeFlags = ["CC=${stdenv.cc.targetPrefix}cc"];
 
   patches = [ ./bcc-warning-fix.patch ];
 

--- a/pkgs/misc/emulators/simh/default.nix
+++ b/pkgs/misc/emulators/simh/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   dontConfigure = true;
 
-  makeFlags = [ "GCC=cc" "CC_STD=-std=c99" "LDFLAGS=-lm" ];
+  makeFlags = [ "GCC=${stdenv.cc.targetPrefix}cc" "CC_STD=-std=c99" "LDFLAGS=-lm" ];
 
   preInstall = ''
     install -d ${placeholder "out"}/bin

--- a/pkgs/os-specific/linux/libvolume_id/default.nix
+++ b/pkgs/os-specific/linux/libvolume_id/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   };
 
   preBuild = "
-    makeFlagsArray=(prefix=$out E=echo RANLIB=ranlib INSTALL='install -c')
+    makeFlagsArray=(prefix=$out E=echo RANLIB=${stdenv.cc.targetPrefix}ranlib INSTALL='install -c')
   ";
 
   # Work around a broken Makefile.

--- a/pkgs/tools/X11/setroot/default.nix
+++ b/pkgs/tools/X11/setroot/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libX11 imlib2 ]
     ++ lib.optional enableXinerama libXinerama;
 
-  buildFlags = [ "CC=cc" (if enableXinerama then "xinerama=1" else "xinerama=0") ] ;
+  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" (if enableXinerama then "xinerama=1" else "xinerama=0") ] ;
 
   installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 

--- a/pkgs/tools/archivers/unar/default.nix
+++ b/pkgs/tools/archivers/unar/default.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     for f in Makefile.linux ../UniversalDetector/Makefile.linux ; do
       substituteInPlace $f \
-        --replace "= gcc" "=cc" \
-        --replace "= g++" "=c++" \
+        --replace "= gcc" "=${stdenv.cc.targetPrefix}cc" \
+        --replace "= g++" "=${stdenv.cc.targetPrefix}c++" \
         --replace "-DGNU_RUNTIME=1" "" \
         --replace "-fgnu-runtime" "-fobjc-nonfragile-abi"
     done

--- a/pkgs/tools/cd-dvd/bchunk/default.nix
+++ b/pkgs/tools/cd-dvd/bchunk/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "12dxx98kbpc5z4dgni25280088bhlsb677rp832r82zzc1drpng7";
   };
 
-  makeFlags = lib.optionals stdenv.cc.isClang [ "CC=cc" "LD=cc" ];
+  makeFlags = lib.optionals stdenv.cc.isClang [ "CC=${stdenv.cc.targetPrefix}cc" "LD=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     install -Dt $out/bin bchunk

--- a/pkgs/tools/cd-dvd/cue2pops/default.nix
+++ b/pkgs/tools/cd-dvd/cue2pops/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   dontConfigure = true;
 
-  makeFlags = [ "CC=cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     install --directory --mode=755 $out/bin

--- a/pkgs/tools/compression/hactool/default.nix
+++ b/pkgs/tools/compression/hactool/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     mv config.mk.template config.mk
   '';
 
-  makeFlags = lib.optionals stdenv.isDarwin [ "CC=${stdenv.cc.targetPrefix}cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     install -D hactool $out/bin/hactool

--- a/pkgs/tools/compression/hactool/default.nix
+++ b/pkgs/tools/compression/hactool/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     mv config.mk.template config.mk
   '';
 
-  makeFlags = lib.optionals stdenv.isDarwin [ "CC=cc" ];
+  makeFlags = lib.optionals stdenv.isDarwin [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     install -D hactool $out/bin/hactool

--- a/pkgs/tools/graphics/pngcrush/default.nix
+++ b/pkgs/tools/graphics/pngcrush/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0l43c59d6v9l0g07z3q3ywhb8xb3vz74llv3mna0izk9bj6aqkiv";
   };
 
-  makeFlags = [ "CC=cc" "LD=cc" ];      # gcc and/or clang compat
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "LD=${stdenv.cc.targetPrefix}cc" ];      # gcc and/or clang compat
 
   configurePhase = ''
     sed -i s,/usr,$out, Makefile

--- a/pkgs/tools/misc/convbin/default.nix
+++ b/pkgs/tools/misc/convbin/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0n502zj8igm583kbfvyv7zhd97vb71jac41ncb9jr2yz2v5ir8j9";
   };
 
-  makeFlags = [ "CC=cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   checkPhase = ''
     pushd test

--- a/pkgs/tools/misc/convfont/default.nix
+++ b/pkgs/tools/misc/convfont/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "1lj24yq5gj9hxhy1srk73521q95zyqzkws0q4v271hf5wmqaxa2f";
   };
 
-  makeFlags = [ "CC=cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     install -Dm755 convfont $out/bin/convfont

--- a/pkgs/tools/misc/convimg/default.nix
+++ b/pkgs/tools/misc/convimg/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  makeFlags = [ "CC=cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   checkPhase = ''
     pushd test

--- a/pkgs/tools/misc/moreutils/default.nix
+++ b/pkgs/tools/misc/moreutils/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = with perlPackages; [ perl IPCRun TimeDate TimeDuration ];
 
-  buildFlags = [ "CC=cc" ];
+  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
   installFlags = [ "PREFIX=$(out)" ];
 
   postInstall = ''

--- a/pkgs/tools/misc/tldr/default.nix
+++ b/pkgs/tools/misc/tldr/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ curl libzip ];
   nativeBuildInputs = [ pkg-config ];
 
-  makeFlags = ["CC=cc" "LD=cc" "CFLAGS="];
+  makeFlags = ["CC=${stdenv.cc.targetPrefix}cc" "LD=${stdenv.cc.targetPrefix}cc" "CFLAGS="];
 
   installFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/tools/misc/unclutter/default.nix
+++ b/pkgs/tools/misc/unclutter/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   buildInputs = [xlibsWrapper];
 
-  buildFlags = [ "CC=cc" ];
+  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     mkdir -pv "$out/bin"

--- a/pkgs/tools/networking/connect/default.nix
+++ b/pkgs/tools/networking/connect/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "00yld6yinc8s4xv3b8kbvzn2f4rja5dmp6ysv3n4847qn4k60dh7";
   };
 
-  makeFlags = [ "CC=cc" ];      # gcc and/or clang compat
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];      # gcc and/or clang compat
 
   installPhase = ''
     install -D -m ugo=rx connect $out/bin/connect

--- a/pkgs/tools/networking/flvstreamer/default.nix
+++ b/pkgs/tools/networking/flvstreamer/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildPhase = ''
-    make CC=cc posix
+    make CC=${stdenv.cc.targetPrefix}cc posix
   '';
 
   installPhase = ''

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     "USE_GETADDRINFO=1"
   ] ++ lib.optionals withPrometheusExporter [
     "EXTRA_OBJS=contrib/prometheus-exporter/service-prometheus.o"
-  ] ++ lib.optional stdenv.isDarwin "CC=cc";
+  ] ++ lib.optional stdenv.isDarwin "CC=${stdenv.cc.targetPrefix}cc";
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     "USE_GETADDRINFO=1"
   ] ++ lib.optionals withPrometheusExporter [
     "EXTRA_OBJS=contrib/prometheus-exporter/service-prometheus.o"
-  ] ++ lib.optional stdenv.isDarwin "CC=${stdenv.cc.targetPrefix}cc";
+  ] ++ [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/security/apg/default.nix
+++ b/pkgs/tools/security/apg/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     substituteInPlace Makefile --replace /usr/local "$out"
   '';
-  makeFlags = lib.optionals stdenv.isDarwin ["CC=${stdenv.cc.targetPrefix}cc"];
+  makeFlags = ["CC=${stdenv.cc.targetPrefix}cc"];
 
   patches = [
     ./apg.patch

--- a/pkgs/tools/security/apg/default.nix
+++ b/pkgs/tools/security/apg/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     substituteInPlace Makefile --replace /usr/local "$out"
   '';
-  makeFlags = lib.optionals stdenv.isDarwin ["CC=cc"];
+  makeFlags = lib.optionals stdenv.isDarwin ["CC=${stdenv.cc.targetPrefix}cc"];
 
   patches = [
     ./apg.patch

--- a/pkgs/tools/security/masscan/default.nix
+++ b/pkgs/tools/security/masscan/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
-  makeFlags = [ "PREFIX=$(out)" "GITVER=${version}" "CC=cc" ];
+  makeFlags = [ "PREFIX=$(out)" "GITVER=${version}" "CC=${stdenv.cc.targetPrefix}cc" ];
 
   preInstall = ''
     mkdir -p $out/bin

--- a/pkgs/tools/security/sslscan/default.nix
+++ b/pkgs/tools/security/sslscan/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ];
 
-  makeFlags = [ "PREFIX=$(out)" "CC=cc" ];
+  makeFlags = [ "PREFIX=$(out)" "CC=${stdenv.cc.targetPrefix}cc" ];
 
   meta = with lib; {
     description = "Tests SSL/TLS services and discover supported cipher suites";

--- a/pkgs/tools/security/stricat/default.nix
+++ b/pkgs/tools/security/stricat/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1axg8r4g5n5kdqj5013pgck80nni3z172xkg506vz4zx1zcmrm4r";
   };
 
-  buildFlags = [ "CC=cc" ];
+  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/tools/text/boxes/default.nix
+++ b/pkgs/tools/text/boxes/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
                 "GLOBALCONF=${placeholder "out"}/share/boxes/boxes-config"
   '';
 
-  makeFlags = lib.optionals stdenv.isDarwin [ "CC=cc" ];
+  makeFlags = lib.optionals stdenv.isDarwin [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     install -Dm755 -t $out/bin src/boxes

--- a/pkgs/tools/text/boxes/default.nix
+++ b/pkgs/tools/text/boxes/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
                 "GLOBALCONF=${placeholder "out"}/share/boxes/boxes-config"
   '';
 
-  makeFlags = lib.optionals stdenv.isDarwin [ "CC=${stdenv.cc.targetPrefix}cc" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     install -Dm755 -t $out/bin src/boxes

--- a/pkgs/tools/video/yamdi/default.nix
+++ b/pkgs/tools/video/yamdi/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "4a6630f27f6c22bcd95982bf3357747d19f40bd98297a569e9c77468b756f715";
   };
 
-  buildFlags = [ "CC=cc" ];
+  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     install -D {,$out/bin/}yamdi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
While working on fixing cross-compilation of some packages, I noticed that over and over I had to replace `CC=cc` with `CC=${stdenv.cc.targetPrefix}cc` so that it would use the cross-compiler. I have made this change treewide.

Should not affect `build -> build` compilation since the prefix becomes the empty string.

Replicate with

```ShellSession
$ find pkgs -type f -name '*nix' | xargs sed -i '' 's/CXX=c\+\+/CXX=\$\{stdenv\.cc\.targetPrefix\}c\+\+/g'
$ find pkgs -type f -name '*nix' | xargs sed -i '' 's/LD=cc/LD=\$\{stdenv\.cc\.targetPrefix\}cc/g'
$ find pkgs -type f -name '*nix' | xargs sed -i '' 's/CC=cc/CC=\$\{stdenv\.cc\.targetPrefix\}cc/g'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
