### PR TITLE
smartmontools: drop mailutils dependency by default

### DIFF
--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, autoreconfHook
-, mailutils, enableMail ? true
-, inetutils
+, enableMail ? false, mailutils, inetutils
 , IOKit, ApplicationServices }:
 
 let
@@ -23,15 +22,17 @@ in stdenv.mkDerivation rec {
     sha256 = "1mlc25sd5rgj5xmzcllci47inmfdw7cp185fday6hc9rwqkqmnaw";
   };
 
-  patches = [ ./smartmontools.patch ];
+  patches = [
+    # fixes darwin build
+    ./smartmontools.patch
+  ];
   postPatch = "cp -v ${driverdb} drivedb.h";
 
-  configureFlags = [
-    "--with-scriptpath=${lib.makeBinPath ([ inetutils ] ++ lib.optional enableMail mailutils)}"
-  ];
+  configureFlags = lib.optional enableMail
+    "--with-scriptpath=${lib.makeBinPath [ inetutils mailutils ]}";
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [] ++ lib.optionals stdenv.isDarwin [IOKit ApplicationServices];
+  buildInputs = lib.optionals stdenv.isDarwin [ IOKit ApplicationServices ];
   enableParallelBuilding = true;
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
mailutils somehow depends on OpenSSL 1.0.2 on macOS, which is marked as insecure and thus prevents this package from being built on Hydra. Excluding it by default should re-enable binary builds for users who don't need the email feature.

This change is unlikely to be a disruptive one. The mailutils dependency is supplemental and is either omitted or optional on Arch[1], Debian[2], Fedora[3], and Homebrew[4]. It isn't strictly a build time dependency either, so it could be picked up from the runtime PATH even we drop the build time dependency.

This change also makes the dependance on inetutils optional. inetutils is needed for the 'hostname' command, and is only used for providing email support.

[1]: https://archlinux.org/packages/extra/x86_64/smartmontools/
[2]: https://sources.debian.org/src/smartmontools/7.2-1/debian/control/
[3]: https://src.fedoraproject.org/rpms/smartmontools/blob/rawhide/f/smartmontools.spec
[4]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/smartmontools.rb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Impact on package closure size
Before: 193.1 MB
After: 9.9 MB