### PR TITLE
virt-manager: support building on darwin

### DIFF
--- a/pkgs/data/misc/osinfo-db/default.nix
+++ b/pkgs/data/misc/osinfo-db/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "Osinfo database of information about operating systems for virtualization provisioning tools";
     homepage = "https://gitlab.com/libosinfo/osinfo-db/";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     description = "GObject based library API for managing information about operating systems, hypervisors and the (virtual) hardware devices they can support";
     homepage = "https://libosinfo.org/";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -12,8 +12,12 @@ stdenv.mkDerivation rec {
     sha256 = "1zpbv4ninc57c9rw4zmmkvvqn7154iv1qfr20kyxn8xplalqrzvz";
   };
 
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1304981
+  patches = [ ./rm-version-script-linker-flag.patch ];
+
   nativeBuildInputs = [ pkg-config intltool vala gobject-introspection ];
-  buildInputs = [ libcap_ng libvirt libxml2 gobject-introspection ];
+  buildInputs = [ libvirt libxml2 gobject-introspection ]
+    ++ lib.optional (!stdenv.isDarwin) [ libcap_ng  ];
 
   enableParallelBuilding = true;
   strictDeps = true;
@@ -30,6 +34,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://libvirt.org/";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libvirt-glib/rm-version-script-linker-flag.patch
+++ b/pkgs/development/libraries/libvirt-glib/rm-version-script-linker-flag.patch
@@ -1,0 +1,33 @@
+diff -ZNaur a/libvirt-gconfig/Makefile.in b/libvirt-gconfig/Makefile.in
+--- a/libvirt-gconfig/Makefile.in	2019-11-26 13:37:24.000000000 +0100
++++ b/libvirt-gconfig/Makefile.in	2021-02-16 12:14:38.106167715 +0100
+@@ -844,7 +844,6 @@
+ libvirt_gconfig_1_0_la_LDFLAGS = \
+ 			$(COVERAGE_CFLAGS:-f%=-Wc,f%) \
+ 			$(CYGWIN_EXTRA_LDFLAGS) $(MINGW_EXTRA_LDFLAGS) \
+-			-Wl,--version-script=$(srcdir)/libvirt-gconfig.sym \
+ 			-version-info $(LIBVIRT_GLIB_VERSION_INFO)
+ 
+ BUILT_SOURCES = $(GCONFIG_GENERATED_FILES)
+diff -ZNaur a/libvirt-glib/Makefile.in b/libvirt-glib/Makefile.in
+--- a/libvirt-glib/Makefile.in	2019-11-26 13:37:24.000000000 +0100
++++ b/libvirt-glib/Makefile.in	2021-02-16 12:14:58.544075496 +0100
+@@ -437,7 +437,6 @@
+ libvirt_glib_1_0_la_LDFLAGS = \
+ 			$(COVERAGE_CFLAGS:-f%=-Wc,f%) \
+ 			$(CYGWIN_EXTRA_LDFLAGS) $(MINGW_EXTRA_LDFLAGS) \
+-			-Wl,--version-script=$(srcdir)/libvirt-glib.sym \
+ 			-version-info $(LIBVIRT_GLIB_VERSION_INFO)
+ 
+ INTROSPECTION_GIRS = $(am__append_1)
+diff -ZNaur a/libvirt-gobject/Makefile.in b/libvirt-gobject/Makefile.in
+--- a/libvirt-gobject/Makefile.in	2019-11-26 13:37:24.000000000 +0100
++++ b/libvirt-gobject/Makefile.in	2021-02-16 12:15:08.498376955 +0100
+@@ -542,7 +542,6 @@
+ libvirt_gobject_1_0_la_LDFLAGS = \
+ 			$(COVERAGE_CFLAGS:-f%=-Wc,f%) \
+ 			$(CYGWIN_EXTRA_LDFLAGS) $(MINGW_EXTRA_LDFLAGS) \
+-			-Wl,--version-script=$(srcdir)/libvirt-gobject.sym \
+ 			-version-info $(LIBVIRT_GLIB_VERSION_INFO)
+ 
+ BUILT_SOURCES = $(GOBJECT_GENERATED_FILES)

--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/vcrhonek/hwdata";
     description = "Hardware Database, including Monitors, pci.ids, usb.ids, and video cards";
     license = lib.licenses.gpl2;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/misc/osinfo-db-tools/default.nix
+++ b/pkgs/tools/misc/osinfo-db-tools/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "Tools for managing the osinfo database";
     homepage = "https://libosinfo.org/";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This enables building and running `virt-manager` on darwin. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
