### PR TITLE
authy: init at 1.8.3

### DIFF
--- a/pkgs/applications/misc/authy/default.nix
+++ b/pkgs/applications/misc/authy/default.nix
@@ -1,0 +1,110 @@
+{ alsaLib, at-spi2-atk, at-spi2-core, atk, autoPatchelfHook, cairo, cups
+, dbus, electron_9, expat, fetchurl, gdk-pixbuf, glib, gtk3, lib
+, libappindicator-gtk3, libdbusmenu-gtk3, libuuid, makeWrapper
+, nspr, nss, pango, squashfsTools, stdenv, systemd, xorg
+}:
+
+let
+  # Currently only works with electron 9
+  electron = electron_9;
+in
+
+stdenv.mkDerivation rec {
+  pname = "authy";
+  version = "1.8.3";
+  rev = "5";
+
+  buildInputs = [
+    alsaLib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    gdk-pixbuf
+    glib
+    gtk3
+    libappindicator-gtk3
+    libdbusmenu-gtk3
+    libuuid
+    nspr
+    nss
+    pango
+    stdenv.cc.cc
+    systemd
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libxcb
+  ];
+
+  src = fetchurl {
+    url = "https://api.snapcraft.io/api/v1/snaps/download/H8ZpNgIoPyvmkgxOWw5MSzsXK1wRZiHn_${rev}.snap";
+    sha256 = "1yfvkmy34mc1dan9am11yka88jv7a4dslsszy4kcc8vap4cjmgpn";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper squashfsTools ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    unsquashfs "$src"
+    cd squashfs-root
+    if ! grep -q '${version}' meta/snap.yaml; then
+      echo "Package version differs from version found in snap metadata:"
+      grep 'version: ' meta/snap.yaml
+      echo "While the nix package specifies: ${version}."
+      echo "You probably chose the wrong revision or forgot to update the nix version."
+      exit 1
+    fi
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/
+
+    cp -r ./* $out/
+    rm -R ./*
+
+    # The snap package has the `ffmpeg.so` file which is copied over with other .so files
+    mv $out/*.so $out/lib/
+
+    # Replace icon name in Desktop file
+    sed -i 's|''${SNAP}/meta/gui/icon.png|authy|g' "$out/meta/gui/authy.desktop"
+
+    # Move the desktop file, icon, binary to their appropriate locations
+    mkdir -p $out/bin $out/share/applications $out/share/pixmaps/apps
+    cp $out/meta/gui/authy.desktop $out/share/applications/
+    cp $out/meta/gui/icon.png $out/share/pixmaps/authy.png
+    cp $out/${pname} $out/bin/${pname}
+
+    # Cleanup
+    rm -r $out/{data-dir,gnome-platform,meta,scripts,usr,*.sh,*.so}
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
+      --add-flags $out/resources/app.asar
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.authy.com";
+    description = "Twilio Authy two factor authentication desktop application";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ iammrinal0 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -158,6 +158,8 @@ in
 
   fishnet = callPackage ../servers/fishnet { };
 
+  authy = callPackage ../applications/misc/authy { };
+
   avro-tools = callPackage ../development/tools/avro-tools { };
 
   bacnet-stack = callPackage ../tools/networking/bacnet-stack {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package [Authy](https://snapcraft.io/authy). Closes #112697

This is my first init package. I'd like some feedback on how things can be simplified. Adding a few things that I personally had difficulty with and/or learnt through the process:
* I started off with having the `buildInputs` in the `let` block due to which `autoPatchelfHook` could not find the required libraries.
* Found out from  [Nixos Wiki](https://nixos.wiki/wiki/Packaging/Binaries) that I needn't `patchelf` manually and `autoPatchelfHook` will take care of finding the required libraries based on `buildInputs`.
* Instead of running the `authy` binary, we could run the electron app directly. So wrapped the app with `electron`
* The existing derivation for `spotify` helped as a reference for `snap` apps and am glad that it had good comments around it.

I had support from quite a few helpful people over at the NixOS Discord which made this a bit easier as they also debugged it to help out in getting this sorted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
