### PR TITLE
ocamlPackages.base64: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/base64/default.nix
+++ b/pkgs/development/ocaml-modules/base64/default.nix
@@ -1,20 +1,21 @@
-{ lib, fetchurl, buildDunePackage, alcotest, bos, dune-configurator }:
+{ lib, fetchurl, buildDunePackage, ocaml, alcotest, bos, rresult }:
 
 buildDunePackage rec {
   pname = "base64";
-  version = "3.4.0";
+  version = "3.5.0";
+
+  minimumOCamlVersion = "4.03";
 
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-base64/releases/download/v${version}/base64-v${version}.tbz";
-    sha256 = "0d0n5gd4nkdsz14jnxq13f1f7rzxmndg5xql039a8wfppmazd70w";
+    sha256 = "sha256-WJ3pwAV46/54QZismBjTWGxHSyMWts0+HEbMsfYq46Q=";
   };
 
-  buildInputs = [ bos dune-configurator ];
-
-  doCheck = true;
-  checkInputs = [ alcotest ];
+  # otherwise fmt breaks evaluation
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  checkInputs = [ alcotest bos rresult ];
 
   meta = {
     homepage = "https://github.com/mirage/ocaml-base64";


### PR DESCRIPTION
#112955, fixed and cleaned up:

dune-configurator is no longer necessary.

Also do some minor cleanups like:

* moving bos to checkInputs
* adding rresult to checkInputs
* adding minimumOCamlVersion
* make doCheck conditional to fix evaluation for ocaml < 4.05

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
