### PR TITLE
ocamlPackages.uucp: 11.0.0 -> 13.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -2,11 +2,13 @@
 
 let
   pname = "uucp";
-  version = "11.0.0";
+  version = "13.0.0";
   webpage = "https://erratique.ch/software/${pname}";
+  minimumOCamlVersion = "4.03";
 in
 
-assert lib.versionAtLeast ocaml.version "4.01";
+assert lib.assertMsg (lib.versionAtLeast ocaml.version minimumOCamlVersion)
+  "${pname} needs at least OCaml ${minimumOCamlVersion}";
 
 stdenv.mkDerivation {
 
@@ -14,7 +16,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "0pidg2pmqsifmk4xx9cc5p5jprhg26xb68g1xddjm7sjzbdzhlm4";
+    sha256 = "sha256-OPpHbCOC/vMFdyHwyhCSisUv2PyO8xbeY2oq1a9HbqY=";
   };
 
   buildInputs = [ ocaml findlib ocamlbuild topkg uutf uunf ];

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -1,10 +1,11 @@
-{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, uchar, uutf, uunf }:
+{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, uchar, uutf, uunf, uucd }:
 
 let
   pname = "uucp";
   version = "13.0.0";
   webpage = "https://erratique.ch/software/${pname}";
   minimumOCamlVersion = "4.03";
+  doCheck = true;
 in
 
 assert lib.assertMsg (lib.versionAtLeast ocaml.version minimumOCamlVersion)
@@ -23,9 +24,21 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [ uchar ];
 
-  buildPhase = "${topkg.buildPhase} --with-cmdliner false";
+  buildPhase = ''
+    runHook preBuild
+    ${topkg.buildPhase} --with-cmdliner false --tests ${lib.boolToString doCheck}
+    runHook postBuild
+  '';
 
   inherit (topkg) installPhase;
+
+  inherit doCheck;
+  checkPhase = ''
+    runHook preCheck
+    ${topkg.run} test
+    runHook postCheck
+  '';
+  checkInputs = [ uucd ];
 
   meta = with lib; {
     description = "An OCaml library providing efficient access to a selection of character properties of the Unicode character database";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/dbuenzli/uucp/blob/master/CHANGES.md#v1300-2020-03-10-la-forclaz-vs>

Fixed up #112347 and enabled tests.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
