### PR TITLE
nix-prefetch-git: Run git-init with --initial-branch=master

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -105,7 +105,7 @@ fi
 
 init_remote(){
     local url=$1
-    clean_git init
+    clean_git init --initial-branch=master
     clean_git remote add origin "$url"
     ( [ -n "$http_proxy" ] && clean_git config http.proxy "$http_proxy" ) || true
 }


### PR DESCRIPTION
**Edit:** Please cast your vote on `master` vs. `main` here: https://github.com/NixOS/nixpkgs/pull/113313#issuecomment-780589956

---

The reason for this change is simply to avoid the following messages
that are unnecessary and can be confusing (and these messages will be
repeated for each submodule):
```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
```

This shouldn't cause any hashes to change and nix-prefetch-git uses the
"fetchgit" branch anyway:
```
Switched to a new branch 'fetchgit'
```

For that reason the initial branch name doesn't really matter anyway and
since we're not relying on / hardcoding "master" we can simply switch to
"main" (which seems most common nowadays).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without this change (I'm using an image to showcase the yellow color that makes it look like a warning):
![image](https://user-images.githubusercontent.com/7537109/108076635-f0481700-706b-11eb-93b3-5e23cb245ac8.png)

With this change:
![image](https://user-images.githubusercontent.com/7537109/108076700-0229ba00-706c-11eb-9427-6d43fa8ad88d.png)

Tested using (**edit:** `--check` doesn't work to test this btw, which I only found out later - luckily I ran additional tests though):
```
nix-build -A iwd.src --check # Doesn't use submodules
nix-build -A tev.src --check # Uses submodules, even recursively
```

cc @bjornfor

We could (/should?) also test this on `staging` first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
