### PR TITLE
ocamlPackages.stdint: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/stdint/default.nix
+++ b/pkgs/development/ocaml-modules/stdint/default.nix
@@ -1,17 +1,38 @@
-{ lib, fetchFromGitHub, buildDunePackage }:
+{ lib, fetchurl, fetchpatch, buildDunePackage, qcheck }:
 
 buildDunePackage rec {
   pname = "stdint";
-  version = "0.6.0";
+  version = "0.7.0";
 
-  minimumOCamlVersion = "4.07";
+  useDune2 = true;
 
-  src = fetchFromGitHub {
-    owner = "andrenth";
-    repo = "ocaml-stdint";
-    rev = version;
-    sha256 = "19ccxs0vij81vyc9nqc9kbr154ralb9dgc2y2nr71a5xkx6xfn0y";
+  minimumOCamlVersion = "4.03";
+
+  src = fetchurl {
+    url = "https://github.com/andrenth/ocaml-stdint/releases/download/${version}/stdint-${version}.tbz";
+    sha256 = "4fcc66aef58e2b96e7af3bbca9d910aa239e045ba5fb2400aaef67d0041252dc";
   };
+
+  patches = [
+    # fix test bug, remove at next release
+    (fetchpatch {
+      url = "https://github.com/andrenth/ocaml-stdint/commit/fc64293f99f597cdfd4470954da6fb323988e2af.patch";
+      sha256 = "0nxck14vfjfzldsf8cdj2jg1cvhnyh37hqnrcxbdkqmpx4rxkbxs";
+    })
+  ];
+
+  # disable remaining broken tests, see
+  # https://github.com/andrenth/ocaml-stdint/issues/59
+  postPatch = ''
+    substituteInPlace tests/stdint_test.ml \
+      --replace 'test "An integer should perform left-shifts correctly"' \
+                'skip "An integer should perform left-shifts correctly"' \
+      --replace 'test "Logical shifts must not sign-extend"' \
+                'skip "Logical shifts must not sign-extend"'
+  '';
+
+  doCheck = true;
+  checkInputs = [ qcheck ];
 
   meta = {
     description = "Various signed and unsigned integers for OCaml";


### PR DESCRIPTION
Fixed version of #106072

<https://github.com/andrenth/ocaml-stdint/releases/tag/0.7.0>

* Lower minimumOCamlVersion like upstream.
* Enable tests which unfortunately require some fixing up.
* Use `fetchurl`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
