### PR TITLE
Added ruby gem postrunner

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8628,6 +8628,12 @@
     email = "nfjinjing@gmail.com";
     name = "Jinjing Wang";
   };
+  ngiger = {
+    email = "niklaus.giger@member.fsf.org";
+    github = "ngiger";
+    githubId = 265800;
+    name = "Niklaus Giger";
+  };
   nh2 = {
     email = "mail@nh2.me";
     matrix = "@nh2:matrix.org";

--- a/pkgs/applications/misc/postrunner/Gemfile
+++ b/pkgs/applications/misc/postrunner/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'postrunner'

--- a/pkgs/applications/misc/postrunner/Gemfile.lock
+++ b/pkgs/applications/misc/postrunner/Gemfile.lock
@@ -1,0 +1,25 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bindata (2.4.10)
+    fit4ruby (3.9.0)
+      bindata (~> 2.4.8)
+    mini_portile2 (2.7.1)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
+    perobs (4.3.0)
+    postrunner (1.0.5)
+      fit4ruby (~> 3.9.0)
+      nokogiri
+      perobs (~> 4.3.0)
+    racc (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  postrunner
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/applications/misc/postrunner/default.nix
+++ b/pkgs/applications/misc/postrunner/default.nix
@@ -1,0 +1,21 @@
+# To run it call: nix-build -A postrunner.tests
+{ lib, bundlerApp, bundlerUpdateScript, callPackage }:
+
+bundlerApp {
+  pname = "postrunner";
+  gemdir = ./.;
+  exes = [ "postrunner" ];
+  passthru.updateScript = bundlerUpdateScript "postrunner";
+  passthru.tests = {
+    simple-execution = callPackage ./tests.nix { };
+  };
+
+
+  meta = with lib; {
+    description = "PostRunner is an application to manage FIT files produced by Garmin products";
+    homepage    = "https://github.com/scrapper/postrunner";
+    license     = licenses.gpl2Only;
+    maintainers = with maintainers; [ ngiger ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/applications/misc/postrunner/gemset.nix
+++ b/pkgs/applications/misc/postrunner/gemset.nix
@@ -1,0 +1,75 @@
+{
+  bindata = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06lqi4svq5qls9f7nnvd2zmjdqmi2sf82sq78ci5d78fq0z5x2vr";
+      type = "gem";
+    };
+    version = "2.4.10";
+  };
+  fit4ruby = {
+    dependencies = ["bindata"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1s30g027v0pvk53fgkszm1qj7mmljgam4gwd9wbljap7i4c32w7d";
+      type = "gem";
+    };
+    version = "3.9.0";
+  };
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0d3ga166pahsxavzwj19yjj4lr13rw1vsb36s2qs8blcxigrdp6z";
+      type = "gem";
+    };
+    version = "2.7.1";
+  };
+  nokogiri = {
+    dependencies = ["mini_portile2" "racc"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zqzawia52cdcmi55lp7v8jmiqyw7pcpwsksqlnirwfm3f7bnf11";
+      type = "gem";
+    };
+    version = "1.13.1";
+  };
+  perobs = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cygqn869fvlsiq27qfg5ak8dr7pagp8yqr34h0hvzg8h8yq9fjq";
+      type = "gem";
+    };
+    version = "4.3.0";
+  };
+  postrunner = {
+    dependencies = ["fit4ruby" "nokogiri" "perobs"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "116xs2zn1178906ybpfll3f1k0jai2ccr3bxq1c175faiskdalxg";
+      type = "gem";
+    };
+    version = "1.0.5";
+  };
+  racc = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0la56m0z26j3mfn1a9lf2l03qx1xifanndf9p3vx1azf6sqy7v9d";
+      type = "gem";
+    };
+    version = "1.6.0";
+  };
+}

--- a/pkgs/applications/misc/postrunner/tests.nix
+++ b/pkgs/applications/misc/postrunner/tests.nix
@@ -1,0 +1,20 @@
+{ runCommand, postrunner, stdenv }:
+
+let
+  inherit (postrunner) name;
+  version = (import ./gemset.nix).postrunner.version;
+in
+
+runCommand "${name}-tests" { meta.timeout = 3; }
+  ''
+    # get version of installed program and compare with package version
+    if [[ `${postrunner}/bin/postrunner version` != *"${version}"*  ]]; then
+      echo "Error: program version does not match package version"
+      exit 1
+    fi
+    # run help
+    ${postrunner}/bin/postrunner --help | grep 'Usage postrunner .command. .options.'
+    echo All test for $name passed
+    # needed for Nix to register the command as successful
+    touch $out
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26485,6 +26485,8 @@ with pkgs;
     buildGoModule = buildGo117Module;
   };
 
+  postrunner = callPackage ../applications/misc/postrunner { };
+
   slack = callPackage ../applications/networking/instant-messengers/slack { };
 
   slack-cli = callPackage ../tools/networking/slack-cli { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a ruby gem I use for importing FIT data after jogging

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I am puzzled, that testing it locally does not work, as show by
```export NIXPKGS=/opt/src/nixpkgs
nix-build $NIXPKGS -A postrunner
/nix/store/hir9dlqwcxzliakqwzvvmvmn1hhwvk3a-postrunner-1.0.4
result/bin/postrunner --version
Traceback (most recent call last):
9: from result/bin/postrunner:18:in `<main>'
8: from /nix/store/iwxp1n2manz98yrkznqmpfvq07h4nax6-bundler-2.1.4/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler.rb:149:in `setup'
7: from /nix/store/iwxp1n2manz98yrkznqmpfvq07h4nax6-bundler-2.1.4/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:20:in `setup'
6: from /nix/store/iwxp1n2manz98yrkznqmpfvq07h4nax6-bundler-2.1.4/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:101:in `block in definition_method'
5: from /nix/store/iwxp1n2manz98yrkznqmpfvq07h4nax6-bundler-2.1.4/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/definition.rb:226:in `requested_specs'
4: from /nix/store/iwxp1n2manz98yrkznqmpfvq07h4nax6-bundler-2.1.4/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/definition.rb:237:in `specs_for'
3: from /nix/store/iwxp1n2manz98yrkznqmpfvq07h4nax6-bundler-2.1.4/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/definition.rb:170:in `specs'
2: from /nix/store/iwxp1n2manz98yrkznqmpfvq07h4nax6-bundler-2.1.4/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/spec_set.rb:80:in `materialize'
1: from /nix/store/iwxp1n2manz98yrkznqmpfvq07h4nax6-bundler-2.1.4/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/spec_set.rb:80:in `map!'
/nix/store/iwxp1n2manz98yrkznqmpfvq07h4nax6-bundler-2.1.4/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/spec_set.rb:86:in `block in materialize': Could not find bindata-2.4.8 in any of the sources (Bundler::GemNotFound)
```
Running the tests via `nix-build nixos/tests/postrunner.nix` shows not problem.
But this is the same with gollum (another ruby gem) I tested with.