### PR TITLE
linuxPackages_latest.hid-playstation: init at unstable-2021-02-25

### DIFF
--- a/pkgs/os-specific/linux/hid-playstation/default.nix
+++ b/pkgs/os-specific/linux/hid-playstation/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchgit, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "hid-playstation-${kernel.version}";
+  version = "unstable-2021-02-25";
+
+  src = fetchgit {
+    url = "https://aur.archlinux.org/hid-playstation-dkms.git";
+    rev = "91d7194235d5d1116c038edf40fc2720f14353ec";
+    sha256 = "sha256-Uv1Wd8Fkho2EYSkwFhqQ0c6zE6W/sjHqOHnS2caOc4A=";
+  };
+
+  patches = [ "${src}/disable-ff-enabled-check.patch" ];
+
+  makeFlags = [
+    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "DESTDIR=\${out}/lib/modules/${kernel.modDirVersion}/kernel/drivers/hid"
+  ];
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/hid"
+  '';
+
+  meta = with lib; {
+    description = "Sony's official HID driver for the PS5 DualSense controller";
+    homepage = "https://patchwork.kernel.org/project/linux-input/list/?series=429573";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ samuelgrf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19258,6 +19258,8 @@ in
 
     gcadapter-oc-kmod = callPackage ../os-specific/linux/gcadapter-oc-kmod { };
 
+    hid-playstation = if lib.versionAtLeast kernel.version "5.10" then callPackage ../os-specific/linux/hid-playstation { } else null;
+
     hyperv-daemons = callPackage ../os-specific/linux/hyperv-daemons { };
 
     e1000e = if lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

PS5 controller (DualSense) support.

I don't think it makes sense to merge this pr since `hid-playstation` is likely going to be merged into the kernel soon.
I'm opening this as a draft for people who want to use the controller right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
