### PR TITLE
gnome3.gnome-autoar: 0.2.4 -> 0.3.0

### DIFF
--- a/pkgs/desktops/gnome-3/misc/gnome-autoar/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-autoar/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-autoar";
-  version = "0.2.4";
+  version = "0.3.0";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-autoar/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0yk56ch46n3wfy633mq31kif9n7v06rlij4vqbsbn6l4z1vw6d0a";
+    sha256 = "0ssqckfkyldwld88zizy446y2359rg40lnrcm3sjpjhc2b015hgj";
   };
 
   passthru = {
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     platforms = platforms.linux;
     maintainers = teams.gnome.members;
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
     description = "Library to integrate compressed files management with GNOME";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes CVE-2020-36241.
Changes: https://gitlab.gnome.org/GNOME/gnome-autoar/-/blob/0.3.0/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>20 packages built:</summary>
  <ul>
    <li>adapta-gtk-theme</li>
    <li>chrome-gnome-shell</li>
    <li>dropbox-cli</li>
    <li>gnome-recipes</li>
    <li>gnome3.file-roller</li>
    <li>gnome3.gnome-autoar</li>
    <li>gnome3.gnome-control-center</li>
    <li>gnome3.gnome-session</li>
    <li>gnome3.gnome-shell</li>
    <li>gnome3.gnome-terminal</li>
    <li>gnome3.gnome-tweak-tool</li>
    <li>gnome3.gnome-user-share</li>
    <li>gnome3.nautilus</li>
    <li>gnome3.nautilus-python</li>
    <li>gnome3.pomodoro</li>
    <li>gnomeExtensions.easyScreenCast</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.night-theme-switcher</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.extra-elementary-contracts</li>
  </ul>
</details>