### PR TITLE
lrzip: 0.631 -> 0.640

### DIFF
--- a/pkgs/tools/compression/lrzip/default.nix
+++ b/pkgs/tools/compression/lrzip/default.nix
@@ -1,15 +1,19 @@
-{lib, stdenv, fetchurl, zlib, lzo, bzip2, nasm, perl}:
+{lib, stdenv, fetchurl, zlib, lzo, bzip2, lz4, nasm, perl}:
 
 stdenv.mkDerivation rec {
-  version = "0.631";
+  version = "0.640";
   pname = "lrzip";
 
   src = fetchurl {
-    url = "http://ck.kolivas.org/apps/lrzip/${pname}-${version}.tar.bz2";
-    sha256 = "0mb449vmmwpkalq732jdyginvql57nxyd31sszb108yps1lf448d";
+    url = "http://ck.kolivas.org/apps/lrzip/${pname}-${version}.tar.xz";
+    sha256 = "175466drfpz8rsfr0pzfn5rqrj3wmcmcs3i2sfmw366w2kbjm4j9";
   };
 
-  buildInputs = [ zlib lzo bzip2 nasm perl ];
+  buildInputs = [ zlib lzo bzip2 lz4 nasm perl ];
+
+  configureFlags = [
+    "--disable-asm"
+  ];
 
   meta = {
     homepage = "http://ck.kolivas.org/apps/lrzip/";


### PR DESCRIPTION
###### Motivation for this change
#90873

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
