### PR TITLE
libthai: Fix cross & make multi output

### DIFF
--- a/pkgs/development/libraries/libdatrie/default.nix
+++ b/pkgs/development/libraries/libdatrie/default.nix
@@ -7,6 +7,8 @@ stdenv.mkDerivation rec {
   pname = "libdatrie";
   version = "2019-12-20";
 
+  outputs = [ "bin" "out" "lib" "dev" ];
+
   src = fetchFromGitHub {
     owner = "tlwg";
     repo = "libdatrie";

--- a/pkgs/development/libraries/libthai/default.nix
+++ b/pkgs/development/libraries/libthai/default.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation rec {
   pname = "libthai";
   version = "0.1.28";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "https://github.com/tlwg/libthai/releases/download/v${version}/libthai-${version}.tar.xz";
     sha256 = "04g93bgxrcnay9fglpq2lj9nr7x1xh06i60m7haip8as9dxs3q7z";
@@ -11,7 +13,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  nativeBuildInputs = [ installShellFiles libdatrie pkg-config ];
+  nativeBuildInputs = [ installShellFiles (lib.getBin libdatrie) pkg-config ];
 
   buildInputs = [ libdatrie ];
 


### PR DESCRIPTION
###### Motivation for this change
~Fixing cross (already fixed on staging)~ Reducing some closure size.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
