### PR TITLE
xtrt: init at 61884fb

### DIFF
--- a/pkgs/tools/archivers/xtrt/default.nix
+++ b/pkgs/tools/archivers/xtrt/default.nix
@@ -1,0 +1,36 @@
+{ bzip2, fetchFromGitHub, gzip, gnutar, lib, stdenv, unzip, xz }:
+
+stdenv.mkDerivation rec {
+  pname = "xtrt";
+  version = "unstable-2021-02-17";
+
+  src = fetchFromGitHub {
+    owner = "figsoda";
+    repo = pname;
+    rev = "61884fb7c48c7e1e2194afd82b85f415a6dc7c20";
+    sha256 = "073l4q6mx5if791p5a6w8m8bz2aypmjmycaijq4spql8bh6h12vf";
+  };
+
+  postPatch = ''
+    substituteInPlace xtrt \
+      --replace "bzip2 " "${bzip2}/bin/bzip2 " \
+      --replace "gzip " "${gzip}/bin/gzip " \
+      --replace "tar " "${gnutar}/bin/tar " \
+      --replace "unzip " "${unzip}/bin/unzip " \
+      --replace "xz " "${xz}/bin/xz "
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp xtrt $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tiny script to extract archives by their extensions";
+    homepage = "https://github.com/figsoda/xtrt";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -748,6 +748,8 @@ in
 
   metapixel = callPackage ../tools/graphics/metapixel { };
 
+  xtrt = callPackage ../tools/archivers/xtrt { };
+
   yabridge = callPackage ../tools/audio/yabridge {
     wine = wineWowPackages.minimal;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

xtrt is a tiny script to extract archives by their extensions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
