### PR TITLE
nixos/mastodon: fix group membership for nginx

### DIFF
--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -111,7 +111,6 @@ in {
       group = lib.mkOption {
         description = ''
           Group under which mastodon runs.
-          If it is set to "mastodon", a group will be created.
         '';
         type = lib.types.str;
         default = "mastodon";
@@ -555,10 +554,9 @@ in {
         };
       })
       (lib.attrsets.setAttrByPath [ cfg.user "packages" ] [ cfg.package mastodonEnv ])
-      (lib.mkIf cfg.configureNginx {${config.services.nginx.user}.extraGroups = [ cfg.user ];})
     ];
 
-    users.groups.mastodon = lib.mkIf (cfg.group == "mastodon") { };
+    users.groups.${cfg.group}.members = lib.optional cfg.configureNginx config.services.nginx.user;
   };
 
   meta.maintainers = with lib.maintainers; [ happy-river erictapen ];


### PR DESCRIPTION


###### Motivation for this change

4255954d972a67d2e50104cb4c72a0f22e1234dd set the StateDirectory to 0750, but nginx wasn't in the Mastodon group. This led to nginx not being able to access e.g. `/var/lib/mastodon/public-system/media_attachments/files/`. This commit also deletes a line, that was probably intended to serve this purpose, but makes no sense. Why should the Mastodon user be added as an extraGroup to the nginx user?

Also let's create the `cfg.group` unconditionally, as I don't see any reason to have it not created and it would make the logic much more complex.

See also the [nextcloud module](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/web-apps/nextcloud.nix#L575) for a similar pattern.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
