### PR TITLE
mcrypt: remove unwanted info from patch

### DIFF
--- a/pkgs/tools/misc/mcrypt/malloc_to_stdlib.patch
+++ b/pkgs/tools/misc/mcrypt/malloc_to_stdlib.patch
@@ -1,5 +1,5 @@
 From e295844e8ef5c13487996ab700e5f12a7fadb1a6 Mon Sep 17 00:00:00 2001
-From: Nima Vasseghi <nmv@fb.com>
+From: Private <private@private.priv>
 Date: Wed, 30 Dec 2020 16:06:46 -0800
 Subject: [PATCH] malloc.h to stdlib.h in rfc2440.c
 


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Removes unwanted personally identifiable info so that it is not searchable on GitHub.

###### Things done
Anonymizes email and name on the particular patch

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
