### PR TITLE
libtpms: init at 0.7.4

### DIFF
--- a/pkgs/tools/security/libtpms/default.nix
+++ b/pkgs/tools/security/libtpms/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkgconfig
+, autoconf, automake, libtool
+, openssl, perl
+, tpm2Support ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libtpms";
+  version = "0.7.4";
+
+  src = fetchFromGitHub {
+    owner = "stefanberger";
+    repo = "libtpms";
+    rev = "v${version}";
+    sha256 = "sha256-nZSBD3WshlZHVMBFmDBBdFkhBjNgtASfg6+lYOOAhZ8=";
+  };
+
+  nativeBuildInputs = [
+    autoconf automake libtool
+    pkgconfig
+    perl # needed for pod2man
+  ];
+  buildInputs = [
+    openssl
+  ];
+
+  outputs = [
+    "out"
+    "lib"
+    "man"
+    "dev"
+  ];
+  patchPhase = ''
+    patchShebangs bootstrap.sh
+  '';
+  preConfigure = ''
+    ./bootstrap.sh
+  '';
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--with-openssl"
+  ] ++ lib.optionals tpm2Support [
+    "--with-tpm2" # TPM2 support is flagged experimental by upstream
+  ];
+
+  meta = {
+    description = "The libtpms library provides software emulation of a Trusted Platform Module (TPM 1.2 and TPM 2.0)";
+    homepage = https://github.com/stefanberger/libtpms;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.baloo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
