### PR TITLE
swtpm: init at 0.5.2

### DIFF
--- a/pkgs/tools/security/libtpms/default.nix
+++ b/pkgs/tools/security/libtpms/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config, autoreconfHook
+, openssl, perl
+, tpm2Support ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libtpms";
+  version = "0.7.4";
+
+  src = fetchFromGitHub {
+    owner = "stefanberger";
+    repo = "libtpms";
+    rev = "v${version}";
+    sha256 = "sha256-nZSBD3WshlZHVMBFmDBBdFkhBjNgtASfg6+lYOOAhZ8=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    perl # needed for pod2man
+  ];
+  buildInputs = [ openssl ];
+
+  outputs = [ "out" "lib" "man" "dev" ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--with-openssl"
+  ] ++ lib.optionals tpm2Support [
+    "--with-tpm2" # TPM2 support is flagged experimental by upstream
+  ];
+
+  meta = with lib; {
+    description = "The libtpms library provides software emulation of a Trusted Platform Module (TPM 1.2 and TPM 2.0)";
+    homepage = "https://github.com/stefanberger/libtpms";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.baloo ];
+  };
+}

--- a/pkgs/tools/security/swtpm/default.nix
+++ b/pkgs/tools/security/swtpm/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, libtasn1, openssl, fuse, glib, libseccomp
+, libtpms
+, unixtools, expect, socat
+, gnutls
+, perl
+, python3, python3Packages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "swtpm";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "stefanberger";
+    repo = "swtpm";
+    rev = "v${version}";
+    sha256 = "sha256-KY5V4z/8I15ePjorgZueNahlD/xvFa3tDarA0tuRxFk=";
+  };
+
+  pythonPath = with python3Packages; requiredPythonModules [
+    setuptools
+    cryptography
+  ];
+
+  patches = [
+    # upstream looks for /usr directory in $prefix to check
+    # whether or not to proceed with installation of python
+    # tools (swtpm_setup utility).
+    ./python-installation.patch
+  ];
+
+  prePatch = ''
+    patchShebangs src/swtpm_setup/setup.py
+    patchShebangs samples/setup.py
+  '';
+
+  nativeBuildInputs = [
+    pkg-config unixtools.netstat expect socat
+    perl # for pod2man
+    autoreconfHook
+    python3
+  ];
+  buildInputs = [
+    libtpms
+    openssl libtasn1 libseccomp
+    fuse glib
+    gnutls
+    python3.pkgs.wrapPython
+  ];
+  propagatedBuildInputs = pythonPath;
+
+  configureFlags = [
+    "--with-cuse"
+  ];
+
+  postInstall = ''
+    wrapPythonProgramsIn $out/bin "$out $pythonPath"
+    wrapPythonProgramsIn $out/share/swtpm "$out $pythonPath"
+  '';
+
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "man" ];
+
+  meta = with lib; {
+    description = "Libtpms-based TPM emulator";
+    homepage = "https://github.com/stefanberger/swtpm";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.baloo ];
+  };
+}

--- a/pkgs/tools/security/swtpm/python-installation.patch
+++ b/pkgs/tools/security/swtpm/python-installation.patch
@@ -1,0 +1,60 @@
+commit 353794feb596d95e3f8893e39b174c5a89d1013e
+Author: Arthur Gautier <baloo@superbaloo.net>
+Date:   Wed Feb 17 02:27:40 2021 +0000
+
+    python-install
+    
+    Signed-off-by: Arthur Gautier <baloo@superbaloo.net>
+
+diff --git a/samples/Makefile.am b/samples/Makefile.am
+index 7d69bf8..1803bb9 100644
+--- a/samples/Makefile.am
++++ b/samples/Makefile.am
+@@ -39,19 +39,9 @@ python-uninstall:
+ 	$(PIP3) uninstall -y $(PY_PACKAGE_NAME)
+ 
+ if PYTHON_INSTALLATION
+-install-exec-local: $(PY_PACKAGE)
+-	@if ! test $(findstring /usr, "$(DESTDIR)$(bindir)"); then \
+-		echo "Warning: Not installing python package to $(DESTDIR)$(bindir)"; \
+-	else \
+-		$(MAKE) python-install; \
+-	fi
++install-exec-local: python-install
+ 
+-uninstall-local:
+-	@if ! test $(findstring /usr, "$(DESTDIR)$(bindir)"); then \
+-		echo "Cleanup for distcheck build not implemented" ; \
+-	else \
+-		$(MAKE) python-uninstall; \
+-	fi
++uninstall-local: python-uninstall
+ endif
+ 
+ 
+diff --git a/src/swtpm_setup/Makefile.am b/src/swtpm_setup/Makefile.am
+index 529eefe..533b1b3 100644
+--- a/src/swtpm_setup/Makefile.am
++++ b/src/swtpm_setup/Makefile.am
+@@ -29,19 +29,9 @@ python-uninstall:
+ 	$(PIP3) uninstall -y $(PY_PACKAGE_NAME)
+ 
+ if PYTHON_INSTALLATION
+-install-exec-local: $(PY_PACKAGE)
+-	@if ! test $(findstring /usr, "$(DESTDIR)$(bindir)"); then \
+-		echo "Warning: Not installing python package to $(DESTDIR)$(bindir)"; \
+-	else \
+-		$(MAKE) python-install; \
+-	fi
++install-exec-local: python-install
+ 
+-uninstall-local:
+-	@if ! test $(findstring /usr, "$(DESTDIR)$(bindir)"); then \
+-		echo "Cleanup for distcheck build not implemented" ; \
+-	else \
+-		$(MAKE) python-uninstall; \
+-	fi
++uninstall-local: python-uninstall
+ endif
+ 
+ # for out-of-tree builds we need to clean up

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8222,6 +8222,11 @@ in
   swec = callPackage ../tools/networking/swec { };
 
   swtpm = callPackage ../tools/security/swtpm { };
+  swtpm-tpm2 = swtpm.override {
+    libtpms = libtpms.override {
+      tpm2Support = true;
+    };
+  };
 
   svn2git = callPackage ../applications/version-management/git-and-tools/svn2git {
     git = gitSVN;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8221,6 +8221,8 @@ in
 
   swec = callPackage ../tools/networking/swec { };
 
+  swtpm = callPackage ../tools/security/swtpm { };
+
   svn2git = callPackage ../applications/version-management/git-and-tools/svn2git {
     git = gitSVN;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15588,6 +15588,8 @@ in
     libtoxcore_0_1 libtoxcore_0_2;
   libtoxcore = libtoxcore_0_2;
 
+  libtpms = callPackage ../tools/security/libtpms { };
+
   libtap = callPackage ../development/libraries/libtap { };
 
   libtgvoip = callPackage ../development/libraries/libtgvoip { };


### PR DESCRIPTION
###### Motivation for this change

Goes along with #113361 which introduces a direct dependency

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
