### PR TITLE
kernelPackages.ena: 2.3.0 -> 2.4.1

### DIFF
--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 
 stdenv.mkDerivation rec {
-  version = "2.3.0";
+  version = "2.4.1";
   name = "ena-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "amzn";
     repo = "amzn-drivers";
     rev = "ena_linux_${version}";
-    sha256 = "sha256-ho6yKCgYo3p50leQUCmzNO/3wqzSzs27Eash3AWBaiE=";
+    sha256 = "0f3i878g11yfw6n68p3qf125jsnggy706jhc8sc0z1xgap6qgh09";
   };
 
   hardeningDisable = [ "pic" ];
@@ -19,23 +19,28 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
 
   configurePhase = ''
+    runHook preConfigure
     cd kernel/linux/ena
     substituteInPlace Makefile --replace '/lib/modules/$(BUILD_KERNEL)' ${kernel.dev}/lib/modules/${kernel.modDirVersion}
+    runHook postConfigure
   '';
 
   installPhase = ''
+    runHook preInstall
     strip -S ena.ko
     dest=$out/lib/modules/${kernel.modDirVersion}/misc
     mkdir -p $dest
     cp ena.ko $dest/
     xz $dest/ena.ko
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Amazon Elastic Network Adapter (ENA) driver for Linux";
     homepage = "https://github.com/amzn/amzn-drivers";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.eelco ];
     platforms = platforms.linux;
+    broken = kernel.kernelOlder "4.5";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Release notes: https://github.com/amzn/amzn-drivers/blob/master/kernel/linux/ena/RELEASENOTES.md#r241-release-notes

I found that I was not able to nixos-rebuild with `boot.kernelPackages = pkgs.linuxPackages_latest` on AWS with `imports = [ <nixpkgs/nixos/modules/virtualisation/amazon-image.nix> ];`

 - (a) with 20.09 (which pulled in `ena-2.2.11-5.10.15`); or 
 - (b) with 20.09 after cherry-picking #107008 (which pulled in `ena-2.3.0-5.10.15`)

Perhaps this should be backported to 20.09 and the `broken` bit (https://github.com/NixOS/nixpkgs/blob/08327493801e12217891826604c2812e7f48eb28/pkgs/os-specific/linux/ena/default.nix#L40) should be unset on 20.09 as well.

With this change applied on top of 20.09, I was able to boot on AWS with linuxPackages_latest.

Also thanks to @samueldr who helped me get this running.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).