### PR TITLE
nixos/bluetooth: hotfix for stupidity

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -113,7 +113,7 @@ in
           aliases = [ "dbus-org.bluez.service" ];
           serviceConfig.ExecStart = [
             ""
-            "${package}/libexec/bluetooth/bluetoothd ${escapeShellArgs " " args}"
+            "${package}/libexec/bluetooth/bluetoothd ${escapeShellArgs args}"
           ];
           # restarting can leave people without a mouse/keyboard
           unitConfig.X-RestartIfChanged = false;


### PR DESCRIPTION
###### Motivation for this change

Further to #112493 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
