### PR TITLE
chromium: 88.0.4324.150 -> 88.0.4324.182

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -1,8 +1,8 @@
 {
   "stable": {
-    "version": "88.0.4324.150",
-    "sha256": "1hrqrggg4g1hjmaajbpydwsij2mfkfj5ccs1lj76nv4qj91yj4mf",
-    "sha256bin64": "0xyhvhppxk95clk6vycg2yca1yyzpi13rs3lhs4j9a482api6ks0",
+    "version": "88.0.4324.182",
+    "sha256": "10av060ix6lgsvv99lyvyy03r0m3zwdg4hddbi6dycrdxk1iyh9h",
+    "sha256bin64": "1rjg23xiybpnis93yb5zkvglm3r4fds9ip5mgl6f682z5x0yj05b",
     "deps": {
       "gn": {
         "version": "2020-11-05",


### PR DESCRIPTION
###### Motivation for this change
https://chromereleases.googleblog.com/2021/02/stable-channel-update-for-desktop_16.html

This update includes 10 security fixes.

CVEs:
CVE-2021-21149 CVE-2021-21150 CVE-2021-21151 CVE-2021-21152
CVE-2021-21153 CVE-2021-21154 CVE-2021-21155 CVE-2021-21156
CVE-2021-21157

###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).