### PR TITLE
prometheus-systemd-exporter: Init at 0.4.0

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -51,6 +51,7 @@ let
     "smokeping"
     "sql"
     "surfboard"
+    "systemd"
     "tor"
     "unifi"
     "unifi-poller"

--- a/nixos/modules/services/monitoring/prometheus/exporters/systemd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/systemd.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let cfg = config.services.prometheus.exporters.systemd;
+
+in {
+  port = 9558;
+
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-systemd-exporter}/bin/systemd_exporter \
+          --web.listen-address ${cfg.listenAddress}:${toString cfg.port}
+      '';
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -802,6 +802,22 @@ let
       '';
     };
 
+    systemd = {
+      exporterConfig = {
+        enable = true;
+      };
+      metricProvider = { };
+      exporterTest = ''
+        wait_for_unit("prometheus-systemd-exporter.service")
+        wait_for_open_port(9558)
+        succeed(
+            "curl -sSf localhost:9558/metrics | grep -q '{}'".format(
+                'systemd_unit_state{name="basic.target",state="active",type="target"} 1'
+            )
+        )
+      '';
+    };
+
     tor = {
       exporterConfig = {
         enable = true;

--- a/pkgs/servers/monitoring/prometheus/systemd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/systemd-exporter.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGittHub, }:
+{ lib, buildGoModule, fetchFromGitHub, nixosTests }:
 
 buildGoModule rec {
   pname = "systemd_exporter";
@@ -12,6 +12,8 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "sha256-JDfRHczFnTP9sxA7polUE9qzJhSPIiAU58GBNDYkX4c=";
   };
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) systemd; };
 
   meta = with lib; {
     description = "Exporter for systemd unit metrics";

--- a/pkgs/servers/monitoring/prometheus/systemd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/systemd-exporter.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGittHub, }:
+
+buildGoModule rec {
+  pname = "systemd_exporter";
+  version = "0.4.0";
+
+  vendorSha256 = "sha256-bYoB0r+d0j3esi/kK2a7/Duup9cf4M3WJjiBNs2+bj8=";
+
+  src = fetchFromGitHub {
+    owner = "povilasv";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-JDfRHczFnTP9sxA7polUE9qzJhSPIiAU58GBNDYkX4c=";
+  };
+
+  meta = with lib; {
+    description = "Exporter for systemd unit metrics";
+    homepage = "https://github.com/povilasv/systemd_exporter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ chkno ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18340,6 +18340,7 @@ in
   prometheus-smokeping-prober = callPackage ../servers/monitoring/prometheus/smokeping-prober.nix { };
   prometheus-snmp-exporter = callPackage ../servers/monitoring/prometheus/snmp-exporter.nix { };
   prometheus-sql-exporter = callPackage ../servers/monitoring/prometheus/sql-exporter.nix { };
+  prometheus-systemd-exporter = callPackage ../servers/monitoring/prometheus/systemd-exporter.nix { };
   prometheus-tor-exporter = callPackage ../servers/monitoring/prometheus/tor-exporter.nix { };
   prometheus-statsd-exporter = callPackage ../servers/monitoring/prometheus/statsd-exporter.nix { };
   prometheus-surfboard-exporter = callPackage ../servers/monitoring/prometheus/surfboard-exporter.nix { };


### PR DESCRIPTION
###### Motivation for this change
Make prometheus-systemd-exporter available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    0 → 46337688
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).