### PR TITLE
knightos: reduce build time dependency graph

### DIFF
--- a/pkgs/development/tools/knightos/genkfs/default.nix
+++ b/pkgs/development/tools/knightos/genkfs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, asciidoc }:
+{ lib, stdenv, fetchFromGitHub, asciidoc, cmake, libxslt }:
 
 stdenv.mkDerivation rec {
   pname = "genkfs";
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "0f50idd2bb73b05qjmwlirjnhr1bp43zhrgy6z949ab9a7hgaydp";
   };
 
-  nativeBuildInputs = [ asciidoc cmake ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ asciidoc libxslt.bin cmake ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/tools/knightos/kcc/default.nix
+++ b/pkgs/development/tools/knightos/kcc/default.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation rec {
     sha256 = "13sbpv8ynq8sjackv93jqxymk0bsy76c5fc0v29wz97v53q3izjp";
   };
 
-  nativeBuildInputs = [ cmake bison flex ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ bison cmake flex ];
 
   buildInputs = [ boost ];
 

--- a/pkgs/development/tools/knightos/kimg/default.nix
+++ b/pkgs/development/tools/knightos/kimg/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, asciidoc }:
+{ lib, stdenv, fetchFromGitHub, cmake, libxslt, asciidoc }:
 
 stdenv.mkDerivation rec {
   pname = "kimg";
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "040782k3rh2a5mhbfgr9gnbfis0wgxvi27vhfn7l35vrr12sw1l3";
   };
 
-  nativeBuildInputs = [ cmake asciidoc ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ asciidoc cmake libxslt.bin ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/tools/knightos/kpack/default.nix
+++ b/pkgs/development/tools/knightos/kpack/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, asciidoc, libxslt, docbook_xsl }:
+{ lib, stdenv, fetchFromGitHub, cmake, asciidoc, libxslt }:
 
 stdenv.mkDerivation rec {
   pname = "kpack";
@@ -12,9 +12,9 @@ stdenv.mkDerivation rec {
     sha256 = "1l6bm2j45946i80qgwhrixg9sckazwb5x4051s76d3mapq9bara8";
   };
 
-  nativeBuildInputs = [ cmake ];
+  strictDeps = true;
 
-  buildInputs = [ asciidoc libxslt.bin docbook_xsl ];
+  nativeBuildInputs = [ asciidoc cmake libxslt.bin ];
 
   hardeningDisable = [ "fortify" ];
 

--- a/pkgs/development/tools/knightos/mkrom/default.nix
+++ b/pkgs/development/tools/knightos/mkrom/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, asciidoc }:
+{ lib, stdenv, fetchFromGitHub, cmake, libxslt, asciidoc }:
 
 stdenv.mkDerivation rec {
   pname = "mkrom";
@@ -11,10 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0xgvanya40mdwy35j94j61hsp80dm5b440iphmr5ng3kjgchvpx2";
   };
 
-  nativeBuildInputs = [
-    asciidoc
-    cmake
-  ];
+  strictDeps = true;
+  nativeBuildInputs = [ asciidoc cmake libxslt.bin ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/tools/knightos/mktiupgrade/default.nix
+++ b/pkgs/development/tools/knightos/mktiupgrade/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, asciidoc }:
+{ lib, stdenv, fetchFromGitHub, cmake, libxslt, asciidoc }:
 
 stdenv.mkDerivation rec {
   pname = "mktiupgrade";
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "15y3rxvv7ipgc80wrvrpksxzdyqr21ywysc9hg6s7d3w8lqdq8dm";
   };
 
-  nativeBuildInputs = [ asciidoc cmake ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ asciidoc cmake libxslt.bin ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/tools/knightos/patchrom/default.nix
+++ b/pkgs/development/tools/knightos/patchrom/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, asciidoc, libxslt, docbook_xsl }:
+{ lib, stdenv, fetchFromGitHub, cmake, asciidoc, libxslt }:
 
 
 stdenv.mkDerivation rec {
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "0yc4q7n3k7k6rx3cxq5ddd5r0la8gw1287a74kql6gwkxjq0jmcv";
   };
 
-  nativeBuildInputs = [ cmake asciidoc docbook_xsl ];
+  strictDeps = true;
 
-  buildInputs = [ libxslt ];
+  nativeBuildInputs = [ asciidoc cmake libxslt.bin ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/tools/knightos/scas/default.nix
+++ b/pkgs/development/tools/knightos/scas/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DSCAS_LIBRARY=1" ];
 
+  strictDeps = true;
+
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {

--- a/pkgs/development/tools/knightos/z80e/default.nix
+++ b/pkgs/development/tools/knightos/z80e/default.nix
@@ -11,9 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-FQMYHxKxHEP+x98JbGyjaM0OL8QK/p3epsAWvQkv6bc=";
   };
 
-  nativeBuildInputs = [ cmake knightos-scas ];
+  nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ readline SDL2 ];
+  buildInputs = [ readline SDL2 knightos-scas ];
 
   cmakeFlags = [ "-Denable-sdl=YES" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10427,27 +10427,19 @@ in
 
   jwasm =  callPackage ../development/compilers/jwasm { };
 
-  knightos-genkfs = callPackage ../development/tools/knightos/genkfs {
-    asciidoc = asciidoc-full;
-  };
+  knightos-genkfs = callPackage ../development/tools/knightos/genkfs { };
 
   knightos-kcc = callPackage ../development/tools/knightos/kcc { };
 
-  knightos-kimg = callPackage ../development/tools/knightos/kimg {
-    asciidoc = asciidoc-full;
-  };
+  knightos-kimg = callPackage ../development/tools/knightos/kimg { };
 
   knightos-kpack = callPackage ../development/tools/knightos/kpack { };
 
-  knightos-mkrom = callPackage ../development/tools/knightos/mkrom {
-    asciidoc = asciidoc-full;
-  };
+  knightos-mkrom = callPackage ../development/tools/knightos/mkrom { };
 
   knightos-patchrom = callPackage ../development/tools/knightos/patchrom { };
 
-  knightos-mktiupgrade = callPackage ../development/tools/knightos/mktiupgrade {
-    asciidoc = asciidoc-full;
-  };
+  knightos-mktiupgrade = callPackage ../development/tools/knightos/mktiupgrade { };
 
   knightos-scas = callPackage ../development/tools/knightos/scas { };
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Using asciidoc-full was unnecessary to build KnightOS-related packages since only the a2x command matters. This change makes cross-compilation far more noticeably faster. Closure size for each package reduced from around 7 MB to 2 MB.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
