### PR TITLE
nmap-unfree: init at 7.91

### DIFF
--- a/pkgs/tools/security/nmap-unfree/default.nix
+++ b/pkgs/tools/security/nmap-unfree/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchurl
+, libpcap
+, pkg-config
+, openssl
+, lua5_3
+, pcre
+, liblinear
+, libssh2
+, zlib
+, withLua ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nmap-unfree";
+  version = "7.91";
+
+  src = fetchurl {
+    url = "https://nmap.org/dist/nmap-${version}.tar.bz2";
+    sha256 = "001kb5xadqswyw966k2lqi6jr6zz605jpp9w4kmm272if184pk0q";
+  };
+
+  prePatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace libz/configure \
+        --replace /usr/bin/libtool ar \
+        --replace 'AR="libtool"' 'AR="ar"' \
+        --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
+  '';
+
+  configureFlags = [
+    (if withLua then "--with-liblua=${lua5_3}" else "--without-liblua")
+  ];
+
+  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "AR=${stdenv.cc.bintools.targetPrefix}ar"
+    "RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib"
+    "CC=${stdenv.cc.targetPrefix}gcc"
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    pcre
+    liblinear
+    libssh2
+    libpcap
+    openssl
+    zlib
+  ];
+
+  enableParallelBuilding = true;
+
+  # Tests require network access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Open source utility for network discovery and security auditing";
+    homepage = "http://www.nmap.org";
+    # Nmap Public Source License Version 0.93
+    # https://github.com/nmap/nmap/blob/master/LICENSE
+    license = licenses.unfree;
+    maintainers = with maintainers; [ fab SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6586,6 +6586,8 @@ in
     graphicalSupport = true;
   };
 
+  nmap-unfree = callPackage ../tools/security/nmap-unfree { };
+
   nmapsi4 = libsForQt514.callPackage ../tools/security/nmap/qt.nix { };
 
   nnn = callPackage ../applications/misc/nnn { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
With 7.91 `nmap` changed the license and the new home-made license which is considered "non-free" by multiple parties. In the last couple of weeks there was not much process (see https://github.com/nmap/nmap/issues/2199) in resolving the issue. 

This means that `nmap-7.80`is the last release which is available under an "Open source" license. We hope that this is only for now and that `nmap-unfree` is a temporarily workaround.

The graphical part was removed as `zenmap` is still Python 2 and depends no longer maintained parts. There is an [upstream PR](https://github.com/nmap/nmap/pull/2088) pending that contains the migration to Python 3 and pygobject. The same goes for `ndiff`. It's still Python 2 and the porting is [not done](https://github.com/nmap/nmap/pull/1807). Both patches are huge and it seems that they can't be applied without modifications. Thus, `nmap-unfree` focuses on the scanner itself.

Related #105119

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
