### PR TITLE
python3Packages.pytest: 6.1.2 -> 6.2.2

### DIFF
--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -1,19 +1,16 @@
 { lib, buildPythonPackage, pythonOlder, fetchPypi, isPy3k, isPyPy
 , atomicwrites
 , attrs
-, funcsigs
 , hypothesis
 , iniconfig
-, mock
 , more-itertools
 , packaging
 , pathlib2
 , pluggy
 , py
 , pygments
-, python
 , setuptools
-, setuptools_scm
+, setuptools-scm
 , six
 , toml
 , wcwidth
@@ -21,18 +18,17 @@
 }:
 
 buildPythonPackage rec {
-  version = "6.1.2";
   pname = "pytest";
-
+  version = "6.2.2";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e";
+    sha256 = "sha256-nR7fnn0LhNcuo9vN/SKzX7VDpejypgCS3VeJNr9j1/k=";
   };
 
-  checkInputs = [ hypothesis pygments ];
-  nativeBuildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
+
   propagatedBuildInputs = [
     atomicwrites
     attrs
@@ -46,6 +42,11 @@ buildPythonPackage rec {
     toml
     wcwidth
   ] ++ lib.optionals (pythonOlder "3.6") [ pathlib2 ];
+
+  checkInputs = [
+    hypothesis
+    pygments
+  ];
 
   doCheck = !isPyPy; # https://github.com/pytest-dev/pytest/issues/3460
 
@@ -80,8 +81,9 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    homepage = "https://docs.pytest.org";
     description = "Framework for writing tests";
+    homepage = "https://docs.pytest.org";
+    changelog = "https://github.com/pytest-dev/pytest/releases/tag/${version}";
     maintainers = with maintainers; [ domenkozar lovek323 madjar lsix ];
     license = licenses.mit;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 6.2.2

Change log: https://github.com/pytest-dev/pytest/releases/tag/6.2.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
