### PR TITLE
python3Packages.pytest-xdist: 2.1.0 -> 2.2.1

### DIFF
--- a/pkgs/development/python-modules/execnet/default.nix
+++ b/pkgs/development/python-modules/execnet/default.nix
@@ -2,8 +2,8 @@
 , buildPythonPackage
 , isPyPy
 , fetchPypi
-, pytest
-, setuptools_scm
+, pytestCheckHook
+, setuptools-scm
 , apipkg
 }:
 
@@ -16,8 +16,8 @@ buildPythonPackage rec {
     sha256 = "sha256-tzxVZeUX8kti3qilzqwXjGYcQwnTqgw+QghWwHLEEbQ=";
   };
 
-  checkInputs = [ pytest ];
-  nativeBuildInputs = [ setuptools_scm ];
+  checkInputs = [ pytestCheckHook ];
+  nativeBuildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ apipkg ];
 
   # remove vbox tests
@@ -29,15 +29,13 @@ buildPythonPackage rec {
     ${lib.optionalString isPyPy "rm -v testing/test_multi.py"}
   '';
 
-  checkPhase = ''
-    py.test testing
-  '';
+  pythonImportsCheck = [ "execnet" ];
 
   __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
-    description = "Rapid multi-Python deployment";
-    license = licenses.gpl2;
+    description = "Distributed Python deployment and communication";
+    license = licenses.mit;
     homepage = "https://execnet.readthedocs.io/";
     maintainers = with maintainers; [ nand0p ];
   };

--- a/pkgs/development/python-modules/execnet/default.nix
+++ b/pkgs/development/python-modules/execnet/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "execnet";
-  version = "1.7.1";
+  version = "1.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50";
+    sha256 = "sha256-tzxVZeUX8kti3qilzqwXjGYcQwnTqgw+QghWwHLEEbQ=";
   };
 
   checkInputs = [ pytest ];

--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -1,19 +1,19 @@
 { lib, fetchPypi, buildPythonPackage, execnet, pytest_6
-, setuptools_scm, pytest-forked, filelock, psutil, six, isPy3k }:
+, setuptools_scm, pytest-forked, filelock, psutil, isPy3k }:
 
 buildPythonPackage rec {
   pname = "pytest-xdist";
-  version = "2.1.0";
+  version = "2.2.1";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0wh6pn66nncfs6ay0n863bgyriwsgppn8flx5l7551j1lbqkinc2";
+    sha256 = "sha256-cYiHKWiS+SaD9qUfJaOuWEmTsG9wds4eH9SC5ZqCIKI=";
   };
 
   nativeBuildInputs = [ setuptools_scm pytest_6 ];
   checkInputs = [ pytest_6 filelock ];
-  propagatedBuildInputs = [ execnet pytest-forked psutil six ];
+  propagatedBuildInputs = [ execnet pytest-forked psutil ];
 
   # pytest6 doesn't allow for new lines
   # capture_deprecated not compatible with latest pytest6
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "py.test xdist plugin for distributed testing and loop-on-failing modes";
+    description = "pytest xdist plugin for distributed testing and loop-on-failing modes";
     homepage = "https://github.com/pytest-dev/pytest-xdist";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.2.1

Change log: https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst#pytest-xdist-221-2021-02-09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
