### PR TITLE
python3Packages.pyserial: patches for RFC2217

### DIFF
--- a/pkgs/development/python-modules/pyserial/001-rfc2217-only-negotiate-on-value-change.patch
+++ b/pkgs/development/python-modules/pyserial/001-rfc2217-only-negotiate-on-value-change.patch
@@ -1,0 +1,42 @@
+From c8b35f4b871d00e3020f525425517548bed9f6ad Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Uwe=20Kleine-K=C3=B6nig?= <u.kleine-koenig@pengutronix.de>
+Date: Sun, 9 Sep 2018 20:13:27 +0200
+Subject: [PATCH] serial/rfc2217: only subnegotiate on value change
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This was suggested and is a direct copy of Uwe Kleine König's patch
+from [1].
+
+[1]: https://github.com/pyserial/pyserial/issues/376#issuecomment-418885211
+Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>
+---
+ serial/rfc2217.py | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/serial/rfc2217.py b/serial/rfc2217.py
+index d962c1e8..2148512d 100644
+--- a/serial/rfc2217.py
++++ b/serial/rfc2217.py
+@@ -330,11 +330,15 @@ def set(self, value):
+         the client needs to know if the change is performed he has to check the
+         state of this object.
+         """
+-        self.value = value
+-        self.state = REQUESTED
+-        self.connection.rfc2217_send_subnegotiation(self.option, self.value)
+-        if self.connection.logger:
+-            self.connection.logger.debug("SB Requesting {} -> {!r}".format(self.name, self.value))
++        if value != self.value:
++            self.value = value
++            self.state = REQUESTED
++            self.connection.rfc2217_send_subnegotiation(self.option, self.value)
++            if self.connection.logger:
++                self.connection.logger.debug("SB Requesting {} -> {!r}".format(self.name, self.value))
++        else:
++            if self.connection.logger:
++                self.connection.logger.debug("SB Requesting {} -> {!r} (skipped)".format(self.name, self.value))
+
+     def is_ready(self):
+         """\

--- a/pkgs/development/python-modules/pyserial/002-rfc2217-timeout-setter-for-rfc2217.patch
+++ b/pkgs/development/python-modules/pyserial/002-rfc2217-timeout-setter-for-rfc2217.patch
@@ -1,0 +1,42 @@
+From a3698dc952fce0d07628133e987b7b43ed6e1157 Mon Sep 17 00:00:00 2001
+From: Rouven Czerwinski <rouven@czerwinskis.de>
+Date: Sun, 9 Sep 2018 20:08:40 +0200
+Subject: [PATCH] serial/rfc2217: add timeout.setter for rfc2217
+
+Add a new setter method for the timeout property which does not invoke
+the port reconfiguration.
+This is a direct copy of the SerialBase timeout property without the port
+reconfiguration.
+
+Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>
+---
+ serial/rfc2217.py | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/serial/rfc2217.py b/serial/rfc2217.py
+index d962c1e8..12615cf3 100644
+--- a/serial/rfc2217.py
++++ b/serial/rfc2217.py
+@@ -722,5 +722,22 @@ def cd(self):
+             raise portNotOpenError
+         return bool(self.get_modem_state() & MODEMSTATE_MASK_CD)
+
++    @property
++    def timeout(self):
++        """Get the current timeout setting."""
++        return self._timeout
++
++    @timeout.setter
++    def timeout(self, timeout):
++        """Change timeout setting."""
++        if timeout is not None:
++            try:
++                timeout + 1     # test if it's a number, will throw a TypeError if not...
++            except TypeError:
++                raise ValueError("Not a valid timeout: {!r}".format(timeout))
++            if timeout < 0:
++                raise ValueError("Not a valid timeout: {!r}".format(timeout))
++        self._timeout = timeout
++
+     # - - - platform specific - - -
+     # None so far

--- a/pkgs/development/python-modules/pyserial/default.nix
+++ b/pkgs/development/python-modules/pyserial/default.nix
@@ -9,6 +9,11 @@ buildPythonPackage rec {
     sha256 = "1nyd4m4mnrz8scbfqn4zpq8gnbl4x42w5zz62vcgpzqd2waf0xrw";
   };
 
+  patches = [
+    ./001-rfc2217-only-negotiate-on-value-change.patch
+    ./002-rfc2217-timeout-setter-for-rfc2217.patch
+  ];
+
   checkPhase = "python -m unittest discover -s test";
   doCheck = !stdenv.hostPlatform.isDarwin; # broken on darwin
 


### PR DESCRIPTION
###### Motivation for this change
These two patches significantly improve the RFC2217 negotiation and
support for devices like the Moxa serial servers. The patches reduce the
amount of negotiations done over RFC2217 and, in case of the timeout
setter patch, prevent pyserial from setting the timeout again on every
send line. We have been using these in a downstream fork for 2 years now
and have not seen problems in the field. Upstream has acted neither on
the issue [1] nor on the proposed pull request [2], so I am proposing to
include them downstream within nixpkgs instead.

[1]: https://github.com/pyserial/pyserial/issues/376
[2]: https://github.com/pyserial/pyserial/pull/382

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
