### PR TITLE
sbcl: Small fixes around the phase definitions

### DIFF
--- a/pkgs/development/compilers/sbcl/common.nix
+++ b/pkgs/development/compilers/sbcl/common.nix
@@ -39,9 +39,6 @@ stdenv.mkDerivation rec {
     # Fix the tests
     sed -e '5,$d' -i contrib/sb-bsd-sockets/tests.lisp
     sed -e '5,$d' -i contrib/sb-simple-streams/*test*.lisp
-
-    substituteInPlace src/runtime/Config.x86-64-darwin \
-      --replace mmacosx-version-min=10.4 mmacosx-version-min=10.5
   ''
   + (if purgeNixReferences
     then

--- a/pkgs/development/compilers/sbcl/common.nix
+++ b/pkgs/development/compilers/sbcl/common.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
   buildInputs = [texinfo];
 
   postPatch = ''
+    echo '"${version}.nixos"' > version.lisp-expr
+
     # SBCL checks whether files are up-to-date in many places..
     # Unfortunately, same timestamp is not good enough
     sed -e 's@> x y@>= x y@' -i contrib/sb-aclrepl/repl.lisp

--- a/pkgs/development/compilers/sbcl/common.nix
+++ b/pkgs/development/compilers/sbcl/common.nix
@@ -40,9 +40,6 @@ stdenv.mkDerivation rec {
     sed -e '5,$d' -i contrib/sb-bsd-sockets/tests.lisp
     sed -e '5,$d' -i contrib/sb-simple-streams/*test*.lisp
 
-    # Use whatever `cc` the stdenv provides
-    substituteInPlace src/runtime/Config.x86-64-darwin --replace gcc cc
-
     substituteInPlace src/runtime/Config.x86-64-darwin \
       --replace mmacosx-version-min=10.4 mmacosx-version-min=10.5
   ''


### PR DESCRIPTION
- Remove some debugging output at the start of the `patchPhase` section,
  which appears to have outlived its value.
- Rename `patchPhase` to `postPatch`, to avoid preventing people adding
  patches via the `patches` variable.
- Add `preBuild` and `postBuild` run-hooks to the `buildPhase` section.
- Add `preInstall` and `postInstall` run-hooks to the `installPhase`
  section.

###### Motivation for this change

This replaces PR https://github.com/NixOS/nixpkgs/pull/113132 which was obsoleted by a separate bit of refactoring.

Small improvements to the common functionality for building the SBCL compiler: remove debug output which is now effectively cruft, and make it easier for people to use standard mechanisms to modify this package.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ * ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ * ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   - N/A - there aren't any tests
- [ * ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
   - "No diff detected"
- [ * ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
    - N/A - no documentation to change
- [ * ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
