### PR TITLE
python3Packages.adb-shell: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/development/python-modules/adb-shell/default.nix
+++ b/pkgs/development/python-modules/adb-shell/default.nix
@@ -1,5 +1,16 @@
-{ aiofiles, buildPythonPackage, cryptography, fetchFromGitHub, isPy3k, lib
-, libusb1, mock, pyasn1, python, pycryptodome, rsa }:
+{ lib
+, aiofiles
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, isPy3k
+, libusb1
+, mock
+, pyasn1
+, pycryptodome
+, pytestCheckHook
+, rsa
+}:
 
 buildPythonPackage rec {
   pname = "adb-shell";
@@ -15,16 +26,24 @@ buildPythonPackage rec {
     sha256 = "sha256-b+9ySme44TdIlVnF8AHBBGd8pkoeYG99wmDK/nyAreo=";
   };
 
-  propagatedBuildInputs = [ aiofiles cryptography libusb1 pyasn1 rsa ];
+  propagatedBuildInputs = [
+    aiofiles
+    cryptography
+    libusb1
+    pyasn1
+    rsa
+  ];
 
-  checkInputs = [ mock pycryptodome ];
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests -t .
-  '';
+  checkInputs = [
+    mock
+    pycryptodome
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "adb_shell" ];
 
   meta = with lib; {
-    description =
-      "A Python implementation of ADB with shell and FileSync functionality.";
+    description = "Python implementation of ADB with shell and FileSync functionality";
     homepage = "https://github.com/JeffLIrion/adb_shell";
     license = licenses.asl20;
     maintainers = with maintainers; [ jamiemagee ];

--- a/pkgs/development/python-modules/adb-shell/default.nix
+++ b/pkgs/development/python-modules/adb-shell/default.nix
@@ -3,7 +3,7 @@
 
 buildPythonPackage rec {
   pname = "adb-shell";
-  version = "0.3.0";
+  version = "0.3.1";
 
   disabled = !isPy3k;
 
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     owner = "JeffLIrion";
     repo = "adb_shell";
     rev = "v${version}";
-    sha256 = "0qnlhcd58zxh39cd5xzdx8yc5hc0pf8kix4rbn4avsapwb0l75n2";
+    sha256 = "sha256-b+9ySme44TdIlVnF8AHBBGd8pkoeYG99wmDK/nyAreo=";
   };
 
   propagatedBuildInputs = [ aiofiles cryptography libusb1 pyasn1 rsa ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.3.1

- Switched to `pytestCheckHook`
- Ran `nixpkgs-fmt`
- Added `pythonImportsCheck`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
