### PR TITLE
haskellPackages.Agda: unbreak the build by dropping a (by now) unnecessary patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -92,11 +92,4 @@ self: super: {
 
   # Break out of "Cabal < 3.2" constraint.
   stylish-haskell = doJailbreak super.stylish-haskell;
-
-  # Agda 2.6.1.2 only declares a transformers dependency for ghc < 8.10.3.
-  # https://github.com/agda/agda/issues/5109
-  Agda = appendPatch super.Agda (pkgs.fetchpatch {
-    url = "https://github.com/agda/agda/commit/76278c23d447b49f59fac581ca4ac605792aabbc.patch";
-    sha256 = "1g34g8a09j73h89pk4cdmri0nb0qg664hkff45amcr9kyz14a9f3";
-  });
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without this commit, building Agda fails as follows:

```
$ nix-shell -p agda
these derivations will be built:
  /nix/store/j13y12xa4g6dkn60k6y0ypp3rs62r7zn-Agda-2.6.1.3.drv
  /nix/store/xcvdw97bglp440pr0ad0xqqlk8lvxagc-agdaWithPackages-2.6.1.3.drv
building '/nix/store/j13y12xa4g6dkn60k6y0ypp3rs62r7zn-Agda-2.6.1.3.drv'...
[...]
applying patch /nix/store/38bnrnh7sbfawsyll5hlzijzvf9x09q2-76278c23d447b49f59fac581ca4ac605792aabbc.patch
patching file Agda.cabal
Hunk #1 FAILED at 249.
1 out of 1 hunk FAILED -- saving rejects to file Agda.cabal.rej
builder for '/nix/store/j13y12xa4g6dkn60k6y0ypp3rs62r7zn-Agda-2.6.1.3.drv' failed with exit code 1
cannot build derivation '/nix/store/xcvdw97bglp440pr0ad0xqqlk8lvxagc-agdaWithPackages-2.6.1.3.drv': 1 dependencies couldn't be built
error: build of '/nix/store/xcvdw97bglp440pr0ad0xqqlk8lvxagc-agdaWithPackages-2.6.1.3.drv' failed
```

The patch the build is complaining about was necessary for Agda 2.6.1.2, fixing a version bound in the Cabal file. Meanwhile this patch has found its way into upstream Agda 2.6.1.3 and is hence no longer required.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
