### PR TITLE
casync: 2-219-ga8f6c84 -> 2-219-ga8f6c84 

### DIFF
--- a/pkgs/applications/networking/sync/casync/default.nix
+++ b/pkgs/applications/networking/sync/casync/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "casync";
-  version = "2-219-ga8f6c84";
+  version = "2-226-gbd8898e";
 
   src = fetchFromGitHub {
-    owner  = "systemd";
-    repo   = "casync";
-    rev    = "a8f6c841ccfe59ca8c68aad64df170b64042dce8";
-    sha256 = "1i3c9wmpabpmx2wfbcyabmwfa66vz92iq5dlbm89v5mvgavz7bws";
+    owner = "systemd";
+    repo = "casync";
+    rev = "bd8898ed92685e12022dd33a04c87786b5262344";
+    sha256 = "04ibglizjzyd7ih13q6m7ic78n0mzw9nfmb3zd1fcm9j62qlq11i";
   };
 
   buildInputs = [ acl curl xz zstd ]

--- a/pkgs/applications/networking/sync/casync/default.nix
+++ b/pkgs/applications/networking/sync/casync/default.nix
@@ -1,10 +1,23 @@
-{ lib, stdenv, fetchFromGitHub
-, meson, ninja, pkg-config, python3, sphinx
-, acl, curl, fuse, libselinux, udev, xz, zstd
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, python3
+, sphinx
+, acl
+, curl
+, fuse
+, libselinux
+, udev
+, xz
+, zstd
 , fuseSupport ? true
 , selinuxSupport ? true
 , udevSupport ? true
-, glibcLocales, rsync
+, glibcLocales
+, rsync
 }:
 
 stdenv.mkDerivation {
@@ -19,9 +32,9 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ acl curl xz zstd ]
-                ++ lib.optionals (fuseSupport) [ fuse ]
-                ++ lib.optionals (selinuxSupport) [ libselinux ]
-                ++ lib.optionals (udevSupport) [ udev ];
+    ++ lib.optionals (fuseSupport) [ fuse ]
+    ++ lib.optionals (selinuxSupport) [ libselinux ]
+    ++ lib.optionals (udevSupport) [ udev ];
   nativeBuildInputs = [ meson ninja pkg-config python3 sphinx ];
   checkInputs = [ glibcLocales rsync ];
 
@@ -34,8 +47,8 @@ stdenv.mkDerivation {
 
   PKG_CONFIG_UDEV_UDEVDIR = "lib/udev";
   mesonFlags = lib.optionals (!fuseSupport) [ "-Dfuse=false" ]
-               ++ lib.optionals (!udevSupport) [ "-Dudev=false" ]
-               ++ lib.optionals (!selinuxSupport) [ "-Dselinux=false" ];
+    ++ lib.optionals (!udevSupport) [ "-Dudev=false" ]
+    ++ lib.optionals (!selinuxSupport) [ "-Dselinux=false" ];
 
   doCheck = true;
   preCheck = ''
@@ -44,9 +57,9 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Content-Addressable Data Synchronizer";
-    homepage    = "https://github.com/systemd/casync";
-    license     = licenses.lgpl21;
-    platforms   = platforms.linux;
+    homepage = "https://github.com/systemd/casync";
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ flokli ];
   };
 }


### PR DESCRIPTION
Changes:

```
 - bd8898e Merge pull request #244 from timgates42/bugfix_typo_distinguish
 - a904fda docs: fix simple typo, distuingish -> distinguish
 - 4ad9bcb caprotocol: fix typo in protocol description
 - 6cfe2d4 Call stat again after changing ownership of created files, so we detect reset setuid/setgid bits and reset them.
 - d246d6d We erroneously use the st_dev value in place of the magic value if the st_dev value is cached. This causes problems extracting trees containing subvolumes.
 - f9718df Merge pull request #228 from johannbg/FEDORA31
 - 1abde25 Update to Fedora31
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
