### PR TITLE
logrotate: minor cleanup

### DIFF
--- a/pkgs/tools/system/logrotate/default.nix
+++ b/pkgs/tools/system/logrotate/default.nix
@@ -14,27 +14,21 @@ stdenv.mkDerivation rec {
   };
 
   # Logrotate wants to access the 'mail' program; to be done.
-  patchPhase = ''
-    sed -i -e 's,[a-z/]\+gzip,${gzip}/bin/gzip,' \
-           -e 's,[a-z/]\+gunzip,${gzip}/bin/gunzip,' configure.ac
-
-    ${lib.optionalString (mailutils != null) ''
-    sed -i -e 's,[a-z/]\+mail,${mailutils}/bin/mail,' configure.ac
-    ''}
-  '';
-
-  autoreconfPhase = ''
-    ./autogen.sh
-  '';
+  configureFlags = [
+    "--with-compress-command=${gzip}/bin/gzip"
+    "--with-uncompress-command=${gzip}/bin/gunzip"
+  ] ++ lib.optionals (mailutils != null) [
+    "--with-default-mail-command=${mailutils}/bin/mail"
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ popt ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://fedorahosted.org/releases/l/o/logrotate/";
     description = "Rotates and compresses system logs";
-    license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.viric ];
-    platforms = lib.platforms.all;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.viric ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Minor cleanup.

Quick snippet of build log to confirm this change should be working fine:
```
configure: creating ./config.status
config.status: creating Makefile
config.status: creating test/Makefile
config.status: creating logrotate.8
config.status: creating logrotate.spec
config.status: creating config.h
config.status: executing depfiles commands

  logrotate source

  SELinux support:        no
  ACL support:            no
  default mail command:   /nix/store/xcw8ippwdkg8pgqkp5m28gv99xdbar76-mailutils-3.12/bin/mail
  compress command:       /nix/store/v9095vj6ch6vcj86s48fp8v68ql09k6q-gzip-1.10/bin/gzip
  uncompress command:     /nix/store/v9095vj6ch6vcj86s48fp8v68ql09k6q-gzip-1.10/bin/gunzip
  compress extension:     .gz
  statefile path:         /var/lib/logrotate.status
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @jslight90 