### PR TITLE
zasm: 4.2.6 -> 4.4.7, fix darwin build and cross-compilation

### DIFF
--- a/pkgs/development/compilers/zasm/default.nix
+++ b/pkgs/development/compilers/zasm/default.nix
@@ -1,20 +1,26 @@
-{ fetchFromGitHub, zlib, lib, stdenv }:
+{ lib, stdenv, fetchFromGitHub, zlib }:
 let
   libs-src = fetchFromGitHub {
     owner = "megatokio";
     repo = "Libraries";
-    rev = "97ea480051b106e83a086dd42583dfd3e9d458a1";
-    sha256 = "1kqmjb9660mnb0r18s1grrrisx6b73ijsinlyr97vz6992jd5dzh";
+    # 2021-02-02
+    rev = "c5cb3ed512c677db6f33e2d3539dfbb6e547030b";
+    sha256 = "sha256-GiplhZf640uScVdKL6E/fegOgtC9SE1xgBqcX86XADk=";
   };
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "zasm";
-  version = "4.2.6";
+  version = "4.4.7";
+
   src = fetchFromGitHub {
     owner = "megatokio";
     repo = "zasm";
-    rev = "f1424add17a5514895a598d6b5e3982579961519";
-    sha256 = "1kqnqdqp2bfsazs6vfx2aiqanxxagn8plx8g6rc11vmr8yqnnpks";
+    rev = version;
+    sha256 = "sha256-Zbno8kmzss1H2FjwzHB4U7UXxa6oDfsPV80MVVFfM68=";
+    extraPostFetch = ''
+      # remove folder containing files with weird names (causes the hash to turn out differently under macOS vs. Linux)
+      rm -rv $out/Test
+    '';
   };
 
   buildInputs = [ zlib ];
@@ -23,22 +29,23 @@ stdenv.mkDerivation {
     ln -sf ${libs-src} Libraries
   '';
 
-  buildPhase = ''
-    cd Linux
-    make
-  '';
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "CXX=${stdenv.cc.targetPrefix}c++"
+    "LINK=${stdenv.cc.targetPrefix}c++"
+    "STRIP=${stdenv.cc.targetPrefix}strip"
+  ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv zasm $out/bin
+    install -Dm755 -t $out/bin zasm
   '';
 
   meta = with lib; {
-    description = "Z80 / 8080 assembler (for unix-style OS)";
+    description = "Z80 / 8080 / Z180 assembler (for unix-style OS)";
     homepage = "https://k1.spdns.de/Develop/Projects/zasm/Distributions/";
     license = licenses.bsd2;
     maintainers = [ maintainers.turbomack ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     badPlatforms = platforms.aarch64;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package version bump and cross-compilation fix (test with `nix build .#pkgsCross.raspberryPi.zasm`)
@SuperSandro2000 please check to see if it's still broken on aarch64.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
