### PR TITLE
python3Package.mocket: 3.9.39 -> 3.9.40

### DIFF
--- a/pkgs/development/python-modules/furl/default.nix
+++ b/pkgs/development/python-modules/furl/default.nix
@@ -1,4 +1,12 @@
-{ lib, buildPythonPackage, fetchPypi, flake8, six, orderedmultidict, pytest }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, flake8
+, orderedmultidict
+, pytestCheckHook
+, six
+}:
 
 buildPythonPackage rec {
   pname = "furl";
@@ -9,17 +17,33 @@ buildPythonPackage rec {
     sha256 = "08dnw3bs1mk0f1ccn466a5a7fi1ivwrp0jspav9arqpf3wd27q60";
   };
 
-  checkInputs = [ flake8 pytest ];
+  patches = [
+    (fetchpatch {
+      name = "tests_overcome_bpo42967.patch";
+      url = "https://github.com/gruns/furl/files/6030371/tests_overcome_bpo42967.patch.txt";
+      sha256 = "1l0lxmcp9x73kxy0ky2bh7zxa4n1cf1qxyyax97n90d1s3dc7k2q";
+    })
+  ];
 
-  propagatedBuildInputs = [ six orderedmultidict ];
+  propagatedBuildInputs = [
+    orderedmultidict
+    six
+  ];
 
-  # see https://github.com/gruns/furl/issues/121
-  checkPhase = ''
-    pytest -k 'not join'
-  '';
+  checkInputs = [
+    flake8
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+     # see https://github.com/gruns/furl/issues/121
+    "join"
+  ];
+
+  pythonImportsCheck = [ "furl" ];
 
   meta = with lib; {
-    description = "furl is a small Python library that makes parsing and manipulating URLs easy";
+    description = "Python library that makes parsing and manipulating URLs easy";
     homepage = "https://github.com/gruns/furl";
     license = licenses.unlicense;
     maintainers = with maintainers; [ vanzef ];

--- a/pkgs/development/python-modules/geoip2/default.nix
+++ b/pkgs/development/python-modules/geoip2/default.nix
@@ -1,15 +1,16 @@
-{ buildPythonPackage, lib, fetchPypi, isPy27
+{ buildPythonPackage, lib, fetchPypi, pythonOlder
 , aiohttp
 , maxminddb
 , mocket
 , requests
 , requests-mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   version = "4.1.0";
   pname = "geoip2";
-  disabled = isPy27;
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -22,11 +23,17 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ aiohttp requests maxminddb ];
 
-  checkInputs = [ mocket requests-mock ];
+  checkInputs = [
+    mocket
+    requests-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "geoip2" ];
 
   meta = with lib; {
-    description = "MaxMind GeoIP2 API";
-    homepage = "https://www.maxmind.com/en/home";
+    description = "Python client for GeoIP2 webservice client and database reader";
+    homepage = "https://github.com/maxmind/GeoIP2-python";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/mocket/default.nix
+++ b/pkgs/development/python-modules/mocket/default.nix
@@ -1,10 +1,11 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy27
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, isPy3k
 , decorator
 , http-parser
-, importlib-metadata
-, python
 , python_magic
-, six
 , urllib3
 , pytestCheckHook
 , pytest-mock
@@ -13,15 +14,17 @@
 , redis
 , requests
 , sure
+, pook
 }:
 
 buildPythonPackage rec {
   pname = "mocket";
   version = "3.9.40";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "dbe4349a0ed30ed0c5d04684dd5d98517f8d1e4585fe0da4832747e2f01f3c18";
+    sha256 = "061w3zqf4ir7hfj0vzl58lg8szsik1fxv126s32x03nk1sd39r6v";
   };
 
   propagatedBuildInputs = [
@@ -29,8 +32,7 @@ buildPythonPackage rec {
     http-parser
     python_magic
     urllib3
-    six
-  ] ++ lib.optionals (isPy27) [ six ];
+  ];
 
   checkInputs = [
     pytestCheckHook
@@ -40,13 +42,14 @@ buildPythonPackage rec {
     redis
     requests
     sure
+    pook
   ];
 
   pytestFlagsArray = [
-    "--ignore=tests/main/test_pook.py" # pook is not packaged
-    "--ignore=tests/main/test_redis.py" # requires a live redis instance
+    # Requires a live Redis instance
+    "--ignore=tests/main/test_redis.py"
   ] ++ lib.optionals (pythonOlder "3.8") [
-    # uses IsolatedAsyncioTestCase which is only available >= 3.8
+    # Uses IsolatedAsyncioTestCase which is only available >= 3.8
     "--ignore=tests/tests38/test_http_aiohttp.py"
   ];
 
@@ -61,6 +64,7 @@ buildPythonPackage rec {
     "test_truesendall_with_recording_https"
     "test_truesendall_after_mocket_session"
     "test_real_request_session"
+    "test_asyncio_record_replay"
   ];
 
   pythonImportsCheck = [ "mocket" ];

--- a/pkgs/development/python-modules/pook/default.nix
+++ b/pkgs/development/python-modules/pook/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, furl
+, jsonschema
+, nose
+, pytestCheckHook
+, pythonOlder
+, requests
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "pook";
+  version = "1.0.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "h2non";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0z48vswj07kr2sdvq5qzrwqyijpmj2rlnh2z2b32id1mckr6nnz8";
+  };
+
+  patches = [
+    (fetchpatch {
+      # Will be fixed with the new release, https://github.com/h2non/pook/issues/69
+      name = "use-match-keyword-in-pytest.patch";
+      url = "https://github.com/h2non/pook/commit/2071da27701c82ce02b015e01e2aa6fd203e7bb5.patch";
+      sha256 = "0i3qcpbdqqsnbygi46dyqamgkh9v8rhpbm4lkl75riw48j4n080k";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    furl
+    jsonschema
+    requests
+    xmltodict
+  ];
+
+  checkInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pook" ];
+
+  meta = with lib; {
+    description = "HTTP traffic mocking and testing made simple in Python";
+    homepage = "https://github.com/h2non/pook";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/sopel/default.nix
+++ b/pkgs/development/python-modules/sopel/default.nix
@@ -51,6 +51,8 @@ buildPythonPackage rec {
     popd
   '';
 
+  pythonImportsCheck = [ "sopel" ];
+
   meta = with lib; {
     description = "Simple and extensible IRC bot";
     homepage = "http://sopel.chat";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5072,6 +5072,8 @@ in {
 
   pooch = callPackage ../development/python-modules/pooch { };
 
+  pook = callPackage ../development/python-modules/pook { };
+
   poolsense = callPackage ../development/python-modules/poolsense { };
 
   poppler-qt5 = callPackage ../development/python-modules/poppler-qt5 {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.9.40

Change log: https://github.com/mindflayer/python-mocket/releases/tag/3.9.40

- Add `python3Packages.pook` to be able to run more tests
- Python 2 compatibility layer was removed with 3.9.35

Depends on #112854.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
