### PR TITLE
vscode-extensions.hashicorp.terraform: Init at 2.6.0

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -357,6 +357,8 @@ let
         };
       };
 
+      hashicorp.terraform = callPackage ./terraform {};
+
       hookyqr.beautify = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "beautify";

--- a/pkgs/misc/vscode-extensions/terraform/default.nix
+++ b/pkgs/misc/vscode-extensions/terraform/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchurl, vscode-utils, terraform-ls }:
+vscode-utils.buildVscodeMarketplaceExtension rec {
+  mktplcRef = {
+    name = "terraform";
+    publisher = "hashicorp";
+    version = "2.6.0";
+  };
+
+  vsix = fetchurl {
+    name = "${mktplcRef.publisher}-${mktplcRef.name}.zip";
+    url = "https://github.com/hashicorp/vscode-terraform/releases/download/v${mktplcRef.version}/terraform-${mktplcRef.version}.vsix";
+    sha256 = "1zg90x2asl6gakd2w8fn4imllqgrzdb1dn3728s63blmml42a1xp";
+  };
+
+  patches = [ ./fix-terraform-ls.patch ];
+
+  postPatch = ''
+    substituteInPlace out/extension.js --replace TERRAFORM-LS-PATH ${terraform-ls}/bin/terraform-ls
+  '';
+
+  meta = with lib; {
+    license = licenses.mit;
+    maintainers = with maintainers; [ rhoriguchi ];
+  };
+}

--- a/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
+++ b/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
@@ -1,0 +1,25 @@
+diff --git a/out/extension.js b/out/extension.js
+index 1de8aab..e2b3a3e 100644
+--- a/out/extension.js
++++ b/out/extension.js
+@@ -204,19 +204,7 @@ function pathToBinary() {
+         if (!_pathToBinaryPromise) {
+             let command = vscodeUtils_1.config('terraform').get('languageServer.pathToBinary');
+             if (!command) { // Skip install/upgrade if user has set custom binary path
+-                const installDir = `${extensionPath}/lsp`;
+-                const installer = new languageServerInstaller_1.LanguageServerInstaller();
+-                try {
+-                    yield installer.install(installDir);
+-                }
+-                catch (err) {
+-                    vscode.window.showErrorMessage(err);
+-                    throw err;
+-                }
+-                finally {
+-                    yield installer.cleanupZips(installDir);
+-                }
+-                command = `${installDir}/terraform-ls`;
++                command = 'TERRAFORM-LS-PATH';
+             }
+             _pathToBinaryPromise = Promise.resolve(command);
+         }


### PR DESCRIPTION
###### Motivation for this change

Add support for [Terraform](https://github.com/hashicorp/vscode-terraform) VS Code extensions.

Make proposed changes in PR [#110505](https://github.com/NixOS/nixpkgs/pull/110505#issuecomment-766369814).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
