### PR TITLE
[20.09] bambootracker: 0.4.5 -> 0.4.6

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -62,6 +62,14 @@ mkDerivation rec {
 
   postConfigure = "make qmake_all";
 
+  # installs app bundle on darwin, re-extract the binary
+  # wrapQtAppsHook fails to wrap mach-o binaries, manually call wrapper (https://github.com/NixOS/nixpkgs/issues/102044)
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mv $out/bin/BambooTracker{.app/Contents/MacOS/BambooTracker,}
+    rm -r $out/bin/BambooTracker.app
+    wrapQtApp $out/bin/BambooTracker
+  '';
+
   meta = with lib; {
     description = "A tracker for YM2608 (OPNA) which was used in NEC PC-8801/9801 series computers";
     homepage = "https://rerrahkr.github.io/BambooTracker";

--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -33,6 +33,11 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace BambooTracker/BambooTracker.pro \
+      --replace '# Temporary known-error downgrades here' 'CPP_WARNING_FLAGS += -Wno-missing-braces'
+  '';
+
   nativeBuildInputs = [ qmake qttools pkg-config ];
 
   buildInputs = [ qtbase ]

--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , stdenv
 , lib
+, stdenv
 , fetchFromGitHub
 , qmake
 , pkg-config
@@ -57,5 +58,6 @@ mkDerivation rec {
     license = licenses.gpl2Only;
     platforms = platforms.all;
     maintainers = with maintainers; [ OPNA2608 ];
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -1,8 +1,8 @@
 { mkDerivation
 , stdenv
 , lib
-, stdenv
 , fetchFromGitHub
+, fetchpatch
 , qmake
 , pkg-config
 , qttools
@@ -33,10 +33,15 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace BambooTracker/BambooTracker.pro \
-      --replace '# Temporary known-error downgrades here' 'CPP_WARNING_FLAGS += -Wno-missing-braces'
-  '';
+  # TODO Remove when updating past 0.4.6
+  # Fixes build failure on darwin
+  patches = [
+    (fetchpatch {
+      name = "bambootracker-Add_braces_in_initialization_of_std-array.patch";
+      url = "https://github.com/rerrahkr/BambooTracker/commit/0fc96c60c7ae6c2504ee696bb7dec979ac19717d.patch";
+      sha256 = "1z28af46mqrgnyrr4i8883gp3wablkk8rijnj0jvpq01s4m2sfjn";
+    })
+  ];
 
   nativeBuildInputs = [ qmake qttools pkg-config ];
 
@@ -63,6 +68,5 @@ mkDerivation rec {
     license = licenses.gpl2Only;
     platforms = platforms.all;
     maintainers = with maintainers; [ OPNA2608 ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19631,7 +19631,10 @@ in
 
   azpainter = callPackage ../applications/graphics/azpainter { };
 
-  bambootracker = libsForQt5.callPackage ../applications/audio/bambootracker { };
+  bambootracker = libsForQt5.callPackage ../applications/audio/bambootracker {
+    jack = libjack2;
+    inherit (darwin.apple_sdk.frameworks) CoreAudio CoreMIDI CoreFoundation CoreServices;
+  };
 
   cadence = let
     # Use Qt 5.14 consistently


### PR DESCRIPTION
###### Motivation for this change
Backporting [0.4.6](https://github.com/NixOS/nixpkgs/pull/112810) and multiple followup PRs to stable. ~~Refactoring commits of RtAudio/RtMidi required to fix pc file problems with them during configuration - I don't think that'll break anything but if it's too much of a delta I can do that in a separate PR or enable vendored Rt-libs instead.~~

I've dropped the RtAudio/RtMidi refactorings and instead adapted the bump commit to work as it did previously, with vendored versions of RtAudio/RtMidi.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
