### PR TITLE
ocamlPackages.psmt2-frontend: 0.2 → 0.3.1

### DIFF
--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -9,20 +9,22 @@ let
     sha256 = "124k2a4ikk4wdpmvgjpgl97x9skvr9qznk8m68dzsynzpv6yksaj";
   };
 
+  useDune2 = true;
+
   nativeBuildInputs = [ which ];
 
 in
 
 let alt-ergo-lib = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-lib";
-  inherit version src nativeBuildInputs;
+  inherit version src useDune2 nativeBuildInputs;
   configureFlags = pname;
   propagatedBuildInputs = with ocamlPackages; [ num ocplib-simplex stdlib-shims zarith ];
 }; in
 
 let alt-ergo-parsers = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-parsers";
-  inherit version src nativeBuildInputs;
+  inherit version src useDune2 nativeBuildInputs;
   configureFlags = pname;
   buildInputs = with ocamlPackages; [ menhir ];
   propagatedBuildInputs = [ alt-ergo-lib ] ++ (with ocamlPackages; [ camlzip psmt2-frontend ]);
@@ -30,7 +32,7 @@ let alt-ergo-parsers = ocamlPackages.buildDunePackage rec {
 
 ocamlPackages.buildDunePackage {
 
-  inherit pname version src nativeBuildInputs;
+  inherit pname version src useDune2 nativeBuildInputs;
 
   configureFlags = pname;
 

--- a/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
+++ b/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
@@ -1,35 +1,27 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, ocaml, findlib, menhir }:
+{ lib, fetchFromGitHub, buildDunePackage, menhir }:
 
-if !lib.versionAtLeast ocaml.version "4.03"
-then throw "psmt2-frontend is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  version = "0.2";
-  name = "ocaml${ocaml.version}-psmt2-frontend-${version}";
+buildDunePackage rec {
+  version = "0.3.1";
+  pname = "psmt2-frontend";
 
   src = fetchFromGitHub {
-    owner = "Coquera";
-    repo = "psmt2-frontend";
+    owner = "ACoquereau";
+    repo = pname;
     rev = version;
-    sha256 = "097zmbrx4gp2gnrxdmsm9lkkp5450gwi0blpxqy3833m6k5brx3n";
+    sha256 = "038jrfsq09nhnzpjiishg4adk09w3aw1bpczgbj66lqqilkd6gci";
   };
 
-  prefixKey = "-prefix ";
+  useDune2 = true;
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ocaml findlib menhir ];
+  minimumOCamlVersion = "4.03";
 
-  createFindlibDestdir = true;
-
-  installFlags = [ "LIBDIR=$(OCAMLFIND_DESTDIR)" ];
+  buildInputs = [ menhir ];
 
   meta = {
     description = "A simple parser and type-checker for polomorphic extension of the SMT-LIB 2 language";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.
Required by latest version of alt-ergo.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
