### PR TITLE
python3Packages.linode-api: 4.1.8b1 -> 5.0.0

### DIFF
--- a/pkgs/development/python-modules/linode-api/default.nix
+++ b/pkgs/development/python-modules/linode-api/default.nix
@@ -1,41 +1,38 @@
-{
-  buildPythonPackage,
-  fetchFromGitHub,
-  pythonOlder,
-  lib,
-  requests,
-  future,
-  enum34,
-  mock }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, requests
+, pytestCheckHook
+, mock
+}:
 
 buildPythonPackage rec {
   pname = "linode-api";
-  version = "4.1.8b1"; # NOTE: this is a beta, and the API may change in future versions.
-
-  disabled = (pythonOlder "2.7");
-
-  propagatedBuildInputs = [ requests future ]
-                             ++ lib.optionals (pythonOlder "3.4") [ enum34 ];
-
-  postPatch = (lib.optionalString (!pythonOlder "3.4") ''
-    sed -i -e '/"enum34",/d' setup.py
-  '');
-
-  doCheck = true;
-  checkInputs = [ mock ];
+  version = "5.0.0";
+  disabled = pythonOlder "3.6";
 
   # Sources from Pypi exclude test fixtures
   src = fetchFromGitHub {
-    rev = "v${version}";
     owner = "linode";
     repo = "python-linode-api";
-    sha256 = "0qfqn92fr876dncwbkf2vhm90hnf7lwpg80hzwyzyzwz1hcngvjg";
+    rev = version;
+    sha256 = "0lqi15vks4fxbki1l7n1bfzygjy3w17d9wchjxvp22ijmas44yai";
   };
 
-  meta = {
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "linode_api4" ];
+
+  meta = with lib; {
+    description = "Python library for the Linode API v4";
     homepage = "https://github.com/linode/python-linode-api";
-    description = "The official python library for the Linode API v4 in python.";
-    license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ glenns ];
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ glenns ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 5.0.0

Switch to `pytestCheckHook` additionally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
