### PR TITLE
python3Packages.requests: 2.25.0 -> 2.25.1

### DIFF
--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -1,24 +1,59 @@
-{ lib, fetchPypi, buildPythonPackage
-, urllib3, idna, chardet, certifi
-, pytest }:
+{ lib
+, buildPythonPackage
+, certifi
+, chardet
+, fetchPypi
+, idna
+, pytest-mock
+, pytest-xdist
+, pytestCheckHook
+, urllib3
+}:
 
 buildPythonPackage rec {
   pname = "requests";
-  version = "2.25.0";
+  version = "2.25.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1y6mb8c0ipd64d5axq2p368yxndp3f966hmabjka2q2a5y9hn6kz";
+    sha256 = "sha256-J5c91KkEpPE7JjoZyGbBO5KjntHJZGVfAl8/jT11uAQ=";
   };
 
-  nativeBuildInputs = [ pytest ];
-  propagatedBuildInputs = [ urllib3 idna chardet certifi ];
-  # sadly, tests require networking
-  doCheck = false;
+  propagatedBuildInputs = [
+    certifi
+    chardet
+    idna
+    urllib3
+  ];
+
+  checkInputs = [
+    pytest-mock
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Disable tests that require network access and use httpbin
+    "requests.api.request"
+    "requests.models.PreparedRequest"
+    "requests.sessions.Session"
+    "requests"
+    "test_redirecting_to_bad_url"
+    "test_requests_are_updated_each_time"
+    "test_should_bypass_proxies_pass_only_hostname"
+    "test_urllib3_pool_connection_closed"
+    "test_urllib3_retries"
+    "test_use_proxy_from_environment"
+    "TestRequests"
+    "TestTimeout"
+  ];
+
+  pythonImportsCheck = [ "requests" ];
 
   meta = with lib; {
-    description = "An Apache2 licensed HTTP library, written in Python, for human beings";
+    description = "Simple HTTP library for Python";
     homepage = "http://docs.python-requests.org/en/latest/";
     license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.25.1

Change log: https://github.com/psf/requests/blob/master/HISTORY.md#2251-2020-12-16

Tests are now partially enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
