### PR TITLE
argocd: 1.8.3 -> 1.8.4

### DIFF
--- a/pkgs/applications/networking/cluster/argocd/default.nix
+++ b/pkgs/applications/networking/cluster/argocd/default.nix
@@ -2,14 +2,14 @@
 
 buildGoModule rec {
   pname = "argocd";
-  version = "1.8.3";
-  commit = "ef5010c3a0b5e027fd642732d03c5b0391b1e574";
+  version = "1.8.4";
+  commit = "28aea3dfdede00443b52cc584814d80e8f896200";
 
   src = fetchFromGitHub {
     owner = "argoproj";
     repo = "argo-cd";
     rev = "v${version}";
-    sha256 = "sha256-do5DAxaQ1gBdvNN/YGKAkmkFcJ+j/ojBaWPwrXXQko0=";
+    sha256 = "sha256:155396rnihha31jxy0zk1jykiirpv4dhc69w45y6nx3nx4k0gwhk";
   };
 
   vendorSha256 = "sha256-6DOay+aeXz7EQKe5SzQSmg/5KyUI0g6wzPgx/+F2RW4=";


### PR DESCRIPTION
Bump argocd to [1.8.4](https://github.com/argoproj/argo-cd/releases/tag/v1.8.4). Includes fix for [auth issue](https://github.com/argoproj/argo-cd/issues/5381).

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
