### PR TITLE
wafw00f: init at 2.1.0

### DIFF
--- a/pkgs/tools/security/wafw00f/default.nix
+++ b/pkgs/tools/security/wafw00f/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, pluginbase
+, requests
+}:
+
+buildPythonApplication rec {
+  pname = "wafw00f";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "EnableSecurity";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0526kz6ypww9nxc2vddkhpn1gqvn25mzj3wmi91wwxwxjjb6w4qj";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    pluginbase
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "wafw00f" ];
+
+  meta = with lib; {
+    description = "Tool to identify and fingerprint Web Application Firewalls (WAF)";
+    homepage = "https://github.com/EnableSecurity/wafw00f";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25659,6 +25659,8 @@ in
 
   wad = python3Packages.callPackage ../tools/security/wad { };
 
+  wafw00f = python3Packages.callPackage ../tools/security/wafw00f { };
+
   waon = callPackage ../applications/audio/waon { };
 
   w3m = callPackage ../applications/networking/browsers/w3m { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to identify and fingerprint Web Application Firewalls (WAF)

https://github.com/EnableSecurity/wafw00f

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
