### PR TITLE
zrepl: init at 0.3.1.

### DIFF
--- a/pkgs/tools/backup/zrepl/default.nix
+++ b/pkgs/tools/backup/zrepl/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "zrepl";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "zrepl";
+    repo = "zrepl";
+    rev = "v${version}";
+    sha256 = "sha256-wtUL8GGSJxn9yEdyTWKtkHODfxxLOxojNPlPLRjI9xo=";
+  };
+
+  vendorSha256 = "sha256-4LBX0bD8qirFaFkV52QFU50lEW4eae6iObIa5fFT/wA=";
+
+  subPackages = [ "." ];
+
+  postInstall = ''
+    mkdir -p $out/lib/systemd/system
+    substitute dist/systemd/zrepl.service $out/lib/systemd/system/zrepl.service \
+      --replace /usr/local/bin/zrepl $out/bin/zrepl
+  '';
+
+  meta = with lib; {
+    homepage = "https://zrepl.github.io/";
+    description = "A one-stop, integrated solution for ZFS replication";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ cole-h danderson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29967,6 +29967,8 @@ in
 
   zfs-replicate = python3Packages.callPackage ../tools/backup/zfs-replicate { };
 
+  zrepl = callPackage ../tools/backup/zrepl { };
+
   runwayml = callPackage ../applications/graphics/runwayml {};
 
   uhubctl = callPackage ../tools/misc/uhubctl {};


### PR DESCRIPTION
###### Motivation for this change

I want to use zrepl :)

cc @grahamc 

/marvin opt-in
/status needs_reviewer

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
