### PR TITLE
nixos/locale: set TZ to :/etc/localtime

### DIFF
--- a/nixos/modules/config/locale.nix
+++ b/nixos/modules/config/locale.nix
@@ -74,12 +74,29 @@ in
 
   config = {
 
-    environment.sessionVariables.TZDIR = "/etc/zoneinfo";
+    environment.sessionVariables = {
+      TZDIR = "/etc/zoneinfo";
+    } // lib.optionalAttrs (config.time.timeZone != null) {
+      # TZ is set to prevent glibc from calling stat() every time localtime() is called,
+      # which can be a significant performance problem if /etc is on an NFS filesystem.
+      #
+      # We point to the /etc/localtime symlink so that we don't have to re-login to pick
+      # up a time zone change.
+      TZ = ":/etc/localtime";
+    };
 
     services.geoclue2.enable = mkIf (lcfg.provider == "geoclue2") true;
 
-    # This way services are restarted when tzdata changes.
-    systemd.globalEnvironment.TZDIR = tzdir;
+    systemd.globalEnvironment = {
+      # This way services are restarted when tzdata changes.
+      TZDIR = tzdir;
+    } // lib.optionalAttrs (config.time.timeZone != null) {
+      # See comment above about TZ.
+      # Here, we point to the actual time zone file, instead of the /etc/localtime
+      # symlink, so that systemd services are restarted automatically when the time
+      # zone changes.
+      TZ = ":/etc/zoneinfo/${config.time.timeZone}";
+    };
 
     systemd.services.systemd-timedated.environment = lib.optionalAttrs (config.time.timeZone != null) { NIXOS_STATIC_TIMEZONE = "1"; };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This rebases https://github.com/NixOS/nixpkgs/pull/23078.

This prevents glibc from calling stat() every time localtime() is called, which could be a significant performance problem if /etc is on an NFS filesystem.

For systemd services, we point TZ to the actual time zone file instead of the /etc/localtime symlink so that systemd services are restarted if the time zone is changed.

Note that Go supports this feature from 1.16, so backporting https://github.com/golang/go/commit/58fe2cd4022c77946ce4b598cf3e30ccc8367143 to 1.14 and 1.15 might be needed. Any opinions?
Also, it would be appropriated if you could report any programming languages not working with it. I confirmed that Python supports it and many others should be fine as long as they use libc routines to handle timezones.

Fixes https://github.com/NixOS/nixpkgs/issues/23053
Closes https://github.com/NixOS/nixpkgs/pull/23078

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
