### PR TITLE
acgtk: 1.5.1 → 1.5.2

### DIFF
--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -1,20 +1,20 @@
-{ lib, stdenv, fetchurl, dune, ocamlPackages }:
+{ lib, stdenv, fetchurl, dune_2, ocamlPackages }:
 
 stdenv.mkDerivation {
 
   pname = "acgtk";
-  version = "1.5.1";
+  version = "1.5.2";
 
   src = fetchurl {
-    url = "https://acg.loria.fr/software/acg-1.5.1-20191113.tar.gz";
-    sha256 = "17595qfwhzz5q091ak6i6bg5wlppbn8zfn58x3hmmmjvx2yfajn1";
+    url = "https://acg.loria.fr/software/acg-1.5.2-20201204.tar.gz";
+    sha256 = "09yax7dyw8kgwzlb69r9d20y7rrymzwi3bbq2dh0qdq01vjz2xwq";
   };
 
-  buildInputs = [ dune ] ++ (with ocamlPackages; [
+  buildInputs = [ dune_2 ] ++ (with ocamlPackages; [
     ocaml findlib ansiterminal cairo2 cmdliner fmt logs menhir mtime yojson
   ]);
 
-  buildPhase = "dune build";
+  buildPhase = "dune build --profile=release";
 
   installPhase = ''
     dune install --prefix $out --libdir $OCAMLFIND_DESTDIR


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
