### PR TITLE
libetpan: Fix CVE-2020-15953

### DIFF
--- a/pkgs/development/libraries/libetpan/default.nix
+++ b/pkgs/development/libraries/libetpan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub
+{ stdenv, lib, fetchFromGitHub, fetchpatch
 , autoconf, automake, libtool, openssl, pkg-config
 }:
 
@@ -12,6 +12,28 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0g7an003simfdn7ihg9yjv7hl2czsmjsndjrp39i7cad8icixscn";
   };
+
+  patches = [
+    # The following two patches are fixing CVE-2020-15953, as reported in the
+    # issue tracker: https://github.com/dinhvh/libetpan/issues/386
+    # They might be removed for the next version bump.
+
+    # CVE-2020-15953: Detect extra data after STARTTLS response and exit
+    # https://github.com/dinhvh/libetpan/pull/387
+    (fetchpatch {
+      name = "cve-2020-15953-imap.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/1002a0121a8f5a9aee25357769807f2c519fa50b.patch";
+      sha256 = "1h9ds2z4jii40a0i3z6hsnzx1ldmd2jqidsxp2y2ksyp1ijcgabn";
+    })
+
+    # CVE-2020-15953: Detect extra data after STARTTLS responses in SMTP and POP3 and exit
+    # https://github.com/dinhvh/libetpan/pull/388
+    (fetchpatch {
+      name = "cve-2020-15953-pop3-smtp.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/298460a2adaabd2f28f417a0f106cb3b68d27df9.patch";
+      sha256 = "0lq829djar7nb3fai3vdzirmks3w2lfagzqc809lx2lln6y213a0";
+    })
+  ];
 
   nativeBuildInputs = [ autoconf automake libtool pkg-config ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This commit patches the vulnerable libetpan release 1.9.4 with its upstream patches against the CVE-2020-15953.

Merging this will close #113463.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
