### PR TITLE
dockertools: sort tar-members by name for reproducibility

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -770,6 +770,7 @@ rec {
           mkdir $out
 
           tar \
+            --sort name \
             --owner 0 --group 0 --mtime "@$SOURCE_DATE_EPOCH" \
             --hard-dereference \
             -C old_out \


### PR DESCRIPTION
###### Motivation for this change
The customisation (final) layer that buildLayeredImage produces is currently not reproducible.
The reason is that tar-member ordering vary. Depedending on the filesystem used, the default order might be inode-based, or just "random".

On my system at least, the problem can be demonstrated by re-building the customisation layer ( on nixpkgs-unstable ):

```
nix-build $(nix-store -qR $(nix-store -qd $(nix-build '<nixpkgs>' -A dockerTools.examples.bashLayeredWithUser)) | grep customisation-layer)

nix-build $(nix-store -qR $(nix-store -qd $(nix-build '<nixpkgs>' -A dockerTools.examples.bashLayeredWithUser)) | grep customisation-layer) --check
```

Sorting tar-members by name seems to restore determinism.

cc @utdemir @srhb 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
