### PR TITLE
fetchgit: install git LFS with --local

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -217,6 +217,14 @@ init_submodules(){
     done
 }
 
+# Fetch extra files from LFS
+init_lfs(){
+    # use --local because the nix-builders are $HOME-less
+    clean_git lfs install --local
+    clean_git lfs fetch
+    clean_git lfs checkout
+}
+
 clone(){
     local top=$PWD
     local dir="$1"
@@ -239,6 +247,9 @@ clone(){
     # Checkout linked sources.
     if test -n "$fetchSubmodules"; then
         init_submodules
+    fi
+    if test -n "$fetchLFS"; then
+        init_lfs
     fi
 
     if [ -z "$builder" ] && [ -f .topdeps ]; then
@@ -298,11 +309,6 @@ clone_user_rev() {
     local dir="$1"
     local url="$2"
     local rev="${3:-HEAD}"
-
-    if [ -n "$fetchLFS" ]; then
-        HOME=$TMPDIR
-        git lfs install
-    fi
 
     # Perform the checkout.
     case "$rev" in
@@ -396,6 +402,7 @@ print_results() {
   "date": "$(json_escape "$commitDateStrict8601")",
   "path": "$(json_escape "$finalPath")",
   "$(json_escape "$hashType")": "$(json_escape "$hash")",
+  "fetchLFS": $([[ -n "$fetchLFS" ]] && echo true || echo false),
   "fetchSubmodules": $([[ -n "$fetchSubmodules" ]] && echo true || echo false),
   "deepClone": $([[ -n "$deepClone" ]] && echo true || echo false),
   "leaveDotGit": $([[ -n "$leaveDotGit" ]] && echo true || echo false)

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, makeWrapper, buildEnv
-, breezy, coreutils, cvs, findutils, gawk, git, gnused, mercurial, nix, subversion
+, breezy, coreutils, cvs, findutils, gawk, git, git-lfs, gnused, mercurial, nix, subversion
 }:
 
 let mkPrefetchScript = tool: src: deps:
@@ -28,7 +28,7 @@ let mkPrefetchScript = tool: src: deps:
 in rec {
   nix-prefetch-bzr = mkPrefetchScript "bzr" ../../../build-support/fetchbzr/nix-prefetch-bzr [ breezy ];
   nix-prefetch-cvs = mkPrefetchScript "cvs" ../../../build-support/fetchcvs/nix-prefetch-cvs [ cvs ];
-  nix-prefetch-git = mkPrefetchScript "git" ../../../build-support/fetchgit/nix-prefetch-git [ coreutils findutils gawk git ];
+  nix-prefetch-git = mkPrefetchScript "git" ../../../build-support/fetchgit/nix-prefetch-git [ coreutils findutils gawk git git-lfs ];
   nix-prefetch-hg  = mkPrefetchScript "hg"  ../../../build-support/fetchhg/nix-prefetch-hg   [ mercurial ];
   nix-prefetch-svn = mkPrefetchScript "svn" ../../../build-support/fetchsvn/nix-prefetch-svn [ subversion ];
 


### PR DESCRIPTION
###### Motivation for this change
nix-builders run with GIT_CONFIG_NOSYSTEM (#63774) and `git lfs install` fails. The approach taken in PR #105998 sets `HOME=$TMPDIR` to make it work. However, `git lfs install` [supports](https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-install.1.ronn) a `--local` flag to set itself up in the local repository's git config. I believe this would be cleaner than the current approach. Furthermore, `nix-prefetch-git` lacks the git-lfs dependence and does not publicly document the command line switch `--fetch-lfs`.

Note: I suspect this PR could cause `git-lfs` files in submodules not be fetched, so it may still need minor refinement.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
