### PR TITLE
nixos/tests/openldap: fix evaluation when auto-called

### DIFF
--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -1,4 +1,9 @@
-{ pkgs, system ? builtins.currentSystem, ... }: let
+{ pkgs ? (import ../.. { inherit system; config = { }; })
+, system ? builtins.currentSystem
+, ...
+}:
+
+let
   dbContents = ''
     dn: dc=example
     objectClass: domain
@@ -16,7 +21,7 @@
   '';
 in {
   # New-style configuration
-  current = import ./make-test-python.nix {
+  current = import ./make-test-python.nix ({ pkgs, ... }: {
     inherit testScript;
     name = "openldap";
 
@@ -53,10 +58,10 @@ in {
         declarativeContents."dc=example" = dbContents;
       };
     };
-  };
+  }) { inherit pkgs system; };
 
   # Old-style configuration
-  oldOptions = import ./make-test-python.nix {
+  oldOptions = import ./make-test-python.nix ({ pkgs, ... }: {
     inherit testScript;
     name = "openldap";
 
@@ -72,10 +77,10 @@ in {
         declarativeContents."dc=example" = dbContents;
       };
     };
-  };
+  }) { inherit system pkgs; };
 
   # Manually managed configDir, for example if dynamic config is essential
-  manualConfigDir = import ./make-test-python.nix {
+  manualConfigDir = import ./make-test-python.nix ({ pkgs, ... }: {
     name = "openldap";
 
     machine = { pkgs, ... }: {
@@ -121,5 +126,5 @@ in {
           "systemctl restart openldap",
       )
     '' + testScript;
-  };
+  }) { inherit system pkgs; };
 }


### PR DESCRIPTION
The NixOS manual documents that you can invoke every tests using

    nix-build path/to/nixos/tests/test.nix

which was not the case for openldap since it is not autocallable, but
requires pkgs and system as arguments. Usually, make-test-pythons.nix
takes care of this if it is imported at the top-level, but since
openldap.nix contains multiple tests, this was not the case.

This is however easily fixed by:

* Adding default values for the pkgs and system arguments based on the
  definition in make-test-python.nix
* Passing pkgs and system explicitly to make-test-python.nix to ensure
  the pkgs and system values passed from all-tests.nix are used.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
