### PR TITLE
gimpPlugins.farbfeld: init at 2019-08-12

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -81,6 +81,29 @@ in
     };
   };
 
+  farbfeld = pluginDerivation rec {
+    pname = "farbfeld";
+    version = "unstable-2019-08-12";
+
+    src = fetchFromGitHub {
+      owner = "ids1024";
+      repo = "gimp-farbfeld";
+      rev = "5feacebf61448bd3c550dda03cd08130fddc5af4";
+      sha256 = "1vmw7k773vrndmfffj0m503digdjmkpcqy2r3p3i5x0qw9vkkkc6";
+    };
+
+    installPhase = ''
+      installPlugin farbfeld
+    '';
+
+    meta = {
+      description = "Gimp plug-in for the farbfeld image format";
+      homepage = "https://github.com/ids1024/gimp-farbfeld";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ sikmir ];
+    };
+  };
+
   fourier = pluginDerivation rec {
     /* menu:
        Filters/Generic/FFT Forward


### PR DESCRIPTION
###### Motivation for this change
* [Farbfeld format](http://tools.suckless.org/farbfeld/)
* [Gimp plug-in for the farbfeld image format](https://github.com/ids1024/gimp-farbfeld)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
