### PR TITLE
python3Packages.librouteros: init at 3.1.0

### DIFF
--- a/pkgs/development/python-modules/librouteros/default.nix
+++ b/pkgs/development/python-modules/librouteros/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, pytestCheckHook
+, pytest-xdist
+}:
+
+buildPythonPackage rec {
+  pname = "librouteros";
+  version = "3.1.0";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "luqasz";
+    repo = pname;
+    rev = version;
+    sha256 = "1skjwnqa3vcpq9gzgpw93wdmisq15fp0q07kzyq3fgx4yg7b6sql";
+  };
+
+  checkInputs = [
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Disable tests which require QEMU to run
+    "test_login"
+    "test_long_word"
+    "test_query"
+    "test_add_then_remove"
+    "test_add_then_update"
+    "test_generator_ditch"
+  ];
+
+  pythonImportsCheck = [ "librouteros" ];
+
+  meta = with lib; {
+    description = "Python implementation of the MikroTik RouterOS API";
+    homepage = "https://librouteros.readthedocs.io/";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -496,7 +496,7 @@
     "microsoft_face_detect" = ps: with ps; [ aiohttp-cors ];
     "microsoft_face_identify" = ps: with ps; [ aiohttp-cors ];
     "miflora" = ps: with ps; [ bluepy ]; # missing inputs: miflora
-    "mikrotik" = ps: with ps; [ ]; # missing inputs: librouteros
+    "mikrotik" = ps: with ps; [ librouteros ];
     "mill" = ps: with ps; [ ]; # missing inputs: millheater
     "min_max" = ps: with ps; [ ];
     "minecraft_server" = ps: with ps; [ aiodns getmac ]; # missing inputs: mcstatus

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3692,6 +3692,8 @@ in {
 
   librosa = callPackage ../development/python-modules/librosa { };
 
+  librouteros = callPackage ../development/python-modules/librouteros { };
+
   libsass = (callPackage ../development/python-modules/libsass { inherit (pkgs) libsass; });
 
   libsavitar = callPackage ../development/python-modules/libsavitar { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python implementation of the MikroTik RouterOS API

https://librouteros.readthedocs.io/

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
