### PR TITLE
emacs: precompile all trampolines

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -159,6 +159,10 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
   '' + lib.optionalString (nativeComp && withNS) ''
     ln -snf $out/lib/emacs/*/native-lisp $out/Applications/Emacs.app/Contents/native-lisp
   '' + lib.optionalString nativeComp ''
+    $out/bin/emacs --batch \
+      -l comp --eval "(mapatoms (lambda (s) \
+                        (when (subr-primitive-p (symbol-function s)) \
+                          (comp-trampoline-compile s))))"
     mkdir -p $out/share/emacs/native-lisp
     $out/bin/emacs --batch \
       --eval "(add-to-list 'comp-eln-load-path \"$out/share/emacs/native-lisp\")" \


### PR DESCRIPTION
Alternative solution to the `emacs-git-commit` compilation problem (described at https://github.com/nix-community/emacs-overlay/issues/110, https://github.com/nix-community/emacs-overlay/issues/74#issuecomment-758160258), which I previously tried to fix in #109370 by disabling trampoline generation. The Elisp was taken from https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44238#8.

Since trampolines are only generated for primitives, this patch stores them at the same location used by the base emacs build (`/nix/store/*-emacs-gcc-VERSION/lib/emacs/28.0.50/native-lisp`). On my 6 year old laptop, generation takes about 10 minutes to run. The `native-lisp` folder increases from 131MB to 158MB (1331 extra files, all around 20KB).

cc @tadfisher @acowley

- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
