### PR TITLE
python3Packages.packageurl: init at 0.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -734,6 +734,12 @@
     githubId = 1296771;
     name = "Anders Riutta";
   };
+  armijnhemel = {
+    email = "armijn@tjaldur.nl";
+    github = "armijnhemel";
+    githubId = 10587952;
+    name = "Armijn Hemel";
+  };
   arnarg = {
     email = "arnarg@fastmail.com";
     github = "arnarg";

--- a/pkgs/development/python-modules/packageurl-python/default.nix
+++ b/pkgs/development/python-modules/packageurl-python/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "A parser and builder for purl aka 'Package URLs' for Python 2 and 3.";
+    description = "Python parser and builder for package URLs";
     homepage = "https://github.com/package-url/packageurl-python";
     license = licenses.mit;
     maintainers = with maintainers; [ armijnhemel ];

--- a/pkgs/development/python-modules/packageurl-python/default.nix
+++ b/pkgs/development/python-modules/packageurl-python/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "A parser and builder for purl aka. Package URLs for Python 2 and 3.";
+    description = "A parser and builder for purl aka 'Package URLs' for Python 2 and 3.";
     homepage = "https://github.com/package-url/packageurl-python";
     license = licenses.mit;
     maintainers = with maintainers; [ armijnhemel ];

--- a/pkgs/development/python-modules/packageurl-python/default.nix
+++ b/pkgs/development/python-modules/packageurl-python/default.nix
@@ -1,0 +1,17 @@
+{ buildPythonPackage, fetchPypi, lib }:
+
+buildPythonPackage rec {
+  pname = "packageurl-python";
+  version = "0.9.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mpvj8imsaqhrgfq1cxx16flc5201y78kqa7bh2i5zxsc29843mx";
+  };
+
+  meta = with lib; {
+    description = "A parser and builder for purl aka. Package URLs for Python 2 and 3.";
+    homepage = "https://github.com/package-url/packageurl-python";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/packageurl-python/default.nix
+++ b/pkgs/development/python-modules/packageurl-python/default.nix
@@ -13,5 +13,6 @@ buildPythonPackage rec {
     description = "A parser and builder for purl aka. Package URLs for Python 2 and 3.";
     homepage = "https://github.com/package-url/packageurl-python";
     license = licenses.mit;
+    maintainers = with maintainers; [ armijnhemel ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4642,7 +4642,7 @@ in {
 
   oyaml = callPackage ../development/python-modules/oyaml { };
 
-  packageurl-python = callPackage ../development/python-modules/packageurl-python { };
+  packageurl = callPackage ../development/python-modules/packageurl-python { };
 
   packaging = if isPy3k
     then callPackage ../development/python-modules/packaging { }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4642,6 +4642,8 @@ in {
 
   oyaml = callPackage ../development/python-modules/oyaml { };
 
+  packageurl-python = callPackage ../development/python-modules/packageurl-python { };
+
   packaging = if isPy3k
     then callPackage ../development/python-modules/packaging { }
     else callPackage ../development/python-modules/packaging/2.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

packageurl (AKA purl) is an upcoming standard to describe packages in a more uniform way across operating systems and Linux distributions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
