### PR TITLE
sage: disable intermittent test and fix threejs breakage

### DIFF
--- a/pkgs/applications/science/math/sage/patches/disable-pexpect-intermittent-failure.patch
+++ b/pkgs/applications/science/math/sage/patches/disable-pexpect-intermittent-failure.patch
@@ -1,0 +1,29 @@
+diff --git a/src/sage/interfaces/singular.py b/src/sage/interfaces/singular.py
+index 88a33b0349..b3321f0bec 100644
+--- a/src/sage/interfaces/singular.py
++++ b/src/sage/interfaces/singular.py
+@@ -495,24 +495,6 @@ class Singular(ExtraTabCompletion, Expect):
+         """
+         Send an interrupt to Singular. If needed, additional
+         semi-colons are sent until we get back at the prompt.
+-
+-        TESTS:
+-
+-        The following works without restarting Singular::
+-
+-            sage: a = singular(1)
+-            sage: _ = singular._expect.sendline('1+')  # unfinished input
+-            sage: try:
+-            ....:     alarm(0.5)
+-            ....:     singular._expect_expr('>')  # interrupt this
+-            ....: except KeyboardInterrupt:
+-            ....:     pass
+-            Control-C pressed.  Interrupting Singular. Please wait a few seconds...
+-
+-        We can still access a::
+-
+-            sage: 2*a
+-            2
+         """
+         # Work around for Singular bug
+         # http://www.singular.uni-kl.de:8002/trac/ticket/727

--- a/pkgs/applications/science/math/sage/patches/dont-grep-threejs-version-from-minified-js.patch
+++ b/pkgs/applications/science/math/sage/patches/dont-grep-threejs-version-from-minified-js.patch
@@ -1,0 +1,16 @@
+diff --git a/src/sage/repl/rich_output/display_manager.py b/src/sage/repl/rich_output/display_manager.py
+index fb21f7a9c9..f39470777d 100644
+--- a/src/sage/repl/rich_output/display_manager.py
++++ b/src/sage/repl/rich_output/display_manager.py
+@@ -749,9 +749,9 @@ class DisplayManager(SageObject):
+             import sage.env
+             import re
+             import os
+-            with open(os.path.join(sage.env.THREEJS_DIR, 'build', 'three.min.js')) as f:
++            with open(os.path.join(sage.env.THREEJS_DIR, 'build', 'three.js')) as f:
+                 text = f.read().replace('\n','')
+-            version = re.search(r'REVISION="(\d+)"', text).group(1)
++            version = re.search(r"REVISION = '(\d+)'", text).group(1)
+             return """
+ <script src="https://cdn.jsdelivr.net/gh/mrdoob/three.js@r{0}/build/three.min.js"></script>
+ <script src="https://cdn.jsdelivr.net/gh/mrdoob/three.js@r{0}/examples/js/controls/OrbitControls.js"></script>

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -109,6 +109,9 @@ stdenv.mkDerivation rec {
 
     # fix test output with sympy 1.7 (https://trac.sagemath.org/ticket/30985)
     ./patches/sympy-1.7-update.patch
+
+    # workaround until we use sage's fork of threejs, which contains a "version" file
+    ./patches/dont-grep-threejs-version-from-minified-js.patch
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -71,6 +71,9 @@ stdenv.mkDerivation rec {
 
     # fix intermittent errors in sagespawn.pyx: https://trac.sagemath.org/ticket/31052
     ./patches/sagespawn-implicit-casting.patch
+
+    # disable pexpect interrupt test (see https://trac.sagemath.org/ticket/30945)
+    ./patches/disable-pexpect-intermittent-failure.patch
   ];
 
   # Patches needed because of package updates. We could just pin the versions of


### PR DESCRIPTION
This PR contains two changes:

1) Following the suggestion in https://github.com/NixOS/nixpkgs/pull/107663#issuecomment-755433414, I have disabled a test which occasionally causes a segfault. The segfault happens upstream too, see https://trac.sagemath.org/ticket/30945.

2) Starting with Three.js r125, the minified file does not contain the string `REVISION="125"` directly (it contains `n="125",...,REVISION=n`), breaking Sage's fragile way of obtaining revision data. I did not import a patch from upstream because Sage has since migrated to [its own fork of Three.js](https://github.com/sagemath/threejs-sage) in https://trac.sagemath.org/ticket/30915.

Sage migrated to a Three.js fork because they needed to add some extra exports, see https://trac.sagemath.org/ticket/30620 or the fork's README. This probably means that Sage 9.2 already has some incompatibilities with upstream Three.js >= r121, which does not export `OrbitControls`, `Line2`, `LineGeometry`, `LineMaterial`, `LineSegments2` and `LineSegmentsGeometry` (the `examples` folder does not end up in the final `three.js`/`three.min.js` files now). Three.js r121 is in nixpkgs since September (c1834f41029950b41e2e87ad3abb2819deaaee83), so I think unbreaking Sage first makes sense. (Edit: Looking at the relevant Three.js PRs, I see that this was deprecated in r124, not r121. Sorry for the inaccuracy.)

In the future, we have to decide if we want to use Sage's fork or if we want to patch upstream to include the extra exports. I prefer the second option to be honest. It should be easy, but I won't have time to do it until next week. If we do decide to use Sage's fork instead, perhaps we should wait for https://github.com/sagemath/threejs-sage/pull/1 which will upload the library to PyPI.

cc @omasanori @timokau