### PR TITLE
[20.09] nixos/moinmoin: fix module by switching to eventlet worker

### DIFF
--- a/nixos/modules/services/web-apps/moinmoin.nix
+++ b/nixos/modules/services/web-apps/moinmoin.nix
@@ -211,7 +211,7 @@ in
             environment = let
               penv = python.buildEnv.override {
                 # setuptools: https://github.com/benoitc/gunicorn/issues/1716
-                extraLibs = [ python.pkgs.gevent python.pkgs.setuptools pkg ];
+                extraLibs = [ python.pkgs.eventlet python.pkgs.setuptools pkg ];
               };
             in {
               PYTHONPATH = "${dataDir}/${wikiIdent}/config:${penv}/${python.sitePackages}";
@@ -231,7 +231,7 @@ in
               ExecStart = ''${python.pkgs.gunicorn}/bin/gunicorn moin_wsgi \
                 --name gunicorn-${wikiIdent} \
                 --workers ${toString cfg.gunicorn.workers} \
-                --worker-class gevent \
+                --worker-class eventlet \
                 --bind unix:/run/moin/${wikiIdent}/gunicorn.sock
               '';
 


### PR DESCRIPTION
Backport of #108045.

----


###### Motivation for this change

The service (and consequently `nixosTests.moinmoin`) was failing with:
```
gunicorn[2192104]: [2020-12-31 13:35:28 +0000] [2192104] [ERROR] Exception in worker process
gunicorn[2192104]: Traceback (most recent call last):
gunicorn[2192104]:   File "/nix/store/jmc14qf1sfnlhw27xyyj862ghkmdkj5a-python2.7-gunicorn-19.10.0/lib/python2.7/site-packages/gunicorn/arbiter.py", line 586, in spawn_worker
gunicorn[2192104]:     worker.init_process()
gunicorn[2192104]:   File "/nix/store/jmc14qf1sfnlhw27xyyj862ghkmdkj5a-python2.7-gunicorn-19.10.0/lib/python2.7/site-packages/gunicorn/workers/ggevent.py", line 196, in init_process
gunicorn[2192104]:     self.patch()
gunicorn[2192104]:   File "/nix/store/jmc14qf1sfnlhw27xyyj862ghkmdkj5a-python2.7-gunicorn-19.10.0/lib/python2.7/site-packages/gunicorn/workers/ggevent.py", line 65, in patch
gunicorn[2192104]:     monkey.patch_all(subprocess=True)
gunicorn[2192104]:   File "/nix/store/fysf67w3i8iv1hfvp536nl8jbzqyk1s7-python-2.7.18-env/lib/python2.7/site-packages/gevent/monkey.py", line 1160, in patch_all
gunicorn[2192104]:     from gevent import events
gunicorn[2192104]:   File "/nix/store/fysf67w3i8iv1hfvp536nl8jbzqyk1s7-python-2.7.18-env/lib/python2.7/site-packages/gevent/events.py", line 67, in <module>
gunicorn[2192104]:     from zope.interface import Interface
gunicorn[2192104]: ImportError: No module named zope.interface
```

The `gevent` package does depend on `zope_interface` however. I wasn't able to figure out why exactly cannot the module be imported and decided to switch to different `gunicorn` backend instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).