### PR TITLE
mullvad-vpn: 2021.1 -> 2021.2

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -41,11 +41,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "mullvad-vpn";
-  version = "2021.1";
+  version = "2021.2";
 
   src = fetchurl {
-    url = "https://www.mullvad.net/media/app/MullvadVPN-${version}_amd64.deb";
-    sha256 = "1ksa327zaiwmcmzv4n4ycfzc4sqhj2492c5ir0mqlx7x2nnhx6q7";
+    url = "https://github.com/mullvad/mullvadvpn-app/releases/download/${version}/MullvadVPN-${version}_amd64.deb";
+    sha256 = "sha256-nNZK11MckiQ+z8NDgDc7aJ6yrXWI1hPOvMZkrGwDDgU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
@Br1ght0ne @ymarkus 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump mullvad-vpn to `2021.2`

Moved to the github release copy of the deb as at the time of creating this PR there isn't a 2021.2 release on mullvad.net yet. It likely gets copied over there at some point either by hand or with some automation that has several minutes of delay.
The github release looks like the source of the deb built

Edit: it looks like about 16:30 UTC the deb was added to mullvad.net, The release hit github at 16:04 UTC so that's quite a long delay

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
