### PR TITLE
cnijfilter2: 5.70 -> 5.90

### DIFF
--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation {
   pname = "cnijfilter2";
 
-  version = "5.70";
+  version = "5.90";
 
   src = fetchzip {
-    url = "http://gdlp01.c-wss.com/gds/0/0100009930/01/cnijfilter2-source-5.70-1.tar.gz";
-    sha256 = "045zjsmaidn1m44ki6m1018gjzbj77gm234n5i2lshxpbzpyh0is";
+    url = "https://gdlp01.c-wss.com/gds/4/0100010484/01/cnijfilter2-source-5.90-1.tar.gz";
+    sha256 = "1bwyv9s6xv18xxp3m04a5fyh628nzcjdjvsgmgqndnk7832h5ani";
   };
 
   buildInputs = [
@@ -115,7 +115,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Canon InkJet printer drivers for the MG7500, MG6700, MG6600, MG5600, MG2900, MB2000, MB2300, iB4000, MB5000, MB5300, iP110, E450, MX490, E480, MG7700, MG6900, MG6800, MG5700, MG3600, and G3000 series";
-    homepage = "http://support-th.canon-asia.com/contents/TH/EN/0100712901.html";
+    homepage = "https://hk.canon/en/support/0101048401/1";
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];

--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -117,7 +117,7 @@ stdenv.mkDerivation {
     description = "Canon InkJet printer drivers for the MG7500, MG6700, MG6600, MG5600, MG2900, MB2000, MB2300, iB4000, MB5000, MB5300, iP110, E450, MX490, E480, MG7700, MG6900, MG6800, MG5700, MG3600, and G3000 series";
     homepage = "https://hk.canon/en/support/0101048401/1";
     license = licenses.unfree;
-    platforms = platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
     maintainers = with maintainers; [ cstrahan ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Just a bump to the latest revision. Tested as working on a Canon G6050 (also my reason for the bump).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
