### PR TITLE
borgmatic: init at 1.5.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3939,6 +3939,12 @@
     githubId = 993484;
     name = "Greg Hale";
   };
+  imlonghao = {
+    email = "nixos@esd.cc";
+    github = "imlonghao";
+    githubId = 4951333;
+    name = "Hao Long";
+  };
   immae = {
     email = "ismael@bouya.org";
     github = "immae";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -243,6 +243,7 @@
   ./services/backup/automysqlbackup.nix
   ./services/backup/bacula.nix
   ./services/backup/borgbackup.nix
+  ./services/backup/borgmatic.nix
   ./services/backup/duplicati.nix
   ./services/backup/duplicity.nix
   ./services/backup/mysql-backup.nix

--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.borgmatic;
+  cfgfile = pkgs.writeText "config.yaml" (builtins.toJSON cfg.settings);
+in {
+  options.services.borgmatic = {
+    enable = mkEnableOption "borgmatic";
+
+    settings = mkOption {
+      description = ''
+        See https://torsion.org/borgmatic/docs/reference/configuration/
+      '';
+      type = types.submodule {
+        freeformType = with lib.types; attrsOf anything;
+        options.location = {
+          source_directories = mkOption {
+            type = types.listOf types.str;
+            description = ''
+              List of source directories to backup (required). Globs and
+              tildes are expanded.
+            '';
+            example = [ "/home" "/etc" "/var/log/syslog*" ];
+          };
+          repositories = mkOption {
+            type = types.listOf types.str;
+            description = ''
+              Paths to local or remote repositories (required). Tildes are
+              expanded. Multiple repositories are backed up to in
+              sequence. Borg placeholders can be used. See the output of
+              "borg help placeholders" for details. See ssh_command for
+              SSH options like identity file or port. If systemd service
+              is used, then add local repository paths in the systemd
+              service file to the ReadWritePaths list.
+            '';
+            example = [
+              "user@backupserver:sourcehostname.borg"
+              "user@backupserver:{fqdn}"
+            ];
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.borgmatic ];
+
+    environment.etc."borgmatic/config.yaml".source = cfgfile;
+
+    systemd.packages = [ pkgs.borgmatic ];
+
+  };
+}

--- a/pkgs/tools/backup/borgmatic/default.nix
+++ b/pkgs/tools/backup/borgmatic/default.nix
@@ -1,0 +1,50 @@
+{ borgbackup, coreutils, lib, python3Packages, systemd }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "borgmatic";
+  version = "1.5.12";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-XLbBJvNRmH8W9SnOjF7zUbazRYFCMW6SEO2wKN/2VTY=";
+  };
+
+  checkInputs = with python3Packages; [ flexmock pytestCheckHook pytest-cov ];
+
+  # - test_borgmatic_version_matches_news_version
+  # The file NEWS not available on the pypi source, and this test is useless
+  # - test_collect_configuration_run_summary_logs_outputs_merged_json_results
+  # Upstream fixed in the next version, see
+  # https://github.com/witten/borgmatic/commit/ea6cd53067435365a96786b006aec391714501c4
+  disabledTests = [
+    "test_borgmatic_version_matches_news_version"
+    "test_collect_configuration_run_summary_logs_outputs_merged_json_results"
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    borgbackup
+    colorama
+    pykwalify
+    ruamel_yaml
+    requests
+    setuptools
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib/systemd/system
+    cp sample/systemd/borgmatic.timer $out/lib/systemd/system/
+    substitute sample/systemd/borgmatic.service \
+               $out/lib/systemd/system/borgmatic.service \
+               --replace /root/.local/bin/borgmatic $out/bin/borgmatic \
+               --replace systemd-inhibit ${systemd}/bin/systemd-inhibit \
+               --replace sleep ${coreutils}/bin/sleep
+  '';
+
+  meta = with lib; {
+    description = "Simple, configuration-driven backup software for servers and workstations";
+    homepage = "https://torsion.org/borgmatic/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ imlonghao ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1703,6 +1703,8 @@ in
 
   borgbackup = callPackage ../tools/backup/borg { };
 
+  borgmatic = callPackage ../tools/backup/borgmatic { };
+
   boringtun = callPackage ../tools/networking/boringtun { };
 
   # Upstream recommends qt5.12 and it doesn't build with qt5.15


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

borgmatic is simple, configuration-driven backup software for servers and workstations. Protect your files with client-side encryption. Backup your databases too. Monitor it all with integrated third-party services.

Close #91358

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
