### PR TITLE
fwupd: comment about 1.5.6 release

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -91,6 +91,12 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
+    # A regression is present in https://github.com/fwupd/fwupd/commit/fde4b1676a2c64e70bebd88f7720307c62635654
+    # released with 1.5.6.
+    # Fix for the regression: https://github.com/fwupd/fwupd/pull/2902
+    # Maintainer says a new release is to be expected in a few days:
+    #   https://twitter.com/hughsient/status/1362476792297185289
+    # In the mean time, please do not release 1.5.6 and go strait to 1.5.7
     version = "1.5.5";
 
     # libfwupd goes to lib


### PR DESCRIPTION
###### Motivation for this change

Warn about a regression present in 1.5.6.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
