### PR TITLE
ocamlPackages.atd: 2.0.0 → 2.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/atd/default.nix
+++ b/pkgs/development/ocaml-modules/atd/default.nix
@@ -1,22 +1,22 @@
-{ lib, menhir, easy-format, fetchFromGitHub, buildDunePackage, which, biniou, yojson }:
+{ lib, menhir, easy-format, fetchurl, buildDunePackage, which, re }:
 
 buildDunePackage rec {
   pname = "atd";
-  version = "2.0.0";
+  version = "2.2.1";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.02";
 
-  src = fetchFromGitHub {
-    owner = "mjambon";
-    repo = pname;
-    rev = version;
-    sha256 = "0alzmk97rxg7s6irs9lvf89dy9n3r769my5n4j9p9qyigcdgjaia";
+  src = fetchurl {
+    url = "https://github.com/ahrefs/atd/releases/download/2.2.1/atd-2.2.1.tbz";
+    sha256 = "17jm79np69ixp53a4njxnlb1pg8sd1g47nm3nyki9clkc8d4qsyv";
   };
 
-  createFindlibDestdir = true;
-
   buildInputs = [ which menhir ];
-  propagatedBuildInputs = [ easy-format biniou yojson ];
+  propagatedBuildInputs = [ easy-format re ];
+
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/mjambon/atd";

--- a/pkgs/development/ocaml-modules/atdgen/default.nix
+++ b/pkgs/development/ocaml-modules/atdgen/default.nix
@@ -3,7 +3,7 @@
 let runtime =
   buildDunePackage {
     pname = "atdgen-runtime";
-    inherit (atd) version src;
+    inherit (atd) version useDune2 src;
 
     propagatedBuildInputs = [ biniou yojson ];
 
@@ -13,7 +13,7 @@ let runtime =
 
 buildDunePackage {
   pname = "atdgen";
-  inherit (atd) version src;
+  inherit (atd) version useDune2 src;
 
   buildInputs = [ atd ];
 


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
