### PR TITLE
uchess: init at 0.2.1

### DIFF
--- a/pkgs/games/uchess/default.nix
+++ b/pkgs/games/uchess/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, stockfish }:
+
+buildGoModule rec {
+  pname = "uchess";
+  version = "0.2.1";
+
+  subPackages = [ "cmd/uchess" ];
+
+  src = fetchFromGitHub {
+    owner = "tmountain";
+    repo = "uchess";
+    rev = "v${version}";
+    sha256 = "1njl3f41gshdpj431zkvpv2b7zmh4m2m5q6xsijb0c0058dk46mz";
+  };
+
+  vendorSha256 = "0dkq240ch1z3gihn8yc5d723nnvfxirk2nhw12r1c2hj1ga088g3";
+
+  # package does not contain any tests as of v0.2.1
+  doCheck = false;
+
+  buildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/uchess --suffix PATH : ${stockfish}/bin
+  '';
+
+  meta = with lib; {
+    description = "Play chess against UCI engines in your terminal.";
+    homepage = "https://tmountain.github.io/uchess/";
+    maintainers = with maintainers; [ tmountain ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27322,6 +27322,10 @@ in
 
   typespeed = callPackage ../games/typespeed { };
 
+  uchess = callPackage ../games/uchess {
+    buildGoModule = buildGo116Module;
+  };
+
   udig = callPackage ../applications/gis/udig { };
 
   ufoai = callPackage ../games/ufoai { };


### PR DESCRIPTION
###### Motivation for this change

Initial import. I am the author of this software.

###### Things done

- Built on platform(s)
   - [X] NixOS
   - [X] macOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
