### PR TITLE
turbovnc: init at 2.2.5

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -1,4 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, nasm
+, openjdk
+, enableJava ? false # whether to build the java wrapper
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
@@ -26,11 +28,18 @@ stdenv.mkDerivation rec {
     moveToOutput include/transupp.h $dev_private
   '';
 
-  nativeBuildInputs = [ cmake nasm ];
+  nativeBuildInputs = [
+    cmake
+    nasm
+  ] ++ lib.optionals enableJava [
+    openjdk
+  ];
 
   cmakeFlags = [
     "-DENABLE_STATIC=${if enableStatic then "1" else "0"}"
     "-DENABLE_SHARED=${if enableShared then "1" else "0"}"
+  ] ++ lib.optionals enableJava [
+    "-DWITH_JAVA=1"
   ];
 
   doInstallCheck = true;

--- a/pkgs/tools/admin/turbovnc/default.nix
+++ b/pkgs/tools/admin/turbovnc/default.nix
@@ -1,0 +1,111 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+# Dependencies
+, cmake
+, libjpeg_turbo
+, makeWrapper
+, mesa # for built-in 3D software rendering using swrast
+, openjdk # for the client with Java GUI
+, openjdk_headless # for the server
+, openssh
+, openssl
+, pam
+, perl
+, which
+, xkbcomp
+, xkeyboard_config
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "turbovnc";
+  version = "2.2.5";
+
+  src = fetchFromGitHub {
+    owner = "TurboVNC";
+    repo = "turbovnc";
+    rev = version;
+    sha256 = "0r2lk5lza7a9h02g4z5j59d8qj0x1q1my665d1x1plny4g46vam0";
+  };
+
+  # TODO:
+  # * Build outputs that are unclear:
+  #   * `-- FONT_ENCODINGS_DIRECTORY = /var/empty/share/X11/fonts/encodings`
+  #     Maybe relevant what the tigervnc and tightvnc derivations
+  #     do with their `fontDirectories`?
+  #   * `SERVER_MISC_CONFIG_PATH = /var/empty/lib64/xorg`
+  #   * The thing about xorg `protocol.txt`
+  # * Does SSH support require `openssh` on PATH?
+  # * Add `enableClient ? true` flag that disables the client GUI
+  #   so that the server can be built without openjdk dependency.
+  # * Perhaps allow to build the client on non-Linux platforms.
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    openjdk_headless
+  ];
+
+  buildInputs = [
+    libjpeg_turbo
+    openssl
+    pam
+    perl
+  ] ++ (with xorg; [
+    libSM
+    libX11
+    libXext
+    libXi
+    xorgproto
+  ]);
+
+  cmakeFlags = [
+    # For the 3D software rendering built into TurboVNC, pass the path
+    # to the swrast dri driver in Mesa.
+    # Can also be given at runtime to its `Xvnc` as:
+    #   -dridir /nix/store/...-mesa-20.1.10-drivers/lib/dri/
+    "-DDRI_DRIVER_PATH=${mesa.drivers}/lib/dri"
+    # The build system doesn't find these files automatically.
+    "-DTJPEG_JAR=${libjpeg_turbo.out}/share/java/turbojpeg.jar"
+    "-DTJPEG_JNILIBRARY=${libjpeg_turbo.out}/lib/libturbojpeg.so"
+    "-DXKB_BASE_DIRECTORY=${xkeyboard_config}/share/X11/xkb"
+    "-DXKB_BIN_DIRECTORY=${xkbcomp}/bin"
+  ];
+
+  postInstall = ''
+    # turbovnc dlopen()s libssl.so depending on the requested encryption.
+    wrapProgram $out/bin/Xvnc \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ openssl ]}
+
+    # `twm` is the default window manager that `vncserver` tries to start,
+    # and it has minimal dependencies (no non-Xorg).
+    # (This default is written by `vncserver` to `~/.vnc/xstartup.turbovnc`,
+    # see https://github.com/TurboVNC/turbovnc/blob/ffdb57d9/unix/vncserver.in#L201.)
+    # It checks for it using `which twm`.
+    wrapProgram $out/bin/vncserver \
+      --prefix PATH : ${lib.makeBinPath [ which xorg.twm ]}
+
+    # Patch /usr/bin/perl
+    patchShebangs $out/bin/vncserver
+
+    # vncserver needs `xauth`
+    wrapProgram $out/bin/vncserver \
+      --prefix PATH : ${lib.makeBinPath (with xorg; [ xauth ])}
+
+    # The viewer is in Java and requires `JAVA_HOME`.
+    # For SSH support, `ssh` is required on `PATH`.
+    wrapProgram $out/bin/vncviewer \
+      --prefix JAVA_HOME : "${lib.makeLibraryPath [ openjdk ]}/openjdk" \
+      --prefix PATH : ${lib.makeBinPath [ openssh ]}
+  '';
+
+  meta = {
+    homepage = "https://turbovnc.org/";
+    license = lib.licenses.gpl2Plus;
+    description = "High-speed version of VNC derived from TightVNC";
+    maintainers = with lib.maintainers; [ nh2 ];
+    platforms = with lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8934,6 +8934,11 @@ in
 
   ttwatch = callPackage ../tools/misc/ttwatch { };
 
+  turbovnc = callPackage ../tools/admin/turbovnc {
+    # fontDirectories = [ xorg.fontadobe75dpi xorg.fontmiscmisc xorg.fontcursormisc xorg.fontbhlucidatypewriter75dpi ];
+    libjpeg_turbo = libjpeg_turbo.override { enableJava = true; };
+  };
+
   udunits = callPackage ../development/libraries/udunits { };
 
   uftp = callPackage ../servers/uftp {};


### PR DESCRIPTION
###### Motivation for this change

`turbovnc` is a VNC server + client forked from TightVNC, and made by the makers of `libjpeg-turbo` and `virtualgl`.

A key point about it is that it integrates 3D software rendering via mesa/swrast (in which case `virtualgl` is then unnecessary), allowing to run 3D programs easily on the VNC server.

**How to test:**

To run the server, run either:

* `vncserver`, a wrapper script, which asks to set a password set in your home dir, determines default settings and backgrounds itself
* run what that wrapper script starts (see `ps aux | grep Xvnc`), which looks like e.g.
  ```sh
  Xvnc :4 \
  -httpd /nix/store/4fbj9mlyhw8ypayf0pyyd7zgb831p7gp-turbovnc-2.2.5/share/turbovnc/classes \
  -auth /root/.Xauthority \
  -geometry 1240x900 \
  -depth 24 \
  -rfbwait 120000 \
  -rfbauth ~/.vnc/passwd \
  -x509cert ~/.vnc/x509_cert.pem \
  -x509key ~/.vnc/x509_private.pem \
  -rfbport 5904 \
  -deferupdate 1 \
  -verbose
  ```

Note the port in `-rfbport 5904` and the `:4` to choose a free X display.

(I added the `-verbose`, it's useful to see errors, e.g. I could see in there that software rendering didn't work before I added the path to mesa swrast, such as: `(EE) AIGLX error: dlopen of /var/empty/lib64/dri/swrast_dri.so failed (/var/empty/lib64/dri/swrast_dri.so: cannot open shared object file: No such file or directory`).

To run the server, run `vncviewer` (it's a GUI, but also accepts CLI arguments).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
