### PR TITLE
nvme-cli: add libuuid input

### DIFF
--- a/pkgs/os-specific/linux/nvme-cli/default.nix
+++ b/pkgs/os-specific/linux/nvme-cli/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, pkg-config
+, libuuid
+}:
 
 stdenv.mkDerivation rec {
   pname = "nvme-cli";
@@ -12,6 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libuuid ];
 
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The `nvme-cli` tool has a `gen-hostnqn` option which is not currently supported in Nix. In order to better support users of NVMe devices, this feature would be helpful to enable.

Current status:

```bash
$ nix shell -f '<nixpkgs>' nvme-cli -c "nvme" gen-hostnqn
"gen-hostnqn" not supported. Install lib uuid and rebuild.
```

After this PR:

```bash
$ nix shell -f . nvme-cli -c "nvme" gen-hostnqn
nqn.2014-08.org.nvmexpress:uuid:dd4888a6-2e02-40ac-87fe-2c4470509999
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
