### PR TITLE
openafs: Add upstream patches for Linux kernel 5.11

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -19,21 +19,35 @@ in stdenv.mkDerivation {
   buildInputs = [ kerberos ];
 
   patches = [
+    # LINUX 5.8: Replace kernel_setsockopt with new funcs
     (fetchpatch {
       url = "https://github.com/openafs/openafs/commit/d7fc5bf9bf031089d80703c48daf30d5b15a80ca.patch";
       sha256 = "0469ydzgvyvrl1b2s1qbl9cd8c5c1nb99c3z52z5i685da5z6pab";
     })
+    # LINUX 5.8: do not set name field in backing_dev_info
     (fetchpatch {
       url = "https://github.com/openafs/openafs/commit/335f37be13d2ff954e4aeea617ee66502170805e.patch";
       sha256 = "0jr6cgplnip61cjlcd3fvgsc6n3jhfk93mm9m7ak04w1vc26dk9x";
     })
+    # LINUX 5.8: use lru_cache_add
     (fetchpatch {
       url = "https://github.com/openafs/openafs/commit/facff58b840a47853592510617ba7a1da2e3eaa9.patch";
       sha256 = "0izafg6bi5iaigq3jjx0zlg1cxwaddz3238hk0s08fcb6nyhkvx1";
     })
+    # LINUX 5.9: Remove HAVE_UNLOCKED_IOCTL/COMPAT_IOCTL
     (fetchpatch {
       url = "https://github.com/openafs/openafs/commit/e7902252f15acfc28453c531f6fa3b29c9c91b92.patch";
       sha256 = "1jy4v8yx8p6mhma6b3h3g94mb38bw7hg7q6lnyc8bijkbnl0d1rl";
+    })
+    # Linux: Refactor test for 32bit compat
+    (fetchpatch {
+      url = "https://github.com/openafs/openafs/commit/4ad1057ab8fd206c9fa8d5e3bdde4f1a8417afdb.patch";
+      sha256 = "0v2537wkav78yi8lv6fkd1n6rf2g17igf44rpa3kd0kkidxv5lqr";
+    })
+    # Linux 5.11: Test 32bit compat with in_compat_syscall
+    (fetchpatch {
+      url = "https://github.com/openafs/openafs/commit/ee53dd3bc087a05e22fc4111297a51ddb30013f0.patch";
+      sha256 = "0dfab3zk0dmf6iksna5n09lf5dn4f8w43q4irl2yf5dgqm35shkr";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

OpenAFS doesn’t build with Linux kernel 5.11 without these upstream patches from the `openafs-stable-1_8_x` branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
