### PR TITLE
common-config: fixup compilation for linux 5.11

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -251,7 +251,8 @@ let
       # (stable) amdgpu support for bonaire and newer chipsets
       DRM_AMDGPU_CIK = whenAtLeast "4.9" yes;
       # amdgpu support for RX6000 series
-      DRM_AMD_DC_DCN3_0 = whenAtLeast "5.9.12" yes;
+      DRM_AMD_DC_DCN3_0 = whenBetween "5.9.12" "5.11" yes;
+      DRM_AMD_DC_DCN = whenAtLeast "5.11" yes;
       # Allow device firmware updates
       DRM_DP_AUX_CHARDEV = whenAtLeast "4.6" yes;
     } // optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux") {


### PR DESCRIPTION
###### Motivation for this change

DRM_AMD_DC_DCN3_0 has been renamed DRM_AMD_DC_DCN in linux 5.11
see:
https://github.com/torvalds/linux/commit/20f2ffe504728612d7b0c34e4f8280e34251e704
https://github.com/NixOS/nixpkgs/pull/113194#issuecomment-781766471

#113194 does not work for people relying on `pkgs.linuxPackages_latest`

Patch is from @mweinelt I just tested it, and made a pull request for convenience.

cc @adisbladis @NeQuissimus

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
