### PR TITLE
nix-direnv: Fix nix executable paths

### DIFF
--- a/pkgs/tools/misc/nix-direnv/default.nix
+++ b/pkgs/tools/misc/nix-direnv/default.nix
@@ -15,9 +15,8 @@ stdenv.mkDerivation rec {
   # getting sourced, not executed:
   postPatch = ''
     substituteInPlace direnvrc \
-      --replace "grep" "${gnugrep}/bin/grep" \
-      --replace "nix-shell" "${nix}/bin/nix-shell" \
-      --replace "nix-instantiate" "${nix}/bin/nix-instantiate"
+      --replace "\''${NIX_BIN_PREFIX:-}" "\''${NIX_BIN_PREFIX:-${nix}/bin/}" \
+      --replace "grep" "${gnugrep}/bin/grep"
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Match the upstream change in:
https://github.com/nix-community/nix-direnv/commit/991ea66bb86f5f188f4d5292aa2283458436b5b1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Mic92
