### PR TITLE
top-level/packages-config.nix: Correctly index package subsets delimited by dots

### DIFF
--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -8,10 +8,12 @@
   # purposes of the index.
   packageOverrides = super:
   let
+    inherit (super) lib;
     recurseIntoAttrs = sets:
-      super.lib.genAttrs
-        (builtins.filter (set: builtins.hasAttr set super) sets)
-        (set: super.recurseIntoAttrs (builtins.getAttr set super));
+      lib.genAttrs
+        # Recursively filter sets delimited by dots
+        (builtins.filter (set: builtins.foldl' (super: attr: if builtins.hasAttr attr super then super.${attr} else { }) super (lib.splitString "." set) != { }) sets)
+        (set: super.recurseIntoAttrs (builtins.foldl' (super: attr: super.${attr}) super (lib.splitString "." set)));
   in recurseIntoAttrs [
     "roundcubePlugins"
     "emscriptenfastcompPackages"


### PR DESCRIPTION
###### Motivation for this change

Fixes the issue discovered by @Atemu in https://github.com/NixOS/nixpkgs/issues/110348#issuecomment-782010897 where dot delimited subsets were not taken into account.

Note: I haven't tested how this interacts with search at all, I've just assumed it's probably fine. This needs more testing to see what the implications are, hence I've marked it as draft.

cc @garbas 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
