### PR TITLE
nxpmicro-mfgtools: add udev rules

### DIFF
--- a/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
+++ b/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
@@ -25,6 +25,14 @@ stdenv.mkDerivation rec {
 
   preConfigure = "echo ${version} > .tarball-version";
 
+  postInstall = ''
+    # rules printed by the following invocation are static,
+    # they come from hardcoded configs in libuuu/config.cpp:48
+    $out/bin/uuu -udev > udev-rules 2>stderr.txt
+    rules_file="$(cat stderr.txt|grep '1: put above udev run into'|sed 's|^.*/||')"
+    install -D udev-rules "$out/lib/udev/rules.d/$rules_file"
+  '';
+
   meta = with lib; {
     description = "Freescale/NXP I.MX chip image deploy tools";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

The package now contains udev rules that `uuu` generates, so you can set `services.udev.packages = [pkgs.nxpmicro-mfgtools]` and enable them. It is very useful, as otherwise flashing scripts for Librem 5 won't be able to access the phone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
