### PR TITLE
python3Packages.pychannels: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/pychannels/default.nix
+++ b/pkgs/development/python-modules/pychannels/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pychannels";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "fancybits";
+    repo = pname;
+    rev = version;
+    sha256 = "0dqc0vhf6c5r3g7nfbpa668x6z2zxrznk6h907s6sxkq4sbqnhqf";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # Project has not published tests yet
+  doCheck = false;
+  pythonImportsCheck = [ "pychannels" ];
+
+  meta = with lib; {
+    description = "Python library for interacting with the Channels app";
+    homepage = "https://github.com/fancybits/pychannels";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -110,7 +110,7 @@
     "canary" = ps: with ps; [ ha-ffmpeg ]; # missing inputs: py-canary
     "cast" = ps: with ps; [ aiohttp-cors hass-nabucasa mutagen plexapi plexauth plexwebsocket PyChromecast zeroconf ];
     "cert_expiry" = ps: with ps; [ ];
-    "channels" = ps: with ps; [ ]; # missing inputs: pychannels
+    "channels" = ps: with ps; [ pychannels ];
     "circuit" = ps: with ps; [ ]; # missing inputs: circuit-webhook
     "cisco_ios" = ps: with ps; [ pexpect ];
     "cisco_mobility_express" = ps: with ps; [ ciscomobilityexpress ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5311,6 +5311,8 @@ in {
 
   pycfdns = callPackage ../development/python-modules/pycfdns { };
 
+  pychannels = callPackage ../development/python-modules/pychannels { };
+
   pychart = callPackage ../development/python-modules/pychart { };
 
   pychef = callPackage ../development/python-modules/pychef { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for interacting with the Channels app

https://github.com/fancybits/pychannels

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
