### PR TITLE
python3Packages.python-velbus: init 2.1.2

### DIFF
--- a/pkgs/development/python-modules/python-velbus/default.nix
+++ b/pkgs/development/python-modules/python-velbus/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+}:
+
+buildPythonPackage rec {
+  pname = "python-velbus";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner = "thomasdelaet";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0dv7dsjp5li87ispdphaz7jd0a9xc328rxwawf2f58b1ii904xr4";
+  };
+
+  propagatedBuildInputs = [ pyserial ];
+
+  # Project has not tests
+  doCheck = false;
+  pythonImportsCheck = [ "velbus" ];
+
+  meta = with lib; {
+    description = "Python library to control the Velbus home automation system";
+    homepage = "https://github.com/thomasdelaet/python-velbus";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -894,7 +894,7 @@
     "vacuum" = ps: with ps; [ ];
     "vallox" = ps: with ps; [ ]; # missing inputs: vallox-websocket-api
     "vasttrafik" = ps: with ps; [ ]; # missing inputs: vtjp
-    "velbus" = ps: with ps; [ ]; # missing inputs: python-velbus
+    "velbus" = ps: with ps; [ python-velbus ];
     "velux" = ps: with ps; [ pyvlx ];
     "venstar" = ps: with ps; [ ]; # missing inputs: venstarcolortouch
     "vera" = ps: with ps; [ pyvera ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6493,6 +6493,8 @@ in {
 
   python-vagrant = callPackage ../development/python-modules/python-vagrant { };
 
+  python-velbus = callPackage ../development/python-modules/python-velbus { };
+
   python-vipaccess = callPackage ../development/python-modules/python-vipaccess { };
 
   python-vlc = callPackage ../development/python-modules/python-vlc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to control the Velbus home automation system

https://github.com/thomasdelaet/python-velbus

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
