### PR TITLE
python3Packages.mcstatus: init at 5.1.1

### DIFF
--- a/pkgs/development/python-modules/asyncio-dgram/default.nix
+++ b/pkgs/development/python-modules/asyncio-dgram/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "asyncio-dgram";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "jsbronder";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1zkmjvq47zw2fsbnzhr5mh9rsazx0z1f8m528ash25jrxsza5crm";
+    sha256 = "sha256-wgcL/BdNjzitkkaGyRUQbW1uv1enLDnHk30YHClK58o=";
   };
 
   # OSError: AF_UNIX path too long

--- a/pkgs/development/python-modules/mcstatus/default.nix
+++ b/pkgs/development/python-modules/mcstatus/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, asyncio-dgram
+, buildPythonPackage
+, click
+, dnspython
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, pythonOlder
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "mcstatus";
+  version = "5.1.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Dinnerbone";
+    repo = pname;
+    rev = "release-${version}";
+    sha256 = "1a3qrl6w76ayqkl1knaz5ai0brrzpjfdk33lyb1n1p7gnc73nhlr";
+  };
+
+  propagatedBuildInputs = [
+    asyncio-dgram
+    click
+    dnspython
+    six
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt --replace "dnspython3" "dnspython"
+  '';
+
+  pythonImportsCheck = [ "mcstatus" ];
+
+  meta = with lib; {
+    description = "Python library for checking the status of Minecraft servers";
+    homepage = "https://github.com/Dinnerbone/mcstatus";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -499,7 +499,7 @@
     "mikrotik" = ps: with ps; [ librouteros ];
     "mill" = ps: with ps; [ ]; # missing inputs: millheater
     "min_max" = ps: with ps; [ ];
-    "minecraft_server" = ps: with ps; [ aiodns getmac ]; # missing inputs: mcstatus
+    "minecraft_server" = ps: with ps; [ aiodns getmac mcstatus ];
     "minio" = ps: with ps; [ minio ];
     "mitemp_bt" = ps: with ps; [ ]; # missing inputs: mitemp_bt
     "mjpeg" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4006,6 +4006,8 @@ in {
 
   mccabe = callPackage ../development/python-modules/mccabe { };
 
+  mcstatus = callPackage ../development/python-modules/mcstatus { };
+
   MDP = callPackage ../development/python-modules/mdp { };
 
   measurement = callPackage ../development/python-modules/measurement { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for checking the status of Minecraft servers

https://github.com/Dinnerbone/mcstatus

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
