### PR TITLE
ocamlPackages.janeStreet{,_0_9_0}: join the ocamlPackages fix point, allowing overriding to work as expected

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.12.nix
@@ -1,13 +1,22 @@
-{ janePackage
-, ctypes
-, num
-, octavius
-, ppxlib
-, re
+{ self
+, super
 , openssl
 }:
 
-rec {
+let
+  inherit (super)
+    janePackage
+    ctypes
+    num
+    octavius
+    ppxlib
+    re
+    ;
+in
+
+with self;
+
+{
 
   ocaml-compiler-libs = janePackage {
     pname = "ocaml-compiler-libs";

--- a/pkgs/development/ocaml-modules/janestreet/0.12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.12.nix
@@ -1,18 +1,6 @@
 { self
-, super
 , openssl
 }:
-
-let
-  inherit (super)
-    janePackage
-    ctypes
-    num
-    octavius
-    ppxlib
-    re
-    ;
-in
 
 with self;
 

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -1,35 +1,7 @@
 { self
-, super
 , openssl
 , zstd
 }:
-
-let
-  inherit (super)
-    janePackage
-    alcotest
-    angstrom
-    angstrom-async
-    base64
-    cryptokit
-    ctypes
-    dune-configurator
-    faraday
-    inotify
-    js_of_ocaml
-    js_of_ocaml-ppx
-    lambdasoup
-    magic-mime
-    num
-    octavius
-    ppxlib
-    re
-    tyxml
-    uri-sexp
-    zarith
-    ounit
-    ;
-in
 
 with self;
 

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -1,30 +1,39 @@
-{ janePackage
-, alcotest
-, angstrom
-, angstrom-async
-, base64
-, cryptokit
-, ctypes
-, dune-configurator
-, faraday
-, inotify
-, js_of_ocaml
-, js_of_ocaml-ppx
-, lambdasoup
-, magic-mime
-, num
-, octavius
-, ppxlib
-, re
-, tyxml
-, uri-sexp
-, zarith
+{ self
+, super
 , openssl
-, ounit
 , zstd
 }:
 
-rec {
+let
+  inherit (super)
+    janePackage
+    alcotest
+    angstrom
+    angstrom-async
+    base64
+    cryptokit
+    ctypes
+    dune-configurator
+    faraday
+    inotify
+    js_of_ocaml
+    js_of_ocaml-ppx
+    lambdasoup
+    magic-mime
+    num
+    octavius
+    ppxlib
+    re
+    tyxml
+    uri-sexp
+    zarith
+    ounit
+    ;
+in
+
+with self;
+
+{
 
   accessor = janePackage {
     pname = "accessor";

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -1,10 +1,30 @@
-{ janePackage, ocamlbuild, angstrom, cryptokit, ctypes,
-  magic-mime, ocaml-migrate-parsetree, octavius, ounit, ppx_deriving, re,
-  num, openssl
-, ppxlib
+{ self
+, super
+, openssl
 }:
 
-rec {
+let
+  inherit (super)
+    janePackage
+    ocamlbuild
+    angstrom
+    cryptokit
+    ctypes
+    magic-mime
+    ocaml-migrate-parsetree
+    octavius
+    ounit
+    ppx_deriving
+    re
+    num
+    ppxlib
+    ;
+
+in
+
+with self;
+
+{
 
   ocaml-compiler-libs = janePackage {
     pname = "ocaml-compiler-libs";

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -1,26 +1,6 @@
 { self
-, super
 , openssl
 }:
-
-let
-  inherit (super)
-    janePackage
-    ocamlbuild
-    angstrom
-    cryptokit
-    ctypes
-    magic-mime
-    ocaml-migrate-parsetree
-    octavius
-    ounit
-    ppx_deriving
-    re
-    num
-    ppxlib
-    ;
-
-in
 
 with self;
 

--- a/pkgs/development/ocaml-modules/janestreet/old.nix
+++ b/pkgs/development/ocaml-modules/janestreet/old.nix
@@ -1,8 +1,32 @@
-{ stdenv, lib, janePackage, ocaml, ocamlbuild, cryptokit, ctypes, magic-mime,
-  ocaml-migrate-parsetree, octavius, ounit, ppx_deriving, re, zarith, num,
-  openssl }:
+{ self
+, super
+, lib
+, stdenv
+, openssl
+}:
 
-rec {
+let
+  inherit (super)
+    janePackage
+    ocaml
+    ocamlbuild
+    cryptokit
+    ctypes
+    magic-mime
+    ocaml-migrate-parsetree
+    octavius
+    ounit
+    ppx_deriving
+    re
+    zarith
+    num
+    ;
+
+in
+
+with self;
+
+{
 
   # Jane Street packages, up to ppx_core
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1268,11 +1268,11 @@ let
       inherit (pkgs) openssl;
     }
     else import ../development/ocaml-modules/janestreet {
-      inherit janePackage ocamlbuild angstrom ctypes cryptokit;
-      inherit magic-mime num ocaml-migrate-parsetree octavius ounit;
-      inherit ppx_deriving re;
+      super = self // {
+        ppxlib = ppxlib.override { version = "0.8.1"; };
+      };
+      self = self.janeStreet;
       inherit (pkgs) openssl;
-      ppxlib = ppxlib.override { version = "0.8.1"; };
     };
 
     janeStreet_0_9_0 = import ../development/ocaml-modules/janestreet/old.nix {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1261,9 +1261,11 @@ let
     }
     else if lib.versionOlder "4.07" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.12.nix {
-      inherit ctypes janePackage num octavius re;
+      super = self // {
+        ppxlib = ppxlib.override { version = "0.8.1"; };
+      };
+      self = self.janeStreet;
       inherit (pkgs) openssl;
-      ppxlib = ppxlib.override { version = "0.8.1"; };
     }
     else import ../development/ocaml-modules/janestreet {
       inherit janePackage ocamlbuild angstrom ctypes cryptokit;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1255,23 +1255,20 @@ let
     janeStreet =
     if lib.versionOlder "4.08" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.14.nix {
-      super = self;
-      self = self.janeStreet;
+      inherit self;
       inherit (pkgs) openssl zstd;
     }
     else if lib.versionOlder "4.07" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.12.nix {
-      super = self // {
+      self = self // {
         ppxlib = ppxlib.override { version = "0.8.1"; };
       };
-      self = self.janeStreet;
       inherit (pkgs) openssl;
     }
     else import ../development/ocaml-modules/janestreet {
-      super = self // {
+      self = self // {
         ppxlib = ppxlib.override { version = "0.8.1"; };
       };
-      self = self.janeStreet;
       inherit (pkgs) openssl;
     };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1276,11 +1276,13 @@ let
     };
 
     janeStreet_0_9_0 = import ../development/ocaml-modules/janestreet/old.nix {
-      janePackage = callPackage ../development/ocaml-modules/janestreet/janePackage.nix { defaultVersion = "0.9.0"; };
-      inherit lib ocaml ocamlbuild ctypes cryptokit;
-      inherit magic-mime num ocaml-migrate-parsetree octavius ounit;
-      inherit ppx_deriving re zarith;
-      inherit (pkgs) stdenv openssl;
+      self = self.janeStreet_0_9_0;
+      super = self // {
+        janePackage = callPackage ../development/ocaml-modules/janestreet/janePackage.nix {
+          defaultVersion = "0.9.0";
+        };
+      };
+      inherit (pkgs) stdenv lib openssl;
     };
 
     js_build_tools = callPackage ../development/ocaml-modules/janestreet/js-build-tools.nix {};

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1255,10 +1255,8 @@ let
     janeStreet =
     if lib.versionOlder "4.08" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.14.nix {
-      inherit alcotest angstrom angstrom-async base64 cryptokit ctypes
-        dune-configurator faraday inotify janePackage js_of_ocaml
-        js_of_ocaml-ppx lambdasoup magic-mime num octavius ounit
-        ppxlib re tyxml uri-sexp zarith;
+      super = self;
+      self = self.janeStreet;
       inherit (pkgs) openssl zstd;
     }
     else if lib.versionOlder "4.07" ocaml.version


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix long standing `ocamlPackages` issue #75485: The `janeStreet` package set is maintained as a sub set of `ocamlPackages`  and merged into it using `liftJaneStreet` in a second step. This is not an issue in itself, however inner-janestreet dependencies are done by using a `rec` set in the respective nix expressions. This means that `janeStreet` packages are oblivious to overrides being done in `ocamlPackages` to other `janeStreet` packages and use the original derivation regardless.

This is now fixed, see the commit message of ff40bbe for an example of this.

Another issue arising due to this is that `janeStreet` packages are both available via `ocamlPackages.package` and `ocamlPackages.janeStreet.package`. This creates an issue with overriding as overriding one the two attributes will always be ignored, as we only can use either `ocamlPackages` or `ocamlPackages.janeStreet` as the `self` fix point to get dependencies from.  Due to `liftJaneStreet` it feels more natural to use the top level attribute. To prevent confusion in the future we add a warning when using `ocamlPackages.janeStreet` instead of the top level attributes (2f413da).

cc @nomeata (original reporter) @vbgl

GitHub thingy: Resolves #75485.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
