### PR TITLE
cm-rgb: add pysensors and lm_sensors

### DIFF
--- a/pkgs/tools/system/cm-rgb/default.nix
+++ b/pkgs/tools/system/cm-rgb/default.nix
@@ -6,8 +6,10 @@
 , wrapGAppsHook
 , click
 , hidapi
+, lm_sensors
 , psutil
 , pygobject3
+, pysensors
 }:
 
 buildPythonApplication rec {
@@ -32,8 +34,10 @@ buildPythonApplication rec {
   propagatedBuildInputs = [
     click
     hidapi
+    lm_sensors
     psutil
     pygobject3
+    pysensors
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Add some dependencies so that `cm-rgb-monitor` works.

<https://github.com/gfduszynski/cm-rgb/wiki/3.-Monitor-usage#temperature-display>
> This requires `lm-sensor` to be installed and a python wrapper for it called `pysensors`:

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested with a Wraith Prism cooler.
