### PR TITLE
python3Packages.twitterapi: init 2.6.6

### DIFF
--- a/pkgs/development/python-modules/twitterapi/default.nix
+++ b/pkgs/development/python-modules/twitterapi/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+, requests_oauthlib
+}:
+
+buildPythonPackage rec {
+  pname = "twitterapi";
+  version = "2.6.6";
+
+  src = fetchFromGitHub {
+    owner = "geduldig";
+    repo = "TwitterAPI";
+    rev = "v${version}";
+    sha256 = "0ib4yggigpkn8rp71j94xyxl20smh3d04xsa9fhyh0mws4ri33j8";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    requests_oauthlib
+  ];
+
+  # Tests are interacting with the Twitter API
+  doCheck = false;
+  pythonImportsCheck = [ "TwitterAPI" ];
+
+  meta = with lib; {
+    description = "Python wrapper for Twitter's REST and Streaming APIs";
+    homepage = "https://github.com/geduldig/TwitterAPI";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -872,7 +872,7 @@
     "twilio_sms" = ps: with ps; [ aiohttp-cors twilio ];
     "twinkly" = ps: with ps; [ ]; # missing inputs: twinkly-client
     "twitch" = ps: with ps; [ python-twitch-client ];
-    "twitter" = ps: with ps; [ ]; # missing inputs: TwitterAPI
+    "twitter" = ps: with ps; [ twitterapi ];
     "ubus" = ps: with ps; [ ];
     "ue_smart_radio" = ps: with ps; [ ];
     "uk_transport" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8031,6 +8031,8 @@ in {
 
   twitter-common-options = callPackage ../development/python-modules/twitter-common-options { };
 
+  twitterapi = callPackage ../development/python-modules/twitterapi { };
+
   twofish = callPackage ../development/python-modules/twofish { };
 
   txaio = callPackage ../development/python-modules/txaio { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python wrapper for Twitter's REST and Streaming APIs

https://github.com/geduldig/TwitterAPI

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
