### PR TITLE
nixos/sane: allow to disable enabled-by-default plugins

### DIFF
--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -32,7 +32,7 @@ let
   };
 
   backends = [ pkg netConf ] ++ optional config.services.saned.enable sanedConf ++ config.hardware.sane.extraBackends;
-  saneConfig = pkgs.mkSaneConfig { paths = backends; };
+  saneConfig = pkgs.mkSaneConfig { paths = backends; inherit (config.hardware.sane) disabledDefaultBackends; };
 
   enabled = config.hardware.sane.enable || config.services.saned.enable;
 
@@ -73,6 +73,16 @@ in
         </para></note>
       '';
       example = literalExample "[ pkgs.hplipWithPlugin ]";
+    };
+
+    hardware.sane.disabledDefaultBackends = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "v4l" ];
+      description = ''
+        Names of backends which are enabled by default but should be disabled.
+        See <literal>$SANE_CONFIG_DIR/dll.conf</literal> for the list of possible names.
+      '';
     };
 
     hardware.sane.configDir = mkOption {

--- a/pkgs/applications/graphics/sane/config.nix
+++ b/pkgs/applications/graphics/sane/config.nix
@@ -1,9 +1,10 @@
 { lib, stdenv }:
 
-{ paths }:
+{ paths, disabledDefaultBackends ? [] }:
 
 with lib;
-let installSanePath = path: ''
+let
+installSanePath = path: ''
       if [ -e "${path}/lib/sane" ]; then
         find "${path}/lib/sane" -maxdepth 1 -not -type d | while read backend; do
           symlink "$backend" "$out/lib/sane/$(basename "$backend")"
@@ -27,6 +28,10 @@ let installSanePath = path: ''
         done
       fi
     '';
+    disableBackend = backend: ''
+      grep -q '${backend}' $out/etc/sane.d/dll.conf || { echo '${backend} is not a default plugin in $SANE_CONFIG_DIR/dll.conf'; exit 1; }
+      substituteInPlace $out/etc/sane.d/dll.conf --replace '${backend}' '# ${backend} disabled in nixos config'
+    '';
 in
 stdenv.mkDerivation {
   name = "sane-config";
@@ -42,5 +47,7 @@ stdenv.mkDerivation {
     }
 
     mkdir -p $out/etc/sane.d $out/etc/sane.d/dll.d $out/lib/sane
-  '' + concatMapStrings installSanePath paths;
+  ''
+  + (concatMapStrings installSanePath paths)
+  + (concatMapStrings disableBackend disabledDefaultBackends);
 }


### PR DESCRIPTION
use case: disabling v4l plugin because I don't use my webcam as a
scanner.


Tested by running the module on 20.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
