### PR TITLE
python3Packages.pyxiaomigateway: init at 0.13.4

### DIFF
--- a/pkgs/development/python-modules/pyxiaomigateway/default.nix
+++ b/pkgs/development/python-modules/pyxiaomigateway/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "pyxiaomigateway";
+  version = "0.13.4";
+
+  src = fetchFromGitHub {
+    owner = "Danielhiversen";
+    repo = "PyXiaomiGateway";
+    rev = version;
+    sha256 = "1xg89sdds04wgil88ihs84cjr3df6lajjbkyb1aymj638ibdyqns";
+  };
+
+  propagatedBuildInputs = [ cryptography ];
+
+  # Tests are not mocking the gateway completely
+  doCheck = false;
+  pythonImportsCheck = [ "xiaomi_gateway" ];
+
+  meta = with lib; {
+    description = "Python library to communicate with the Xiaomi Gateway";
+    homepage = "https://github.com/Danielhiversen/PyXiaomiGateway/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -948,7 +948,7 @@
     "xeoma" = ps: with ps; [ pyxeoma ];
     "xfinity" = ps: with ps; [ ]; # missing inputs: xfinity-gateway
     "xiaomi" = ps: with ps; [ ha-ffmpeg ];
-    "xiaomi_aqara" = ps: with ps; [ aiohttp-cors netdisco zeroconf ]; # missing inputs: PyXiaomiGateway
+    "xiaomi_aqara" = ps: with ps; [ pyxiaomigateway aiohttp-cors netdisco zeroconf ];
     "xiaomi_miio" = ps: with ps; [ construct python-miio ];
     "xiaomi_tv" = ps: with ps; [ ]; # missing inputs: pymitv
     "xmpp" = ps: with ps; [ slixmpp ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6636,6 +6636,8 @@ in {
 
   pyxeoma = callPackage ../development/python-modules/pyxeoma { };
 
+  pyxiaomigateway = callPackage ../development/python-modules/pyxiaomigateway { };
+
   pyxl3 = callPackage ../development/python-modules/pyxl3 { };
 
   pyxml = disabledIf isPy3k (callPackage ../development/python-modules/pyxml { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to communicate with the Xiaomi Gateway

https://github.com/Danielhiversen/PyXiaomiGateway/

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
