### PR TITLE
python3Packages.pymysensors: init at 0.20.1

### DIFF
--- a/pkgs/development/python-modules/getmac/default.nix
+++ b/pkgs/development/python-modules/getmac/default.nix
@@ -1,5 +1,10 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, pytest, pytest-benchmark, pytest-mock }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-benchmark
+, pytest-mock
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "getmac";
@@ -7,19 +12,32 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "GhostofGoes";
-    repo = "getmac";
+    repo = pname;
     rev = version;
     sha256 = "08d4iv5bjl1s4i9qhzf3pzjgj1rgbwi0x26qypf3ycgdj0a6gvh2";
   };
 
-  checkInputs = [ pytest pytest-benchmark pytest-mock ];
-  checkPhase = ''
-    pytest --ignore tests/test_cli.py
-  '';
+  checkInputs = [
+    pytestCheckHook
+    pytest-benchmark
+    pytest-mock
+  ];
+
+  disabledTests = [
+    # Disable CLI tests
+    "test_cli_main_basic"
+    "test_cli_main_verbose"
+    "test_cli_main_debug"
+    "test_cli_multiple_debug_levels"
+    # Disable test that require network access
+    "test_uuid_lanscan_iface"
+  ];
+
+  pythonImportsCheck = [ "getmac" ];
 
   meta = with lib; {
+    description = "Python package to get the MAC address of network interfaces and hosts on the local network";
     homepage = "https://github.com/GhostofGoes/getmac";
-    description = "Pure-Python package to get the MAC address of network interfaces and hosts on the local network.";
     license = licenses.mit;
     maintainers = with maintainers; [ colemickens ];
   };

--- a/pkgs/development/python-modules/pymysensors/default.nix
+++ b/pkgs/development/python-modules/pymysensors/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, click
+, crcmod
+, fetchFromGitHub
+, getmac
+, intelhex
+, paho-mqtt
+, pyserial
+, pyserial-asyncio
+, pytest-sugar
+, pytest-timeout
+, pytestCheckHook
+, pythonOlder
+, voluptuous
+}:
+
+buildPythonPackage rec {
+  pname = "pymysensors";
+  version = "0.20.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "theolind";
+    repo = pname;
+    rev = version;
+    sha256 = "1hz3551ydsmd23havd0dljmvkhzjnmd28k41ws60s8ms3gzlzqfy";
+  };
+
+  propagatedBuildInputs = [
+    click
+    crcmod
+    getmac
+    intelhex
+    paho-mqtt
+    pyserial
+    pyserial-asyncio
+    voluptuous
+  ];
+
+  checkInputs = [
+    pytest-sugar
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "mysensors" ];
+
+  meta = with lib; {
+    description = "Python API for talking to a MySensors gateway";
+    homepage = "https://github.com/theolind/pymysensors";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -523,7 +523,7 @@
     "mychevy" = ps: with ps; [ ]; # missing inputs: mychevy
     "mycroft" = ps: with ps; [ ]; # missing inputs: mycroftapi
     "myq" = ps: with ps; [ pymyq ];
-    "mysensors" = ps: with ps; [ aiohttp-cors paho-mqtt ]; # missing inputs: pymysensors
+    "mysensors" = ps: with ps; [ aiohttp-cors paho-mqtt pymysensors ];
     "mystrom" = ps: with ps; [ aiohttp-cors python-mystrom ];
     "mythicbeastsdns" = ps: with ps; [ ]; # missing inputs: mbddns
     "n26" = ps: with ps; [ ]; # missing inputs: n26

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5718,6 +5718,8 @@ in {
 
   pymyq = callPackage ../development/python-modules/pymyq { };
 
+  pymysensors = callPackage ../development/python-modules/pymysensors { };
+
   pymysql = callPackage ../development/python-modules/pymysql { };
 
   pymysqlsa = callPackage ../development/python-modules/pymysqlsa { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API for talking to a MySensors gateway

https://github.com/theolind/pymysensors

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
