### PR TITLE
python3Packages.freebox-api: init at 0.0.9

### DIFF
--- a/pkgs/development/python-modules/freebox-api/default.nix
+++ b/pkgs/development/python-modules/freebox-api/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, poetry
+, pythonOlder
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "freebox-api";
+  version = "0.0.9";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "hacf-fr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0qn7jqfbp850aqgfsxjfv14myi6idz6sf7024p6wpqpa2xk0vfiq";
+  };
+
+  nativeBuildInputs = [ poetry ];
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "freebox_api" ];
+
+  meta = with lib; {
+    description = "Python module to interact with the Freebox OS API";
+    homepage = "https://github.com/hacf-fr/freebox-api";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2438,6 +2438,8 @@ in {
 
   fpylll = callPackage ../development/python-modules/fpylll { };
 
+  freebox-api = callPackage ../development/python-modules/freebox-api { };
+
   freetype-py = callPackage ../development/python-modules/freetype-py { };
 
   freezegun = if isPy27 then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to interact with the Freebox OS API

https://github.com/hacf-fr/freebox-api

For Home Assistant is still `aiofreepybox` used but `freebox-api` seems to be the successor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
