### PR TITLE
ocamlPackages.git: 3.2.0 -> 3.3.0; ocamlPackages.irmin: 2.4.0 -> 2.5.1 

### DIFF
--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -1,23 +1,26 @@
 { stdenv, lib, fetchurl, buildDunePackage
 , alcotest, mtime, mirage-crypto-rng, tls, git-binary
 , angstrom, astring, cstruct, decompress, digestif, encore, duff, fmt, checkseum
-, fpath, ke, logs, lwt, ocamlgraph, uri, rresult
+, fpath, ke, logs, lwt, ocamlgraph, uri, rresult, base64
 , result, bigstringaf, optint, mirage-flow, domain-name, emile
 , mimic, carton, carton-lwt, carton-git, ipaddr, psq, crowbar, alcotest-lwt
 }:
 
 buildDunePackage rec {
   pname = "git";
-  version = "3.2.0";
+  version = "3.3.0";
 
   minimumOCamlVersion = "4.08";
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${version}/git-${version}.tbz";
-    sha256 = "14rq7h1n5v2n0507ycbac8sq21xnzhgirxmlmqv4j5k3aajdcj16";
+    sha256 = "090b67e8f8a02fb52b4d0c7aa445b5ff7353fdb2da00fb37b908f089c6776cd0";
   };
 
+  buildInputs = [
+    base64
+  ];
   propagatedBuildInputs = [
     angstrom astring checkseum cstruct decompress digestif encore duff fmt fpath
     ke logs lwt ocamlgraph uri rresult result bigstringaf optint mirage-flow

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -34,7 +34,7 @@ buildDunePackage rec {
   meta = {
     description = "Git format and protocol in pure OCaml";
     license = lib.licenses.isc;
-    maintainers = [ lib.maintainers.vbgl ];
+    maintainers = with lib.maintainers; [ sternenseemann vbgl ];
     homepage = "https://github.com/mirage/ocaml-git";
   };
 }

--- a/pkgs/development/ocaml-modules/git/unix.nix
+++ b/pkgs/development/ocaml-modules/git/unix.nix
@@ -6,6 +6,7 @@
 , tcpip, awa-mirage, mirage-flow
 , alcotest, alcotest-lwt, base64, cstruct
 , ke, mirage-crypto-rng, ocurl, git-binary
+, ptime
 }:
 
 buildDunePackage {
@@ -13,6 +14,14 @@ buildDunePackage {
   inherit (git) version src minimumOCamlVersion;
 
   useDune2 = true;
+
+  patches = [
+    # https://github.com/mirage/ocaml-git/pull/472
+    (fetchpatch {
+      url = "https://github.com/sternenseemann/ocaml-git/commit/54998331eb9d5c61afe8901fabe0c74c2877f096.patch";
+      sha256 = "12kd45mlfaj4hxh33k9920a22mq1q2sdrin2j41w1angvg00d3my";
+    })
+  ];
 
   buildInputs = [
     awa awa-mirage cmdliner git-cohttp-unix
@@ -26,16 +35,9 @@ buildDunePackage {
   ];
   checkInputs = [
     alcotest alcotest-lwt base64 cstruct ke
-    mirage-crypto-rng ocurl git-binary
+    mirage-crypto-rng ocurl git-binary ptime
   ];
   doCheck = true;
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/mirage/ocaml-git/commit/09b41073fa869c0a595e1d8ed7224d539682af1c.patch";
-      sha256 = "1avbxv60gbrll9gny1pl6jwbx5b8282h3frhzy2ghb0fx1pggp6w";
-    })
-  ];
 
   meta = {
     description = "Unix backend for the Git protocol(s)";

--- a/pkgs/development/ocaml-modules/irmin/default.nix
+++ b/pkgs/development/ocaml-modules/irmin/default.nix
@@ -1,5 +1,5 @@
 { lib, buildDunePackage
-, astring, base64, digestif, fmt, jsonm, logs, ocaml_lwt, ocamlgraph, uri
+, astring, digestif, fmt, jsonm, logs, ocaml_lwt, ocamlgraph, uri
 , repr, ppx_irmin, bheap
 }:
 
@@ -13,7 +13,6 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     astring
-    base64
     digestif
     fmt
     jsonm

--- a/pkgs/development/ocaml-modules/irmin/graphql.nix
+++ b/pkgs/development/ocaml-modules/irmin/graphql.nix
@@ -1,4 +1,6 @@
-{ lib, buildDunePackage, cohttp-lwt, graphql-cohttp, graphql-lwt, irmin }:
+{ lib, buildDunePackage, cohttp-lwt, graphql-cohttp, graphql-lwt, irmin
+, alcotest, alcotest-lwt, logs, yojson, cohttp-lwt-unix
+}:
 
 buildDunePackage rec {
 
@@ -10,8 +12,14 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ cohttp-lwt graphql-cohttp graphql-lwt irmin ];
 
-  # test requires network
-  doCheck = false;
+  doCheck = true;
+  checkInputs = [
+    alcotest
+    alcotest-lwt
+    logs
+    cohttp-lwt-unix
+    yojson
+  ];
 
   meta = irmin.meta // {
     description = "GraphQL server for Irmin";

--- a/pkgs/development/ocaml-modules/irmin/layers.nix
+++ b/pkgs/development/ocaml-modules/irmin/layers.nix
@@ -12,9 +12,6 @@ buildDunePackage {
     lwt
   ];
 
-  # mutual dependency on irmin-test
-  doCheck = false;
-
   meta = irmin.meta // {
     description = "Combine different Irmin stores into a single, layered store";
   };

--- a/pkgs/development/ocaml-modules/irmin/ppx.nix
+++ b/pkgs/development/ocaml-modules/irmin/ppx.nix
@@ -2,11 +2,11 @@
 
 buildDunePackage rec {
   pname = "ppx_irmin";
-  version = "2.4.0";
+  version = "2.5.1";
 
   src = fetchurl {
     url = "https://github.com/mirage/irmin/releases/download/${version}/irmin-${version}.tbz";
-    sha256 = "1b6lav5br1b83cwdc3gj9mqkzhlbfjrbyjx0107zvj54m82dbrxb";
+    sha256 = "131pcgmpys6danprcbxzf4pdsl0ka74bpmmxz8db4507cvxhsz3n";
   };
 
   minimumOCamlVersion = "4.08";
@@ -17,9 +17,6 @@ buildDunePackage rec {
     ppx_repr
     ppxlib
   ];
-
-  # tests depend on irmin, would create mutual dependency
-  doCheck = false;
 
   meta = {
     homepage = "https://irmin.org/";

--- a/pkgs/development/ocaml-modules/irmin/ppx.nix
+++ b/pkgs/development/ocaml-modules/irmin/ppx.nix
@@ -22,6 +22,6 @@ buildDunePackage rec {
     homepage = "https://irmin.org/";
     description = "PPX deriver for Irmin generics";
     license = lib.licenses.isc;
-    maintainers = [ lib.maintainers.vbgl ];
+    maintainers = with lib.maintainers; [ vbgl sternenseemann ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* <https://github.com/mirage/ocaml-git/releases/tag/3.3.0>
* <https://github.com/mirage/irmin/releases/tag/2.5.0>
* <https://github.com/mirage/irmin/releases/tag/2.5.1>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
