### PR TITLE
gpuvis: init at 20210220

### DIFF
--- a/pkgs/development/tools/misc/gpuvis/default.nix
+++ b/pkgs/development/tools/misc/gpuvis/default.nix
@@ -1,0 +1,42 @@
+{ fetchFromGitHub
+, freetype
+, gtk3
+, lib
+, meson
+, ninja
+, pkg-config
+, SDL2
+, stdenv
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gpuvis";
+  version = "20210220";
+
+  src = fetchFromGitHub {
+    owner = "mikesart";
+    repo = pname;
+    rev = "216f7d810e182a89fd96ab9fad2a5c2b1e425ea9";
+    sha256 = "15pj7gy0irlp849a85z68n184jksjri0xhihgh56rs15kq333mwz";
+  };
+
+  # patch dlopen path for gtk3
+  # python2 is wrongly added in the meson file, upstream PR: https://github.com/mikesart/gpuvis/pull/62
+  postPatch = ''
+    substituteInPlace src/hook_gtk3.h \
+      --replace "libgtk-3.so" "${lib.getLib gtk3}/lib/libgtk-3.so"
+  '';
+
+  nativeBuildInputs = [ pkg-config meson ninja wrapGAppsHook ];
+
+  buildInputs = [ SDL2 gtk3 freetype ];
+
+  meta = with lib; {
+    description = "GPU Trace Visualizer";
+    homepage = "https://github.com/mikesart/gpuvis";
+    license = licenses.mit;
+    maintainers = with maintainers; [ emantor ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12337,6 +12337,8 @@ in
 
   gputils = callPackage ../development/tools/misc/gputils { };
 
+  gpuvis = callPackage ../development/tools/misc/gpuvis { };
+
   gradleGen = callPackage ../development/tools/build-managers/gradle {
     java = jdk8; # TODO: upgrade https://github.com/NixOS/nixpkgs/pull/89731
   };


### PR DESCRIPTION
###### Motivation for this change
Add gpuvis, a program to visualize kernel traces of the GPU subsystem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
