### PR TITLE
hol: 10 -> 14

### DIFF
--- a/pkgs/applications/science/logic/hol/default.nix
+++ b/pkgs/applications/science/logic/hol/default.nix
@@ -3,14 +3,14 @@
 
 let
   pname = "hol4";
-  vnum = "10";
+  vnum = "14";
 in
 
 let
   version = "k.${vnum}";
   longVersion = "kananaskis-${vnum}";
   holsubdir = "hol-${longVersion}";
-  kernelFlag = if experimentalKernel then "-expk" else "-stdknl";
+  kernelFlag = if experimentalKernel then "--expk" else "--stdknl";
 in
 
 let
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/hol/hol/${longVersion}/${holsubdir}.tar.gz";
-    sha256 = "0x2wxksr305h1lrbklf6p42lp09rbhb4rsh74g0l70sgapyiac9b";
+    sha256 = "6Mc/qsEjzxGqzt6yP6x/1Tmqpwc1UDGlwV1Gl+4pMsY=";
   };
 
   buildInputs = [polymlEnableShared graphviz fontconfig liberation_ttf];
@@ -46,8 +46,8 @@ stdenv.mkDerivation {
     cd ${holsubdir}
 
     substituteInPlace tools/Holmake/Holmake_types.sml \
-      --replace "\"/bin/mv\"" "\"mv\"" \
-      --replace "\"/bin/cp\"" "\"cp\""
+      --replace "\"/bin/" "\"" \
+
 
     for f in tools/buildutils.sml help/src-sml/DOT;
     do
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
 
     poly < tools/smart-configure.sml
 
-    bin/build ${kernelFlag} -symlink
+    bin/build ${kernelFlag}
 
     mkdir -p "$out/bin"
     ln -st $out/bin  $out/src/${holsubdir}/bin/*
@@ -81,8 +81,7 @@ stdenv.mkDerivation {
     '';
     homepage = "http://hol.sourceforge.net/";
     license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ mudri ];
-    platforms = with platforms; linux;
-    broken = true;
   };
 }


### PR DESCRIPTION
also cleared broken status; builds on NixOS

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
@potan asked me to package it, so I did. Also it has a new version, and it was trivial to package it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
