### PR TITLE
fairymax: enable clang/darwin build

### DIFF
--- a/pkgs/games/fairymax/default.nix
+++ b/pkgs/games/fairymax/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     cp ${ini} fmax.ini
   '';
   buildPhase = ''
-    gcc *.c -o fairymax -DINI_FILE='"'"$out/share/fairymax/fmax.ini"'"'
+    $CC *.c -Wno-return-type -o fairymax -DINI_FILE='"'"$out/share/fairymax/fmax.ini"'"'
   '';
   installPhase = ''
     mkdir -p "$out"/{bin,share/fairymax}
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.free ;
     maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
     homepage = "http://home.hccnet.nl/h.g.muller/dwnldpage.html";
   };
 }

--- a/pkgs/games/fairymax/default.nix
+++ b/pkgs/games/fairymax/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.free ;
     maintainers = [lib.maintainers.raskin];
+    platforms = lib.platforms.all;
     homepage = "http://home.hccnet.nl/h.g.muller/dwnldpage.html";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This is a simple change to make fairymax build on darwin. It's the default engine for xboard, so it'd be nice to have it work. The `-Wno-return-type` flag is necessary because clang is more strict than gcc and will fatal on this warning.

###### Things done

- Built on platform(s)
   - [X] NixOS
   - [X] macOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
