### PR TITLE
nextcloud-client: 3.0.3 -> 3.1.3

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -12,6 +12,7 @@
 , qtkeychain
 , qttools
 , qtwebengine
+, qtwebsockets
 , qtquickcontrols2
 , qtgraphicaleffects
 , sqlite
@@ -19,16 +20,17 @@
 
 mkDerivation rec {
   pname = "nextcloud-client";
-  version = "3.0.3";
+  version = "3.1.3";
 
   src = fetchFromGitHub {
     owner = "nextcloud";
     repo = "desktop";
     rev = "v${version}";
-    sha256 = "0idh8i71jivdjjs2y62l22yl3qxwgcr0hf53dad587bzgkkkr223";
+    sha256 = "sha256-8Ql6tOvWOjAvMJA87WlT9TbpnbciBsjDxRuYlMVi/m8=";
   };
 
   patches = [
+    # Explicitly move dbus configuration files to the store path rather than `/etc/dbus-1/services`.
     ./0001-Explicitly-copy-dbus-files-into-the-store-dir.patch
   ];
 
@@ -40,6 +42,7 @@ mkDerivation rec {
   buildInputs = [
     inotify-tools
     libcloudproviders
+    libsecret
     openssl
     pcre
     qtbase
@@ -48,11 +51,8 @@ mkDerivation rec {
     qtwebengine
     qtquickcontrols2
     qtgraphicaleffects
+    qtwebsockets
     sqlite
-  ];
-
-  qtWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret ]}"
   ];
 
   cmakeFlags = [
@@ -63,7 +63,7 @@ mkDerivation rec {
   meta = with lib; {
     description = "Nextcloud themed desktop client";
     homepage = "https://nextcloud.com";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ caugner ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated to the latest version and add qtwebsockets for cmake errors and libsecret for ld errors.

This can potentially close https://github.com/NixOS/nixpkgs/issues/103680

NOTE: I'm not sure if adding libsecret directly to buildinputs is a good idea, but it was the way I managed to compile and use the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
