### PR TITLE
teslajsonpy: fix tests

### DIFF
--- a/pkgs/development/python-modules/teslajsonpy/default.nix
+++ b/pkgs/development/python-modules/teslajsonpy/default.nix
@@ -5,6 +5,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
+, pytest-asyncio
 , pytestCheckHook
 , wrapt
 }:
@@ -35,15 +36,11 @@ buildPythonPackage rec {
     wrapt
   ];
 
-  checkInputs = [ pytestCheckHook ];
-
-  # Not all Home Assistant related check pass
-  # https://github.com/zabuldon/teslajsonpy/issues/121
-  # https://github.com/zabuldon/teslajsonpy/pull/124
-  disabledTests = [
-    "test_values_on_init"
-    "test_get_value_on_init"
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
   ];
+
   pythonImportsCheck = [ "teslajsonpy" ];
 
   meta = with lib; {


### PR DESCRIPTION
teslajsonpy has some dependencies between tests, which were masked upstream but
caused failures in nixpkgs because all the asyncio tests were skipped.  Tests
pass as they do upstream with pytest-asyncio added.

Test isolation issue is being dealt with here:
https://github.com/zabuldon/teslajsonpy/issues/121.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
