### PR TITLE
garble: fix aarch64-linux and pin go to 1.15

### DIFF
--- a/pkgs/build-support/go/garble.nix
+++ b/pkgs/build-support/go/garble.nix
@@ -1,4 +1,5 @@
-{ buildGoModule
+{ stdenv
+, buildGoModule
 , fetchFromGitHub
 , lib
 }:
@@ -14,6 +15,15 @@ buildGoModule rec {
   };
 
   vendorSha256 = "sha256-x2fk2QmZDK2yjyfYdK7x+sQjvt7tuggmm8ieVjsNKek=";
+
+  preBuild = ''
+    # https://github.com/burrowers/garble/issues/184
+    substituteInPlace testdata/scripts/tiny.txt \
+      --replace "{6,8}" "{4,8}"
+  '' + lib.optionalString (!stdenv.isx86_64) ''
+    # The test assumex amd64 assembly
+    rm testdata/scripts/asm.txt
+  '';
 
   meta = {
     description = "Obfuscate Go code by wrapping the Go toolchain";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13794,7 +13794,10 @@ in
 
   ganv = callPackage ../development/libraries/ganv { };
 
-  garble = callPackage ../build-support/go/garble.nix { };
+  garble = callPackage ../build-support/go/garble.nix {
+    # https://github.com/burrowers/garble/issues/124
+    buildGoModule = buildGo115Module;
+  };
 
   gcab = callPackage ../development/libraries/gcab { };
 


### PR DESCRIPTION
###### Motivation for this change

Fixing both `x86-64-linux` and `aarch64-linux` builds, darwin was always broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
