### PR TITLE
numactl: enable on all linux platforms

### DIFF
--- a/pkgs/os-specific/linux/numactl/default.nix
+++ b/pkgs/os-specific/linux/numactl/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     patchShebangs test
   '';
 
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isRiscV "-latomic";
+
   # You probably shouldn't ever run these! They will reconfigure Linux
   # NUMA settings, which on my build machine makes the rest of package
   # building ~5% slower until reboot. Ugh!
@@ -26,6 +28,6 @@ stdenv.mkDerivation rec {
     description = "Library and tools for non-uniform memory access (NUMA) machines";
     homepage = "https://github.com/numactl/numactl";
     license = with licenses; [ gpl2 lgpl21 ]; # libnuma is lgpl21
-    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This is a dependency of building VMs for e.g. ppc64 and riscv64 platform.

Also fixed an issue with linking libatomic on riscv.

Fixes `pkgsCross.riscv64.numactl`, `pkgsCross.powernv.numactl`.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/101651

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
