### PR TITLE
gcc: don't disable decimal-float when cross-compiling

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -86,7 +86,6 @@ let
                           else if targetPlatform.isWindows then "mcf"
                           else "single"}"
       "--enable-nls"
-      "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
     ] ++ lib.optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
       # libsanitizer requires netrom/netrom.h which is not
       # available in uclibc.


### PR DESCRIPTION
This causes some minor ugliness during stdenv bootstrap on powerpc64le
using cross-compiled bootstrap tools. MPFR wants to use decimal floats
by default so they have to be manually disabled in the configure flags
when using cross-compiled bootstrap tools.

The lineage of this particular configure flag traces back to 2010 (!)
It was added in commit: 9b1d5353a951a29e33a3a137cb3d5246c1eff6a7
I've built various cross bootstrap tools and they seem to work fine,
so I don't think this is needed anymore.

Ran `nix build -j8 -f pkgs/stdenv/linux/make-bootstrap-tools-cross.nix powerpc64le.build powerpc64.build aarch64.build riscv64.build` on x86_64-linux with no failures. Let me know if there is anything in particular I should test for this.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
