### PR TITLE
cen64: init at unstable-2020-02-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -82,6 +82,12 @@
     githubId = 882455;
     name = "Elliot Cameron";
   };
+  _414owen = {
+    email = "owen@owen.cafe";
+    github = "414owen";
+    githubId = 1714287;
+    name = "Owen Shepherd";
+  };
   _6AA4FD = {
     email = "f6442954@gmail.com";
     github = "6AA4FD";

--- a/pkgs/misc/emulators/cen64/default.nix
+++ b/pkgs/misc/emulators/cen64/default.nix
@@ -1,0 +1,29 @@
+{ lib, cmake, fetchFromGitHub, libGL, libiconv, libX11, openal, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "cen64";
+  version = "unstable-2020-02-20";
+
+  src = fetchFromGitHub {
+    owner = "n64dev";
+    repo = "cen64";
+    rev = "6f9f5784bf0a720522c4ecb0915e20229c126aed";
+    sha256 = "08q0a3b2ilb95zlz4cw681gwz45n2wrb2gp2z414cf0bhn90vz0s";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libGL libiconv openal libX11 ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv cen64 $out/bin
+  '';
+
+  meta = with lib; {
+    description = "A Cycle-Accurate Nintendo 64 Emulator";
+    license = licenses.bsd3;
+    homepage = "https://github.com/n64dev/cen64";
+    maintainers = [ maintainers._414owen ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -192,6 +192,8 @@ in
 
   castxml = callPackage ../development/tools/castxml { };
 
+  cen64 = callPackage ../misc/emulators/cen64 { };
+
   cereal = callPackage ../development/libraries/cereal { };
 
   checkov = callPackage ../development/tools/analysis/checkov {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

cen64 is an emulator that's useful for n64 development

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
