### PR TITLE
mesa: fix missing timespec_get on darwin

### DIFF
--- a/pkgs/development/libraries/mesa/aarch64-darwin.patch
+++ b/pkgs/development/libraries/mesa/aarch64-darwin.patch
@@ -1,0 +1,33 @@
+From 8ac29b952e638ec1ea8c3734a3b91253e50c336d Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Sun, 24 Jan 2021 21:10:29 -0800
+Subject: [PATCH 4/4] Hack to address build failure when using newer macOS SDKs
+ with older deployment targets
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+---
+ include/c11/threads_posix.h | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/include/c11/threads_posix.h b/include/c11/threads_posix.h
+index 45cb6075e6e..355d725f7da 100644
+--- a/include/c11/threads_posix.h
++++ b/include/c11/threads_posix.h
+@@ -382,7 +382,13 @@ tss_set(tss_t key, void *val)
+ 
+ /*-------------------- 7.25.7 Time functions --------------------*/
+ // 7.25.6.1
+-#ifndef HAVE_TIMESPEC_GET
++#if !defined(HAVE_TIMESPEC_GET) || defined(__APPLE__)
++
++#ifdef __APPLE__
++#include <time.h>
++#define timespec_get(ts, b) mesa_timespec_get(ts, b)
++#endif
++
+ static inline int
+ timespec_get(struct timespec *ts, int base)
+ {
+-- 
+2.29.2 (Apple Git-129)
+

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -65,6 +65,10 @@ stdenv.mkDerivation {
       url = "https://gitlab.freedesktop.org/mesa/mesa/commit/aebbf819df6d1e.patch";
       sha256 = "17248hyzg43d73c86p077m4lv1pkncaycr3l27hwv9k4ija9zl8q";
     })
+  ] ++ optionals (stdenv.isDarwin && stdenv.isAarch64) [
+    # Fix aarch64-darwin build, remove when upstreaam supports it out of the box.
+    # See: https://gitlab.freedesktop.org/mesa/mesa/-/issues/1020
+    ./aarch64-darwin.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Similar to #113751.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
