### PR TITLE
ocamlPackages.ocamlmod: disable tests if ounit is not available

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlmod/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlmod/default.nix
@@ -1,5 +1,10 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, ounit }:
 
+let
+  # ounit is only available for OCaml >= 4.04
+  doCheck = lib.versionAtLeast ocaml.version "4.04";
+in
+
 stdenv.mkDerivation {
   pname = "ocamlmod";
   version = "0.0.9";
@@ -9,13 +14,15 @@ stdenv.mkDerivation {
     sha256 = "0cgp9qqrq7ayyhddrmqmq1affvfqcn722qiakjq4dkywvp67h4aa";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ounit ];
+  buildInputs = [ ocaml findlib ocamlbuild ];
 
-  configurePhase = "ocaml setup.ml -configure --prefix $out --enable-tests";
+  configurePhase = "ocaml setup.ml -configure --prefix $out"
+    + lib.optionalString doCheck " --enable-tests";
   buildPhase     = "ocaml setup.ml -build";
   installPhase   = "ocaml setup.ml -install";
 
-  doCheck = true;
+  inherit doCheck;
+  checkInputs = [ ounit ];
 
   checkPhase = "ocaml setup.ml -test";
 


### PR DESCRIPTION
When we redid ounit and ounit2, the minimumOCamlVersion was also pushed
to OCaml 4.04. ocamlmod builds on earlier versions as well, but doesn't
evaluate if we pull in ounit.

Therefore we conditionally disable tests for OCaml < 4.04 which means
for example oasis is available for those versions again as well.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
