### PR TITLE
pcsctools: temporarily remove the gscriptor binary

### DIFF
--- a/pkgs/tools/security/pcsctools/default.nix
+++ b/pkgs/tools/security/pcsctools/default.nix
@@ -20,8 +20,11 @@ in stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/scriptor \
       --set PERL5LIB "${with perlPackages; makePerlPath [ pcscperl ]}"
-    wrapProgram $out/bin/gscriptor \
-      --set PERL5LIB "${with perlPackages; makePerlPath [ pcscperl GlibObjectIntrospection Glib Gtk3 Pango Cairo CairoGObject ]}"
+    # gscriptor requires perlPackages.GlibObjectIntrospection, which is
+    # currently broken once fixed, it should be wrapped with the following
+    # perl packages:
+    # pcscperl GlibObjectIntrospection Glib Gtk3 Pango Cairo CairoGObject
+    rm $out/bin/gscriptor
     wrapProgram $out/bin/ATR_analysis \
       --set PERL5LIB "${with perlPackages; makePerlPath [ pcscperl ]}"
     wrapProgram $out/bin/pcsc_scan \

--- a/pkgs/tools/security/pcsctools/default.nix
+++ b/pkgs/tools/security/pcsctools/default.nix
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
     description = "Tools used to test a PC/SC driver, card or reader";
     homepage = "http://ludovic.rousseau.free.fr/softwares/pcsc-tools/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ eduardosm ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/security/pcsctools/default.nix
+++ b/pkgs/tools/security/pcsctools/default.nix
@@ -5,10 +5,11 @@
 let deps = lib.makeBinPath [ wget coreutils ];
 
 in stdenv.mkDerivation rec {
-  name = "pcsc-tools-1.5.7";
+  pname = "pcsc-tools";
+  version = "1.5.7";
 
   src = fetchurl {
-    url = "http://ludovic.rousseau.free.fr/softwares/pcsc-tools/${name}.tar.bz2";
+    url = "http://ludovic.rousseau.free.fr/softwares/pcsc-tools/${pname}-${version}.tar.bz2";
     sha256 = "17b9jxvcxmn007lavan20l25v4jvm6dqc4x9dlqzbg6mjs28zsp0";
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8764,6 +8764,7 @@ let
       # see https://github.com/NixOS/nixpkgs/pull/68115
       # and https://github.com/NixOS/nixpkgs/issues/68116
       # adding pkgs.gnome3.gjs does not fix it
+      # once this is fixed, gscriptor in pcsctools should be enabled again
       description = "Dynamically create Perl language bindings";
       license = lib.licenses.lgpl2Plus;
     };


### PR DESCRIPTION
###### Motivation for this change

It depends on perlPackages.GlibObjectIntrospection, which is broken and prevents the whole pcsctools package from building. However, the other tools in pcsctools should still work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
