### PR TITLE
python3Packages.pyalmond: init at 0.0.3

### DIFF
--- a/pkgs/development/python-modules/pyalmond/default.nix
+++ b/pkgs/development/python-modules/pyalmond/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyalmond";
+  version = "0.0.3";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "stanford-oval";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0d1w83lr7k2wxcs846iz4mjyqn1ximnw6155kgl515v10fqyrhgk";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  # Tests require a running Almond instance
+  doCheck = false;
+  pythonImportsCheck = [ "pyalmond" ];
+
+  meta = with lib; {
+    description = "Python client for the Almond API";
+    homepage = "https://github.com/stanford-oval/pyalmond";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -23,7 +23,7 @@
     "alarmdecoder" = ps: with ps; [ adext ];
     "alert" = ps: with ps; [ ];
     "alexa" = ps: with ps; [ aiohttp-cors ];
-    "almond" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pyalmond
+    "almond" = ps: with ps; [ aiohttp-cors pyalmond ];
     "alpha_vantage" = ps: with ps; [ ]; # missing inputs: alpha_vantage
     "amazon_polly" = ps: with ps; [ boto3 ];
     "ambiclimate" = ps: with ps; [ aiohttp-cors ambiclimate ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5229,6 +5229,8 @@ in {
 
   pyalgotrade = callPackage ../development/python-modules/pyalgotrade { };
 
+  pyalmond = callPackage ../development/python-modules/pyalmond { };
+
   pyamf = callPackage ../development/python-modules/pyamf { };
 
   pyamg = callPackage ../development/python-modules/pyamg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for the Almond API

https://github.com/stanford-oval/pyalmond

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
