### PR TITLE
pythonPackages.buildVenv: build a venv with Python

### DIFF
--- a/pkgs/development/interpreters/python/builders/build-venv.nix
+++ b/pkgs/development/interpreters/python/builders/build-venv.nix
@@ -1,0 +1,50 @@
+# Function to build a `venv`.
+
+{ stdenv
+, lib
+, pythonPackages
+, symlinkJoin
+, runCommand
+}:
+
+f:
+
+let
+  packages = lib.remove python (pythonPackages.requiredPythonModules (f pythonPackages));
+
+  paths = lib.concatStringsSep " " (map (pkg: (lib.getOutput "wheel" pkg)) packages);
+
+  wheelsEnv = runCommand "wheels-cache" { } ''
+    mkdir -p $out/dist
+    cd $out/dist
+    for path in ${paths}; do
+      echo $path
+      if [ -d "$path/dist" ]; then
+        for file in "$path/dist/*.whl"; do
+          ln -s $file .
+        done
+      fi
+    done
+  '';
+
+  python = pythonPackages.python;
+
+  # Assume pname corresponds to the project name. This should be the case.
+  names = lib.concatStringsSep " " (map (pkg: pkg.pname) packages);
+
+in stdenv.mkDerivation {
+  name = "${python.pname}-venv";
+
+  dontUnpack = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    ${python.interpreter} -m venv $out
+    export PATH="$out/bin:$PATH"
+    pip install --find-links ${wheelsEnv}/dist --no-index ${names}
+  '';
+
+  passthru.wheels = wheelsEnv;
+
+}

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -53,6 +53,7 @@ with pkgs;
               pytestCheckHook
               pythonCatchConflictsHook
               pythonImportsCheckHook
+              pythonMoveWheelHook
               pythonNamespacesHook
               pythonRecompileBytecodeHook
               pythonRemoveBinBytecodeHook

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -91,6 +91,11 @@ in rec {
       };
     } ./python-imports-check-hook.sh) {};
 
+  pythonMoveWheelHook = callPackage ({}:
+    makeSetupHook {
+      name = "python-move-wheel-hook.sh";
+    } ./python-move-wheel-hook.sh) {};
+
   pythonNamespacesHook = callPackage ({}:
     makeSetupHook {
       name = "python-namespaces-hook.sh";

--- a/pkgs/development/interpreters/python/hooks/python-move-wheel-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-move-wheel-hook.sh
@@ -1,0 +1,11 @@
+# Setup hook for moving wheel to an output.
+echo "Sourcing python-move-wheel-hook.sh"
+
+pythonMoveWheelPhase () {
+    mkdir -p "$wheel"
+    mv dist/ $wheel
+}
+
+if [ -z "${dontUsePythonMoveWheel-}" ]; then
+    preDistPhases+=" pythonMoveWheelPhase"
+fi

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -16,6 +16,7 @@
 , pipInstallHook
 , pythonCatchConflictsHook
 , pythonImportsCheckHook
+, pythonMoveWheelHook
 , pythonNamespacesHook
 , pythonRemoveBinBytecodeHook
 , pythonRemoveTestsDirHook
@@ -114,6 +115,7 @@ let
       python
       wrapPython
       ensureNewerSourcesForZipFilesHook  # move to wheel installer (pip) or builder (setuptools, flit, ...)?
+      pythonMoveWheelHook
       pythonRemoveTestsDirHook
     ] ++ lib.optionals catchConflicts [
       setuptools pythonCatchConflictsHook
@@ -166,6 +168,11 @@ let
 
     # Python packages built through cross-compilation are always for the host platform.
     disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [ python.pythonForBuild ];
+
+    outputs = [
+      "out"
+      "wheel"
+    ];
 
     meta = {
       # default to python's platforms

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -115,6 +115,7 @@ in {
     pytestCheckHook
     pythonCatchConflictsHook
     pythonImportsCheckHook
+    pythonMoveWheelHook
     pythonNamespacesHook
     pythonRecompileBytecodeHook
     pythonRemoveBinBytecodeHook
@@ -130,6 +131,8 @@ in {
 
   # Dont take pythonPackages from "global" pkgs scope to avoid mixing python versions
   pythonPackages = self;
+
+  buildVenv = callPackage ../development/interpreters/python/builders/build-venv.nix { };
 
   # specials
 


### PR DESCRIPTION
This function behaves like `withPackages`, however, it installs wheels
using `python3 -m venv`.

The following example installs the Nixpkgs pip and pytest in a venv:

    nix-build -E "((import ./. {}).python3.pkgs.buildVenv(ps: with ps; [ pip pytest ]))"

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Simple example showing how we could use venv. Downsides with this approach:
- only wheels can be installed;
- everything `postBuild` is not considered, so wrapper arguments are not considered. As soon as we have declarative wrappers, we could utilize it here;
- wheels will be stored, taking extra space.
- extra venv will take additional space.

I don't think we should be using this in Nixpkgs, but it may be of use to users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
