### PR TITLE
plasma-applet-virtual-desktop-bar: init at unstable-2021-02-20

### DIFF
--- a/pkgs/desktops/plasma-5/3rdparty/addons/virtual-desktop-bar.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/addons/virtual-desktop-bar.nix
@@ -1,0 +1,40 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, extra-cmake-modules
+, kwindowsystem
+, plasma-framework
+, qtx11extras
+}:
+
+mkDerivation rec {
+  pname = "plasma-applet-virtual-desktop-bar";
+  version = "unstable-2021-02-20";
+
+  src = fetchFromGitHub {
+    owner = "wsdfhjxc";
+    repo = "virtual-desktop-bar";
+    rev = "3e9bbddb8def8da65071a1c325eaa06598e8a473";
+    sha256 = "192ns6c2brzq46pg385n0v1ydbz52aaa8f5dgfw5251hrw9c7bxg";
+  };
+
+  buildInputs = [
+    kwindowsystem plasma-framework qtx11extras
+  ];
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
+
+  cmakeFlags = [
+    "-Wno-dev"
+  ];
+
+  meta = with lib; {
+    description = "Manage virtual desktops dynamically in a convenient way";
+    homepage = "https://github.com/wsdfhjxc/virtual-desktop-bar";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -143,6 +143,7 @@ let
 
       thirdParty = let inherit (libsForQt5) callPackage; in {
         plasma-applet-caffeine-plus = callPackage ./3rdparty/addons/caffeine-plus.nix { };
+        plasma-applet-virtual-desktop-bar = callPackage ./3rdparty/addons/virtual-desktop-bar.nix { };
         kwin-dynamic-workspaces = callPackage ./3rdparty/kwin/scripts/dynamic-workspaces.nix { };
         kwin-tiling = callPackage ./3rdparty/kwin/scripts/tiling.nix { };
         krohnkite = callPackage ./3rdparty/kwin/scripts/krohnkite.nix { };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -924,6 +924,7 @@ mapAliases ({
   ;
   inherit (plasma5Packages.thirdParty)
     plasma-applet-caffeine-plus
+    plasma-applet-virtual-desktop-bar
     kwin-dynamic-workspaces
     kwin-tiling
     krohnkite


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/107151. 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
