### PR TITLE
meson: 0.56.0 → 0.57.1

### DIFF
--- a/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
+++ b/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
@@ -1,14 +1,14 @@
 --- a/mesonbuild/coredata.py
 +++ b/mesonbuild/coredata.py
-@@ -491,7 +491,6 @@ class CoreData:
+@@ -506,7 +506,6 @@ class CoreData:
              return value
-         if option.endswith('dir') and value.is_absolute() and \
-            option not in builtin_dir_noprefix_options:
+         if option.name.endswith('dir') and value.is_absolute() and \
+            option not in BULITIN_DIR_NOPREFIX_OPTIONS:
 -            # Value must be a subdir of the prefix
              # commonpath will always return a path in the native format, so we
              # must use pathlib.PurePath to do the same conversion before
              # comparing.
-@@ -503,7 +502,7 @@ class CoreData:
+@@ -518,7 +517,7 @@ class CoreData:
              try:
                  value = value.relative_to(prefix)
              except ValueError:

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -9,11 +9,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meson";
-  version = "0.56.0";
+  version = "0.57.1";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "04vj250bwrzq7c0z1r96b0z0vgirvn0m367wm3ygqmfdy67x6799";
+    sha256 = "19n8alcpzv6npgp27iqljkmvdmr7s2c7zm8y997j1nlvpa1cgqbj";
   };
 
   patches = [

--- a/pkgs/development/tools/build-managers/meson/more-env-vars.patch
+++ b/pkgs/development/tools/build-managers/meson/more-env-vars.patch
@@ -1,8 +1,8 @@
-diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
-index 219b62ec8..e3ceaddbd 100644
---- a/mesonbuild/envconfig.py
-+++ b/mesonbuild/envconfig.py
-@@ -94,7 +94,7 @@ def get_env_var_pair(for_machine: MachineChoice,
+diff --git a/mesonbuild/environment.py b/mesonbuild/environment.py
+index 756dd8193..a5cc6ef8b 100644
+--- a/mesonbuild/environment.py
++++ b/mesonbuild/environment.py
+@@ -151,7 +151,7 @@ def _get_env_var(for_machine: MachineChoice, is_cross: bool, var_name: str) -> T
          # compiling we fall back on the unprefixed host version. This
          # allows native builds to never need to worry about the 'BUILD_*'
          # ones.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- https://mesonbuild.com/Release-notes-for-0-57-0.html
- https://github.com/mesonbuild/meson/releases/tag/0.57.0
- https://github.com/mesonbuild/meson/releases/tag/0.57.1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] systemd builds
- [x] fwupd builds
- [x] gtk4 builds
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
