### PR TITLE
python3Packages.pyvolumio: init 0.1.3

### DIFF
--- a/pkgs/development/python-modules/pyvolumio/default.nix
+++ b/pkgs/development/python-modules/pyvolumio/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyvolumio";
+  version = "0.1.3";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "OnFreund";
+    repo = "PyVolumio";
+    rev = "v${version}";
+    sha256 = "0x2dzmd9lwnak2iy6v54y24qjq37y3nlfhsvx7hddgv8jj1klvap";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pyvolumio" ];
+
+  meta = with lib; {
+    description = "Python module to control Volumio";
+    homepage = "https://github.com/OnFreund/PyVolumio";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -911,7 +911,7 @@
     "vlc_telnet" = ps: with ps; [ ]; # missing inputs: python-telnet-vlc
     "voicerss" = ps: with ps; [ ];
     "volkszaehler" = ps: with ps; [ volkszaehler ];
-    "volumio" = ps: with ps; [ ]; # missing inputs: pyvolumio
+    "volumio" = ps: with ps; [ pyvolumio ];
     "volvooncall" = ps: with ps; [ ]; # missing inputs: volvooncall
     "vultr" = ps: with ps; [ vultr ];
     "w800rf32" = ps: with ps; [ ]; # missing inputs: pyW800rf32

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6600,6 +6600,8 @@ in {
 
   pyvmomi = callPackage ../development/python-modules/pyvmomi { };
 
+  pyvolumio = callPackage ../development/python-modules/pyvolumio { };
+
   pyvoro = callPackage ../development/python-modules/pyvoro { };
 
   pywal = callPackage ../development/python-modules/pywal { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to control Volumio

https://github.com/OnFreund/PyVolumio

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
