### PR TITLE
python3Packages.yalesmartalarmclient: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/yalesmartalarmclient/default.nix
+++ b/pkgs/development/python-modules/yalesmartalarmclient/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "yalesmartalarmclient";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "domwillcode";
+    repo = "yale-smart-alarm-client";
+    rev = "v${version}";
+    sha256 = "0fscp9n66h8a8khvjs2rjgm95xsdckpknadnyxqdmhw3hlj0aw6h";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "yalesmartalarmclient" ];
+
+  meta = with lib; {
+    description = "Python module to interface with Yale Smart Alarm Systems";
+    homepage = "https://github.com/mampfes/python-wiffi";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -953,7 +953,7 @@
     "xiaomi_tv" = ps: with ps; [ ]; # missing inputs: pymitv
     "xmpp" = ps: with ps; [ slixmpp ];
     "xs1" = ps: with ps; [ ]; # missing inputs: xs1-api-client
-    "yale_smart_alarm" = ps: with ps; [ ]; # missing inputs: yalesmartalarmclient
+    "yale_smart_alarm" = ps: with ps; [ yalesmartalarmclient ];
     "yamaha" = ps: with ps; [ rxv ];
     "yamaha_musiccast" = ps: with ps; [ ]; # missing inputs: pymusiccast
     "yandex_transport" = ps: with ps; [ ]; # missing inputs: aioymaps

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8512,6 +8512,8 @@ in {
 
   yahooweather = callPackage ../development/python-modules/yahooweather { };
 
+  yalesmartalarmclient = callPackage ../development/python-modules/yalesmartalarmclient { };
+
   yamale = callPackage ../development/python-modules/yamale { };
 
   yamllint = callPackage ../development/python-modules/yamllint { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
###### Motivation for this change
Python module to interface with Yale Smart Alarm Systems

https://github.com/domwillcode/yale-smart-alarm-client

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
