### PR TITLE
abseil-cpp: Factor out version specific attrs

### DIFF
--- a/pkgs/development/libraries/abseil-cpp/20200923.nix
+++ b/pkgs/development/libraries/abseil-cpp/20200923.nix
@@ -1,0 +1,4 @@
+import ./generic.nix {
+  version = "20200923.3";
+  sha256 = "1p4djhm1f011ficbjjxx3n8428p8481p20j4glpaawnpsi362hkl";
+}

--- a/pkgs/development/libraries/abseil-cpp/generic.nix
+++ b/pkgs/development/libraries/abseil-cpp/generic.nix
@@ -1,14 +1,17 @@
+# Version specific attributes
+{ version, sha256 }:
+# Generic attributes
 { lib, stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "abseil-cpp";
-  version = "20200923.3";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "abseil";
     repo = "abseil-cpp";
     rev = version;
-    sha256 = "1p4djhm1f011ficbjjxx3n8428p8481p20j4glpaawnpsi362hkl";
+    inherit sha256;
   };
 
   cmakeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13131,7 +13131,8 @@ in
 
   aalib = callPackage ../development/libraries/aalib { };
 
-  abseil-cpp = callPackage ../development/libraries/abseil-cpp { };
+  abseil-cpp_20200923 = callPackage ../development/libraries/abseil-cpp/20200923.nix { };
+  abseil-cpp = abseil-cpp_20200923;
 
   accountsservice = callPackage ../development/libraries/accountsservice { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is an attempt at solving the issues with abseil-cpp described described in #110323 and #107846 by providing multiple versions of the package. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
