### PR TITLE
mysqltuner: add password list to output

### DIFF
--- a/pkgs/tools/misc/mysqltuner/default.nix
+++ b/pkgs/tools/misc/mysqltuner/default.nix
@@ -11,17 +11,29 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Yv1XjD8sZcmGr2SVD6TEElUH7vspJ61WwQwfXLOrao0=";
   };
 
+  postPatch = ''
+    substituteInPlace mysqltuner.pl \
+      --replace '$basic_password_files = "/usr/share/mysqltuner/basic_passwords.txt"' "\$basic_password_files = \"$out/share/basic_passwords.txt\"" \
+      --replace '$opt{cvefile} = "/usr/share/mysqltuner/vulnerabilities.csv"' "\$opt{cvefile} = \"$out/share/vulnerabilities.csv\""
+  '';
+
   buildInputs = [ perl ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    install -m0755 mysqltuner.pl $out/bin/mysqltuner
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    install -Dm 0755 mysqltuner.pl "$out/bin/mysqltuner"
+    install -Dm 0644 basic_passwords.txt "$out/share/basic_passwords.txt"
+    install -Dm 0644 vulnerabilities.csv "$out/share/vulnerabilities.csv"
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Make recommendations for increased performance and stability of MariaDB/MySQL";
     homepage = "http://mysqltuner.com";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ peterhoeg ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ peterhoeg shamilton ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/113517

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
