### PR TITLE
python3Packages.pymfy: init at 0.9.4

### DIFF
--- a/pkgs/development/python-modules/pymfy/default.nix
+++ b/pkgs/development/python-modules/pymfy/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, httpretty
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests_oauthlib
+}:
+
+buildPythonPackage rec {
+  pname = "pymfy";
+  version = "0.9.4";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "tetienne";
+    repo = "somfy-open-api";
+    rev = "v${version}";
+    sha256 = "1ml536dvva2xd52jfgrd557h2sr5w6567sxnyq0blhkgpyz4m2av";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    requests
+    requests_oauthlib
+  ];
+
+  checkInputs = [
+    httpretty
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pymfy" ];
+
+  meta = with lib; {
+    description = "Python client for the Somfy Open API";
+    homepage = "https://github.com/tetienne/somfy-open-api";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -763,7 +763,7 @@
     "solarlog" = ps: with ps; [ ]; # missing inputs: sunwatcher
     "solax" = ps: with ps; [ solax ];
     "soma" = ps: with ps; [ pysoma ];
-    "somfy" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pymfy
+    "somfy" = ps: with ps; [ aiohttp-cors pymfy ];
     "somfy_mylink" = ps: with ps; [ ]; # missing inputs: somfy-mylink-synergy
     "sonarr" = ps: with ps; [ ]; # missing inputs: sonarr
     "songpal" = ps: with ps; [ ]; # missing inputs: python-songpal

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5710,6 +5710,8 @@ in {
 
   pymitv = callPackage ../development/python-modules/pymitv { };
 
+  pymfy = callPackage ../development/python-modules/pymfy { };
+
   pymodbus = callPackage ../development/python-modules/pymodbus { };
 
   pymongo = callPackage ../development/python-modules/pymongo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for the Somfy Open API

https://github.com/tetienne/somfy-open-api

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
