### PR TITLE
[20.09] grafana-loki: build with go 1.15

### DIFF
--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub, makeWrapper, systemd }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, fetchpatch, makeWrapper, systemd }:
 
 buildGoPackage rec {
   version = "1.6.1";
@@ -19,6 +19,20 @@ buildGoPackage rec {
       '"eth0", "en0", "lo0"' \
       '"lo"'
   '';
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/grafana/loki/pull/2647
+      url = "https://github.com/grafana/loki/commit/85696d00eb5c3aa4aa6289e12b3656a42f581e58.patch";
+      sha256 = "1drkc1qdmfbh243kwd3v58ycgf7pbq1rd9f9j4ahcqbwfkhbi7di";
+    })
+    (fetchpatch {
+      # Fix expected return value in Test_validateDropConfig
+      # https://github.com/grafana/loki/issues/2519
+      url = "https://github.com/grafana/loki/commit/1316c0f0c5cda7c272c4873ea910211476fc1db8.patch";
+      sha256 = "06hwga58qpmivbhyjgyqzb75602hy8212a4b5vh99y9pnn6c913h";
+    })
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = stdenv.lib.optionals stdenv.isLinux [ systemd.dev ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16431,9 +16431,7 @@ in
 
   grafana-agent = callPackage ../servers/monitoring/grafana-agent { };
 
-  grafana-loki = callPackage ../servers/monitoring/loki {
-    buildGoPackage = buildGo114Package;
-  };
+  grafana-loki = callPackage ../servers/monitoring/loki { };
 
   grafana_reporter = callPackage ../servers/monitoring/grafana-reporter { };
 


### PR DESCRIPTION
###### Motivation for this change
Fix evaluation of systems depending on this.

I'm really not sure if we want to backport this, as it's a new major release. Some other options are reverting 38eaa62 or potentially setting `doCheck = false` or some other way to make this build with go 1.14 that isn't a strict backport.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
