### PR TITLE
kotatogram-desktop: 1.2 -> 1.3.5

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -1,20 +1,20 @@
 { mkDerivation, lib, fetchFromGitHub, pkg-config, python3, cmake, ninja
 , qtbase, qtimageformats, libdbusmenu, hunspell, xdg-utils, ffmpeg_3, openalSoft
-, lzma, lz4, xxHash, zlib, minizip, openssl, libtgvoip, microsoft_gsl, tl-expected
-, range-v3
+, lzma, lz4, xxHash, zlib, minizip, openssl, libtgvoip, tl-expected
+, range-v3, libopus, alsaLib, libpulseaudio
 }:
 
 with lib;
 
 mkDerivation rec {
   pname = "kotatogram-desktop";
-  version = "1.2";
+  version = "1.3.5";
 
   src = fetchFromGitHub {
     owner = "kotatogram";
     repo = "kotatogram-desktop";
     rev = "k${version}";
-    sha256 = "00pdx3cjhrihf7ihhmszcf159jrzn1bcx20vwiiizs5r1qk8l210";
+    sha256 = "sha256-BSVz8aXy2UdNvlkG8dfXyNlA1K2UUMfV95LdS2GJYn0=";
     fetchSubmodules = true;
   };
 
@@ -22,7 +22,8 @@ mkDerivation rec {
 
   buildInputs = [
     qtbase qtimageformats ffmpeg_3 openalSoft lzma lz4 xxHash libdbusmenu
-    zlib minizip openssl hunspell libtgvoip microsoft_gsl tl-expected range-v3
+    zlib minizip openssl hunspell libtgvoip tl-expected range-v3
+    libopus alsaLib libpulseaudio
   ];
 
   qtWrapperArgs = [
@@ -30,9 +31,12 @@ mkDerivation rec {
   ];
 
   cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
     "-DTDESKTOP_API_TEST=ON"
+    "-DDESKTOP_APP_USE_PACKAGED_GSL=OFF"
     "-DDESKTOP_APP_USE_PACKAGED_RLOTTIE=OFF"
     "-DDESKTOP_APP_USE_PACKAGED_VARIANT=OFF"
+    "-DTDESKTOP_USE_PACKAGED_TGVOIP=OFF"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Many new features and bugfixes: https://github.com/kotatogram/kotatogram-desktop/releases/tag/k1.3.5

Based on AUR recipe: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=kotatogram-desktop

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
