### PR TITLE
mrustc: init at 0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7517,6 +7517,12 @@
     githubId = 18549627;
     name = "Proglodyte";
   };
+  progval = {
+    email = "progval+nix@progval.net";
+    github = "ProgVal";
+    githubId = 406946;
+    name = "Valentin Lorentz";
+  };
   protoben = {
     email = "protob3n@gmail.com";
     github = "protoben";

--- a/pkgs/development/compilers/mrustc/bootstrap.nix
+++ b/pkgs/development/compilers/mrustc/bootstrap.nix
@@ -1,0 +1,153 @@
+{ lib, stdenv
+, fetchurl
+, mrustc
+, mrustc-minicargo
+, rust
+, llvm_7
+, llvmPackages_7
+, libffi
+, cmake
+, python3
+, zlib
+, libxml2
+, openssl
+, pkg-config
+, curl
+, which
+, time
+}:
+
+let
+  rustcVersion = "1.29.0";
+  rustcSrc = fetchurl {
+    url = "https://static.rust-lang.org/dist/rustc-${rustcVersion}-src.tar.gz";
+    sha256 = "1sb15znckj8pc8q3g7cq03pijnida6cg64yqmgiayxkzskzk9sx4";
+  };
+  rustcDir = "rustc-${rustcVersion}-src";
+in
+
+stdenv.mkDerivation rec {
+  pname = "mrustc-bootstrap";
+  version = "${mrustc.version}_${rustcVersion}";
+
+  inherit (mrustc) src;
+  postUnpack = "tar -xf ${rustcSrc} -C source/";
+
+  # the rust build system complains that nix alters the checksums
+  dontFixLibtool = true;
+
+  patches = [
+    ./patches/0001-use-shared-llvm.patch
+    ./patches/0002-dont-build-llvm.patch
+    ./patches/0003-echo-newlines.patch
+    ./patches/0004-increase-parallelism.patch
+  ];
+
+  postPatch = ''
+    echo "applying patch ./rustc-${rustcVersion}-src.patch"
+    patch -p0 -d ${rustcDir}/ < rustc-${rustcVersion}-src.patch
+
+    for p in ${lib.concatStringsSep " " llvmPackages_7.compiler-rt.patches}; do
+      echo "applying patch $p"
+      patch -p1 -d ${rustcDir}/src/libcompiler_builtins/compiler-rt < $p
+    done
+  '';
+
+  # rustc unfortunately needs cmake to compile llvm-rt but doesn't
+  # use it for the normal build. This disables cmake in Nix.
+  dontUseCmakeConfigure = true;
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    cmake
+    mrustc
+    mrustc-minicargo
+    pkg-config
+    python3
+    time
+    which
+  ];
+  buildInputs = [
+    # for rustc
+    llvm_7 libffi zlib libxml2
+    # for cargo
+    openssl curl
+  ];
+
+  makeFlags = [
+    # Use shared mrustc/minicargo/llvm instead of rebuilding them
+    "MRUSTC=${mrustc}/bin/mrustc"
+    "MINICARGO=${mrustc-minicargo}/bin/minicargo"
+    "LLVM_CONFIG=${llvm_7}/bin/llvm-config"
+    "RUSTC_TARGET=${rust.toRustTarget stdenv.targetPlatform}"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    local flagsArray=(
+      PARLEVEL=$NIX_BUILD_CORES
+      ${toString makeFlags}
+    )
+
+    echo minicargo.mk: libs
+    make -f minicargo.mk "''${flagsArray[@]}" LIBS
+
+    echo minicargo.mk: deps
+    mkdir -p output/cargo-build
+    # minicargo has concurrency issues when running these; let's build them
+    # without parallelism
+    for crate in regex regex-0.2.11 curl-sys
+    do
+      echo "building $crate"
+      minicargo ${rustcDir}/src/vendor/$crate \
+        --vendor-dir ${rustcDir}/src/vendor \
+        --output-dir output/cargo-build -L output/
+    done
+
+    echo minicargo.mk: rustc
+    make -f minicargo.mk "''${flagsArray[@]}" output/rustc
+
+    echo minicargo.mk: cargo
+    make -f minicargo.mk "''${flagsArray[@]}" output/cargo
+
+    echo run_rustc
+    make -C run_rustc "''${flagsArray[@]}"
+
+    unset flagsArray
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    run_rustc/output/prefix/bin/hello_world | grep "hello, world"
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin/ $out/lib/
+    cp run_rustc/output/prefix/bin/cargo $out/bin/cargo
+    cp run_rustc/output/prefix/bin/rustc_binary $out/bin/rustc
+
+    cp -r run_rustc/output/prefix/lib/* $out/lib/
+    cp $out/lib/rustlib/${rust.toRustTarget stdenv.targetPlatform}/lib/*.so $out/lib/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "A minimal build of Rust";
+    longDescription = ''
+      A minimal build of Rust, built from source using mrustc.
+      This is useful for bootstrapping the main Rust compiler without
+      an initial binary toolchain download.
+    '';
+    maintainers = with maintainers; [ progval r-burns ];
+    license = with licenses; [ mit asl20 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}
+

--- a/pkgs/development/compilers/mrustc/default.nix
+++ b/pkgs/development/compilers/mrustc/default.nix
@@ -1,0 +1,53 @@
+{ lib, stdenv
+, fetchFromGitHub
+, zlib
+}:
+
+let
+  version = "0.9";
+  tag = "v${version}";
+  rev = "15773561e40ca5c8cffe0a618c544b6cfdc5ad7e";
+in
+
+stdenv.mkDerivation rec {
+  pname = "mrustc";
+  inherit version;
+
+  # Always update minicargo.nix and bootstrap.nix in lockstep with this
+  src = fetchFromGitHub {
+    owner = "thepowersgang";
+    repo = "mrustc";
+    rev = tag;
+    sha256 = "194ny7vsks5ygiw7d8yxjmp1qwigd71ilchis6xjl6bb2sj97rd2";
+  };
+
+  postPatch = ''
+    sed -i 's/\$(shell git show --pretty=%H -s)/${rev}/' Makefile
+    sed -i 's/\$(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)/${tag}/' Makefile
+    sed -i 's/\$(shell git diff-index --quiet HEAD; echo $$?)/0/' Makefile
+  '';
+
+  strictDeps = true;
+  buildInputs = [ zlib ];
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp bin/mrustc $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Mutabah's Rust Compiler";
+    longDescription = ''
+      In-progress alternative rust compiler, written in C++.
+      Capable of building a fully-working copy of rustc,
+      but not yet suitable for everyday use.
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.mit;
+    maintainers = with maintainers; [ progval r-burns ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/compilers/mrustc/minicargo.nix
+++ b/pkgs/development/compilers/mrustc/minicargo.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv
+, makeWrapper
+, mrustc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mrustc-minicargo";
+  inherit (mrustc) src version;
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  enableParallelBuilding = true;
+  makefile = "minicargo.mk";
+  makeFlags = [ "tools/bin/minicargo" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp tools/bin/minicargo $out/bin
+
+    # without it, minicargo defaults to "<minicargo_path>/../../bin/mrustc"
+    wrapProgram "$out/bin/minicargo" --set MRUSTC_PATH ${mrustc}/bin/mrustc
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A minimalist builder for Rust";
+    longDescription = ''
+      A minimalist builder for Rust, similar to Cargo but written in C++.
+      Designed to work with mrustc to build Rust projects
+      (like the Rust compiler itself).
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.mit;
+    maintainers = with maintainers; [ progval r-burns ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/compilers/mrustc/patches/0001-use-shared-llvm.patch
+++ b/pkgs/development/compilers/mrustc/patches/0001-use-shared-llvm.patch
@@ -1,0 +1,12 @@
+--- a/rustc-1.29.0-src/src/librustc_llvm/lib.rs
+--- b/rustc-1.29.0-src/src/librustc_llvm/lib.rs
+@@ -23,6 +23,9 @@
+ #![feature(link_args)]
+ #![feature(static_nobundle)]
+ 
++// https://github.com/rust-lang/rust/issues/34486
++#[link(name = "ffi")] extern {}
++
+ // See librustc_cratesio_shim/Cargo.toml for a comment explaining this.
+ #[allow(unused_extern_crates)]
+ extern crate rustc_cratesio_shim;

--- a/pkgs/development/compilers/mrustc/patches/0002-dont-build-llvm.patch
+++ b/pkgs/development/compilers/mrustc/patches/0002-dont-build-llvm.patch
@@ -1,0 +1,14 @@
+--- a/minicargo.mk
++++ b/minicargo.mk
+@@ -116,11 +116,6 @@
+ LLVM_CMAKE_OPTS += CMAKE_BUILD_TYPE=RelWithDebInfo
+ 
+ 
+-$(LLVM_CONFIG): $(RUSTCSRC)build/Makefile
+-	$Vcd $(RUSTCSRC)build && $(MAKE)
+-$(RUSTCSRC)build/Makefile: $(RUSTCSRC)src/llvm/CMakeLists.txt
+-	@mkdir -p $(RUSTCSRC)build
+-	$Vcd $(RUSTCSRC)build && cmake $(addprefix -D , $(LLVM_CMAKE_OPTS)) ../src/llvm
+ 
+ 
+ #

--- a/pkgs/development/compilers/mrustc/patches/0003-echo-newlines.patch
+++ b/pkgs/development/compilers/mrustc/patches/0003-echo-newlines.patch
@@ -1,0 +1,13 @@
+--- a/run_rustc/Makefile
++++ b/run_rustc/Makefile
+@@ -103,7 +103,9 @@
+ else
+ 	cp $(OUTDIR)build-rustc/release/rustc_binary $(BINDIR)rustc_binary
+ endif
+-	echo '#!/bin/sh\nd=$$(dirname $$0)\nLD_LIBRARY_PATH="$(abspath $(LIBDIR))" $$d/rustc_binary $$@' >$@
++	echo '#!$(shell which bash)' > $@
++	echo 'd=$$(dirname $$0)' >> $@
++	echo 'LD_LIBRARY_PATH="$(abspath $(LIBDIR))" $$d/rustc_binary $$@' >> $@
+ 	chmod +x $@
+ 
+ $(BINDIR)hello_world: $(RUST_SRC)test/run-pass/hello.rs $(LIBDIR)libstd.rlib $(BINDIR)rustc

--- a/pkgs/development/compilers/mrustc/patches/0004-increase-parallelism.patch
+++ b/pkgs/development/compilers/mrustc/patches/0004-increase-parallelism.patch
@@ -1,0 +1,28 @@
+--- a/run_rustc/Makefile
++++ b/run_rustc/Makefile
+@@ -79,14 +79,14 @@
+ 	@mkdir -p $(OUTDIR)build-std
+ 	@mkdir -p $(LIBDIR)
+ 	@echo [CARGO] $(RUST_SRC)libstd/Cargo.toml
+-	$VCARGO_TARGET_DIR=$(OUTDIR)build-std RUSTC=$(BINDIR_S)rustc $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)libstd/Cargo.toml  -j 1 --release --features panic-unwind
++	$VCARGO_TARGET_DIR=$(OUTDIR)build-std RUSTC=$(BINDIR_S)rustc $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)libstd/Cargo.toml  -j $(NIX_BUILD_CORES) --release --features panic-unwind
+ 	$Vcp --remove-destination $(OUTDIR)build-std/release/deps/*.rlib $(LIBDIR)
+ 	$Vcp --remove-destination $(OUTDIR)build-std/release/deps/*.so $(LIBDIR)
+ # libtest
+ $(LIBDIR)libtest.rlib: $(BINDIR)rustc_m $(LIBDIR)libstd.rlib $(CARGO_HOME)config
+ 	@mkdir -p $(OUTDIR)build-test
+ 	@echo [CARGO] $(RUST_SRC)libtest/Cargo.toml
+-	$VCARGO_TARGET_DIR=$(OUTDIR)build-test RUSTC=$(BINDIR)rustc_m $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)libtest/Cargo.toml  -j 1 --release
++	$VCARGO_TARGET_DIR=$(OUTDIR)build-test RUSTC=$(BINDIR)rustc_m $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)libtest/Cargo.toml  -j $(NIX_BUILD_CORES) --release
+ 	@mkdir -p $(LIBDIR)
+ 	$Vcp --remove-destination $(OUTDIR)build-test/release/deps/*.rlib $(LIBDIR)
+ 	$Vcp --remove-destination $(OUTDIR)build-test/release/deps/*.so $(LIBDIR)
+@@ -95,7 +95,7 @@
+ $(BINDIR)rustc: $(BINDIR)rustc_m $(BINDIR)cargo $(CARGO_HOME)config $(LIBDIR)libtest.rlib
+ 	@mkdir -p $(PREFIX)tmp
+ 	@echo [CARGO] $(RUST_SRC)rustc/Cargo.toml
+-	$V$(RUSTC_ENV_VARS) TMPDIR=$(abspath $(PREFIX)tmp) CARGO_TARGET_DIR=$(OUTDIR)build-rustc RUSTC=$(BINDIR)rustc_m RUSTC_ERROR_METADATA_DST=$(abspath $(PREFIX)) $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)rustc/Cargo.toml --release -j 1
++	$V$(RUSTC_ENV_VARS) TMPDIR=$(abspath $(PREFIX)tmp) CARGO_TARGET_DIR=$(OUTDIR)build-rustc RUSTC=$(BINDIR)rustc_m RUSTC_ERROR_METADATA_DST=$(abspath $(PREFIX)) $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)rustc/Cargo.toml --release -j $(NIX_BUILD_CORES)
+ 	cp $(OUTDIR)build-rustc/release/deps/*.so $(LIBDIR)
+ 	cp $(OUTDIR)build-rustc/release/deps/*.rlib $(LIBDIR)
+ ifeq ($(RUSTC_VERSION),1.19.0)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10799,6 +10799,10 @@ in
   };
   rust = rust_1_49;
 
+  mrustc = callPackage ../development/compilers/mrustc { };
+  mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
+  mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
+
   rustPackages_1_45 = rust_1_45.packages.stable;
   rustPackages_1_49 = rust_1_49.packages.stable;
   rustPackages = rustPackages_1_49;


### PR DESCRIPTION
This is rebased from the excellent work done by @ProgVal in https://github.com/NixOS/nixpkgs/pull/85542, with the hopes that we can merge the underlying mrustc expressions and iterate on them while we sort out the bootstrapping logic.

Functional changes:
* Needs compiler-rt patch for glibc ≥ 2.31

Cleanups:
* Add pre/post hooks for all steps
* Reuse src from main mrustc derivation
* Use strictDeps
* Override make variables with makeflags rather than patches + env vars

The mrustc-bootstrap builds rustc and cargo using mrustc. This is the main
motivator for mrustc and is very finicky so it's important that we
build this regularly and keep it green.

@ProgVal says:
> The initial build of Rust 1.29 (by mrustc) requires 2.5GB in /build
  and 15GB of RAM and takes about 30 minutes on a modern x86 machine.

Can I tell hydra that this build will need a lot of RAM?
Compilation might take several hours on less beefy machines;
I hope Hydra doesn't timeout on this.

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
