### PR TITLE
Fix tzdata cross-compilation

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -42,10 +42,10 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "ZIC=./zic-native" ];
 
-  # NOTE: in cross-compilation scenarios, this is built for the build platform.
   preInstall = ''
      mv zic.o zic.o.orig
      mv zic zic.orig
+     # NOTE: in cross-compilation scenarios, this is built for the build platform.
      make $makeFlags cc=cc AR=ar zic
      mv zic zic-native
      mv zic.o.orig zic.o

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -42,10 +42,11 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "ZIC=./zic-native" ];
 
+  # NOTE: in cross-compilation scenarios, this is built for the build platform.
   preInstall = ''
      mv zic.o zic.o.orig
      mv zic zic.orig
-     make $makeFlags cc=${stdenv.cc.targetPrefix}cc AR=${stdenv.cc.targetPrefix}ar zic
+     make $makeFlags cc=cc AR=ar zic
      mv zic zic-native
      mv zic.o.orig zic.o
      mv zic.orig zic


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/113295 tree-wide change broke tzdata's installation when cross-compiling as the target `zic` needs to be run on the build platform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
