### PR TITLE
gst_all_1.gst-plugins-bad: adds voaacenc support

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -1,10 +1,8 @@
 { lib, stdenv
 , fetchurl
-, fetchpatch
 , meson
 , ninja
 , gettext
-, config
 , pkg-config
 , python3
 , gst-plugins-base
@@ -81,6 +79,7 @@
 , x265
 , libxml2
 , srt
+, vo-aacenc
 }:
 
 assert faacSupport -> faac != null;
@@ -99,6 +98,7 @@ in stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Use pkgconfig to inject the includedirs
     ./fix_pkgconfig_includedir.patch
   ];
 
@@ -117,6 +117,8 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     gst-plugins-base
     orc
+    # gobject-introspection has to be in both nativeBuildInputs and
+    # buildInputs. The build tries to link against libgirepository-1.0.so
     gobject-introspection
     faad2
     libass
@@ -163,6 +165,7 @@ in stdenv.mkDerivation rec {
     libxml2
     libintl
     srt
+    vo-aacenc
   ] ++ optionals enableZbar [
     zbar
   ] ++ optionals faacSupport [
@@ -241,7 +244,6 @@ in stdenv.mkDerivation rec {
     "-Dsvthevcenc=disabled" # required `SvtHevcEnc` library not packaged in nixpkgs as of writing
     "-Dteletext=disabled" # required `zvbi` library not packaged in nixpkgs as of writing
     "-Dtinyalsa=disabled" # not packaged in nixpkgs as of writing
-    "-Dvoaacenc=disabled" # required `vo-aacenc` library not packaged in nixpkgs as of writing
     "-Dvoamrwbenc=disabled" # required `vo-amrwbenc` library not packaged in nixpkgs as of writing
     "-Dvulkan=disabled" # Linux-only, and we haven't figured out yet which of the vulkan nixpkgs it needs
     "-Dwasapi=disabled" # not packaged in nixpkgs as of writing / no Windows support

--- a/pkgs/development/libraries/vo-aacenc/default.nix
+++ b/pkgs/development/libraries/vo-aacenc/default.nix
@@ -1,0 +1,19 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "vo-aacenc";
+  version = "0.1.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/opencore-amr/fdk-aac/${pname}-${version}.tar.gz";
+    sha256 = "sha256-5Rp0d6NZ8Y33xPgtGV2rThTnQUy9SM95zBlfxEaFDzY=";
+  };
+
+  meta = with lib; {
+    description = "VisualOn AAC encoder library";
+    homepage    = "https://sourceforge.net/projects/opencore-amr/";
+    license     = licenses.asl20;
+    maintainers = [ maintainers.baloo ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8765,6 +8765,8 @@ in
 
   vo-amrwbenc = callPackage ../development/libraries/vo-amrwbenc { };
 
+  vo-aacenc = callPackage ../development/libraries/vo-aacenc { };
+
   vobcopy = callPackage ../tools/cd-dvd/vobcopy { };
 
   vobsub2srt = callPackage ../tools/cd-dvd/vobsub2srt { };


### PR DESCRIPTION
###### Motivation for this change

Adds vo-aacenc packaging and add support for voaacenc in gstreamer-plugins-bad

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
