### PR TITLE
ocamlPackages.qcheck*: 0.16 -> 0.17

### DIFF
--- a/pkgs/development/ocaml-modules/qcheck/core.nix
+++ b/pkgs/development/ocaml-modules/qcheck/core.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "qcheck-core";
-  version = "0.16";
+  version = "0.17";
 
   useDune2 = true;
 
@@ -12,7 +12,7 @@ buildDunePackage rec {
     owner = "c-cube";
     repo = "qcheck";
     rev = version;
-    sha256 = "1s5dpqj8zvd3wr2w3fp4wb6yc57snjpxzzfv9fb6l9qgigswwjdr";
+    sha256 = "0qfyqhfg98spmfci9z6f527a16gwjnx2lrbbgw67p37ys5acrfar";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/stdint/default.nix
+++ b/pkgs/development/ocaml-modules/stdint/default.nix
@@ -21,14 +21,18 @@ buildDunePackage rec {
     })
   ];
 
-  # disable remaining broken tests, see
-  # https://github.com/andrenth/ocaml-stdint/issues/59
+  # 1. disable remaining broken tests, see
+  #    https://github.com/andrenth/ocaml-stdint/issues/59
+  # 2. fix tests to liberal test range
+  #    https://github.com/andrenth/ocaml-stdint/pull/61
   postPatch = ''
     substituteInPlace tests/stdint_test.ml \
       --replace 'test "An integer should perform left-shifts correctly"' \
                 'skip "An integer should perform left-shifts correctly"' \
       --replace 'test "Logical shifts must not sign-extend"' \
-                'skip "Logical shifts must not sign-extend"'
+                'skip "Logical shifts must not sign-extend"' \
+      --replace 'let pos_int = QCheck.map_same_type abs in_range' \
+                'let pos_int = QCheck.int_range 0 maxi'
   '';
 
   doCheck = true;


### PR DESCRIPTION
* New exposed function, bug fixes:
  https://github.com/c-cube/qcheck/blob/0.17/CHANGELOG.md#017

* Fix a too liberal testing range causing an integer overflow in stdint
  which for some reason only qcheck 0.17 and not 0.16 seems to find

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
