### PR TITLE
reddsaver: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/applications/misc/reddsaver/default.nix
+++ b/pkgs/applications/misc/reddsaver/default.nix
@@ -8,22 +8,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "reddsaver";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "manojkarthick";
     repo = "reddsaver";
     rev = "v${version}";
-    sha256 = "0wiyzbl9vqx5aq3lpaaqkm3ivj77lqd8bmh8ipgshdflgm1z6yvp";
+    sha256 = "0kww3abgvxr7azr7yb8aiw28fz13qb4sn3x7nnz1ihmd4yczi9fg";
   };
 
-  cargoSha256 = "0kw5gk7pf4xkmjffs2jxm6sc4chybns88cii2wlgpyvgn4c3cwaa";
+  cargoSha256 = "09xm22vgmd3dc0wr6n3jczxvhwpcsijwfbv50dz1lnsx57g8mgmd";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ]
     ++ lib.optional stdenv.isDarwin Security;
 
-  # package does not contain tests as of v0.3.0
+  # package does not contain tests as of v0.3.1
   docCheck = false;
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version update: 0.3.0 -> 0.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
