### PR TITLE
cargo-limit: 0.0.5 -> 0.0.6, shellhub-agent: 0.5.1 -> 0.5.2 

### DIFF
--- a/pkgs/applications/networking/shellhub-agent/default.nix
+++ b/pkgs/applications/networking/shellhub-agent/default.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "shellhub-agent";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "shellhub-io";
     repo = "shellhub";
     rev = "v${version}";
-    sha256 = "1vg236vc2v4g47lb68hb1vy3phamhsyb383fdbblh3vc4vf46j8a";
+    sha256 = "1g3sjkc6p9w3mm7lnr513zwjh7y945hx311b6g068q2lywisqf0x";
   };
 
   modRoot = "./agent";

--- a/pkgs/development/tools/rust/cargo-limit/default.nix
+++ b/pkgs/development/tools/rust/cargo-limit/default.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-limit";
-  version = "0.0.5";
+  version = "0.0.6";
 
   src = fetchFromGitHub {
     owner = "alopatindev";
     repo = "cargo-limit";
     rev = version;
-    sha256 = "sha256-GYdWKRgdS9gCQRu1C8ht0wC1eBTtIMg585OuAfDn/+4=";
+    sha256 = "sha256-2YngMRPNiUVqg82Ck/ovcMbZV+STGyowT9zlwBkcKok=";
   };
 
-  cargoSha256 = "0381wgyb2xnsiick8invrkhcvp905rrfyikgv01w6qn9872z11s0";
+  cargoSha256 = "sha256-4HQhBE4kNhOhO48PBiAxtppmaqy7jaV8p/jb/Uv7vJk=";
 
   passthru = {
     updateScript = nix-update-script {


### PR DESCRIPTION
###### Motivation for this change

I've upgraded those two packages which I am the maintainer.

 - shellhub-agent
 - cargo-limit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
