### PR TITLE
vector: fix tests

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, rustPlatform
 , openssl, pkg-config, protobuf
 , Security, libiconv, rdkafka
-, tzdata
+, tzdata, fetchpatch
 
 , features ?
     ((if stdenv.isAarch64
@@ -25,6 +25,15 @@ rustPlatform.buildRustPackage rec {
     rev    = "v${version}";
     sha256 = "0q6x3fvwwh18iyznqlr09n3zppzgw9jaz973s8haz54hnxj16wx0";
   };
+
+  patches = [
+    # Changes tests not to assume the current year is 2020. Should be included
+    # In the next release after v0.11.1
+    (fetchpatch {
+      url = "https://github.com/timberio/vector/commit/1ff96dc57ea8bff0aad29c107335947f612c21b2.patch";
+      sha256 = "0kx01wk8jl3xjrk4s0syn2pjm4sfykqyz35l28lqx2v1q8mac3qd";
+    })
+  ];
 
   cargoSha256 = "Y/vDYXWQ65zZ86vTwP4aCZYCMZuqbz6tpfv4uRkFAzc=";
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
For some reason the tests still don't run correctly. cc maintainers @thoughtpolice and @happysalada
hydra failures: https://hydra.nixos.org/build/136738848/nixlog/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
