### PR TITLE
nixos/rngd: Remove module entirely, leave an explanation

### DIFF
--- a/nixos/doc/manual/installation/installing-virtualbox-guest.xml
+++ b/nixos/doc/manual/installation/installing-virtualbox-guest.xml
@@ -83,17 +83,12 @@
   VirtualBox settings (Machine / Settings / Shared Folders, then click on the
   "Add" icon). Add the following to the
   <literal>/etc/nixos/configuration.nix</literal> to auto-mount them. If you do
-  not add <literal>"nofail"</literal>, the system will not boot properly. The
-  same goes for disabling <literal>rngd</literal> which is normally used to get
-  randomness but this does not work in virtual machines.
+  not add <literal>"nofail"</literal>, the system will not boot properly.
  </para>
 
 <programlisting>
 { config, pkgs, ...} :
 {
-  security.rngd.enable = false; // otherwise vm will not boot
-  ...
-
   fileSystems."/virtualboxshare" = {
     fsType = "vboxsf";
     device = "nameofthesharedfolder";

--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -509,6 +509,15 @@ self: super:
      <varname>services.flashpolicyd</varname> module.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      The <literal>security.rngd</literal> module has been removed.
+      It was disabled by default in 20.09 as it was functionally redundent
+      with krngd in the linux kernel. It is not necessary for any device that the kernel recognises
+      as an hardware RNG, as it will automatically run the krngd task to periodically collect random
+      data from the device and mix it into the kernel's RNG.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -185,8 +185,6 @@ in
           { description = "Initialisation of swap device ${sw.device}";
             wantedBy = [ "${realDevice'}.swap" ];
             before = [ "${realDevice'}.swap" ];
-            # If swap is encrypted, depending on rngd resolves a possible entropy starvation during boot
-            after = mkIf (config.security.rngd.enable && sw.randomEncryption.enable) [ "rngd.service" ];
             path = [ pkgs.util-linux ] ++ optional sw.randomEncryption.enable pkgs.cryptsetup;
 
             script =

--- a/nixos/modules/security/rngd.nix
+++ b/nixos/modules/security/rngd.nix
@@ -1,56 +1,16 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
+{ lib, ... }:
 let
-  cfg = config.security.rngd;
+  removed = k: lib.mkRemovedOptionModule [ "security" "rngd" k ];
 in
 {
-  options = {
-    security.rngd = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the rng daemon.  Devices that the kernel recognises
-          as entropy sources are handled automatically by krngd.
-        '';
-      };
-      debug = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable debug output (-d).";
-      };
-    };
-  };
-
-  config = mkIf cfg.enable {
-    systemd.services.rngd = {
-      bindsTo = [ "dev-random.device" ];
-
-      after = [ "dev-random.device" ];
-
-      # Clean shutdown without DefaultDependencies
-      conflicts = [ "shutdown.target" ];
-      before = [
-        "sysinit.target"
-        "shutdown.target"
-      ];
-
-      description = "Hardware RNG Entropy Gatherer Daemon";
-
-      # rngd may have to start early to avoid entropy starvation during boot with encrypted swap
-      unitConfig.DefaultDependencies = false;
-      serviceConfig = {
-        ExecStart = "${pkgs.rng-tools}/sbin/rngd -f"
-          + optionalString cfg.debug " -d";
-        # PrivateTmp would introduce a circular dependency if /tmp is on tmpfs and swap is encrypted,
-        # thus depending on rngd before swap, while swap depends on rngd to avoid entropy starvation.
-        NoNewPrivileges = true;
-        PrivateNetwork = true;
-        ProtectSystem = "full";
-        ProtectHome = true;
-      };
-    };
-  };
+  imports = [
+    (removed "enable" ''
+       rngd is not necessary for any device that the kernel recognises
+       as an hardware RNG, as it will automatically run the krngd task
+       to periodically collect random data from the device and mix it
+       into the kernel's RNG.
+    '')
+    (removed "debug"
+      "The rngd module was removed, so its debug option does nothing.")
+  ];
 }

--- a/nixos/modules/virtualisation/hyperv-guest.nix
+++ b/nixos/modules/virtualisation/hyperv-guest.nix
@@ -40,8 +40,6 @@ in {
 
     environment.systemPackages = [ config.boot.kernelPackages.hyperv-daemons.bin ];
 
-    security.rngd.enable = false;
-
     # enable hotadding cpu/memory
     services.udev.packages = lib.singleton (pkgs.writeTextFile {
       name = "hyperv-cpu-and-memory-hotadd-udev-rules";


### PR DESCRIPTION
###### Motivation for this change

@shlevy's [request] on #96092:

> Perhaps we should remove rngd altogether, but this is the only hardware that rngd helps for anyway.
> If someone explicitly enables it presumably they want it for their devices?

TL;DR of the relevant discussions:

- rngd was auto-enabled for devices that the kernel handles on its own anyhow.
- The rngd module had no affordances to work with devices that the kernel doesn't automatically recognise as hardware RNGs, o it couldn't do anything useful for any user.
- We disabled it by default, but the module is still hanging around; it's both technical debt and might mislead users.

[request]: https://github.com/NixOS/nixpkgs/pull/96092#issuecomment-678826635


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] No NixOS test(s) for this module exist ~~if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] ~~Tested execution of all binary files~~ N/A
- [x] ~~Determined the impact on package closure size~~  N/A
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Removed uses of `rngd` in modules `hyperv-guest` and `swap`.
- [x] Ensured that relevant documentation is up to date
- [ ] Rebuilding/checking the manual.