### PR TITLE
python3Packages.authcaptureproxy: init at 0.4.2

### DIFF
--- a/pkgs/development/python-modules/authcaptureproxy/default.nix
+++ b/pkgs/development/python-modules/authcaptureproxy/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, aiohttp
+, beautifulsoup4
+, importlib-metadata
+, multidict
+, poetry
+, pytest-asyncio
+, pytestCheckHook
+, pythonAtLeast
+, pythonOlder
+, typer
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "authcaptureproxy";
+  version = "0.4.2";
+  format = "pyproject";
+
+  # Fetch from Github because PyPI distribution does not include tests
+  src = fetchFromGitHub {
+    owner = "alandtse";
+    repo = "auth_capture_proxy";
+    rev = "v${version}";
+    sha256 = "1r22k5h35nrqcg128z2jyfa7shkf873d3l813fzfv7869c9msbs9";
+  };
+
+  disabled = !isPy3k;
+
+  # Lower importlib-metadata requirement and remove entirely Python >= 3.8 since
+  # it's built-in (and the code will use the built-in version)
+  #
+  # TODO: update once we have importlib-metadata >= 3.4.0 in nixpkgs
+  patchPhase = if pythonAtLeast "3.8" then ''
+    sed -i '/importlib-metadata/d' pyproject.toml
+  '' else ''
+    sed -i 's/importlib-metadata = "^3.4.0"/importlib-metadata = "^1.7.0"/' pyproject.toml
+  '';
+
+  nativeBuildInputs = [
+    poetry
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    beautifulsoup4
+    multidict
+    typer
+    yarl
+  ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/alandtse/auth_capture_proxy";
+    license = licenses.asl20;
+    description = "A Python project to create a proxy to capture authentication information from a webpage.";
+    maintainers = with maintainers; [ graham33 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -554,6 +554,8 @@ in {
 
   auth0-python = callPackage ../development/python-modules/auth0-python { };
 
+  authcaptureproxy = callPackage ../development/python-modules/authcaptureproxy { };
+
   authheaders = callPackage ../development/python-modules/authheaders { };
 
   authlib = callPackage ../development/python-modules/authlib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Required for new version of teslajsonpy (PR coming soon).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
