### PR TITLE
kustomize-sops: init at 2.4.0

### DIFF
--- a/pkgs/development/tools/kustomize/kustomize-sops.nix
+++ b/pkgs/development/tools/kustomize/kustomize-sops.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kustomize-sops";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "viaduct-ai";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0sr4d7amwn62xywwn83y58ynl8xv6l1q6zwbky5rmy0qxk909bqp";
+  };
+
+  vendorSha256 = "0vn6vrczbdln7ngz061xixjwn899jn7p2a46770xqx44bh3f2lgv";
+
+  installPhase = ''
+    mkdir -p $out/lib/viaduct.ai/v1/ksops-exec/
+    mv $GOPATH/bin/kustomize-sops $out/lib/viaduct.ai/v1/ksops-exec/ksops-exec
+  '';
+
+  # Tests are broken in a nix environment
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Flexible Kustomize Plugin for SOPS Encrypted Resource";
+    longDescription = ''
+      KSOPS can be used to decrypt any Kubernetes resource, but is most commonly
+      used to decrypt encrypted Kubernetes Secrets and ConfigMaps.
+    '';
+    homepage = "https://github.com/viaduct-ai/kustomize-sops";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ starcraft66 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12507,6 +12507,8 @@ in
 
   kustomize = callPackage ../development/tools/kustomize { };
 
+  kustomize-sops = callPackage ../development/tools/kustomize/kustomize-sops.nix { };
+
   ktlint = callPackage ../development/tools/ktlint { };
 
   kythe = callPackage ../development/tools/kythe { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There are not any [Kustomize](https://github.com/kubernetes-sigs/kustomize) plugins currently packaged in Nixpkgs yet.

Kustomize doesn't have a very robust plugin loading search path yet, it can only load plugins from a single "root" path which unfortunately means `buildEnv` must be used to merge multiple kustomize plugins into a single folder to make this package useful at the moment. Hopefully kustomize will eventually move to a plugin search path where multiple nix store paths can simply be appended to it in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
