### PR TITLE
traefik: update test to use virtualisation.oci-containers

### DIFF
--- a/nixos/tests/traefik.nix
+++ b/nixos/tests/traefik.nix
@@ -11,8 +11,8 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       environment.systemPackages = [ pkgs.curl ];
     };
     traefik = { config, pkgs, ... }: {
-      docker-containers.nginx = {
-        extraDockerOptions = [
+      virtualisation.oci-containers.containers.nginx = {
+        extraOptions = [
           "-l" "traefik.enable=true"
           "-l" "traefik.http.routers.nginx.entrypoints=web"
           "-l" "traefik.http.routers.nginx.rule=Host(`nginx.traefik.test`)"


### PR DESCRIPTION
###### Motivation for this change

Fix #113884

Maybe that could fix the issue in https://github.com/NixOS/nixpkgs/pull/113878 too? Spoiler: No. It still fails in 2 of 6 tries...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
