### PR TITLE
nixos/grub: fix whitespace in install-grub

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -164,7 +164,7 @@ sub GrubFs {
     my $fs = GetFs($dir);
     my $path = substr($dir, length($fs->mount));
     if (substr($path, 0, 1) ne "/") {
-      $path = "/$path";
+        $path = "/$path";
     }
     my $search = "";
 
@@ -371,11 +371,11 @@ else {
         if ($suffix eq ".jpg") {
             $suffix = ".jpeg";
         }
-		if ($backgroundColor) {
-			$conf .= "
-		    background_color '$backgroundColor'
-		    ";
-		}
+        if ($backgroundColor) {
+            $conf .= "
+            background_color '$backgroundColor'
+            ";
+        }
         copy $splashImage, "$bootPath/background$suffix" or die "cannot copy $splashImage to $bootPath: $!\n";
         $conf .= "
             insmod " . substr($suffix, 1) . "
@@ -399,17 +399,17 @@ else {
             set theme=" . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/theme/theme.txt
             export theme
             # Load theme fonts, if any
-         ";
+        ";
 
-         find( { wanted => sub {
-             if ($_ =~ /\.pf2$/i) {
-                 $font = File::Spec->abs2rel($File::Find::name, $theme);
-                 $conf .= "
-                     loadfont " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/theme/$font
-                 ";
-             }
-         }, no_chdir => 1 }, $theme );
-     }
+        find( { wanted => sub {
+            if ($_ =~ /\.pf2$/i) {
+                $font = File::Spec->abs2rel($File::Find::name, $theme);
+                $conf .= "
+                    loadfont " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/theme/$font
+                ";
+            }
+        }, no_chdir => 1 }, $theme );
+    }
 }
 
 $conf .= "$extraConfig\n";
@@ -448,25 +448,25 @@ sub addEntry {
 
     # Include second initrd with secrets
     if (-e -x "$path/append-initrd-secrets") {
-      my $initrdName = basename($initrd);
-      my $initrdSecretsPath = "$bootPath/kernels/$initrdName-secrets";
+        my $initrdName = basename($initrd);
+        my $initrdSecretsPath = "$bootPath/kernels/$initrdName-secrets";
 
-      mkpath(dirname($initrdSecretsPath), 0, 0755);
-      my $oldUmask = umask;
-      # Make sure initrd is not world readable (won't work if /boot is FAT)
-      umask 0137;
-      my $initrdSecretsPathTemp = File::Temp::mktemp("$initrdSecretsPath.XXXXXXXX");
-      system("$path/append-initrd-secrets", $initrdSecretsPathTemp) == 0 or die "failed to create initrd secrets: $!\n";
-      # Check whether any secrets were actually added
-      if (-e $initrdSecretsPathTemp && ! -z _) {
-        rename $initrdSecretsPathTemp, $initrdSecretsPath or die "failed to move initrd secrets into place: $!\n";
-        $copied{$initrdSecretsPath} = 1;
-        $initrd .= " " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/kernels/$initrdName-secrets";
-      } else {
-        unlink $initrdSecretsPathTemp;
-        rmdir dirname($initrdSecretsPathTemp);
-      }
-      umask $oldUmask;
+        mkpath(dirname($initrdSecretsPath), 0, 0755);
+        my $oldUmask = umask;
+        # Make sure initrd is not world readable (won't work if /boot is FAT)
+        umask 0137;
+        my $initrdSecretsPathTemp = File::Temp::mktemp("$initrdSecretsPath.XXXXXXXX");
+        system("$path/append-initrd-secrets", $initrdSecretsPathTemp) == 0 or die "failed to create initrd secrets: $!\n";
+        # Check whether any secrets were actually added
+        if (-e $initrdSecretsPathTemp && ! -z _) {
+            rename $initrdSecretsPathTemp, $initrdSecretsPath or die "failed to move initrd secrets into place: $!\n";
+            $copied{$initrdSecretsPath} = 1;
+            $initrd .= " " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/kernels/$initrdName-secrets";
+        } else {
+            unlink $initrdSecretsPathTemp;
+            rmdir dirname($initrdSecretsPathTemp);
+        }
+        umask $oldUmask;
     }
 
     my $xen = -e "$path/xen.gz" ? copyToKernelsDir(Cwd::abs_path("$path/xen.gz")) : undef;
@@ -587,7 +587,7 @@ $extraPrepareConfig =~ s/\@bootPath\@/$bootPath/g;
 
 # Run extraPrepareConfig in sh
 if ($extraPrepareConfig ne "") {
-  system((get("shell"), "-c", $extraPrepareConfig));
+    system((get("shell"), "-c", $extraPrepareConfig));
 }
 
 # write the GRUB config.

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -103,10 +103,10 @@ if (stat($bootPath)->dev != stat("/nix/store")->dev) {
 
 # Discover information about the location of the bootPath
 struct(Fs => {
-        device => '$',
-        type => '$',
-        mount => '$',
-    });
+    device => '$',
+    type => '$',
+    mount => '$',
+});
 sub PathInMount {
     my ($path, $mount) = @_;
     my @splitMount = split /\//, $mount;
@@ -155,16 +155,16 @@ sub GetFs {
     return $bestFs;
 }
 struct (Grub => {
-        path => '$',
-        search => '$',
-    });
+    path => '$',
+    search => '$',
+});
 my $driveid = 1;
 sub GrubFs {
     my ($dir) = @_;
     my $fs = GetFs($dir);
     my $path = substr($dir, length($fs->mount));
     if (substr($path, 0, 1) ne "/") {
-        $path = "/$path";
+      $path = "/$path";
     }
     my $search = "";
 
@@ -254,8 +254,8 @@ if ($grubVersion == 1) {
     # $defaultEntry might be "saved", indicating that we want to use the last selected configuration as default.
     # Incidentally this is already the correct value for the grub 1 config to achieve this behaviour.
     $conf .= "
-    default $defaultEntry
-    timeout $timeout
+        default $defaultEntry
+        timeout $timeout
     ";
     if ($splashImage) {
         copy $splashImage, "$bootPath/background.xpm.gz" or die "cannot copy $splashImage to $bootPath: $!\n";
@@ -305,7 +305,7 @@ else {
 
     if ($copyKernels == 0) {
         $conf .= "
-        " . $grubStore->search;
+            " . $grubStore->search;
     }
     # FIXME: should use grub-mkconfig.
     my $defaultEntryText = $defaultEntry;
@@ -313,55 +313,55 @@ else {
         $defaultEntryText = "\"\${saved_entry}\"";
     }
     $conf .= "
-    " . $grubBoot->search . "
-    if [ -s \$prefix/grubenv ]; then
-    load_env
-    fi
-
-    # ‘grub-reboot’ sets a one-time saved entry, which we process here and
-    # then delete.
-    if [ \"\${next_entry}\" ]; then
-    set default=\"\${next_entry}\"
-    set next_entry=
-    save_env next_entry
-    set timeout=1
-    set boot_once=true
-    else
-    set default=$defaultEntryText
-    set timeout=$timeout
-    fi
-
-    function savedefault {
-        if [ -z \"\${boot_once}\"]; then
-        saved_entry=\"\${chosen}\"
-        save_env saved_entry
+        " . $grubBoot->search . "
+        if [ -s \$prefix/grubenv ]; then
+          load_env
         fi
-    }
 
-    # Setup the graphics stack for bios and efi systems
-    if [ \"\${grub_platform}\" = \"efi\" ]; then
-    insmod efi_gop
-    insmod efi_uga
-    else
-    insmod vbe
-    fi
+        # ‘grub-reboot’ sets a one-time saved entry, which we process here and
+        # then delete.
+        if [ \"\${next_entry}\" ]; then
+          set default=\"\${next_entry}\"
+          set next_entry=
+          save_env next_entry
+          set timeout=1
+          set boot_once=true
+        else
+          set default=$defaultEntryText
+          set timeout=$timeout
+        fi
+
+        function savedefault {
+            if [ -z \"\${boot_once}\"]; then
+            saved_entry=\"\${chosen}\"
+            save_env saved_entry
+            fi
+        }
+
+        # Setup the graphics stack for bios and efi systems
+        if [ \"\${grub_platform}\" = \"efi\" ]; then
+          insmod efi_gop
+          insmod efi_uga
+        else
+          insmod vbe
+        fi
     ";
 
     if ($font) {
         copy $font, "$bootPath/converted-font.pf2" or die "cannot copy $font to $bootPath: $!\n";
         $conf .= "
-        insmod font
-        if loadfont " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/converted-font.pf2; then
-        insmod gfxterm
-        if [ \"\${grub_platform}\" = \"efi\" ]; then
-        set gfxmode=$gfxmodeEfi
-        set gfxpayload=$gfxpayloadEfi
-        else
-        set gfxmode=$gfxmodeBios
-        set gfxpayload=$gfxpayloadBios
-        fi
-        terminal_output gfxterm
-        fi
+            insmod font
+            if loadfont " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/converted-font.pf2; then
+              insmod gfxterm
+              if [ \"\${grub_platform}\" = \"efi\" ]; then
+                set gfxmode=$gfxmodeEfi
+                set gfxpayload=$gfxpayloadEfi
+              else
+                set gfxmode=$gfxmodeBios
+                set gfxpayload=$gfxpayloadBios
+              fi
+              terminal_output gfxterm
+            fi
         ";
     }
     if ($splashImage) {
@@ -371,21 +371,21 @@ else {
         if ($suffix eq ".jpg") {
             $suffix = ".jpeg";
         }
-        if ($backgroundColor) {
-            $conf .= "
-            background_color '$backgroundColor'
-            ";
-        }
+		if ($backgroundColor) {
+			$conf .= "
+		    background_color '$backgroundColor'
+		    ";
+		}
         copy $splashImage, "$bootPath/background$suffix" or die "cannot copy $splashImage to $bootPath: $!\n";
         $conf .= "
-        insmod " . substr($suffix, 1) . "
-        if background_image --mode '$splashMode' " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/background$suffix; then
-        set color_normal=white/black
-        set color_highlight=black/white
-        else
-        set menu_color_normal=cyan/blue
-        set menu_color_highlight=white/blue
-        fi
+            insmod " . substr($suffix, 1) . "
+            if background_image --mode '$splashMode' " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/background$suffix; then
+              set color_normal=white/black
+              set color_highlight=black/white
+            else
+              set menu_color_normal=cyan/blue
+              set menu_color_highlight=white/blue
+            fi
         ";
     }
 
@@ -395,21 +395,21 @@ else {
         # Copy theme
         rcopy($theme, "$bootPath/theme") or die "cannot copy $theme to $bootPath\n";
         $conf .= "
-        # Sets theme.
-        set theme=" . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/theme/theme.txt
-        export theme
-        # Load theme fonts, if any
-        ";
+            # Sets theme.
+            set theme=" . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/theme/theme.txt
+            export theme
+            # Load theme fonts, if any
+         ";
 
-        find( { wanted => sub {
-                    if ($_ =~ /\.pf2$/i) {
-                        $font = File::Spec->abs2rel($File::Find::name, $theme);
-                        $conf .= "
-                        loadfont " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/theme/$font
-                        ";
-                    }
-                }, no_chdir => 1 }, $theme );
-    }
+         find( { wanted => sub {
+             if ($_ =~ /\.pf2$/i) {
+                 $font = File::Spec->abs2rel($File::Find::name, $theme);
+                 $conf .= "
+                     loadfont " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/theme/$font
+                 ";
+             }
+         }, no_chdir => 1 }, $theme );
+     }
 }
 
 $conf .= "$extraConfig\n";
@@ -448,25 +448,25 @@ sub addEntry {
 
     # Include second initrd with secrets
     if (-e -x "$path/append-initrd-secrets") {
-        my $initrdName = basename($initrd);
-        my $initrdSecretsPath = "$bootPath/kernels/$initrdName-secrets";
+      my $initrdName = basename($initrd);
+      my $initrdSecretsPath = "$bootPath/kernels/$initrdName-secrets";
 
-        mkpath(dirname($initrdSecretsPath), 0, 0755);
-        my $oldUmask = umask;
-        # Make sure initrd is not world readable (won't work if /boot is FAT)
-        umask 0137;
-        my $initrdSecretsPathTemp = File::Temp::mktemp("$initrdSecretsPath.XXXXXXXX");
-        system("$path/append-initrd-secrets", $initrdSecretsPathTemp) == 0 or die "failed to create initrd secrets: $!\n";
-        # Check whether any secrets were actually added
-        if (-e $initrdSecretsPathTemp && ! -z _) {
-            rename $initrdSecretsPathTemp, $initrdSecretsPath or die "failed to move initrd secrets into place: $!\n";
-            $copied{$initrdSecretsPath} = 1;
-            $initrd .= " " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/kernels/$initrdName-secrets";
-        } else {
-            unlink $initrdSecretsPathTemp;
-            rmdir dirname($initrdSecretsPathTemp);
-        }
-        umask $oldUmask;
+      mkpath(dirname($initrdSecretsPath), 0, 0755);
+      my $oldUmask = umask;
+      # Make sure initrd is not world readable (won't work if /boot is FAT)
+      umask 0137;
+      my $initrdSecretsPathTemp = File::Temp::mktemp("$initrdSecretsPath.XXXXXXXX");
+      system("$path/append-initrd-secrets", $initrdSecretsPathTemp) == 0 or die "failed to create initrd secrets: $!\n";
+      # Check whether any secrets were actually added
+      if (-e $initrdSecretsPathTemp && ! -z _) {
+        rename $initrdSecretsPathTemp, $initrdSecretsPath or die "failed to move initrd secrets into place: $!\n";
+        $copied{$initrdSecretsPath} = 1;
+        $initrd .= " " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/kernels/$initrdName-secrets";
+      } else {
+        unlink $initrdSecretsPathTemp;
+        rmdir dirname($initrdSecretsPathTemp);
+      }
+      umask $oldUmask;
     }
 
     my $xen = -e "$path/xen.gz" ? copyToKernelsDir(Cwd::abs_path("$path/xen.gz")) : undef;
@@ -474,8 +474,8 @@ sub addEntry {
     # FIXME: $confName
 
     my $kernelParams =
-    "init=" . Cwd::abs_path("$path/init") . " " .
-    readFile("$path/kernel-params");
+        "init=" . Cwd::abs_path("$path/init") . " " .
+        readFile("$path/kernel-params");
     my $xenParams = $xen && -e "$path/xen-params" ? readFile("$path/xen-params") : "";
 
     if ($grubVersion == 1) {
@@ -524,9 +524,9 @@ foreach my $link (@links) {
 
     my $date = strftime("%F", localtime(lstat($link)->mtime));
     my $version =
-    -e "$link/nixos-version"
-    ? readFile("$link/nixos-version")
-    : basename((glob(dirname(Cwd::abs_path("$link/kernel")) . "/lib/modules/*"))[0]);
+        -e "$link/nixos-version"
+        ? readFile("$link/nixos-version")
+        : basename((glob(dirname(Cwd::abs_path("$link/kernel")) . "/lib/modules/*"))[0]);
 
     if ($cfgName) {
         $entryName = $cfgName;
@@ -551,8 +551,8 @@ sub addProfile {
     sub nrFromGen { my ($x) = @_; $x =~ /\/\w+-(\d+)-link/; return $1; }
 
     my @links = sort
-    { nrFromGen($b) <=> nrFromGen($a) }
-    (glob "$profile-*-link");
+        { nrFromGen($b) <=> nrFromGen($a) }
+        (glob "$profile-*-link");
 
     my $curEntry = 0;
     foreach my $link (@links) {
@@ -563,9 +563,9 @@ sub addProfile {
         }
         my $date = strftime("%F", localtime(lstat($link)->mtime));
         my $version =
-        -e "$link/nixos-version"
-        ? readFile("$link/nixos-version")
-        : basename((glob(dirname(Cwd::abs_path("$link/kernel")) . "/lib/modules/*"))[0]);
+            -e "$link/nixos-version"
+            ? readFile("$link/nixos-version")
+            : basename((glob(dirname(Cwd::abs_path("$link/kernel")) . "/lib/modules/*"))[0]);
         addEntry("NixOS - Configuration " . nrFromGen($link) . " ($date - $version)", $link);
     }
 
@@ -587,7 +587,7 @@ $extraPrepareConfig =~ s/\@bootPath\@/$bootPath/g;
 
 # Run extraPrepareConfig in sh
 if ($extraPrepareConfig ne "") {
-    system((get("shell"), "-c", $extraPrepareConfig));
+  system((get("shell"), "-c", $extraPrepareConfig));
 }
 
 # write the GRUB config.
@@ -653,13 +653,13 @@ foreach my $fn (glob "$bootPath/kernels/*") {
 #
 
 struct(GrubState => {
-        name => '$',
-        version => '$',
-        efi => '$',
-        devices => '$',
-        efiMountPoint => '$',
-        extraGrubInstallArgs => '@',
-    });
+    name => '$',
+    version => '$',
+    efi => '$',
+    devices => '$',
+    efiMountPoint => '$',
+    extraGrubInstallArgs => '@',
+});
 # If you add something to the state file, only add it to the end
 # because it is read line-by-line.
 sub readGrubState {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/113570 accidentally changed the layout of the generated boot script, fix this.
This is a revert of the relevant commit followed by redoing the changes, except for the places related to the boot script (so its easier to review by just looking at the new commit).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
