### PR TITLE
python3Packages.pyflunearyou: init at 2.0.0

### DIFF
--- a/pkgs/development/python-modules/aiocache/default.nix
+++ b/pkgs/development/python-modules/aiocache/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, aioredis
+, buildPythonPackage
+, fetchFromGitHub
+, msgpack
+}:
+
+buildPythonPackage rec {
+  pname = "aiocache";
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "aio-libs";
+    repo = pname;
+    rev = version;
+    sha256 = "1czs8pvhzi92qy2dch2995rb62mxpbhd80dh2ir7zpa9qcm6wxvx";
+  };
+
+  propagatedBuildInputs = [
+    aioredis
+    msgpack
+  ];
+
+  # aiomcache would be required but last release was in 2017
+  doCheck = false;
+  pythonImportsCheck = [ "aiocache" ];
+
+  meta = with lib; {
+    description = "Python API Rate Limit Decorator";
+    homepage = "https://github.com/tomasbasham/ratelimit";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pyflunearyou/default.nix
+++ b/pkgs/development/python-modules/pyflunearyou/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, aiohttp
+, aresponses
+, aiocache
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytest-asyncio
+, pytest-aiohttp
+, pytestCheckHook
+, pythonOlder
+, msgpack
+, ujson
+}:
+
+buildPythonPackage rec {
+  pname = "pyflunearyou";
+  version = "2.0.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "bachya";
+    repo = pname;
+    rev = version;
+    sha256 = "18vxwfyvicbx8idpa0h0alp4ygnwfph6g4kq93hfm0fc94gi6h94";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    aiocache
+    msgpack
+    ujson
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest-asyncio
+    pytest-aiohttp
+    pytestCheckHook
+  ];
+
+  # Ignore the examples directory as the files are prefixed with test_.
+  # disabledTestFiles doesn't seem to work here
+  pytestFlagsArray = [ "--ignore examples/" ];
+  pythonImportsCheck = [ "pyflunearyou" ];
+
+  meta = with lib; {
+    description = "Python library for retrieving UV-related information from Flu Near You";
+    homepage = "https://github.com/bachya/pyflunearyou";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -265,7 +265,7 @@
     "flo" = ps: with ps; [ aioflo ];
     "flock" = ps: with ps; [ ];
     "flume" = ps: with ps; [ pyflume ];
-    "flunearyou" = ps: with ps; [ ]; # missing inputs: pyflunearyou
+    "flunearyou" = ps: with ps; [ pyflunearyou ];
     "flux" = ps: with ps; [ ];
     "flux_led" = ps: with ps; [ flux-led ];
     "folder" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5468,6 +5468,8 @@ in {
 
   pyflume = callPackage ../development/python-modules/pyflume { };
 
+  pyflunearyou = callPackage ../development/python-modules/pyflunearyou { };
+
   pyfma = callPackage ../development/python-modules/pyfma { };
 
   pyfribidi = callPackage ../development/python-modules/pyfribidi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -210,6 +210,8 @@ in {
 
   aioasuswrt = callPackage ../development/python-modules/aioasuswrt { };
 
+  aiocache = callPackage ../development/python-modules/aiocache { };
+
   aiocoap = callPackage ../development/python-modules/aiocoap { };
 
   aioconsole = callPackage ../development/python-modules/aioconsole { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Successor of #113810

Python library for retrieving UV-related information from Flu Near You

https://github.com/bachya/pyflunearyou

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
