### PR TITLE
 taskwarrior-tui: 0.9.10 -> 0.10.3 

### DIFF
--- a/pkgs/applications/misc/taskwarrior-tui/default.nix
+++ b/pkgs/applications/misc/taskwarrior-tui/default.nix
@@ -5,19 +5,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "taskwarrior-tui";
-  version = "0.9.15";
+  version = "0.10.4";
 
   src = fetchFromGitHub {
     owner = "kdheepak";
     repo = "taskwarrior-tui";
     rev = "v${version}";
-    sha256 = "0jcqla93f4akmf05afdppv5cma346ci6nmwn4wkyxi53jx49x4n7";
+    sha256 = "1rs6xpnmqzp45jkdzi8x06i8764gk7zl86sp6s0hiirbfqf7vwsy";
   };
 
   # Because there's a test that requires terminal access
   doCheck = false;
 
-  cargoSha256 = "1izzb0x1m0yni7861p99zs5ayxy9r72ad1mbrji42gqw3vx8c75p";
+  cargoSha256 = "0xblxsp7jgqbb3kr5k7yy6ziz18a8wlkrhls0vz9ak2n0ngddg3r";
 
   meta = with lib; {
     description = "A terminal user interface for taskwarrior ";

--- a/pkgs/applications/misc/taskwarrior-tui/default.nix
+++ b/pkgs/applications/misc/taskwarrior-tui/default.nix
@@ -5,19 +5,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "taskwarrior-tui";
-  version = "0.9.10";
+  version = "0.9.15";
 
   src = fetchFromGitHub {
     owner = "kdheepak";
     repo = "taskwarrior-tui";
     rev = "v${version}";
-    sha256 = "sha256-NQzZhWoLeDF7iTgIljbVi0ULAe7DeIn45Cu6bgFCfKQ=";
+    sha256 = "0jcqla93f4akmf05afdppv5cma346ci6nmwn4wkyxi53jx49x4n7";
   };
 
   # Because there's a test that requires terminal access
   doCheck = false;
 
-  cargoSha256 = "sha256-9qfqQ7zFw+EwY7o35Y6RhBJ8h5eXnTAsdbqo/w0zO5w=";
+  cargoSha256 = "1izzb0x1m0yni7861p99zs5ayxy9r72ad1mbrji42gqw3vx8c75p";
 
   meta = with lib; {
     description = "A terminal user interface for taskwarrior ";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Submitted by @matthiasbeyer via [mail](https://lists.sr.ht/~andir/nixpkgs-dev/patches/20225).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
