### PR TITLE
msitools: 0.98 -> 0.99

### DIFF
--- a/pkgs/development/tools/misc/msitools/default.nix
+++ b/pkgs/development/tools/misc/msitools/default.nix
@@ -1,15 +1,15 @@
-{ lib, stdenv, fetchurl, intltool, glib, pkg-config, libgsf, libuuid, gcab, bzip2, gnome3 }:
+{ lib, stdenv, fetchurl, bison, intltool, glib, pkg-config, libgsf, libuuid, gcab, bzip2, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "msitools";
-  version = "0.98";
+  version = "0.99";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "19wb3n3nwkpc6bjr0q3f1znaxsfaqgjbdxxnbx8ic8bb5b49hwac";
+    sha256 = "sha256-1HWTml4zayBesxN7rHM96Ambx0gpBA4GWwGxX2yLNjU=";
   };
 
-  nativeBuildInputs = [ intltool pkg-config ];
+  nativeBuildInputs = [ bison intltool pkg-config ];
   buildInputs = [ glib libgsf libuuid gcab bzip2 ];
 
   passthru = {
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     description = "Set of programs to inspect and build Windows Installer (.MSI) files";
     homepage = "https://wiki.gnome.org/msitools";
     license = [ licenses.gpl2 licenses.lgpl21 ];
+    maintainers = with maintainers; [ PlushBeaver ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

* https://gitlab.gnome.org/GNOME/msitools/-/blob/v0.99/NEWS
* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1629516

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
