### PR TITLE
cpython: Pull in the mime-types database

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -4,6 +4,7 @@
 , libffi
 , gdbm
 , lzma
+, mime-types
 , ncurses
 , openssl
 , readline
@@ -175,6 +176,8 @@ in with passthru; stdenv.mkDerivation {
     # (since it will do a futile invocation of gcc (!) to find
     # libuuid, slowing down program startup a lot).
     (./. + "/${sourceVersion.major}.${sourceVersion.minor}/no-ldconfig.patch")
+    # Make the mimetypes module refer to the right file
+    ./mimetypes.patch
   ] ++ optionals (isPy35 || isPy36) [
     # Determinism: Write null timestamps when compiling python files.
     ./3.5/force_bytecode_determinism.patch
@@ -230,6 +233,8 @@ in with passthru; stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace Lib/subprocess.py \
       --replace "'/bin/sh'" "'${bash}/bin/sh'"
+    substituteInPlace Lib/mimetypes.py \
+      --replace "@mime-types@" "${mime-types}"
   '' + optionalString (x11Support && (tix != null)) ''
     substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
   '';

--- a/pkgs/development/interpreters/python/cpython/mimetypes.patch
+++ b/pkgs/development/interpreters/python/cpython/mimetypes.patch
@@ -1,0 +1,23 @@
+diff --git i/Lib/mimetypes.py w/Lib/mimetypes.py
+index f3343c8..ab5b886 100644
+--- i/Lib/mimetypes.py
++++ w/Lib/mimetypes.py
+@@ -40,16 +40,8 @@
+ ]
+ 
+ knownfiles = [
+-    "/etc/mime.types",
+-    "/etc/httpd/mime.types",                    # Mac OS X
+-    "/etc/httpd/conf/mime.types",               # Apache
+-    "/etc/apache/mime.types",                   # Apache 1
+-    "/etc/apache2/mime.types",                  # Apache 2
+-    "/usr/local/etc/httpd/conf/mime.types",
+-    "/usr/local/lib/netscape/mime.types",
+-    "/usr/local/etc/httpd/conf/mime.types",     # Apache 1.2
+-    "/usr/local/etc/mime.types",                # Apache 1.3
+-    ]
++    "@mime-types@/etc/mime.types",
++]
+ 
+ inited = False
+ _db = None


### PR DESCRIPTION
###### Motivation for this change

Fix #113901


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
