### PR TITLE
esphome: 1.16.0 -> 1.16.2

### DIFF
--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -11,11 +11,11 @@ let
 
 in python.pkgs.buildPythonApplication rec {
   pname = "esphome";
-  version = "1.16.0";
+  version = "1.16.2";
 
   src = python.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "0pvwzkdcpjqdf7lh1k3xv1la5v60lhjixzykapl7f2xh71fbm144";
+    sha256 = "1b3g64ksj9w83pr69rmrjp5j1ahaq9bmcm5rhnd9x86na7fk3ic7";
   };
 
   ESPHOME_USE_SUBPROCESS = "";
@@ -23,7 +23,7 @@ in python.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python.pkgs; [
     voluptuous pyyaml paho-mqtt colorlog colorama
     tornado protobuf tzlocal pyserial ifaddr
-    protobuf click
+    protobuf click pillow
   ];
 
   # remove all version pinning (E.g tornado==5.1.1 -> tornado)


### PR DESCRIPTION
###### Motivation for this change

* bump esphome to latest version 1.16.0
* add python-pillow to the propagated build-inputs for fonts support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
