### PR TITLE
nixos/gnome3: enable uresourced

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -859,6 +859,7 @@
   ./services/system/nscd.nix
   ./services/system/saslauthd.nix
   ./services/system/uptimed.nix
+  ./services/system/uresourced.nix
   ./services/torrent/deluge.nix
   ./services/torrent/flexget.nix
   ./services/torrent/magnetico.nix

--- a/nixos/modules/services/system/uresourced.nix
+++ b/nixos/modules/services/system/uresourced.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.uresourced;
+
+in
+
+{
+  options = {
+    services.uresourced = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Uresourced, a daemon that dynamically assigns a resource allocation to the active graphical user.
+          If the user has an active graphical session managed using systemd (e.g. GNOME), then the memory
+          allocation will be used to protect the sessions core processes (session.slice)";
+      '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.packages = [
+      pkgs.uresourced
+    ];
+
+    services.dbus.packages = [
+      pkgs.uresourced
+    ];
+
+    environment.etc."uresourced.conf".source = "${pkgs.uresourced}/etc/uresourced.conf";
+  };
+}

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -284,6 +284,7 @@ in
       services.packagekit.enable = mkDefault true;
       services.udisks2.enable = true;
       services.upower.enable = config.powerManagement.enable;
+      services.uresourced.enable = true;
       services.xserver.libinput.enable = mkDefault true; # for controlling touchpad settings via gnome control center
 
       xdg.portal.enable = true;

--- a/pkgs/os-specific/linux/uresourced/0001-build-add-systemd-unit-dir-options.patch
+++ b/pkgs/os-specific/linux/uresourced/0001-build-add-systemd-unit-dir-options.patch
@@ -1,0 +1,49 @@
+From fba01d7b4d5927f511afc8be0699eb5439cc6b86 Mon Sep 17 00:00:00 2001
+From: WORLDofPEACE <worldofpeace@protonmail.ch>
+Date: Sun, 21 Feb 2021 09:07:59 -0500
+Subject: [PATCH] build: add systemd unit dir options
+
+Also use define variable only for systemdunitdir.
+---
+ meson.build       | 15 +++++++++++++--
+ meson_options.txt |  2 ++
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+ create mode 100644 meson_options.txt
+
+diff --git a/meson.build b/meson.build
+index fa3a5de..8d29bb9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -26,8 +26,19 @@ libexecdir = join_paths(get_option('prefix'), get_option('libexecdir'))
+ gnome  = import('gnome')
+ 
+ systemd_dep = dependency('systemd')
+-systemd_userunitdir = systemd_dep.get_pkgconfig_variable('systemduserunitdir')
+-systemd_systemunitdir = systemd_dep.get_pkgconfig_variable('systemdsystemunitdir')
++
++if get_option('systemdsystemunitdir') != ''
++  systemd_systemunitdir = get_option('systemdsystemunitdir')
++else
++  systemd_systemunitdir = systemd_dep.get_pkgconfig_variable('systemdsystemunitdir')
++endif
++
++if get_option('systemduserunitdir') != ''
++  systemd_userunitdir = get_option('systemduserunitdir')
++else
++  systemd_userunitdir = systemd_dep.get_pkgconfig_variable('systemduserunitdir',
++                                                           define_variable: ['prefix', get_option('prefix')])
++endif
+ 
+ # Detect whether we have memory_recursiveprot
+ if systemd_dep.version().version_compare('>=247')
+diff --git a/meson_options.txt b/meson_options.txt
+new file mode 100644
+index 0000000..456d057
+--- /dev/null
++++ b/meson_options.txt
+@@ -0,0 +1,2 @@
++option('systemdsystemunitdir', type: 'string', value: '', description: 'Directory for systemd service files.')
++option('systemduserunitdir', type: 'string', value: '', description: 'Directory for systemd user service files.')
+-- 
+2.30.0
+

--- a/pkgs/os-specific/linux/uresourced/default.nix
+++ b/pkgs/os-specific/linux/uresourced/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, glib
+, systemd
+, meson
+, ninja
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "uresourced";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "benzea";
+    repo = "uresourced";
+    rev = "v${version}";
+    sha256 = "QYvCqoFIlP/nLNp/cf4zPjMgPAsMc9nVegS36sMloqQ=";
+  };
+
+  patches = [
+   ./0001-build-add-systemd-unit-dir-options.patch
+   ./fix-paths.patch
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    systemd
+  ];
+
+  mesonFlags = [
+    "-Dsystemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+    "-Dsysconfdir=/etc"
+  ];
+
+  meta = with lib; {
+    description = "Dynamically allocate resources to the active user";
+    homepage = "https://gitlab.freedesktop.org/benzea/uresourced";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/uresourced/fix-paths.patch
+++ b/pkgs/os-specific/linux/uresourced/fix-paths.patch
@@ -1,0 +1,11 @@
+diff --git a/data/meson.build b/data/meson.build
+index b95e997..12d76b4 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -11,5 +11,5 @@ install_data(['org.freedesktop.UResourced.conf'],
+ 
+ install_data(
+     'uresourced.conf',
+-    install_dir: sysconfdir
++    install_dir: join_paths(get_option('prefix'), 'etc')
+ )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8656,6 +8656,8 @@ in
 
   ursadb = callPackage ../servers/ursadb {};
 
+  uresourced = callPackage ../os-specific/linux/uresourced { };
+
   usbmuxd = callPackage ../tools/misc/usbmuxd {};
 
   usync = callPackage ../applications/misc/usync { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Uresourced was created to fix https://github.com/systemd/systemd/issues/15028, and is used in Fedora.

I've added a patch that has been sent upstream https://gitlab.freedesktop.org/benzea/uresourced/-/merge_requests/7

Currently need to test that it actually does anything with https://fedoraproject.org/wiki/Changes/Reserve_resources_for_active_user_WS#How_To_Test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
