### PR TITLE
sweethome3d: run using the default jre

### DIFF
--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -1,5 +1,20 @@
-{ lib, stdenv, fetchurl, fetchsvn, makeWrapper, makeDesktopItem, jdk, jre, ant
-, gtk3, gsettings-desktop-schemas, p7zip, libXxf86vm }:
+{ lib
+, stdenv
+, fetchurl
+, fetchsvn
+, makeWrapper
+, makeDesktopItem
+# sweethome3d 6.4.2 does not yet build with jdk 9 and later.
+# this is fixed on trunk (7699?) but let's build with jdk8 until then.
+, jdk8
+# it can run on the latest stable jre fine though
+, jre
+, ant
+, gtk3
+, gsettings-desktop-schemas
+, p7zip
+, libXxf86vm
+}:
 
 let
 
@@ -27,23 +42,29 @@ let
       categories = "Graphics;2DGraphics;3DGraphics;";
     };
 
-    patchPhase = ''
+    postPatch = ''
       patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/amd64/libnativewindow_awt.so
       patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/amd64/libnativewindow_x11.so
       patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/i586/libnativewindow_awt.so
       patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/i586/libnativewindow_x11.so
     '';
 
-    buildInputs = [ ant jdk makeWrapper p7zip gtk3 gsettings-desktop-schemas ];
+    buildInputs = [ ant jdk8 makeWrapper p7zip gtk3 gsettings-desktop-schemas ];
 
     buildPhase = ''
+      runHook preBuild
+
       ant furniture textures help
       mkdir -p $out/share/{java,applications}
       mv "build/"*.jar $out/share/java/.
       ant
+
+      runHook postBuild
     '';
 
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/bin
       cp install/${module}-${version}.jar $out/share/java/.
 
@@ -59,6 +80,8 @@ let
         --set MESA_GL_VERSION_OVERRIDE 2.1 \
         --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3.out}/share:${gsettings-desktop-schemas}/share:$out/share:$GSETTINGS_SCHEMAS_PATH" \
         --add-flags "-Dsun.java2d.opengl=true -jar $out/share/java/${module}-${version}.jar -cp $out/share/java/Furniture.jar:$out/share/java/Textures.jar:$out/share/java/Help.jar -d${toString stdenv.hostPlatform.parsed.cpu.bits}"
+
+      runHook postInstall
     '';
 
     dontStrip = true;

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -1,5 +1,17 @@
-{ lib, stdenv, fetchcvs, makeWrapper, makeDesktopItem, jdk, jre, ant
-, gtk3, gsettings-desktop-schemas, sweethome3dApp }:
+{ lib
+, stdenv
+, fetchcvs
+, makeWrapper
+, makeDesktopItem
+# sweethome3d 6.4.2 does not yet build with jdk 9 and later.
+# this is fixed on trunk (7699?) but let's build with jdk8 until then.
+, jdk8
+# it can run on the latest stable jre fine though
+, jre
+, ant
+, gtk3
+, gsettings-desktop-schemas
+, sweethome3dApp }:
 
 let
 
@@ -23,15 +35,19 @@ let
       categories = "Graphics;2DGraphics;3DGraphics;";
     };
 
-    buildInputs = [ ant jre jdk makeWrapper gtk3 gsettings-desktop-schemas ];
+    buildInputs = [ ant jdk8 makeWrapper gtk3 gsettings-desktop-schemas ];
 
-    patchPhase = ''
+    postPatch = ''
       sed -i -e 's,../SweetHome3D,${application.src},g' build.xml
       sed -i -e 's,lib/macosx/java3d-1.6/jogl-all.jar,lib/java3d-1.6/jogl-all.jar,g' build.xml
     '';
 
     buildPhase = ''
-      ant -lib ${application.src}/libtest -lib ${application.src}/lib -lib ${jdk}/lib
+      runHook preBuild
+
+      ant -lib ${application.src}/libtest -lib ${application.src}/lib -lib ${jdk8}/lib
+
+      runHook postBuild
     '';
 
     installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24948,16 +24948,12 @@ in
 
   linuxstopmotion = libsForQt5.callPackage ../applications/video/linuxstopmotion { };
 
-  sweethome3d = recurseIntoAttrs (  (callPackage ../applications/misc/sweethome3d {
-    jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-    jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-  })
-                                 // (callPackage ../applications/misc/sweethome3d/editors.nix {
-                                      jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-                                      jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-                                      sweethome3dApp = sweethome3d.application;
-                                    })
-                                 );
+  sweethome3d = recurseIntoAttrs (
+    (callPackage ../applications/misc/sweethome3d { }) //
+    (callPackage ../applications/misc/sweethome3d/editors.nix {
+      sweethome3dApp = sweethome3d.application;
+    })
+  );
 
   swingsane = callPackage ../applications/graphics/swingsane { };
 


### PR DESCRIPTION
###### Motivation for this change

The default jdk was updated, but various applications were kept at
jdk8 so they could be updated one-by-one, testing that the update
does not break those packages.

I tested sweethome3d, and found out that while it runs fine with
the default jre, the build script of the current release does not
work on JDK9 or higher. This has already been fixed on trunk but
not yet released. Since this is specific to this package, I
moved the selection of 'jdk8' to inside the packages' .nix, with a
note so we don't forget to update to the default jdk as well when
a new version of sweethome3d is released.

There are of course other approaches possible, see
https://discourse.nixos.org/t/package-version-arguments-vs-generic-package-arguments/9071/8,
but since we have not landed on one rule yet I think we should look
at this case-by-case and in this particular case I think putting
`jdk8` inside is not bad.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).