### PR TITLE
appgate-sdp: fix substitution bug

### DIFF
--- a/pkgs/applications/networking/appgate-sdp/default.nix
+++ b/pkgs/applications/networking/appgate-sdp/default.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation rec {
         --replace "/bin/sh" "${bash}/bin/sh" \
         --replace "cat" "${coreutils}/bin/cat" \
         --replace "chattr" "${e2fsprogs}/bin/chattr" \
-        --replace "mv" "${coreutils}/bin/mv" \
+        --replace "mv " "${coreutils}/bin/mv " \
         --replace "pkill" "${procps}/bin/pkill"
     done
 
@@ -145,7 +145,7 @@ stdenv.mkDerivation rec {
         --replace "/bin/sh" "${bash}/bin/sh" \
         --replace "/opt/" "$out/opt/" \
         --replace "chattr" "${e2fsprogs}/bin/chattr" \
-        --replace "mv" "${coreutils}/bin/mv"
+        --replace "mv " "${coreutils}/bin/mv "
     done
 
     substituteInPlace $out/lib/systemd/system/appgatedriver.service \
@@ -174,7 +174,7 @@ stdenv.mkDerivation rec {
   '';
   meta = with lib; {
     description = "Appgate SDP (Software Defined Perimeter) desktop client";
-    homepage = https://www.appgate.com/support/software-defined-perimeter-support;
+    homepage = "https://www.appgate.com/support/software-defined-perimeter-support";
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ymatsiuk ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Hacky fix for the situation when nix-store hash contains `mv` in it. @etu 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
