### PR TITLE
nixos/etebase-server: replace customIni with more flexible settings

### DIFF
--- a/nixos/modules/services/misc/etebase-server.nix
+++ b/nixos/modules/services/misc/etebase-server.nix
@@ -94,6 +94,12 @@ in
                   used as django's SECRET_KEY.
                 '';
               };
+              static_root = mkOption {
+                type = types.str;
+                default = "${cfg.dataDir}/static";
+                defaultText = "\${config.services.etebase-server.dataDir}/static";
+                description = "The directory for static files.";
+              };
               media_root = mkOption {
                 type = types.str;
                 default = "${cfg.dataDir}/media";
@@ -180,13 +186,14 @@ in
       };
       environment = {
         PYTHONPATH = "${pythonEnv}/${pkgs.python3.sitePackages}";
-        ETEBASE_EASY_CONFIG_PATH = "${configIni}";
+        ETEBASE_EASY_CONFIG_PATH = configIni;
       };
       preStart = ''
         # Auto-migrate on first run or if the package has changed
         versionFile="${cfg.dataDir}/src-version"
         if [[ $(cat "$versionFile" 2>/dev/null) != ${pkgs.etebase-server} ]]; then
           ${pythonEnv}/bin/etebase-server migrate
+          ${pythonEnv}/bin/etebase-server collectstatic
           echo ${pkgs.etebase-server} > "$versionFile"
         fi
       '';

--- a/nixos/modules/services/misc/etebase-server.nix
+++ b/nixos/modules/services/misc/etebase-server.nix
@@ -8,31 +8,28 @@ let
   pythonEnv = pkgs.python3.withPackages (ps: with ps;
     [ etebase-server daphne ]);
 
-  dbConfig = {
-    sqlite3 = ''
-      engine = django.db.backends.sqlite3
-      name = ${cfg.dataDir}/db.sqlite3
-    '';
-  };
+  iniFmt = pkgs.formats.ini {};
 
-  defaultConfigIni = toString (pkgs.writeText "etebase-server.ini" ''
-    [global]
-    debug = false
-    secret_file = ${if cfg.secretFile != null then cfg.secretFile else ""}
-    media_root = ${cfg.dataDir}/media
-
-    [allowed_hosts]
-    allowed_host1 = ${cfg.host}
-
-    [database]
-    ${dbConfig."${cfg.database.type}"}
-  '');
-
-  configIni = if cfg.customIni != null then cfg.customIni else defaultConfigIni;
+  configIni = iniFmt.generate "etebase-server.ini" cfg.settings;
 
   defaultUser = "etebase-server";
 in
 {
+  imports = [
+    (mkRemovedOptionModule
+      [ "services" "etebase-server" "customIni" ]
+      "Set the option `services.etebase-server.settings' instead.")
+    (mkRemovedOptionModule
+      [ "services" "etebase-server" "database" ]
+      "Set the option `services.etebase-server.settings.database' instead.")
+    (mkRenamedOptionModule
+      [ "services" "etebase-server" "secretFile" ]
+      [ "services" "etebase-server" "settings" "secret_file" ])
+    (mkRenamedOptionModule
+      [ "services" "etebase-server" "host" ]
+      [ "services" "etebase-server" "settings" "allowed_hosts" "allowed_host1" ])
+  ];
+
   options = {
     services.etebase-server = {
       enable = mkOption {
@@ -42,18 +39,10 @@ in
         description = ''
           Whether to enable the Etebase server.
 
-          Once enabled you need to create an admin user using the
-          shell command <literal>etebase-server createsuperuser</literal>.
+          Once enabled you need to create an admin user by invoking the
+          shell command <literal>etebase-server createsuperuser</literal> with
+          the user specified by the <literal>user</literal> option or a superuser.
           Then you can login and create accounts on your-etebase-server.com/admin
-        '';
-      };
-
-      secretFile = mkOption {
-        default = null;
-        type = with types; nullOr str;
-        description = ''
-          The path to a file containing the secret
-          used as django's SECRET_KEY.
         '';
       };
 
@@ -77,15 +66,6 @@ in
         '';
       };
 
-      host = mkOption {
-        type = types.str;
-        default = "0.0.0.0";
-        example = "localhost";
-        description = ''
-          Host to listen on.
-        '';
-      };
-
       unixSocket = mkOption {
         type = with types; nullOr str;
         default = null;
@@ -93,42 +73,75 @@ in
         example = "/run/etebase-server/etebase-server.sock";
       };
 
-      database = {
-        type = mkOption {
-          type = types.enum [ "sqlite3" ];
-          default = "sqlite3";
-          description = ''
-            Database engine to use.
-            Currently only sqlite3 is supported.
-            Other options can be configured using <literal>extraConfig</literal>.
-          '';
+      settings = mkOption {
+        type = lib.types.submodule {
+          freeformType = iniFmt.type;
+
+          options = {
+            global = {
+              debug = mkOption {
+                type = types.bool;
+                default = false;
+                description = ''
+                  Whether to set django's DEBUG flag.
+                '';
+              };
+              secret_file = mkOption {
+                type = with types; nullOr str;
+                default = null;
+                description = ''
+                  The path to a file containing the secret
+                  used as django's SECRET_KEY.
+                '';
+              };
+              media_root = mkOption {
+                type = types.str;
+                default = "${cfg.dataDir}/media";
+                defaultText = "\${config.services.etebase-server.dataDir}/media";
+                description = "The media directory.";
+              };
+            };
+            allowed_hosts = {
+              allowed_host1 = mkOption {
+                type = types.str;
+                default = "0.0.0.0";
+                example = "localhost";
+                description = ''
+                  The main host that is allowed access.
+                '';
+              };
+            };
+            database = {
+              engine = mkOption {
+                type = types.enum [ "django.db.backends.sqlite3" "django.db.backends.postgresql" ];
+                default = "django.db.backends.sqlite3";
+                description = "The database engine to use.";
+              };
+              name = mkOption {
+                type = types.str;
+                default = "${cfg.dataDir}/db.sqlite3";
+                defaultText = "\${config.services.etebase-server.dataDir}/db.sqlite3";
+                description = "The database name.";
+              };
+            };
+          };
         };
-      };
-
-      customIni = mkOption {
-        type = with types; nullOr str;
-        default = null;
+        default = {};
         description = ''
-          Custom etebase-server.ini.
-
-          See <literal>etebase-src/etebase-server.ini.example</literal> for available options.
-
-          Setting this option overrides the default config which is generated from the options
-          <literal>secretFile</literal>, <literal>host</literal> and <literal>database</literal>.
+          Configuration for <package>etebase-server</package>. Refer to
+          <link xlink:href="https://github.com/etesync/server/blob/master/etebase-server.ini.example" />
+          and <link xlink:href="https://github.com/etesync/server/wiki" />
+          for details on supported values.
         '';
-        example = literalExample ''
-          [global]
-          debug = false
-          secret_file = /path/to/secret
-          media_root = /path/to/media
-
-          [allowed_hosts]
-          allowed_host1 = example.com
-
-          [database]
-          engine = django.db.backends.sqlite3
-          name = db.sqlite3
-        '';
+        example = {
+          global = {
+            debug = true;
+            media_root = "/path/to/media";
+          };
+          allowed_hosts = {
+            allowed_host2 = "localhost";
+          };
+        };
       };
 
       user = mkOption {
@@ -166,8 +179,8 @@ in
         WorkingDirectory = cfg.dataDir;
       };
       environment = {
-        PYTHONPATH="${pythonEnv}/${pkgs.python3.sitePackages}";
-        ETEBASE_EASY_CONFIG_PATH="${configIni}";
+        PYTHONPATH = "${pythonEnv}/${pkgs.python3.sitePackages}";
+        ETEBASE_EASY_CONFIG_PATH = "${configIni}";
       };
       preStart = ''
         # Auto-migrate on first run or if the package has changed

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -107,6 +107,7 @@ in
   ergo = handleTest ./ergo.nix {};
   etcd = handleTestOn ["x86_64-linux"] ./etcd.nix {};
   etcd-cluster = handleTestOn ["x86_64-linux"] ./etcd-cluster.nix {};
+  etebase-server = handleTest ./etebase-server.nix {};
   etesync-dav = handleTest ./etesync-dav.nix {};
   fancontrol = handleTest ./fancontrol.nix {};
   fcitx = handleTest ./fcitx {};

--- a/nixos/tests/etebase-server.nix
+++ b/nixos/tests/etebase-server.nix
@@ -1,0 +1,50 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+let
+  dataDir = "/var/lib/foobar";
+
+in {
+    name = "etebase-server";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ felschr ];
+    };
+
+    machine = { pkgs, ... }:
+      {
+        services.etebase-server = {
+          inherit dataDir;
+          enable = true;
+          settings.global.secret_file =
+            toString (pkgs.writeText "secret" "123456");
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("etebase-server.service")
+      machine.wait_for_open_port(8001)
+
+      with subtest("Database & src-version were created"):
+          machine.wait_for_file("${dataDir}/src-version")
+          assert (
+              "${pkgs.etebase-server}"
+              in machine.succeed("cat ${dataDir}/src-version")
+          )
+          machine.wait_for_file("${dataDir}/db.sqlite3")
+          machine.wait_for_file("${dataDir}/static")
+
+      with subtest("Only allow access from allowed_hosts"):
+          machine.succeed("curl -sSfL http://0.0.0.0:8001/")
+          machine.fail("curl -sSfL http://127.0.0.1:8001/")
+          machine.fail("curl -sSfL http://localhost:8001/")
+
+      with subtest("Run tests"):
+          machine.succeed("etebase-server check")
+          machine.succeed("etebase-server test")
+
+      with subtest("Create superuser"):
+          machine.succeed(
+              "etebase-server createsuperuser --no-input --username admin --email root@localhost"
+          )
+    '';
+  }
+)


### PR DESCRIPTION
###### Motivation for this change

Fixes incorrect documentation of the `customIni` option reported in #112834.

While having this opportunity I've added the new option `extraConfig` to replace `customIni` which is now merged with the default configuration and still allows overriding options when needed. This makes it easier to add or change single options rather than creating an entirely new config.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
