### PR TITLE
cyberpunk-neon: init at b4b293c

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8097,6 +8097,12 @@
     githubId = 592876;
     name = "Robert W. Pearce";
   };
+  rpgwaiter = {
+    email = "rpgwaiter+nix@based.zone";
+    github = "rpgwaiter";
+    githubId = 	12245941;
+    name = "Rpgwaiter";
+  };
   rprospero = {
     email = "rprospero+nix@gmail.com";
     github = "rprospero";

--- a/pkgs/data/themes/cyberpunk-neon/default.nix
+++ b/pkgs/data/themes/cyberpunk-neon/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+    pname = "cyberpunk-neon";
+    version = "b4b293c";
+
+    src = fetchFromGitHub {
+        owner = "Roboron3042";
+        repo = "Cyberpunk-Neon";
+        rev = version;
+        sha256 = "sha256-yqr4xga4hzd+BJpEECPK0xQDP3CjABfJISQS684SbwM=";
+    };
+
+    dontBuild = true;
+
+    installPhase = ''
+        # gtk
+        mkdir -p $out/share/themes
+        tar xzf gtk/materia-cyberpunk-neon.tar.gz -C $out/share/themes/
+        tar xzf gtk/arc-cyberpunk-neon.tar.gz -C $out/share/themes/
+        
+        # kde
+        mkdir -p $out/share/color-schemes
+        cp kde/cyberpunk-neon.colors $out/share/color-schemes/
+        # terminal
+        mkdir -p $out/share/konsole
+        cp terminal/konsole/cyberpunk-neon.colorscheme $out/share/konsole
+        mkdir -p $out/share/tilix/schemes
+        cp terminal/tilix/cyberpunk-neon.json $out/share/tilix/schemes
+    '';
+
+    meta = with stdenv.lib; {
+        description = "Theme for GTK, plasma, konsole and tilix ";
+        license = licenses.cc-by-sa-40;
+        platforms = platforms.unix;
+        maintainers = [ maintainers.rpgwaiter ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20367,6 +20367,8 @@ in
 
   crimson = callPackage ../data/fonts/crimson {};
 
+  cyberpunk-neon = callPackage ../data/themes/cyberpunk-neon {};
+
   dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts {});
 
   # solve collision for nix-env before https://github.com/NixOS/nix/pull/815


### PR DESCRIPTION
###### Motivation for this change
I wanted to add the desktop theme I use to nixpkgs


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)

   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
   
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).