### PR TITLE
nix-prefetch-git: try to shallow fetch commits when supported

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -148,7 +148,17 @@ checkout_hash(){
         hash=$(hash_from_ref "$ref")
     fi
 
-    clean_git fetch -t ${builder:+--progress} origin || return 1
+    if [[ -n "$deepClone" ]]; then
+        clean_git fetch -t ${builder:+--progress} origin || return 1
+        # Try to shallow fetch specific hash if it doesn't exist in any ref.
+        # For example, if a ref was force-pushed but the server still exposes the old hash.
+        clean_git fetch ${builder:+--progress} --depth 1 origin "$hash" 2> /dev/null
+    else
+        # Try to shallow fetch specific hash if server supports uploadpack.allowReachableSha1InWant.
+        # Fallback to full fetch on failure.
+        clean_git fetch ${builder:+--progress} --depth 1 origin "$hash" 2> /dev/null ||
+        clean_git fetch -t ${builder:+--progress} origin || return 1
+    fi
 
     local object_type=$(git cat-file -t "$hash")
     if [[ "$object_type" == "commit" ]]; then


### PR DESCRIPTION
###### Motivation for this change
Fix fetching commits that don't belong to any ref (closes #113926), and reduce fetch time by using a shallow fetch.

This requires `uploadpack.allowReachableSha1InWant` to be enabled on the git server, so we fallback to a full fetch if it fails.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@CajuM