### PR TITLE
freeplane: init at 1.8.11

### DIFF
--- a/pkgs/applications/misc/freeplane/default.nix
+++ b/pkgs/applications/misc/freeplane/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchzip, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  pname = "freeplane";
+  version = "1.8.11";
+
+  src = fetchzip {
+    url = "https://sourceforge.net/projects/freeplane/files/freeplane%20stable/freeplane_bin-${version}.zip/download#freeplane_bin-${version}.zip";
+    sha256 = "tJyJ7LQoeEFakjOgOU6yUA8dlCuXSCvbUB+gRq4ElMw=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+    cp -r * $out/share
+    makeWrapper $out/share/freeplane.sh $out/bin/freeplane \
+      --set JAVA_HOME "${jre}/lib/openjdk"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Mind-mapping software";
+    homepage = "https://www.freeplane.org/wiki/index.php/Home";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ maxhbr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22426,6 +22426,8 @@ in
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
 
+  freeplane = callPackage ../applications/misc/freeplane { };
+
   freenet = callPackage ../applications/networking/p2p/freenet {
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };


### PR DESCRIPTION
Add Freeplane to nixpkgs.

based on: https://github.com/NixOS/nixpkgs/pull/34752/files

###### Motivation for this change

Freeplane is the more advanced and more actively developed successor of [freemind](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/freemind/default.nix).

Development take place at  https://github.com/freeplane/freeplane

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
