### PR TITLE
llvm-mode: Init (verison inherited from llvm)

### DIFF
--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -113,6 +113,21 @@
 
   jam-mode = callPackage ./jam-mode { };
 
+  llvm-mode = trivialBuild {
+    pname = "llvm-mode";
+    inherit (external.llvmPackages.llvm) src version;
+
+    dontConfigure = true;
+    buildPhase = ''
+      cp utils/emacs/*.el .
+    '';
+
+    meta = {
+      inherit (external.llvmPackages.llvm.meta) homepage license;
+      description = "Major mode for the LLVM assembler language.";
+    };
+  };
+
   org-mac-link =
     callPackage ./org-mac-link { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
adding llvm ir mode for emacs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
