### PR TITLE
spicy: init at unstable-2020-02-21

### DIFF
--- a/pkgs/development/tools/spicy/default.nix
+++ b/pkgs/development/tools/spicy/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "spicy";
+  version = "unstable-2020-02-21";
+
+  goPackagePath = "github.com/trhodeos/spicy";
+
+  src = fetchFromGitHub {
+    owner = "trhodeos";
+    repo = "spicy";
+    rev = "47409fb73e0b20b323c46cc06a3858d0a252a817";
+    sha256 = "022r8klmr21vaz5qd72ndrzj7pyqpfxc3jljz7nzsa50fjf82c3a";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "A Nintendo 64 segment assembler";
+    longDescription = ''
+      An open-source version of the Nintendo64 sdk's mild.exe. Assembles
+      segments into an n64-compatible rom.
+    '';
+    homepage = "https://github.com/trhodeos/spicy";
+    license = licenses.mit;
+    maintainers = [ maintainers._414owen];
+  };
+}

--- a/pkgs/development/tools/spicy/deps.nix
+++ b/pkgs/development/tools/spicy/deps.nix
@@ -1,0 +1,56 @@
+[
+  {
+    goPackagePath = "github.com/alecthomas/participle";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/participle.git";
+      rev = "fed0e8fbb638b11091014aa838748210dc9ff576";
+      sha256 = "0yhhm42lis8ak9m6x6aai280xq0652vcq5v17pibbf74dalxyims";
+    };
+  }
+  {
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus.git";
+      rev = "f104497f2b2129ab888fd274891f3a278756bcde";
+      sha256 = "0gr2c7s3ffdaynzn1zplp79zz16qgqpnsq2z9zg79wxksq5mz5l1";
+    };
+  }
+  {
+    goPackagePath = "github.com/ogier/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ogier/pflag.git";
+      rev = "73e519546fc0bce0c395610afcf6aa4e5aec88eb";
+      sha256 = "114zpgl6l47gsz0sifpq62hi2i6k0ra9hi8wx7d39giablf9i4ii";
+    };
+  }
+  {
+    goPackagePath = "github.com/trhodeos/n64rom";
+    fetch = {
+      type = "git";
+      url = "https://github.com/trhodeos/n64rom.git";
+      rev = "504dba7b4d4675bd3396c052d64016c5725c2f5e";
+      sha256 = "01hybm8nxh1lym0wc9sxrms3wyqhhs0dm1a2nwz6xc60lkjcp8kb";
+    };
+  }
+  {
+    goPackagePath = "github.com/trhodeos/ecoff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/trhodeos/ecoff.git";
+      rev = "e54570a0fac23c0fa7f605681345611f345ce0f6";
+      sha256 = "0pc0yj7hy43m00br0q0f1y5a3bc3a134imcyy2jvzim45g6g12kj";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/sys";
+      rev = "9a76102bfb4322425a1228caa377974426e82c84";
+      sha256 = "07qn19yla2w604p3dc8h1c75xj2pxc4fajvg0mf0d4c72d5qiss4";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7997,6 +7997,8 @@ in
 
   spglib = callPackage ../development/libraries/spglib { };
 
+  spicy = callPackage ../development/tools/spicy { };
+
   ssh-askpass-fullscreen = callPackage ../tools/networking/ssh-askpass-fullscreen { };
 
   sshguard = callPackage ../tools/security/sshguard {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I'm creating a nix-centered Nintendo64 development environment

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
