### PR TITLE
python3Packages.sagemaker: 2.24.5 -> 2.25.1

### DIFF
--- a/pkgs/development/python-modules/sagemaker/default.nix
+++ b/pkgs/development/python-modules/sagemaker/default.nix
@@ -1,13 +1,23 @@
-{ lib, buildPythonPackage, fetchPypi, attrs, boto3, google-pasta
-, importlib-metadata, numpy, protobuf, protobuf3-to-dict, smdebug-rulesconfig }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, attrs
+, boto3
+, google-pasta
+, importlib-metadata
+, numpy
+, protobuf
+, protobuf3-to-dict
+, smdebug-rulesconfig
+}:
 
 buildPythonPackage rec {
   pname = "sagemaker";
-  version = "2.24.5";
+  version = "2.25.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1j1a058ic00yxnf0cc364fzn82pacih5ffrh5s4dw1q4s3by4cvd";
+    sha256 = "sha256-xQ1nt8FcjuoilzM5PbU8KHgirPyj9us+ykyjfgEqZhg=";
   };
 
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
