### PR TITLE
nextcloud21: init at 21.0.0, set as default version

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -552,14 +552,16 @@ self: super:
    </listitem>
    <listitem>
     <para>
-     The default-version of <literal>nextcloud</literal> is <package>nextcloud20</package>.
+     The default-version of <literal>nextcloud</literal> is <package>nextcloud21</package>.
      Please note that it's <emphasis>not</emphasis> possible to upgrade <literal>nextcloud</literal>
      across multiple major versions! This means that it's e.g. not possible to upgrade
-     from <package>nextcloud18</package> to <package>nextcloud20</package> in a single deploy.
+     from <package>nextcloud18</package> to <package>nextcloud20</package> in a single deploy and
+     most <literal>20.09</literal> users will have to upgrade to <package>nextcloud20</package>
+     first.
     </para>
     <para>
      The package can be manually upgraded by setting <xref linkend="opt-services.nextcloud.package" />
-     to <package>nextcloud20</package>.
+     to <package>nextcloud21</package>.
     </para>
    </listitem>
    <listitem>

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -280,6 +280,24 @@ in {
           may be served via HTTPS.
         '';
       };
+
+      defaultPhoneRegion = mkOption {
+        default = null;
+        type = types.nullOr types.str;
+        example = "DE";
+        description = ''
+          <warning>
+           <para>This option exists since Nextcloud 21! If older versions are used,
+            this will throw an eval-error!</para>
+          </warning>
+
+          <link xlink:href="https://www.iso.org/iso-3166-country-codes.html">ISO 3611-1</link>
+          country codes for automatic phone-number detection without a country code.
+
+          With e.g. <literal>DE</literal> set, the <literal>+49</literal> can be omitted for
+          phone-numbers.
+        '';
+      };
     };
 
     caching = {
@@ -344,6 +362,9 @@ in {
         { assertion = ((acfg.adminpass != null || acfg.adminpassFile != null)
             && !(acfg.adminpass != null && acfg.adminpassFile != null));
           message = "Please specify exactly one of adminpass or adminpassFile";
+        }
+        { assertion = versionOlder cfg.package.version "21" -> cfg.config.defaultPhoneRegion == null;
+          message = "The `defaultPhoneRegion'-setting is only supported for Nextcloud >=21!";
         }
       ];
 
@@ -442,6 +463,7 @@ in {
               'dbtype' => '${c.dbtype}',
               'trusted_domains' => ${writePhpArrary ([ cfg.hostName ] ++ c.extraTrustedDomains)},
               'trusted_proxies' => ${writePhpArrary (c.trustedProxies)},
+              ${optionalString (c.defaultPhoneRegion != null) "'default_phone_region' => '${c.defaultPhoneRegion}',"}
             ];
           '';
           occInstallCmd = let

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -28,7 +28,10 @@ let
     upload_max_filesize = cfg.maxUploadSize;
     post_max_size = cfg.maxUploadSize;
     memory_limit = cfg.maxUploadSize;
-  } // cfg.phpOptions;
+  } // cfg.phpOptions
+    // optionalAttrs cfg.caching.apcu {
+      "apc.enable_cli" = "1";
+    };
 
   occ = pkgs.writeScriptBin "nextcloud-occ" ''
     #! ${pkgs.runtimeShell}

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -86,7 +86,7 @@ in {
     package = mkOption {
       type = types.package;
       description = "Which package to use for the Nextcloud instance.";
-      relatedPackages = [ "nextcloud18" "nextcloud19" "nextcloud20" ];
+      relatedPackages = [ "nextcloud19" "nextcloud20" "nextcloud21" ];
     };
 
     maxUploadSize = mkOption {
@@ -348,7 +348,7 @@ in {
       ];
 
       warnings = let
-        latest = 20;
+        latest = 21;
         upgradeWarning = major: nixos:
           ''
             A legacy Nextcloud install (from before NixOS ${nixos}) may be installed.
@@ -366,9 +366,9 @@ in {
           Using config.services.nextcloud.poolConfig is deprecated and will become unsupported in a future release.
           Please migrate your configuration to config.services.nextcloud.poolSettings.
         '')
-        ++ (optional (versionOlder cfg.package.version "18") (upgradeWarning 17 "20.03"))
         ++ (optional (versionOlder cfg.package.version "19") (upgradeWarning 18 "20.09"))
-        ++ (optional (versionOlder cfg.package.version "20") (upgradeWarning 19 "21.05"));
+        ++ (optional (versionOlder cfg.package.version "20") (upgradeWarning 19 "21.05"))
+        ++ (optional (versionOlder cfg.package.version "21") (upgradeWarning 20 "21.05"));
 
       services.nextcloud.package = with pkgs;
         mkDefault (
@@ -378,14 +378,13 @@ in {
               nextcloud defined in an overlay, please set `services.nextcloud.package` to
               `pkgs.nextcloud`.
             ''
-          else if versionOlder stateVersion "20.03" then nextcloud17
           else if versionOlder stateVersion "20.09" then nextcloud18
           # 21.03 will not be an official release - it was instead 21.05.
           # This versionOlder statement remains set to 21.03 for backwards compatibility.
           # See https://github.com/NixOS/nixpkgs/pull/108899 and
           # https://github.com/NixOS/rfcs/blob/master/rfcs/0080-nixos-release-schedule.md.
           else if versionOlder stateVersion "21.03" then nextcloud19
-          else nextcloud20
+          else nextcloud21
         );
     }
 

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -612,6 +612,14 @@ in {
               access_log off;
             '';
           };
+          "= /" = {
+            priority = 100;
+            extraConfig = ''
+              if ( $http_user_agent ~ ^DavClnt ) {
+                return 302 /remote.php/webdav/$is_args$args;
+              }
+            '';
+          };
           "/" = {
             priority = 900;
             extraConfig = "rewrite ^ /index.php;";
@@ -629,6 +637,9 @@ in {
               }
               location = /.well-known/caldav {
                 return 301 /remote.php/dav;
+              }
+              location ~ ^/\.well-known/(?!acme-challenge|pki-validation) {
+                return 301 /index.php$request_uri;
               }
               try_files $uri $uri/ =404;
             '';

--- a/nixos/modules/services/web-apps/nextcloud.xml
+++ b/nixos/modules/services/web-apps/nextcloud.xml
@@ -11,7 +11,7 @@
   desktop client is packaged at <literal>pkgs.nextcloud-client</literal>.
  </para>
  <para>
-  The current default by NixOS is <package>nextcloud20</package> which is also the latest
+  The current default by NixOS is <package>nextcloud21</package> which is also the latest
   major version available.
  </para>
  <section xml:id="module-services-nextcloud-basic-usage">

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -43,7 +43,7 @@ in {
     [1] https://docs.nextcloud.com/server/18/admin_manual/release_schedule.html
   '';
 
-  # FIXME(@Ma27) remove on 2021-06
+  # FIXME(@Ma27) remove on 21.05
   nextcloud19 = generic {
     version = "19.0.6";
     sha256 = "sha256-pqqIayE0OyTailtd2zeYi+G1APjv/YHqyO8jCpq7KJg=";

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -31,24 +31,19 @@ let
     };
   };
 in {
-  nextcloud17 = throw ''
-    Nextcloud v17 has been removed from `nixpkgs` as the support for it will be dropped
-    by upstream within the lifetime of NixOS 20.09[1]. Please upgrade to Nextcloud v18 by
+  nextcloud18 = throw ''
+    Nextcloud v18 has been removed from `nixpkgs` as the support for it was dropped
+    by upstream in 2021-01. Please upgrade to at least Nextcloud v19 by
     declaring
 
-        services.nextcloud.package = pkgs.nextcloud18;
+        services.nextcloud.package = pkgs.nextcloud19;
 
     in your NixOS config.
 
     [1] https://docs.nextcloud.com/server/18/admin_manual/release_schedule.html
   '';
 
-  nextcloud18 = generic {
-    version = "18.0.10";
-    sha256 = "0kv9mdn36shr98kh27969b8xs7pgczbyjklrfskxy9mph7bbzir6";
-    eol = true;
-  };
-
+  # FIXME(@Ma27) remove on 2021-06
   nextcloud19 = generic {
     version = "19.0.6";
     sha256 = "sha256-pqqIayE0OyTailtd2zeYi+G1APjv/YHqyO8jCpq7KJg=";
@@ -60,5 +55,10 @@ in {
   nextcloud20 = generic {
     version = "20.0.7";
     sha256 = "sha256-jO2Ct3K/CvZ9W+EyPkD5d0KbwKK8yGQJXvx4dnUAtys=";
+  };
+
+  nextcloud21 = generic {
+    version = "21.0.0";
+    sha256 = "sha256-zq2u72doWhGvxbI7Coa6PHvQp7E41dHswFJiODZV8fA=";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6544,7 +6544,7 @@ in
   grocy = callPackage ../servers/grocy { };
 
   inherit (callPackage ../servers/nextcloud {})
-    nextcloud17 nextcloud18 nextcloud19 nextcloud20;
+    nextcloud18 nextcloud19 nextcloud20 nextcloud21;
 
   nextcloud-client = libsForQt5.callPackage ../applications/networking/nextcloud-client { };
 


### PR DESCRIPTION
###### Motivation for this change

<del>:warning: This is marked as draft on purpose since [a 21.0.0 tag exists](https://github.com/nextcloud/server/releases/tag/v21.0.0), but no changelog is available at nextcloud.com. Since Nextcloud is planning an "announcement" on 22 Feb, I guess that it's not official yet.</del>

<del>However I decided to give it a try (successfully btw), so I decided to open this PR already :) </del>

------

ChangeLog: https://nextcloud.com/changelog/#latest21

* Packaged 21.0.0, test-deployed it to my personal instance and tested
  the most basic functionality (`davfs2`-mount, {card,cal}dav sync, file
  management).

* Bumped the default version for unstable/21.05 to `nextcloud21`. Since
  `nextcloud20` was added after the release of 20.09 (and thus the
  default on 20.09 is still `nextcloud19`), it's now needed to upgrade
  across two majors.

  This is not a problem though since it's possible to upgrade to v20 on
  20.09 already and if not, the module will guard the administrator
  through the upgrade with eval warnings as it's the case since 20.03.

* Dropped `nextcloud17` attribute and marked `nextcloud18` as EOL.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
