### PR TITLE
vimPlugins: add coc-{clangd,cmake,texlab}

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -788,6 +788,8 @@ self: super: {
 } // (
   let
     nodePackageNames = [
+      "coc-clangd"
+      "coc-cmake"
       "coc-css"
       "coc-diagnostic"
       "coc-emmet"
@@ -805,8 +807,8 @@ self: super: {
       "coc-metals"
       "coc-pairs"
       "coc-prettier"
-      "coc-python"
       "coc-pyright"
+      "coc-python"
       "coc-r-lsp"
       "coc-rls"
       "coc-rust-analyzer"
@@ -815,6 +817,7 @@ self: super: {
       "coc-solargraph"
       "coc-stylelint"
       "coc-tabnine"
+      "coc-texlab"
       "coc-tslint"
       "coc-tslint-plugin"
       "coc-tsserver"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I added these to `nodePackages` but forgot to add to the `vimPlugins` override.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
