### PR TITLE
mysqltuner: do not pollute global /share

### DIFF
--- a/pkgs/tools/misc/mysqltuner/default.nix
+++ b/pkgs/tools/misc/mysqltuner/default.nix
@@ -5,16 +5,15 @@ stdenv.mkDerivation rec {
   version = "1.7.21";
 
   src = fetchFromGitHub {
-    owner  = "major";
-    repo   = "MySQLTuner-perl";
-    rev    = version;
+    owner = "major";
+    repo = "MySQLTuner-perl";
+    rev = version;
     sha256 = "sha256-Yv1XjD8sZcmGr2SVD6TEElUH7vspJ61WwQwfXLOrao0=";
   };
 
   postPatch = ''
     substituteInPlace mysqltuner.pl \
-      --replace '$basic_password_files = "/usr/share/mysqltuner/basic_passwords.txt"' "\$basic_password_files = \"$out/share/basic_passwords.txt\"" \
-      --replace '$opt{cvefile} = "/usr/share/mysqltuner/vulnerabilities.csv"' "\$opt{cvefile} = \"$out/share/vulnerabilities.csv\""
+      --replace '/usr/share' "$out/share"
   '';
 
   buildInputs = [ perl ];
@@ -22,10 +21,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/bin"
-    install -Dm 0755 mysqltuner.pl "$out/bin/mysqltuner"
-    install -Dm 0644 basic_passwords.txt "$out/share/basic_passwords.txt"
-    install -Dm 0644 vulnerabilities.csv "$out/share/vulnerabilities.csv"
+    install -Dm0555 mysqltuner.pl $out/bin/mysqltuner
+    install -Dm0444 -t $out/share/mysqltuner basic_passwords.txt vulnerabilities.csv
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Motivation for this change

Further to #113798 which I didn't look at in time, do not store files directly in the global /share but use a dedicated subdirectory.

A few additional cleanups as well.

The formatting changes to `src` is due to `nixpkgs-fmt`.

Cc: @SCOTT-HAMILTON @davidak @SuperSandro2000 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
