### PR TITLE
[20.09] linuxPackages.nvidia_x11: fix sporadic kmalloc crash

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -2,10 +2,11 @@
 
 let
 
-generic = args:
-if ((!lib.versionOlder args.version "391")
-    && stdenv.hostPlatform.system != "x86_64-linux") then null
-  else callPackage (import ./generic.nix args) { };
+  generic = args:
+    if ((!lib.versionOlder args.version "391")
+        && stdenv.hostPlatform.system != "x86_64-linux") then null
+    else callPackage (import ./generic.nix args) { };
+
   kernel = callPackage # a hacky way of extracting parameters from callPackage
     ({ kernel, libsOnly ? false }: if libsOnly then { } else kernel) { };
 
@@ -26,6 +27,8 @@ rec {
       sha256_64bit = "0x6w2kcjm5q9z9l6rkxqabway4qq4h3ynngn36i8ky2dpxc1wzfq";
       settingsSha256 = "1hk4yvbb7xhfwm8jiwq6fj5m7vg3w7yvgglhfyhq7bbrlklfb4hm";
       persistencedSha256 = "00mmazv8sy93jvp60v7p954n250f4q3kxc13l4f8fmi28lgv0844";
+
+      patches = [ ./kvmalloc.patch ];
     }
     else legacy_390;
 

--- a/pkgs/os-specific/linux/nvidia-x11/kvmalloc.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/kvmalloc.patch
@@ -1,0 +1,45 @@
+diff --git a/kernel/nvidia-modeset/nvidia-modeset-linux.c b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+index ffbbeb9..2302541 100644
+--- a/kernel/nvidia-modeset/nvidia-modeset-linux.c
++++ b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+@@ -21,6 +21,8 @@
+ #include <linux/file.h>
+ #include <linux/list.h>
+ #include <linux/rwsem.h>
++#include <linux/mm.h>
++#include <linux/version.h>
+
+ #include "nvstatus.h"
+
+@@ -169,8 +171,9 @@ static inline void nvkms_write_unlock_pm_lock(void)
+  * are called while nvkms_lock is held.
+  *************************************************************************/
+
+-/* Don't use kmalloc for allocations larger than 128k */
+-#define KMALLOC_LIMIT (128 * 1024)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 12, 0)
++/* Don't use kmalloc for allocations larger than PAGE_SIZE */
++#define KMALLOC_LIMIT (PAGE_SIZE)
+
+ void* NVKMS_API_CALL nvkms_alloc(size_t size, NvBool zero)
+ {
+@@ -197,6 +200,19 @@ void NVKMS_API_CALL nvkms_free(void *ptr, size_t size)
+         vfree(ptr);
+     }
+ }
++#else
++void* NVKMS_API_CALL nvkms_alloc(size_t size, NvBool zero)
++{
++    if (zero)
++        return kvzalloc(size, GFP_KERNEL);
++    return kvmalloc(size, GFP_KERNEL);
++}
++
++void NVKMS_API_CALL nvkms_free(void *ptr, size_t size)
++{
++    kvfree(ptr);
++}
++#endif
+
+ void* NVKMS_API_CALL nvkms_memset(void *ptr, NvU8 c, size_t size)
+ {


### PR DESCRIPTION
Patch from Balbir Singh on the NVIDIA developer forums:

  https://forums.developer.nvidia.com/t/455-23-04-page-allocation-failure-in-kernel-module-at-random-points/155250/79

Fixes the issue described at the top of the thread, i.e. intermittent
crashes (kernel BUG) in nvkms_alloc, by replacing the custom logic for switching
between kmalloc() and vmalloc() with direct calls to kvmalloc() on recent
kernels, and similarly for kfree() and vfree() and kvfree().

On older kernels where kvmalloc() and friends are not available, the existing
custom logic is tweaked to fall back to vmalloc for allocations smaller than
PAGE_SIZE, rather than smaller than 128k.  But this isn't relevant to NixOS,
since our kernel is already new enough for using kmalloc() and friends.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

My system keeps hanging.

Note: making a PR directly to release-20.09 because master has version 260.x of the nvidia drivers, which don't need this patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
