### PR TITLE
ocamlPackages.bap: 2.1.0 → 2.2.0

### DIFF
--- a/pkgs/development/libraries/libbap/default.nix
+++ b/pkgs/development/libraries/libbap/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation {
   pname = "libbap";
-  version = "master-2019-11-15";
+  version = "master-2020-11-25";
 
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
     repo = "bap-bindings";
-    rev = "1a30dd3e1df18c432a83a7038b555662d6982ae3";
-    sha256 = "140gmak2kymh3r0fagb6ms66lmvwhhqj8pcd3qxc1p4ar330fwrh";
+    rev = "3193cb31e1b1f2455406ea0c819dad9dfa2ba10d";
+    sha256 = "0m4spva3z6fgbwlg4zq53l5p227dic893q2qq65pvzxyf7k7nmil";
   };
 
   nativeBuildInputs = [ autoreconfHook which ];

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -2,28 +2,26 @@
 , ocaml, findlib, ocamlbuild, ocaml_oasis
 , bitstring, camlzip, cmdliner, core_kernel, ezjsonm, fileutils, ocaml_lwt, ocamlgraph, ocurl, re, uri, zarith, piqi, piqi-ocaml, uuidm, llvm, frontc, ounit, ppx_jane, parsexp
 , utop, libxml2, ncurses
+, linenoise
+, ppx_bap
 , ppx_bitstring
-, ppx_tools_versioned
+, yojson
 , which, makeWrapper, writeText
 , z3
 }:
 
-if !lib.versionAtLeast ocaml.version "4.07"
+if !lib.versionAtLeast ocaml.version "4.08"
 then throw "BAP is not available for OCaml ${ocaml.version}"
-else
-
-if lib.versionAtLeast core_kernel.version "0.13"
-then throw "BAP needs core_kernel-0.12 (hence OCaml 4.07)"
 else
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-bap-${version}";
-  version = "2.1.0";
+  version = "2.2.0";
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
     repo = "bap";
     rev = "v${version}";
-    sha256 = "10fkr6p798ad18j4h9bvp9dg4pmjdpv3hmj7k389i0vhqniwi5xq";
+    sha256 = "0c53sps6ba9n5cjdmapi8ylzlpcc11pksijp9swzlwgxyz5d276f";
   };
 
   sigs = fetchurl {
@@ -41,12 +39,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which makeWrapper ];
 
   buildInputs = [ ocaml findlib ocamlbuild ocaml_oasis
-                  llvm ppx_bitstring ppx_tools_versioned
+                  linenoise
+                  ounit
+                  ppx_bitstring
                   z3
                   utop libxml2 ncurses ];
 
-  propagatedBuildInputs = [ bitstring camlzip cmdliner ppx_jane core_kernel ezjsonm fileutils ocaml_lwt ocamlgraph ocurl re uri zarith piqi parsexp
-                            piqi-ocaml uuidm frontc ounit ];
+  propagatedBuildInputs = [ bitstring camlzip cmdliner ppx_bap core_kernel ezjsonm fileutils ocaml_lwt ocamlgraph ocurl re uri zarith piqi parsexp
+                            piqi-ocaml uuidm frontc yojson ];
 
   installPhase = ''
     export OCAMLPATH=$OCAMLPATH:$OCAMLFIND_DESTDIR;
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
   patches = [ ./curses_is_ncurses.patch ];
 
   preConfigure = ''
-    substituteInPlace oasis/elf --replace bitstring.ppx ppx_bitstring
+    substituteInPlace oasis/elf-loader --replace bitstring.ppx ppx_bitstring
   '';
 
   configureFlags = [ "--enable-everything ${disableIda}" "--with-llvm-config=${llvm}/bin/llvm-config" ];

--- a/pkgs/development/ocaml-modules/ppx_bap/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_bap/default.nix
@@ -1,0 +1,51 @@
+{ lib, buildDunePackage
+, fetchFromGitHub
+, ppx_assert
+, ppx_bench
+, ppx_bin_prot
+, ppx_compare
+, ppx_enumerate
+, ppx_hash
+, ppx_here
+, ppx_optcomp
+, ppx_sexp_conv
+, ppx_sexp_value
+}:
+
+buildDunePackage rec {
+  pname = "ppx_bap";
+  version = "0.14";
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.07";
+
+  src = fetchFromGitHub {
+    owner = "BinaryAnalysisPlatform";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1c6rcdp8bicdiwqc2mb59cl9l2vxlp3y8hmnr9x924fq7acly248";
+  };
+
+  buildInputs = [
+    ppx_optcomp
+    ppx_sexp_value
+  ];
+
+  propagatedBuildInputs = [
+    ppx_assert
+    ppx_bench
+    ppx_bin_prot
+    ppx_compare
+    ppx_enumerate
+    ppx_hash
+    ppx_here
+    ppx_sexp_conv
+  ];
+
+  meta = {
+    description = "The set of ppx rewriters for BAP";
+    license = lib.licenses.mit;
+    inherit (src.meta) homepage;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14671,7 +14671,7 @@ in
   libbacktrace = callPackage ../development/libraries/libbacktrace { };
 
   libbap = callPackage ../development/libraries/libbap {
-    inherit (ocaml-ng.ocamlPackages_4_07) bap ocaml findlib ctypes;
+    inherit (ocaml-ng.ocamlPackages) bap ocaml findlib ctypes;
   };
 
   libbass = (callPackage ../development/libraries/audio/libbass { }).bass;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -917,6 +917,8 @@ let
       inherit (pkgs) postgresql;
     };
 
+    ppx_bap = callPackage ../development/ocaml-modules/ppx_bap { };
+
     ppx_bitstring = callPackage ../development/ocaml-modules/bitstring/ppx.nix { };
 
     ppxfind = callPackage ../development/ocaml-modules/ppxfind { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -878,7 +878,7 @@ in {
 
   bandit = callPackage ../development/python-modules/bandit { };
 
-  bap = callPackage ../development/python-modules/bap { bap = pkgs.ocaml-ng.ocamlPackages_4_07.bap; };
+  bap = callPackage ../development/python-modules/bap { inherit (pkgs.ocaml-ng.ocamlPackages) bap; };
 
   baron = callPackage ../development/python-modules/baron { };
 


### PR DESCRIPTION
###### Motivation for this change

Support for recent OCaml.

cc maintainer @maurer

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
