### PR TITLE
[20.09] release-combined: remove flaky boot.biosUsb

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -56,7 +56,9 @@ in rec {
         (onSystems ["x86_64-linux"] "nixos.ova")
         (onSystems ["aarch64-linux"] "nixos.sd_image")
         (onSystems ["x86_64-linux"] "nixos.tests.boot.biosCdrom")
-        (onSystems ["x86_64-linux"] "nixos.tests.boot.biosUsb")
+        # Flaky test, blocking the release channel far too often.
+        # https://github.com/NixOS/nixpkgs/issues/15690
+        # (onSystems ["x86_64-linux"] "nixos.tests.boot.biosUsb")
         (onFullSupported "nixos.tests.boot-stage1")
         (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiCdrom")
         (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiUsb")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Channel blocks too often and for too long because of this test.

Not doing this on master, because the test should be fixed; not disabled. The release has different priorities though, because basically no boot related development happens there.

https://github.com/NixOS/nixpkgs/issues/15690

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
