### PR TITLE
calibre-web: init at 0.6.11

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -885,6 +885,7 @@
   ./services/web-apps/atlassian/crowd.nix
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/bookstack.nix
+  ./services/web-apps/calibre-web.nix
   ./services/web-apps/convos.nix
   ./services/web-apps/cryptpad.nix
   ./services/web-apps/documize.nix

--- a/nixos/modules/services/web-apps/calibre-web.nix
+++ b/nixos/modules/services/web-apps/calibre-web.nix
@@ -1,0 +1,165 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.calibre-web;
+
+  inherit (lib) concatStringsSep mkEnableOption mkIf mkOption optional optionalString types;
+in
+{
+  options = {
+    services.calibre-web = {
+      enable = mkEnableOption "Calibre-Web";
+
+      listen = {
+        ip = mkOption {
+          type = types.str;
+          default = "::1";
+          description = ''
+            IP address that Calibre-Web should listen on.
+          '';
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 8083;
+          description = ''
+            Listen port for Calibre-Web.
+          '';
+        };
+      };
+
+      dataDir = mkOption {
+        type = types.str;
+        default = "calibre-web";
+        description = ''
+          The directory below <filename>/var/lib</filename> where Calibre-Web stores its data.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "calibre-web";
+        description = "User account under which Calibre-Web runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "calibre-web";
+        description = "Group account under which Calibre-Web runs.";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Open ports in the firewall for the server.
+        '';
+      };
+
+      options = {
+        calibreLibrary = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = ''
+            Path to Calibre library.
+          '';
+        };
+
+        enableBookConversion = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Configure path to the Calibre's ebook-convert in the DB.
+          '';
+        };
+
+        enableBookUploading = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Allow books to be uploaded via Calibre-Web UI.
+          '';
+        };
+
+        reverseProxyAuth = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Enable authorization using auth proxy.
+            '';
+          };
+
+          header = mkOption {
+            type = types.str;
+            default = "";
+            description = ''
+              Auth proxy header name.
+            '';
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.calibre-web = let
+      appDb = "/var/lib/${cfg.dataDir}/app.db";
+      gdriveDb = "/var/lib/${cfg.dataDir}/gdrive.db";
+      calibreWebCmd = "${pkgs.calibre-web}/bin/calibre-web -p ${appDb} -g ${gdriveDb}";
+
+      settings = concatStringsSep ", " (
+        [
+          "config_port = ${toString cfg.listen.port}"
+          "config_uploading = ${if cfg.options.enableBookUploading then "1" else "0"}"
+          "config_allow_reverse_proxy_header_login = ${if cfg.options.reverseProxyAuth.enable then "1" else "0"}"
+          "config_reverse_proxy_login_header_name = '${cfg.options.reverseProxyAuth.header}'"
+        ]
+        ++ optional (cfg.options.calibreLibrary != null) "config_calibre_dir = '${cfg.options.calibreLibrary}'"
+        ++ optional cfg.options.enableBookConversion "config_converterpath = '${pkgs.calibre}/bin/ebook-convert'"
+      );
+    in
+      {
+        description = "Web app for browsing, reading and downloading eBooks stored in a Calibre database";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+
+          StateDirectory = cfg.dataDir;
+          ExecStartPre = pkgs.writeShellScript "calibre-web-pre-start" (
+            ''
+              __RUN_MIGRATIONS_AND_EXIT=1 ${calibreWebCmd}
+
+              ${pkgs.sqlite}/bin/sqlite3 ${appDb} "update settings set ${settings}"
+            '' + optionalString (cfg.options.calibreLibrary != null) ''
+              test -f ${cfg.options.calibreLibrary}/metadata.db || { echo "Invalid Calibre library"; exit 1; }
+            ''
+          );
+
+          ExecStart = "${calibreWebCmd} -i ${cfg.listen.ip}";
+          Restart = "on-failure";
+        };
+      };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.listen.port ];
+    };
+
+    users.users = mkIf (cfg.user == "calibre-web") {
+      calibre-web = {
+        isSystemUser = true;
+        group = cfg.group;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "calibre-web") {
+      calibre-web = {};
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ pborzenkov ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -49,6 +49,7 @@ in
   cadvisor = handleTestOn ["x86_64-linux"] ./cadvisor.nix {};
   cage = handleTest ./cage.nix {};
   cagebreak = handleTest ./cagebreak.nix {};
+  calibre-web = handleTest ./calibre-web.nix {};
   cassandra_2_1 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_2_1; };
   cassandra_2_2 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_2_2; };
   cassandra_3_0 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_3_0; };

--- a/nixos/tests/calibre-web.nix
+++ b/nixos/tests/calibre-web.nix
@@ -1,0 +1,53 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+
+    let
+      port = 3142;
+      defaultPort = 8083;
+    in
+      with lib;
+      {
+        name = "calibre-web";
+        meta.maintainers = with pkgs.lib.maintainers; [ pborzenkov ];
+
+        nodes = {
+          default = { ... }: {
+            services.calibre-web.enable = true;
+          };
+
+          customized = { pkgs, ... }: {
+            services.calibre-web = {
+              enable = true;
+              listen.port = port;
+              options = {
+                calibreLibrary = "/tmp/books";
+                reverseProxyAuth = {
+                  enable = true;
+                  header = "X-User";
+                };
+              };
+            };
+            environment.systemPackages = [ pkgs.calibre ];
+          };
+        };
+        testScript = ''
+          start_all()
+
+          default.wait_for_unit("calibre-web.service")
+          default.wait_for_open_port(${toString defaultPort})
+          default.succeed(
+              "curl --fail 'http://localhost:${toString defaultPort}/basicconfig' | grep -q 'Basic Configuration'"
+          )
+
+          customized.succeed(
+              "mkdir /tmp/books && calibredb --library-path /tmp/books add -e --title test-book"
+          )
+          customized.succeed("systemctl restart calibre-web")
+          customized.wait_for_unit("calibre-web.service")
+          customized.wait_for_open_port(${toString port})
+          customized.succeed(
+              "curl --fail -H X-User:admin 'http://localhost:${toString port}' | grep -q test-book"
+          )
+        '';
+      }
+)

--- a/pkgs/servers/calibre-web/db-migrations.patch
+++ b/pkgs/servers/calibre-web/db-migrations.patch
@@ -1,0 +1,14 @@
+diff --git a/cps/__init__.py b/cps/__init__.py
+index 627cca0b..233bb2dd 100644
+--- a/cps/__init__.py
++++ b/cps/__init__.py
+@@ -87,6 +87,9 @@ db.CalibreDB.setup_db(config, cli.settingspath)
+ 
+ calibre_db = db.CalibreDB()
+ 
++if os.environ.get('__RUN_MIGRATIONS_AND_EXIT'):
++    sys.exit(0)
++
+ def create_app():
+     app.wsgi_app = ReverseProxied(app.wsgi_app)
+     # For python2 convert path to unicode

--- a/pkgs/servers/calibre-web/default-logger.patch
+++ b/pkgs/servers/calibre-web/default-logger.patch
@@ -1,0 +1,17 @@
+diff --git a/cps/logger.py b/cps/logger.py
+index b204de31..3206e2bf 100644
+--- a/cps/logger.py
++++ b/cps/logger.py
+@@ -32,10 +32,10 @@ ACCESS_FORMATTER_TORNADO = Formatter("[%(asctime)s] %(message)s")
+ 
+ FORMATTER           = Formatter("[%(asctime)s] %(levelname)5s {%(name)s:%(lineno)d} %(message)s")
+ DEFAULT_LOG_LEVEL   = logging.INFO
+-DEFAULT_LOG_FILE    = os.path.join(_CONFIG_DIR, "calibre-web.log")
+-DEFAULT_ACCESS_LOG  = os.path.join(_CONFIG_DIR, "access.log")
+ LOG_TO_STDERR       = '/dev/stderr'
+ LOG_TO_STDOUT       = '/dev/stdout'
++DEFAULT_LOG_FILE    = LOG_TO_STDOUT
++DEFAULT_ACCESS_LOG  = LOG_TO_STDOUT
+ 
+ logging.addLevelName(logging.WARNING, "WARN")
+ logging.addLevelName(logging.CRITICAL, "CRIT")

--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, nixosTests
 , python3
 , python3Packages
 }:
@@ -58,6 +59,8 @@ python3.pkgs.buildPythonApplication rec {
     unidecode
     Wand
   ];
+
+  passthru.tests.calibre-web = nixosTests.calibre-web;
 
   meta = with lib; {
     description = "Web app for browsing, reading and downloading eBooks stored in a Calibre database";

--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, fetchFromGitHub
+, python3
+, python3Packages
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "calibre-web";
+  version = "0.6.11";
+
+  src = fetchFromGitHub {
+    owner = "janeczku";
+    repo = "calibre-web";
+    rev = version;
+    sha256 = "10sjllhhcamswpa1wlim4mbm2zl4g804bwly5p4nmklg7n1v226g";
+  };
+
+  prePatch = ''
+    substituteInPlace setup.cfg \
+        --replace "requests>=2.11.1,<2.25.0" "requests>=2.11.1,<2.26.0" \
+        --replace "cps = calibreweb:main" "calibre-web = calibreweb:main"
+  '';
+
+  patches = [
+    # default-logger.patch switches default logger to /dev/stdout. Otherwise calibre-web tries to open a file relative
+    # to its location, which can't be done as the store is read-only. Log file location can later be configured using UI
+    # if needed.
+    ./default-logger.patch
+    # DB migrations adds an env var __RUN_MIGRATIONS_ANDEXIT that, when set, instructs calibre-web to run DB migrations
+    # and exit. This is gonna be used to configure calibre-web declaratively, as most of its configuration parameters
+    # are stored in the DB.
+    ./db-migrations.patch
+  ];
+
+  # calibre-web doesn't follow setuptools directory structure. The following is taken from the script
+  # that calibre-web's maintainer is using to package it:
+  # https://github.com/OzzieIsaacs/calibre-web-test/blob/master/build/make_release.py
+  postPatch = ''
+    mkdir -p src/calibreweb
+    mv cps.py src/calibreweb/__init__.py
+    mv cps src/calibreweb
+  '';
+
+  # Upstream repo doesn't provide any tests.
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [
+    backports_abc
+    flask-babel
+    flask_login
+    flask_principal
+    iso-639
+    pypdf2
+    requests
+    singledispatch
+    sqlalchemy
+    tornado
+    unidecode
+    Wand
+  ];
+
+  meta = with lib; {
+    description = "Web app for browsing, reading and downloading eBooks stored in a Calibre database";
+    maintainers = with maintainers; [ pborzenkov ];
+    homepage = "https://github.com/janeczku/calibre-web";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21817,6 +21817,8 @@ in
 
   calibre = libsForQt5.callPackage ../applications/misc/calibre { };
 
+  calibre-web = callPackage ../servers/calibre-web { };
+
   calligra = libsForQt5.callPackage ../applications/office/calligra {
     # Must use the same Qt version as Calligra itself:
     poppler = libsForQt5.poppler_0_61;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The PR adds `calibre-web` package, which is a Web frontend for Calibre ebook management software.

There are two patches applied to `calibre-web` in order to make it more
NixOS friendly:

  - default-logger.patch switches default log output to /dev/stdout, as
    otherwise calibre-web tries to open a file relative to its location,
    which it can't do as the store is read-only. It's not possible to
    pass log file location via command line flags.

  - run-migrations.patch adds a cli flag that instructs calibre-web to
    run DB migrations and exit. As almost all config parameters are
    configured via UI in sqlite3 DB, this patch allows the DB to be
    pre-created so it can be updated by systemd pre-start script later.
    Thus, allowing calibre-web to be configured declaratively.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
