### PR TITLE
nixos/plymouth: use bgrt theme

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -24,6 +24,7 @@ let
   configFile = pkgs.writeText "plymouthd.conf" ''
     [Daemon]
     ShowDelay=0
+    DeviceTimeout=8
     Theme=${cfg.theme}
     ${cfg.extraConfig}
   '';

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -118,6 +118,12 @@ in
       copy_bin_and_libs ${pkgs.plymouth}/bin/plymouthd
       copy_bin_and_libs ${pkgs.plymouth}/bin/plymouth
 
+      # Check if the actual requested theme is here
+      if [[ ! -d ${themesEnv}/share/plymouth/themes/${cfg.theme} ]]; then
+          echo "The requested theme: ${cfg.theme} is not provided by any of the packages in boot.plymouth.themePackages"
+          exit 1
+      fi
+
       moduleName="$(sed -n 's,ModuleName *= *,,p' ${themesEnv}/share/plymouth/themes/${cfg.theme}/${cfg.theme}.plymouth)"
 
       mkdir -p $out/lib/plymouth/renderers

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -86,7 +86,8 @@ in
 
       logo = mkOption {
         type = types.path;
-        default = "${nixos-icons}/share/icons/hicolor/128x128/apps/nix-snowflake.png";
+        # Dimensions are 48x48 to match GDM logo
+        default = "${nixos-icons}/share/icons/hicolor/48x48/apps/nix-snowflake-white.png";
         defaultText = ''pkgs.fetchurl {
           url = "https://nixos.org/logo/nixos-hires.png";
           sha256 = "1ivzgd7iz0i06y36p8m5w48fd8pjqwxhdaavc0pxs7w1g7mcy5si";

--- a/pkgs/os-specific/linux/plymouth/default.nix
+++ b/pkgs/os-specific/linux/plymouth/default.nix
@@ -1,64 +1,111 @@
-{ stdenv, fetchurl, autoreconfHook, pkg-config, libxslt, docbook_xsl
-, gtk3, udev, systemd, lib
+{ lib
+, stdenv
+, fetchpatch
+, fetchFromGitLab
+, pkg-config
+, autoreconfHook
+, libxslt
+, docbook-xsl-nons
+, gettext
+, gtk3
+, systemd
+, pango
+, cairo
+, libdrm
 }:
 
 stdenv.mkDerivation rec {
-  pname = "plymouth";
-  version = "0.9.4";
+  pname = "plymouth-unstable";
+  version = "2020-12-07";
 
-  src = fetchurl {
-    url = "https://www.freedesktop.org/software/plymouth/releases/${pname}-${version}.tar.xz";
-    sha256 = "0l8kg7b2vfxgz9gnrn0v2w4jvysj2cirp0nxads5sy05397pl6aa";
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "plymouth";
+    repo = "plymouth";
+    rev = "c4ced2a2d70edea7fbb95274aa1d01d95928df1b";
+    sha256 = "7CPuKMA0fTt8DBsaA4Td74kHT/O7PW8N3awP04nUnOI=";
   };
 
   nativeBuildInputs = [
-    autoreconfHook pkg-config libxslt docbook_xsl
+    autoreconfHook
+    docbook-xsl-nons
+    gettext
+    libxslt
+    pkg-config
   ];
 
   buildInputs = [
-    gtk3 udev systemd
+    cairo
+    gtk3
+    libdrm
+    pango
+    systemd
+  ];
+
+  patches = [
+    # KillMode=none is deprecated
+    # https://gitlab.freedesktop.org/plymouth/plymouth/-/issues/123
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/plymouth/plymouth/-/commit/b406b0895a95949db2adfedaeda451f36f2b51c3.patch";
+      sha256 = "/UBImNuFO0G/oxlttjGIXon8YXMXlc9XU8uVuR9QuxY=";
+    })
   ];
 
   postPatch = ''
     sed -i \
-      -e "s#\$(\$PKG_CONFIG --variable=systemdsystemunitdir systemd)#$out/etc/systemd/system#g" \
       -e "s#plymouthplugindir=.*#plymouthplugindir=/etc/plymouth/plugins/#" \
       -e "s#plymouththemedir=.*#plymouththemedir=/etc/plymouth/themes#" \
       -e "s#plymouthpolicydir=.*#plymouthpolicydir=/etc/plymouth/#" \
+      -e "s#plymouthconfdir=.*#plymouthconfdir=/etc/plymouth/#" \
       configure.ac
   '';
 
+  configurePlatforms = [ "host" ];
+
   configureFlags = [
-    "--sysconfdir=/etc"
-    "--with-systemdunitdir=${placeholder "out"}/etc/systemd/system"
-    "--localstatedir=/var"
-    "--with-logo=/etc/plymouth/logo.png"
-    "--with-background-color=0x000000"
-    "--with-background-start-color-stop=0x000000"
-    "--with-background-end-color-stop=0x000000"
-    "--with-release-file=/etc/os-release"
-    "--without-system-root-install"
-    "--without-rhgb-compat-link"
-    "--enable-tracing"
-    "--enable-systemd-integration"
-    "--enable-pango"
-    "--enable-gdm-transition"
+    "--enable-documentation"
+    "--enable-drm"
     "--enable-gtk"
+    "--enable-pango"
+    "--enable-systemd-integration"
+    "--enable-tracing"
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "--with-background-color=0x000000"
+    "--with-background-end-color-stop=0x000000"
+    "--with-background-start-color-stop=0x000000"
+    "--with-logo=/etc/plymouth/logo.png"
+    "--with-release-file=/etc/os-release"
+    "--with-runtimedir=/run"
+    "--with-systemdunitdir=${placeholder "out"}/etc/systemd/system"
+    "--without-rhgb-compat-link"
+    "--without-system-root-install"
     "ac_cv_path_SYSTEMD_ASK_PASSWORD_AGENT=${lib.getBin systemd}/bin/systemd-tty-ask-password-agent"
   ];
 
-  configurePlatforms = [ "host" ];
-
   installFlags = [
-    "plymouthd_defaultsdir=$(out)/share/plymouth"
-    "plymouthd_confdir=$(out)/etc/plymouth"
+    "localstatedir=\${TMPDIR}"
+    "plymouthd_confdir=${placeholder "out"}/etc/plymouth"
+    "plymouthd_defaultsdir=${placeholder "out"}/share/plymouth"
+    "sysconfdir=${placeholder "out"}/etc"
   ];
 
+  postInstall = ''
+    # Makes a symlink to /usr/share/pixmaps/system-logo-white.png
+    # We'll handle it in the nixos module.
+    rm $out/share/plymouth/themes/spinfinity/header-image.png
+  '';
+
   meta = with lib; {
-    homepage = "http://www.freedesktop.org/wiki/Software/Plymouth";
-    description = "A graphical boot animation";
-    license = licenses.gpl2;
-    maintainers = [ maintainers.goibhniu ];
+    homepage = "https://www.freedesktop.org/wiki/Software/Plymouth/";
+    description = "Boot splash and boot logger";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.goibhniu teams.gnome.members ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
#### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/pull/84158.
In a followup I'd like to pick up or encourage @puckipedia towards https://github.com/NixOS/nixpkgs/pull/88789. LUKS+ZFS is a tentative goal to having plymouth working entirely as expected.

This pull request focuses on getting "FlickerFree Boot" with the BGRT theme, an initiative from Fedora https://fedoraproject.org/wiki/Changes/FlickerFreeBoot, that now (as usual because RedHat values) other projects can benefit from. Most recently (IIRC), Ubuntu is using the master branch of plymouth. Whether plymouth is ready for release is debated, but if you look at this pull request certain polishing upstream is needed, but if you want it we certainly can use it.

I tested this pull request on a machine with using i915 and it worked pretty well, nothing seemed weird.
Here's an actual example of how the bootsplash should look: https://ic.pics.livejournal.com/hansdegoede/13347631/433/433_900.png, with a vendor image, a logo, and spinner. 

If you want to see examples in other situations the mockup is useful: https://gitlab.gnome.org/Teams/Design/os-mockups/-/blob/master/boot/boot-progress.png, but they changed the shutdown to be the same as the startup.

#### Todo's:
- [x] Need a better logo available

~We need something monochromatic, the current image we have looks too big and draws too much attention to itself.
Mentioned this in https://github.com/NixOS/nixos-artwork/pull/58.~

- [x] Switch to the white version of the nixos logo https://github.com/NixOS/nixpkgs/pull/114276
  - [x] Merge https://github.com/NixOS/nixos-artwork/pull/59 and update nixos-artwork

- [x] We need to sync the GDM logo with this logo change for a smooth transition https://github.com/NixOS/nixpkgs/pull/114387

- [ ] Testing for AMD+Nvidia users would be helpful but isn't required

- [x] logo doesn't show up at shutdown
In initrd we copy these logo's, but on the actual system we
would need to use `environment.etc`. However, when I try to do this I get `ln permission denied` errors.  It's also rather confusing that in initrd everything is in $out/share,  but on the running system it's /etc. ~This might require patching all theme files `ImageDir` to /run/current-system, and using `runCommand` to get an installable derivation with the logos?
It seems the source code attempts to change directory to the location of the image files, so no XDG_DATA_DIRS.~
Why doesn't plymouth use the logo path it's configured to use?
 

#### Questions:
In pull request the following nix code is added:
```nix
boot.initrd.availableKernelModules = [ "i915" ];
```

also part of the work done by Fedora to get fastboot enabled for Intel users.
This sort of thing is a part of nixos-hardware, but I think ideally nixos really should have some base profiles that `nixos-generate-hardware` detects and adds like https://github.com/NixOS/nixos-hardware/blob/0cb5491af9da8d6f16540ffc4db24e2361852e46/flake.nix#L77
Perhaps in the release note nixos-hardware can be mentioned or just the configuration for intel users if they're not already using it.

#### Thanks
@eadwu and @andersk were motivation to finally fix this


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
