### PR TITLE
nerdctl: correct shas to match 0.6.0

### DIFF
--- a/pkgs/applications/networking/cluster/nerdctl/default.nix
+++ b/pkgs/applications/networking/cluster/nerdctl/default.nix
@@ -15,10 +15,10 @@ buildGoModule rec {
     owner = "AkihiroSuda";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-lSvYiTh67gK9kJls7VsayV8T3H6RzFEEKe49BOWnUBw=";
+    sha256 = "sha256-QhAN30ge0dbC9dGT1yP4o0VgrcS9+g+r6YJ07ZjPJtg=";
   };
 
-  vendorSha256 = "sha256-qywiaNoO3pI7sfyPbwWR8BLd86RvJ2xSWwCJUsm3RkM=";
+  vendorSha256 = "sha256-bX1GfKbAbdEAnW3kPNsbF/cJWufxvuhm//G88qJ3u08=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -30,6 +30,9 @@ buildGoModule rec {
     "-X github.com/AkihiroSuda/nerdctl/pkg/version.Revision=<unknown>"
   ];
 
+  # Many checks require a containerd socket and running nerdctl after it's built
+  doCheck = false;
+
   postInstall = ''
     wrapProgram $out/bin/nerdctl \
       --prefix PATH : "${lib.makeBinPath ([ buildkit ] ++ extraPackages)}" \
@@ -39,6 +42,9 @@ buildGoModule rec {
   doInstallCheck = true;
   installCheckPhase = ''
     runHook preInstallCheck
+    # nerdctl expects XDG_RUNTIME_DIR to be set
+    export XDG_RUNTIME_DIR=$TMPDIR
+
     $out/bin/nerdctl --help
     # --version will error without containerd.sock access
     $out/bin/nerdctl --help | grep "${version}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In my last version bump my script failed to swap out the shas
This PR corrects that

Not sure if there's any special process to correct this

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
