### PR TITLE
fix idris with megaparsec override

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -695,7 +695,7 @@ self: super: {
         # compatibility with haskeline >= 0.8
         url = "https://github.com/idris-lang/Idris-dev/commit/89a87cf666eb8b27190c779e72d0d76eadc1bc14.patch";
         sha256 = "0fv493zlpgjsf57w0sncd4vqfkabfczp3xazjjmqw54m9rsfix35";
-      })
+      }),
       (pkgs.fetchpatch {
         # compatibility with megaparsec >= 9
         url = "https://github.com/idris-lang/Idris-dev/commit/6ea9bc913877d765048d7cdb7fc5aec60b196fac.patch";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -695,7 +695,7 @@ self: super: {
         # compatibility with haskeline >= 0.8
         url = "https://github.com/idris-lang/Idris-dev/commit/89a87cf666eb8b27190c779e72d0d76eadc1bc14.patch";
         sha256 = "0fv493zlpgjsf57w0sncd4vqfkabfczp3xazjjmqw54m9rsfix35";
-      }),
+      })
       (pkgs.fetchpatch {
         # compatibility with megaparsec >= 9
         url = "https://github.com/idris-lang/Idris-dev/commit/6ea9bc913877d765048d7cdb7fc5aec60b196fac.patch";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -690,13 +690,18 @@ self: super: {
   # * We need a patch from master to fix compilation with haskeline 0.8.0
   #   which can be removed as soon as idris 1.3.4 hits presumably.
   idris = generateOptparseApplicativeCompletion "idris" (doJailbreak (dontCheck
-    (appendPatch (super.idris.override {
-      megaparsec = self.megaparsec_8_0_0;
-    }) (pkgs.fetchpatch {
-      # compatibility with haskeline >= 0.8
-      url = "https://github.com/idris-lang/Idris-dev/commit/89a87cf666eb8b27190c779e72d0d76eadc1bc14.patch";
-      sha256 = "0fv493zlpgjsf57w0sncd4vqfkabfczp3xazjjmqw54m9rsfix35";
-    }))
+    (appendPatches super.idris [
+      (pkgs.fetchpatch {
+        # compatibility with haskeline >= 0.8
+        url = "https://github.com/idris-lang/Idris-dev/commit/89a87cf666eb8b27190c779e72d0d76eadc1bc14.patch";
+        sha256 = "0fv493zlpgjsf57w0sncd4vqfkabfczp3xazjjmqw54m9rsfix35";
+      }),
+      (pkgs.fetchpatch {
+        # compatibility with megaparsec >= 9
+        url = "https://github.com/idris-lang/Idris-dev/commit/6ea9bc913877d765048d7cdb7fc5aec60b196fac.patch";
+        sha256 = "0yms74d1xdxd1c08dnp45nb1ddzq54n6hqgzxx0r494wy614ir8q";
+      })
+    )
   ));
 
   # https://github.com/pontarius/pontarius-xmpp/issues/105

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -684,11 +684,19 @@ self: super: {
     '';
   });
 
-  # The standard libraries are compiled separately.
-  # Megaparsec override is needed because https://github.com/idris-lang/Idris-dev/issues/4826
-  # declares idris1 has no plans to migrate to megaparsec-9
+  # * The standard libraries are compiled separately.
+  # * Megaparsec override is needed because https://github.com/idris-lang/Idris-dev/issues/4826
+  #   declares idris1 has no plans to migrate to megaparsec-9
+  # * We need a patch from master to fix compilation with haskeline 0.8.0
+  #   which can be removed as soon as idris 1.3.4 hits presumably.
   idris = generateOptparseApplicativeCompletion "idris" (doJailbreak (dontCheck
-    (super.idris.override { megaparsec = self.megaparsec_8_0_0; })
+    (appendPatch (super.idris.override {
+      megaparsec = self.megaparsec_8_0_0;
+    }) (pkgs.fetchpatch {
+      # compatibility with haskeline >= 0.8
+      url = "https://github.com/idris-lang/Idris-dev/commit/89a87cf666eb8b27190c779e72d0d76eadc1bc14.patch";
+      sha256 = "0fv493zlpgjsf57w0sncd4vqfkabfczp3xazjjmqw54m9rsfix35";
+    }))
   ));
 
   # https://github.com/pontarius/pontarius-xmpp/issues/105

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -695,13 +695,13 @@ self: super: {
         # compatibility with haskeline >= 0.8
         url = "https://github.com/idris-lang/Idris-dev/commit/89a87cf666eb8b27190c779e72d0d76eadc1bc14.patch";
         sha256 = "0fv493zlpgjsf57w0sncd4vqfkabfczp3xazjjmqw54m9rsfix35";
-      }),
+      })
       (pkgs.fetchpatch {
         # compatibility with megaparsec >= 9
         url = "https://github.com/idris-lang/Idris-dev/commit/6ea9bc913877d765048d7cdb7fc5aec60b196fac.patch";
         sha256 = "0yms74d1xdxd1c08dnp45nb1ddzq54n6hqgzxx0r494wy614ir8q";
       })
-    )
+    ])
   ));
 
   # https://github.com/pontarius/pontarius-xmpp/issues/105

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -685,7 +685,11 @@ self: super: {
   });
 
   # The standard libraries are compiled separately.
-  idris = generateOptparseApplicativeCompletion "idris" (dontCheck super.idris);
+  # Megaparsec override is needed because https://github.com/idris-lang/Idris-dev/issues/4826
+  # declares idris1 has no plans to migrate to megaparsec-9
+  idris = generateOptparseApplicativeCompletion "idris" (doJailbreak (dontCheck
+    (super.idris.override { megaparsec = self.megaparsec_8_0_0; })
+  ));
 
   # https://github.com/pontarius/pontarius-xmpp/issues/105
   pontarius-xmpp = dontCheck super.pontarius-xmpp;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2724,7 +2724,6 @@ extra-packages:
   - haskell-lsp == 0.23.0.0             # required by hls-plugin-api 0.7.0.0, 2021-02-08
   - haskell-lsp-types == 0.23.0.0       # required by hls-plugin-api 0.7.0.0, 2021-02-08
   - lsp-test == 0.11.0.7                # required by hls-plugin-api 0.7.0.0, 2021-02-08
-  - megaparsec == 8.0.0                 # required by idris 1.3.3 https://github.com/idris-lang/Idris-dev/issues/4826
 
 package-maintainers:
   peti:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2724,6 +2724,7 @@ extra-packages:
   - haskell-lsp == 0.23.0.0             # required by hls-plugin-api 0.7.0.0, 2021-02-08
   - haskell-lsp-types == 0.23.0.0       # required by hls-plugin-api 0.7.0.0, 2021-02-08
   - lsp-test == 0.11.0.7                # required by hls-plugin-api 0.7.0.0, 2021-02-08
+  - megaparsec == 8.0.0                 # required by idris 1.3.3 https://github.com/idris-lang/Idris-dev/issues/4826
 
 package-maintainers:
   peti:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6997,7 +6997,6 @@ broken-packages:
   - identifiers
   - idiii
   - idna2008
-  - idris
   - IDynamic
   - ieee-utils
   - iexcloud


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Idris 1.3.3 is broken

https://github.com/NixOS/nixpkgs/issues/86500

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
