### PR TITLE
mastodon-assets: build all assets

### DIFF
--- a/pkgs/servers/mastodon/default.nix
+++ b/pkgs/servers/mastodon/default.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation rec {
       fi
       chmod -R u+w node_modules
       rake webpacker:compile
+      rails assets:precompile
     '';
 
     installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Fixing missing files.
Before updating:
```
l /nix/store/18xhsy0nigdiz155q7qk1im7l2vx2f7h-mastodon-assets-3.3.0/public/assets
итого 48K
dr-xr-xr-x 2 root root    3 янв  1  1970 .
dr-xr-xr-x 4 root root    4 янв  1  1970 ..
-r--r--r-- 2 root root 104K янв  1  1970 sw.js
```
After update:
```
l /nix/store/fnk8zn8dqhskz7nzdq3y63lwiavjidg3-mastodon-assets-3.3.0/public/assets
итого 82K
dr-xr-xr-x 4 root root    7 янв  1  1970 .
dr-xr-xr-x 4 root root    4 янв  1  1970 ..
-r--r--r-- 1 root root  894 янв  1  1970 500.html
dr-xr-xr-x 3 root root    5 янв  1  1970 doorkeeper
dr-xr-xr-x 2 root root    7 янв  1  1970 pghero
-r--r--r-- 1 root root 2,2K янв  1  1970 .sprockets-manifest-78a0d15e693725519f88dd0cac948b57.json
-r--r--r-- 1 root root 104K янв  1  1970 sw.js
```

cc @erictapen @happy-river

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
