### PR TITLE
mindustry,mindustry-server: 124.1 -> 125.1

### DIFF
--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -29,20 +29,20 @@ let
   # Note: when raising the version, ensure that all SNAPSHOT versions in
   # build.gradle are replaced by a fixed version
   # (the current one at the time of release) (see postPatch).
-  version = "124.1";
+  version = "125.1";
   buildVersion = makeBuildVersion version;
 
   Mindustry = fetchFromGitHub {
     owner = "Anuken";
     repo = "Mindustry";
     rev = "v${version}";
-    sha256 = "1k4k559y8l6wmj9m4980f7xmaaxzx84x86rqc77j4nd3y3x53546";
+    sha256 = "0p05ndxhl3zgwm4k9cbqclp995kvcjxxhmbkmpjvv7cphiw82hvw";
   };
   Arc = fetchFromGitHub {
     owner = "Anuken";
     repo = "Arc";
     rev = "v${version}";
-    sha256 = "08v929sgxy1pclzc00p7l7fak2h9l306447w5k5db3719kacj059";
+    sha256 = "1injdyxwgc9dn49zvr4qggsfrsslkvh5d53z3yv28ayx48qpsgxk";
   };
   soloud = fetchFromGitHub {
     owner = "Anuken";
@@ -114,7 +114,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "18yfchv55f0fza6gdxd3f6gm0m4wy2a9jkw5wgl84id518jal6la";
+    outputHash = "0dk4w8h0kg0mgbn0ifmk29rw8aj917k3nf27qdf1lyr6wl8k7f8k";
   };
 
 in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
