### PR TITLE
pythonPackages.json-rpc: init at 1.13.0

### DIFF
--- a/pkgs/development/python-modules/json-rpc/default.nix
+++ b/pkgs/development/python-modules/json-rpc/default.nix
@@ -1,0 +1,24 @@
+{ lib, isPy27, buildPythonPackage, fetchPypi, pytestCheckHook, mock }:
+
+let
+  pythonEnv = lib.optional isPy27 mock;
+in buildPythonPackage rec {
+  pname = "json-rpc";
+  version = "1.13.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12bmblnznk174hqg2irggx4hd3cq1nczbwkpsqqzr13hbg7xpw6y";
+  };
+
+  checkInputs = pythonEnv ++ [ pytestCheckHook ];
+
+  nativeBuildInputs = pythonEnv;
+
+  meta = with lib; {
+    description = "JSON-RPC 1/2 transport implementation";
+    homepage = "https://github.com/pavlov99/json-rpc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3399,6 +3399,8 @@ in {
 
   jsonref = callPackage ../development/python-modules/jsonref { };
 
+  json-rpc = callPackage ../development/python-modules/json-rpc { };
+
   jsonrpc-async = callPackage ../development/python-modules/jsonrpc-async { };
 
   jsonrpc-base = callPackage ../development/python-modules/jsonrpc-base { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the json-rpc package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
