### PR TITLE
platformio: 5.0.4 -> 5.1.1

### DIFF
--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -1,9 +1,25 @@
-{ stdenv, lib, buildPythonApplication, bottle
-, click, click-completion, colorama, semantic-version
-, lockfile, pyserial, requests
-, tabulate, pyelftools, marshmallow
-, pytest, tox, jsondiff
-, git, spdx-license-list-data
+{ stdenv, lib, buildPythonApplication
+, ajsonrpc
+, bottle
+, click
+, click-completion
+, colorama
+, git
+, jsondiff
+, lockfile
+, marshmallow
+, pyelftools
+, pyserial
+, pytest
+, requests
+, semantic-version
+, spdx-license-list-data
+, starlette
+, tabulate
+, tox
+, uvicorn
+, wsproto
+, zeroconf
 , version, src
 }:
 
@@ -78,10 +94,24 @@ in buildPythonApplication rec {
   pname = "platformio";
   inherit version src;
 
-  propagatedBuildInputs =  [
-    bottle click click-completion colorama git
-    lockfile pyserial requests semantic-version
-    tabulate pyelftools marshmallow
+  propagatedBuildInputs = [
+    ajsonrpc
+    bottle
+    click
+    click-completion
+    colorama
+    git
+    lockfile
+    marshmallow
+    pyelftools
+    pyserial
+    requests
+    semantic-version
+    starlette
+    tabulate
+    uvicorn
+    wsproto
+    zeroconf
   ];
 
   HOME = "/tmp";

--- a/pkgs/development/arduino/platformio/default.nix
+++ b/pkgs/development/arduino/platformio/default.nix
@@ -4,14 +4,14 @@
 let
   callPackage = newScope self;
 
-  version = "5.0.4";
+  version = "5.1.1";
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
   src = fetchFromGitHub {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    sha256 = "15jnhlhkk9z6cyzxw065r3080dqan951klwf65p152vfzg79wf84";
+    sha256 = "1m9vq5r4g04n3ckmb3hrrc4ar5v31k6isc76bw4glrn2xb7r8c00";
   };
 
   self = {

--- a/pkgs/development/arduino/platformio/use-local-spdx-license-list.patch
+++ b/pkgs/development/arduino/platformio/use-local-spdx-license-list.patch
@@ -1,11 +1,15 @@
 diff --git a/platformio/package/manifest/schema.py b/platformio/package/manifest/schema.py
-index f293ba5a..a818271f 100644
+index addc4c5..514b0ad 100644
 --- a/platformio/package/manifest/schema.py
 +++ b/platformio/package/manifest/schema.py
-@@ -252,5 +252,4 @@ class ManifestSchema(BaseSchema):
+@@ -253,9 +253,4 @@ class ManifestSchema(BaseSchema):
      @staticmethod
      @memoized(expire="1h")
      def load_spdx_licenses():
--        spdx_data_url = "https://dl.bintray.com/platformio/dl-misc/spdx-licenses-3.json"
+-        version = "3.12"
+-        spdx_data_url = (
+-            "https://raw.githubusercontent.com/spdx/license-list-data/"
+-            "v%s/json/licenses.json" % version
+-        )
 -        return json.loads(fetch_remote_content(spdx_data_url))
 +        return json.load(open("@SPDX_LICENSE_LIST_DATA@/json/licenses.json"))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update platformio to its latest release. However, to get this changes working, the following pull requests needed to be merged first:

- [x] #112701, python3Packages.starlette: 0.13.8 -> 0.14.2
- [x] #114012, pythonPackages.json-rpc: init at 1.13.0
- [x] #116727, pythonPackages.ajsonrpc: init at 1.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
