### PR TITLE
qemu: fix wrong localstatedir

### DIFF
--- a/nixos/modules/virtualisation/qemu-guest-agent.nix
+++ b/nixos/modules/virtualisation/qemu-guest-agent.nix
@@ -35,6 +35,11 @@ in {
           RestartSec = 0;
         };
       };
+      systemd.sockets.qemu-guest-agent = {
+        description = "QEMU Guest Agent socket";
+        wantedBy = [ "sockets.target" ];
+        listenStreams = [ "/run/qga.sock" ];
+      };
     }
   ]
   );

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -326,6 +326,7 @@ in
   proxy = handleTest ./proxy.nix {};
   pt2-clone = handleTest ./pt2-clone.nix {};
   qboot = handleTestOn ["x86_64-linux" "i686-linux"] ./qboot.nix {};
+  qemu-guest-agent = handleTest ./qemu-guest-agent.nix {};
   quagga = handleTest ./quagga.nix {};
   quorum = handleTest ./quorum.nix {};
   rabbitmq = handleTest ./rabbitmq.nix {};

--- a/nixos/tests/qemu-guest-agent.nix
+++ b/nixos/tests/qemu-guest-agent.nix
@@ -1,0 +1,44 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+let
+  # qemu-ga-execstart = "${pkgs.qemu.ga}/bin/qemu-ga -f /var/run/qemu-ga.pid -m isa-serial";
+  qemu-ga-execstart = "${pkgs.qemu.ga}/bin/qemu-ga -l /var/run/qga.log -f /var/run/qemu-ga.pid";
+
+  print_unit_file = pkgs: unit: pkgs.writeScriptBin "print-${unit}-file" ''
+    #!${pkgs.bash}/bin/bash
+    echo 'UNIT ${unit}: ' 1>&2
+    export UNITFILE=$(systemctl show ${unit}.service | ${pkgs.gnugrep}/bin/grep FragmentPath= | ${pkgs.coreutils}/bin/cut -d= -f2)
+    echo Unit file is : \`$UNITFILE\` 1>&2
+    cat $UNITFILE 1>&2
+    echo 'UNIT FILE END' 1>&2
+  '';
+in
+{
+  name = "qemu-guest-agent";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ shamilton ];
+  };
+
+  nodes = {
+    machine = { pkgs, lib, ... }: {
+      imports = [ ./common/x11.nix ];
+      systemd.services.qemu-guest-agent.serviceConfig.ExecStart = lib.mkForce qemu-ga-execstart;
+      services.qemuGuest.enable = true;
+      environment.systemPackages = with pkgs; [ qemu (print_unit_file pkgs "qemu-guest-agent") ];
+    };
+  };
+
+  testScript = { nodes, ... }: ''
+    start_all()
+    machine.wait_for_x()
+    machine.succeed(
+        "export DISPLAY=:0",
+        "qemu-system-x86_64 &",
+    )
+    machine.succeed("print-qemu-guest-agent-file")
+    machine.succeed("systemctl start qemu-guest-agent.service 1>&2")
+    machine.succeed("systemctl start qemu-guest-agent.socket 1>&2 ")
+    machine.wait_for_unit("qemu-guest-agent.service")
+    machine.succeed("journalctl -xe -u qemu-guest-agent.service 1>&2")
+    machine.succeed("systemctl status qemu-guest-agent.service 1>&2")
+  '';
+})

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -101,6 +101,9 @@ stdenv.mkDerivation rec {
       sha256 = "0wk0rrcqywhrw9hygy6ap0lfg314m9z1wr2hn8338r5gfcw75mav";
     })
   ];
+  postPatch = ''
+    sed -i 's=#define QGA_STATE_RELATIVE_DIR  ".*"=#define QGA_STATE_RELATIVE_DIR  ""=g' qga/main.c
+  '';
 
   hardeningDisable = [ "stackprotector" ];
 
@@ -159,6 +162,9 @@ stdenv.mkDerivation rec {
     done
   '';
   preBuild = "cd build";
+  postConfigure = ''
+    sed -i 's=#define CONFIG_QEMU_LOCALSTATEDIR ".*"=#define CONFIG_QEMU_LOCALSTATEDIR "/run"=g' build/config-host.h
+  '';
 
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/113909

###### Things done

Not sure if this is the fix and I couldn't test it as the build runs out of space. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The easiest way to see if the fix worked is to use 
`nix-build -A nixosTests.qemu-guest-agent`