### PR TITLE
python3Packages.dicom2nifti: 2.2.8 -> 2.2.12

### DIFF
--- a/pkgs/development/python-modules/dicom2nifti/default.nix
+++ b/pkgs/development/python-modules/dicom2nifti/default.nix
@@ -8,11 +8,12 @@
 , numpy
 , pydicom
 , scipy
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "dicom2nifti";
-  version = "2.2.8";
+  version = "2.2.12";
   disabled = isPy27;
 
   # no tests in PyPI dist
@@ -20,10 +21,10 @@ buildPythonPackage rec {
     owner = "icometrix";
     repo = pname;
     rev = version;
-    sha256 = "1qi2map6f4pa1l8wsif7ff7rhja6ynrjlm7w306dzvi9l25mia34";
+    sha256 = "0ddzaw0yasyi2wsh7a6r73cdcmdfbb0nh0k0n4yxp9vnkw1ag5z4";
   };
 
-  propagatedBuildInputs = [ gdcm nibabel numpy pydicom scipy ];
+  propagatedBuildInputs = [ nibabel numpy pydicom scipy setuptools ];
 
   checkInputs = [ nose gdcm ];
   checkPhase = "nosetests tests";


### PR DESCRIPTION
###### Motivation for this change

Routine update

###### Things done

results of `nixpkgs-review`:

```
3 packages updated:
python37Packages.dicom2nifti python38Packages.dicom2nifti python39Packages.dicom2nifti
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
