### PR TITLE
steam: fix proton versions with pressure-vessel

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -4,6 +4,13 @@ with lib;
 
 let
   cfg = config.programs.steam;
+
+  steam = pkgs.steam.override {
+    extraLibraries = pkgs: with config.hardware.opengl;
+      if pkgs.hostPlatform.is64bit
+      then [ package ] ++ extraPackages
+      else [ package32 ] ++ extraPackages32;
+  };
 in {
   options.programs.steam.enable = mkEnableOption "steam";
 
@@ -18,7 +25,7 @@ in {
 
     hardware.steam-hardware.enable = true;
 
-    environment.systemPackages = [ pkgs.steam ];
+    environment.systemPackages = [ steam ];
   };
 
   meta.maintainers = with maintainers; [ mkg20001 ];

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -25,7 +25,7 @@ in {
 
     hardware.steam-hardware.enable = true;
 
-    environment.systemPackages = [ steam ];
+    environment.systemPackages = [ steam steam.run ];
   };
 
   meta.maintainers = with maintainers; [ mkg20001 ];

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, runCommandLocal, writeShellScriptBin, glibc, coreutils, bubblewrap }:
+{ lib, callPackage, runCommandLocal, writeShellScriptBin, glibc, pkgsi686Linux, coreutils, bubblewrap }:
 
 let buildFHSEnv = callPackage ./env.nix { }; in
 
@@ -143,6 +143,11 @@ let
       --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache \
       --ro-bind ${glibc}/etc/rpc ${glibc}/etc/rpc \
       --remount-ro ${glibc}/etc \
+      --tmpfs ${pkgsi686Linux.glibc}/etc \
+      --symlink /etc/ld.so.conf ${pkgsi686Linux.glibc}/etc/ld.so.conf \
+      --symlink /etc/ld.so.cache ${pkgsi686Linux.glibc}/etc/ld.so.cache \
+      --ro-bind ${pkgsi686Linux.glibc}/etc/rpc ${pkgsi686Linux.glibc}/etc/rpc \
+      --remount-ro ${pkgsi686Linux.glibc}/etc \
       ${etcBindFlags}
       "''${ro_mounts[@]}"
       "''${symlinks[@]}"

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -138,6 +138,13 @@ let
       ${lib.optionalString unshareCgroup "--unshare-cgroup"}
       --die-with-parent
       --ro-bind /nix /nix
+      # Our glibc will look for the cache in its own path in `/nix/store`.
+      # As such, we need a cache to exist there, because pressure-vessel
+      # depends on the existence of an ld cache. However, adding one
+      # globally proved to be a bad idea (see #100655), the solution we
+      # settled on being mounting one via bwrap.
+      # Also, the cache needs to go to both 32 and 64 bit glibcs, for games
+      # of both architectures to work.
       --tmpfs ${glibc}/etc \
       --symlink /etc/ld.so.conf ${glibc}/etc/ld.so.conf \
       --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache \

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildEnv, writeText, writeScriptBin, pkgs, pkgsi686Linux }:
+{ stdenv, lib, buildEnv, writeText, writeScriptBin, pkgs, pkgsi686Linux }:
 
 { name, profile ? ""
 , targetPkgs ? pkgs: [], multiPkgs ? pkgs: []
@@ -138,7 +138,20 @@ let
     mkdir -m0755 usr
     cd usr
     ${setupLibDirs}
-    for i in bin sbin share include; do
+    ${lib.optionalString isMultiBuild ''
+    if [ -d "${staticUsrProfileMulti}/share" ]; then
+      cp -rLf ${staticUsrProfileMulti}/share share
+    fi
+    ''}
+    if [ -d "${staticUsrProfileTarget}/share" ]; then
+      if [ -d share ]; then
+        chmod -R 755 share
+        cp -rLTf ${staticUsrProfileTarget}/share share
+      else
+        cp -rLf ${staticUsrProfileTarget}/share share
+      fi
+    fi
+    for i in bin sbin include; do
       if [ -d "${staticUsrProfileTarget}/$i" ]; then
         cp -rsHf "${staticUsrProfileTarget}/$i" "$i"
       fi

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildEnv, writeText, writeScriptBin, pkgs, pkgsi686Linux }:
+{ stdenv, lib, buildEnv, writeText, writeShellScriptBin, pkgs, pkgsi686Linux }:
 
 { name, profile ? ""
 , targetPkgs ? pkgs: [], multiPkgs ? pkgs: []
@@ -49,9 +49,7 @@ let
     [ (toString gcc.cc.lib)
     ];
 
-  ldconfig = writeScriptBin "ldconfig" ''
-    #!${pkgs.stdenv.shell}
-
+  ldconfig = writeShellScriptBin "ldconfig" ''
     exec ${pkgs.glibc.bin}/bin/ldconfig -f /etc/ld.so.conf -C /etc/ld.so.cache "$@"
   '';
   etcProfile = writeText "profile" ''

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -139,6 +139,7 @@ in buildFHSUserEnv rec {
     libcap
 
     # dependencies for mesa drivers, needed inside pressure-vessel
+    mesa.drivers
     expat
     wayland
     xlibs.libxcb

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -134,6 +134,19 @@ in buildFHSUserEnv rec {
     libuuid
     libbsd
     alsaLib
+
+    # needed by getcap for vr startup
+    libcap
+
+    # dependencies for mesa drivers, needed inside pressure-vessel
+    expat
+    wayland
+    xlibs.libxcb
+    xlibs.libXdamage
+    xlibs.libxshmfence
+    xlibs.libXxf86vm
+    llvm_11.lib
+    libelf
   ] ++ (if (!nativeOnly) then [
     (steamPackages.steam-runtime-wrapped.override {
       inherit runtimeOnly;

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -265,6 +265,8 @@ in buildFHSUserEnv rec {
     fi
 
     export STEAM_RUNTIME=${if nativeOnly then "0" else "/steamrt"}
+
+    export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/intel_icd.x86_64.json:/usr/share/vulkan/icd.d/intel_icd.i686.json:/usr/share/vulkan/icd.d/lvp_icd.x86_64.json:/usr/share/vulkan/icd.d/lvp_icd.i686.json:/usr/share/vulkan/icd.d/nvidia_icd.json:/usr/share/vulkan/icd.d/nvidia_icd32.json:/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:/usr/share/vulkan/icd.d/radeon_icd.i686.json
   '' + extraProfile;
 
   runScript = writeScript "steam-wrapper.sh" ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

As detailed in #100655, Proton 5.13 and onward, due to the addition of pressure-vessel, stopped working on NixOS. pressure-vessel implements its own wrapping and distribution logic, and assumes an FHS-compatible environment all across its inner workings. As such, the old way we wrapped Steam was no longer enough. It's still backwards compatible, to allow older Proton to work (maybe some optimization could be done with the knowledge learned here, though). This PR's purpose is to get newer Proton working, hopefully to the same extent it works on other typical FHS distributions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

----

- Tested various 64 and 32 bit games on nvidia (@LuigiPiucco) and amdgpu (@ashkitten);
- Used official (5.13 and Experimental) and unofficial (GE 5.21 and GE 6.1) Proton versions;

###### Additional details

A key component of how pressure-vessel works is `ld.so.cache`. Since neither NixOS nor our Steam bwrap provided one, it failed in multiple ways to find libraries. A cache was added to the bwrapping expression, along with a change to merge `share` folders of 32 and 64 bit packages, preferring 64 bit for conflicting files. This was to bring things like ICDs for both architectures. Environment variables and a few libraries were added to Steam's bwrap, and so were the system's graphics drivers. To this end, the `programs.steam` module was complemented, to add a version of Steam with appropriate drivers to `systemPackages`. As such, it is best to add Steam through `programs.steam.enable = true`, not by making it system-wide yourself.

Possible improvements to this PR include trying to find a better way to pass the system's drivers in a way that pressure-vessel will find them, allowing steam to be added and work without activating the module, and checking documentation to see if already points to `programs.steam`.

Fixes #100655.
Fixes #106571.
Fixes https://github.com/NixOS/nixpkgs/issues/103547