### PR TITLE
python3Packages.batchgenerators: 0.20.1 -> 0.21

### DIFF
--- a/pkgs/development/python-modules/batchgenerators/default.nix
+++ b/pkgs/development/python-modules/batchgenerators/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , isPy27
 , fetchFromGitHub
-, fetchpatch
 , pytestCheckHook
 , unittest2
 , future
@@ -16,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "batchgenerators";
-  version = "0.20.1";
+  version = "0.21";
 
   disabled = isPy27;
 
@@ -24,17 +23,9 @@ buildPythonPackage rec {
     owner = "MIC-DKFZ";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1f91yflv9rschyl5bnfn735hp1rxrzcxkx18aajmlzb067h0ip8m";
+    sha256 = "16bk4r0q3m2c9fawpmj4l7kz0x3fyv1spb92grf44gmyricq3jdb";
 
   };
-
-  patches = [
-    # lift Pillow bound; should be merged in next release
-    (fetchpatch {
-      url = "https://github.com/MIC-DKFZ/batchgenerators/pull/59.patch";
-      sha256 = "171b3dm40yn0wi91m9s2nq3j565s1w39jpdf1mvc03rn75i8vdp0";
-    })
-  ];
 
   propagatedBuildInputs = [
     future numpy pillow scipy scikitlearn scikitimage threadpoolctl


### PR DESCRIPTION

###### Motivation for this change

Routine update.

###### Things done

Result of `nixpkgs-review`:

```
3 packages updated:
python37Packages.batchgenerators (0.20.1 \u2192 0.21) python38Packages.batchgenerators (0.20.1 \u2192 0.21) python39Packages.batchgenerators (0.20.1 \u2192 0.21)
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
