### PR TITLE
catt: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/applications/video/catt/default.nix
+++ b/pkgs/applications/video/catt/default.nix
@@ -1,32 +1,26 @@
 { lib, python3 }:
 
-let
-  py = python3.override {
-    packageOverrides = self: super: {
-      PyChromecast = super.PyChromecast.overridePythonAttrs (oldAttrs: rec {
-        version = "6.0.0";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "05f8r3b2pdqbl76hwi5sv2xdi1r7g9lgm69x8ja5g22mn7ysmghm";
-        };
-      });
-    };
-  };
+with python3.pkgs;
 
-in with py.pkgs; buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "catt";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1vq1wg79b7855za6v6bsfgypm0v3b4wakap4rash45mhzbgjj0kq";
+    sha256 = "sha256-6RUeinHhAvvSz38hHQP5/MXNiY00rCM8k2ONaFYbwPc=";
   };
 
   propagatedBuildInputs = [
-    youtube-dl PyChromecast click ifaddr requests
+    click
+    ifaddr
+    PyChromecast
+    requests
+    youtube-dl
   ];
 
   doCheck = false; # attempts to access various URLs
+  pythonImportsCheck = [ "catt" ];
 
   meta = with lib; {
     description = "Cast All The Things allows you to send videos from many, many online sources to your Chromecast";

--- a/pkgs/development/python-modules/pychromecast/default.nix
+++ b/pkgs/development/python-modules/pychromecast/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "PyChromecast";
-  version = "8.0.0";
+  version = "8.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0dlxgh57j25cvk2pqr2dj4lv6yn0pix2rcl2kzqsg2405rdjks91";
+    sha256 = "sha256-3wKV9lPO51LeOM+O8J8TrZeCxTkk37qhkcpivV4dzhQ=";
   };
 
   disabled = !isPy3k;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.12.0

`catt` now support later `PyChromecast` releases.

Change log: https://github.com/skorokithakis/catt/releases/tag/v0.12.0

Update `PyChromecast` in the process.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
