### PR TITLE
lagrange: 1.1.1 → 1.1.4

### DIFF
--- a/pkgs/applications/networking/browsers/lagrange/default.nix
+++ b/pkgs/applications/networking/browsers/lagrange/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lagrange";
-  version = "1.1.1";
+  version = "1.1.4";
 
   src = fetchFromGitHub {
     owner = "skyjake";
     repo = "lagrange";
     rev = "v${version}";
-    sha256 = "0c7w4a19cwx3bkmbhc9c1wx0zmqd3a1grrj4ffifdic95wdihv7x";
+    sha256 = "sha256-EN0fQ5Scwrd7Tv31upQVbuqoNCoYudtruwtPR1IKTzE=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
