### PR TITLE
ocamlPackages.directories: init at 0.2

### DIFF
--- a/pkgs/development/ocaml-modules/directories/default.nix
+++ b/pkgs/development/ocaml-modules/directories/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchFromGitHub, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "directories";
+  version = "0.2";
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.07";
+
+  src = fetchFromGitHub {
+    owner = "ocamlpro";
+    repo = pname;
+    rev = version;
+    sha256 = "0s7ginh0g0fhw8xf9v58cx99a8q9jqsf4i0p134m5qzf84qpjwff";
+  };
+
+  meta = {
+    homepage = "https://github.com/ocamlpro/directories";
+    description = "An OCaml library that provides configuration, cache and data paths (and more!) following the suitable conventions on Linux, macOS and Windows";
+    longDescription = ''
+      directories is an OCaml library that provides configuration, cache and
+      data paths (and more!) following the suitable conventions on Linux, macOS
+      and Windows. It is inspired by similar libraries for other languages such
+      as directories-jvm.
+
+      The following conventions are used: XDG Base Directory Specification and
+      xdg-user-dirs on Linux, Known Folders on Windows, Standard Directories on
+      macOS.
+    '';
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ bcc32 ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -242,6 +242,8 @@ let
 
     digestif =  callPackage ../development/ocaml-modules/digestif { };
 
+    directories =  callPackage ../development/ocaml-modules/directories { };
+
     dispatch =  callPackage ../development/ocaml-modules/dispatch { };
 
     dns =  callPackage ../development/ocaml-modules/dns { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add `directories`, an OCaml library implementing the XDG Base directory specification, as well as the analogous conventions on macOS and Windows.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
