### PR TITLE
 pythonPackages.fuzzyfinder: init at 2.1.0, caerbannog: init at 0.3 

### DIFF
--- a/pkgs/applications/misc/caerbannog/default.nix
+++ b/pkgs/applications/misc/caerbannog/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchgit
+, python3
+, glib
+, gobject-introspection
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+, atk
+, libhandy
+, libnotify
+, pango
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "caerbannog";
+  version = "0.3";
+  format = "other";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~craftyguy/caerbannog";
+    rev = version;
+    sha256 = "0wqkb9zcllxm3fdsr5lphknkzy8r1cr80f84q200hbi99qql1dxh";
+  };
+
+  nativeBuildInputs = [
+    glib
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    atk
+    gobject-introspection
+    libhandy
+    libnotify
+    pango
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    anytree
+    fuzzyfinder
+    gpgme
+    pygobject3
+  ];
+
+  meta = with lib; {
+    description = "Mobile-friendly Gtk frontend for password-store";
+    homepage = "https://sr.ht/~craftyguy/caerbannog/";
+    changelog = "https://git.sr.ht/~craftyguy/caerbannog/refs/${version}";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/fuzzyfinder/default.nix
+++ b/pkgs/development/python-modules/fuzzyfinder/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "fuzzyfinder";
+  version = "2.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c56d86f110866becad6690c7518f7036c20831c0f82fc87eba8fdb943132f04b";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "fuzzyfinder" ];
+
+  meta = with lib; {
+    description = "Fuzzy Finder implemented in Python";
+    homepage = "https://github.com/amjith/fuzzyfinder";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21444,6 +21444,8 @@ in
 
   bviplus = callPackage ../applications/editors/bviplus { };
 
+  caerbannog = callPackage ../applications/misc/caerbannog { };
+
   cage = callPackage ../applications/window-managers/cage { };
 
   calf = callPackage ../applications/audio/calf {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2481,6 +2481,8 @@ in {
 
   futures = callPackage ../development/python-modules/futures { };
 
+  fuzzyfinder = callPackage ../development/python-modules/fuzzyfinder { };
+
   fuzzywuzzy = callPackage ../development/python-modules/fuzzywuzzy { };
 
   fx2 = callPackage ../development/python-modules/fx2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Heard about it in https://cast.postmarketos.org/episode/03-Librem5-Mainlining-Feedbackd-Plasma521/.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @craftyguy