### PR TITLE
python3Packages.fiblary3: init at 0.1.12

### DIFF
--- a/pkgs/development/python-modules/fiblary3-fork/default.nix
+++ b/pkgs/development/python-modules/fiblary3-fork/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchPypi
+, fixtures
+, jsonpatch
+, netaddr
+, prettytable
+, python-dateutil
+, pytestCheckHook
+, requests
+, requests-mock
+, six
+, sphinx
+, testtools
+}:
+
+buildPythonPackage rec {
+  pname = "fiblary3-fork";
+  version = "0.1.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "001wqh7gx2dv3sf7a5xsbppz9r88f5qwrp05jzjsjcm6cbcvmsz0";
+  };
+
+  propagatedBuildInputs = [
+    jsonpatch
+    netaddr
+    prettytable
+    python-dateutil
+    requests
+    six
+  ];
+
+  checkInputs = [
+    fixtures
+    pytestCheckHook
+    requests-mock
+    testtools
+  ];
+
+  pythonImportsCheck = [ "fiblary3" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/graham33/fiblary";
+    description = "Fibaro Home Center API Python Library";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ graham33 ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -264,7 +264,7 @@
     "ffmpeg" = ps: with ps; [ ha-ffmpeg ];
     "ffmpeg_motion" = ps: with ps; [ ha-ffmpeg ];
     "ffmpeg_noise" = ps: with ps; [ ha-ffmpeg ];
-    "fibaro" = ps: with ps; [ ]; # missing inputs: fiblary3
+    "fibaro" = ps: with ps; [ fiblary3-fork ];
     "fido" = ps: with ps; [ pyfido ];
     "file" = ps: with ps; [ ];
     "filesize" = ps: with ps; [ ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -216,7 +216,7 @@
     "ecobee" = ps: with ps; [ python-ecobee-api ];
     "econet" = ps: with ps; [ pyeconet ];
     "ecovacs" = ps: with ps; [ ]; # missing inputs: sucks
-    "eddystone_temperature" = ps: with ps; [ construct ]; # missing inputs: beacontools[scan]
+    "eddystone_temperature" = ps: with ps; [ construct ]; # missing inputs: beacontools
     "edimax" = ps: with ps; [ pyedimax ];
     "edl21" = ps: with ps; [ pysml ];
     "efergy" = ps: with ps; [ pyefergy ];

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -34,16 +34,11 @@ from rich.table import Table
 COMPONENT_PREFIX = "homeassistant.components"
 PKG_SET = "home-assistant.python.pkgs"
 
-# If some requirements are matched by multiple Python packages,
-# the following can be used to choose one of them
+# If some requirements are matched by multiple or no Python packages, the
+# following can be used to choose the correct one
 PKG_PREFERENCES = {
-    # Use python3Packages.youtube-dl-light instead of python3Packages.youtube-dl
-    "youtube-dl": "youtube-dl-light",
-    "tensorflow-bin": "tensorflow",
-    "tensorflow-bin_2": "tensorflow",
-    "tensorflowWithoutCuda": "tensorflow",
-    "tensorflow-build_2": "tensorflow",
-    "whois": "python-whois",
+    "youtube_dl": "youtube-dl-light",
+    "tensorflow": "tensorflow",
 }
 
 
@@ -120,39 +115,28 @@ def dump_packages() -> Dict[str, Dict[str, str]]:
 
 
 def name_to_attr_path(req: str, packages: Dict[str, Dict[str, str]]) -> Optional[str]:
-    attr_paths = set()
+    if req in PKG_PREFERENCES:
+        return f"{PKG_SET}.{PKG_PREFERENCES[req]}"
+    attr_paths = []
     names = [req]
     # E.g. python-mpd2 is actually called python3.6-mpd2
     # instead of python-3.6-python-mpd2 inside Nixpkgs
     if req.startswith("python-") or req.startswith("python_"):
         names.append(req[len("python-") :])
-    # Add name variant without extra_require, e.g. samsungctl
-    # instead of samsungctl[websocket]
-    if req.endswith("]"):
-        names.append(req[:req.find("[")])
     for name in names:
         # treat "-" and "_" equally
         name = re.sub("[-_]", "[-_]", name)
         # python(minor).(major)-(pname)-(version or unstable-date)
         # we need the version qualifier, or we'll have multiple matches
         # (e.g. pyserial and pyserial-asyncio when looking for pyserial)
-        pattern = re.compile("^python\\d\\.\\d-{}-(?:\\d|unstable-.*)".format(name), re.I)
+        pattern = re.compile(f"^python\\d\\.\\d-{name}-(?:\\d|unstable-.*)", re.I)
         for attr_path, package in packages.items():
             if pattern.match(package["name"]):
-                attr_paths.add(attr_path)
-    if len(attr_paths) > 1:
-        for to_replace, replacement in PKG_PREFERENCES.items():
-            try:
-                attr_paths.remove(PKG_SET + "." + to_replace)
-                attr_paths.add(PKG_SET + "." + replacement)
-            except KeyError:
-                pass
+                attr_paths.append(attr_path)
     # Let's hope there's only one derivation with a matching name
-    assert len(attr_paths) <= 1, "{} matches more than one derivation: {}".format(
-        req, attr_paths
-    )
-    if len(attr_paths) == 1:
-        return attr_paths.pop()
+    assert len(attr_paths) <= 1, f"{req} matches more than one derivation: {attr_paths}"
+    if attr_paths:
+        return attr_paths[0]
     else:
         return None
 
@@ -180,6 +164,10 @@ def main() -> None:
             # Therefore, if there's a "#" in the line, only take the part after it
             req = req[req.find("#") + 1 :]
             name, required_version = req.split("==", maxsplit=1)
+            # Remove extra_require from name, e.g. samsungctl instead of
+            # samsungctl[websocket]
+            if name.endswith("]"):
+                name = name[:name.find("[")]
             attr_path = name_to_attr_path(name, packages)
             if our_version := get_pkg_version(name, packages):
                 if Version.parse(our_version) < Version.parse(required_version):

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -39,6 +39,7 @@ PKG_SET = "home-assistant.python.pkgs"
 PKG_PREFERENCES = {
     "youtube_dl": "youtube-dl-light",
     "tensorflow": "tensorflow",
+    "fiblary3": "fiblary3-fork", # https://github.com/home-assistant/core/issues/66466
 }
 
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2833,6 +2833,8 @@ in {
 
   ffmpeg-progress-yield = callPackage ../development/python-modules/ffmpeg-progress-yield { };
 
+  fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };
+
   fido2 = callPackage ../development/python-modules/fido2 { };
 
   fields = callPackage ../development/python-modules/fields { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Library for Fibaro devices (used in Home Assistant).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
