### PR TITLE
pythonPackages.signify: init at 0.3.0 

### DIFF
--- a/pkgs/development/python-modules/certvalidator/default.nix
+++ b/pkgs/development/python-modules/certvalidator/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, asn1crypto, oscrypto
+, cacert
+}:
+
+buildPythonPackage rec {
+  pname = "certvalidator";
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "wbond";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-yVF7t4FuU3C9fDg67JeM7LWZZh/mv5F4EKmjlO4AuBY=";
+  };
+
+  propagatedBuildInputs = [ asn1crypto oscrypto ];
+
+  checkInputs = [ cacert ];
+  checkPhase = ''
+    # Tests are run with a custom executor/loader
+    # The regex to skip specific tests relies on negative lookahead of regular expressions
+    # We're skipping the few tests that rely on the network, fetching CRLs, OCSP or remote certificates
+    python -c 'import dev.tests; dev.tests.run("^(?!.*test_(basic_certificate_validator_tls|fetch|revocation|build_path)).*$")'
+  '';
+  pythonImportsCheck = [ "certvalidator" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/wbond/certvalidator";
+    description = "Validates X.509 certificates and paths";
+    license = licenses.mit;
+    maintainers = with maintainers; [ baloo ];
+  };
+}

--- a/pkgs/development/python-modules/signify/certificate-expiration-date.patch
+++ b/pkgs/development/python-modules/signify/certificate-expiration-date.patch
@@ -1,0 +1,18 @@
+diff --git a/tests/test_authenticode.py b/tests/test_authenticode.py
+index 7e2c709..2f27e09 100644
+--- a/tests/test_authenticode.py
++++ b/tests/test_authenticode.py
+@@ -153,10 +153,12 @@ class AuthenticodeParserTestCase(unittest.TestCase):
+         """this certificate is revoked"""
+         with open(str(root_dir / "test_data" / "jameslth"), "rb") as f:
+             pefile = SignedPEFile(f)
+-            pefile.verify()
++            pefile.verify(verification_context_kwargs=
++                          {'timestamp': datetime.datetime(2021, 1, 1, tzinfo=datetime.timezone.utc)})
+
+     def test_jameslth_revoked(self):
+         """this certificate is revoked"""
++        # TODO: this certificate is now expired, so it will not show up as valid anyway
+         with open(str(root_dir / "test_data" / "jameslth"), "rb") as f:
+             pefile = SignedPEFile(f)
+             with self.assertRaises(VerificationError):

--- a/pkgs/development/python-modules/signify/default.nix
+++ b/pkgs/development/python-modules/signify/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pytestCheckHook
+, certvalidator, pyasn1, pyasn1-modules
+}:
+
+buildPythonPackage rec {
+  pname = "signify";
+  version = "0.3.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "ralphje";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-JxQECpwHhPm8TCVW/bCnEpu5I/WETyZVBx29SQE4NmE=";
+  };
+  patches = [
+    # Upstream patch is available here:
+    #  https://github.com/ralphje/signify/commit/8c345be954e898a317825bb450bed5ba0304b2b5.patch
+    # But update a couple other things and dont apply cleanly. This is an extract of the part
+    # we care about and breaks the tests after 2021-03-01
+    ./certificate-expiration-date.patch
+  ];
+
+  propagatedBuildInputs = [ certvalidator pyasn1 pyasn1-modules ];
+
+  checkInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [ "-v" ];
+  pythonImportsCheck = [ "signify" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/ralphje/signify";
+    description = "library that verifies PE Authenticode-signed binaries";
+    license = licenses.mit;
+    maintainers = with maintainers; [ baloo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1244,6 +1244,8 @@ in {
 
   certipy = callPackage ../development/python-modules/certipy { };
 
+  certvalidator = callPackage ../development/python-modules/certvalidator { };
+
   cffi = callPackage ../development/python-modules/cffi { };
 
   cfgv = callPackage ../development/python-modules/cfgv { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7368,6 +7368,8 @@ in {
 
   singledispatch = callPackage ../development/python-modules/singledispatch { };
 
+  signify = callPackage ../development/python-modules/signify { };
+
   sip = callPackage ../development/python-modules/sip { };
 
   sip_5 = callPackage ../development/python-modules/sip/5.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

Adds a packaging for signify (and certvalidator as a direct dependency).
This is used to get the expected hash for an EFI payload.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
