### PR TITLE
nixos/libvirtd: adds support for swtpm

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -138,6 +138,21 @@ in {
       '';
     };
 
+    tpmSupport = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Provide tpm support in libvirt
+      '';
+    };
+
+    tpmPackage = mkOption {
+      type = types.package;
+      default = pkgs.swtpm;
+      description = ''
+        swtpm package to use with libvirt.
+      '';
+    };
   };
 
 
@@ -222,7 +237,8 @@ in {
         ] ++ cfg.extraOptions);
 
       path = [ cfg.qemuPackage ] # libvirtd requires qemu-img to manage disk images
-             ++ optional vswitch.enable vswitch.package;
+             ++ optional vswitch.enable vswitch.package
+             ++ optional cfg.tpmSupport cfg.tpmPackage;
 
       serviceConfig = {
         Type = "notify";


### PR DESCRIPTION
###### Motivation for this change

The purpose is to provide VMs running on libvirt the capability to run with TPM support.
swtpm itself has been merged with #113362

This PR is not enough to get a good UX for TPM support.

swtpm is finicky about it's configuration.
The way I'm currently running libvirt is like that:
```
let
  issuer = pkgs.writeText "issuer.key" ''
-----BEGIN PRIVATE KEY-----
-----END PRIVATE KEY-----
  '';

  cert = pkgs.writeText "issuer.pem" ''
-----BEGIN CERTIFICATE-----
-----END CERTIFICATE-----
  '';

  swtpm_localca_config = pkgs.writeText "swtpm-localca.conf" ''
    certserial=/var/lib/libvirt/swtpm/serial
    statedir=/var/lib/libvirt/swtpm
    signingkey=${issuer}
    issuercert=${cert}
  '';

  swtpm_config = pkgs.writeText "swtpm_setup.conf" ''
    create_certs_tool=${swtpm}/share/swtpm/swtpm-localca
    create_certs_tool_config=${swtpm_localca_config}
    create_certs_tool_options=${swtpm}/etc/swtpm-localca.options
  '';

  swtpm' = pkgs.stdenv.mkDerivation {
    name = "swtpm-wrappers";
    buildInputs = [ pkgs.makeWrapper ];
    buildCommand = ''
      mkdir -p $out/bin
      makeWrapper ${swtpm}/bin/swtpm_setup "$out/bin/swtpm_setup" \
         --add-flags "--config=${swtpm_config}"
      for executable in swtpm swtpm_ioctl swtpm_bios swtpm_cert swtpm_cuse
      do
        ln -s "${swtpm}/bin/$executable" "$out/bin/$executable"
      done
      mkdir -p "$out/share"
      ln -s '${swtpm}/share/man' "$out/share/"
    '';
  };
in {
  virtualisation.libvirtd = {
    enable = true;
    qemuOvmf = true;

    tpmSupport = true;
    tpmPackage = swtpm';
  };
}
```
But that sounds like a ton of work for the end-user.
Any idea is most welcome.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
