### PR TITLE
ebumeter: init at 0.4.2

### DIFF
--- a/pkgs/applications/audio/ebumeter/default.nix
+++ b/pkgs/applications/audio/ebumeter/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl
+, libX11, libXft, libclthreads, libclxclient, libjack2, libpng, libsndfile, zita-resampler
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ebumeter";
+  version = "0.4.2";
+
+  src = fetchurl {
+    url = "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pname}-${version}.tar.bz2";
+    sha256 = "1wm9j1phmpicrp7jdsvdbc3mghdd92l61yl9qbps0brq2ljjyd5s";
+  };
+
+  buildInputs = [
+    libX11 libXft libclthreads libclxclient libjack2 libpng libsndfile zita-resampler
+  ];
+
+  preConfigure = ''
+    cd source
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Level metering according to the EBU R-128 recommendation";
+    homepage = "http://kokkinizita.linuxaudio.org/linuxaudio/index.html";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21848,6 +21848,8 @@ in
 
   eaglemode = callPackage ../applications/misc/eaglemode { };
 
+  ebumeter = callPackage ../applications/audio/ebumeter { };
+
   echoip = callPackage ../servers/echoip { };
 
   eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse {


### PR DESCRIPTION
###### Motivation for this change

Measure audio file loudness.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
