### PR TITLE
pythonPackages.tpm2-pytss: init at 0.2.4

### DIFF
--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -1,0 +1,42 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, pkg-config, swig
+, tpm2-tss
+, cryptography, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "tpm2-pytss";
+
+  # Last version on github is 0.2.4, but it looks
+  # like a mistake (it's missing commits from 0.1.9)
+  version = "0.1.9";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-v5Xth0A3tFnLFg54nvWYL2TD201e/GWv+2y5Qc60CmU=";
+  };
+  postPatch = ''
+    substituteInPlace tpm2_pytss/config.py --replace \
+      'SYSCONFDIR = CONFIG.get("sysconfdir", "/etc")' \
+      'SYSCONFDIR = "${tpm2-tss}/etc"'
+  '';
+
+  nativeBuildInputs = [ pkg-config swig ];
+  buildInputs = [ tpm2-tss ];
+
+  checkInputs = [ cryptography pytest ];
+  checkPhase = ''
+    # Most of the tests requires a simulator (tpm_server from ibm-sw-tpm2)
+    # that simulator looks broken in tcti mode
+
+    pytest tests/test_binding.py tests/test_util_retry.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/tpm2-software/tpm2-pytss";
+    description = "TPM2 TSS Python bindings for Enhanced System API (ESYS)";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ baloo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7944,6 +7944,8 @@ in {
 
   tox = callPackage ../development/python-modules/tox { };
 
+  tpm2-pytss = callPackage ../development/python-modules/tpm2-pytss { };
+
   tqdm = callPackage ../development/python-modules/tqdm { };
 
   traceback2 = callPackage ../development/python-modules/traceback2 { };


### PR DESCRIPTION
###### Motivation for this change

tpm2-pytss is a python binding on tpm2-tss library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
