### PR TITLE
maven: use default jdk

### DIFF
--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -1,9 +1,12 @@
-{ lib, stdenv, fetchurl, makeWrapper, pkg-config, which, maven, cmake, jre, bash
+{ lib, stdenv, fetchurl, makeWrapper, pkg-config, which, maven, cmake, jre, jdk8, bash
 , coreutils, glibc, protobuf2_5, fuse, snappy, zlib, bzip2, openssl, openssl_1_0_2
 }:
 
 let
-  common = { version, sha256, dependencies-sha256, tomcat, opensslPkg ? openssl }:
+  maven-jdk8 = maven.override {
+    jdk = jdk8;
+  };
+  common = { version, sha256, dependencies-sha256, maven, tomcat, opensslPkg ? openssl }:
     let
       # compile the hadoop tarball from sources, it requires some patches
       binary-distributon = stdenv.mkDerivation rec {
@@ -131,6 +134,7 @@ in {
     dependencies-sha256 = "1lsr9nvrynzspxqcamb10d596zlnmnfpxhkd884gdiva0frm0b1r";
     tomcat = tomcat_6_0_48;
     opensslPkg = openssl_1_0_2;
+    maven = maven-jdk8;
   };
   hadoop_2_8 = common {
     version = "2.8.4";
@@ -138,6 +142,7 @@ in {
     dependencies-sha256 = "1j4f461487fydgr5978nnm245ksv4xbvskfr8pbmfhcyss6b7w03";
     tomcat = tomcat_6_0_48;
     opensslPkg = openssl_1_0_2;
+    maven = maven-jdk8;
   };
   hadoop_2_9 = common {
     version = "2.9.1";
@@ -145,17 +150,20 @@ in {
     dependencies-sha256 = "1d5i8jj5y746rrqb9lscycnd7acmxlkz64ydsiyqsh5cdqgy2x7x";
     tomcat = tomcat_6_0_48;
     opensslPkg = openssl_1_0_2;
+    maven = maven-jdk8;
   };
   hadoop_3_0 = common {
     version = "3.0.3";
     sha256 = "1vvkci0kx4b48dg0niifn2d3r4wwq8pb3c5z20wy8pqsqrqhlci5";
     dependencies-sha256 = "1kzkna9ywacm2m1cirj9cyip66bgqjhid2xf9rrhq6g10lhr8j9m";
     tomcat = null;
+    maven = maven-jdk8;
   };
   hadoop_3_1 = common {
     version = "3.1.1";
     sha256 = "04hhdbyd4x1hy0fpy537f8mi0864hww97zap29x7dk1smrffwabd";
     dependencies-sha256 = "1q63jsxg3d31x0p8hvhpvbly2b07almyzsbhwphbczl3fhlqgiwn";
     tomcat = null;
+    maven = maven-jdk8;
   };
 }

--- a/pkgs/development/java-modules/junit/default.nix
+++ b/pkgs/development/java-modules/junit/default.nix
@@ -1,12 +1,17 @@
-{ lib, pkgs, mavenbuild, fetchMaven }:
+{ lib, pkgs, mavenbuild, fetchMaven, maven, jdk8 }:
 
 with pkgs.javaPackages;
 
 let
   poms = import (../poms.nix) { inherit fetchMaven; };
   collections = import (../collections.nix) { inherit pkgs; };
+  mavenbuild-jdk8 = mavenbuild.override {
+    maven = maven.override {
+      jdk = jdk8;
+    };
+  };
 in rec {
-  junitGen = { mavenDeps, sha512, version }: mavenbuild {
+  junitGen = { mavenDeps, sha512, version }: mavenbuild-jdk8 {
     inherit mavenDeps sha512 version;
 
     name = "junit-${version}";

--- a/pkgs/development/java-modules/maven-hello/default.nix
+++ b/pkgs/development/java-modules/maven-hello/default.nix
@@ -1,11 +1,21 @@
-{ lib, pkgs, mavenbuild }:
+{ lib
+, pkgs
+, mavenbuild
+, maven
+, jdk8
+}:
 
 with pkgs.javaPackages;
 
 let
   poms = import ../poms.nix { inherit fetchMaven; };
+  mavenbuild-jdk8 = mavenbuild.override {
+    maven = maven.override {
+      jdk = jdk8;
+    };
+  };
 in rec {
-  mavenHelloRec = { mavenDeps, sha512, version, skipTests ? true, quiet ? true }: mavenbuild {
+  mavenHelloRec = { mavenDeps, mavenbuild, sha512, version, skipTests ? true, quiet ? true }: mavenbuild {
     inherit mavenDeps sha512 version skipTests quiet;
 
     name = "maven-hello-${version}";
@@ -31,6 +41,7 @@ in rec {
     mavenDeps = [];
     sha512 = "3kv5z1i02wfb0l5x3phbsk3qb3wky05sqn4v3y4cx56slqfp9z8j76vnh8v45ydgskwl2vs9xjx6ai8991mzb5ikvl3vdgmrj1j17p2";
     version = "1.0";
+    mavenbuild = mavenbuild-jdk8;
   };
 
   mavenHello_1_1 = mavenHelloRec {
@@ -39,5 +50,6 @@ in rec {
     version = "1.1";
     skipTests = false;
     quiet = false;
+    mavenbuild = mavenbuild-jdk8;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12538,9 +12538,7 @@ in
   massif-visualizer = libsForQt5.callPackage ../development/tools/analysis/massif-visualizer { };
 
   maven = maven3;
-  maven3 = callPackage ../development/tools/build-managers/apache-maven {
-    jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-  };
+  maven3 = callPackage ../development/tools/build-managers/apache-maven { };
 
   mavproxy = python3Packages.callPackage ../applications/science/robotics/mavproxy { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

While builds using maven are relatively likely to target jdk8,
they typically support building using default jdk.

The main exception is the default jdk no longer supports targeting
JRE's before version 8. For projects that do that we can override the
jdk version for the maven used there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).