### PR TITLE
pythonPackages.tpm2-pytss: init at 0.2.4

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -27,7 +27,21 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  postPatch = "patchShebangs script";
+  patches = [
+    # Do not rely on dynamic loader path
+    # TCTI loader relies on dlopen(), this patch prefixes all calls with the output directory
+    ./no-dynamic-loader-path.patch
+  ];
+
+  postPatch = ''
+    patchShebangs script
+    substituteInPlace src/tss2-tcti/tctildr-dl.c \
+      --replace '@PREFIX@' $out/lib/
+    substituteInPlace ./test/unit/tctildr-dl.c \
+      --replace ', "libtss2' ", \"$out/lib/libtss2" \
+      --replace ', "foo' ", \"$out/lib/foo" \
+      --replace ', TEST_TCTI_NAME' ", \"$out/lib/\"TEST_TCTI_NAME"
+  '';
 
   configureFlags = [
     "--enable-unit"
@@ -35,6 +49,14 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
+  preCheck = ''
+    # Since we rewrote the load path in the dynamic loader for the TCTI
+    # The various tcti implementation should be placed in their target directory
+    # before we could run tests
+    installPhase
+    # install already done, dont need another one
+    dontInstall=1
+  '';
 
   postInstall = ''
     # Do not install the upstream udev rules, they rely on specific

--- a/pkgs/development/libraries/tpm2-tss/no-dynamic-loader-path.patch
+++ b/pkgs/development/libraries/tpm2-tss/no-dynamic-loader-path.patch
@@ -1,0 +1,39 @@
+diff --git a/src/tss2-tcti/tctildr-dl.c b/src/tss2-tcti/tctildr-dl.c
+index b364695c..b13be3ef 100644
+--- a/src/tss2-tcti/tctildr-dl.c
++++ b/src/tss2-tcti/tctildr-dl.c
+@@ -85,7 +85,15 @@ handle_from_name(const char *file,
+     if (handle == NULL) {
+         return TSS2_TCTI_RC_BAD_REFERENCE;
+     }
+-    *handle = dlopen(file, RTLD_NOW);
++    size = snprintf(file_xfrm,
++                    sizeof (file_xfrm),
++                    "@PREFIX@%s",
++                    file);
++    if (size >= sizeof (file_xfrm)) {
++        LOG_ERROR("TCTI name truncated in transform.");
++        return TSS2_TCTI_RC_BAD_VALUE;
++    }
++    *handle = dlopen(file_xfrm, RTLD_NOW);
+     if (*handle != NULL) {
+         return TSS2_RC_SUCCESS;
+     } else {
+@@ -94,7 +102,7 @@ handle_from_name(const char *file,
+     /* 'name' alone didn't work, try libtss2-tcti-<name>.so.0 */
+     size = snprintf(file_xfrm,
+                     sizeof (file_xfrm),
+-                    TCTI_NAME_TEMPLATE_0,
++                    "@PREFIX@" TCTI_NAME_TEMPLATE_0,
+                     file);
+     if (size >= sizeof (file_xfrm)) {
+         LOG_ERROR("TCTI name truncated in transform.");
+@@ -109,7 +117,7 @@ handle_from_name(const char *file,
+     /* libtss2-tcti-<name>.so.0 didn't work, try libtss2-tcti-<name>.so */
+     size = snprintf(file_xfrm,
+                     sizeof (file_xfrm),
+-                    TCTI_NAME_TEMPLATE,
++                    "@PREFIX@" TCTI_NAME_TEMPLATE,
+                     file);
+     if (size >= sizeof (file_xfrm)) {
+         LOG_ERROR("TCTI name truncated in transform.");

--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -1,0 +1,41 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, pkg-config, swig
+, tpm2-tss
+, cryptography, ibm-sw-tpm2
+}:
+
+buildPythonPackage rec {
+  pname = "tpm2-pytss";
+
+  # Last version on github is 0.2.4, but it looks
+  # like a mistake (it's missing commits from 0.1.9)
+  version = "0.1.9";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-v5Xth0A3tFnLFg54nvWYL2TD201e/GWv+2y5Qc60CmU=";
+  };
+  postPatch = ''
+    substituteInPlace tpm2_pytss/config.py --replace \
+      'SYSCONFDIR = CONFIG.get("sysconfdir", "/etc")' \
+      'SYSCONFDIR = "${tpm2-tss}/etc"'
+  '';
+
+  nativeBuildInputs = [ pkg-config swig ];
+  # The TCTI is dynamically loaded from tpm2-tss, we have to provide the library to the end-user
+  propagatedBuildInputs = [ tpm2-tss ];
+
+  checkInputs = [
+    cryptography
+    # provide tpm_server used as simulator for the tests
+    ibm-sw-tpm2
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/tpm2-software/tpm2-pytss";
+    description = "TPM2 TSS Python bindings for Enhanced System API (ESYS)";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ baloo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7944,6 +7944,8 @@ in {
 
   tox = callPackage ../development/python-modules/tox { };
 
+  tpm2-pytss = callPackage ../development/python-modules/tpm2-pytss { };
+
   tqdm = callPackage ../development/python-modules/tqdm { };
 
   traceback2 = callPackage ../development/python-modules/traceback2 { };


### PR DESCRIPTION
###### Motivation for this change

tpm2-pytss is a python binding on tpm2-tss library

Unlike tpm2-tools, we cant provide a `LD_LIBRARY_PATH` at startup here. even editing the `os.environ['LD_LIBRARY_PATH']` does not work, it's only read at start up.
To overcome this limitation, I patched tpm2-tss itself, to ensure it would only `dlopen` from known path, like any other compiled package would do on nixos.
I think this also solve problems for people who would link against tpm2-tss itself, as I believe they currently would need to provide a `LD_LIBRARY_PATH` which I think is inconvenient.

cc @delroth I'd love if I could get your feedback on this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
