### PR TITLE
pythonPackages.libusb1: 1.9.1 -> 1.9.2

### DIFF
--- a/pkgs/development/python-modules/libusb1/default.nix
+++ b/pkgs/development/python-modules/libusb1/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "libusb1";
-  version = "1.9.1";
+  version = "1.9.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "14ljk7rywy3fiv23dpayvk14y1ywma729r3b1x2cxf68919g2gnh";
+    sha256 = "17hqck808m59jv6m2g4hasnay44pycy3y0im01fq9jpr3ymcdbi7";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using nixpkgs-review
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>glasgow (python38Packages.glasgow)</li>
    <li>python37Packages.glasgow</li>
    <li>python39Packages.glasgow</li>
  </ul>
</details>
<details>
  <summary>35 packages built:</summary>
  <ul>
    <li>electron-cash</li>
    <li>electrum</li>
    <li>electrum-ltc</li>
    <li>hwi (python38Packages.hwi)</li>
    <li>keepkey_agent (python38Packages.keepkey_agent)</li>
    <li>libfx2 (python38Packages.fx2)</li>
    <li>nrfutil</li>
    <li>python37Packages.adb-homeassistant</li>
    <li>python37Packages.adb-shell</li>
    <li>python37Packages.androidtv</li>
    <li>python37Packages.firetv</li>
    <li>python37Packages.fx2</li>
    <li>python37Packages.hwi</li>
    <li>python37Packages.keepkey</li>
    <li>python37Packages.keepkey_agent</li>
    <li>python37Packages.libusb1</li>
    <li>python37Packages.trezor</li>
    <li>python37Packages.trezor_agent</li>
    <li>python38Packages.adb-homeassistant</li>
    <li>python38Packages.adb-shell</li>
    <li>python38Packages.androidtv</li>
    <li>python38Packages.firetv</li>
    <li>python38Packages.keepkey</li>
    <li>python38Packages.libusb1</li>
    <li>trezorctl (python38Packages.trezor)</li>
    <li>trezor_agent (python38Packages.trezor_agent)</li>
    <li>python39Packages.adb-homeassistant</li>
    <li>python39Packages.adb-shell</li>
    <li>python39Packages.androidtv</li>
    <li>python39Packages.firetv</li>
    <li>python39Packages.fx2</li>
    <li>python39Packages.keepkey</li>
    <li>python39Packages.libusb1</li>
    <li>python39Packages.trezor</li>
    <li>steamcontroller</li>
  </ul>
</details>
