### PR TITLE
[staging-next] libcdr: fix build

### DIFF
--- a/pkgs/development/libraries/libcdr/default.nix
+++ b/pkgs/development/libraries/libcdr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libwpg, libwpd, lcms, pkg-config, librevenge, icu, boost, cppunit }:
+{ lib, stdenv, fetchurl, fetchpatch, libwpg, libwpd, lcms, pkg-config, librevenge, icu, boost, cppunit }:
 
 stdenv.mkDerivation rec {
   name = "libcdr-0.1.6";
@@ -7,6 +7,16 @@ stdenv.mkDerivation rec {
     url = "https://dev-www.libreoffice.org/src/${name}.tar.xz";
     sha256 = "0qgqlw6i25zfq1gf7f6r5hrhawlrgh92sg238kjpf2839aq01k81";
   };
+
+  patches = [
+    # Fix build with icu 68
+    # Remove in next release
+    (fetchpatch {
+      name = "libcdr-fix-icu-68";
+      url = "https://cgit.freedesktop.org/libreoffice/libcdr/patch/?id=bf3e7f3bbc414d4341cf1420c99293debf1bd894";
+      sha256 = "0cgra10p8ibgwn8y5q31jrpan317qj0ribzjs4jq0bwavjq92w2k";
+    })
+  ];
 
   buildInputs = [ libwpg libwpd lcms librevenge icu boost cppunit ];
 


### PR DESCRIPTION
Unblocks inkscape.x86_64-darwin constituent

Note that this is broken on master too, it's needed for staging-next because it has entered the dependency tree of mesa. I wasn't too sure which branch to target - I went with staging-next with the assumption that fixing the staging-next jobset is higher priority. Let me know if it is preferable in this case to simply target master and wait for the auto-merge.

cc @FRidh re: https://github.com/NixOS/nixpkgs/pull/113757

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
