### PR TITLE
gitlab-runner: 13.8.0 -> 13.9.0

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,16 +1,16 @@
 { lib, buildGoPackage, fetchFromGitLab, fetchurl }:
 
 let
-  version = "13.8.0";
+  version = "13.9.0";
   # Gitlab runner embeds some docker images these are prebuilt for arm and x86_64
   docker_x86_64 = fetchurl {
     url = "https://gitlab-runner-downloads.s3.amazonaws.com/v${version}/helper-images/prebuilt-x86_64.tar.xz";
-    sha256 = "15pf6mxma8gkzyxkzm1rjwa514p7gzabn3c474lcvsjpmp76wv68";
+    sha256 = "0zgnp6l0p1i7x6lppd24nfb6kqa8mw7rnr2p5gmwbmjv9i9zkycs";
   };
 
   docker_arm = fetchurl {
     url = "https://gitlab-runner-downloads.s3.amazonaws.com/v${version}/helper-images/prebuilt-arm.tar.xz";
-    sha256 = "1c4lpy7nc62rqk8bfwiy5pcgvcwx70qkz3lv9w512fr3n5hjd4c0";
+    sha256 = "06b5p9ygcnrjrisp6bcgw9s3j2zlycp8jsri259bjf7rrfbwpkma";
   };
 in
 buildGoPackage rec {
@@ -30,7 +30,7 @@ buildGoPackage rec {
     owner = "gitlab-org";
     repo = "gitlab-runner";
     rev = "v${version}";
-    sha256 = "0v0iqpllzaabkahlc5pidzzw0bjlli984pdna3f3bbg67lm5a421";
+    sha256 = "0wzqrfjg43wnf9lr34jn3ydlxi7vsnqs55pm5igba592q8ykfbxk";
   };
 
   patches = [ ./fix-shell-path.patch ];


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.com/gitlab-org/gitlab-runner/blob/v13.9.0/CHANGELOG.md

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @bachp @zimbatm @globin @dlouzan