### PR TITLE
trafficserver: init at 9.0.0

### DIFF
--- a/pkgs/servers/trafficserver/default.nix
+++ b/pkgs/servers/trafficserver/default.nix
@@ -1,0 +1,41 @@
+{ pcre, openssl, tcl, expat, perl, hwloc, unwind, libcurl, curses }:
+
+stdenv.mkDerivation rec {
+  version = "9.0.0";
+  pname = "trafficserver";
+
+  # not using fetchFromGitHub as the git repo relies on submodules that are included in the tar file
+  src = fetchurl {
+    url = "https://www.apache.org/dyn/closer.cgi/trafficserver/trafficserver-${version}.tar.bz2";
+    sha256 = "sha256-1cffdff67711828df21d942ceff8acc798cdc50f5de1a7158edb5037fd4c6945";
+  };
+
+  nativeBuildInputs = [
+    gcc
+    make
+    binutils
+  ];
+
+configureFlags = [
+    "--with-experimental-plugins"
+];
+
+  enableParallelBuilding = true;
+
+  stripDebugList = [ "lib" "modules" "bin" ];
+
+  postInstall = ''
+    make install
+    mv $out /
+  '';
+
+  meta = with lib; {
+    description = "Traffic Server";
+    homepage = "https://trafficserver.apache.org";
+    license = with licenses; [ asl20 gpl2Only ];
+    maintainers = with maintainers; [
+      joaquinito2051
+    ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Traffic Server

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
