### PR TITLE
guile-1.8: fix CVE-2016-8605

### DIFF
--- a/pkgs/development/interpreters/guile/1.8.nix
+++ b/pkgs/development/interpreters/guile/1.8.nix
@@ -37,7 +37,10 @@ stdenv.mkDerivation rec {
     libtool
   ];
 
-  patches = [ ./cpp-4.5.patch ];
+  patches = [
+    ./cpp-4.5.patch
+    ./CVE-2016-8605.patch
+  ];
 
   preBuild = ''
     sed -e '/lt_dlinit/a  lt_dladdsearchdir("'$out/lib'");' -i libguile/dynl.c

--- a/pkgs/development/interpreters/guile/CVE-2016-8605.patch
+++ b/pkgs/development/interpreters/guile/CVE-2016-8605.patch
@@ -1,0 +1,59 @@
+commit d514e3fc42eb14a1bc5846b27ef89f50ba3a5d48
+Author: Ludovic Courtès <ludo@gnu.org>
+Date:   Tue Oct 11 10:14:26 2016 +0200
+
+    Remove 'umask' calls from 'mkdir'.
+    
+    Fixes <http://bugs.gnu.org/24659>.
+    
+    * libguile/filesys.c (SCM_DEFINE): Remove calls to 'umask' when MODE is
+    unbound; instead, use 0777 as the mode.  Update docstring to clarify
+    this.
+
+diff --git a/libguile/filesys.c b/libguile/filesys.c
+index c8acb13ef..921f765f1 100644
+--- a/libguile/filesys.c
++++ b/libguile/filesys.c
+@@ -1,4 +1,5 @@
+-/* Copyright (C) 1996,1997,1998,1999,2000,2001, 2002, 2004, 2006, 2008 Free Software Foundation, Inc.
++/* Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2004, 2006,
++ *   2009, 2010, 2011, 2012, 2013, 2014, 2016 Free Software Foundation, Inc.
+  * 
+  * This library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Lesser General Public
+@@ -791,26 +792,21 @@ SCM_DEFINE (scm_delete_file, "delete-file", 1, 0, 0,
+ SCM_DEFINE (scm_mkdir, "mkdir", 1, 1, 0,
+             (SCM path, SCM mode),
+ 	    "Create a new directory named by @var{path}.  If @var{mode} is omitted\n"
+-	    "then the permissions of the directory file are set using the current\n"
+-	    "umask.  Otherwise they are set to the decimal value specified with\n"
+-	    "@var{mode}.  The return value is unspecified.")
++	    "then the permissions of the directory are set to @code{#o777}\n"
++	    "masked with the current umask (@pxref{Processes, @code{umask}}).\n"
++	    "Otherwise they are set to the value specified with @var{mode}.\n"
++	    "The return value is unspecified.")
+ #define FUNC_NAME s_scm_mkdir
+ {
+   int rv;
+-  mode_t mask;
++  mode_t c_mode;
+ 
+-  if (SCM_UNBNDP (mode))
+-    {
+-      mask = umask (0);
+-      umask (mask);
+-      STRING_SYSCALL (path, c_path, rv = mkdir (c_path, 0777 ^ mask));
+-    }
+-  else
+-    {
+-      STRING_SYSCALL (path, c_path, rv = mkdir (c_path, scm_to_uint (mode)));
+-    }
++  c_mode = SCM_UNBNDP (mode) ? 0777 : scm_to_uint (mode);
++
++  STRING_SYSCALL (path, c_path, rv = mkdir (c_path, c_mode));
+   if (rv != 0)
+     SCM_SYSERROR;
++
+   return SCM_UNSPECIFIED;
+ }
+ #undef FUNC_NAME


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It backports [245608911698adb3472803856019bdd5670b6614](https://git.savannah.gnu.org/cgit/guile.git/commit/?id=245608911698adb3472803856019bdd5670b6614) from `guile.git`'s `stable-2.0` branch to Guile 1.8 series.

Fixes https://github.com/NixOS/nixpkgs/issues/73648

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>spring</li>
    <li>springLobby</li>
  </ul>
</details>
<details>
  <summary>38 packages built:</summary>
  <ul>
    <li>adapta-gtk-theme</li>
    <li>asciidocFull (asciidoc-full)</li>
    <li>asciidoc-full-with-plugins</li>
    <li>ballAndPaddle</li>
    <li>btrbk</li>
    <li>ccache</li>
    <li>ccacheStdenv</li>
    <li>ccacheWrapper</li>
    <li>chrome-gnome-shell</li>
    <li>clevis</li>
    <li>denemo</li>
    <li>disorderfs</li>
    <li>drgeo</li>
    <li>frescobaldi</li>
    <li>gnome3.gnome-session</li>
    <li>gnome3.gnome-shell</li>
    <li>gnome3.gnome-terminal</li>
    <li>gnome3.gnome-tweak-tool</li>
    <li>gnome3.pomodoro</li>
    <li>gnomeExtensions.easyScreenCast</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.night-theme-switcher</li>
    <li>gnufdisk</li>
    <li>guileLint (guile-lint)</li>
    <li>guile_1_8</li>
    <li>herbstluftwm</li>
    <li>lilypond</li>
    <li>lilypond-unstable</li>
    <li>lilypond-with-fonts</li>
    <li>luksmeta</li>
    <li>mcron</li>
    <li>pantheon.elementary-session-settings</li>
    <li>rep</li>
    <li>slibGuile</li>
    <li>solfege</li>
    <li>tang</li>
    <li>texmacs</li>
    <li>udiskie</li>
  </ul>
</details>

Note that it fails to build `spring` and `springLobby` regardless of this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
