### PR TITLE
clips: 6.30 -> 6.31; supersedes and closes #109914

### DIFF
--- a/pkgs/development/interpreters/clips/default.nix
+++ b/pkgs/development/interpreters/clips/default.nix
@@ -3,10 +3,8 @@
 stdenv.mkDerivation rec {
   version = "6.31";
   pname = "clips";
-  src = let v = builtins.replaceStrings [ "." ] [ "" ] version;
   in fetchurl {
-    url =
-      "mirror://sourceforge/clipsrules/CLIPS/${version}/clips_core_source_${v}.tar.gz";
+    url = "mirror://sourceforge/clipsrules/CLIPS/${version}/clips_core_source_${builtins.replaceStrings [ "." ] [ "" ] version}.tar.gz";
     sha256 = "165k0z7dsv04q432sanmw0jxmxwf56cnhsdfw5ffjqxd3lzkjnv6";
   };
   makeFlags = [ "-C" "core" ];

--- a/pkgs/development/interpreters/clips/default.nix
+++ b/pkgs/development/interpreters/clips/default.nix
@@ -1,14 +1,16 @@
 { lib, stdenv, fetchurl }:
 
-stdenv.mkDerivation {
-  version = "6.30";
+stdenv.mkDerivation rec {
+  version = "6.31";
   pname = "clips";
-  src = fetchurl {
-    url = "mirror://sourceforge/clipsrules/CLIPS/6.30/clips_core_source_630.tar.Z";
-    sha256 = "1r0m59l3mk9cwzq3nmyr5qxrlkzp3njls4hfv8ml85dmqh7n3ysy";
+  src = let v = builtins.replaceStrings [ "." ] [ "" ] version;
+  in fetchurl {
+    url =
+      "mirror://sourceforge/clipsrules/CLIPS/${version}/clips_core_source_${v}.tar.gz";
+    sha256 = "165k0z7dsv04q432sanmw0jxmxwf56cnhsdfw5ffjqxd3lzkjnv6";
   };
   buildPhase = ''
-    make -C core -f ../makefiles/makefile.gcc
+    make -C core
   '';
   installPhase = ''
     install -D -t $out/bin core/clips
@@ -23,7 +25,7 @@ stdenv.mkDerivation {
       easier to implement and maintain than an algorithmic solution.
     '';
     license = licenses.publicDomain;
-    maintainers = [maintainers.league];
+    maintainers = [ maintainers.league ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/interpreters/clips/default.nix
+++ b/pkgs/development/interpreters/clips/default.nix
@@ -3,8 +3,10 @@
 stdenv.mkDerivation rec {
   version = "6.31";
   pname = "clips";
-  in fetchurl {
-    url = "mirror://sourceforge/clipsrules/CLIPS/${version}/clips_core_source_${builtins.replaceStrings [ "." ] [ "" ] version}.tar.gz";
+  src = fetchurl {
+    url = "mirror://sourceforge/clipsrules/CLIPS/${version}/clips_core_source_${
+        builtins.replaceStrings [ "." ] [ "" ] version
+      }.tar.gz";
     sha256 = "165k0z7dsv04q432sanmw0jxmxwf56cnhsdfw5ffjqxd3lzkjnv6";
   };
   makeFlags = [ "-C" "core" ];

--- a/pkgs/development/interpreters/clips/default.nix
+++ b/pkgs/development/interpreters/clips/default.nix
@@ -9,11 +9,7 @@ stdenv.mkDerivation rec {
       "mirror://sourceforge/clipsrules/CLIPS/${version}/clips_core_source_${v}.tar.gz";
     sha256 = "165k0z7dsv04q432sanmw0jxmxwf56cnhsdfw5ffjqxd3lzkjnv6";
   };
-  buildPhase = ''
-    runHook preBuild
-    make -C core
-    runHook postBuild
-  '';
+  makeFlags = [ "-C" "core" ];
   installPhase = ''
     runHook preInstall
     install -D -t $out/bin core/clips

--- a/pkgs/development/interpreters/clips/default.nix
+++ b/pkgs/development/interpreters/clips/default.nix
@@ -10,10 +10,14 @@ stdenv.mkDerivation rec {
     sha256 = "165k0z7dsv04q432sanmw0jxmxwf56cnhsdfw5ffjqxd3lzkjnv6";
   };
   buildPhase = ''
+    runHook preBuild
     make -C core
+    runHook postBuild
   '';
   installPhase = ''
+    runHook preInstall
     install -D -t $out/bin core/clips
+    runHook postInstall
   '';
   meta = with lib; {
     description = "A Tool for Building Expert Systems";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New stable release. This also follows a bot-initiated update #109914 that didn't work out on its own, but it's now specified to (hopefully) be more amenable to auto-updates in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
