### PR TITLE
argus-clients: Fix build, build client tools

### DIFF
--- a/pkgs/tools/networking/argus-clients/default.nix
+++ b/pkgs/tools/networking/argus-clients/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libpcap, bison, flex, cyrus_sasl, tcp_wrappers, pkg-config, perl }:
+{ lib, stdenv, fetchurl, libpcap, bison, flex, cyrus_sasl, tcp_wrappers, pkg-config, perl, libtirpc, libnsl }:
 
 stdenv.mkDerivation rec {
   pname = "argus-clients";
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "1c9vj6ma00gqq9h92fg71sxcsjzz912166sdg90ahvnmvmh3l1rj";
   };
 
-  patchPhase = ''
+  NIX_CFLAGS_COMPILE = [ "-I${libtirpc.dev}/include/tirpc" ];
+
+  postPatch = ''
     for file in ./examples/*/*.pl; do
       substituteInPlace $file \
         --subst-var-by PERLBIN ${perl}/bin/perl
@@ -19,7 +21,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-perl=${perl}/bin/perl" ];
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libpcap bison cyrus_sasl tcp_wrappers flex ];
+  buildInputs = [ libpcap bison cyrus_sasl tcp_wrappers flex libnsl ];
 
   meta = with lib; {
     description = "Clients for ARGUS";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Fix build
- Influde `libnsl` so the client tools can be built

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
