### PR TITLE
python3Packages.pyvizio: init at 0.1.59

### DIFF
--- a/pkgs/development/python-modules/pyvizio/default.nix
+++ b/pkgs/development/python-modules/pyvizio/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, click
+, fetchPypi
+, jsonpickle
+, requests
+, tabulate
+, xmltodict
+, zeroconf
+}:
+
+buildPythonPackage rec {
+  pname = "pyvizio";
+  version = "0.1.59";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1j2zbziklx4az55m3997y7yp4xflk7i0gsbdfh7fp9k0qngb2053";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    click
+    jsonpickle
+    requests
+    tabulate
+    xmltodict
+    zeroconf
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pyvizio" ];
+
+  meta = with lib; {
+    description = "Python client for Vizio SmartCast";
+    homepage = "https://github.com/vkorn/pyvizio";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -906,7 +906,7 @@
     "vicare" = ps: with ps; [ ]; # missing inputs: PyViCare
     "vilfo" = ps: with ps; [ ]; # missing inputs: vilfo-api-client
     "vivotek" = ps: with ps; [ ]; # missing inputs: libpyvivotek
-    "vizio" = ps: with ps; [ ]; # missing inputs: pyvizio
+    "vizio" = ps: with ps; [ pyvizio ];
     "vlc" = ps: with ps; [ python-vlc ];
     "vlc_telnet" = ps: with ps; [ ]; # missing inputs: python-telnet-vlc
     "voicerss" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6606,6 +6606,8 @@ in {
 
   pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
 
+  pyvizio = callPackage ../development/python-modules/pyvizio { };
+
   pyvips = callPackage ../development/python-modules/pyvips {
     inherit (pkgs) pkg-config vips glib;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for Vizio SmartCast

https://github.com/vkorn/pyvizio

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
