### PR TITLE
bdfresize: init at 1.5

### DIFF
--- a/pkgs/tools/misc/bdfresize/default.nix
+++ b/pkgs/tools/misc/bdfresize/default.nix
@@ -1,0 +1,20 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "bdfresize";
+  version = "1.5";
+
+  src = fetchurl {
+    url = "http://openlab.ring.gr.jp/efont/dist/tools/bdfresize/${pname}-${version}.tar.gz";
+    hash = "sha256-RAz8BiCgI35GNSwUoHdMqj8wWXWbCiDe/vyU6EkIl6Y=";
+  };
+
+  patches = [ ./remove-malloc-declaration.patch ];
+
+  meta = with lib; {
+    description = "Tool to resize BDF fonts";
+    homepage = "http://openlab.ring.gr.jp/efont/dist/tools/bdfresize/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ malvo ];
+  };
+}

--- a/pkgs/tools/misc/bdfresize/remove-malloc-declaration.patch
+++ b/pkgs/tools/misc/bdfresize/remove-malloc-declaration.patch
@@ -1,0 +1,11 @@
+Remove an unneeded declaration of malloc so gcc doesn't complain.
+--- a/charresize.c
++++ b/charresize.c
+@@ -46,7 +46,6 @@ static int	bit[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
+ void
+ processChar(void)
+ {
+-  char	*malloc();
+   char	*srcimage;
+   int	*dstgray;
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2615,6 +2615,8 @@ with pkgs;
 
   bdf2sfd = callPackage ../tools/misc/bdf2sfd { };
 
+  bdfresize = callPackage ../tools/misc/bdfresize { };
+
   bcache-tools = callPackage ../tools/filesystems/bcache-tools { };
 
   bchunk = callPackage ../tools/cd-dvd/bchunk { };


### PR DESCRIPTION
bdfresize is a little tool used to resize BDF bitmap fonts. The code is quite dated, so I had to patch out an unneeded declaration of `malloc`. Now it compiles and works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
