### PR TITLE
foundationdb60: fix build

### DIFF
--- a/pkgs/servers/foundationdb/default.nix
+++ b/pkgs/servers/foundationdb/default.nix
@@ -69,6 +69,7 @@ in with builtins; {
 
     patches = [
       ./patches/ldflags-6.0.patch
+      ./patches/include-fixes-6.0.patch
     ];
   };
 

--- a/pkgs/servers/foundationdb/patches/include-fixes-6.0.patch
+++ b/pkgs/servers/foundationdb/patches/include-fixes-6.0.patch
@@ -1,0 +1,137 @@
+diff --git a/fdbrpc/ContinuousSample.h b/fdbrpc/ContinuousSample.h
+index 54ff1b109..577c228ae 100644
+--- a/fdbrpc/ContinuousSample.h
++++ b/fdbrpc/ContinuousSample.h
+@@ -26,6 +26,7 @@
+ #include "flow/IRandom.h"
+ #include <vector>
+ #include <algorithm>
++#include <cmath>
+ 
+ template <class T>
+ class ContinuousSample {
+diff --git a/fdbrpc/Smoother.h b/fdbrpc/Smoother.h
+index 3ed8e6e98..f3e4504b6 100644
+--- a/fdbrpc/Smoother.h
++++ b/fdbrpc/Smoother.h
+@@ -23,6 +23,7 @@
+ #pragma once
+ 
+ #include "flow/flow.h"
++#include <cmath>
+ 
+ struct Smoother {
+ 	// Times (t) are expected to be nondecreasing
+@@ -50,7 +51,7 @@ struct Smoother {
+ 		double elapsed = t - time;
+ 		if(elapsed) {
+ 			time = t;
+-			estimate += (total-estimate) * (1-exp( -elapsed/eFoldingTime ));
++			estimate += (total-estimate) * (1-std::exp( -elapsed/eFoldingTime ));
+ 		}
+ 	}
+ 
+@@ -83,11 +84,11 @@ struct TimerSmoother {
+ 	void update(double t) {
+ 		double elapsed = t - time;
+ 		time = t;
+-		estimate += (total-estimate) * (1-exp( -elapsed/eFoldingTime ));
++		estimate += (total-estimate) * (1-std::exp( -elapsed/eFoldingTime ));
+ 	}
+ 
+ 	double eFoldingTime;
+ 	double time, total, estimate;
+ };
+ 
+-#endif
+\ No newline at end of file
++#endif
+diff --git a/fdbserver/Knobs.cpp b/fdbserver/Knobs.cpp
+index a924bc905..0dc70e7ac 100644
+--- a/fdbserver/Knobs.cpp
++++ b/fdbserver/Knobs.cpp
+@@ -20,6 +20,7 @@
+ 
+ #include "Knobs.h"
+ #include "fdbrpc/Locality.h"
++#include <cmath>
+ 
+ ServerKnobs const* SERVER_KNOBS = new ServerKnobs();
+ 
+diff --git a/flow/Knobs.cpp b/flow/Knobs.cpp
+index 2d706dddd..5dbe08861 100644
+--- a/flow/Knobs.cpp
++++ b/flow/Knobs.cpp
+@@ -20,6 +20,7 @@
+ 
+ #include "Knobs.h"
+ #include "flow/flow.h"
++#include <cmath>
+ 
+ FlowKnobs const* FLOW_KNOBS = new FlowKnobs();
+ 
+@@ -128,7 +129,7 @@ FlowKnobs::FlowKnobs(bool randomize, bool isSimulated) {
+ 	init( MAX_METRICS,                                         600 );
+ 	init( MAX_METRIC_SIZE,                                    2500 );
+ 	init( MAX_METRIC_LEVEL,                                     25 );
+-	init( METRIC_LEVEL_DIVISOR,                             log(4) );
++	init( METRIC_LEVEL_DIVISOR,                        std::log(4) );
+ 	init( METRIC_LIMIT_START_QUEUE_SIZE,                        10 );  // The queue size at which to start restricting logging by disabling levels
+ 	init( METRIC_LIMIT_RESPONSE_FACTOR,                         10 );  // The additional queue size at which to disable logging of another level (higher == less restrictive)
+ 
+diff --git a/flow/Platform.cpp b/flow/Platform.cpp
+index a754c8747..4d47fad32 100644
+--- a/flow/Platform.cpp
++++ b/flow/Platform.cpp
+@@ -98,6 +98,8 @@
+ #include <sys/resource.h>
+ /* Needed for crash handler */
+ #include <signal.h>
++/* Needed for major() and minor() with recent glibc */
++#include <sys/sysmacros.h>
+ #endif
+ 
+ #ifdef __APPLE__
+diff --git a/flow/Profiler.actor.cpp b/flow/Profiler.actor.cpp
+index 4603dcb77..78eda7278 100644
+--- a/flow/Profiler.actor.cpp
++++ b/flow/Profiler.actor.cpp
+@@ -35,8 +35,6 @@
+ 
+ extern volatile int profilingEnabled;
+ 
+-static uint64_t gettid() { return syscall(__NR_gettid); }
+-
+ struct SignalClosure {
+ 	void (* func)(int, siginfo_t*, void*, void*);
+ 	void *userdata;
+diff --git a/flow/TDMetric.actor.h b/flow/TDMetric.actor.h
+index 306352c39..fc63e12f9 100755
+--- a/flow/TDMetric.actor.h
++++ b/flow/TDMetric.actor.h
+@@ -35,6 +35,7 @@
+ #include "genericactors.actor.h"
+ #include "CompressedInt.h"
+ #include <algorithm>
++#include <cmath>
+ #include <functional>
+ 
+ struct MetricNameRef {
+@@ -799,7 +800,7 @@ struct EventMetric : E, ReferenceCounted<EventMetric<E>>, MetricUtil<EventMetric
+ 		if (x == 0.0)
+ 			l = FLOW_KNOBS->MAX_METRIC_LEVEL-1;
+ 		else
+-			l = std::min(FLOW_KNOBS->MAX_METRIC_LEVEL-1, (int64_t)(::log(1.0/x) / FLOW_KNOBS->METRIC_LEVEL_DIVISOR));
++			l = std::min(FLOW_KNOBS->MAX_METRIC_LEVEL-1, (int64_t)(std::log(1.0/x) / FLOW_KNOBS->METRIC_LEVEL_DIVISOR));
+ 
+ 		if(!canLog(l))
+ 			return 0;
+@@ -1274,7 +1275,7 @@ public:
+ 				l = std::min(
+ 					FLOW_KNOBS->MAX_METRIC_LEVEL-1,
+ 					(int64_t)(
+-						log((toggleTime - tv.time) / x) /
++						std::log((toggleTime - tv.time) / x) /
+ 							FLOW_KNOBS->METRIC_LEVEL_DIVISOR
+ 					)
+ 				);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes build failures on the `foundationdb60` package.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>foundationdb60</li>
    <li>python37Packages.foundationdb60</li>
    <li>python38Packages.foundationdb60</li>
    <li>python39Packages.foundationdb60</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
