### PR TITLE
io: 2015.11.11 -> 2017.09.06

### DIFF
--- a/pkgs/development/interpreters/io/default.nix
+++ b/pkgs/development/interpreters/io/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, zlib, sqlite, gmp, libffi, cairo,
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, zlib, sqlite, gmp, libffi, cairo,
   ncurses, freetype, libGLU, libGL, libpng, libtiff, libjpeg, readline, libsndfile,
   libxml2, freeglut, libsamplerate, pcre, libevent, libedit, yajl,
   python3, openssl, glfw, pkg-config, libpthreadstubs, libXdmcp, libmemcached
@@ -12,6 +12,14 @@ stdenv.mkDerivation {
     rev = "1fc725e0a8635e2679cbb20521f4334c25273caa";
     sha256 = "0ll2kd72zy8vf29sy0nnx3awk7nywpwpv21rvninjjaqkygrc0qw";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "check-for-sysctl-h.patch";
+      url = "https://github.com/IoLanguage/io/pull/446/commits/9f3e4d87b6d4c1bf583134d55d1cf92d3464c49f.patch";
+      sha256 = "9f06073ac17f26c2ef6298143bdd1babe7783c228f9667622aa6c91bb7ec7fa0";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/interpreters/io/default.nix
+++ b/pkgs/development/interpreters/io/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation {
-  name = "io-2015.11.11";
+  name = "io-2017.09.06";
   src = fetchFromGitHub {
     owner = "stevedekorte";
     repo = "io";
-    rev = "1fc725e0a8635e2679cbb20521f4334c25273caa";
-    sha256 = "0ll2kd72zy8vf29sy0nnx3awk7nywpwpv21rvninjjaqkygrc0qw";
+    rev = "b8a18fc199758ed09cd2f199a9bc821f6821072a";
+    sha256 = "07rg1zrz6i6ghp11cm14w7bbaaa1s8sb0y5i7gr2sds0ijlpq223";
   };
 
   patches = [

--- a/pkgs/development/interpreters/io/default.nix
+++ b/pkgs/development/interpreters/io/default.nix
@@ -40,6 +40,17 @@ stdenv.mkDerivation {
     sed -ie \
           "s/add_subdirectory(addons)/#add_subdirectory(addons)/g" \
           CMakeLists.txt
+    # Bind Libs STATIC to avoid a segfault when relinking
+    sed -i 's/basekit SHARED/basekit STATIC/' libs/basekit/CMakeLists.txt
+    sed -i 's/garbagecollector SHARED/garbagecollector STATIC/' libs/garbagecollector/CMakeLists.txt
+    sed -i 's/coroutine SHARED/coroutine STATIC/' libs/coroutine/CMakeLists.txt
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/io
+    $out/bin/io_static
   '';
 
   # for gcc5; c11 inline semantics breaks the build

--- a/pkgs/development/interpreters/io/default.nix
+++ b/pkgs/development/interpreters/io/default.nix
@@ -5,7 +5,8 @@
 }:
 
 stdenv.mkDerivation {
-  name = "io-2017.09.06";
+  pname = "io";
+  version = "2017.09.06";
   src = fetchFromGitHub {
     owner = "stevedekorte";
     repo = "io";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The package had three distinct problems:
- It did not build since glibc 2.32 dropped sys/sysctl.h. Luckily it ~~is only needed with Cygwin anyways~~ seems to be of little importance, see https://github.com/IoLanguage/io/issues/433#issuecomment-727950520
- The dynamically linked version of the interpreter tried to link to libm.so and segfaulted. I did not figure out the reason but instead statically linked the libraries themselves. The resulting difference in package size is 2.3M -> 3.0M.
- The version was not the latest stable release

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>io</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
