### PR TITLE
php: fixed building with cliSupport = false

### DIFF
--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -123,7 +123,9 @@ let
                 postBuild = ''
                   cp ${extraInit} $out/lib/php.ini
 
-                  wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
+                  if test -e $out/bin/php; then
+                    wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
+                  fi
 
                   if test -e $out/bin/php-fpm; then
                     wrapProgram $out/bin/php-fpm --set PHP_INI_SCAN_DIR $out/lib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
###### Motivation for this change
If you build PHP without `cliSupport` you will get an error like `Builder called die: Cannot wrap '/nix/store/15n44xmcvm48w0c444691j6iw1nck4kw-php-with-extensions-7.4.15/bin/php' because it is not an executable file`

This is not something we want, as you can have a need for only having php-fpm, without the cli support.

This pull request fixes this.

Can be tested using

```nix
{ pkgs ? import <nixpkgs> {} }:

let
  nocliphp = pkgs.php.override {
    cliSupport = false;
  };
in nocliphp
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
