### PR TITLE
foundationdb61: 6.1.12 -> 6.1.13, fix build

### DIFF
--- a/pkgs/servers/foundationdb/default.nix
+++ b/pkgs/servers/foundationdb/default.nix
@@ -76,13 +76,14 @@ in with builtins; {
   # ------------------------------------------------------
 
   foundationdb61 = cmakeBuild {
-    version = "6.1.12";
+    version = "6.1.13";
     branch  = "release-6.1";
-    sha256  = "1yh5hx6rim41m0dwhnb2pcwz67wlnk0zwvyw845d36b29gwy58ab";
+    sha256  = "10vd694dcnh2pp91mri1m80kfbwjanhiy50c53c5ncqfa6pwvk00";
 
     patches = [
       ./patches/clang-libcxx.patch
       ./patches/suppress-clang-warnings.patch
+      ./patches/stdexcept-6.1.patch
       glibc230-fix
     ];
   };

--- a/pkgs/servers/foundationdb/patches/stdexcept-6.1.patch
+++ b/pkgs/servers/foundationdb/patches/stdexcept-6.1.patch
@@ -1,0 +1,24 @@
+diff --git a/FDBLibTLS/FDBLibTLSPolicy.cpp b/FDBLibTLS/FDBLibTLSPolicy.cpp
+index 728ff871d..46e1dd289 100644
+--- a/FDBLibTLS/FDBLibTLSPolicy.cpp
++++ b/FDBLibTLS/FDBLibTLSPolicy.cpp
+@@ -31,6 +31,7 @@
+ #include <algorithm>
+ #include <exception>
+ #include <map>
++#include <stdexcept>
+ #include <string>
+ #include <vector>
+ 
+diff --git a/FDBLibTLS/FDBLibTLSVerify.cpp b/FDBLibTLS/FDBLibTLSVerify.cpp
+index 594389916..1c8b9b50d 100644
+--- a/FDBLibTLS/FDBLibTLSVerify.cpp
++++ b/FDBLibTLS/FDBLibTLSVerify.cpp
+@@ -25,6 +25,7 @@
+ #include <algorithm>
+ #include <exception>
+ #include <cstring>
++#include <stdexcept>
+ 
+ static int hexValue(char c) {
+ 	static char const digits[] = "0123456789ABCDEF";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It fixes build breakage of the `foundationdb61` package.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>foundationdb</li>
    <li>python37Packages.foundationdb61</li>
    <li>python38Packages.foundationdb61</li>
    <li>python39Packages.foundationdb61</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
