### PR TITLE
maelstrom: init at 3.0.7

### DIFF
--- a/pkgs/games/maelstrom/default.nix
+++ b/pkgs/games/maelstrom/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchurl, makeDesktopItem, SDL2, SDL2_net }:
+
+stdenv.mkDerivation rec {
+  name = "maelstrom";
+  version = "3.0.7";
+
+  src = fetchurl {
+    url = "http://www.libsdl.org/projects/Maelstrom/src/Maelstrom-${version}.tar.gz";
+    sha256 = "0dm0m5wd7amrsa8wnrblkv34sq4v4lglc2wfx8klfkdhyhi06s4k";
+  };
+
+  patches = [ ./fix-compilation.patch ];
+
+  buildInputs = [ SDL2 SDL2_net ];
+
+  postInstall = ''
+    mkdir -p $out/bin
+    ln -s $out/games/Maelstrom/Maelstrom $out/bin/maelstrom
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "maelstrom";
+      exec = "maelstrom";
+      desktopName = "Maelstrom";
+      genericName = "Maelstrom";
+      comment = "An arcade-style game resembling Asteroids";
+      categories = "Game;";
+    })
+  ];
+
+  meta = with lib; {
+    description = "An arcade-style game resembling Asteroids";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ tmountain ];
+  };
+}

--- a/pkgs/games/maelstrom/default.nix
+++ b/pkgs/games/maelstrom/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dm0m5wd7amrsa8wnrblkv34sq4v4lglc2wfx8klfkdhyhi06s4k";
   };
 
+  # this fixes a typedef compilation error with gcc-3.x
   patches = [ ./fix-compilation.patch ];
 
   buildInputs = [ SDL2 SDL2_net ];
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An arcade-style game resembling Asteroids";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ tmountain ];
   };

--- a/pkgs/games/maelstrom/default.nix
+++ b/pkgs/games/maelstrom/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, makeDesktopItem, SDL2, SDL2_net }:
 
 stdenv.mkDerivation rec {
-  name = "maelstrom";
+  pname = "maelstrom";
   version = "3.0.7";
 
   src = fetchurl {

--- a/pkgs/games/maelstrom/fix-compilation.patch
+++ b/pkgs/games/maelstrom/fix-compilation.patch
@@ -1,0 +1,42 @@
+diff -Naur Maelstrom-3.0.7/buttonlist.h Maelstrom-3.0.7-patched/buttonlist.h
+--- Maelstrom-3.0.7/buttonlist.h	2000-01-25 11:41:32.000000000 -0500
++++ Maelstrom-3.0.7-patched/buttonlist.h	2021-02-22 08:34:01.000000000 -0500
+@@ -16,7 +16,7 @@
+ 
+ 	void Add_Button(Uint16 x, Uint16 y, Uint16 width, Uint16 height, 
+ 						void (*callback)(void)) {
+-		struct button *belem;
++        button *belem;
+ 		
+ 		for ( belem=&button_list; belem->next; belem=belem->next );
+ 		belem->next = new button;
+@@ -30,7 +30,7 @@
+ 	}
+ 
+ 	void Activate_Button(Uint16 x, Uint16 y) {
+-		struct button *belem;
++        button *belem;
+ 
+ 		for ( belem=button_list.next; belem; belem=belem->next ) {
+ 			if ( (x >= belem->x1) && (x <= belem->x2) &&
+@@ -42,7 +42,7 @@
+ 	}
+ 
+ 	void Delete_Buttons(void) {
+-		struct button *belem, *btemp;
++        button *belem, *btemp;
+ 
+ 		for ( belem=button_list.next; belem; ) {
+ 			btemp = belem;
+diff -Naur Maelstrom-3.0.7/main.cpp Maelstrom-3.0.7-patched/main.cpp
+--- Maelstrom-3.0.7/main.cpp	2021-02-04 11:50:27.000000000 -0500
++++ Maelstrom-3.0.7-patched/main.cpp	2021-02-22 08:34:34.000000000 -0500
+@@ -153,7 +153,7 @@
+ 	error("or\n");
+ 	error("Usage: %s <options>\n\n", progname);
+ 	error("Where <options> can be any of:\n\n"
+-"	-fullscreen		# Run Maelstrom in full-screen mode\n"
++"	-windowed		# Run Maelstrom in windowed mode\n"
+ "	-gamma [0-8]		# Set the gamma correction\n"
+ "	-volume [0-8]		# Set the sound volume\n"
+ "	-netscores		# Use the world-wide network score server\n"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -509,6 +509,8 @@ in
 
   madonctl = callPackage ../applications/misc/madonctl { };
 
+  maelstrom = callPackage ../games/maelstrom { };
+
   copyDesktopItems = makeSetupHook { } ../build-support/setup-hooks/copy-desktop-items.sh;
 
   makeDesktopItem = callPackage ../build-support/make-desktopitem { };


### PR DESCRIPTION
###### Motivation for this change

Add maelstrom to nixpkgs.

###### Things done

- Built on platform(s)
   - [X] macOS
   - [X] other Linux distributions
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
