### PR TITLE
ytcc: 2.0.1 -> 2.1.0

### DIFF
--- a/pkgs/tools/networking/ytcc/default.nix
+++ b/pkgs/tools/networking/ytcc/default.nix
@@ -2,18 +2,25 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ytcc";
-  version = "2.0.1";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "woefe";
     repo = "ytcc";
     rev = "v${version}";
-    sha256 = "11gwpqmq611j07pjscch28jsrfgyzy69ph2w1miz3arqmxz7dqjp";
+    sha256 = "04l5bfyq53r8803q24bfw49ji7jx8z9irhhh30cvq2va1ywwd4ww";
   };
 
   nativeBuildInputs = [ gettext ];
 
-  propagatedBuildInputs = with python3Packages; [ click feedparser lxml sqlalchemy youtube-dl ];
+  propagatedBuildInputs = with python3Packages; [
+    click
+    feedparser
+    lxml
+    sqlalchemy
+    youtube-dl
+    wcwidth
+  ];
 
   checkInputs = with python3Packages; [ nose pytestCheckHook ];
 
@@ -24,6 +31,11 @@ python3Packages.buildPythonApplication rec {
     "download_videos"
     "update_all"
     "add_channel_duplicate"
+    "test_subscribe"
+    "test_import"
+    "test_import_duplicate"
+    "test_update"
+    "test_download"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The `ytcc` package in unstable is outdated and has the wrong hash (https://github.com/NixOS/nixpkgs/pull/109088 forgot to update the hash)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
