### PR TITLE
python3Packages.jsonpath-ng: init at 1.5.2

### DIFF
--- a/pkgs/development/python-modules/jsonpath-ng/default.nix
+++ b/pkgs/development/python-modules/jsonpath-ng/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, decorator
+, fetchFromGitHub
+, ply
+, pytestCheckHook
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "jsonpath-ng";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "h2non";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1cxjwhx0nj85a3awnl7j6afnk07awzv45qfwxl5jqbbc9cxh5bd6";
+  };
+
+  propagatedBuildInputs = [
+    decorator
+    ply
+    six
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  disabledTestFiles = [
+    # Exclude tests that require oslotest
+    "tests/test_jsonpath_rw_ext.py"
+  ];
+
+  pythonImportsCheck = [ "jsonpath_ng" ];
+
+  meta = with lib; {
+    description = "JSONPath implementation for Python";
+    homepage = "https://github.com/h2non/jsonpath-ng";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3393,6 +3393,8 @@ in {
 
   jsonpath_rw = callPackage ../development/python-modules/jsonpath_rw { };
 
+  jsonpath-ng = callPackage ../development/python-modules/jsonpath-ng { };
+
   jsonpickle = callPackage ../development/python-modules/jsonpickle { };
 
   jsonpointer = callPackage ../development/python-modules/jsonpointer { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
JSONPath implementation for Python

https://github.com/h2non/jsonpath-ng

Will become a dependency of `home-assistant-cli` in the next release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
