### PR TITLE
ags: init at 3.5.0.30

### DIFF
--- a/pkgs/games/ags/default.nix
+++ b/pkgs/games/ags/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, stdenv
+, cmake
+, fetchurl
+, fetchFromGitHub
+, alsaLib
+, dumb
+, libjack2
+, libogg
+, libtheora
+, libvorbis
+, libXext
+, libXxf86vm
+, libX11
+, pkg-config
+, SDL2
+}:
+
+stdenv.mkDerivation rec {
+  name = "ags";
+  version = "3.5.0.30";
+
+  src = fetchurl {
+    url = "https://github.com/adventuregamestudio/ags/releases/download/v.${version}/ags_${version}_source.tar.gz";
+    sha256 = "1d74ajw8p2g8rbklr73hm9di6az71vlw7m8r8jxiw0lfbk0iv2i9";
+  };
+
+  # prevent the original builder from trying to download
+  patches = [ ./no-download.patch ];
+
+  # download the deps manually for subsequent unpacking
+  libAllegro = fetchFromGitHub {
+    owner = "adventuregamestudio";
+    repo = "lib-allegro";
+    rev = "allegro-4.4.3.1-agspatch";
+    sha256 = "0vg8fkqqy78f46sl6xagja7g91n9xck8z0z22q5xvlcz41lf3cb5";
+  };
+
+  libOgg = fetchFromGitHub {
+    owner = "xiph";
+    repo = "ogg";
+    rev = "f7dadaaf75634289f7ead64ed1802b627d761ee3";
+    sha256 = "1whvkq4x4hx61zbbc912qzv1hfqk64b6c02ab5m8y0xk24ghlfgq";
+  };
+
+  libTheora = fetchFromGitHub {
+    owner = "xiph";
+    repo = "theora";
+    rev = "e5d205bfe849f1b41f45b91a0b71a3bdc6cd458f";
+    sha256 = "1qpy7c6f7wc8f8zph0cvy6z8ag9r7vszpkxhy7z3x523d1lcrmsd";
+  };
+
+  libVorbis = fetchFromGitHub {
+    owner = "xiph";
+    repo = "vorbis";
+    rev = "9eadeccdc4247127d91ac70555074239f5ce3529";
+    sha256 = "1phdcr6mfv85g6qabq811bw9p87kdfnrvjvapsq2b8yfwdddgi0s";
+  };
+
+  # default behavior breaks the build
+  dontUseCmakeBuildDir = true;
+  dontFixCmake = true;
+
+  cmakeFlags = [
+    "-Wno-dev" # kill dev warnings that are useless for packaging
+  ];
+
+  # copy files that are typically fetched by git
+  preConfigure = ''
+    mkdir -p _deps
+    cp -a $libAllegro _deps/allegro_content-src
+    cp -a $libOgg _deps/ogg_content-src
+    cp -a $libVorbis _deps/vorbis_content-src
+    cp -a $libTheora _deps/theora_content-src
+    chmod -R +w _deps/allegro_content-src
+    chmod -R +w _deps/ogg_content-src
+    chmod -R +w _deps/vorbis_content-src
+    chmod -R +w _deps/theora_content-src
+  '';
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ alsaLib dumb libjack2 libogg SDL2 libtheora libvorbis libXext libXxf86vm libX11 ];
+
+  installPhase = "install -Dm755 ags -t $out/bin";
+
+  meta = with lib; {
+    description = "Adventure Game Studio runtime engine";
+    homepage = "https://www.adventuregamestudio.co.uk/";
+    license = licenses.artistic2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/ags/default.nix
+++ b/pkgs/games/ags/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     mkdir -p _deps
     cp -a $libAllegro _deps/allegro_content-src
-    cp -a $libOgg _deps/ogg_content-src
+    cp -a ${libogg.src} _deps/ogg_content-src
     cp -a $libVorbis _deps/vorbis_content-src
     cp -a $libTheora _deps/theora_content-src
     chmod -R +w _deps/allegro_content-src

--- a/pkgs/games/ags/default.nix
+++ b/pkgs/games/ags/default.nix
@@ -78,7 +78,6 @@ stdenv.mkDerivation rec {
     chmod -R +w _deps/theora_content-src
   '';
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ alsaLib dumb libjack2 libogg SDL2 libtheora libvorbis libXext libXxf86vm libX11 ];
 

--- a/pkgs/games/ags/no-download.patch
+++ b/pkgs/games/ags/no-download.patch
@@ -1,0 +1,53 @@
+diff --git a/CMake/FetchAllegro.cmake b/CMake/FetchAllegro.cmake
+index c29d247..6c9a083 100644
+--- a/CMake/FetchAllegro.cmake
++++ b/CMake/FetchAllegro.cmake
+@@ -1,8 +1,6 @@
+ FetchContent_Declare(
+   allegro_content
+-  GIT_REPOSITORY https://github.com/adventuregamestudio/lib-allegro.git
+-  GIT_TAG        allegro-4.4.3.1-agspatch
+-  GIT_SHALLOW    yes
++  DOWNLOAD_COMMAND true
+ )
+ 
+ FetchContent_GetProperties(allegro_content)
+diff --git a/CMake/FetchOgg.cmake b/CMake/FetchOgg.cmake
+index c4cd544..4c306fe 100644
+--- a/CMake/FetchOgg.cmake
++++ b/CMake/FetchOgg.cmake
+@@ -1,7 +1,6 @@
+ FetchContent_Declare(
+   ogg_content
+-  GIT_REPOSITORY https://github.com/xiph/ogg.git
+-  GIT_TAG        f7dadaaf75634289f7ead64ed1802b627d761ee3
++  DOWNLOAD_COMMAND true
+ )
+ 
+ FetchContent_GetProperties(ogg_content)
+diff --git a/CMake/FetchTheora.cmake b/CMake/FetchTheora.cmake
+index 0698bab..50caf27 100644
+--- a/CMake/FetchTheora.cmake
++++ b/CMake/FetchTheora.cmake
+@@ -1,7 +1,6 @@
+ FetchContent_Declare(
+   theora_content
+-  GIT_REPOSITORY https://github.com/xiph/theora.git
+-  GIT_TAG        e5d205bfe849f1b41f45b91a0b71a3bdc6cd458f
++  DOWNLOAD_COMMAND true
+ )
+ 
+ FetchContent_GetProperties(theora_content)
+diff --git a/CMake/FetchVorbis.cmake b/CMake/FetchVorbis.cmake
+index 893f744..cab0d81 100644
+--- a/CMake/FetchVorbis.cmake
++++ b/CMake/FetchVorbis.cmake
+@@ -1,7 +1,6 @@
+ FetchContent_Declare(
+   vorbis_content
+-  GIT_REPOSITORY https://github.com/xiph/vorbis.git
+-  GIT_TAG        9eadeccdc4247127d91ac70555074239f5ce3529
++  DOWNLOAD_COMMAND true
+ )
+ 
+ FetchContent_GetProperties(vorbis_content)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -150,6 +150,11 @@ in
 
   alda = callPackage ../development/interpreters/alda { };
 
+  ags = callPackage ../games/ags {
+    inherit (xorg) libXext libXxf86vm ;
+    inherit (pkgs.xorg) libX11 ;
+  };
+
   among-sus = callPackage ../games/among-sus { };
 
   ankisyncd = callPackage ../servers/ankisyncd { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -151,8 +151,7 @@ in
   alda = callPackage ../development/interpreters/alda { };
 
   ags = callPackage ../games/ags {
-    inherit (xorg) libXext libXxf86vm ;
-    inherit (pkgs.xorg) libX11 ;
+    inherit (xorg) libX11 libXext libXxf86vm ;
   };
 
   among-sus = callPackage ../games/among-sus { };


### PR DESCRIPTION
###### Motivation for this change

Add ags (adventure game studio) runtime to nixpkgs.

###### Things done

- Built on platform(s)
   - [X] NixOS
   - [X] other Linux distributions
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
