### PR TITLE
neochat: 1.0.1 -> 1.1.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/neochat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/neochat/default.nix
@@ -3,8 +3,6 @@
 , fetchFromGitLab
 , pkg-config
 , cmake
-, qtbase
-, qttools
 , qtquickcontrols2
 , qtmultimedia
 , qtgraphicaleffects
@@ -26,14 +24,14 @@
 
 mkDerivation rec {
   pname = "neochat";
-  version = "1.0.1";
+  version = "1.1.1";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "network";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-xGqGFJHyoZXHLv/n3UGr/KVbgs5Gc9kKKWIuKMr9DtQ=";
+    sha256 = "sha256-HvLPsU+fxlyPDP7i9OSnZ/C1RjouOQCp+4WCl6FlFJo=";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkg-config ];

--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "libquotient";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchFromGitHub {
     owner = "quotient-im";
     repo = "libQuotient";
     rev = version;
-    sha256 = "sha256-bWqZiRv/mJzw+WY+7dLIzYBu8jhglBqgTjiXyQ1y6IQ=";
+    sha256 = "sha256-TAfo4BkNHE8r32FPT2iDjddq2lk1yC9DrRGZurSO48c=";
   };
 
   buildInputs = [ qtbase qtmultimedia ];


### PR DESCRIPTION
###### Motivation for this change

Bumps libquotient as part of this. Also tested with quaternion, which is also working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
