### PR TITLE
cvise: init at 2.1.0

### DIFF
--- a/pkgs/development/tools/misc/cvise/default.nix
+++ b/pkgs/development/tools/misc/cvise/default.nix
@@ -1,0 +1,46 @@
+{ lib, buildPythonApplication, fetchFromGitHub, cmake, flex
+, clang-unwrapped, llvm, unifdef
+, pebble, psutil, pytestCheckHook, pytest-flake8
+}:
+
+buildPythonApplication rec {
+  pname = "cvise";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "marxin";
+    repo = "cvise";
+    rev = "v${version}";
+    sha256 = "0ljl0r5jqj6lrddrbxjkcphcz5p4njnn2hqz07jyh30jd9sm7dmj";
+  };
+
+  patches = [
+    # Refer to unifdef by absolute path.
+    ./unifdef.patch
+  ];
+
+  nativeBuildInputs = [ cmake flex ];
+  buildInputs = [ clang-unwrapped llvm unifdef ];
+  propagatedBuildInputs = [ pebble psutil ];
+  checkInputs = [ pytestCheckHook pytest-flake8 unifdef ];
+
+  preCheck = ''
+    patchShebangs cvise.py
+  '';
+  disabledTests = [
+    # Needs gcc, fails when run noninteractively (without tty).
+    "test_simple_reduction"
+  ];
+
+  dontUsePipInstall = true;
+  dontUseSetuptoolsBuild = true;
+  dontUseSetuptoolsCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/marxin/cvise";
+    description = "Super-parallel Python port of C-Reduce";
+    license = licenses.ncsa;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/cvise/unifdef.patch
+++ b/pkgs/development/tools/misc/cvise/unifdef.patch
@@ -1,0 +1,8 @@
+--- a/cvise.py
++++ b/cvise.py
+@@ -93,4 +93,5 @@ def find_external_programs():
+     # Special case for clang-format
+     programs['clang-format'] = '@CLANG_FORMAT_PATH@'
++    programs['unifdef'] = '@UNIFDEF@'
+ 
+     return programs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12114,6 +12114,10 @@ in
 
   csslint = callPackage ../development/web/csslint { };
 
+  cvise = python3Packages.callPackage ../development/tools/misc/cvise {
+    inherit (llvmPackages_11) llvm clang-unwrapped;
+  };
+
   libcxx = llvmPackages.libcxx;
   libcxxabi = llvmPackages.libcxxabi;
 


### PR DESCRIPTION
###### Motivation for this change

Using C-Vise, a new alternative to C-Reduce, a tool for reducing reproducers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
