### PR TITLE
redis: 6.0.10 -> 6.2.0 

### DIFF
--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchurl, lua, pkg-config, systemd, jemalloc, nixosTests
+{ lib, stdenv, fetchurl, lua, pkg-config, systemd, nixosTests
 , tlsSupport ? true, openssl
 }:
 
 stdenv.mkDerivation rec {
-  version = "6.0.10";
   pname = "redis";
+  version = "6.2.0";
 
   src = fetchurl {
-    url = "http://download.redis.io/releases/${pname}-${version}.tar.gz";
-    sha256 = "1gc529nfh8frk4pynyjlnmzvwa0j9r5cmqwyd7537sywz6abifvr";
+    url = "https://download.redis.io/releases/${pname}-${version}.tar.gz";
+    sha256 = "1jnv6acjlljvrlxmz0mqarsx1fl5vwss24l8zy5dcawnbp129mk7";
   };
 
   # Cross-compiling fixes
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
     ++ lib.optionals tlsSupport [ "BUILD_TLS=yes" ];
 
   enableParallelBuilding = true;
+
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isClang [ "-std=c11" ];
 
   doCheck = false; # needs tcl
 

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.all;
     changelog = "https://github.com/redis/redis/raw/${version}/00-RELEASENOTES";
-    maintainers = with maintainers; [ berdario globin ];
+    maintainers = with maintainers; [ berdario globin marsam ];
   };
 }

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -46,7 +46,8 @@ stdenv.mkDerivation rec {
     homepage = "https://redis.io";
     description = "An open source, advanced key-value store";
     license = licenses.bsd3;
-    platforms = platforms.unix;
+    platforms = platforms.all;
+    changelog = "https://github.com/redis/redis/raw/${version}/00-RELEASENOTES";
     maintainers = with maintainers; [ berdario globin ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/redis/redis/blob/6.2.0/00-RELEASENOTES

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
