### PR TITLE
top-level/php-packages: fix types

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -268,7 +268,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         buildInputs = [ libxml2 ];
         configureFlags = [ "--enable-dom" ]
           # Required to build on darwin.
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
       { name = "enchant";
         buildInputs = [ enchant1 ];
         configureFlags = [ "--with-enchant=${enchant1}" ];
@@ -331,10 +331,12 @@ lib.makeScope pkgs.newScope (self: with self; {
       # interbase (7.3, 7.2)
       { name = "intl";
         buildInputs = [ icu64 ];
-        patches = lib.optional (lib.versionOlder php.version "7.4") (fetchpatch {
-          url = "https://github.com/php/php-src/commit/93a9b56c90c334896e977721bfb3f38b1721cec6.patch";
-          sha256 = "055l40lpyhb0rbjn6y23qkzdhvpp7inbnn6x13cpn4inmhjqfpg4";
-        });
+        patches = lib.optionals (lib.versionOlder php.version "7.4") [
+          (fetchpatch {
+            url = "https://github.com/php/php-src/commit/93a9b56c90c334896e977721bfb3f38b1721cec6.patch";
+            sha256 = "055l40lpyhb0rbjn6y23qkzdhvpp7inbnn6x13cpn4inmhjqfpg4";
+          })
+        ];
       }
       { name = "json"; enable = lib.versionOlder php.version "8.0"; }
       { name = "ldap";
@@ -344,7 +346,9 @@ lib.makeScope pkgs.newScope (self: with self; {
           "LDAP_DIR=${openldap.dev}"
           "LDAP_INCDIR=${openldap.dev}/include"
           "LDAP_LIBDIR=${openldap.out}/lib"
-        ] ++ lib.optional stdenv.isLinux "--with-ldap-sasl=${cyrus_sasl.dev}";
+        ] ++ lib.optionals stdenv.isLinux [
+          "--with-ldap-sasl=${cyrus_sasl.dev}"
+        ];
         doCheck = false; }
       { name = "mbstring"; buildInputs = [ oniguruma ] ++ lib.optionals (lib.versionAtLeast php.version "8.0") [
           pcre'
@@ -374,7 +378,7 @@ lib.makeScope pkgs.newScope (self: with self; {
                +----------------------------------------------------------------------+
                | Copyright (c) The PHP Group                                          |
           '')
-        ] ++ lib.optional (lib.versionOlder php.version "7.4.8") [
+        ] ++ lib.optionals (lib.versionOlder php.version "7.4.8") [
           (pkgs.writeText "mysqlnd_fix_compression.patch" ''
             --- a/ext/mysqlnd/mysqlnd.h
             +++ b/ext/mysqlnd/mysqlnd.h
@@ -398,7 +402,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         buildInputs = [ pcre' ] ++ lib.optionals (lib.versionAtLeast php.version "8.0") [
           valgrind.dev
         ];
-        patches = [] ++ lib.optional (lib.versionOlder php.version "7.4") [
+        patches = [] ++ lib.optionals (lib.versionOlder php.version "7.4") [
           (pkgs.writeText "zend_file_cache_config.patch" ''
             --- a/ext/opcache/zend_file_cache.c
             +++ b/ext/opcache/zend_file_cache.c
@@ -468,7 +472,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         buildInputs = [ libxml2 pcre' ];
         configureFlags = [ "--enable-simplexml" ]
           # Required to build on darwin.
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
       { name = "snmp";
         buildInputs = [ net-snmp openssl ];
         configureFlags = [ "--with-snmp" ];
@@ -479,7 +483,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         buildInputs = [ libxml2 ];
         configureFlags = [ "--enable-soap" ]
           # Required to build on darwin.
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
         doCheck = false; }
       { name = "sockets"; doCheck = false; }
       { name = "sodium"; buildInputs = [ libsodium ]; }
@@ -499,7 +503,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         buildInputs = [ libxml2 ];
         configureFlags = [ "--enable-xml" ]
           # Required to build on darwin.
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
         doCheck = false; }
       { name = "xmlreader";
         buildInputs = [ libxml2 ];
@@ -507,19 +511,19 @@ lib.makeScope pkgs.newScope (self: with self; {
         NIX_CFLAGS_COMPILE = [ "-I../.." "-DHAVE_DOM" ];
         configureFlags = [ "--enable-xmlreader" ]
           # Required to build on darwin.
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
       { name = "xmlrpc";
         buildInputs = [ libxml2 libiconv ];
         # xmlrpc was unbundled in 8.0 https://php.watch/versions/8.0/xmlrpc
         enable = lib.versionOlder php.version "8.0";
         configureFlags = [ "--with-xmlrpc" ]
           # Required to build on darwin.
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
       { name = "xmlwriter";
         buildInputs = [ libxml2 ];
         configureFlags = [ "--enable-xmlwriter" ]
           # Required to build on darwin.
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
       { name = "xsl";
         buildInputs = [ libxslt libxml2 ];
         doCheck = lib.versionOlder php.version "8.0";
@@ -528,8 +532,8 @@ lib.makeScope pkgs.newScope (self: with self; {
       { name = "zip";
         buildInputs = [ libzip pcre' ];
         configureFlags = [ "--with-zip" ]
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]
-          ++ lib.optional (lib.versionOlder php.version "7.3") [ "--with-libzip" ];
+          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]
+          ++ lib.optionals (lib.versionOlder php.version "7.3") [ "--with-libzip" ];
         doCheck = false; }
       { name = "zlib";
         buildInputs = [ zlib ];
@@ -538,7 +542,7 @@ lib.makeScope pkgs.newScope (self: with self; {
           ../development/interpreters/php/zlib-darwin-tests.patch
         ];
         configureFlags = [ "--with-zlib" ]
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]; }
+          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]; }
     ];
 
     # Convert the list of attrs:


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
﻿
Passing list to `optional` wraps it in another list but we just want to return it as is.

Let’s just use `optionals` everywhere as that is much more predictable and makes such mistakes obvious.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
