### PR TITLE
ocamlPackages.digestif: 0.9.0 → 1.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/digestif/default.nix
+++ b/pkgs/development/ocaml-modules/digestif/default.nix
@@ -5,13 +5,13 @@
 
 buildDunePackage rec {
   pname = "digestif";
-  version = "0.9.0";
+  version = "1.0.0";
 
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/digestif/releases/download/v${version}/digestif-v${version}.tbz";
-    sha256 = "0vk9prgjp46xs8qizq7szkj6mqjj2ymncs2016bc8zswcdc1a3q4";
+    sha256 = "11188ya6ksb0p0zvs6saz3qxv4a8pyy8m3sq35f3qfxrxhghqi99";
   };
 
   propagatedBuildInputs = [ bigarray-compat eqaf stdlib-shims ];


### PR DESCRIPTION
###### Motivation for this change

Major release: https://github.com/mirage/digestif/releases/tag/v1.0.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
