### PR TITLE
teensyduino: fix missing library paths

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -23,6 +23,7 @@
 , glib
 , pango
 , gdk-pixbuf
+, gtk2
 , libpng12
 , expat
 , freetype
@@ -56,7 +57,7 @@ let
     gcc.cc.lib
     gdk-pixbuf
     glib
-    gtk3
+    gtk2
     libpng12
     libusb-compat-0_1
     pango
@@ -240,7 +241,7 @@ stdenv.mkDerivation rec {
       patchelf --debug \
           --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
           --set-rpath "${teensy_libpath}" \
-          $out/share/arduino/hardware/tools/teensy
+          $out/share/arduino/hardware/tools/teensy{,_ports,_reboot,_restart,_serialmon}
     ''}
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- The teensy binary requires Gtk2, not Gtk3.
- The teensy_{ports,reboot,restart,serialmon} binaries need libudev.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
