### PR TITLE
scheme48: refactor and add siraben as maintainer

### DIFF
--- a/pkgs/development/interpreters/scheme48/default.nix
+++ b/pkgs/development/interpreters/scheme48/default.nix
@@ -1,17 +1,24 @@
 { lib, stdenv, fetchurl }:
 
-stdenv.mkDerivation {
-  name = "scheme48-1.9.2";
-
-  meta = {
-    homepage = "http://s48.org/";
-    description = "Scheme 48";
-    platforms = with lib.platforms; unix;
-    license = lib.licenses.bsd3;
-  };
+stdenv.mkDerivation rec {
+  pname = "scheme48";
+  version = "1.9.2";
 
   src = fetchurl {
-    url = "http://s48.org/1.9.2/scheme48-1.9.2.tgz";
+    url = "http://s48.org/${version}/scheme48-${version}.tgz";
     sha256 = "1x4xfm3lyz2piqcw1h01vbs1iq89zq7wrsfjgh3fxnlm1slj2jcw";
+  };
+
+  # Make more reproducible by removing build user and date.
+  postPatch = ''
+    substituteInPlace build/build-usual-image --replace '"(made by $USER on $date)"' '""'
+  '';
+
+  meta = with lib; {
+    homepage = "http://s48.org/";
+    description = "Scheme 48 interpreter for R5RS";
+    platforms = platforms.unix;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.siraben ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Refactor. Non-blocking but doesn't cross-compile yet.

<details>
<summary>cross-compilation build log</summary>

```
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/vyw62ihgi9470mzq5af25y6lfz8ybi6q-scheme48-1.9.2.tgz
source root is scheme48-1.9.2
setting SOURCE_DATE_EPOCH to timestamp 1397315280 of file scheme48-1.9.2/build/minor-version-number
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
updateAutotoolsGnuConfigScriptsPhase
Updating Autotools / GNU config script to a newer upstream version: ./config.sub
Updating Autotools / GNU config script to a newer upstream version: ./config.guess
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
configure flags: --prefix=/nix/store/lpgvs2iym06z113nlmac16qxxw0rwvrf-scheme48-1.9.2-armv6l-unknown-linux-gnueabihf --build=x86_64-apple-darwin --host=armv6l-unknown-linux-gnueabihf
checking build system type... x86_64-apple-darwin
checking host system type... armv6l-unknown-linux-gnueabihf
checking for armv6l-unknown-linux-gnueabihf-gcc... armv6l-unknown-linux-gnueabihf-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... yes
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether armv6l-unknown-linux-gnueabihf-gcc accepts -g... yes
checking for armv6l-unknown-linux-gnueabihf-gcc option to accept ISO C89... none needed
checking whether we must build a 32bit binary... no
checking bits per byte... configure: error: failed to compile test program
```
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
