### PR TITLE
python3Packages.readme_renderer: 28.0 -> 29.0

### DIFF
--- a/pkgs/development/python-modules/django-mailman3/default.nix
+++ b/pkgs/development/python-modules/django-mailman3/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "django-mailman3";
-  version = "1.3.4";
+  version = "1.3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7e37b68bb47e9ae196ca19018f576e2c8c90189c5bd82d4e549d0c2f2f3f35fb";
+    sha256 = "sha256-NoWVs8JiPt6spb7qXxKIdCTDhO3W9wUs9EJEMHUIQxM=";
   };
 
   propagatedBuildInputs = [
@@ -21,10 +21,12 @@ buildPythonPackage rec {
     PYTHONPATH=.:$PYTHONPATH django-admin.py test --settings=django_mailman3.tests.settings_test
   '';
 
+  pythonImportsCheck = [ "django_mailman3" ];
+
   meta = with lib; {
     description = "Django library for Mailman UIs";
     homepage = "https://gitlab.com/mailman/django-mailman3";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ globin peti ];
   };
 }

--- a/pkgs/development/python-modules/readme_renderer/default.nix
+++ b/pkgs/development/python-modules/readme_renderer/default.nix
@@ -1,14 +1,13 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-, pytest
-, mock
-, cmarkgfm
 , bleach
+, buildPythonPackage
+, cmarkgfm
 , docutils
+, fetchPypi
 , future
+, mock
 , pygments
-, six
+, pytestCheckHook
 , pythonOlder
 }:
 
@@ -22,21 +21,25 @@ buildPythonPackage rec {
     sha256 = "sha256-kv1awr+Gd/MQ8zA6pLzludX58glKuYwp8TeR17gFo9s=";
   };
 
-  checkInputs = [ pytest mock ];
-
   propagatedBuildInputs = [
-    bleach cmarkgfm docutils future pygments six
+    bleach
+    cmarkgfm
+    docutils
+    future
+    pygments
   ];
 
-  checkPhase = ''
-    # disable one failing test case
-    # fixtures test is failing for incorrect class name
-    py.test -k "not test_invalid_link and not fixtures"
-  '';
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
 
-  meta = {
-    description = "readme_renderer is a library for rendering readme descriptions for Warehouse";
+  pythonImportsCheck = [ "readme_renderer" ];
+
+  meta = with lib; {
+    description = "Python library for rendering readme descriptions";
     homepage = "https://github.com/pypa/readme_renderer";
-    license = lib.licenses.asl20;
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/readme_renderer/default.nix
+++ b/pkgs/development/python-modules/readme_renderer/default.nix
@@ -9,15 +9,17 @@
 , future
 , pygments
 , six
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "readme_renderer";
-  version = "28.0";
+  version = "29.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6b7e5aa59210a40de72eb79931491eaf46fefca2952b9181268bd7c7c65c260a";
+    sha256 = "sha256-kv1awr+Gd/MQ8zA6pLzludX58glKuYwp8TeR17gFo9s=";
   };
 
   checkInputs = [ pytest mock ];

--- a/pkgs/servers/mail/mailman/postorius.nix
+++ b/pkgs/servers/mail/mailman/postorius.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "postorius";
-  version = "1.3.3";
+  version = "1.3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "08jn23gblbkfl09qlykbpsmp39mmach3sl69h1j5cd5kkx839rwa";
+    sha256 = "sha256-L2ApUGQNvR0UVvodVM+wMzjYLZkegI4fT4yUiU/cibU=";
   };
 
   propagatedBuildInputs = [ django-mailman3 readme_renderer ];
@@ -17,10 +17,10 @@ buildPythonPackage rec {
   # Tries to connect to database.
   doCheck = false;
 
-  meta = {
-    homepage = "https://www.gnu.org/software/mailman/";
+  meta = with lib; {
+    homepage = "https://docs.mailman3.org/projects/postorius";
     description = "Web-based user interface for managing GNU Mailman";
-    license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ globin peti ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ globin peti ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 29.0

Change log: https://github.com/pypa/readme_renderer/blob/main/CHANGES.rst#290-2021-02-22

Also, switch to `pytestCheckHook`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
