### PR TITLE
corrscope: init at 0.7.0

### DIFF
--- a/pkgs/applications/video/corrscope/default.nix
+++ b/pkgs/applications/video/corrscope/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, mkDerivationWith
+, python3Packages
+, wrapQtAppsHook
+, ffmpeg
+, qtbase
+}:
+
+mkDerivationWith python3Packages.buildPythonApplication rec {
+  pname = "corrscope";
+  version = "0.7.0";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0m62p3jlbx5dlp3j8wn1ka1sqpffsxbpsgv2h5cvj1n1lsgbss2s";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'attrs>=18.2.0,<19.0.0' 'attrs>=18.2.0' \
+      --replace 'numpy>=1.15,<2.0,!=1.19.4' 'numpy>=1.15,<2.0'
+  '';
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  buildInputs = [ ffmpeg qtbase ];
+
+  propagatedBuildInputs = with python3Packages; [ appdirs attrs click matplotlib numpy pyqt5 ruamel_yaml ];
+
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      --prefix PATH : ${ffmpeg}/bin
+      "''${qtWrapperArgs[@]}"
+    )
+  '';
+
+  preCheck = "export HOME=$TEMP";
+
+  meta = with lib; {
+    description = "Render wave files into oscilloscope views, featuring advanced correlation-based triggering algorithm";
+    longDescription = ''
+      Corrscope renders oscilloscope views of WAV files recorded from chiptune (game music from
+      retro sound chips).
+
+      Corrscope uses "waveform correlation" to track complex waves (including SNES and Sega
+      Genesis/FM synthesis) which jump around on other oscilloscope programs.
+    '';
+    homepage = "https://github.com/corrscope/corrscope";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21629,6 +21629,8 @@ in
     inherit (gnome2) libgnomeui GConf;
   };
 
+  corrscope = libsForQt5.callPackage ../applications/video/corrscope { };
+
   csa = callPackage ../applications/audio/csa { };
 
   csound = callPackage ../applications/audio/csound {


### PR DESCRIPTION
###### Motivation for this change
Package [corrscope](https://github.com/corrscope/corrscope), a cross-platform program frequently used for rendering oscilloscope visualisations of audio tracks.

![grafik](https://user-images.githubusercontent.com/23431373/108980950-8b547880-768c-11eb-8404-6d0e35a01610.png)


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
