### PR TITLE
waypoint: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/applications/networking/cluster/waypoint/default.nix
+++ b/pkgs/applications/networking/cluster/waypoint/default.nix
@@ -2,29 +2,45 @@
 
 buildGoModule rec {
   pname = "waypoint";
-  version = "0.2.2";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-JeuVrlm6JB8MgSUmgMLQPuPmlKSScSdsVga9jUwLWHM=";
+    sha256 = "sha256-FTBBDKFUoyC+Xdm3+2QWXK57fLwitYrFP89OvAyHHVY=";
   };
 
   deleteVendor = true;
-  vendorSha256 = "sha256-ArebHOjP3zvpASVAoaPXpSbrG/jq+Jbx7+EaQ1uHSVY=";
+  vendorSha256 = "sha256-ihelAumTRgLALevJdVq3V3SISitiRPCQZUh2h5/eczA=";
 
   nativeBuildInputs = [ go-bindata ];
 
   # GIT_{COMMIT,DIRTY} filled in blank to prevent trying to run git and ending up blank anyway
   buildPhase = ''
+    runHook preBuild
     make bin GIT_DESCRIBE="v${version}" GIT_COMMIT="" GIT_DIRTY=""
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     install -D waypoint $out/bin/waypoint
+    runHook postInstall
   '';
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    # `version` tries to write to ~/.config/waypoint
+    export HOME="$TMPDIR"
+
+    $out/bin/waypoint --help
+    $out/bin/waypoint version # | grep "Waypoint v${version}"
+    runHook postInstallCheck
+  '';
+
+  # Binary is static
   dontPatchELF = true;
   dontPatchShebangs = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump waypoint to `0.2.3`

Also:
- add installCheckPhase
- add runHooks to build and install

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
