### PR TITLE
emacs-packages: Make pkgs & lib overrideable

### DIFF
--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -1,4 +1,4 @@
-{ lib, external, pkgs }: self: with self; with lib.licenses; {
+{ lib, pkgs }: self: with self; with lib.licenses; {
 
   elisp-ffi = melpaBuild rec {
     pname = "elisp-ffi";
@@ -9,7 +9,7 @@
       rev = version;
       sha256 = "0z2n3h5l5fj8wl8i1ilfzv11l3zba14sgph6gz7dx7q12cnp9j22";
     };
-    buildInputs = [ external.libffi ];
+    buildInputs = [ pkgs.libffi ];
     preBuild = "make";
     recipe = pkgs.writeText "recipe" ''
       (elisp-ffi
@@ -29,15 +29,15 @@
     };
   };
 
-  agda2-mode = with external; trivialBuild {
+  agda2-mode = trivialBuild {
     pname = "agda-mode";
-    version = Agda.version;
+    version = pkgs.haskellPackages.Agda.version;
 
     phases = [ "buildPhase" "installPhase" ];
 
     # already byte-compiled by Agda builder
     buildPhase = ''
-      agda=`${Agda}/bin/agda-mode locate`
+      agda=`${pkgs.haskellPackages.Agda}/bin/agda-mode locate`
       cp `dirname $agda`/*.el* .
     '';
 
@@ -47,21 +47,21 @@
         Wrapper packages that liberates init.el from `agda-mode locate` magic.
         Simply add this to user profile or systemPackages and do `(require 'agda2)` in init.el.
       '';
-      homepage = Agda.meta.homepage;
-      license = Agda.meta.license;
+      homepage = pkgs.haskellPackages.Agda.meta.homepage;
+      license = pkgs.haskellPackages.Agda.meta.license;
     };
   };
 
   agda-input = self.trivialBuild {
     pname = "agda-input";
 
-    inherit (external.Agda) src version;
+    inherit (pkgs.haskellPackages.Agda) src version;
 
     postUnpack = "mv $sourceRoot/src/data/emacs-mode/agda-input.el $sourceRoot";
 
     meta = {
       description = "Standalone package providing the agda-input method without building Agda.";
-      inherit (external.Agda.meta) homepage license;
+      inherit (pkgs.haskellPackages.Agda.meta) homepage license;
     };
   };
 
@@ -74,10 +74,10 @@
 
   ghc-mod = melpaBuild {
     pname = "ghc";
-    version = external.ghc-mod.version;
-    src = external.ghc-mod.src;
+    version = pkgs.haskellPackages.ghc-mod.version;
+    src = pkgs.haskellPackages.ghc-mod.src;
     packageRequires = [ haskell-mode ];
-    propagatedUserEnvPkgs = [ external.ghc-mod ];
+    propagatedUserEnvPkgs = [ pkgs.haskellPackages.ghc-mod ];
     recipe = pkgs.writeText "recipe" ''
       (ghc-mod :repo "DanielG/ghc-mod" :fetcher github :files ("elisp/*.el"))
     '';
@@ -115,7 +115,7 @@
 
   llvm-mode = trivialBuild {
     pname = "llvm-mode";
-    inherit (external.llvmPackages.llvm) src version;
+    inherit (pkgs.llvmPackages.llvm) src version;
 
     dontConfigure = true;
     buildPhase = ''
@@ -123,7 +123,7 @@
     '';
 
     meta = {
-      inherit (external.llvmPackages.llvm.meta) homepage license;
+      inherit (pkgs.llvmPackages.llvm.meta) homepage license;
       description = "Major mode for the LLVM assembler language.";
     };
   };
@@ -134,13 +134,13 @@
   ott-mode = self.trivialBuild {
     pname = "ott-mod";
 
-    inherit (external.ott) src version;
+    inherit (pkgs.ott) src version;
 
     postUnpack = "mv $sourceRoot/emacs/ott-mode.el $sourceRoot";
 
     meta = {
       description = "Standalone package providing ott-mode without building ott and with compiled bytecode.";
-      inherit (external.Agda.meta) homepage license;
+      inherit (pkgs.haskellPackages.Agda.meta) homepage license;
     };
   };
 

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -22,7 +22,7 @@ instantenous and formats commits for you.
 
 */
 
-{ lib, external, pkgs }: variant: self:
+{ lib, pkgs }: variant: self:
 let
   dontConfigure = pkg:
     if pkg != null then pkg.override (args: {
@@ -53,7 +53,7 @@ let
   });
 
   fix-rtags = pkg:
-    if pkg != null then dontConfigure (externalSrc pkg external.rtags)
+    if pkg != null then dontConfigure (externalSrc pkg pkgs.rtags)
     else null;
 
   generateMelpa = lib.makeOverridable ({ archiveJson ? ./recipes-archive-melpa.json
@@ -79,9 +79,9 @@ let
         };
 
         auto-complete-clang-async = super.auto-complete-clang-async.overrideAttrs (old: {
-          buildInputs = old.buildInputs ++ [ external.llvmPackages.llvm ];
-          CFLAGS = "-I${external.llvmPackages.clang}/include";
-          LDFLAGS = "-L${external.llvmPackages.clang}/lib";
+          buildInputs = old.buildInputs ++ [ pkgs.llvmPackages.llvm ];
+          CFLAGS = "-I${pkgs.llvmPackages.clang}/include";
+          LDFLAGS = "-L${pkgs.llvmPackages.clang}/lib";
         });
 
         # part of a larger package
@@ -132,8 +132,8 @@ let
         flycheck-rtags = fix-rtags super.flycheck-rtags;
 
         pdf-tools = super.pdf-tools.overrideAttrs (old: {
-          nativeBuildInputs = [ external.pkg-config ];
-          buildInputs = with external; old.buildInputs ++ [ autoconf automake libpng zlib poppler ];
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = with pkgs; old.buildInputs ++ [ autoconf automake libpng zlib poppler ];
           preBuild = "make server/epdfinfo";
           recipe = pkgs.writeText "recipe" ''
             (pdf-tools
@@ -143,7 +143,7 @@ let
         });
 
         # Build same version as Haskell package
-        hindent = (externalSrc super.hindent external.hindent).overrideAttrs (attrs: {
+        hindent = (externalSrc super.hindent pkgs.haskellPackages.hindent).overrideAttrs (attrs: {
           packageRequires = [ self.haskell-mode ];
         });
 
@@ -169,7 +169,7 @@ let
           dontUseCmakeBuildDir = true;
           doCheck = true;
           packageRequires = [ self.emacs ];
-          nativeBuildInputs = [ external.cmake external.llvmPackages.llvm external.llvmPackages.clang ];
+          nativeBuildInputs = [ pkgs.cmake pkgs.llvmPackages.llvm pkgs.llvmPackages.clang ];
         });
 
         # tries to write a log file to $HOME
@@ -286,18 +286,18 @@ let
         # part of a larger package
         notmuch = dontConfigure super.notmuch;
 
-        rtags = dontConfigure (externalSrc super.rtags external.rtags);
+        rtags = dontConfigure (externalSrc super.rtags pkgs.rtags);
 
         rtags-xref = dontConfigure super.rtags;
 
         shm = super.shm.overrideAttrs (attrs: {
-          propagatedUserEnvPkgs = [ external.structured-haskell-mode ];
+          propagatedUserEnvPkgs = [ pkgs.haskellPackages.structured-haskell-mode ];
         });
 
         # Telega has a server portion for it's network protocol
         telega = super.telega.overrideAttrs (old: {
           buildInputs = old.buildInputs ++ [ pkgs.tdlib ];
-          nativeBuildInputs = [ external.pkg-config ];
+          nativeBuildInputs = [ pkgs.pkg-config ];
 
           postBuild = ''
             cd source/server
@@ -314,12 +314,12 @@ let
         treemacs-magit = super.treemacs-magit.overrideAttrs (attrs: {
           # searches for Git at build time
           nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
+            (attrs.nativeBuildInputs or [ ]) ++ [ pkgs.git ];
         });
 
         vdiff-magit = super.vdiff-magit.overrideAttrs (attrs: {
           nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
+            (attrs.nativeBuildInputs or [ ]) ++ [ pkgs.git ];
         });
 
         zmq = super.zmq.overrideAttrs (old: {
@@ -328,11 +328,11 @@ let
             make
           '';
           nativeBuildInputs = [
-            external.autoconf
-            external.automake
-            external.pkg-config
-            external.libtool
-            (external.zeromq.override { enableDrafts = true; })
+            pkgs.autoconf
+            pkgs.automake
+            pkgs.pkg-config
+            pkgs.libtool
+            (pkgs.zeromq.override { enableDrafts = true; })
           ];
           postInstall = ''
             mv $out/share/emacs/site-lisp/elpa/zmq-*/src/.libs/emacs-zmq.so $out/share/emacs/site-lisp/elpa/zmq-*
@@ -415,7 +415,7 @@ let
         window-numbering = markBroken super.window-numbering;
 
         editorconfig = super.editorconfig.overrideAttrs (attrs: {
-          propagatedUserEnvPkgs = [ external.editorconfig-core-c ];
+          propagatedUserEnvPkgs = [ pkgs.editorconfig-core-c ];
         });
 
         # missing dependencies
@@ -433,7 +433,7 @@ let
         racer = super.racer.overrideAttrs (attrs: {
           postPatch = attrs.postPatch or "" + ''
             substituteInPlace racer.el \
-              --replace /usr/local/src/rust/src ${external.rustPlatform.rustcSrc}
+              --replace /usr/local/src/rust/src ${pkgs.rustPlatform.rustcSrc}
           '';
         });
 
@@ -462,7 +462,7 @@ let
         w3m = super.w3m.override (args: {
           melpaBuild = drv: args.melpaBuild (drv // {
             prePatch =
-              let w3m = "${lib.getBin external.w3m}/bin/w3m"; in
+              let w3m = "${lib.getBin pkgs.w3m}/bin/w3m"; in
               ''
                 substituteInPlace w3m.el \
                 --replace 'defcustom w3m-command nil' \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21952,14 +21952,6 @@ in
     inherit fetchFromGitHub fetchurl;
     inherit emacs texinfo makeWrapper runCommand writeText;
     inherit (xorg) lndir;
-
-    trivialBuild = callPackage ../build-support/emacs/trivial.nix {
-      inherit emacs;
-    };
-
-    melpaBuild = callPackage ../build-support/emacs/melpa.nix {
-      inherit emacs;
-    };
   };
 
   inherit (gnome3) empathy;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21947,12 +21947,7 @@ in
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   };
 
-  emacsPackagesFor = emacs: import ./emacs-packages.nix {
-    inherit lib newScope stdenv pkgs;
-    inherit fetchFromGitHub fetchurl;
-    inherit emacs texinfo makeWrapper runCommand writeText;
-    inherit (xorg) lndir;
-  };
+  emacsPackagesFor = emacs: import ./emacs-packages.nix { inherit pkgs lib emacs; };
 
   inherit (gnome3) empathy;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21960,15 +21960,6 @@ in
     melpaBuild = callPackage ../build-support/emacs/melpa.nix {
       inherit emacs;
     };
-
-    external = {
-      inherit (haskellPackages)
-        ghc-mod structured-haskell-mode Agda hindent;
-      inherit
-        autoconf automake editorconfig-core-c git libffi libpng pkg-config
-        poppler rtags w3m zlib substituteAll rustPlatform cmake llvmPackages
-        libtool zeromq openssl ott;
-    };
   };
 
   inherit (gnome3) empathy;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21947,7 +21947,11 @@ in
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   };
 
-  emacsPackagesFor = emacs: import ./emacs-packages.nix { inherit pkgs lib emacs; };
+  emacsPackagesFor = emacs: import ./emacs-packages.nix {
+    inherit (lib) makeScope makeOverridable;
+    inherit emacs;
+    pkgs' = pkgs;  # default pkgs used for bootstrapping the emacs package set
+  };
 
   inherit (gnome3) empathy;
 

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -21,17 +21,6 @@
   (package-initialize)
 */
 
-## FOR CONTRIBUTORS
-#
-# When adding a new package here please note that
-# * please use `elpaBuild` for pre-built package.el packages and
-#   `melpaBuild` or `trivialBuild` if the package must actually
-#   be built from the source.
-# * lib.licenses are `with`ed on top of the file here
-# * both trivialBuild and melpaBuild will automatically derive a
-#   `meta` with `platforms` and `homepage` set to something you are
-#   unlikely to want to override for most packages
-
 { pkgs', makeScope, makeOverridable, emacs }:
 
 let

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -38,7 +38,6 @@
 , trivialBuild
 , melpaBuild
 
-, external
 , pkgs
 }:
 
@@ -50,7 +49,7 @@ let
 
   # Contains both melpa stable & unstable
   melpaGeneric = import ../applications/editors/emacs-modes/melpa-packages.nix {
-    inherit external lib pkgs;
+    inherit lib pkgs;
   };
   mkMelpaStablePackages = melpaGeneric "stable";
   mkMelpaPackages = melpaGeneric "unstable";
@@ -64,7 +63,7 @@ let
   };
 
   mkManualPackages = import ../applications/editors/emacs-modes/manual-packages.nix {
-    inherit external lib pkgs;
+    inherit lib pkgs;
   };
 
 in lib.makeScope newScope (self: lib.makeOverridable ({

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -32,12 +32,7 @@
 #   `meta` with `platforms` and `homepage` set to something you are
 #   unlikely to want to override for most packages
 
-{ lib, newScope, stdenv, fetchurl, fetchFromGitHub, runCommand, writeText
-
-, emacs, texinfo, lndir, makeWrapper
-
-, pkgs
-}:
+{ pkgs, lib ? pkgs.lib, emacs }:
 
 let
 
@@ -50,7 +45,8 @@ let
   };
 
   mkElpaPackages = import ../applications/editors/emacs-modes/elpa-packages.nix {
-    inherit lib stdenv texinfo writeText;
+    inherit (pkgs) stdenv texinfo writeText;
+    inherit lib;
   };
 
   # Contains both melpa stable & unstable
@@ -65,14 +61,15 @@ let
   };
 
   emacsWithPackages = import ../build-support/emacs/wrapper.nix {
-    inherit lib lndir makeWrapper runCommand;
+    inherit (pkgs) lndir makeWrapper runCommand;
+    inherit lib;
   };
 
   mkManualPackages = import ../applications/editors/emacs-modes/manual-packages.nix {
     inherit lib pkgs;
   };
 
-in lib.makeScope newScope (self: lib.makeOverridable ({
+in lib.makeScope pkgs.newScope (self: lib.makeOverridable ({
   elpaPackages ? mkElpaPackages self
   , melpaStablePackages ? mkMelpaStablePackages self
   , melpaPackages ? mkMelpaPackages self

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -35,13 +35,19 @@
 { lib, newScope, stdenv, fetchurl, fetchFromGitHub, runCommand, writeText
 
 , emacs, texinfo, lndir, makeWrapper
-, trivialBuild
-, melpaBuild
 
 , pkgs
 }:
 
 let
+
+  trivialBuild = pkgs.callPackage ../build-support/emacs/trivial.nix {
+    inherit emacs;
+  };
+
+  melpaBuild = pkgs.callPackage ../build-support/emacs/melpa.nix {
+    inherit emacs;
+  };
 
   mkElpaPackages = import ../applications/editors/emacs-modes/elpa-packages.nix {
     inherit lib stdenv texinfo writeText;


### PR DESCRIPTION
###### Motivation for this change
With these changes it's possible to override pkgs & lib by:
``` nix
emacs.pkgs.override { pkgs = fooPkgs; }
```
and get them to coherently apply to all emacs packages.

Additionally this fixes some weirdness when using `overrideScope'` and overriding `emacs` itself which previously didn't work because `melpaBuild`/`trivialBuild` weren't using the `self` fixpoint.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
