### PR TITLE
pythonPackages.psutil: disable impure cpu_freq test

### DIFF
--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -30,6 +30,7 @@ buildPythonPackage rec {
     "disk_io_counters"
     "sensors_battery"
     "cpu_times"
+    "cpu_freq"
   ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ darwin.IOKit ];

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, buildPythonPackage, fetchPypi, isPy27, python
 , darwin
-, pytest
+, pytestCheckHook
 , mock
 , ipaddress
 , unittest2
@@ -18,15 +18,19 @@ buildPythonPackage rec {
   # arch doesn't report frequency is the same way
   # tests segfaults on darwin https://github.com/giampaolo/psutil/issues/1715
   doCheck = !stdenv.isDarwin && stdenv.isx86_64;
-  checkInputs = [ pytest ]
+  checkInputs = [ pytestCheckHook ]
     ++ lib.optionals isPy27 [ mock ipaddress unittest2 ];
-  # out must be referenced as test import paths are relative
+  pytestFlagsArray = [
+    "$out/${python.sitePackages}/psutil/tests/test_system.py"
+  ];
   # disable tests which don't work in sandbox
   # cpu_times is flakey on darwin
-  checkPhase = ''
-    pytest $out/${python.sitePackages}/psutil/tests/test_system.py \
-      -k 'not user and not disk_io_counters and not sensors_battery and not cpu_times'
-  '';
+  disabledTests = [
+    "user"
+    "disk_io_counters"
+    "sensors_battery"
+    "cpu_times"
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ darwin.IOKit ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
