### PR TITLE
emacs.pkgs.telega: Prefer telega from melpa stable

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -77,5 +77,14 @@ in makeScope pkgs'.newScope (self: makeOverridable ({
 
     emacsWithPackages = emacsWithPackages { inherit pkgs lib; } self;
     withPackages = emacsWithPackages { inherit pkgs lib; } self;
+
+  }// {
+
+    # Package specific priority overrides goes here
+
+    # Telega uploads packages incompatible with stable tdlib to melpa
+    # Prefer the one from melpa stable
+    inherit (melpaStablePackages) telega;
+
   })
 ) {})


### PR DESCRIPTION
###### Motivation for this change

Telega uploads packages that are incompatible with stable tdlib releases to melpa and ones that are compatible to melpa stable.

This makes the melpa packages very unreliable and we should prefer the one from melpa stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @SeTSeR 