### PR TITLE
python3Packages.curio: fix flaky test due to slow moving time

### DIFF
--- a/pkgs/development/python-modules/curio/default.nix
+++ b/pkgs/development/python-modules/curio/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , isPy3k
 , pytestCheckHook
 , sphinx
@@ -15,6 +16,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "57edce81c837f3c2cf42fbb346dee26e537d1659e6605269fb13bd179e068744";
   };
+
+  patches = [
+    # Fix the flaky test due to slow moving time on Apple Silicon chips.
+    # Remove when https://github.com/dabeaz/curio/pull/339 is in the next release.
+    (fetchpatch {
+      url = "https://github.com/dabeaz/curio/commit/132376724bbfaa0a52d3d63d0791aa4ac1eb6f5f.patch";
+      sha256 = "sha256-AxO0xRcR9l9/NKEJFwyZIoYcyZxpqOhpdNaeaYokVb4=";
+    })
+  ];
 
   disabled = !isPy3k;
 


### PR DESCRIPTION
###### Motivation for this change

This primarily helps with #105026, since otherwise Hydra machines aren't failing on these tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
