### PR TITLE
python3Packages.parso: fix flaky test due to slow moving time

### DIFF
--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , pythonOlder
 , pytestCheckHook
 }:
@@ -14,6 +15,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "2b6db14759c528d857eeb9eac559c2166b2554548af39f5198bdfb976f72aa64";
   };
+
+  patches = [
+    # Fix the flaky test due to slow moving time on Apple Silicon chips.
+    # Remove when https://github.com/davidhalter/parso/pull/177 is in the next release.
+    (fetchpatch {
+      url = "https://github.com/davidhalter/parso/pull/177/commits/2799a7a3c2cf87fdc2d0c19a0890acea425091ce.patch";
+      sha256 = "sha256-A5EQly1wR/7lo+L8Pp0UPSUIhC0WcblXEWQNvRMlZYA=";
+    })
+  ];
 
   checkInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
###### Motivation for this change

This primarily helps with #105026, since otherwise Hydra machines aren't failing on these tests.

Similar to #114255.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
