### PR TITLE
tcpflow: 1.5.2 -> 1.6.1

### DIFF
--- a/pkgs/tools/networking/tcpflow/default.nix
+++ b/pkgs/tools/networking/tcpflow/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname   = "tcpflow";
-  version = "1.5.2";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner  = "simsong";
     repo   = pname;
     rev    = "${pname}-${version}";
-    sha256 = "063n3pfqa0lgzcwk4c0h01g2y5c3sli615j6a17dxpg95aw1zryy";
+    sha256 = "0vbm097jhi5n8pg08ia1yhzc225zv9948blb76f4br739l9l22vq";
     fetchSubmodules = true;
   };
 
@@ -23,8 +23,10 @@ stdenv.mkDerivation rec {
     substituteInPlace bootstrap.sh \
       --replace ".git" "" \
       --replace "/bin/rm" "rm"
-    substituteInPlace configure.ac \
-      --replace "1.5.1" "1.5.2"
+    # Temporary fix for a build error:
+    # https://src.fedoraproject.org/rpms/tcpflow/blob/979e250032b90de2d6b9e5b94b5203d98cccedad/f/tcpflow-1.6.1-format.patch
+    substituteInPlace src/datalink.cpp \
+      --replace 'DEBUG(6)(s.c_str());' 'DEBUG(6) ("%s", s.c_str());'
   '';
 
   preConfigure = "bash ./bootstrap.sh";
@@ -38,7 +40,7 @@ stdenv.mkDerivation rec {
     '';
     inherit (src.meta) homepage;
     license     = licenses.gpl3;
-    maintainers = with maintainers; [ primeos raskin obadz ];
+    maintainers = with maintainers; [ raskin obadz ];
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
The substituteInPlace "patch" is required to fix the following build error:
```
datalink.cpp:177:27: error: format not a string literal and no format
arguments
[8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
  177 |         DEBUG(6)(s.c_str());
      |                           ^
```

This also removes me as maintainer since I don't use tcpflow anymore.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
