### PR TITLE
mastodon: fix media refresh

### DIFF
--- a/pkgs/servers/mastodon/default.nix
+++ b/pkgs/servers/mastodon/default.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation rec {
     fi
     ln -s ${mastodon-assets}/public/assets public/assets
     ln -s ${mastodon-assets}/public/packs public/packs
+    ln -s /var/lib/mastodon/public-system public/system
 
     patchShebangs bin/
     for b in $(ls ${mastodon-gems}/bin/)


### PR DESCRIPTION
###### Motivation for this change
Fixing write error on startup `tootctl media refresh --domain DOMAIN --verbose --force`
```
Processing 1057873106........
Processing 1057873107........
Error processing 1057873107........: File exists @ dir_s_mkdir - /nix/store/72d328fc4jc2rsrngaf2lnlcb6xa3qfp-mastodon-3.3.0/public/system
Error processing 1057873106........: File exists @ dir_s_mkdir - /nix/store/72d328fc4jc2rsrngaf2lnlcb6xa3qfp-mastodon-3.3.0/public/system
```

cc @erictapen
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
