### PR TITLE
webwormhole: init at git-2021-01-16

### DIFF
--- a/pkgs/tools/networking/webwormhole/default.nix
+++ b/pkgs/tools/networking/webwormhole/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "webwormhole";
-  version = "git-2021-01-16";
+  version = "unstable-2021-01-16";
 
   src = fetchFromGitHub {
     owner = "saljam";

--- a/pkgs/tools/networking/webwormhole/default.nix
+++ b/pkgs/tools/networking/webwormhole/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "webwormhole";
+  version = "git-2021-01-16";
+
+  src = fetchFromGitHub {
+    owner = "saljam";
+    repo = pname;
+    rev = "c85e196c8a8a885815136aa8aee1958ad80a3bb5";
+    sha256 = "D10xmBwmEbeR3nU4CmppFBzdeE4Pm2+o/Vb5Yd+pPtM=";
+  };
+
+  vendorSha256 = "sha256-yK04gjDO6JSDcJULcbJBBuPBhx792JNn+B227lDUrWk=";
+
+  meta = with lib; {
+    description = "Send files using peer authenticated WebRTC";
+    homepage = "https://github.com/saljam/webwormhole";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bbigras ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30066,6 +30066,8 @@ in
 
   nix-store-gcs-proxy = callPackage ../tools/nix/nix-store-gcs-proxy {};
 
+  webwormhole = callPackage ../tools/networking/webwormhole { };
+
   wifi-password = callPackage ../os-specific/darwin/wifi-password {};
 
   qubes-core-vchan-xen = callPackage ../applications/qubes/qubes-core-vchan-xen {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Note that the git repo says:

> THIS PROJECT IS STILL IN EARLY DEVELOPMENT IT USES EXPERIMENTAL
> CRYPTOGRAPHIC LIBRARIES AND IT HAS NOT HAD ANY KIND OF SECURITY
> OR CRYPTOGRAPHY REVIEW THIS SOFTWARE MIGHT BE BROKEN AND UNSAFE

but a download link is displayed on https://webwormhole.io/ so ¯\\\_(ツ)_/¯

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
