### PR TITLE
ocaml-ng.ocamlPackages_4_11.ocaml: 4.11.1 → 4.11.2

### DIFF
--- a/pkgs/development/compilers/ocaml/4.11.nix
+++ b/pkgs/development/compilers/ocaml/4.11.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "11";
-  patch_version = "1";
-  sha256 = "0k4521c0p10c5ams6vjv5qkkjhmpkb0bfn04llcz46ah0f3r2jpa";
+  patch_version = "2";
+  sha256 = "1m3wrgkkv3f77wvcymjm0i2srxzmx62y6jln3i0a2px07ng08l9z";
 }


### PR DESCRIPTION
###### Motivation for this change

Bugfix release: https://inbox.ocaml.org/caml-list/78822e22-9131-fac5-9058-0eff1528d5e1@inria.fr/T/#u

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
