### PR TITLE
kodiPlugins.pdfreader: 1.0.2 -> 2.0.2

### DIFF
--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -346,21 +346,19 @@ let self = rec {
   pdfreader = mkKodiPlugin rec {
     plugin = "pdfreader";
     namespace = "plugin.image.pdf";
-    version = "1.0.2";
+    version = "2.0.2";
 
-    src = fetchFromGitHub rec {
-      name = plugin + "-" + version + ".tar.gz";
-      owner = "teeedubb";
-      repo = owner + "-xbmc-repo";
-      rev = "0a405b95208ced8a1365ad3193eade8d1c2117ce";
-      sha256 = "1iv7d030z3xvlflvp4p5v3riqnwg9g0yvzxszy63v1a6x5kpjkqa";
+    src = fetchFromGitHub {
+      owner = "i96751414";
+      repo = "plugin.image.pdfreader";
+      rev = "v${version}";
+      sha256 = "0nkqhlm1gyagq6xpdgqvd5qxyr2ngpml9smdmzfabc8b972mwjml";
     };
 
     meta = {
       homepage = "https://forum.kodi.tv/showthread.php?tid=187421";
       description = "A comic book reader";
       maintainers = with maintainers; [ edwtjo ];
-      broken = true; # requires port to python3
     };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
New version released. Hopefully this resolves #96647.

ping @spiderbit for testing pretty please.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
