### PR TITLE
nixos-icons: 2017-03-16 -> 2021-02-24

### DIFF
--- a/pkgs/data/misc/nixos-artwork/icons.nix
+++ b/pkgs/data/misc/nixos-artwork/icons.nix
@@ -1,13 +1,25 @@
-{ stdenv, fetchFromGitHub, imagemagick }:
+{ stdenv
+, fetchFromGitHub
+, imagemagick
+}:
 
 stdenv.mkDerivation {
-  name = "nixos-icons-2017-03-16";
-  srcs = fetchFromGitHub {
+  pname = "nixos-icons";
+  version = "2021-02-24";
+
+  src = fetchFromGitHub {
     owner = "NixOS";
     repo = "nixos-artwork";
-    rev = "783ca1249fc4cfe523ad4e541f37e2229891bc8b";
-    sha256 = "0wp08b1gh2chs1xri43wziznyjcplx0clpsrb13wzyscv290ay5a";
+    rev = "488c22aad523c709c44169d3e88d34b4691c20dc";
+    sha256 = "ZoanCzn4pqGB1fyMzMyGQVT0eIhNdL7ZHJSn1VZWVRs=";
   };
-  makeFlags = [ "DESTDIR=$(out)" "prefix=" ];
-  nativeBuildInputs = [ imagemagick ];
+
+  nativeBuildInputs = [
+    imagemagick
+  ];
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "prefix="
+  ];
 }


### PR DESCRIPTION
Adds a white variant of the nixos logo

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
