### PR TITLE
emacs.pkgs.matrix-client: init at 0.3.0

### DIFF
--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -128,6 +128,55 @@
     };
   };
 
+  matrix-client = melpaBuild {
+    pname = "matrix-client";
+    version = "0.3.0";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "alphapapa";
+      repo = "matrix-client.el";
+      rev = "d2ac55293c96d4c95971ed8e2a3f6f354565c5ed";
+      sha256 = "1scfv1502yg7x4bsl253cpr6plml1j4d437vci2ggs764sh3rcqq";
+    };
+
+    patches = [
+      (pkgs.fetchpatch {
+        url = "https://github.com/alphapapa/matrix-client.el/commit/5f49e615c7cf2872f48882d3ee5c4a2bff117d07.patch";
+        sha256 = "07bvid7s1nv1377p5n61q46yww3m1w6bw4vnd4iyayw3fby1lxbm";
+      })
+    ];
+
+    packageRequires = [
+      anaphora
+      cl-lib
+      self.map
+      dash-functional
+      esxml
+      f
+      ov
+      tracking
+      rainbow-identifiers
+      dash
+      s
+      request
+      frame-purpose
+      a
+      ht
+    ];
+
+    recipe = pkgs.writeText "recipe" ''
+      (matrix-client
+      :repo "alphapapa/matrix-client.el"
+      :fetcher github)
+    '';
+
+    meta = {
+      description = "A chat client and API wrapper for Matrix.org";
+      license = gpl3Plus;
+    };
+
+  };
+
   org-mac-link =
     callPackage ./org-mac-link { };
 


### PR DESCRIPTION
Note that this does **not** work on `emacsGcc` from the overlay for some reason.
Confirmed working on emacs27.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
