### PR TITLE
zs-apc-spdu-ctl: init at 0.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10756,6 +10756,16 @@
     github = "pulsation";
     githubId = 1838397;
   };
+  zseri = {
+    name = "zseri";
+    email = "zseri.devel@ytrizja.de";
+    github = "zseri";
+    githubId = 1618343;
+    keys = [{
+      longkeyid = "rsa4096/0x229E63AE5644A96D";
+      fingerprint = "7AFB C595 0D3A 77BD B00F  947B 229E 63AE 5644 A96D";
+    }];
+  };
   zupo = {
     name = "Nejc Zupan";
     email = "nejczupan+nix@gmail.com";

--- a/pkgs/development/libraries/libowlevelzs/default.nix
+++ b/pkgs/development/libraries/libowlevelzs/default.nix
@@ -1,0 +1,27 @@
+{ cmake
+, fetchFromGitHub
+, lib
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libowlevelzs";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "zseri";
+    repo = "libowlevelzs";
+    rev = "v${version}";
+    sha256 = "y/EaMMsmJEmnptfjwiat4FC2+iIKlndC2Wdpop3t7vY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Zscheile Lowlevel (utility) library";
+    homepage = "https://github.com/zseri/libowlevelzs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zseri ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
+++ b/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
@@ -1,0 +1,36 @@
+{ cmake
+, fetchFromGitHub
+, fping
+, lib
+, libowlevelzs
+, net-snmp
+, stdenv
+}:
+
+# TODO: add a services entry for the /etc/zs-apc-spdu.conf file
+stdenv.mkDerivation rec {
+  pname = "zs-apc-spdu-ctl";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "zseri";
+    repo = "zs-apc-spdu-ctl";
+    rev = "v${version}";
+    sha256 = "TMV9ETWBVeXq6tZ2e0CrvHBXoyKfOLCQurjBdf/iw/M=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ fping libowlevelzs net-snmp ];
+
+  postPatch = ''
+    substituteInPlace src/confent.cxx \
+      --replace /usr/sbin/fping "${lib.makeBinPath [fping]}/fping"
+  '';
+
+  meta = with lib; {
+    description = "APC SPDU control utility";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zseri ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23423,6 +23423,8 @@ in
 
   libowfat = callPackage ../development/libraries/libowfat { };
 
+  libowlevelzs = callPackage ../development/libraries/libowlevelzs { };
+
   librecad = libsForQt514.callPackage ../applications/misc/librecad { };
 
   libreoffice = hiPrio libreoffice-still;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9352,6 +9352,8 @@ in
 
   zinit = callPackage ../shells/zsh/zinit {} ;
 
+  zs-apc-spdu-ctl = callPackage ../tools/networking/zs-apc-spdu-ctl { };
+
   zsh-autoenv = callPackage ../tools/misc/zsh-autoenv { };
 
   zsh-autopair = callPackage ../shells/zsh/zsh-autopair { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding my own APC SPDU management utility (uses SNMP).
Also adds my own library against which this tool links.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
