### PR TITLE
netplan: init at 0.101

### DIFF
--- a/pkgs/tools/admin/netplan/default.nix
+++ b/pkgs/tools/admin/netplan/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, fetchFromGitHub
+, pkg-config
+, glib
+, pandoc
+, systemd
+, libyaml
+, python3
+, libuuid
+, bash-completion
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "netplan";
+  version = "0.101";
+
+  src = fetchFromGitHub {
+    owner = "CanonicalLtd";
+    repo = "netplan";
+    rev = version;
+    hash = "sha256-bCK7J2pCQUwjZu8c1n6jhF6T/gvUGwydqAXpxUMLgMc=";
+    fetchSubmodules = false;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    glib
+    pandoc
+  ];
+
+  buildInputs = [
+    systemd
+    glib
+    libyaml
+    (python3.withPackages (p: with p; [ pyyaml netifaces ]))
+    libuuid
+    bash-completion
+  ];
+
+  postPatch = ''
+    substituteInPlace netplan/cli/utils.py --replace "/lib/netplan/generate" "$out/lib/netplan/generate"
+    substituteInPlace netplan/cli/utils.py --replace "ctypes.util.find_library('netplan')" "\"$out/lib/libnetplan.so\""
+
+    substituteInPlace Makefile --replace 'SYSTEMD_GENERATOR_DIR=' 'SYSTEMD_GENERATOR_DIR ?= ' \
+        --replace 'SYSTEMD_UNIT_DIR=' 'SYSTEMD_UNIT_DIR ?= ' \
+        --replace 'BASH_COMPLETIONS_DIR=' 'BASH_COMPLETIONS_DIR ?= '
+  '';
+
+  makeFlags = [
+    "PREFIX="
+    "DESTDIR=$(out)"
+    "SYSTEMD_GENERATOR_DIR=lib/systemd/system-generators/"
+    "SYSTEMD_UNIT_DIR=lib/systemd/units/"
+    "BASH_COMPLETIONS_DIR=share/bash-completion/completions"
+  ];
+
+  meta = with lib; {
+    description = "Backend-agnostic network configuration in YAML";
+    homepage = "https://netplan.io";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mkg20001 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3291,6 +3291,8 @@ in
 
   netevent = callPackage ../tools/inputmethods/netevent { };
 
+  netplan = callPackage ../tools/admin/netplan { };
+
   skktools = callPackage ../tools/inputmethods/skk/skktools { };
   skk-dicts = callPackage ../tools/inputmethods/skk/skk-dicts { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add new package

For anyone wondering how this is useful even thought nixOS is declarative: NetworkManager isn't and so that's the perfect addition

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
