### PR TITLE
treewide: add missing lib inputs

### DIFF
--- a/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+{ lib, stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   pname = "CharacterCompressor";
   version = "0.3.3";

--- a/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+{ lib, stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   pname = "CompBus";
   version = "1.1.1";

--- a/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+{ lib, stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   pname = "constant-detune-chorus";
   version = "0.1.3";

--- a/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+{ lib, stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   pname = "LazyLimiter";
   version = "0.3.2";

--- a/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+{ lib, stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   pname = "MBdistortion";
   version = "1.1.1";

--- a/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+{ lib, stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   pname = "RhythmDelay";
   version = "2.1";

--- a/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jack, faust2lv2, helmholtz, mrpeach, puredata-with-plugins }:
+{ lib, stdenv, fetchFromGitHub, faust2jack, faust2lv2, helmholtz, mrpeach, puredata-with-plugins }:
 stdenv.mkDerivation rec {
   pname = "VoiceOfFaust";
   version = "1.1.4";

--- a/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+{ lib, stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   name = "faustCompressors-v${version}";
   version = "1.2";

--- a/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+{ lib, stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   pname = "pluginUtils";
   version = "1.1";

--- a/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+{ lib, stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
   pname = "shelfMultiBand";
   version = "0.6.1";

--- a/pkgs/applications/misc/robomongo/default.nix
+++ b/pkgs/applications/misc/robomongo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, glib, xorg, dbus, fontconfig,
+{ lib, stdenv, fetchurl, zlib, glib, xorg, dbus, fontconfig,
   freetype, xkeyboard_config, makeDesktopItem, makeWrapper }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/science/logic/sad/default.nix
+++ b/pkgs/applications/science/logic/sad/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, haskell, spass }:
+{ lib, stdenv, fetchurl, haskell, spass }:
 
 stdenv.mkDerivation {
   name = "system-for-automated-deduction-2.3.25";

--- a/pkgs/development/compilers/chicken/4/default.nix
+++ b/pkgs/development/compilers/chicken/4/default.nix
@@ -1,4 +1,4 @@
-{ newScope } :
+{ lib, newScope } :
 let
   callPackage = newScope self;
 
@@ -18,4 +18,4 @@ let
     egg2nix = callPackage ./egg2nix.nix { };
   };
 
-in self
+in lib.recurseIntoAttrs self

--- a/pkgs/development/compilers/chicken/4/egg2nix.nix
+++ b/pkgs/development/compilers/chicken/4/egg2nix.nix
@@ -1,4 +1,4 @@
-{ eggDerivation, fetchurl, chickenEggs }:
+{ lib, eggDerivation, fetchurl, chickenEggs }:
 
 # Note: This mostly reimplements the default.nix already contained in
 # the tarball. Is there a nicer way than duplicating code?

--- a/pkgs/development/compilers/chicken/5/default.nix
+++ b/pkgs/development/compilers/chicken/5/default.nix
@@ -1,4 +1,4 @@
-{ newScope } :
+{ lib, newScope } :
 let
   callPackage = newScope self;
 
@@ -18,4 +18,4 @@ let
     egg2nix = callPackage ./egg2nix.nix { };
   };
 
-in self
+in lib.recurseIntoAttrs self

--- a/pkgs/development/libraries/libelf-freebsd/default.nix
+++ b/pkgs/development/libraries/libelf-freebsd/default.nix
@@ -1,4 +1,4 @@
-{ fetchsvn, stdenv, gnum4, tet }:
+{ lib, fetchsvn, stdenv, gnum4, tet }:
 
 stdenv.mkDerivation (rec {
   version = "3258";

--- a/pkgs/development/libraries/libelf-freebsd/default.nix
+++ b/pkgs/development/libraries/libelf-freebsd/default.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation (rec {
     url = "svn://svn.code.sf.net/p/elftoolchain/code/trunk";
     rev = (lib.strings.toInt version);
     name = "elftoolchain-${version}";
+    sha256 = "1rcmddjanlsik0b055x8k914r9rxs8yjsvslia2nh1bhzf1lxmqz";
   };
 
   buildInputs = [ gnum4 tet ];

--- a/pkgs/development/tools/continuous-integration/buildkite-agent/generic.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/generic.nix
@@ -1,4 +1,4 @@
-{ buildGoPackage, makeWrapper, coreutils, git, openssh, bash, gnused, gnugrep
+{ lib, buildGoPackage, makeWrapper, coreutils, git, openssh, bash, gnused, gnugrep
 , src, version, hasBootstrapScript, postPatch ? ""
 , ... }:
 let

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -3,8 +3,8 @@
 , runtimeShell
 , unstableGitUpdater
 
-# Attributes needed for tests of the external plugins
-, callPackage, beets
+# external plugins package set
+, beetsExternalPlugins
 
 , enableAbsubmit         ? lib.elem stdenv.hostPlatform.system essentia-extractor.meta.platforms, essentia-extractor ? null
 , enableAcousticbrainz   ? true
@@ -116,15 +116,6 @@ let
     doInstallCheck = false;
   });
 
-  pluginArgs = externalTestArgs // { inherit pythonPackages; };
-
-  plugins = {
-    alternatives = callPackage ./plugins/alternatives.nix pluginArgs;
-    check = callPackage ./plugins/check.nix pluginArgs;
-    copyartifacts = callPackage ./plugins/copyartifacts.nix pluginArgs;
-    extrafiles = callPackage ./plugins/extrafiles.nix pluginArgs;
-  };
-
 in pythonPackages.buildPythonApplication rec {
   pname = "beets";
   # While there is a stable version, 1.4.9, it is more than 1000 commits behind
@@ -169,7 +160,7 @@ in pythonPackages.buildPythonApplication rec {
               || enableSubsonicupdate
               || enableAcousticbrainz)
                                     pythonPackages.requests
-    ++ optional enableCheck         plugins.check
+    ++ optional enableCheck         beetsExternalPlugins.check
     ++ optional enableConvert       ffmpeg
     ++ optional enableDiscogs       pythonPackages.discogs_client
     ++ optional enableGmusic        pythonPackages.gmusicapi
@@ -179,9 +170,9 @@ in pythonPackages.buildPythonApplication rec {
     ++ optional enableSonosUpdate   pythonPackages.soco
     ++ optional enableThumbnails    pythonPackages.pyxdg
     ++ optional enableWeb           pythonPackages.flask
-    ++ optional enableAlternatives  plugins.alternatives
-    ++ optional enableCopyArtifacts plugins.copyartifacts
-    ++ optional enableExtraFiles    plugins.extrafiles
+    ++ optional enableAlternatives  beetsExternalPlugins.alternatives
+    ++ optional enableCopyArtifacts beetsExternalPlugins.copyartifacts
+    ++ optional enableExtraFiles    beetsExternalPlugins.extrafiles
   ;
 
   buildInputs = [
@@ -289,7 +280,8 @@ in pythonPackages.buildPythonApplication rec {
   makeWrapperArgs = [ "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\"" "--set GST_PLUGIN_SYSTEM_PATH_1_0 \"$GST_PLUGIN_SYSTEM_PATH_1_0\"" ];
 
   passthru = {
-    externalPlugins = plugins;
+    # FIXME: remove in favor of pkgs.beetsExternalPlugins
+    externalPlugins = beetsExternalPlugins;
     updateScript = unstableGitUpdater { url = "https://github.com/beetbox/beets"; };
   };
 

--- a/pkgs/tools/audio/beets/plugins/alternatives.nix
+++ b/pkgs/tools/audio/beets/plugins/alternatives.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, beets, pythonPackages }:
+{ lib, fetchFromGitHub, beets, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
   pname = "beets-alternatives";

--- a/pkgs/tools/audio/beets/plugins/check.nix
+++ b/pkgs/tools/audio/beets/plugins/check.nix
@@ -16,7 +16,7 @@ pythonPackages.buildPythonApplication rec {
   propagatedBuildInputs = [ flac liboggz mp3val ];
 
   # patch out broken tests
-  patches = [ ./beet-check-tests.patch ];
+  patches = [ ./check-tests.patch ];
 
   # patch out futures dependency, it is only needed for Python2 which we don't
   # support.

--- a/pkgs/tools/audio/beets/plugins/copyartifacts.nix
+++ b/pkgs/tools/audio/beets/plugins/copyartifacts.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, beets, pythonPackages, glibcLocales }:
+{ lib, fetchFromGitHub, beets, pythonPackages, glibcLocales }:
 
 pythonPackages.buildPythonApplication {
   name = "beets-copyartifacts";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23602,7 +23602,7 @@ in
 
   mail-notification = callPackage ../desktops/gnome-2/desktop/mail-notification {};
 
-  magnetophonDSP = {
+  magnetophonDSP = lib.recurseIntoAttrs {
     CharacterCompressor = callPackage ../applications/audio/magnetophonDSP/CharacterCompressor { };
     CompBus = callPackage ../applications/audio/magnetophonDSP/CompBus { };
     ConstantDetuneChorus  = callPackage ../applications/audio/magnetophonDSP/ConstantDetuneChorus { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3009,6 +3009,26 @@ in
     pythonPackages = python3Packages;
   };
 
+  beetsExternalPlugins =
+    let
+      pluginArgs = {
+        # This is a stripped down beets for testing of the external plugins.
+        beets = (beets.override {
+          enableAlternatives = false;
+          enableCopyArtifacts = false;
+          enableExtraFiles = false;
+        }).overrideAttrs (lib.const {
+          doInstallCheck = false;
+        });
+        pythonPackages = python3Packages;
+      };
+    in lib.recurseIntoAttrs {
+      alternatives = callPackage ../tools/audio/beets/plugins/alternatives.nix pluginArgs;
+      check = callPackage ../tools/audio/beets/plugins/check.nix pluginArgs;
+      copyartifacts = callPackage ../tools/audio/beets/plugins/copyartifacts.nix pluginArgs;
+      extrafiles = callPackage ../tools/audio/beets/plugins/extrafiles.nix pluginArgs;
+    };
+
   bento4 = callPackage ../tools/video/bento4 { };
 
   bepasty = callPackage ../tools/misc/bepasty { };


### PR DESCRIPTION
This fixes hopefully all remaining missing lib inputs, likely introduced
as a regression by our recent treewide switch from stdenv.lib to lib.
These instances are all I could find using nix-instantiate --parse using
the following command:

    find "$NIXPKGS" -name '*.nix' \
      -and ! -path "$NIXPKGS/pkgs/development/interpreters/python/cpython/docs/template.nix" \
      -and ! -path "$NIXPKGS"'/.git/**' \
      -print0 | xargs -0 nix-instantiate --parse >/dev/null

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
