### PR TITLE
[20.09] binutils: fix multiple vulnerabilities

### DIFF
--- a/pkgs/development/tools/misc/binutils/CVE-2018-20623.patch
+++ b/pkgs/development/tools/misc/binutils/CVE-2018-20623.patch
@@ -1,0 +1,51 @@
+diff -ru binutils-2.31.1.orig/binutils/readelf.c binutils-2.31.1/binutils/readelf.c
+--- binutils-2.31.1.orig/binutils/readelf.c	2021-02-25 06:26:08.511301393 +0900
++++ binutils-2.31.1/binutils/readelf.c	2021-02-25 06:26:49.407303306 +0900
+@@ -19052,7 +19052,7 @@
+       /* Read the next archive header.  */
+       if (fseek (filedata->handle, arch.next_arhdr_offset, SEEK_SET) != 0)
+         {
+-          error (_("%s: failed to seek to next archive header\n"), filedata->file_name);
++          error (_("%s: failed to seek to next archive header\n"), arch.file_name);
+           return FALSE;
+         }
+       got = fread (&arch.arhdr, 1, sizeof arch.arhdr, filedata->handle);
+@@ -19060,7 +19060,10 @@
+         {
+           if (got == 0)
+ 	    break;
+-          error (_("%s: failed to read archive header\n"), filedata->file_name);
++	  /* PR 24049 - we cannot use filedata->file_name as this will
++	     have already been freed.  */
++	  error (_("%s: failed to read archive header\n"), arch.file_name);
++	    
+           ret = FALSE;
+           break;
+         }
+@@ -19080,7 +19083,7 @@
+       name = get_archive_member_name (&arch, &nested_arch);
+       if (name == NULL)
+ 	{
+-	  error (_("%s: bad archive file name\n"), filedata->file_name);
++	  error (_("%s: bad archive file name\n"), arch.file_name);
+ 	  ret = FALSE;
+ 	  break;
+ 	}
+@@ -19089,7 +19092,7 @@
+       qualified_name = make_qualified_name (&arch, &nested_arch, name);
+       if (qualified_name == NULL)
+ 	{
+-	  error (_("%s: bad archive file name\n"), filedata->file_name);
++	  error (_("%s: bad archive file name\n"), arch.file_name);
+ 	  ret = FALSE;
+ 	  break;
+ 	}
+@@ -19135,7 +19138,7 @@
+ 	  if (nested_arch.file == NULL)
+ 	    {
+ 	      error (_("%s: contains corrupt thin archive: %s\n"),
+-		     filedata->file_name, name);
++		     qualified_name, name);
+ 	      ret = FALSE;
+ 	      break;
+ 	    }

--- a/pkgs/development/tools/misc/binutils/CVE-2018-20651.patch
+++ b/pkgs/development/tools/misc/binutils/CVE-2018-20651.patch
@@ -1,0 +1,12 @@
+diff -ru binutils-2.31.1.orig/bfd/elflink.c binutils-2.31.1/bfd/elflink.c
+--- binutils-2.31.1.orig/bfd/elflink.c	2021-02-25 06:26:06.522301300 +0900
++++ binutils-2.31.1/bfd/elflink.c	2021-02-25 06:31:43.924317078 +0900
+@@ -4171,7 +4171,7 @@
+ 	 all sections contained fully therein.  This makes relro
+ 	 shared library sections appear as they will at run-time.  */
+       phdr = elf_tdata (abfd)->phdr + elf_elfheader (abfd)->e_phnum;
+-      while (--phdr >= elf_tdata (abfd)->phdr)
++      while (phdr-- > elf_tdata (abfd)->phdr)
+ 	if (phdr->p_type == PT_GNU_RELRO)
+ 	  {
+ 	    for (s = abfd->sections; s != NULL; s = s->next)

--- a/pkgs/development/tools/misc/binutils/CVE-2018-20671.patch
+++ b/pkgs/development/tools/misc/binutils/CVE-2018-20671.patch
@@ -1,0 +1,26 @@
+diff -ru binutils-2.31.1.orig/binutils/objdump.c binutils-2.31.1/binutils/objdump.c
+--- binutils-2.31.1.orig/binutils/objdump.c	2021-02-25 06:26:08.510301393 +0900
++++ binutils-2.31.1/binutils/objdump.c	2021-02-25 06:33:37.420322385 +0900
+@@ -2503,12 +2503,19 @@
+   section->reloc_info = NULL;
+   section->num_relocs = 0;
+   section->address = bfd_get_section_vma (abfd, sec);
++  section->user_data = sec;
+   section->size = bfd_get_section_size (sec);
+   amt = section->size + 1;
++  if (amt == 0 || amt > bfd_get_file_size (abfd))
++    {
++      section->start = NULL;
++      free_debug_section (debug);
++      printf (_("\nSection '%s' has an invalid size: %#llx.\n"),
++	      section->name, (unsigned long long) section->size);
++      return FALSE;
++    }
+   section->start = contents = malloc (amt);
+-  section->user_data = sec;
+-  if (amt == 0
+-      || section->start == NULL
++  if (section->start == NULL
+       || !bfd_get_full_section_contents (abfd, sec, &contents))
+     {
+       free_debug_section (debug);

--- a/pkgs/development/tools/misc/binutils/CVE-2020-35493.patch
+++ b/pkgs/development/tools/misc/binutils/CVE-2020-35493.patch
@@ -1,0 +1,12 @@
+diff -ru binutils-2.31.1.orig/bfd/pef.c binutils-2.31.1/bfd/pef.c
+--- binutils-2.31.1.orig/bfd/pef.c	2021-02-25 06:26:06.524301300 +0900
++++ binutils-2.31.1/bfd/pef.c	2021-02-25 06:36:23.543330154 +0900
+@@ -797,7 +797,7 @@
+ 	  codepos += 4;
+ 	}
+ 
+-      if ((codepos + 4) > codelen)
++      if ((codepos + 24) > codelen)
+ 	break;
+ 
+       ret = bfd_pef_parse_function_stub (abfd, codebuf + codepos, 24, &sym_index);

--- a/pkgs/development/tools/misc/binutils/CVE-2020-35494.patch
+++ b/pkgs/development/tools/misc/binutils/CVE-2020-35494.patch
@@ -1,0 +1,12 @@
+diff -ru binutils-2.31.1.orig/opcodes/tic4x-dis.c binutils-2.31.1/opcodes/tic4x-dis.c
+--- binutils-2.31.1.orig/opcodes/tic4x-dis.c	2021-02-25 06:26:08.423301389 +0900
++++ binutils-2.31.1/opcodes/tic4x-dis.c	2021-02-25 06:39:57.671340167 +0900
+@@ -275,7 +275,7 @@
+ 
+   if (condtable == NULL)
+     {
+-      condtable = xmalloc (sizeof (tic4x_cond_t *) * 32);
++      condtable = xcalloc (32, sizeof (tic4x_cond_t *));
+       for (i = 0; i < tic4x_num_conds; i++)
+ 	condtable[tic4x_conds[i].cond] = (tic4x_cond_t *)(tic4x_conds + i);
+     }

--- a/pkgs/development/tools/misc/binutils/CVE-2020-35495+CVE-2020-35496+CVE-2020-35497.patch
+++ b/pkgs/development/tools/misc/binutils/CVE-2020-35495+CVE-2020-35496+CVE-2020-35497.patch
@@ -1,0 +1,157 @@
+diff -ru binutils-2.31.1.orig/bfd/elf32-arm.c binutils-2.31.1/bfd/elf32-arm.c
+--- binutils-2.31.1.orig/bfd/elf32-arm.c	2021-02-25 06:26:06.510301300 +0900
++++ binutils-2.31.1/bfd/elf32-arm.c	2021-02-25 07:25:28.095467849 +0900
+@@ -7066,7 +7066,6 @@
+ 
+   tmp_name = (char *) bfd_malloc ((bfd_size_type) strlen (name)
+ 				  + strlen (ARM2THUMB_GLUE_ENTRY_NAME) + 1);
+-
+   BFD_ASSERT (tmp_name);
+ 
+   sprintf (tmp_name, ARM2THUMB_GLUE_ENTRY_NAME, name);
+@@ -7241,7 +7240,6 @@
+ 
+   tmp_name = (char *) bfd_malloc ((bfd_size_type) strlen (name)
+ 				  + strlen (ARM2THUMB_GLUE_ENTRY_NAME) + 1);
+-
+   BFD_ASSERT (tmp_name);
+ 
+   sprintf (tmp_name, ARM2THUMB_GLUE_ENTRY_NAME, name);
+@@ -7319,7 +7317,6 @@
+   /* Add symbol for veneer.  */
+   tmp_name = (char *)
+       bfd_malloc ((bfd_size_type) strlen (ARM_BX_GLUE_ENTRY_NAME) + 1);
+-
+   BFD_ASSERT (tmp_name);
+ 
+   sprintf (tmp_name, ARM_BX_GLUE_ENTRY_NAME, reg);
+@@ -7411,7 +7408,6 @@
+ 
+   tmp_name = (char *) bfd_malloc ((bfd_size_type) strlen
+ 				  (VFP11_ERRATUM_VENEER_ENTRY_NAME) + 10);
+-
+   BFD_ASSERT (tmp_name);
+ 
+   sprintf (tmp_name, VFP11_ERRATUM_VENEER_ENTRY_NAME,
+@@ -7531,7 +7527,6 @@
+ 
+   tmp_name = (char *) bfd_malloc ((bfd_size_type) strlen
+ 				  (STM32L4XX_ERRATUM_VENEER_ENTRY_NAME) + 10);
+-
+   BFD_ASSERT (tmp_name);
+ 
+   sprintf (tmp_name, STM32L4XX_ERRATUM_VENEER_ENTRY_NAME,
+@@ -8562,6 +8557,7 @@
+ 
+   tmp_name = (char *) bfd_malloc ((bfd_size_type) strlen
+ 				  (VFP11_ERRATUM_VENEER_ENTRY_NAME) + 10);
++  BFD_ASSERT (tmp_name);
+ 
+   for (sec = abfd->sections; sec != NULL; sec = sec->next)
+     {
+@@ -8649,6 +8645,7 @@
+ 
+   tmp_name = (char *) bfd_malloc ((bfd_size_type) strlen
+ 				  (STM32L4XX_ERRATUM_VENEER_ENTRY_NAME) + 10);
++  BFD_ASSERT (tmp_name);
+ 
+   for (sec = abfd->sections; sec != NULL; sec = sec->next)
+     {
+@@ -18267,6 +18264,8 @@
+ 
+   maxnamelen = 128;
+   cmse_name = (char *) bfd_malloc (maxnamelen);
++  BFD_ASSERT (cmse_name);
++
+   for (src_count = 0; src_count < symcount; src_count++)
+     {
+       struct elf32_arm_link_hash_entry *cmse_hash;
+@@ -19465,6 +19464,8 @@
+       unsigned int in_index, out_index;
+       bfd_vma add_to_offsets = 0;
+ 
++      if (edited_contents == NULL)
++	return FALSE;
+       for (in_index = 0, out_index = 0; in_index * 8 < input_size || edit_node;)
+ 	{
+ 	  if (edit_node)
+diff -ru binutils-2.31.1.orig/bfd/mach-o.c binutils-2.31.1/bfd/mach-o.c
+--- binutils-2.31.1.orig/bfd/mach-o.c	2021-02-25 06:26:06.586301303 +0900
++++ binutils-2.31.1/bfd/mach-o.c	2021-02-25 07:25:28.097467849 +0900
+@@ -5679,6 +5679,8 @@
+ 	  unsigned char *buf = bfd_malloc (1024);
+ 	  unsigned long size = 1024;
+ 
++	  if (buf == NULL)
++	    return -1;
+ 	  for (;;)
+ 	    {
+ 	      bfd_size_type nread = 0;
+@@ -5724,6 +5726,8 @@
+ 		      bottom = seg->fileoff + seg->filesize - offset;
+ 		      top = seg->fileoff + seg->filesize - 4;
+ 		      *rbuf = bfd_malloc (top - bottom);
++		      if (*rbuf == NULL)
++			return -1;
+ 		      *rlen = top - bottom;
+ 
+ 		      memcpy (*rbuf, buf + size - *rlen, *rlen);
+@@ -5868,6 +5872,9 @@
+   dsym_filename = (char *)bfd_malloc (strlen (base_bfd->filename)
+ 				       + strlen (dsym_subdir) + 1
+ 				       + strlen (base_basename) + 1);
++  if (dsym_filename == NULL)
++    return NULL;
++
+   sprintf (dsym_filename, "%s%s/%s",
+ 	   base_bfd->filename, dsym_subdir, base_basename);
+ 
+diff -ru binutils-2.31.1.orig/bfd/pef.c binutils-2.31.1/bfd/pef.c
+--- binutils-2.31.1.orig/bfd/pef.c	2021-02-25 06:26:06.524301300 +0900
++++ binutils-2.31.1/bfd/pef.c	2021-02-25 07:25:28.098467849 +0900
+@@ -445,6 +445,8 @@
+ 
+   loaderlen = loadersec->size;
+   loaderbuf = bfd_malloc (loaderlen);
++  if (loaderbuf == NULL)
++    return -1;
+ 
+   if (bfd_seek (abfd, loadersec->filepos, SEEK_SET) < 0
+       || bfd_bread ((void *) loaderbuf, loaderlen, abfd) != loaderlen
+@@ -476,6 +478,9 @@
+ 
+   loaderlen = loadersec->size;
+   loaderbuf = bfd_malloc (loaderlen);
++  if (loaderbuf == NULL)
++    goto end;
++
+   if (bfd_seek (abfd, loadersec->filepos, SEEK_SET) < 0)
+     goto error;
+   if (bfd_bread ((void *) loaderbuf, loaderlen, abfd) != loaderlen)
+@@ -751,6 +756,8 @@
+     (header.imported_library_count * sizeof (bfd_pef_imported_library));
+   imports = bfd_malloc
+     (header.total_imported_symbol_count * sizeof (bfd_pef_imported_symbol));
++  if (libraries == NULL || imports == NULL)
++    goto error;
+ 
+   if (loaderlen < (56 + (header.imported_library_count * 24)))
+     goto error;
+@@ -895,6 +902,8 @@
+     {
+       codelen = codesec->size;
+       codebuf = bfd_malloc (codelen);
++      if (codebuf == NULL)
++	goto end;
+       if (bfd_seek (abfd, codesec->filepos, SEEK_SET) < 0)
+ 	goto end;
+       if (bfd_bread ((void *) codebuf, codelen, abfd) != codelen)
+@@ -906,6 +915,8 @@
+     {
+       loaderlen = loadersec->size;
+       loaderbuf = bfd_malloc (loaderlen);
++      if (loaderbuf == NULL)
++	goto end;
+       if (bfd_seek (abfd, loadersec->filepos, SEEK_SET) < 0)
+ 	goto end;
+       if (bfd_bread ((void *) loaderbuf, loaderlen, abfd) != loaderlen)

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -69,6 +69,24 @@ stdenv.mkDerivation {
     # cross-compiling.
     ./always-search-rpath.patch
 
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=24049
+    ./CVE-2018-20623.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=24041
+    ./CVE-2018-20651.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=24005
+    ./CVE-2018-20671.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=25307
+    ./CVE-2020-35493.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=25319
+    ./CVE-2020-35494.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=25306
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=25308
+    ./CVE-2020-35495+CVE-2020-35496+CVE-2020-35497.patch
   ] ++ lib.optionals (!stdenv.targetPlatform.isVc4)
   [
     # https://sourceware.org/bugzilla/show_bug.cgi?id=22868


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It backports patches for the following CVEs to binutils-2.31.1:

- CVE-2018-20623
- CVE-2018-20651
- CVE-2018-20671
- CVE-2020-35493
- CVE-2020-35494
- CVE-2020-35495
- CVE-2020-35496
- CVE-2020-35497

Fixes https://github.com/NixOS/nixpkgs/issues/109147
See also https://github.com/NixOS/nixpkgs/issues/68556

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
