### PR TITLE
uboot: add ATF for ubootNanoPCT4

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -192,6 +192,7 @@ in {
       platforms = ["aarch64-linux"];
       license = lib.licenses.unfreeRedistributableFirmware;
     };
+    BL31="${armTrustedFirmwareRK3399}/bl31.elf";
     filesToInstall = ["u-boot.itb" "idbloader.img"];
     postBuild = ''
       ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/rk33/rk3399_ddr_800MHz_v1.24.bin idbloader.img


### PR DESCRIPTION
###### Motivation for this change

After an additional test of the NanoPC-T4 uboot merge into master (for integration into nixos-aarch64-images), it has become apparent that it does not work without setting BL31.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
