### PR TITLE
cnijfilter2: 5.90 -> 6.00

### DIFF
--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation {
   pname = "cnijfilter2";
 
-  version = "5.90";
+  version = "6.00";
 
   src = fetchzip {
-    url = "https://gdlp01.c-wss.com/gds/4/0100010484/01/cnijfilter2-source-5.90-1.tar.gz";
-    sha256 = "1bwyv9s6xv18xxp3m04a5fyh628nzcjdjvsgmgqndnk7832h5ani";
+    url = "https://gdlp01.c-wss.com/gds/9/0100010739/01/cnijfilter2-source-6.00-1.tar.gz";
+    sha256 = "1n4vq44zya0n4a7jvq3yyqy7dcvc2911cjvxmq48zqicb2xdgafr";
   };
 
   buildInputs = [
@@ -114,7 +114,18 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "Canon InkJet printer drivers for the MG7500, MG6700, MG6600, MG5600, MG2900, MB2000, MB2300, iB4000, MB5000, MB5300, iP110, E450, MX490, E480, MG7700, MG6900, MG6800, MG5700, MG3600, and G3000 series";
+    description = "Canon InkJet printer drivers for many Pixma series printers.";
+    longDescription = ''
+      Canon InjKet printer drivers for series E200, E300, E3100, E3300, E4200, E450, E470, E480,
+      G3000, G3010, G4000, G4010, G5000, G5080, G6000, G6050, G6080, G7000, G7050, G7080, GM2000,
+      GM2080, GM4000, GM4080, iB4000, iB4100, iP110, MB2000, MB2100, MB2300, MB2700, MB5000,
+      MB5100, MB5300, MB5400, MG2900, MG3000, MG3600, MG5600, MG5700, MG6600, MG6700, MG6800,
+      MG6900, MG7500, MG7700, MX490, TR4500, TR703, TR7500, TR7530, TR8500, TR8530, TR8580, TR9530,
+      TS200, TS300, TS3100, TS3300, TS5000, TS5100, TS5300, TS5380, TS6000, TS6100, TS6130, TS6180,
+      TS6200, TS6230, TS6280, TS6300, TS6330, TS6380, TS700, TS708, TS7330, TS8000, TS8100, TS8130,
+      TS8180, TS8200, TS8230, TS8280, TS8300, TS8330, TS8380, TS9000, TS9100, TS9180, TS9500,
+      TS9580, XK50, XK60, XK70, XK80.
+    '';
     homepage = "https://hk.canon/en/support/0101048401/1";
     license = licenses.unfree;
     platforms = [ "i686-linux" "x86_64-linux" ];


### PR DESCRIPTION
###### Motivation for this change
Version bump. Canon apparently only the first version that a printer became supported, rather than latest, so I didn't notice there's 6.00 first time around. Tested as still working with our model (G6050).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
