### PR TITLE
treewide: use perl.withPackages when possible

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -556,10 +556,8 @@ in {
         install -m 0700 -d /root
         install -m 0755 -d /home
 
-        ${pkgs.perl}/bin/perl -w \
-          -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix} \
-          -I${pkgs.perlPackages.JSON}/${pkgs.perl.libPrefix} \
-          ${./update-users-groups.pl} ${spec}
+        ${pkgs.perl.withPackages (p: [ p.FileSlurp p.JSON ])}/bin/perl \
+        -w ${./update-users-groups.pl} ${spec}
       '';
 
     # for backwards compatibility

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -34,7 +34,7 @@ let
     name = "nixos-generate-config";
     src = ./nixos-generate-config.pl;
     path = lib.optionals (lib.elem "btrfs" config.boot.supportedFilesystems) [ pkgs.btrfs-progs ];
-    perl = "${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix}";
+    perl = "${pkgs.perl.withPackages (p: [ p.FileSlurp ])}/bin/perl";
     inherit (config.system.nixos-generate-config) configuration desktopConfiguration;
     xserverEnabled = config.services.xserver.enable;
   };

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -14,10 +14,8 @@ let
     dir = "bin";
     src = ./command-not-found.pl;
     isExecutable = true;
-    inherit (pkgs) perl;
     inherit (cfg) dbPath;
-    perlFlags = concatStrings (map (path: "-I ${path}/${pkgs.perl.libPrefix} ")
-      [ pkgs.perlPackages.DBI pkgs.perlPackages.DBDSQLite pkgs.perlPackages.StringShellQuote ]);
+    perl = pkgs.perl.withPackages (p: [ p.DBDSQLite p.StringShellQuote ]);
   };
 
 in

--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -1,4 +1,4 @@
-#! @perl@/bin/perl -w @perlFlags@
+#! @perl@/bin/perl -w
 
 use strict;
 use DBI;

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -1,4 +1,4 @@
-#! @perl@
+#! @perl@/bin/perl
 
 use strict;
 use warnings;

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -113,8 +113,7 @@ let
     configurationName = config.boot.loader.grub.configurationName;
 
     # Needed by switch-to-configuration.
-
-    perl = "${pkgs.perl}/bin/perl " + (concatMapStringsSep " " (lib: "-I${lib}/${pkgs.perl.libPrefix}") (with pkgs.perlPackages; [ FileSlurp NetDBus XMLParser XMLTwig ]));
+    perl = pkgs.perl.withPackages (p: with p; [ FileSlurp NetDBus XMLParser XMLTwig ]);
   };
 
   # Handle assertions and warnings

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -728,13 +728,17 @@ in
             utillinux = pkgs.util-linux;
             btrfsprogs = pkgs.btrfs-progs;
           };
+          perl = pkgs.perl.withPackages (p: with p; [
+            FileSlurp FileCopyRecursive
+            XMLLibXML XMLSAX XMLSAXBase
+            ListCompare JSON
+          ]);
         in pkgs.writeScript "install-grub.sh" (''
         #!${pkgs.runtimeShell}
         set -e
-        export PERL5LIB=${with pkgs.perlPackages; makePerlPath [ FileSlurp FileCopyRecursive XMLLibXML XMLSAX XMLSAXBase ListCompare JSON ]}
         ${optionalString cfg.enableCryptodisk "export GRUB_ENABLE_CRYPTODISK=y"}
       '' + flip concatMapStrings cfg.mirroredBoots (args: ''
-        ${pkgs.perl}/bin/perl ${install-grub-pl} ${grubConfig args} $@
+        ${perl}/bin/perl ${install-grub-pl} ${grubConfig args} $@
       '') + cfg.extraInstallCommands);
 
       system.build.grub = grub;

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -154,7 +154,7 @@ in
       ''
         # Set up the statically computed bits of /etc.
         echo "setting up /etc..."
-        ${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix} ${./setup-etc.pl} ${etc}/etc
+        ${pkgs.perl.withPackages (p: [ p.FileSlurp ])}/bin/perl ${./setup-etc.pl} ${etc}/etc
       '';
 
   };

--- a/nixos/modules/testing/service-runner.nix
+++ b/nixos/modules/testing/service-runner.nix
@@ -6,7 +6,7 @@ let
 
   makeScript = name: service: pkgs.writeScript "${name}-runner"
     ''
-      #! ${pkgs.perl}/bin/perl -w -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix}
+      #! ${pkgs.perl.withPackages (p: [ p.FileSlurp ])}/bin/perl -w
 
       use File::Slurp;
 

--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, makeWrapper
 , xorg, imlib2, libjpeg, libpng
-, curl, libexif, jpegexiforient, perlPackages
+, curl, libexif, jpegexiforient, perl
 , enableAutoreload ? !stdenv.hostPlatform.isDarwin }:
 
 with lib;
@@ -31,14 +31,7 @@ stdenv.mkDerivation rec {
                                --add-flags '--theme=feh'
   '';
 
-  checkInputs = [ perlPackages.perl perlPackages.TestCommand ];
-  preCheck = ''
-    export PERL5LIB="${perlPackages.TestCommand}/${perlPackages.perl.libPrefix}"
-  '';
-  postCheck = ''
-    unset PERL5LIB
-  '';
-
+  checkInputs = lib.singleton (perl.withPackages (p: [ p.TestCommand ]));
   doCheck = true;
 
   meta = {

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -257,18 +257,9 @@ rec {
   #     print "Howdy!\n" if true;
   #   ''
   writePerl = name: { libraries ? [] }:
-  let
-    perl-env = pkgs.buildEnv {
-      name = "perl-environment";
-      paths = libraries;
-      pathsToLink = [
-        "/${pkgs.perl.libPrefix}"
-      ];
-    };
-  in
-  makeScriptWriter {
-    interpreter = "${pkgs.perl}/bin/perl -I ${perl-env}/${pkgs.perl.libPrefix}";
-  } name;
+    makeScriptWriter {
+      interpreter = "${pkgs.perl.withPackages (p: libraries)}/bin/perl";
+    } name;
 
   # writePerlBin takes the same arguments as writePerl but outputs a directory (like writeScriptBin)
   writePerlBin = name:

--- a/pkgs/development/tools/misc/icon-naming-utils/default.nix
+++ b/pkgs/development/tools/misc/icon-naming-utils/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, perlPackages, librsvg}:
+{lib, stdenv, fetchurl, perl, librsvg}:
 
 stdenv.mkDerivation rec {
   name = "icon-naming-utils-0.8.90";
@@ -8,14 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "071fj2jm5kydlz02ic5sylhmw6h2p3cgrm3gwdfabinqkqcv4jh4";
   };
 
-  buildInputs = [ librsvg ] ++ (with perlPackages; [ perl XMLSimple ]);
-
-  postInstall =
-    ''
-      # Add XML::Simple to the runtime search path.
-      substituteInPlace $out/libexec/icon-name-mapping \
-          --replace '/bin/perl' '/bin/perl -I${perlPackages.XMLSimple}/${perlPackages.perl.libPrefix}'
-    '';
+  buildInputs = [ librsvg (perl.withPackages (p: [ p.XMLSimple ])) ];
 
   meta = with lib; {
     homepage = "http://tango.freedesktop.org/Standard_Icon_Naming_Specification";

--- a/pkgs/misc/screensavers/xscreensaver/default.nix
+++ b/pkgs/misc/screensavers/xscreensaver/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, bc, perl, perlPackages, pam, libXext, libXScrnSaver, libX11
+{ lib, stdenv, fetchurl, pkg-config, bc, perl, pam, libXext, libXScrnSaver, libX11
 , libXrandr, libXmu, libXxf86vm, libXrender, libXxf86misc, libjpeg, libGLU, libGL, gtk2
 , libxml2, libglade, intltool, xorg, makeWrapper, gle, gdk-pixbuf, gdk-pixbuf-xlib
 , forceInstallAllHacks ? false
@@ -38,11 +38,13 @@ stdenv.mkDerivation rec {
   postInstall = ''
       wrapProgram $out/bin/xscreensaver-text \
         --prefix PATH : ${lib.makeBinPath [xorg.appres]}
-      wrapProgram $out/bin/xscreensaver-getimage-file \
-        --set PERL5LIB "$out/${perlPackages.perl.libPrefix}:${with perlPackages; makePerlPath [
-              EncodeLocale HTTPDate HTTPMessage IOSocketSSL LWP LWPProtocolHttps
-              MozillaCA NetHTTP NetSSLeay TryTiny URI
-              ]}"
+
+      substituteInPlace $out/bin/xscreensaver-getimage-file \
+        --replace '${perl}' '${perl.withPackages (p: with p;
+          [ EncodeLocale HTTPDate HTTPMessage IOSocketSSL
+            LWP LWPProtocolHttps MozillaCA NetHTTP
+            NetSSLeay TryTiny URI
+          ])}'
   ''
   + lib.optionalString forceInstallAllHacks ''
     make -C hacks/glx dnalogo

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -136,10 +136,9 @@ let
         wrapProgram $out/bin/$prog --prefix PYTHONPATH : "$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
       done
 
-      substituteInPlace $out/bin/aa-notify --replace /usr/bin/notify-send ${libnotify}/bin/notify-send
-      # aa-notify checks its name and does not work named ".aa-notify-wrapped"
-      mv $out/bin/aa-notify $out/bin/aa-notify-wrapped
-      makeWrapper ${perl}/bin/perl $out/bin/aa-notify --set PERL5LIB ${libapparmor}/${perl.libPrefix} --add-flags $out/bin/aa-notify-wrapped
+      substituteInPlace $out/bin/aa-notify \
+        --replace /usr/bin/notify-send ${libnotify}/bin/notify-send \
+        --replace /usr/bin/perl "${perl}/bin/perl -I ${libapparmor}/${perl.libPrefix}"
     '';
 
     inherit doCheck;

--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config, docutils
 , pandoc, ethtool, iproute, libnl, udev, python3, perl
-, makeWrapper
-} :
+}:
 
 let
   version = "34.0";
@@ -17,7 +16,7 @@ in stdenv.mkDerivation {
     sha256 = "sha256-2HFtj595sDmWqAewIMwKMaiSDVVWKdQA9l0QsPcw8qA=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config pandoc docutils makeWrapper ];
+  nativeBuildInputs = [ cmake pkg-config pandoc docutils ];
   buildInputs = [ libnl ethtool iproute udev python3 perl ];
 
   cmakeFlags = [
@@ -39,7 +38,8 @@ in stdenv.mkDerivation {
   postFixup = ''
     for pls in $out/bin/{ibfindnodesusing.pl,ibidsverify.pl}; do
       echo "wrapping $pls"
-      wrapProgram $pls --prefix PERL5LIB : "$out/${perl.libPrefix}"
+      substituteInPlace $pls --replace \
+        "${perl}/bin/perl" "${perl}/bin/perl -I $out/${perl.libPrefix}"
     done
   '';
 

--- a/pkgs/tools/backup/store-backup/default.nix
+++ b/pkgs/tools/backup/store-backup/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, which, coreutils, perl, fetchurl, perlPackages, makeWrapper, diffutils , writeScriptBin, bzip2}:
+{lib, stdenv, which, coreutils, perl, fetchurl, makeWrapper, diffutils , writeScriptBin, bzip2}:
 
 # quick usage:
 # storeBackup.pl --sourceDir /home/user --backupDir /tmp/my_backup_destination
@@ -37,12 +37,10 @@ stdenv.mkDerivation rec {
     find $out -name "*.pl" | xargs sed -i \
       -e 's@/bin/pwd@${coreutils}/bin/pwd@' \
       -e 's@/bin/sync@${coreutils}/bin/sync@' \
-      -e '1 s@/usr/bin/env perl@${perl}/bin/perl@'
+      -e '1 s@/usr/bin/env perl@${perl.withPackages (p: [ p.DBFile ])}/bin/perl@'
 
     for p in $out/bin/*
-      do wrapProgram "$p" \
-      --prefix PERL5LIB ":" "${perlPackages.DBFile}/${perlPackages.perl.libPrefix}" \
-      --prefix PATH ":" "${lib.makeBinPath [ which bzip2 ]}"
+      do wrapProgram "$p" --prefix PATH ":" "${lib.makeBinPath [ which bzip2 ]}"
     done
 
     patchShebangs $out

--- a/pkgs/tools/backup/znapzend/default.nix
+++ b/pkgs/tools/backup/znapzend/default.nix
@@ -21,6 +21,11 @@ let
     propagatedBuildInputs = [ perlPackages.IOPipely Mojolicious-8-35 ];
   };
 
+  perl' = perl.withPackages (p:
+    [ MojoIOLoopForkCall-0-20
+      p.TAPParserSourceHandlerpgTAP
+    ]);
+
   version = "0.20.0";
   checksum = "15lb5qwksa508m9bj6d3n4rrjpakfaas9qxspg408bcqfp7pqjw3";
 in
@@ -35,7 +40,7 @@ stdenv.mkDerivation {
     sha256 = checksum;
   };
 
-  buildInputs = [ wget perl MojoIOLoopForkCall-0-20 perlPackages.TAPParserSourceHandlerpgTAP ];
+  buildInputs = [ wget perl' ];
 
   nativeBuildInputs = [ autoconf automake autoreconfHook ];
 
@@ -51,30 +56,6 @@ stdenv.mkDerivation {
   preBuild = ''
     aclocal
     automake
-  '';
-
-  postInstall = ''
-    substituteInPlace $out/bin/znapzend --replace "${perl}/bin/perl" \
-      "${perl}/bin/perl \
-      -I${Mojolicious-8-35}/${perl.libPrefix} \
-      -I${perlPackages.TAPParserSourceHandlerpgTAP}/${perl.libPrefix} \
-      -I${MojoIOLoopForkCall-0-20}/${perl.libPrefix} \
-      -I${perlPackages.IOPipely}/${perl.libPrefix} \
-      "
-    substituteInPlace $out/bin/znapzendzetup --replace "${perl}/bin/perl" \
-      "${perl}/bin/perl \
-      -I${Mojolicious-8-35}/${perl.libPrefix} \
-      -I${perlPackages.TAPParserSourceHandlerpgTAP}/${perl.libPrefix} \
-      -I${MojoIOLoopForkCall-0-20}/${perl.libPrefix} \
-      -I${perlPackages.IOPipely}/${perl.libPrefix} \
-      "
-    substituteInPlace $out/bin/znapzendztatz --replace "${perl}/bin/perl" \
-      "${perl}/bin/perl \
-      -I${Mojolicious-8-35}/${perl.libPrefix} \
-      -I${perlPackages.TAPParserSourceHandlerpgTAP}/${perl.libPrefix} \
-      -I${MojoIOLoopForkCall-0-20}/${perl.libPrefix} \
-      -I${perlPackages.IOPipely}/${perl.libPrefix} \
-      "
   '';
 
   meta = with lib; {

--- a/pkgs/tools/filesystems/file-rename/default.nix
+++ b/pkgs/tools/filesystems/file-rename/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, perlPackages, makeWrapper }:
+{ lib, stdenv, fetchurl, perl, perlPackages }:
 
 perlPackages.buildPerlPackage {
   pname = "File-Rename";
@@ -9,17 +9,15 @@ perlPackages.buildPerlPackage {
     sha256 = "1cf6xx2hiy1xalp35fh8g73j67r0w0g66jpcbc6971x9jbm7bvjy";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-
   # Fix an incorrect platform test that misidentifies Darwin as Windows
   postPatch = ''
     substituteInPlace Makefile.PL \
       --replace '/win/i' '/MSWin32/'
   '';
 
-  postInstall = ''
-    wrapProgram $out/bin/rename \
-      --prefix PERL5LIB : $out/${perlPackages.perl.libPrefix}
+  postFixup = ''
+    substituteInPlace $out/bin/rename \
+      --replace "#!${perl}/bin/perl" "#!${perl}/bin/perl -I $out/${perl.libPrefix}"
   '';
 
   doCheck = !stdenv.isDarwin;

--- a/pkgs/tools/misc/rrdtool/default.nix
+++ b/pkgs/tools/misc/rrdtool/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, lib, stdenv, gettext, perl, pkg-config, libxml2, pango, cairo, groff
 , tcl-8_5, darwin }:
 
-stdenv.mkDerivation rec {
+perl.pkgs.toPerlModule (stdenv.mkDerivation rec {
   name = "rrdtool-1.7.2";
 
   src = fetchurl {
@@ -27,4 +27,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ pSub ];
   };
-}
+})

--- a/pkgs/tools/networking/tgt/default.nix
+++ b/pkgs/tools/networking/tgt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, libxslt, libaio, systemd, perl, perlPackages
+{ stdenv, lib, fetchFromGitHub, libxslt, libaio, systemd, perl
 , docbook_xsl, coreutils, lsof, rdma-core, makeWrapper, sg3_utils, util-linux
 }:
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteInPlace $out/sbin/tgt-admin \
-      --replace "#!/usr/bin/perl" "#! ${perl}/bin/perl -I${perlPackages.ConfigGeneral}/${perl.libPrefix}"
+      --replace "#!/usr/bin/perl" "#! ${perl.withPackages (p: [ p.ConfigGeneral ])}/bin/perl"
     wrapProgram $out/sbin/tgt-admin --prefix PATH : \
       ${lib.makeBinPath [ lsof sg3_utils (placeholder "out") ]}
 

--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -56,7 +56,8 @@ stdenv.mkDerivation rec {
     ''
       for i in $out/bin/*; do
         if head -n 1 $i | grep -q perl; then
-          wrapProgram $i --prefix PERL5LIB : $out/${perl.libPrefix}
+          substituteInPlace $i --replace \
+            "${perl}/bin/perl" "${perl}/bin/perl -I $out/${perl.libPrefix}"
         fi
       done
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -11,7 +11,7 @@ let
 common =
   { lib, stdenv, perl, curl, bzip2, sqlite, openssl ? null, xz
   , bash, coreutils, util-linuxMinimal, gzip, gnutar
-  , pkg-config, boehmgc, perlPackages, libsodium, brotli, boost, editline, nlohmann_json
+  , pkg-config, boehmgc, libsodium, brotli, boost, editline, nlohmann_json
   , autoreconfHook, autoconf-archive, bison, flex
   , jq, libarchive, libcpuid
   , lowdown, mdbook
@@ -165,7 +165,7 @@ common =
       };
 
       passthru = {
-        perl-bindings = stdenv.mkDerivation {
+        perl-bindings = perl.pkgs.toPerlModule (stdenv.mkDerivation {
           pname = "nix-perl";
           inherit version;
 
@@ -179,14 +179,14 @@ common =
             [ perl pkg-config curl nix libsodium boost autoreconfHook autoconf-archive nlohmann_json ];
 
           configureFlags =
-            [ "--with-dbi=${perlPackages.DBI}/${perl.libPrefix}"
-              "--with-dbd-sqlite=${perlPackages.DBDSQLite}/${perl.libPrefix}"
+            [ "--with-dbi=${perl.pkgs.DBI}/${perl.libPrefix}"
+              "--with-dbd-sqlite=${perl.pkgs.DBDSQLite}/${perl.libPrefix}"
             ];
 
           preConfigure = "export NIX_STATE_DIR=$TMPDIR";
 
           preBuild = "unset NIX_INDENT_MAKE";
-        };
+        });
       };
     };
   in nix;

--- a/pkgs/tools/virtualization/nixos-container/default.nix
+++ b/pkgs/tools/virtualization/nixos-container/default.nix
@@ -1,11 +1,11 @@
-{ substituteAll, perlPackages, shadow, util-linux }:
+{ substituteAll, perl, shadow, util-linux }:
 
 substituteAll {
     name = "nixos-container";
     dir = "bin";
     isExecutable = true;
     src = ./nixos-container.pl;
-    perl = "${perlPackages.perl}/bin/perl -I${perlPackages.FileSlurp}/${perlPackages.perl.libPrefix}";
+    perl = perl.withPackages (p: [ p.FileSlurp ]);
     su = "${shadow.su}/bin/su";
     utillinux = util-linux;
 

--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -1,4 +1,4 @@
-#! @perl@
+#! @perl@/bin/perl
 
 use strict;
 use POSIX;


### PR DESCRIPTION
###### Motivation for this change

Since 03eaa48 added perl.withPackages, there is a canonical way to
create a perl interpreter from a list of libraries, for use in script
shebangs or generic build inputs. This method is declarative (what we
are doing is clear), produces short shebangs[1] and needs not to wrap
existing scripts.

Unfortunately there are a few exceptions that I've found:

  1. Scripts that are calling perl with the -T switch. This makes perl
  ignore PERL5LIB, which is what perl.withPackages is using to inform
  the interpreter of the library paths.

  2. Perl packages that depends on libraries in their own path. This
  is not possible because perl.withPackages works at build time. The
  workaround is to add `-I $out/${perl.libPrefix}` to the shebang.

In all other cases I propose to switch to perl.withPackages.

[1]: https://lwn.net/Articles/779997/

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
