### PR TITLE
varnishPackages.dynamic: fix build, use autoreconfHook269

### DIFF
--- a/pkgs/servers/varnish/dynamic.nix
+++ b/pkgs/servers/varnish/dynamic.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, varnish, docutils }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook269, pkg-config, varnish, docutils }:
 
 stdenv.mkDerivation rec {
   version = "0.4";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1n94slrm6vn3hpymfkla03gw9603jajclg84bjhwb8kxsk3rxpmk";
   };
 
-  nativeBuildInputs = [ pkg-config docutils autoreconfHook varnish.python ];
+  nativeBuildInputs = [ pkg-config docutils autoreconfHook269 varnish.python ];
   buildInputs = [ varnish ];
   postPatch = ''
     substituteInPlace Makefile.am --replace "''${LIBVARNISHAPI_DATAROOTDIR}/aclocal" "${varnish.dev}/share/aclocal"


### PR DESCRIPTION
###### Motivation for this change
fix build

was broken by autoconf bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
