### PR TITLE
Spotifyd rust packages

### DIFF
--- a/pkgs/applications/audio/spotifyd/default.nix
+++ b/pkgs/applications/audio/spotifyd/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPackages, pkg-config, openssl
+{ lib, fetchFromGitHub, rustPackages_1_45, pkg-config, openssl
 , withALSA ? true, alsaLib ? null
 , withPulseAudio ? false, libpulseaudio ? null
 , withPortAudio ? false, portaudio ? null
@@ -7,7 +7,7 @@
 , dbus ? null
 }:
 
-rustPackages.rustPlatform.buildRustPackage rec {
+rustPackages_1_45.rustPlatform.buildRustPackage rec {
   pname = "spotifyd";
   version = "0.3.0";
 
@@ -39,7 +39,7 @@ rustPackages.rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "An open source Spotify client running as a UNIX daemon";
     homepage = "https://github.com/Spotifyd/spotifyd";
-    license = with licenses; [ gpl3 ];
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ anderslundstedt Br1ght0ne marsam ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change
Spotifyd v0.3.0 does not work - ```Caught panic with message: attempted to zero-initialize type `librespot_tremor::tremor_sys::ov_callbacks`, which is invalid
Caught panic with message: called `Result::unwrap()` on an `Err` value: "SendError(..)"
Player thread panicked!```

According to [this issue](https://github.com/Spotifyd/spotifyd/issues/719) its due to the latest rust version. Pining the version of rust back to `rustPackages_1_45` fixes this error.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
