### PR TITLE
cargo-deb: 1.24.0 -> 1.29.1 + build fix

### DIFF
--- a/pkgs/tools/package-management/cargo-deb/default.nix
+++ b/pkgs/tools/package-management/cargo-deb/default.nix
@@ -13,17 +13,21 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "mmstick";
     repo = pname;
-    rev = "86d02f9cacaf4a4f9b576e2dbd9dad65baa61a0d";
+    rev = "v${version}";
     sha256 = "sha256-oWivGy2azF9zpeZ0UAi7Bxm4iXFWAjcBG0pN7qtkSU8=";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 
-  cargoSha256 = "sha256-HgGl1JWNkPEBODzWa6mfXuAtF8jOgT0Obx4mX9nOLkk=";
+  cargoSha256 = "0j9frvcmy9hydw73v0ffr0bjvq2ykylnpmiw700z344djpaaa08y";
 
   preCheck = ''
     substituteInPlace tests/command.rs \
       --replace 'target/debug' "target/${rust.toRustTarget stdenv.buildPlatform}/release"
+
+    # This is an FHS specific assert depending on glibc location
+    substituteInPlace src/dependencies.rs \
+      --replace 'assert!(deps.iter().any(|d| d.starts_with("libc")));' '// no libc assert here'
   '';
 
   meta = with lib; {

--- a/pkgs/tools/package-management/cargo-deb/default.nix
+++ b/pkgs/tools/package-management/cargo-deb/default.nix
@@ -8,18 +8,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deb";
-  version = "1.24.0";
+  version = "1.29.1";
 
   src = fetchFromGitHub {
     owner = "mmstick";
     repo = pname;
-    rev = "b49351f6770aa7aeb053dd1d4a02d6b086caad2a";
-    sha256 = "1hs96yv0awgi7ggpxp7k3n21jpv642sm0529b21hs9ib6kp4vs8s";
+    rev = "86d02f9cacaf4a4f9b576e2dbd9dad65baa61a0d";
+    sha256 = "sha256-oWivGy2azF9zpeZ0UAi7Bxm4iXFWAjcBG0pN7qtkSU8=";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 
-  cargoSha256 = "1vqnnqn6rzkdi239bh3lk7gaxr7w6v3c4ws4ya1ah04g6v9hkzlw";
+  cargoSha256 = "sha256-HgGl1JWNkPEBODzWa6mfXuAtF8jOgT0Obx4mX9nOLkk=";
 
   preCheck = ''
     substituteInPlace tests/command.rs \

--- a/pkgs/tools/package-management/cargo-deb/default.nix
+++ b/pkgs/tools/package-management/cargo-deb/default.nix
@@ -21,11 +21,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1vqnnqn6rzkdi239bh3lk7gaxr7w6v3c4ws4ya1ah04g6v9hkzlw";
 
-  checkType = "debug";
-
   preCheck = ''
     substituteInPlace tests/command.rs \
-      --replace 'target/debug' "target/${rust.toRustTarget stdenv.buildPlatform}/debug"
+      --replace 'target/debug' "target/${rust.toRustTarget stdenv.buildPlatform}/release"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

The `checkType` attribute does not apply after #113193, and since we're changing tests anyway, let's run them in the release mode to avoid the need for `checkType`.

This fixes the otherwise broken build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).