### PR TITLE
wdomirror: init at unstable-2021-01-08

### DIFF
--- a/pkgs/tools/wayland/wdomirror/default.nix
+++ b/pkgs/tools/wayland/wdomirror/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, wayland
+, wayland-protocols
+}:
+
+stdenv.mkDerivation {
+  pname = "wdomirror";
+  version = "unstable-2021-01-08";
+
+  src = fetchFromGitHub {
+    owner = "progandy";
+    repo = "wdomirror";
+    rev = "e4a4934e6f739909fbf346cbc001c72690b5c906";
+    sha256 = "1fz0sajhdjqas3l6mpik8w1k15wbv65hgh9r9vdgfqvw5l6cx7jv";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config wayland-protocols ];
+
+  buildInputs = [ wayland ];
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D wdomirror $out/bin/wdomirror
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Mirrors an output of a wlroots compositor to a window";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jpas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1994,6 +1994,8 @@ in
 
   wev = callPackage ../tools/wayland/wev { };
 
+  wdomirror = callPackage ../tools/wayland/wdomirror { };
+
   wl-clipboard = callPackage ../tools/wayland/wl-clipboard { };
 
   wlogout = callPackage ../tools/wayland/wlogout { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds a small tool which mirrors the display to a window, useful for wlroots compositors which do not have mirroring capabilities, ex. sway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
