### PR TITLE
obsidian: refactor to build using app.asar

### DIFF
--- a/pkgs/applications/misc/obsidian/default.nix
+++ b/pkgs/applications/misc/obsidian/default.nix
@@ -34,23 +34,20 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url =
-      "https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/obsidian-${version}.asar.gz";
-    sha256 = "AkPx7X00kEds7B1syXJPSV1+TJlqQ7NnR6w9wSG2BRw=";
+      "https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/obsidian-${version}.tar.gz";
+    sha256 = "1acy0dny04c8rdxqvsq70aa7vd8rgyjarcrf57mhh26ai5wiw81s";
   };
 
   nativeBuildInputs = [ makeWrapper graphicsmagick ];
-
-  unpackPhase = ''
-    gzip -dc $src > obsidian.asar
-  '';
 
   installPhase = ''
     mkdir -p $out/bin
 
     makeWrapper ${electron}/bin/electron $out/bin/obsidian \
-      --add-flags $out/share/electron/obsidian.asar
+      --add-flags $out/share/obsidian/app.asar
 
-    install -m 444 -D obsidian.asar $out/share/electron/obsidian.asar
+    install -m 444 -D resources/app.asar $out/share/obsidian/app.asar
+    install -m 444 -D resources/obsidian.asar $out/share/obsidian/obsidian.asar
 
     install -m 444 -D "${desktopItem}/share/applications/"* \
       -t $out/share/applications/


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Previously obsidian was built referencing `obsidian.asar`, which unfortunately has a side effect of running in development mode, hence signing in would not work (as it tries to make the request to `127.0.0.1:3000`).

I had a chat with the devs and to ensure it works, we should be invoking from `app.asar` which wraps `obsidian.asar` to run in production mode.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc maintainers: @ConradMearns @zaninime 