### PR TITLE
python3Packages.pytest-subtests: 0.3.2 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/pytest-subtests/default.nix
+++ b/pkgs/development/python-modules/pytest-subtests/default.nix
@@ -1,22 +1,31 @@
-{ lib, buildPythonPackage, isPy27, fetchPypi, setuptools_scm, pytestCheckHook }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
+, setuptools-scm
+}:
 
 buildPythonPackage rec {
   pname = "pytest-subtests";
   version = "0.4.0";
-  disabled = isPy27;
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-jZ4sHR3OEfe30snQkgLr/HdXt/8MrJtyrTKO3+fuA3s=";
   };
 
-  nativeBuildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
 
   checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pytest_subtests" ];
 
   meta = with lib; {
     description = "pytest plugin for unittest subTest() support and subtests fixture";
     homepage = "https://github.com/pytest-dev/pytest-subtests";
     license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/pytest-subtests/default.nix
+++ b/pkgs/development/python-modules/pytest-subtests/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "pytest-subtests";
-  version = "0.3.2";
+  version = "0.4.0";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1mxg91mrn8672f8hwg0f31xkyarnq7q0hr4fvb9hcb09jshq2wk7";
+    sha256 = "sha256-jZ4sHR3OEfe30snQkgLr/HdXt/8MrJtyrTKO3+fuA3s=";
   };
 
   nativeBuildInputs = [ setuptools_scm ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.4.0

Change log: https://github.com/pytest-dev/pytest-subtests/blob/master/CHANGELOG.rst#040-2020-12-13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
