### PR TITLE
warsow: clean up

### DIFF
--- a/pkgs/games/warsow/engine.nix
+++ b/pkgs/games/warsow/engine.nix
@@ -1,21 +1,22 @@
-{ stdenv, lib, fetchurl, cmake, libogg, libvorbis, libtheora, curl, freetype
+{ stdenv, lib, substituteAll, fetchurl, cmake, libogg, libvorbis, libtheora, curl, freetype
 , libjpeg, libpng, SDL2, libGL, openal, zlib
 }:
 
-let
-  # The game loads all those via dlopen().
-  libs = lib.mapAttrs (name: x: lib.getLib x) {
-    inherit zlib curl libpng libjpeg libogg libvorbis libtheora freetype;
-  };
-
-in stdenv.mkDerivation (libs // rec {
-  name = "warsow-engine-${version}";
+stdenv.mkDerivation rec {
+  pname = "warsow-engine";
   version = "2.1.0";
 
   src = fetchurl {
     url = "http://slice.sh/warsow/warsow_21_sdk.tar.gz";
     sha256 = "0fj5k7qpf6far8i1xhqxlpfjch10zj26xpilhp95aq2yiz08pj4r";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./libpath.patch;
+      inherit zlib curl libpng libjpeg libogg libvorbis libtheora freetype;
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -24,28 +25,30 @@ in stdenv.mkDerivation (libs // rec {
     libpng
   ];
 
-  patches = [ ./libpath.patch ];
-  postPatch = ''
-    cd source/source
-    substituteAllInPlace gameshared/q_arch.h
-  '';
-
   cmakeFlags = [ "-DQFUSION_GAME=Warsow" ];
 
+  preConfigure = ''
+    cd source/source
+  '';
+
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/lib
     cp -r libs $out/lib/warsow
     for i in warsow.* wsw_server.* wswtv_server.*; do
       install -Dm755 "$i" "$out/bin/''${i%.*}"
     done
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Multiplayer FPS game designed for competitive gaming (engine only)";
     homepage = "http://www.warsow.net";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ astsmtl abbradar ];
     platforms = platforms.linux;
     broken = stdenv.isAarch64;
   };
-})
+}


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
﻿- Do not contaminate builder environment with libraries, substitute them in the patch directly.
- Switch to pname from name.
- Run installPhase hooks.
- Correct license.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
