### PR TITLE
python3Packages.pyowm: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/pyowm/default.nix
+++ b/pkgs/development/python-modules/pyowm/default.nix
@@ -1,17 +1,27 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, requests, geojson }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, requests
+, geojson
+, pysocks
+}:
 
 buildPythonPackage rec {
   pname = "pyowm";
-  version = "3.1.1";
-
-  disabled = pythonOlder "3.3";
+  version = "3.2.0";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a7b18297a9189dbe5f6b454b12d61a407e35c7eb9ca75bcabfe5e1c83245290d";
+    sha256 = "sha256-o9QL2KtZdRa/uFq+tq8LDm5jRovNuma96qOSDK/hqN4=";
   };
 
-  propagatedBuildInputs = [ requests geojson ];
+  propagatedBuildInputs = [
+    geojson
+    pysocks
+    requests
+  ];
 
   # This may actually break the package.
   postPatch = ''
@@ -21,9 +31,10 @@ buildPythonPackage rec {
 
   # No tests in archive
   doCheck = false;
+  pythonImportsCheck = [ "" ];
 
   meta = with lib; {
-    description = "A Python wrapper around the OpenWeatherMap web API";
+    description = "Python wrapper around the OpenWeatherMap web API";
     homepage = "https://pyowm.readthedocs.io/";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/pyowm/default.nix
+++ b/pkgs/development/python-modules/pyowm/default.nix
@@ -1,10 +1,11 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, pythonOlder
-, requests
+, fetchFromGitHub
 , geojson
 , pysocks
+, pythonOlder
+, requests
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -12,9 +13,11 @@ buildPythonPackage rec {
   version = "3.2.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-o9QL2KtZdRa/uFq+tq8LDm5jRovNuma96qOSDK/hqN4=";
+  src = fetchFromGitHub {
+    owner = "csparpa";
+    repo = pname;
+    rev = version;
+    sha256 = "0sq8rxcgdiayl5gy4qhkvvsdq1d93sbzn0nfg8f1vr8qxh8qkfq4";
   };
 
   propagatedBuildInputs = [
@@ -23,19 +26,17 @@ buildPythonPackage rec {
     requests
   ];
 
-  # This may actually break the package.
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "requests>=2.18.2,<2.19" "requests"
-  '';
+  checkInputs = [ pytestCheckHook ];
 
-  # No tests in archive
-  doCheck = false;
-  pythonImportsCheck = [ "" ];
+  # Run only tests which don't require network access
+  pytestFlagsArray = [ "tests/unit" ];
+
+  pythonImportsCheck = [ "pyowm" ];
 
   meta = with lib; {
     description = "Python wrapper around the OpenWeatherMap web API";
     homepage = "https://pyowm.readthedocs.io/";
     license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.2.0

Change log: https://github.com/csparpa/pyowm/releases/tag/3.2.0

Tests are now enabled for the ones that don't require network access.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
