### PR TITLE
nixos/modules-closure: unconditionally create version dir

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.nix
+++ b/pkgs/build-support/kernel/modules-closure.nix
@@ -5,11 +5,12 @@
 
 { stdenvNoCC, kernel, firmware, nukeReferences, rootModules
 , kmod, allowMissing ? false }:
-
-stdenvNoCC.mkDerivation {
+let
+  version = kernel.passthru.modDirVersion;
+in stdenvNoCC.mkDerivation {
   name = kernel.name + "-shrunk";
   builder = ./modules-closure.sh;
   nativeBuildInputs = [ nukeReferences kmod ];
-  inherit kernel firmware rootModules allowMissing;
+  inherit kernel firmware rootModules allowMissing version;
   allowedReferences = ["out"];
 }

--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -1,11 +1,15 @@
 source $stdenv/setup
 
+echo "kernel version is $version"
+
+# Always create the modules/$version dir, so the kernel version can be obtained from the output store path.
+mkdir -p $out/lib/modules/"$version"
+
 # When no modules are built, the $out/lib/modules directory will not
 # exist. Because the rest of the script assumes it does exist, we
 # handle this special case first.
 if ! test -d "$kernel/lib/modules"; then
     if test -z "$rootModules" || test -n "$allowMissing"; then
-        mkdir -p "$out"
         exit 0
     else
         echo "Required modules: $rootModules"
@@ -14,12 +18,8 @@ if ! test -d "$kernel/lib/modules"; then
     fi
 fi
 
-version=$(cd $kernel/lib/modules && ls -d *)
-
-echo "kernel version is $version"
 
 # Determine the dependencies of each root module.
-mkdir -p $out/lib/modules/"$version"
 touch closure
 for module in $rootModules; do
     echo "root module: $module"


### PR DESCRIPTION
###### Motivation for this change

This came up in a [discussion](https://github.com/NixOS/nixpkgs/pull/105910#discussion_r582591072) on how to reliably obtain the kernel version from the resultant store path.
The `modDirVersion` attribute used here has been set on kernels for ~10 years since https://github.com/NixOS/nixpkgs/commit/ffdc37215a0ca4d28364f0649108e620272cb8d4 (not that it matters, because `modules-closure.sh` is always in sync with the nixpkgs kernel derivation anyway).  

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
