### PR TITLE
wolfssl: use --enable-reproducible-build in favour of configure.ac hack

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -11,23 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "1aa51j0xnhi49izc8djya68l70jkjv25559pgybfb9sa4fa4gz97";
   };
 
-  # almost same as Debian but for now using --enable-all instead of --enable-distro to ensure options.h gets installed
-  configureFlags = [ "--enable-all" "--enable-pkcs11" "--enable-tls13" "--enable-base64encode" ];
+  # almost same as Debian but for now using --enable-all --enable-reproducible-build instead of --enable-distro to ensure options.h gets installed
+  configureFlags = [ "--enable-all" "--enable-reproducible-build" "--enable-pkcs11" "--enable-tls13" "--enable-base64encode" ];
 
   outputs = [ "out" "dev" "doc" "lib" ];
 
   nativeBuildInputs = [ autoreconfHook ];
-
-  postPatch = ''
-     # fix recursive cycle:
-     # build flags (including location of header files) are exposed in the
-     # public API of wolfssl, causing lib to depend on dev
-     substituteInPlace configure.ac \
-       --replace '#define LIBWOLFSSL_CONFIGURE_ARGS \"$ac_configure_args\"' ' '
-     substituteInPlace configure.ac \
-       --replace '#define LIBWOLFSSL_GLOBAL_CFLAGS \"$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS\"' ' '
-  '';
-
 
   postInstall = ''
      # fix recursive cycle:


### PR DESCRIPTION
###### Motivation for this change

Remove old postPatch configure hack in favour of the new upstream --enable-reproducible-build flag. Also see discussions at https://github.com/NixOS/nixpkgs/pull/111687

cc @lechner

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've manually tested the curl build with the wolfssl feature to ensure it compiles and works as expected.