### PR TITLE
jupp: 39 -> 40

### DIFF
--- a/pkgs/applications/editors/jupp/default.nix
+++ b/pkgs/applications/editors/jupp/default.nix
@@ -1,31 +1,41 @@
-{ lib, stdenv, fetchurl, ncurses, gpm }:
+{ lib
+, stdenv
+, fetchurl
+, ncurses
+, gpm
+}:
 
 stdenv.mkDerivation rec {
-
   pname = "jupp";
-  version = "39";
+  version = "40";
   srcName = "joe-3.1${pname}${version}";
 
   src = fetchurl {
     urls = [
       "https://www.mirbsd.org/MirOS/dist/jupp/${srcName}.tgz"
-      "https://pub.allbsd.org/MirOS/dist/jupp/${srcName}.tgz" ];
-    sha256 = "14gys92dy3kq9ikigry7q2x4w5v2z76d97vp212bddrxiqy5np8d";
+      "https://pub.allbsd.org/MirOS/dist/jupp/${srcName}.tgz"
+    ];
+    sha256 = "S+1DnN5/K+KU6W5J7z6RPqkPvl6RTbiIQD46J+gDWxo=";
   };
 
   preConfigure = "chmod +x ./configure";
 
-  buildInputs = [ ncurses gpm ];
+  buildInputs = [
+    gpm
+    ncurses
+  ];
 
   configureFlags = [
     "--enable-curses"
-    "--enable-termcap"
-    "--enable-termidx"
     "--enable-getpwnam"
     "--enable-largefile"
+    "--enable-termcap"
+    "--enable-termidx"
   ];
 
   meta = with lib; {
+    homepage = "http://www.mirbsd.org/jupp.htm";
+    downloadPage = "https://www.mirbsd.org/MirOS/dist/jupp/";
     description = "A portable fork of Joe's editor";
     longDescription = ''
       This is the portable version of JOE's Own Editor, which is currently
@@ -35,8 +45,8 @@ stdenv.mkDerivation rec {
       and has a lot of bugs fixed. It is based upon an older version of joe
       because these behave better overall.
     '';
-    homepage = "http://www.mirbsd.org/jupp.htm";
-    license = licenses.gpl1;
+    license = licenses.gpl1Only;
     maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
