### PR TITLE
Expose kernel version in toplevel

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -24,7 +24,8 @@ let
 
   systemBuilder =
     let
-      kernelPath = "${config.boot.kernelPackages.kernel}/" +
+      kernel = config.boot.kernelPackages.kernel;
+      kernelPath = "${kernel}/" +
         "${config.system.boot.loader.kernelFile}";
       initrdPath = "${config.system.build.initialRamdisk}/" +
         "${config.system.boot.loader.initrdFile}";
@@ -42,6 +43,7 @@ let
 
         ln -s ${kernelPath} $out/kernel
         ln -s ${config.system.modulesTree} $out/kernel-modules
+        echo -n ${kernel.version} > $out/kernel-version
         ${optionalString (config.hardware.deviceTree.package != null) ''
           ln -s ${config.hardware.deviceTree.package} $out/dtbs
         ''}

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -74,9 +74,16 @@ def describe_generation(generation_dir):
     except IOError:
         nixos_version = "Unknown"
 
-    kernel_dir = os.path.dirname(os.path.realpath("%s/kernel" % generation_dir))
-    module_dir = glob.glob("%s/lib/modules/*" % kernel_dir)[0]
-    kernel_version = os.path.basename(module_dir)
+    try:
+        with open("%s/kernel-version" % generation_dir) as f:
+            kernel_version = f.read()
+    except IOError:
+        kernel_dir = os.path.dirname(os.path.realpath("%s/kernel" % generation_dir))
+        try:
+            module_dir = glob.glob("%s/lib/modules/*" % kernel_dir)[0]
+            kernel_version = os.path.basename(module_dir)
+        except IndexError:
+            kernel_version = "Unknown"
 
     build_time = int(os.path.getctime(generation_dir))
     build_date = datetime.datetime.fromtimestamp(build_time).strftime('%F')


### PR DESCRIPTION
###### Motivation for this change
This came up in https://github.com/NixOS/nixpkgs/pull/105910.
Currently in several places code extracts the kernel version from the kernel symlink in toplevel. This pr instead exposes it directly in a file "kernel-version" in toplevel.
This allows to use the actual kernel version (for example with `rc` suffix) rather than the name of the subdirectory of `lib/modules`.
Also said directory may not exist (e.g. if the kernel is compiled without modules), so the old way introduced some complexity which exposing the version this way avoids. 
The boot loader code will still want to support old generations for some time, so it has to fall back to the old behavior.
I adjusted `systemd-boot`, but my perl is not fluid enough, so I didn't touch the `install-grub` script; help is appreciated here.
Also `install-grub` appears to conflate the nixos version and the kernel version somehow?


This is WIP, because I first want to get some feedback, if that is a good approach at all.


###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
