### PR TITLE
k2tf: init at 0.5.0

### DIFF
--- a/pkgs/development/tools/misc/k2tf/default.nix
+++ b/pkgs/development/tools/misc/k2tf/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "k2tf";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "sl1pm4t";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0i1bhn0sccvnqbd4kv2xgng5r68adhcc61im2mn8hxmds5nf6in2";
+  };
+
+  vendorSha256 = "1c2mwhrj0xapc661z1nb6am4qq3rd1pvbvjaxikjyx95n0gs8gjk";
+
+  meta = with lib; {
+    description = "Kubernetes YAML to Terraform HCL converter";
+    homepage = "https://github.com/sl1pm4t/k2tf";
+    license = licenses.mpl20;
+    maintainers = [ maintainers.flokli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12485,6 +12485,8 @@ in
 
   augustus = callPackage ../games/augustus { };
 
+  k2tf = callPackage ../development/tools/misc/k2tf { };
+
   kafkacat = callPackage ../development/tools/kafkacat { };
 
   kati = callPackage ../development/tools/build-managers/kati { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
