### PR TITLE
emacsWithPackages: prevent the UI showing prematurely during startup

### DIFF
--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -147,9 +147,15 @@ runCommand
         # Begin the new site-start.el by loading the original, which sets some
         # NixOS-specific paths. Paths are searched in the reverse of the order
         # they are specified in, so user and system profile paths are searched last.
+        #
+        # NOTE: Avoid displaying messages early at startup by binding
+        # inhibit-message to t. This would prevent the Emacs GUI from showing up
+        # prematurely. The messages would still be logged to the *Messages*
+        # buffer.
         rm -f $siteStart $siteStartByteCompiled $subdirs $subdirsByteCompiled
         cat >"$siteStart" <<EOF
-        (load-file "$emacs/share/emacs/site-lisp/site-start.el")
+        (let ((inhibit-message t))
+          (load-file "$emacs/share/emacs/site-lisp/site-start.el"))
         (add-to-list 'load-path "$out/share/emacs/site-lisp")
         (add-to-list 'exec-path "$out/bin")
         ${optionalString nativeComp ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This change makes the Emacs wrapper script avoid displaying echo area messages during startup. This helps prevent split second UI glitches early in the startup process. The messages itself will still be logged and therefore will not hamper inspection for debugging purposes.

Here are some screenshots to demonstrate the UI glitches:

<details>
<summary>NixOS, GNOME</summary>
This is how it looks for a split second during startup:

![Screenshot from 2021-02-25 22-20-59](https://user-images.githubusercontent.com/7343721/109162410-85a98080-77bb-11eb-8e0e-9fab5fb554dd.png)

This is how it looks after startup has completed:
![Screenshot from 2021-02-25 22-50-40](https://user-images.githubusercontent.com/7343721/109162803-fb155100-77bb-11eb-8a54-f0c061888e9f.png)

</details>

<details>
<summary>macOS</summary>
This is how it looks for a split second during startup:
<img width="707" alt="Screen Shot 2021-02-25 at 11 46 47 AM" src="https://user-images.githubusercontent.com/7343721/109161525-8261c500-77ba-11eb-95e5-ab6a536bf3d8.png">

This is how it looks after startup has completed:
<img width="1056" alt="Screen Shot 2021-02-25 at 11 51 34 AM" src="https://user-images.githubusercontent.com/7343721/109161618-9e656680-77ba-11eb-9242-ed1ab5acba01.png">
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
