### PR TITLE
unzip: avoid hard links

### DIFF
--- a/pkgs/tools/archivers/unzip/default.nix
+++ b/pkgs/tools/archivers/unzip/default.nix
@@ -69,6 +69,12 @@ stdenv.mkDerivation {
     "prefix=${placeholder "out"}"
   ];
 
+  # Replace hard links with symlinks for reproducibility
+  postFixup = ''
+    rm $out/bin/zipinfo
+    ln -s ./unzip $out/bin/zipinfo
+  '';
+
   setupHook = ./setup-hook.sh;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

The NAR archive format we use for cache.nixos.org does not preserve the
information that some files might be hard links to each other.

However, the squashfs format does preserve this information, which means
when creating a squashfs image containing nix store paths that contain
hard links, the squashfs image would be different depending on whether
that nix store path was fetched from cache.nixos.org or built locally.

For this reason I think we should avoid hard links in the nix store.
For more background see https://github.com/NixOS/nixpkgs/issues/114331


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).