### PR TITLE
pythonPackages.google-auth: add missing dependency on six

### DIFF
--- a/pkgs/development/python-modules/google-auth/default.nix
+++ b/pkgs/development/python-modules/google-auth/default.nix
@@ -12,6 +12,7 @@
 , pytest-localserver
 , responses
 , rsa
+, six
 }:
 
 buildPythonPackage rec {
@@ -23,7 +24,7 @@ buildPythonPackage rec {
     sha256 = "0bmdqkyv8k8n6s8dss4zpbcq1cdxwicpb42kwybd02ia85mh43hb";
   };
 
-  propagatedBuildInputs = [ pyasn1-modules cachetools rsa ];
+  propagatedBuildInputs = [ pyasn1-modules cachetools rsa six ];
 
   checkInputs = [
     flask


### PR DESCRIPTION
google-auth depends on six as indicated here:
https://github.com/googleapis/google-auth-library-python/blob/65074d3fbe488b95923dfa8335d071fa90bf383f/setup.py

It only builds on hydra without it right now,
because another dependency pulls it in as a checkInput:
https://github.com/DavHau/mach-nix/issues/240#issuecomment-786015221

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without this change google-auth does not build without doCheck.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
