### PR TITLE
go_1_14, go_1_15: support colon at start of TZ

### DIFF
--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -150,6 +150,13 @@ stdenv.mkDerivation rec {
     ./skip-nohup-tests.patch
     ./go_no_vendor_checks-1_14.patch
 
+    # support TZ environment variable starting with colon
+    (fetchpatch {
+      name = "tz-support-colon.patch";
+      url = "https://github.com/golang/go/commit/58fe2cd4022c77946ce4b598cf3e30ccc8367143.patch";
+      sha256 = "0vphwiqrm0qykfj3rfayr65qzk22fksg7qkamvaz0lmf6fqvbd2f";
+    })
+
     # fix rare TestDontCacheBrokenHTTP2Conn failure
     (fetchpatch {
       url = "https://github.com/golang/go/commit/ea1437a8cdf6bb3c2d2447833a5d06dbd75f7ae4.patch";

--- a/pkgs/development/compilers/go/1.15.nix
+++ b/pkgs/development/compilers/go/1.15.nix
@@ -158,6 +158,13 @@ stdenv.mkDerivation rec {
     ./skip-nohup-tests.patch
     ./skip-cgo-tests-1.15.patch
     ./go_no_vendor_checks.patch
+
+    # support TZ environment variable starting with colon
+    (fetchpatch {
+      name = "tz-support-colon.patch";
+      url = "https://github.com/golang/go/commit/58fe2cd4022c77946ce4b598cf3e30ccc8367143.patch";
+      sha256 = "0vphwiqrm0qykfj3rfayr65qzk22fksg7qkamvaz0lmf6fqvbd2f";
+    })
   ] ++ [
     # breaks under load: https://github.com/golang/go/issues/25628
     (if stdenv.isAarch32


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It backports https://github.com/golang/go/commit/58fe2cd4022c77946ce4b598cf3e30ccc8367143 from Go 1.16 to older series as a prerequisite of https://github.com/NixOS/nixpkgs/pull/113555.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>garble</li>
  </ul>
</details>
<details>
  <summary>17 packages built:</summary>
  <ul>
    <li>coyim</li>
    <li>credhub-cli</li>
    <li>galene</li>
    <li>go_1_14</li>
    <li>go_1_15</li>
    <li>grafana-loki</li>
    <li>gvisor</li>
    <li>ibus-engines.bamboo</li>
    <li>lefthook</li>
    <li>nncp</li>
    <li>nomad</li>
    <li>nomad_0_12</li>
    <li>oauth2_proxy</li>
    <li>prometheus</li>
    <li>step-ca</li>
    <li>trillian</li>
    <li>v2ray</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
