### PR TITLE
python3Packages.pylitterbot: init at 2021.2.5

### DIFF
--- a/pkgs/development/python-modules/pylitterbot/default.nix
+++ b/pkgs/development/python-modules/pylitterbot/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, authlib
+, buildPythonPackage
+, fetchFromGitHub
+, httpx
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pylitterbot";
+  version = "2021.2.5";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "natekspencer";
+    repo = pname;
+    rev = version;
+    sha256 = "0705bxm0rlpgwg8my7z5pp6y362bs2j53zy1yslha0ya6cgx37g8";
+  };
+
+  propagatedBuildInputs = [
+    authlib
+    httpx
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pylitterbot" ];
+
+  meta = with lib; {
+    description = "Python package for controlling a Litter-Robot";
+    homepage = "https://github.com/natekspencer/pylitterbot";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5698,6 +5698,8 @@ in {
 
   pylint-plugin-utils = callPackage ../development/python-modules/pylint-plugin-utils { };
 
+  pylitterbot = callPackage ../development/python-modules/pylitterbot { };
+
   py-lru-cache = callPackage ../development/python-modules/py-lru-cache { };
 
   pylru = callPackage ../development/python-modules/pylru { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python package for controlling a Litter-Robot

https://github.com/natekspencer/pylitterbot

This will become a Home Assistant [dependency](https://github.com/home-assistant/core/pull/45886).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
