### PR TITLE
gpsd: 3.21 → 3.22

### DIFF
--- a/pkgs/servers/gpsd/default.nix
+++ b/pkgs/servers/gpsd/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gpsd";
-  version = "3.21";
+  version = "3.22";
 
   src = fetchurl {
-    url = "https://download-mirror.savannah.gnu.org/releases/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "14gyqrbrq6jz4y6x59rdpv9d4c3pbn0vh1blq3iwrc6kz0x4ql35";
+    url = "mirror://savannah/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "18rplv1cd76ndb2wc91jarjmfm2nk508pykv1hir79bqbwmdygvq";
   };
 
   nativeBuildInputs = [
@@ -46,15 +46,12 @@ stdenv.mkDerivation rec {
     ./sconstruct-env-fixes.patch
   ];
 
-  postPatch = ''
-    sed -i -e '17i#include <sys/sysmacros.h>' serial.c
-  '';
-
   # - leapfetch=no disables going online at build time to fetch leap-seconds
   #   info. See <gpsd-src>/build.txt for more info.
   preBuild = ''
     patchShebangs .
-    sed -e "s|systemd_dir = .*|systemd_dir = '$out/lib/systemd/system'|" -i SConstruct
+    sed -e "s|systemd_dir = .*|systemd_dir = '$out/lib/systemd/system'|" -i SConscript
+    export TAR=noop
 
     sconsFlags+=" udevdir=$out/lib/udev"
     sconsFlags+=" python_libdir=$out/lib/${python3Packages.python.libPrefix}/site-packages"
@@ -104,7 +101,8 @@ stdenv.mkDerivation rec {
       diagnostic monitoring and profiling of receivers and feeding
       location-aware applications GPS/AIS logs for diagnostic purposes.
     '';
-    homepage = "http://catb.org/gpsd/";
+    homepage = "https://gpsd.gitlab.io/gpsd/index.html";
+    changelog = "https://gitlab.com/gpsd/gpsd/-/blob/release-${version}/NEWS";
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ bjornfor rasendubi ];

--- a/pkgs/servers/gpsd/sconstruct-env-fixes.patch
+++ b/pkgs/servers/gpsd/sconstruct-env-fixes.patch
@@ -1,6 +1,7 @@
---- SConstruct.orig	2020-12-03 12:39:40.759793977 -0600
-+++ gpsd-3.21/SConstruct	2020-12-03 12:44:30.858761753 -0600
-@@ -516,9 +516,11 @@
+diff -Naur gpsd-3.22.orig/SConscript gpsd-3.22/SConscript
+--- gpsd-3.22.orig/SConscript	2021-01-09 05:35:30.000000000 +0300
++++ gpsd-3.22/SConscript	2021-02-25 21:06:47.921044438 +0300
+@@ -518,9 +518,11 @@
      'CWRAPPERS_CONFIG_DIR',      # pkgsrc
      # Variables used in testing
      'WRITE_PAD',       # So we can test WRITE_PAD values on the fly.


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://gitlab.com/gpsd/gpsd/-/blob/release-3.22/NEWS)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
