### PR TITLE
infracost: init at 0.7.20

### DIFF
--- a/pkgs/development/libraries/urfave-cli-completion/default.nix
+++ b/pkgs/development/libraries/urfave-cli-completion/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub, writeShellScript, urfave-cli-completion_1, urfave-cli-completion_2 }:
+
+stdenv.mkDerivation rec {
+  pname = "urfave-cli-completion";
+  version = "2.3.0";
+
+  srcs = [
+    urfave-cli-completion_1
+    urfave-cli-completion_2
+  ];
+
+  dontUnpack = true;
+  installPhase = let
+    linkCompletionsScript = writeShellScript "linkCompletions" ''
+      VER="$1"; NAME="$2"; OUT="$3"
+      DIR="$( cd "$( dirname "''${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+      mkdir -p $OUT/share/bash-completion/completions $OUT/share/zsh/site-functions
+      # Our typical $NAME.bash format wouldn't work with the script
+      ln -s "$DIR/$VER/bash_autocomplete" \
+            "$out/share/bash-completion/completions/$NAME"
+      ln -s "$DIR/$VER/zsh_autocomplete" \
+            "$out/share/zsh/site-functions/_$NAME"
+    '';
+  in
+  ''
+    runHook preInstallCheck
+    mkdir -p $out/share/urfave-cli-complete
+    ln -s ${urfave-cli-completion_2}/share/urfave-cli-complete/v2 $out/share/urfave-cli-complete
+    ln -s ${urfave-cli-completion_1}/share/urfave-cli-complete/v1 $out/share/urfave-cli-complete
+    install -D ${linkCompletionsScript} $out/share/urfave-cli-complete/linkCompletions
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/urfave/cli/";
+    description = "Auto-completion files for urfave/cli powered tools";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jk ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/urfave-cli-completion/v1.nix
+++ b/pkgs/development/libraries/urfave-cli-completion/v1.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub }:
+
+let
+  pname = "urfave-cli-completion";
+  version = "1.22.5";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+  owner = "urfave";
+  repo = "cli";
+  rev = "v${version}";
+  sha256 = "sha256-ZR3f7aFl0F9pZp/Bz2jpxhVrpkn2VnF6alg2Zc7B46o=";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    # remove shebang
+    sed -i '1,2d' autocomplete/bash_autocomplete
+    install -D -m 444 autocomplete/* -t $out/share/urfave-cli-complete/v1
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/urfave/cli/";
+    description = "Auto-completion files for urfave/cli powered tools";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jk ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/libraries/urfave-cli-completion/v2.nix
+++ b/pkgs/development/libraries/urfave-cli-completion/v2.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub }:
+
+let
+  pname = "urfave-cli-completion";
+  version = "2.3.0";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+  owner = "urfave";
+  repo = "cli";
+  rev = "v${version}";
+  sha256 = "sha256-pum0HXz4bnh7x7U2KofgMoYGggSvQtB65798MNOUJcE=";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    # remove shebang
+    sed -i '1,2d' autocomplete/bash_autocomplete
+    install -D -m 444 autocomplete/* -t $out/share/urfave-cli-complete/v2
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/urfave/cli/";
+    description = "Auto-completion files for urfave/cli powered tools";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jk ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/tools/infracost/default.nix
+++ b/pkgs/development/tools/infracost/default.nix
@@ -1,0 +1,62 @@
+{ lib, buildGoModule, fetchFromGitHub, urfave-cli-completion }:
+
+buildGoModule rec {
+  pname = "infracost";
+  version = "0.7.20";
+
+  src = fetchFromGitHub {
+    owner = "infracost";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-3r9OdVhrZtWm/yhgvlUXcdrq2/lIJ3cuYgB/tvuaFcU=";
+  };
+
+  vendorSha256 = "sha256-wdO+cv4EOLJir4dqG9Rvis7vIr68bKPHupWESc9hNtg=";
+
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-s -w -X github.com/infracost/infracost/internal/version.Version=v${version}")
+  '';
+
+  # runs terraform init which attempts to create files
+  doCheck = false;
+
+  # postInstall = ''
+  #   mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions
+  #   ln -s ${urfave-cli-completion}/share/urfave-cli-complete/v2/bash_autocomplete \
+  #         $out/share/bash-completion/completions/infracost
+  #   ln -s ${urfave-cli-completion}/share/urfave-cli-complete/v2/zsh_autocomplete \
+  #         $out/share/zsh/site-functions/_infracost
+  # '';
+  postInstall = ''
+    ${urfave-cli-completion}/share/urfave-cli-complete/linkCompletions "v2" "infracost" "$out"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    # Add statefile to avoid remote update checks
+    export HOME="$TMPDIR"
+    INFRACOST_DIR="$HOME/.config/infracost"
+    mkdir -p "$INFRACOST_DIR"
+    echo '{
+      "installId": "00000000-0000-0000-0000-000000000000",
+      "latestReleaseVersion": "v${version}",
+      "latestReleaseCheckedAt": "1970-01-01T00:00:00Z"
+    }' > "$INFRACOST_DIR/.state.json"
+
+    $out/bin/infracost --help
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://infracost.io/";
+    changelog = "https://github.com/infracost/infracost/releases/tag/v${version}/";
+    description = "Cloud cost estimates for Terraform in your CLI and pull requests";
+    longDescription = ''
+      Infracost shows hourly and monthly cost estimates for a Terraform project.
+      This helps developers, DevOps et al. quickly see the cost breakdown and compare different deployment options upfront.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2495,6 +2495,8 @@ in
 
   ifm = callPackage ../tools/graphics/ifm {};
 
+  infracost = callPackage ../development/tools/infracost { };
+
   ink = callPackage ../tools/misc/ink { };
 
   interlock = callPackage ../servers/interlock {};
@@ -8635,6 +8637,12 @@ in
   urdfdom = callPackage ../development/libraries/urdfdom {};
 
   urdfdom-headers = callPackage ../development/libraries/urdfdom-headers {};
+
+  urfave-cli-completion_2 = callPackage ../development/libraries/urfave-cli-completion/v2.nix {};
+  urfave-cli-completion_1 = callPackage ../development/libraries/urfave-cli-completion/v1.nix {};
+
+  # urfave-cli-completion = urfave-cli-completion_2;
+  urfave-cli-completion = callPackage ../development/libraries/urfave-cli-completion {};
 
   uriparser = callPackage ../development/libraries/uriparser {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

WIP PR to get some thoughts.
Not 100% sure that the completion is working
Might want to modify this to have a `generic.nix` rather than a `v1.nix` and `v2.nix`

Package infracost, init at `0.7.20`
Add completions for go binaries using `urfave/cli`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
