### PR TITLE
tree-sitter: 0.17.3 -> 0.18.2 

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -16,14 +16,14 @@ let
   # 1) change all these hashes
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
   # 3) run the ./result script that is output by that (it updates ./grammars)
-  version = "0.17.3";
-  sha256 = "sha256-uQs80r9cPX8Q46irJYv2FfvuppwonSS5HVClFujaP+U=";
-  cargoSha256 = "sha256-fonlxLNh9KyEwCj7G5vxa7cM/DlcHNFbQpp0SwVQ3j4=";
+  version = "0.18.2";
+  sha256 = "1kh3bqn28nal3mmwszbih8hbq25vxy3zd45pzj904yf0ds5ql684";
+  cargoSha256 = "06jbn4ai5lrxzv51vfjzjs7kgxw4nh2vbafc93gma4k14gggyygc";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";
     repo = "tree-sitter";
-    rev = version;
+    rev = "v${version}";
     inherit sha256;
     fetchSubmodules = true;
   };

--- a/pkgs/development/tools/parsing/tree-sitter/grammar.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar.nix
@@ -30,7 +30,11 @@ stdenv.mkDerivation {
     if [ ! -f "$scanner_cc" ]; then
       scanner_cc=""
     fi
-    $CC -I$src/src/ -shared -o parser -Os $src/src/parser.c $scanner_cc -lstdc++
+    scanner_c="$src/src/scanner.c"
+    if [ ! -f "$scanner_c" ]; then
+      scanner_c=""
+    fi
+    $CC -I$src/src/ -shared -o parser -Os $src/src/parser.c $scanner_cc $scanner_c -lstdc++
     runHook postBuild
   '';
   installPhase = ''

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "aae8ab2b681082ce7a35d8d5fdf75ffcf7f994e5",
-  "date": "2021-01-08T13:18:05+00:00",
-  "path": "/nix/store/fpx44l1j2dz3drnvfb7746d8zxn37gwi-tree-sitter-c-sharp",
-  "sha256": "107bxz9bhyixdla3xli06ism8rnkha7pa79hi7lyx00sfnjmgcc8",
+  "rev": "21ec3c3deb4365085aa353fadbc6a616d7769f9f",
+  "date": "2021-02-18T09:41:56-08:00",
+  "path": "/nix/store/8172rv05dvvlyp4cfmr2b41g4a20vlcf-tree-sitter-c-sharp",
+  "sha256": "1cc0ss09bfv2xy77bpcmy6y2hqis7a8xby9afcaxcn5llj593ynj",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "99151b1e9293c9e025498fee7e6691e1a52e1d03",
-  "date": "2020-05-14T11:39:30-07:00",
-  "path": "/nix/store/b5xqnw967s9a58wcpyspbkgbph6jxarv-tree-sitter-c",
-  "sha256": "07ax01r3npw13jlv20k15q2hdhqa0rwm2km6f5j50byqvmgfc6fm",
+  "rev": "fa408bc9e77f4b770bd1db984ca00c901ddf95fc",
+  "date": "2021-02-24T11:13:22-08:00",
+  "path": "/nix/store/8rlr93kjsvbpc8vgfxw02vcaprlfmprq-tree-sitter-c",
+  "sha256": "03nb8nlnkfw8p8bi4grfyh31l6419sk7ak2hnkpnnjs0y0gqb7jm",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "a35a275df92e7583df38f2de2562361f2b69987e",
-  "date": "2020-12-13T11:27:21-08:00",
-  "path": "/nix/store/l0mv4q1xdxz94ym1nl73y52i1yr9zcgi-tree-sitter-cpp",
-  "sha256": "130vizybkm11j3lpzmf183myz0vjxq75mpy6qz48rrkidhnrlryk",
+  "rev": "3bfe046f3967fef92ebb33f8cd58c3ff373d5e56",
+  "date": "2021-02-25T11:55:19-08:00",
+  "path": "/nix/store/m2sd8ic8j3dayfa0zz0shc2pjaamahpf-tree-sitter-cpp",
+  "sha256": "052imxj6920ia002pzgwj2rg75xq3xpa80w8sjdq4mnlksy8v7g6",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-css",
-  "rev": "23f2cb97d47860c517f67f03e1f4b621d5bd2085",
-  "date": "2020-05-14T14:44:30-07:00",
-  "path": "/nix/store/r5pkz9kly0mhgrmqzdzdsr6d1dpqavld-tree-sitter-css",
-  "sha256": "17svpf36p0p7spppzhm3fi833zpdl2l1scg34r6d4vcbv7dknrjy",
+  "rev": "e882c98b5e62d864f7f9e4d855b19b6050c897a8",
+  "date": "2021-02-12T10:45:27-08:00",
+  "path": "/nix/store/g368rqak07i91ddma16pkccp63y2s5yv-tree-sitter-css",
+  "sha256": "0firlbl81vxnw5dp31inabizjhqc37rnbvwf05668qpfjl9gc03z",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-embedded-template",
-  "rev": "8269c1360e5b1b9ba3e04e7896d9dd2f060de12f",
-  "date": "2020-07-20T12:50:27-07:00",
-  "path": "/nix/store/9ijnzv72vc1n56k6f1xp3kb7lc9hvlhh-tree-sitter-embedded-template",
-  "sha256": "03symsaxp8m128cn5h14pnm30ihpc49syb4vybpdvgcvraa408qq",
+  "rev": "872f037009ae700e3d4c3f83284af8f51c184dd4",
+  "date": "2021-02-05T09:53:39-08:00",
+  "path": "/nix/store/qg1lmgjrvjxg05bf7dczx5my9r83rxyb-tree-sitter-embedded-template",
+  "sha256": "0iffxki8pqavvi0cyndgyr4gp0f4zcdbv7gn7ar4sp17pksk5ss6",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "f7b62ac33d63bea56ce202ace107aaa4285e50af",
-  "date": "2020-10-27T13:41:02-04:00",
-  "path": "/nix/store/h51zjbzdrm89gczcdv7nyih54vnd2xps-tree-sitter-java",
-  "sha256": "0jbh79brs1dskfqw05s9ndrp46hibyc37nfvhxlvanmgj3pjwgxb",
+  "rev": "16c07a726c34c9925b3e28716b2d6d60e3643252",
+  "date": "2021-02-11T09:32:05-08:00",
+  "path": "/nix/store/1b64g1a3cvq1hspys9z2z1lsawg2b9m2-tree-sitter-java",
+  "sha256": "1rag75r71cp8cvkf4f3wj911jppypziri19zysyy3pgzhznqy4zd",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "3f8b62f9befd3cb3b4cb0de22f6595a0aadf76ca",
-  "date": "2020-12-02T10:20:20-08:00",
-  "path": "/nix/store/c17bf7sjq95lank5ygbglv8j48i5z9w3-tree-sitter-javascript",
-  "sha256": "0fjq1jzrzd8c8rfxkh2s25gnqlyc19k3a8i3r1129kakisn1288k",
+  "rev": "37af80d372ae9e2f5adc2c6321d5a34294dc348b",
+  "date": "2021-02-24T09:50:29-08:00",
+  "path": "/nix/store/y8jbjblicw2c65kil2y4d6vdn9r9h9w5-tree-sitter-javascript",
+  "sha256": "0cr75184abpg95bl6wgkqn7ay849bjsib48m9pdb5jrly1idw6n2",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "791b5ff0e4f0da358cbb941788b78d436a2ca621",
-  "date": "2019-05-10T15:57:43-05:00",
-  "path": "/nix/store/5gcddcxf6jfr4f0p203jnbjc0zxk207d-tree-sitter-nix",
-  "sha256": "1y5b3wh3fcmbgq8r2i97likzfp1zp02m58zacw5a1cjqs5raqz66",
+  "rev": "a6bae0619126d70c756c11e404d8f4ad5108242f",
+  "date": "2021-02-09T00:48:18-06:00",
+  "path": "/nix/store/1rfsi62v549h72vw7ysciaw17vr5h9yx-tree-sitter-nix",
+  "sha256": "08n496k0vn7c2751gywl1v40490azlri7c92dr2wfgw5jxhjmb0d",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "f568dfabf7c4611077467a9cd13297fa0658abb6",
-  "date": "2021-01-06T13:32:39-08:00",
-  "path": "/nix/store/5g256n8ym3ll2kp9jlmnkaxpnyf6rpk3-tree-sitter-python",
-  "sha256": "1lxmzrkw4k9pba4xywnbd1pk2x5s99qa4skgqvgy3imgbhy7ilkh",
+  "rev": "3196e288650992bca2399dda15ac703c342a22bb",
+  "date": "2021-01-19T11:31:59-08:00",
+  "path": "/nix/store/0y394nsknvjxpxnsfscab531mivnzhap-tree-sitter-python",
+  "sha256": "0fbkyysz0qsjqzqznwgf52wsgb10h8agc4p68zafiibwlp72gd09",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ql",
-  "rev": "a0d688d62dcb9cbc7c53f0d98343c458b3776b3d",
-  "date": "2020-09-16T12:56:09-07:00",
-  "path": "/nix/store/dfdaf6wg80dfw5fvdiir7n9nj6j30g3g-tree-sitter-ql",
-  "sha256": "0f6rfhrbvpg8czfa7mld45by3rp628bs6fyl47a8mn18w6x0n5g2",
+  "rev": "f3738c138ba753eed5da386c7321cb139d185d39",
+  "date": "2021-02-19T10:26:41+00:00",
+  "path": "/nix/store/dww93fp6psaw4lhiwyn8qajq8mvsyv5s-tree-sitter-ql",
+  "sha256": "15wqyf0q9arr4jh0dfjr5200rghy989wvf311cffma7706ngmgxb",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "2beedf23bedbd7b02b416518693e8eed3944d4a0",
-  "date": "2021-01-05T10:00:48-08:00",
-  "path": "/nix/store/2igv1zlnl535b86zj8s9s3ir4q85933x-tree-sitter-rust",
-  "sha256": "0iicwhxf1f56zqpsagbm8nr30fpssi970mi9i47az206dbs506ly",
+  "rev": "ab7f7962073fec96e0b64fbd1697263fe2c79281",
+  "date": "2021-02-16T21:17:08-08:00",
+  "path": "/nix/store/zy2sccixlk8lwkqamikz03j42s13ndjp-tree-sitter-rust",
+  "sha256": "06zmbwgsvyaz0wgja8r3ir06z67gix7i62zj0k3bbng6smdnhp9w",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "2d1c7d5c10c33cb444d1781fa76f2936810afec4",
-  "date": "2021-01-07T09:49:56-08:00",
-  "path": "/nix/store/s65bv25523lwa9yrqbj9hsh0k4ig6pbx-tree-sitter-typescript",
-  "sha256": "09bv44n181az5rqjd43wngj9bghwy0237gpvs6xkjf9j19kvy0yi",
+  "rev": "543cbe44f16189f7f1b739cf268d70f373d94b87",
+  "date": "2021-02-25T11:54:57-08:00",
+  "path": "/nix/store/liyi8hkl55dcbs1wc4w2jw4zf717bb29-tree-sitter-typescript",
+  "sha256": "0ljhkhi8fp38l1n6wam7l8bdqxr95d0c1mf7i6p1gb6xrjzssik0",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update tree-sitter an grammars

Also include commit from #108639 , without many of the grammars are broken

Closes #110662

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
