### PR TITLE
qt515 compatibility for qpdfview 0.4.18

### DIFF
--- a/pkgs/applications/misc/qpdfview/default.nix
+++ b/pkgs/applications/misc/qpdfview/default.nix
@@ -14,11 +14,12 @@ let
   buildInputs = [
     qtbase qtsvg poppler djvulibre libspectre cups file ghostscript
   ];
+  patches = [ ./qpdfview-qt515-compat.patch ];
 in
 mkDerivation {
   pname = s.baseName;
   inherit (s) version;
-  inherit nativeBuildInputs buildInputs;
+  inherit nativeBuildInputs buildInputs patches;
   src = fetchurl {
     inherit (s) url sha256;
   };

--- a/pkgs/applications/misc/qpdfview/default.nix
+++ b/pkgs/applications/misc/qpdfview/default.nix
@@ -14,6 +14,7 @@ let
   buildInputs = [
     qtbase qtsvg poppler djvulibre libspectre cups file ghostscript
   ];
+  # apply upstream fix for qt5.15 https://bazaar.launchpad.net/~adamreichold/qpdfview/trunk/revision/2104
   patches = [ ./qpdfview-qt515-compat.patch ];
 in
 mkDerivation {
@@ -41,7 +42,7 @@ mkDerivation {
   meta = {
     inherit (s) version;
     description = "A tabbed document viewer";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.linux;
     homepage = "https://launchpad.net/qpdfview";

--- a/pkgs/applications/misc/qpdfview/qpdfview-qt515-compat.patch
+++ b/pkgs/applications/misc/qpdfview/qpdfview-qt515-compat.patch
@@ -1,0 +1,17 @@
+Fix compatibility with Qt 5.15.
+
+Patch copied from upstream source repository:
+
+https://bazaar.launchpad.net/~adamreichold/qpdfview/trunk/revision/2104
+
+--- a/sources/model.h	2017-04-19 21:01:25 +0000
++++ b/sources/model.h	2020-06-09 06:24:11 +0000
+@@ -24,6 +24,7 @@
+ #define DOCUMENTMODEL_H
+ 
+ #include <QList>
++#include <QPainterPath>
+ #include <QtPlugin>
+ #include <QWidget>
+ #include <QVector>
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25594,7 +25594,7 @@ in
 
   vimv = callPackage ../tools/misc/vimv/default.nix { };
 
-  qpdfview = libsForQt514.callPackage ../applications/misc/qpdfview {};
+  qpdfview = libsForQt5.callPackage ../applications/misc/qpdfview {};
 
   qtile = callPackage ../applications/window-managers/qtile {
     inherit (xorg) libxcb;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The release version of qpdfview 0.4.18 has fallen behind the current qt version 5.15 and still uses 5.14 (a version which has issues with theming), and thus integrates poorly into qt desktop environments (I use lxqt) as it cannot be themed. This PR simply ports the aforementioned patch to nix.

There already exists an upstream patch that makes it compatible with qt 5.15, see [here](https://bazaar.launchpad.net/~adamreichold/qpdfview/trunk/revision/2104), [here](https://build.opensuse.org/package/view_file/Publishing/qpdfview/qpdfview-qt5.15.patch?expand=0) and [here](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/patches/qpdfview-qt515-compat.patch). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
