### PR TITLE
boost: fix cross-compile support

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -132,7 +132,8 @@ stdenv.mkDerivation {
     license = licenses.boost;
     platforms = platforms.unix ++ platforms.windows;
     badPlatforms = optional (versionOlder version "1.59") "aarch64-linux"
-                 ++ optional ((versionOlder version "1.57") || version == "1.58") "x86_64-darwin";
+                 ++ optional ((versionOlder version "1.57") || version == "1.58") "x86_64-darwin"
+                 ++ optionals (versionOlder version "1.73") lib.platforms.riscv;
     maintainers = with maintainers; [ peti ];
   };
 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -150,6 +150,9 @@ stdenv.mkDerivation {
     cat << EOF >> user-config.jam
     using gcc : cross : ${stdenv.cc.targetPrefix}c++ ;
     EOF
+    # Build b2 with buildPlatform CC/CXX.
+    sed '2i export CC=$CC_FOR_BUILD; export CXX=$CXX_FOR_BUILD' \
+      -i ./tools/build/src/engine/build.sh
   '';
 
   NIX_CFLAGS_LINK = lib.optionalString stdenv.isDarwin


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes cross-compile support for `boost`. Fixes #96336.

This PR is just to speed up #105478 since it is stalled for months. Changes requested are applied.

Tested to be built successfully: (on 8d46a65f63226c50d3c73ea309e7e35453c7d5fc)
- `boost{15x,16x,17x}` (not changed)
- `pkgsCross.aarch64-multiplatform.boost{15x,16x,17x}`
- `pkgsCross.riscv64.boost17x`

Related: #101651 
Closes: #105478

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @hlandau @veprbl @r-burns 