### PR TITLE
dlib: support sse4

### DIFF
--- a/pkgs/development/libraries/dlib/default.nix
+++ b/pkgs/development/libraries/dlib/default.nix
@@ -2,6 +2,7 @@
 , guiSupport ? false, libX11
 
   # see http://dlib.net/compile.html
+, sse4Support ? stdenv.hostPlatform.sse4_1Support
 , avxSupport ? stdenv.hostPlatform.avxSupport
 , cudaSupport ? true
 }:
@@ -23,6 +24,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DUSE_DLIB_USE_CUDA=${if cudaSupport then "1" else "0"}"
+    "-DUSE_SSE4_INSTRUCTIONS=${if sse4Support then "yes" else "no"}"
     "-DUSE_AVX_INSTRUCTIONS=${if avxSupport then "yes" else "no"}" ];
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -1,4 +1,5 @@
 { buildPythonPackage, stdenv, lib, dlib, python, pytest, more-itertools
+, sse4Support ? stdenv.hostPlatform.sse4_1Support
 , avxSupport ? stdenv.hostPlatform.avxSupport
 }:
 
@@ -12,7 +13,10 @@ buildPythonPackage {
     ${python.interpreter} nix_run_setup test --no USE_AVX_INSTRUCTIONS
   '';
 
-  setupPyBuildFlags = lib.optional avxSupport "--no USE_AVX_INSTRUCTIONS";
+  setupPyBuildFlags = [
+    "--set USE_SSE4_INSTRUCTIONS=${if sse4Support then "yes" else "no"}"
+    "--set USE_AVX_INSTRUCTIONS=${if avxSupport then "yes" else "no"}"
+  ];
 
   patches = [ ./build-cores.patch ];
 


### PR DESCRIPTION
###### Motivation for this change
Support processors that lack sse4. Without this, those processors might experience `Illegal instruction (core dumped)` errors. Also notice the commit message in the python change. It explains the reasoning.

I have tested this with `python3Packages.face_recognition` which depends on this.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
