### PR TITLE
Universal module for matrix appservices/bridges

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -555,6 +555,7 @@
   ./services/misc/matrix-appservice-irc.nix
   ./services/misc/matrix-synapse.nix
   ./services/misc/mautrix-facebook.nix
+  ./services/misc/matrix-appservices/default.nix
   ./services/misc/mautrix-telegram.nix
   ./services/misc/mbpfan.nix
   ./services/misc/mediatomb.nix

--- a/nixos/modules/services/misc/matrix-appservices/as-formats.nix
+++ b/nixos/modules/services/misc/matrix-appservices/as-formats.nix
@@ -81,7 +81,6 @@ in
         id = "${botName}-puppet";
         sender_localpart = "_${botName}puppet_bot";
         protocols = [ ];
-        "de.sorunome.msc2409.push_ephemeral" = true;
         namespaces = {
           rooms = [ ];
           users = [

--- a/nixos/modules/services/misc/matrix-appservices/as-formats.nix
+++ b/nixos/modules/services/misc/matrix-appservices/as-formats.nix
@@ -1,0 +1,167 @@
+{ systemConfig, asConfig, lib, pkgs, ... }:
+
+with lib;
+let
+  inherit (systemConfig.services.matrix-appservices)
+    homeserverURL
+    homeserverDomain;
+  package = asConfig.package;
+  pname = getName package;
+  command = "${package}/bin/${pname}";
+
+  mautrix = {
+    registerScript = ''
+      ${command} --generate-registration \
+        --config=$SETTINGS_FILE \
+        --registration=$REGISTRATION_FILE
+    '';
+
+    # mautrix stores the registration tokens in the config file
+    startupScript = ''
+      mv $SETTINGS_FILE $SETTINGS_FILE.tmp
+      yq -s '.[0].appservice.as_token = .[1].as_token
+        | .[0].appservice.hs_token = .[1].hs_token
+        | .[0]' $SETTINGS_FILE.tmp $REGISTRATION_FILE \
+        > $SETTINGS_FILE
+
+      ${command} --config=$SETTINGS_FILE \
+        --registration=$REGISTRATION_FILE
+    '';
+
+    settings = {
+      homeserver = {
+        address = homeserverURL;
+        domain = homeserverDomain;
+      };
+
+      appservice.state_store_path = "$DIR/mx-state.json";
+
+      bridge.permissions = {
+        ${homeserverDomain} = "user";
+      };
+    };
+  };
+
+in
+{
+  other = {
+    description = ''
+      No defaults will be set.
+    '';
+  };
+
+  matrix-appservice = {
+    registerScript = ''
+      url=$(cat $SETTINGS_FILE | yq .appserviceUrl)
+      if [ -z $url ]; then
+        url="http://localhost:$(cat $SETTINGS_FILE | yq .appservicePort)"
+      fi
+      ${command} --generate-registration \
+        --config=$SETTINGS_FILE --url="$url" \
+        --file=$REGISTRATION_FILE
+    '';
+
+    startupScript = ''
+      port=$(cat $SETTINGS_FILE | yq .appservicePort)
+      ${command} --config=$SETTINGS_FILE --url="$url" \
+        --port=$port --file=$REGISTRATION_FILE
+    '';
+
+    description = ''
+      For bridges based on the matrix-appservice-bridge library. The settings for these
+      bridges are NOT configured automatically, because of the various differences
+      between them. And you must set appservicePort(and optionally apserviceURL)
+      in the settings to pass to the bridge - these settings are not usually part of the config file.
+    '';
+  };
+
+  mx-puppet = {
+    preStart = ''
+      mv $SETTINGS_FILE $SETTINGS_FILE.tmp
+      yq -s '.[0] * .[1]' \
+        ${package.src}/sample.config.yaml $SETTINGS_FILE.tmp > $SETTINGS_FILE
+    '';
+
+    registerScript = ''
+      ${command} \
+        --register \
+        --config=$SETTINGS_FILE \
+        --registration-file=$REGISTRATION_FILE
+    '';
+
+    startupScript = ''
+      ${command} \
+        --config=$SETTINGS_FILE \
+        --registration-file=$REGISTRATION_FILE
+    '';
+
+    settings = {
+      bridge = {
+        domain = homeserverDomain;
+        homeserverUrl = homeserverURL;
+      };
+      database.filename = "$DIR/database.db";
+      provisioning.whitelist = [ "@.*:${homeserverDomain}" ];
+      relay.whitelist = [ "@.*:${homeserverDomain}" ];
+      selfService.whitelist = [ "@.*:${homeserverDomain}" ];
+      logging = {
+        lineDateFormat = "";
+        files = [ ];
+      };
+    };
+
+    serviceConfig.WorkingDirectory =
+      "${package}/lib/node_modules/${pname}";
+
+    description = ''
+      For bridges based on the mx-puppet-bridge library. The settings will be
+      configured to use a sqlite database. Make sure to override database.filename,
+      if you plan to use another database.
+    '';
+
+  };
+
+  mautrix-go = {
+    inherit (mautrix) registerScript startupScript;
+
+    preStart = ''
+      mv $SETTINGS_FILE $SETTINGS_FILE.tmp
+      yq -s '.[0] * .[1]' \
+        ${package.src}/example-config.yaml $SETTINGS_FILE.tmp > $SETTINGS_FILE
+    '';
+
+    settings = recursiveUpdate mautrix.settings {
+      appservice.database = {
+        type = "sqlite3";
+        uri = "$DIR/database.db";
+      };
+      bridge.permissions = {
+        # override defaults
+        "@admin:example.com" = "relaybot";
+        "example.com" = "relaybot";
+      };
+    };
+
+    description = ''
+      The settings are configured to use a sqlite database. The startupScript will
+      create a new config file on every run to set the tokens, because mautrix
+      requires them to be in the config file.
+    '';
+  };
+
+  mautrix-python = {
+    inherit (mautrix) registerScript;
+
+    settings = recursiveUpdate mautrix.settings {
+      appservice.database = "sqlite:///$DIR/database.db";
+    };
+
+    startupScript = optionalString (package ? alembic)
+      "${package.alembic}/bin/alembic -x config=$SETTINGS_FILE upgrade head\n"
+    + mautrix.startupScript;
+    description = ''
+      Same properties as mautrix-go. This will also upgrade the database on every run
+    '';
+  };
+
+}

--- a/nixos/modules/services/misc/matrix-appservices/as-options.nix
+++ b/nixos/modules/services/misc/matrix-appservices/as-options.nix
@@ -1,0 +1,112 @@
+{ systemConfig, lib, pkgs, ... }:
+with lib;
+types.submodule ({ config, ... }:
+  let
+    asFormats = (import ./as-formats.nix) {
+      inherit lib pkgs systemConfig;
+      asConfig = config;
+    };
+    asFormat = asFormats.${config.format};
+    settingsFormat = pkgs.formats.json { };
+  in
+  {
+    options = rec {
+
+      format = mkOption {
+        type = types.enum (mapAttrsToList (n: _: n) asFormats);
+        default = "other";
+        description = ''
+          Format of the appservice, used to set option defaults for appservice.
+          This is usually determined by the library the appservice is based on.
+
+          Below are descriptions for each format
+
+        '' + (concatStringsSep "\n" (mapAttrsToList
+          (n: v: "${n}: ${v.description}")
+          asFormats));
+      };
+
+      package = mkOption {
+        type = types.nullOr types.package;
+        default = null;
+        example = "pkgs.mautrix-whatsapp";
+        description = ''
+          The package for the appservice. Used by formats except 'other'.
+          This is unecessary if startupScript and registerScript is set.
+        '';
+      };
+
+      settings = mkOption rec {
+        type = settingsFormat.type;
+        apply = recursiveUpdate default;
+        default = asFormat.settings or { };
+        defaultText = "Format will attempt to configure database and allow homeserver users";
+        example = literalExpression ''
+          {
+            bridge = {
+              domain = "public-domain.tld";
+              homeserverUrl = "http://public-domain.tld:8008";
+            };
+          }
+        '';
+        description = ''
+          Appservice configuration as a Nix attribute set.
+          All environment variables will be substituted,
+          including $DIR which refers to the appservice's data directory.
+
+          Secret tokens, should be specified in serviceConfig.EnvironmentFile
+          instead of this world-readable attribute set.
+
+          Configuration options should match those described as per your appservice's settings
+          Check out the confg sample for this.
+
+        '';
+      };
+
+      preStart = mkOption {
+        type = types.str;
+        default = asFormat.preStart or "";
+        description = ''
+          Script that is run right before registration and startup.
+          The settings file will be available as $SETTINGS_FILE
+        '';
+      };
+
+      startupScript = mkOption {
+        type = types.str;
+        default = asFormat.startupScript or "";
+        description = ''
+          Script that starts the appservice.
+          The settings file will be available as $SETTINGS_FILE
+          and the registration file as $REGISTRATION_FILE
+        '';
+      };
+
+      registerScript = mkOption {
+        type = types.str;
+        default = asFormat.registerScript or "";
+        description = ''
+          Script that registers the appservice using the settings.
+          The settings file will be available as $SETTINGS_FILE
+          and the registration file must be saved to $REGISTRATION_FILE
+        '';
+      };
+
+      serviceConfig = mkOption rec {
+        type = types.attrs;
+        apply = x: default // x;
+        default = asFormat.serviceConfig or { };
+        description = ''
+          Overrides for settings in the service's serviceConfig
+        '';
+      };
+
+      serviceDependencies = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Services started before this appservice
+        '';
+      };
+    };
+  })

--- a/nixos/modules/services/misc/matrix-appservices/default.nix
+++ b/nixos/modules/services/misc/matrix-appservices/default.nix
@@ -1,0 +1,164 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.matrix-appservices;
+  asOpts = import ./as-options.nix {
+    inherit lib pkgs;
+    systemConfig = config;
+  };
+  mkService = name: opts:
+    with opts;
+    let
+      settingsFormat = pkgs.formats.json { };
+      dataDir = "/var/lib/matrix-as-${name}";
+      registrationFile = "${dataDir}/${name}-registration.yaml";
+      # Replace all references to $DIR to the dat directory
+      settingsData = settingsFormat.generate "config.json" settings;
+      settingsFile = "${dataDir}/config.json";
+      serviceDeps = [ "network-online.target" ] ++ serviceDependencies;
+    in
+    {
+      description = "A matrix appservice for ${name}.";
+
+      wantedBy = [ "multi-user.target" ];
+      wants = serviceDeps;
+      after = serviceDeps;
+      # Appservices don't need synapse up, but synapse exists if registration files are missing
+      before = mkIf (cfg.homeserver != null) [ "${cfg.homeserver}.service" ];
+
+      path = [ pkgs.yq ];
+      environment = {
+        DIR = dataDir;
+        SETTINGS_FILE = settingsFile;
+        REGISTRATION_FILE = registrationFile;
+      };
+
+      preStart = ''
+        ${pkgs.envsubst}/bin/envsubst \
+          -i ${settingsData} \
+          -o ${settingsFile}
+        chmod 640 ${settingsFile}
+
+        ${optionalString (registerScript != "") ''
+          if [ ! -f ${registrationFile} ]; then
+            ${preStart}
+            ${registerScript}
+            chmod 640 ${registrationFile}
+          fi
+        ''}
+      '';
+
+      script = ''
+        ${preStart}
+        ${startupScript}
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+
+        User = "matrix-as-${name}";
+        Group = "matrix-as-${name}";
+        PrivateTmp = true;
+        WorkingDirectory = dataDir;
+        StateDirectory = "${baseNameOf dataDir}";
+        StateDirectoryMode = "0750";
+        UMask = 0027;
+      } // opts.serviceConfig;
+    };
+
+in
+{
+  options = {
+    services.matrix-appservices = {
+      services = mkOption {
+        type = types.attrsOf asOpts;
+        default = { };
+        example = literalExpression ''
+          whatsapp = {
+            format = "mautrix-go";
+            package = pkgs.mautrix-whatsapp;
+          };
+        '';
+        description = ''
+          Appservices to setup.
+          Each appservice will be started as a systemd service with the prefix matrix-as.
+          And its data will be stored in /var/lib/matrix-as-name.
+        '';
+      };
+
+      homeserver = mkOption {
+        type = types.enum [ "matrix-synapse" null ];
+        default = "matrix-synapse";
+        description = ''
+          The homeserver software the appservices connect to. This will ensure appservices
+          start after the homeserver and it will be used by the addRegistrationFiles option.
+        '';
+      };
+
+      homeserverURL = mkOption {
+        type = types.str;
+        default = "https://${cfg.homeserverDomain}";
+        description = ''
+          URL of the homeserver the apservices connect to
+        '';
+      };
+
+      homeserverDomain = mkOption {
+        type = types.str;
+        default = if config.networking.domain != null then config.networking.domain else "";
+        defaultText = "\${config.networking.domain}";
+        description = ''
+          Domain of the homeserver the appservices connect to
+        '';
+      };
+
+      addRegistrationFiles = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to add the application service registration files to the homeserver configuration.
+          It is recommended to verify appservice files, located in /var/lib/matrix-as-*, before adding them
+        '';
+      };
+    };
+  };
+
+  config = mkIf (cfg.services != { }) {
+
+    assertions = mapAttrsToList
+      (n: v: {
+        assertion = v.format == "other" || v.package != null;
+        message = "A package must be provided if a custom format is set";
+      })
+      cfg.services;
+
+    users.users = mapAttrs' (n: v: nameValuePair "matrix-as-${n}" {
+      group = "matrix-as-${n}";
+      isSystemUser = true;
+    }) cfg.services;
+    users.groups = mapAttrs' (n: v: nameValuePair "matrix-as-${n}" { }) cfg.services;
+
+    # Create a service for each appservice
+    systemd.services = (mapAttrs' (n: v: nameValuePair "matrix-as-${n}" (mkService n v)) cfg.services) // {
+      # Add the matrix service to the groups of all appservices to give access to the registration file
+      matrix-synapse.serviceConfig.SupplementaryGroups = mapAttrsToList (n: v: "matrix-as-${n}") cfg.services;
+    };
+
+    services = mkIf cfg.addRegistrationFiles {
+      matrix-synapse.app_service_config_files = mkIf (cfg.homeserver == "matrix-synapse")
+        (mapAttrsToList (n: _: "/var/lib/matrix-as-${n}/${n}-registration.yaml")
+          (filterAttrs (_: v: v.registerScript != "") cfg.services));
+    };
+  };
+
+  meta.maintainers = with maintainers; [ pacman99 Flakebi ];
+
+}

--- a/nixos/modules/services/misc/matrix-appservices/default.nix
+++ b/nixos/modules/services/misc/matrix-appservices/default.nix
@@ -20,7 +20,7 @@ let
 
       registrationContent = {
         id = name;
-        url =  "http://${host}:${toString port}";
+        url = "http://${host}:${toString port}";
         as_token = "$AS_TOKEN";
         hs_token = "$HS_TOKEN";
         sender_localpart = "$SENDER_LOCALPART";
@@ -151,10 +151,12 @@ in
       })
       cfg.services;
 
-    users.users = mapAttrs' (n: v: nameValuePair "matrix-as-${n}" {
-      group = "matrix-as-${n}";
-      isSystemUser = true;
-    }) cfg.services;
+    users.users = mapAttrs'
+      (n: v: nameValuePair "matrix-as-${n}" {
+        group = "matrix-as-${n}";
+        isSystemUser = true;
+      })
+      cfg.services;
     users.groups = mapAttrs' (n: v: nameValuePair "matrix-as-${n}" { }) cfg.services;
 
     # Create a service for each appservice
@@ -167,7 +169,7 @@ in
     services =
       let
         registrationFiles = mapAttrsToList (n: _: "/var/lib/matrix-as-${n}/${n}-registration.yaml")
-            (filterAttrs (_: v: v.registrationData != { }) cfg.services);
+          (filterAttrs (_: v: v.registrationData != { }) cfg.services);
       in
       mkIf cfg.addRegistrationFiles {
         matrix-synapse.app_service_config_files = mkIf (cfg.homeserver == "matrix-synapse") registrationFiles;

--- a/nixos/tests/matrix-appservices.nix
+++ b/nixos/tests/matrix-appservices.nix
@@ -1,0 +1,121 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+    let
+      homeserverURL = "http://homeserver:8008";
+      homeserverDomain = "example.com";
+
+      private_key = pkgs.runCommand "matrix_key.pem" {
+        buildInputs = [ pkgs.dendrite ];
+      } "generate-keys --private-key $out";
+    in
+      {
+        name = "dendrite";
+        meta = with pkgs.lib; {
+          maintainers = teams.matrix.members;
+        };
+
+        nodes = {
+          homeserver = { pkgs, ... }: {
+            services.dendrite = {
+              enable = true;
+              settings = {
+                global.server_name = homeserverDomain;
+                global.private_key = private_key;
+                client_api.registration_disabled = false;
+              };
+            };
+
+            networking.firewall.allowedTCPPorts = [ 8008 ];
+
+            services.matrix-appservices = {
+              inherit homeserverDomain homeserverURL;
+              addRegistrationFiles = true;
+              homeserver = "dendrite";
+              services = {
+                discord = {
+                  port = 29180;
+                  package = pkgs.mx-puppet-discord;
+                  format = "mx-puppet";
+                };
+              };
+            };
+          };
+
+          client = { pkgs, ... }: {
+            environment.systemPackages = [
+              (
+                pkgs.writers.writePython3Bin "do_test"
+                  { libraries = [ pkgs.python3Packages.matrix-nio ]; } ''
+                  import asyncio
+
+                  from nio import AsyncClient
+
+
+                  async def main() -> None:
+                      # Connect to dendrite
+                      client = AsyncClient("http://homeserver:8008", "alice")
+
+                      # Register as user alice
+                      response = await client.register("alice", "my-secret-password")
+
+                      # Log in as user alice
+                      response = await client.login("my-secret-password")
+
+                      # Create a new room
+                      response = await client.room_create(federate=False)
+                      room_id = response.room_id
+
+                      # Join the room
+                      response = await client.join(room_id)
+
+                      # Invite whatsapp user to room
+                      response = await client.room_invite(
+                        room_id,
+                        "@_discordpuppet_bot:${homeserverDomain}"
+                      )
+
+                      # Send a message to the room
+                      response = await client.room_send(
+                          room_id=room_id,
+                          message_type="m.room.message",
+                          content={
+                              "msgtype": "m.text",
+                              "body": "ping"
+                          }
+                      )
+
+                      # Sync responses
+                      response = await client.sync(timeout=30000)
+
+                      response = await client.joined_members(room_id)
+
+                      # Check the message was received by dendrite
+                      # last_message = response.rooms.join[room_id].timeline.events[-1].body
+
+                      # Leave the room
+                      response = await client.room_leave(room_id)
+
+                      # Close the client
+                      await client.close()
+
+                  asyncio.get_event_loop().run_until_complete(main())
+                ''
+              )
+            ];
+          };
+        };
+
+        testScript = ''
+          start_all()
+
+          with subtest("start the homeserver"):
+              homeserver.wait_for_unit("dendrite.service")
+              homeserver.wait_for_open_port(8008)
+              homeserver.wait_for_unit("matrix-as-discord.service")
+
+          with subtest("ensure messages can be exchanged"):
+              client.succeed("do_test")
+        '';
+
+      }
+)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is an attempt to create a universal matrix appservice module. Currently, every time a new bridge is added to nixpkgs, an entire new module has to be created for that bridge. The issue is there are some major differences between how bridges/appservices are setup so creating a new module is the easiest method. But the modules end up with lots of similarities, because appservices do have some standard procedures.

In this module, the appservices can provide start scripts that will be provided necessary environment variables, so appservices can configure how their supposed to be run.
Registration files have tokens that are auto-generated, and important registration data can be supplied with the `registrationData` option. This is usually things like namespaces and aliases.

So if a user wants to setup a really unique bridge, they can setup the registration data, start script and configure everything properly. But if that bridge is based on a standard library(mautrix, mx-puppet, matrix-appservice), then that format can be set so you are not starting from scratch. And as new formats get introduced, it is relatively simple to add them to this module.

This makes it really easy to setup new bridges as long as the library is standard and the package exists, for example:
```
{ pkgs, ... }:
{
  services.matrix-appservices.services.whatsapp = {
    port = 29180;
    format = "mautrix";
    package = pkgs.mautrix-whatsapp;
  };
}
```
Since the format just sets defaults, anything can be overridden if you need something different(ex. use postgres or add service dependency). 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I'm currently using this module on my server to run a mautrix and mx-puppet bridge.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
