### PR TITLE
refind: 0.13.0 -> 0.13.1

### DIFF
--- a/pkgs/tools/bootloaders/refind/default.nix
+++ b/pkgs/tools/bootloaders/refind/default.nix
@@ -14,11 +14,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "refind";
-  version = "0.13.0";
+  version = "0.13.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/refind/${version}/${pname}-src-${version}.tar.gz";
-    sha256 = "0zivlcw1f3zwnrwvbhwq6gg781hh72g2bhc2cxcsb2zmg7q8in65";
+    sha256 = "1yjni0mr3rqrrk4ynwb8i0whpqhd56cck4mxd97qmxn7wbr826i9";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

https://sourceforge.net/p/refind/code/ci/1cb020c4b32d50c594650f7f2eb560eed5271d27/tree/NEWS.txt#l1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
