### PR TITLE
beauty-line-icon-theme: init at 0.0.1

### DIFF
--- a/pkgs/data/icons/beauty-line-icon-theme/default.nix
+++ b/pkgs/data/icons/beauty-line-icon-theme/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchzip, breeze-icons, gtk3, gnome-icon-theme, hicolor-icon-theme, mint-x-icons, pantheon }:
+
+stdenv.mkDerivation rec {
+  pname = "BeautyLine";
+  version = "0.0.1";
+
+  src = fetchzip {
+    name = "${pname}-${version}";
+    url = "https://github.com/gvolpe/BeautyLine/releases/download/${version}/BeautyLine.tar.gz";
+    sha256 = "030bjk333fr9wm1nc740q8i31rfsgf3vg6cvz36xnvavx3q363l7";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  # ubuntu-mono is also required but missing in ubuntu-themes (please add it if it is packaged at some point)
+  propagatedBuildInputs = [
+    breeze-icons
+    gnome-icon-theme
+    hicolor-icon-theme
+    mint-x-icons
+    pantheon.elementary-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
+
+  installPhase = ''
+    mkdir -p $out/share/icons/${pname}
+    cp -r * $out/share/icons/${pname}/
+    gtk-update-icon-cache $out/share/icons/${pname}
+  '';
+
+  meta = with lib; {
+    description = "BeautyLine icon theme";
+    homepage = "https://www.gnome-look.org/p/1425426/";
+    platforms = platforms.linux;
+    license = [ licenses.publicDomain ];
+    maintainers = with maintainers; [ gvolpe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1603,6 +1603,10 @@ in
 
   bat-extras = recurseIntoAttrs (callPackages ../tools/misc/bat-extras { });
 
+  beauty-line-icon-theme = callPackage ../data/icons/beauty-line-icon-theme {
+    inherit (plasma5Packages) breeze-icons;
+  };
+
   bc = callPackage ../tools/misc/bc { };
 
   bdf2psf = callPackage ../tools/misc/bdf2psf { };


### PR DESCRIPTION
###### Motivation for this change

Add the [BeautyLine](https://www.gnome-look.org/p/1425426/) icon theme to Nixpkgs. Here's a screenshot:

![img](https://i.imgur.com/f7wn3oI.jpg)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
