### PR TITLE
octave.pkgs: stdenv.lib -> lib

### DIFF
--- a/pkgs/development/interpreters/octave/build-env.nix
+++ b/pkgs/development/interpreters/octave/build-env.nix
@@ -1,4 +1,4 @@
-{ stdenv, octave, buildEnv
+{ lib, stdenv, octave, buildEnv
 , makeWrapper, texinfo
 , octavePackages
 , wrapOctave
@@ -48,7 +48,7 @@ in buildEnv {
 
       createOctavePackagesPath $out ${octave}
 
-      for path in ${stdenv.lib.concatStringsSep " " packages}; do
+      for path in ${lib.concatStringsSep " " packages}; do
           if [ -e $path/*.tar.gz ]; then
              $out/bin/octave-cli --eval "pkg local_list $out/.octave_packages; \
                                          pkg prefix $out/${octave.octPkgsPath} $out/${octave.octPkgsPath}; \
@@ -61,7 +61,7 @@ in buildEnv {
       # To point to the new local_list in $out
       addPkgLocalList $out ${octave}
 
-      wrapOctavePrograms "${stdenv.lib.concatStringsSep " " packages}"
+      wrapOctavePrograms "${lib.concatStringsSep " " packages}"
      '' + postBuild;
 
   inherit (octave) meta;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
