### PR TITLE
git-credential-gopass: init at 1.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10768,4 +10768,10 @@
     github = "felixscheinost";
     githubId = 31761492;
   };
+  benneti = {
+    name = "Benedikt Tissot";
+    email = "benedikt.tissot@googlemail.com";
+    github = "benneti";
+    githubId = 11725645;
+  };
 }

--- a/pkgs/tools/security/gopass/git-credential.nix
+++ b/pkgs/tools/security/gopass/git-credential.nix
@@ -1,0 +1,43 @@
+{ lib
+, makeWrapper
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, gopass
+}:
+
+buildGoModule rec {
+  pname = "git-credential-gopass";
+  version = "1.12.0";
+
+  src = fetchFromGitHub {
+    owner = "gopasspw";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-IvYxpUMclDAKJ/EkRbNrX8eIFyhtY9Q0B0RipweieZA=";
+  };
+
+  vendorSha256 = "sha256-N6eU6KsnUrYBK90ydwUH8LNkR9KRjgc4ciGOGvy7pw8=";
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  preBuild = ''
+    buildFlagsArray+=(
+      "-ldflags=-s -w -X main.version=${version} -X main.commit=${src.rev}"
+    )
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/git-credential-gopass --prefix PATH : "${lib.makeBinPath [ gopass ]}"
+  '';
+
+  meta = with lib; {
+    description = "Manage git credentials using gopass";
+    homepage = "https://github.com/gopasspw/git-credential-gopass";
+    license = licenses.mit;
+    maintainers = with maintainers; [ benneti ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/security/gopass/git-credential.nix
+++ b/pkgs/tools/security/gopass/git-credential.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  nativeBuildInputs = [ installShellFiles makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   preBuild = ''
     buildFlagsArray+=(

--- a/pkgs/tools/security/gopass/git-credential.nix
+++ b/pkgs/tools/security/gopass/git-credential.nix
@@ -2,7 +2,6 @@
 , makeWrapper
 , buildGoModule
 , fetchFromGitHub
-, installShellFiles
 , gopass
 }:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1416,6 +1416,8 @@ in
 
   gopass-jsonapi = callPackage ../tools/security/gopass/jsonapi.nix { };
 
+  git-credential-gopass = callPackage ../tools/security/gopass/git-credential.nix { };
+
   gospider = callPackage ../tools/security/gospider { };
 
   browserpass = callPackage ../tools/security/browserpass { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
git-credential-gopass was split from gopass and now needs it's own little package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
