### PR TITLE
libjwt: init at 1.12.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7455,6 +7455,16 @@
     githubId = 11365056;
     name = "Kevin Liu";
   };
+  pnotequalnp = {
+    email = "kevin@pnotequalnp.com";
+    github = "pnotequalnp";
+    githubId = 46154511;
+    name = "Kevin Mullins";
+    keys = [{
+      longkeyid = "rsa4096/361820A45DB41E9A";
+      fingerprint = "2CD2 B030 BD22 32EF DF5A  008A 3618 20A4 5DB4 1E9A";
+    }];
+  };
   polyrod = {
     email = "dc1mdp@gmail.com";
     github = "polyrod";

--- a/pkgs/development/libraries/libjwt/default.nix
+++ b/pkgs/development/libraries/libjwt/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkg-config, jansson, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "libjwt";
+  version = "1.12.1";
+
+  src = fetchFromGitHub {
+    owner = "benmcollins";
+    repo = "libjwt";
+    rev = "v${version}";
+    sha256 = "1c69slf9k56gh0xcg6269v712ysm6wckracms4grdsc72xg6x7h2";
+  };
+
+  buildInputs = [ jansson openssl ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  meta = with lib; {
+    homepage = "https://github.com/benmcollins/libjwt";
+    description = "JWT C Library";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ pnotequalnp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15310,6 +15310,8 @@ in
     libmicrohttpd = libmicrohttpd_0_9_72;
   };
 
+  libjwt = callPackage ../development/libraries/libjwt { };
+
   libkate = callPackage ../development/libraries/libkate { };
 
   libkeyfinder = callPackage ../development/libraries/libkeyfinder { };


### PR DESCRIPTION
###### Motivation for this change
Packages `libjwt` since the Haskell package `libjwt-typed` is currently broken because it depends on it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
