### PR TITLE
nixos/ksm: rewrite using systemd-tmpfiles

### DIFF
--- a/nixos/modules/hardware/ksm.nix
+++ b/nixos/modules/hardware/ksm.nix
@@ -26,13 +26,13 @@ in {
     systemd.services.enable-ksm = {
       description = "Enable Kernel Same-Page Merging";
       wantedBy = [ "multi-user.target" ];
-      after = [ "systemd-udev-settle.service" ];
-      script = ''
-        if [ -e /sys/kernel/mm/ksm ]; then
+      script =
+        ''
           echo 1 > /sys/kernel/mm/ksm/run
-          ${optionalString (cfg.sleep != null) ''echo ${toString cfg.sleep} > /sys/kernel/mm/ksm/sleep_millisecs''}
-        fi
-      '';
+        '' + optionalString (cfg.sleep != null)
+        ''
+          echo ${toString cfg.sleep} > /sys/kernel/mm/ksm/sleep_millisecs
+        '';
     };
   };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -195,6 +195,7 @@ in
   keymap = handleTest ./keymap.nix {};
   knot = handleTest ./knot.nix {};
   krb5 = discoverTests (import ./krb5 {});
+  ksm = handleTest ./ksm.nix {};
   kubernetes.dns = handleTestOn ["x86_64-linux"] ./kubernetes/dns.nix {};
   # kubernetes.e2e should eventually replace kubernetes.rbac when it works
   #kubernetes.e2e = handleTestOn ["x86_64-linux"] ./kubernetes/e2e.nix {};

--- a/nixos/tests/ksm.nix
+++ b/nixos/tests/ksm.nix
@@ -1,8 +1,8 @@
-import ./make-test-python.nix ({ pkgs, ...} :
+import ./make-test-python.nix ({ lib, ...} :
 
 {
   name = "ksm";
-  meta = with pkgs.lib.maintainers; {
+  meta = with lib.maintainers; {
     maintainers = [ rnhmjoj ];
   };
 

--- a/nixos/tests/ksm.nix
+++ b/nixos/tests/ksm.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix ({ pkgs, ...} :
+
+{
+  name = "ksm";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ rnhmjoj ];
+  };
+
+  machine = { ... }: {
+    imports = [ ../modules/profiles/minimal.nix ];
+
+    hardware.ksm.enable = true;
+    hardware.ksm.sleep = 300;
+  };
+
+  testScript =
+    ''
+      machine.start()
+      machine.wait_until_succeeds("test $(</sys/kernel/mm/ksm/run) -eq 1")
+      machine.wait_until_succeeds("test $(</sys/kernel/mm/ksm/sleep_millisecs) -eq 300")
+    '';
+})


### PR DESCRIPTION
###### Motivation for this change

This is to get rid of the ugly systemd-udev-settle dependency.
See #73095 for more information.

###### Things done

- [x] Tested via one or more NixOS test (nixosTests.ksm)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
