### PR TITLE
libglvnd: Improve the license information

### DIFF
--- a/pkgs/development/libraries/libglvnd/default.nix
+++ b/pkgs/development/libraries/libglvnd/default.nix
@@ -59,7 +59,8 @@ stdenv.mkDerivation rec {
       Both GLX and EGL are supported, in any combination with OpenGL and OpenGL ES.
     '';
     inherit (src.meta) homepage;
-    license = licenses.bsd2;
+    # https://gitlab.freedesktop.org/glvnd/libglvnd#libglvnd:
+    license = with licenses; [ mit bsd1 bsd3 gpl3Only asl20 ];
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ primeos ];
   };


### PR DESCRIPTION
Unfortunately the upstream licensing is quite complicated:
https://gitlab.freedesktop.org/glvnd/libglvnd#libglvnd

The main libglvnd license is MIT-like but files under different licenses
are also included. This is an approximation that ignores some license
"customizations".

Other distributions use the following license specifications:
- "MIT":
  - https://src.fedoraproject.org/rpms/libglvnd/blob/rawhide/f/libglvnd.spec
  - https://build.opensuse.org/package/view_file/openSUSE:Factory/libglvnd/libglvnd.spec
  - https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/libglvnd/libglvnd-1.3.2-r2.ebuild
- "custom:MIT-alike": https://github.com/void-linux/void-packages/blob/master/srcpkgs/libglvnd/template
- "APACHE20 MIT": https://www.freshports.org/graphics/libglvnd
- "custom:BSD-like": https://archlinux.org/packages/extra/x86_64/libglvnd/

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
