### PR TITLE
babashka: sync native-image arguments with upstream

### DIFF
--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -17,36 +17,71 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  LC_ALL = "en_US.UTF-8";
   nativeBuildInputs = [ graalvm11-ce glibcLocales ];
 
+  LC_ALL = "en_US.UTF-8";
+  BABASHKA_JAR = src;
+  BABASHKA_BINARY = "bb";
+  BABASHKA_XMX = "-J-Xmx4500m";
+
   buildPhase = ''
-    native-image \
-      -jar ${src} \
-      -H:Name=bb \
-      ${lib.optionalString stdenv.isDarwin ''-H:-CheckToolchain''} \
-      -H:+ReportExceptionStackTraces \
-      -J-Dclojure.spec.skip-macros=true \
-      -J-Dclojure.compiler.direct-linking=true \
-      "-H:IncludeResources=BABASHKA_VERSION" \
-      "-H:IncludeResources=SCI_VERSION" \
-      -H:ReflectionConfigurationFiles=${reflectionJson} \
-      --initialize-at-build-time \
-      -H:Log=registerResource: \
-      -H:EnableURLProtocols=http,https \
-      --enable-all-security-services \
-      -H:+JNI \
-      --verbose \
-      --no-fallback \
-      --no-server \
-      --report-unsupported-elements-at-runtime \
-      "--initialize-at-run-time=org.postgresql.sspi.SSPIClient" \
-      "-J-Xmx4500m"
+    runHook preBuild
+
+    # https://github.com/babashka/babashka/blob/77daea7362d8e2562c89c315b1fbcefde6fa56a5/script/compile
+    args=("-jar" "$BABASHKA_JAR"
+          "-H:Name=$BABASHKA_BINARY"
+          "${lib.optionalString stdenv.isDarwin ''-H:-CheckToolchain''}"
+          "-H:+ReportExceptionStackTraces"
+          "-J-Dclojure.spec.skip-macros=true"
+          "-J-Dclojure.compiler.direct-linking=true"
+          "-H:IncludeResources=BABASHKA_VERSION"
+          "-H:IncludeResources=SCI_VERSION"
+          "-H:ReflectionConfigurationFiles=${reflectionJson}"
+          "--initialize-at-build-time"
+          # "-H:+PrintAnalysisCallTree"
+          # "-H:+DashboardAll"
+          # "-H:DashboardDump=reports/dump"
+          # "-H:+DashboardPretty"
+          # "-H:+DashboardJson"
+          "-H:Log=registerResource:"
+          "-H:EnableURLProtocols=http,https,jar"
+          "--enable-all-security-services"
+          "-H:+JNI"
+          "--verbose"
+          "--no-fallback"
+          "--no-server"
+          "--report-unsupported-elements-at-runtime"
+          "--initialize-at-run-time=org.postgresql.sspi.SSPIClient"
+          "--native-image-info"
+          "--verbose"
+          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.sampled.spi.AudioFileReader"
+          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.midi.spi.MidiFileReader"
+          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.sampled.spi.MixerProvider"
+          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.sampled.spi.FormatConversionProvider"
+          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.sampled.spi.AudioFileWriter"
+          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.midi.spi.MidiDeviceProvider"
+          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.midi.spi.SoundbankReader"
+          "-H:ServiceLoaderFeatureExcludeServices=javax.sound.midi.spi.MidiFileWriter"
+          "$BABASHKA_XMX")
+
+     native-image ''${args[@]}
+
+     runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     cp bb $out/bin/bb
+
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    $out/bin/bb --version | grep '${version}'
+    $out/bin/bb '(+ 1 2)' | grep '3'
+    $out/bin/bb '(vec (dedupe *input*))' <<< '[1 1 1 1 2]' | grep '[1 2]'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This commit syncs the arguments passed to the babashka with upstream: https://github.com/babashka/babashka/blob/77daea7362d8e2562c89c315b1fbcefde6fa56a5/script/compile#L41-L74

The idea here is to enable more features and reduce the number of issues compared to upstream.

Also add some tests to ensure everything is working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
