### PR TITLE
python3Packages.python-awair: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/python-awair/default.nix
+++ b/pkgs/development/python-modules/python-awair/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, poetry
+, pytest-aiohttp
+, pytestCheckHook
+, pythonOlder
+, voluptuous
+, vcrpy
+}:
+
+buildPythonPackage rec {
+  pname = "python-awair";
+  version = "0.2.1";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "ahayworth";
+    repo = "python_awair";
+    rev = version;
+    sha256 = "1fqjigc1a0lr9q6bjjq3j8pa39wg1cbkb0l67w94a0i4dkdfri8r";
+  };
+
+  nativeBuildInputs = [ poetry ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    voluptuous
+  ];
+
+  checkInputs = [
+    pytest-aiohttp
+    pytestCheckHook
+    vcrpy
+  ];
+
+  pythonImportsCheck = [ "python_awair" ];
+
+  meta = with lib; {
+    description = "Python library for the Awair API";
+    homepage = "https://github.com/ahayworth/python_awair";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -63,7 +63,7 @@
     "automation" = ps: with ps; [ aiohttp-cors ];
     "avea" = ps: with ps; [ avea ];
     "avion" = ps: with ps; [ avion ];
-    "awair" = ps: with ps; [ ]; # missing inputs: python_awair
+    "awair" = ps: with ps; [ python-awair ];
     "aws" = ps: with ps; [ aiobotocore ];
     "axis" = ps: with ps; [ aiohttp-cors axis paho-mqtt ];
     "azure_devops" = ps: with ps; [ ]; # missing inputs: aioazuredevops

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6309,6 +6309,8 @@ in {
 
   python3-openid = callPackage ../development/python-modules/python3-openid { };
 
+  python-awair = callPackage ../development/python-modules/python-awair { };
+
   python-axolotl = callPackage ../development/python-modules/python-axolotl { };
 
   python-axolotl-curve25519 = callPackage ../development/python-modules/python-axolotl-curve25519 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for the Awair API

https://github.com/ahayworth/python_awair

Switch to `poetry-core` [suggested](https://github.com/ahayworth/python_awair/pull/22) to upstream.

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
