### PR TITLE
yabridge, yabridgectl: 3.0.0 -> 3.0.1

### DIFF
--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -17,7 +17,7 @@ let
       owner = "fraillt";
       repo = "bitsery";
       rev = "v${version}";
-      sha256 = "132b0n0xlpcv97l6bhk9n57hg95pkhwqzvr9jkv57nmggn76s5q7";
+      hash = "sha256-Bxdtjn2v2lP2lCnvjzmct6QHT7FpwmXoSZtd2oEFS4w=";
     };
   };
 
@@ -28,7 +28,7 @@ let
       owner = "Naios";
       repo = "function2";
       rev = version;
-      sha256 = "0abrz2as62725g212qswi35nsdlf5wrhcz78hm2qidbgqr9rkir5";
+      hash = "sha256-JceZU8ZvtYhFheh8BjMvjjZty4hcYxHEK+IIo5X4eSk=";
     };
   };
 
@@ -39,7 +39,7 @@ let
       owner = "marzer";
       repo = "tomlplusplus";
       rev = "v${version}";
-      sha256 = "0fspinnpyk1c9ay0h3wl8d4bbm6aswlypnrw2c7pk2i4mh981b4b";
+      hash = "sha256-i6yAEqwkinkPEzzb6ynXytS1SEOUDwi8SixMf62NVzs=";
     };
   };
 
@@ -51,19 +51,19 @@ let
       repo = "vst3sdk";
       rev = version;
       fetchSubmodules = true;
-      sha256 = "1fqpylkbljifwdw2z75agc0yxnhmv4b09fxs3rvlw1qmm5mwx0p2";
+      sha256 = "sha256-4oLOa6kVB053Hrq7BBbZFdruAXuqnC944y5Kuib1F7s=";
     };
   };
 in stdenv.mkDerivation rec {
   pname = "yabridge";
-  version = "3.0.0";
+  version = "3.0.1";
 
   # NOTE: Also update yabridgectl's cargoSha256 when this is updated
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = pname;
     rev = version;
-    sha256 = "0ha7jhnkd2i49q5rz2hp7sq6hv19bir99x51hs6nvvcf16hlf2bp";
+    hash = "sha256-BT8Qj8WvyRlBwSuIIlfWVhlG3RSv2sFnSskCcjPF/N0=";
   };
 
   # Unpack subproject sources

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -6,9 +6,12 @@ rustPlatform.buildRustPackage rec {
 
   src = yabridge.src;
   sourceRoot = "source/tools/yabridgectl";
-  cargoSha256 = "1sjhani8h7ap42yqlnj05sx59jyz2h12qlm1ibv8ldxcpwps0bwy";
+  cargoHash = "sha256-YSK1DWv9kb6kFUJ4UEhh6psKsVqwpFJjvjJgj2e4BAc=";
 
   patches = [
+    # By default, yabridgectl locates libyabridge.so by using
+    # hard-coded distro-specific lib paths. This patch replaces those
+    # hard coded paths with lib paths from NIX_PROFILE.
     ./libyabridge-from-nix-profiles.patch
   ];
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version: https://github.com/robbert-vdh/yabridge/releases/tag/3.0.1

Also replaces hashes with SRI hashes

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).