### PR TITLE
libayatana-appindicator: Make multi output

### DIFF
--- a/pkgs/development/libraries/libayatana-appindicator/default.nix
+++ b/pkgs/development/libraries/libayatana-appindicator/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
   pname = "libayatana-appindicator-gtk${gtkVersion}";
   version = "0.5.5";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "libayatana-appindicator";


### PR DESCRIPTION
Gtk dev outputs ends up in the runtime closure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
