### PR TITLE
emacs.pkgs.pdf-tools: Remove references to dev outputs in epdfinfo

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -132,9 +132,24 @@ let
         flycheck-rtags = fix-rtags super.flycheck-rtags;
 
         pdf-tools = super.pdf-tools.overrideAttrs (old: {
-          nativeBuildInputs = [ pkgs.pkg-config ];
-          buildInputs = with pkgs; old.buildInputs ++ [ autoconf automake libpng zlib poppler ];
-          preBuild = "make server/epdfinfo";
+          nativeBuildInputs = [
+            pkgs.autoconf
+            pkgs.automake
+            pkgs.pkg-config
+            pkgs.removeReferencesTo
+          ];
+          buildInputs = old.buildInputs ++ [ pkgs.libpng pkgs.zlib pkgs.poppler ];
+          preBuild = ''
+            make server/epdfinfo
+            remove-references-to \
+              -t ${pkgs.stdenv.cc.libc.dev} \
+              -t ${pkgs.glib.dev} \
+              -t ${pkgs.libpng.dev} \
+              -t ${pkgs.poppler.dev} \
+              -t ${pkgs.zlib.dev} \
+              -t ${pkgs.cairo.dev} \
+              server/epdfinfo
+          '';
           recipe = pkgs.writeText "recipe" ''
             (pdf-tools
             :repo "politza/pdf-tools" :fetcher github


### PR DESCRIPTION
###### Motivation for this change
Reducing closure size

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
