### PR TITLE
gst_1_all.gst-plugins-{bad,good}: Remove gstreamer dev output from closures

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -79,6 +79,8 @@
 , x265
 , libxml2
 , srt
+, gstreamer
+, removeReferencesTo
 }:
 
 assert faacSupport -> faac != null;
@@ -108,6 +110,7 @@ in stdenv.mkDerivation rec {
     python3
     gettext
     gobject-introspection
+    removeReferencesTo
   ] ++ optionals stdenv.isLinux [
     wayland # for wayland-scanner
   ];
@@ -283,6 +286,12 @@ in stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs \
       scripts/extract-release-date-from-doap-file.py
+  '';
+
+  # Remove references to gstreamer.dev
+  postInstall = ''
+    remove-references-to -t ${gstreamer.dev} $out/lib/gstreamer-1.0/libgstdvbsubenc.so
+    remove-references-to -t ${gstreamer.dev} $out/lib/libgstcodecparsers-1.0.so.0.*.0
   '';
 
   # This package has some `_("string literal")` string formats

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -7,7 +7,7 @@ rec {
 
   gst-plugins-base = callPackage ./base { inherit gstreamer; };
 
-  gst-plugins-good = callPackage ./good { inherit gst-plugins-base; };
+  gst-plugins-good = callPackage ./good { inherit gstreamer gst-plugins-base; };
 
   gst-plugins-bad = callPackage ./bad { inherit gst-plugins-base; };
 

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -9,7 +9,7 @@ rec {
 
   gst-plugins-good = callPackage ./good { inherit gstreamer gst-plugins-base; };
 
-  gst-plugins-bad = callPackage ./bad { inherit gst-plugins-base; };
+  gst-plugins-bad = callPackage ./bad { inherit gstreamer gst-plugins-base; };
 
   gst-plugins-ugly = callPackage ./ugly { inherit gst-plugins-base; };
 

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -42,6 +42,8 @@
 , xorg
 , libgudev
 , wavpack
+, gstreamer
+, removeReferencesTo
 }:
 
 assert gtkSupport -> gtk3 != null;
@@ -68,6 +70,7 @@ stdenv.mkDerivation rec {
     ninja
     gettext
     nasm
+    removeReferencesTo
   ] ++ optionals stdenv.isLinux [
     wayland-protocols
   ];
@@ -145,6 +148,11 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs \
       scripts/extract-release-date-from-doap-file.py
+  '';
+
+  # Remove references to gstreamer.dev
+  postInstall = ''
+    remove-references-to -t ${gstreamer.dev} $out/lib/gstreamer-1.0/libgstrtpmanager.so
   '';
 
   NIX_LDFLAGS = [


### PR DESCRIPTION
Reduces the run time closure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
