### PR TITLE
llvmPackages_11.openmp: make it compile on aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/llvm/11/openmp.nix
+++ b/pkgs/development/compilers/llvm/11/openmp.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetch
+, fetchpatch
 , cmake
 , llvm
 , perl
@@ -12,6 +13,15 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetch pname "0bh5cswgpc79awlq8j5i7hp355adaac7s6zaz0zwp6mkflxli1yi";
+
+  patches = [
+    # Fix compilation on aarch64-darwin, remove after the next release.
+    (fetchpatch {
+      url = "https://github.com/llvm/llvm-project/commit/7b5254223acbf2ef9cd278070c5a84ab278d7e5f.patch";
+      sha256 = "sha256-A+9/IVIoazu68FK5H5CiXcOEYe1Hpp4xTx2mIw7m8Es=";
+      stripLen = 1;
+    })
+  ];
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];


### PR DESCRIPTION
###### Motivation for this change

Fixing compilation failure for #105026.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
