### PR TITLE
google-cloud-sdk: fix searching for cloud_sql_proxy on the PATH

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/cloud_sql_proxy_path.patch
+++ b/pkgs/tools/admin/google-cloud-sdk/cloud_sql_proxy_path.patch
@@ -1,0 +1,36 @@
+diff --git a/lib/googlecloudsdk/api_lib/sql/instances.py b/lib/googlecloudsdk/api_lib/sql/instances.py
+index 0d88ffe..814a436 100644
+--- a/lib/googlecloudsdk/api_lib/sql/instances.py
++++ b/lib/googlecloudsdk/api_lib/sql/instances.py
+@@ -86,18 +86,19 @@ def GetRegionFromZone(gce_zone):
+ def _GetCloudSqlProxyPath():
+   """Determines the path to the cloud_sql_proxy binary."""
+   sdk_bin_path = config.Paths().sdk_bin_path
+-  if not sdk_bin_path:
+-    # Check if cloud_sql_proxy is located on the PATH.
+-    proxy_path = file_utils.FindExecutableOnPath('cloud_sql_proxy')
+-    if proxy_path:
+-      log.debug(
+-          'Using cloud_sql_proxy found at [{path}]'.format(path=proxy_path))
+-      return proxy_path
+-    else:
+-      raise exceptions.ToolException(
+-          'A Cloud SQL Proxy SDK root could not be found. Please check your '
+-          'installation.')
+-  return os.path.join(sdk_bin_path, 'cloud_sql_proxy')
++  if sdk_bin_path and os.path.isfile(os.path.join(sdk_bin_path, 'cloud_sql_proxy')):
++      return os.path.join(sdk_bin_path, 'cloud_sql_proxy')
++
++  # Check if cloud_sql_proxy is located on the PATH.
++  proxy_path = file_utils.FindExecutableOnPath('cloud_sql_proxy')
++  if proxy_path:
++    log.debug(
++        'Using cloud_sql_proxy found at [{path}]'.format(path=proxy_path))
++    return proxy_path
++
++  raise exceptions.ToolException(
++      'A Cloud SQL Proxy SDK root could not be found. Please check your '
++      'installation.')
+ 
+ 
+ def _RaiseProxyError(error_msg=None):

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -45,6 +45,8 @@ in stdenv.mkDerivation rec {
     ./gcloud-path.patch
     # Disable checking for updates for the package
     ./gsutil-disable-updates.patch
+    # Try to use cloud_sql_proxy from SDK only if it actually exists, otherwise, search for one in PATH
+    ./cloud_sql_proxy_path.patch
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

'gcloud sql connect' command allows to connect to a CloudSQL instance
from a local machine. In order to do so, it starts local
'cloud_sdk_proxy' instance. google-cloud-sdk expects to find one in SDK
root (installed by 'gcloud components') or on the PATH, if SDK is not
correctly installed ('.install' directory is missing).

Since google-cloud-sdk on NixOS is properly installed 'gcloud sql
connect' never looks for 'cloud_sql_proxy' on the PATH and simply
doesn't work at all.

The patch slightly modifies the check by looking not only for
'.install' directory, but for actual 'cloud_sql_proxy' binary before
falling back to the search on the PATH.

With this patch it's now possible to use 'gcloud sql connect' on NixOS,
provided that 'cloud_sql_proxy' is available either in user or system
enviroment (available in nixpkgs).



###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
