### PR TITLE
libtpms: 0.7.4 -> 0.8.0

### DIFF
--- a/pkgs/tools/security/libtpms/default.nix
+++ b/pkgs/tools/security/libtpms/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , pkg-config, autoreconfHook
 , openssl, perl
-, tpm2Support ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -30,8 +29,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-openssl"
-  ] ++ lib.optionals tpm2Support [
-    "--with-tpm2" # TPM2 support is flagged experimental by upstream
+    "--with-tpm2"
   ];
 
   meta = with lib; {

--- a/pkgs/tools/security/libtpms/default.nix
+++ b/pkgs/tools/security/libtpms/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [ openssl ];
 
-  outputs = [ "out" "lib" "man" "dev" ];
+  outputs = [ "out" "man" "dev" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/security/libtpms/default.nix
+++ b/pkgs/tools/security/libtpms/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libtpms";
-  version = "0.7.4";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "stefanberger";
     repo = "libtpms";
     rev = "v${version}";
-    sha256 = "sha256-nZSBD3WshlZHVMBFmDBBdFkhBjNgtASfg6+lYOOAhZ8=";
+    sha256 = "sha256-/zvMXdAOb4J3YaqdVJvTUI1/JFC0OKwgiYwYgYB62Y4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -678,6 +678,7 @@ mapAliases ({
   surf-webkit2 = surf; # added 2017-04-02
   sup = throw "sup was deprecated on 2019-09-10: abandoned by upstream";
   swfdec = throw "swfdec has been removed as broken and unmaintained."; # added 2020-08-23
+  swtpm-tpm2 = swtpm; # added 2021-02-26
   system_config_printer = system-config-printer;  # added 2016-01-03
   systemd-cryptsetup-generator = throw "systemd-cryptsetup-generator is now included in the systemd package"; # added 2020-07-12
   systemd_with_lvm2 = throw "systemd_with_lvm2 is obsolete, enabled by default via the lvm module"; # added 2020-07-12

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8228,11 +8228,6 @@ in
   swec = callPackage ../tools/networking/swec { };
 
   swtpm = callPackage ../tools/security/swtpm { };
-  swtpm-tpm2 = swtpm.override {
-    libtpms = libtpms.override {
-      tpm2Support = true;
-    };
-  };
 
   svn2git = callPackage ../applications/version-management/git-and-tools/svn2git {
     git = gitSVN;


### PR DESCRIPTION
###### Motivation for this change

Bump version to 0.8.0 and adds tpm2 support by default.

supplement #114479

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
