### PR TITLE
python3Packages.simplejson: 3.17.0 -> 3.17.2

### DIFF
--- a/pkgs/development/python-modules/simplejson/default.nix
+++ b/pkgs/development/python-modules/simplejson/default.nix
@@ -2,39 +2,35 @@
 , buildPythonPackage
 , fetchFromGitHub
 , stdenv
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "simplejson";
-  version = "3.17.0";
+  version = "3.17.2";
   doCheck = !stdenv.isDarwin;
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "1b1hhh1dia673vhq3jl2br1iqwb9yjii6iak56w96s9972vjbz3z";
+    sha256 = "sha256-2ZC7aKyUUcth43Ce0j6JdjrJ4gb4QfJDlY2M5TLMQ+o=";
   };
 
-  # Package does not need pytest, but its a bit easier debugging.
-  checkInputs = [ pytest ];
-  # Ignore warnings because test does not expect them in stderr
-  # See https://github.com/simplejson/simplejson/issues/241
-  checkPhase = ''
-    PYTHONWARNINGS="ignore" pytest simplejson/tests
-  '';
+  checkInputs = [ pytestCheckHook ];
 
-  meta = {
-    description = "A simple, fast, extensible JSON encoder/decoder for Python";
+  pythonImportsCheck = [ "simplejson" ];
+
+  meta = with lib; {
+    description = "Extensible JSON encoder/decoder for Python";
     longDescription = ''
-      simplejson is compatible with Python 2.4 and later with no
-      external dependencies.  It covers the full JSON specification
-      for both encoding and decoding, with unicode support.  By
-      default, encoding is done in an encoding neutral fashion (plain
-      ASCII with \uXXXX escapes for unicode characters).
+      simplejson covers the full JSON specification for both encoding
+      and decoding, with unicode support. By default, encoding is done
+      in an encoding neutral fashion (plain ASCII with \uXXXX escapes
+      for unicode characters).
     '';
     homepage = "https://github.com/simplejson/simplejson";
-    license = with lib.licenses; [ mit afl21 ];
+    license = with licenses; [ mit afl21 ];
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.17.2

Change log: https://github.com/simplejson/simplejson/blob/master/CHANGES.txt

Switch to `pytestCheckHook`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
