### PR TITLE
pythonPackages.sfepy: 2019.4 -> 2020.4

### DIFF
--- a/pkgs/development/python-modules/exdown/default.nix
+++ b/pkgs/development/python-modules/exdown/default.nix
@@ -3,12 +3,12 @@
 
 buildPythonPackage rec {
   pname = "exdown";
-  version = "0.7.1";
+  version = "0.8.5";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-vnSso3vmPIjX7JX+NwoxguwqwPHocJACeh5H0ClPcUI=";
+    sha256 = "1ly67whyfn74nr0dncarf3xbd96hacvzgjihx4ibckkc4h9z46bj";
   };
 
   propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [ importlib-metadata ];

--- a/pkgs/development/python-modules/meshio/default.nix
+++ b/pkgs/development/python-modules/meshio/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, netcdf4
+, h5py
+, exdown
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "meshio";
+  version = "4.3.10";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1i34bk8bbc0dnizrlgj0yxnbzyvndkmnl6ryymxgcl9rv1abkfki";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    netcdf4
+    h5py
+  ];
+
+  checkInputs = [
+    exdown
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = ["meshio"];
+
+  meta = with lib; {
+    homepage = "https://github.com/nschloe/meshio";
+    description = "I/O for mesh files.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wd15 ];
+  };
+}

--- a/pkgs/development/python-modules/sfepy/default.nix
+++ b/pkgs/development/python-modules/sfepy/default.nix
@@ -9,15 +9,21 @@
 , cython
 , python
 , sympy
+, meshio
+, mpi4py
+, psutil
+, openssh
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  name = "sfepy_${version}";
-  version = "2019.4";
+  name = "sfepy";
+  version = "2020.4";
+  disabled = pythonOlder "3.8";
 
   src = fetchurl {
     url="https://github.com/sfepy/sfepy/archive/release_${version}.tar.gz";
-    sha256 = "1l9vgcw09l6bwhgfzlbn68fzpvns25r6nkd1pcp7hz5165hs6zzn";
+    sha256 = "1wb0ik6kjg3mksxin0abr88bhsly67fpg36qjdzabhj0xn7j1yaz";
   };
 
   propagatedBuildInputs = [
@@ -28,12 +34,15 @@ buildPythonPackage rec {
     pyparsing
     tables
     sympy
+    meshio
+    mpi4py
+    psutil
+    openssh
   ];
 
   postPatch = ''
-    # broken test
-    rm tests/test_homogenization_perfusion.py
-    rm tests/test_splinebox.py
+    # broken tests
+    rm tests/test_meshio.py
 
     # slow tests
     rm tests/test_input_*.py
@@ -47,6 +56,7 @@ buildPythonPackage rec {
   '';
 
   checkPhase = ''
+    export OMPI_MCA_plm_rsh_agent=${openssh}/bin/ssh
     export HOME=$TMPDIR
     mv sfepy sfepy.hidden
     mkdir -p $HOME/.matplotlib

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4058,6 +4058,8 @@ in {
 
   mesa = callPackage ../development/python-modules/mesa { };
 
+  meshio = callPackage ../development/python-modules/meshio { };
+
   meshlabxml = callPackage ../development/python-modules/meshlabxml { };
 
   meson = disabledIf (pythonOlder "3.5") (toPythonModule ((pkgs.meson.override { python3 = python; }).overrideAttrs


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update Sfepy to its latest version.

 * Sfepy no longer appears to work with Python 3.7 anymore so turned it off for 3.7.
 * Sfepy has a new dependency on meshio, which I've added. Meshio was added by @Wulfsta in #100135, but that PR appears to be in a zombie state (also #86518 didn't go anywhere). 
 * Updated exdown as meshio requires a later version than the current one on master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
