### PR TITLE
vimiv-qt: init at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2473,6 +2473,16 @@
     githubId = 10198051;
     name = "Drew Risinger";
   };
+  dschrempf = {
+    name = "Dominik Schrempf";
+    email = "dominik.schrempf@gmail.com";
+    github = "dschrempf";
+    githubId = 5596239;
+    keys = [{
+      longkeyid = "rsa2048/0x875F2BCF163F1B29";
+      fingerprint = "62BC E2BD 49DF ECC7 35C7  E153 875F 2BCF 163F 1B29";
+    }];
+  };
   dsferruzza = {
     email = "david.sferruzza@gmail.com";
     github = "dsferruzza";

--- a/pkgs/applications/graphics/vimiv-qt/default.nix
+++ b/pkgs/applications/graphics/vimiv-qt/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, python3
+, qt5
+, installShellFiles
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "vimiv-qt";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "karlch";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1pj3gak7nxkw9r9m71zsfvcaq8dk9crbk5rz4n7pravxkl5hs2bg";
+  };
+
+  nativeBuildInputs = [ installShellFiles qt5.wrapQtAppsHook python3.pkgs.setuptools ];
+
+  propagatedBuildInputs = with python3.pkgs; [ pyqt5 py3exiv2 qt5.qtsvg ];
+
+  postInstall = ''
+    install -Dm644 misc/vimiv.desktop $out/share/applications/vimiv.desktop
+    install -Dm644 misc/org.karlch.vimiv.qt.metainfo.xml $out/metainfo/org.karlch.vimiv.qt.metainfo.xml
+    install -Dm644 LICENSE $out/licenses/vimiv/LICENSE
+    install -Dm644 icons/vimiv.svg $out/icons/hicolor/scalable/apps/vimiv.svg
+    installManPage misc/vimiv.1
+
+    for i in 16 32 64 128 256 512; do
+      install -Dm644 icons/vimiv_''${i}x''${i}.png $out/icons/hicolor/''${i}x''${i}/apps/vimiv.png
+    done
+  '';
+
+  # Vimiv has to be wrapped manually because it is a non-ELF executable.
+  dontWrapQtApps = true;
+  preFixup = ''
+      wrapQtApp $out/bin/vimiv
+  '';
+
+  meta = with lib; {
+    description = "Image viewer with Vim-like keybindings (Qt port)";
+    license = licenses.gpl3Plus;
+    homepage = "https://github.com/karlch/vimiv-qt";
+    maintainers = with maintainers; [ dschrempf ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25588,6 +25588,8 @@ in
 
   vimiv = callPackage ../applications/graphics/vimiv { };
 
+  vimiv-qt = callPackage ../applications/graphics/vimiv-qt { };
+
   macvim = callPackage ../applications/editors/vim/macvim-configurable.nix { stdenv = clangStdenv; };
 
   vimHugeX = vim_configurable;


### PR DESCRIPTION
###### Motivation for this change
Vimiv is an image viewer with Vim-like keybindings. A Qt version has long been developed and is meant to superseed the old and now outdated GTK version (which is already in Nixpkgs). This pull request adds the newer Qt based `vimiv-qt`.

Please review carefully! This is my first contribution to Nixpkgs.

In particular, I have the following questions:
- At the moment updates have to be done manually. I am not monitoring the development of `vimiv-qt`. How will I know when the package is outdated? I know that there are automated ways using bots. What is the preferrable way to get notified about updates as a maintainer?
- I manually added the commands of the [make file](https://github.com/karlch/vimiv-qt/blob/master/misc/Makefile) into `postInstall`. Please let me know if this is OK! 

Thank you!

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
