### PR TITLE
[20.09] salt: 3001.3 -> 3001.6

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -7,11 +7,11 @@
 }:
 python3.pkgs.buildPythonApplication rec {
   pname = "salt";
-  version = "3001.3";
+  version = "3001.6";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "05lqgwp087dm3hvhdr8b6rfbd0ww8f4fw44k3svgzy089g0xklcf";
+    sha256 = "Eyl8A80WEYRRpUCpAXyG57FamQzeXed8rVrF+gpaZgw=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [


### PR DESCRIPTION
Backport of #114461 (sticking to the 3001 releases).

https://saltproject.io/security_announcements/active-saltstack-cve-release-2021-feb-25/

Fixes: CVE-2021-3197, CVE-2021-25281, CVE-2021-25282, CVE-2021-25283,
CVE-2021-25284, CVE-2021-3148, CVE-2020-35662, CVE-2021-3144,
CVE-2020-28972, CVE-2020-28243

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
