### PR TITLE
sub-batch: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/applications/video/alass/default.nix
+++ b/pkgs/applications/video/alass/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, makeWrapper
+, ffmpeg
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "alass";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "kaegi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-q1IV9TtmznpR7RO75iN0p16nmTja5ADWqFj58EOPWvU=";
+  };
+
+  cargoSha256 = "sha256-6CVa/ypz37bm/3R0Gi65ovu4SIwWcgVde3Z2W1R16mk=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/alass-cli" --prefix PATH : "${lib.makeBinPath [ ffmpeg ]}"
+  '';
+
+  meta = with lib; {
+    description = "Automatic Language-Agnostic Subtitle Synchronization";
+    homepage = "https://github.com/kaegi/alass";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ erictapen ];
+  };
+}

--- a/pkgs/applications/video/sub-batch/default.nix
+++ b/pkgs/applications/video/sub-batch/default.nix
@@ -1,21 +1,29 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitHub
 , rustPlatform
+, makeWrapper
+, alass
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "sub-batch";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "kl";
     repo = pname;
-    # Upstream doesn't tag releases.
-    rev = "631bd6e2d931f8a8e12798f4b6460739a14bcfff";
-    sha256 = "sha256-424e40v2LBxlmgDKxvsT/iuUn/IKWPKMwih0cSQ5sFE=";
+    rev = "v${version}";
+    sha256 = "sha256-5fDnSmnnVB1RGrNrnmp40OGFF+OAhppnhOjVgnYxXr0=";
   };
 
-  cargoSha256 = "sha256-l+BTF9PGb8bG8QHhNCoBsrsVX8nlRjPlaea1ESFfMW0=";
+  cargoSha256 = "sha256-cj1htJcUPCeYbP0t15UcMv4WQAG7tUROb97v4rUeMvU=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/sub-batch" --prefix PATH : "${lib.makeBinPath [ alass ]}"
+  '';
 
   meta = with lib; {
     description = "Match and rename subtitle files to video files and perform other batch operations on subtitle files";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13199,6 +13199,8 @@ in
 
   agg = callPackage ../development/libraries/agg { };
 
+  alass = callPackage ../applications/video/alass { };
+
   allegro = allegro4;
   allegro4 = callPackage ../development/libraries/allegro {};
   allegro5 = callPackage ../development/libraries/allegro/5.nix {};


### PR DESCRIPTION
Also introduced `alass` as dependency at 2.0.0, made dependency available via `makeWrapper`.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
