### PR TITLE
cyberpunk-neon: init at unstable-2021-02-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8175,6 +8175,12 @@
     githubId = 592876;
     name = "Robert W. Pearce";
   };
+  rpgwaiter = {
+    email = "rpgwaiter+nix@based.zone";
+    github = "rpgwaiter";
+    githubId = 12245941;
+    name = "Rpgwaiter";
+  };
   rprospero = {
     email = "rprospero+nix@gmail.com";
     github = "rprospero";

--- a/pkgs/data/themes/cyberpunk-neon/default.nix
+++ b/pkgs/data/themes/cyberpunk-neon/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "cyberpunk-neon";
+  version = "unstable-2021-02-02";
+
+  src = fetchFromGitHub {
+    owner = "Roboron3042";
+    repo = "Cyberpunk-Neon";
+    rev = "b4b293c7de87688841d504cb9a983e67d97749f3";
+    sha256 = "sha256-yqr4xga4hzd+BJpEECPK0xQDP3CjABfJISQS684SbwM=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    # gtk
+    mkdir -p $out/share/themes
+    tar xzf gtk/materia-cyberpunk-neon.tar.gz -C $out/share/themes/
+    tar xzf gtk/arc-cyberpunk-neon.tar.gz -C $out/share/themes/
+
+    # kde
+    mkdir -p $out/share/color-schemes
+    cp kde/cyberpunk-neon.colors $out/share/color-schemes/
+
+    # terminal
+    mkdir -p $out/share/konsole
+    cp terminal/konsole/cyberpunk-neon.colorscheme $out/share/konsole
+    mkdir -p $out/share/tilix/schemes
+    cp terminal/tilix/cyberpunk-neon.json $out/share/tilix/schemes
+  '';
+
+  meta = with lib; {
+    description = "Themes for KDE Plasma, GTK, Telegram, Tilix, Vim, Zim and more.";
+    license = licenses.cc-by-sa-40;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.rpgwaiter ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20520,6 +20520,8 @@ in
 
   crimson = callPackage ../data/fonts/crimson {};
 
+  cyberpunk-neon = callPackage ../data/themes/cyberpunk-neon { };
+
   dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts {});
 
   # solve collision for nix-env before https://github.com/NixOS/nix/pull/815


### PR DESCRIPTION
###### Motivation for this change
I wanted to add the desktop theme I use to nixpkgs


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)

   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
   
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).