### PR TITLE
poke: init at 1.0

### DIFF
--- a/pkgs/applications/editors/poke/default.nix
+++ b/pkgs/applications/editors/poke/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchurl
+, gettext
+, help2man
+, pkg-config
+, texinfo
+, makeWrapper
+, boehmgc
+, readline
+, guiSupport ? false, tcl, tcllib, tk
+, miSupport ? true, json_c
+, nbdSupport ? true, libnbd
+, textStylingSupport ? true
+, dejagnu
+}:
+
+stdenv.mkDerivation rec {
+  pname = "poke";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "mirror://gnu/${pname}/${pname}-${version}.tar.gz";
+    hash = "sha256-3pMLhwDAdys8LNDQyjX1D9PXe9+CxiUetRa0noyiWwo=";
+  };
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gettext
+    help2man
+    pkg-config
+    texinfo
+  ] ++ lib.optional guiSupport makeWrapper;
+
+  buildInputs = [ boehmgc dejagnu readline ]
+  ++ lib.optional guiSupport tk
+  ++ lib.optional miSupport json_c
+  ++ lib.optional nbdSupport libnbd
+  ++ lib.optional textStylingSupport gettext;
+
+  configureFlags = lib.optionals guiSupport [
+    "--with-tcl=${tcl}/lib"
+    "--with-tk=${tk}/lib"
+    "--with-tkinclude=${tk.dev}/include"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+  checkInputs = [ dejagnu ];
+
+  postFixup = lib.optionalString guiSupport ''
+    wrapProgram "$out/bin/poke-gui" \
+      --prefix TCLLIBPATH ' ' ${tcllib}/lib/tcllib${tcllib.version}
+  '';
+
+  meta = with lib; {
+    description = "Interactive, extensible editor for binary data";
+    homepage = "http://www.jemarch.net/poke";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres metadark ];
+    platforms = platforms.unix;
+  };
+}
+
+# TODO: Enable guiSupport by default once it's more than just a stub

--- a/pkgs/applications/editors/poke/default.nix
+++ b/pkgs/applications/editors/poke/default.nix
@@ -15,7 +15,9 @@
 , dejagnu
 }:
 
-stdenv.mkDerivation rec {
+let
+  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+in stdenv.mkDerivation rec {
   pname = "poke";
   version = "1.0";
 
@@ -37,11 +39,12 @@ stdenv.mkDerivation rec {
     texinfo
   ] ++ lib.optional guiSupport makeWrapper;
 
-  buildInputs = [ boehmgc dejagnu readline ]
+  buildInputs = [ boehmgc readline ]
   ++ lib.optional guiSupport tk
   ++ lib.optional miSupport json_c
   ++ lib.optional nbdSupport libnbd
-  ++ lib.optional textStylingSupport gettext;
+  ++ lib.optional textStylingSupport gettext
+  ++ lib.optional (!isCross) dejagnu;
 
   configureFlags = lib.optionals guiSupport [
     "--with-tcl=${tcl}/lib"
@@ -51,8 +54,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
-  checkInputs = [ dejagnu ];
+  doCheck = !isCross;
+  checkInputs = lib.optionals (!isCross) [ dejagnu ];
 
   postFixup = lib.optionalString guiSupport ''
     wrapProgram "$out/bin/poke-gui" \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24570,6 +24570,8 @@ in
 
   plugin-torture = callPackage ../applications/audio/plugin-torture { };
 
+  poke = callPackage ../applications/editors/poke { };
+
   polar-bookshelf = callPackage ../applications/misc/polar-bookshelf { };
 
   poezio = python3Packages.poezio;


### PR DESCRIPTION
###### Motivation for this change
GNU poke has had its first release: https://savannah.gnu.org/forum/forum.php?forum_id=9949

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).