### PR TITLE
ocamlPackages.ocaml: fix assembler detection for aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -66,6 +66,10 @@ stdenv.mkDerivation (args // {
   preConfigure = optionalString (!lib.versionAtLeast version "4.04") ''
     CAT=$(type -tp cat)
     sed -e "s@/bin/cat@$CAT@" -i config/auto-aux/sharpbang
+  '' + optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    # Do what upstream does by default now: https://github.com/ocaml/ocaml/pull/10176
+    # This is required for aarch64-darwin, everything else works as is.
+    AS="${stdenv.cc}/bin/cc -c" ASPP="${stdenv.cc}/bin/cc -c"
   '';
   postBuild = ''
     mkdir -p $out/include


### PR DESCRIPTION
###### Motivation for this change

Another fix for #105026.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).