### PR TITLE
ocamlPackages.ocaml: 4.10.0 -> 4.10.2

### DIFF
--- a/pkgs/development/compilers/ocaml/4.10.nix
+++ b/pkgs/development/compilers/ocaml/4.10.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "10";
-  patch_version = "0";
-  sha256 = "1dzy7lbdapcmwn1wg8k87419khi54f8hb6n314bdv7v0gfqlswrh";
+  patch_version = "2";
+  sha256 = "sha256-locUYQeCgtXbAiB32JveJchfteN2YStE+MN9ToTwAOM=";
 }


### PR DESCRIPTION
###### Motivation for this change

Version bump + unlocking `aarch64-darwin` for #105026 (#114525 is required for that).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
