### PR TITLE
perl530: backport aarch64-darwin patch

### DIFF
--- a/pkgs/development/interpreters/perl/aarch64-darwin.patch
+++ b/pkgs/development/interpreters/perl/aarch64-darwin.patch
@@ -1,0 +1,46 @@
+diff --git a/hints/darwin.sh b/hints/darwin.sh
+index 0a91bc083c0..fdfbdd4a3b9 100644
+--- a/hints/darwin.sh
++++ b/hints/darwin.sh
+@@ -301,7 +301,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [1-9][0-9].*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -313,7 +313,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
+ 
+ *** Unexpected MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET
+ ***
+-*** Please either set it to 10.something, or to empty.
++*** Please either set it to a valid macOS version number (e.g., 10.15) or to empty.
+ 
+ EOM
+       exit 1
+@@ -327,7 +327,7 @@ EOM
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [1-9][0-9].*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;
+@@ -342,11 +342,10 @@ EOM
+       exit 1
+     esac
+ 
+-    # The X in 10.X
+-    prodvers_minor=$(echo $prodvers|awk -F. '{print $2}')
++    darwin_major=$(echo $osvers|awk -F. '{print $1}')
+ 
+-    # macOS (10.12) deprecated syscall().
+-    if [ "$prodvers_minor" -ge 12 ]; then
++    # macOS 10.12 (darwin 16.0.0) deprecated syscall().
++    if [ "$darwin_major" -ge 16 ]; then
+         d_syscall='undef'
+         # If deploying to pre-10.12, suppress Time::HiRes's detection of the system clock_gettime()
+         case "$MACOSX_DEPLOYMENT_TARGET" in

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -41,7 +41,10 @@ let
       ]
       ++ optional stdenv.isSunOS ./ld-shared.patch
       ++ optionals stdenv.isDarwin [ ./cpp-precomp.patch ./sw_vers.patch ]
-      ++ optional crossCompiling ./MakeMaker-cross.patch;
+      ++ optional crossCompiling ./MakeMaker-cross.patch
+      # Backporting https://github.com/Perl/perl5/pull/17946, can be
+      # removed if there's ever a 5.30.x release with it included.
+      ++ optional (versionOlder version "5.32.1") ./aarch64-darwin.patch;
 
     # This is not done for native builds because pwd may need to come from
     # bootstrap tools when building bootstrap perl.


### PR DESCRIPTION
###### Motivation for this change

This was originally in #105026, but then 5.30.1 happened with this change included, so there were conflict and the patch
got dropped. Let's introduce it separately for only one version that still needs it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).