### PR TITLE
python37: remove win64 workaround to fix aarch64-darwin

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -106,6 +106,12 @@ let
 
       ./CVE-2021-3177.patch
 
+      # The workaround is for unittests on Win64, which we don't support.
+      # It does break aarch64-darwin, which we do support. See:
+      # * https://bugs.python.org/issue35523
+      # * https://github.com/python/cpython/commit/e6b247c8e524
+      ../3.7/no-win64-workaround.patch
+
     ] ++ optionals (x11Support && stdenv.isDarwin) [
       ./use-correct-tcl-tk-on-darwin.patch
     ] ++ optionals stdenv.isLinux [

--- a/pkgs/development/interpreters/python/cpython/3.7/no-win64-workaround.patch
+++ b/pkgs/development/interpreters/python/cpython/3.7/no-win64-workaround.patch
@@ -1,0 +1,37 @@
+From e6b247c8e524dbe5fc03b3492f628d0d5348bc49 Mon Sep 17 00:00:00 2001
+From: Victor Stinner <vstinner@redhat.com>
+Date: Tue, 18 Dec 2018 14:47:21 +0100
+Subject: [PATCH] bpo-35523: Remove ctypes callback workaround (GH-11211)
+
+Remove ctypes callback workaround: no longer create a callback at startup.
+Avoid SELinux alert on "import ctypes" and "import uuid".
+---
+ Lib/ctypes/__init__.py                                       | 5 -----
+ .../next/Library/2018-12-18-13-52-13.bpo-35523.SkoMno.rst    | 2 ++
+ 2 files changed, 2 insertions(+), 5 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Library/2018-12-18-13-52-13.bpo-35523.SkoMno.rst
+
+diff --git a/Lib/ctypes/__init__.py b/Lib/ctypes/__init__.py
+index 6146773988648..5f78beda5866e 100644
+--- a/Lib/ctypes/__init__.py
++++ b/Lib/ctypes/__init__.py
+@@ -266,11 +266,6 @@ def _reset_cache():
+     # _SimpleCData.c_char_p_from_param
+     POINTER(c_char).from_param = c_char_p.from_param
+     _pointer_type_cache[None] = c_void_p
+-    # XXX for whatever reasons, creating the first instance of a callback
+-    # function is needed for the unittests on Win64 to succeed.  This MAY
+-    # be a compiler bug, since the problem occurs only when _ctypes is
+-    # compiled with the MS SDK compiler.  Or an uninitialized variable?
+-    CFUNCTYPE(c_int)(lambda: None)
+ 
+ def create_unicode_buffer(init, size=None):
+     """create_unicode_buffer(aString) -> character array
+diff --git a/Misc/NEWS.d/next/Library/2018-12-18-13-52-13.bpo-35523.SkoMno.rst b/Misc/NEWS.d/next/Library/2018-12-18-13-52-13.bpo-35523.SkoMno.rst
+new file mode 100644
+index 0000000000000..94a9fd257383e
+--- /dev/null
++++ b/Misc/NEWS.d/next/Library/2018-12-18-13-52-13.bpo-35523.SkoMno.rst
+@@ -0,0 +1,2 @@
++Remove :mod:`ctypes` callback workaround: no longer create a callback at
++startup. Avoid SELinux alert on ``import ctypes`` and ``import uuid``.

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -185,6 +185,11 @@ in with passthru; stdenv.mkDerivation {
     # Backport a fix for discovering `rpmbuild` command when doing `python setup.py bdist_rpm` to 3.5, 3.6, 3.7.
     # See: https://bugs.python.org/issue11122
     ./3.7/fix-hardcoded-path-checking-for-rpmbuild.patch
+    # The workaround is for unittests on Win64, which we don't support.
+    # It does break aarch64-darwin, which we do support. See:
+    # * https://bugs.python.org/issue35523
+    # * https://github.com/python/cpython/commit/e6b247c8e524
+    ./3.7/no-win64-workaround.patch
   ] ++ optionals (isPy37 || isPy38 || isPy39) [
     # Fix darwin build https://bugs.python.org/issue34027
     ./3.7/darwin-libutil.patch


### PR DESCRIPTION
###### Motivation for this change

The issue manifests itself as the following on `aarch64-darwin` (#105026 is coming):

```
>>> import ctypes
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/i8cq0xrjirz1rcp65wzcyhj6ypzlw9il-python3-3.7.10/lib/python3.7/ctypes/__init__.py", line 551, in <module>
    _reset_cache()
  File "/nix/store/i8cq0xrjirz1rcp65wzcyhj6ypzlw9il-python3-3.7.10/lib/python3.7/ctypes/__init__.py", line 273, in _reset_cache
    CFUNCTYPE(c_int)(lambda: None)
MemoryError
```

The commit we backport is included in Python 3.8, and it reverts the change that was introduced all the way back in Python 2.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
