### PR TITLE
rst2html5: fix download now that it is a wheel

### DIFF
--- a/pkgs/tools/text/rst2html5/default.nix
+++ b/pkgs/tools/text/rst2html5/default.nix
@@ -3,12 +3,12 @@
 let
   pname = "rst2html5";
   version = "1.10.6";
-in python3Packages.buildPythonPackage {
-  inherit pname version;
   format = "wheel";
+in python3Packages.buildPythonPackage {
+  inherit pname version format;
 
   src = python3Packages.fetchPypi {
-    inherit pname version;
+    inherit pname version format;
     sha256 = "sha256-jmToDFLQODqgTycBp2J8LyoJ1Zxho9w1VdhFMzvDFkg=";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Fixing up #105489.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).