### PR TITLE
python3Packages.slicedimage: switch to pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/slicedimage/default.nix
+++ b/pkgs/development/python-modules/slicedimage/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , boto3
 , diskcache
 , enum34
@@ -10,7 +10,7 @@
 , requests
 , scikitimage
 , six
-, pytest
+, pytestCheckHook
 , isPy27
 , tifffile
 }:
@@ -19,9 +19,11 @@ buildPythonPackage rec {
   pname = "slicedimage";
   version = "4.1.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "7369f1d7fa09f6c9969625c4b76a8a63d2507a94c6fc257183da1c10261703e9";
+  src = fetchFromGitHub {
+    owner = "spacetx";
+    repo = pname;
+    rev = version;
+    sha256 = "1vpg8varvfx0nj6xscdfm7m118hzsfz7qfzn28r9rsfvrhr0dlcw";
   };
 
   propagatedBuildInputs = [
@@ -36,13 +38,13 @@ buildPythonPackage rec {
   ] ++ lib.optionals isPy27 [ pathlib enum34 ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
   ];
 
-  # ignore tests which require setup
-  checkPhase = ''
-    pytest --ignore tests/io_
-  '';
+  # Ignore tests which require setup, check again if disabledTestFiles can be used
+  pytestFlagsArray = [ "--ignore tests/io_" ];
+
+  pythonImportsCheck = [ "slicedimage" ];
 
   meta = with lib; {
     description = "Library to access sliced imaging data";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update tests part

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
