### PR TITLE
Revert "adoptopenjdk-bin: add support for GTK+ Look and Feel"

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -4,31 +4,16 @@ sourcePerArch:
 , lib
 , fetchurl
 , autoPatchelfHook
-, makeWrapper
-# minimum dependencies
 , alsaLib
-, fontconfig
 , freetype
-, libffi
-, xorg
+, fontconfig
 , zlib
-# runtime dependencies
-, cups
-# runtime dependencies for GTK+ Look and Feel
-, gtkSupport ? true
-, cairo
-, glib
-, gtk3
+, xorg
+, libffi
 }:
 
 let
   cpuName = stdenv.hostPlatform.parsed.cpu.name;
-  runtimeDependencies = [
-    cups
-  ] ++ lib.optionals gtkSupport [
-    cairo glib gtk3
-  ];
-  runtimeLibraryPath = lib.makeLibraryPath runtimeDependencies;
 in
 
 let result = stdenv.mkDerivation rec {
@@ -43,19 +28,11 @@ let result = stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    alsaLib # libasound.so wanted by lib/libjsound.so
-    fontconfig
-    freetype
-    stdenv.cc.cc.lib # libstdc++.so.6
-    xorg.libX11
-    xorg.libXext
-    xorg.libXi
-    xorg.libXrender
-    xorg.libXtst
-    zlib
+    alsaLib freetype fontconfig zlib xorg.libX11 xorg.libXext xorg.libXtst
+    xorg.libXi xorg.libXrender stdenv.cc.cc.lib
   ] ++ lib.optional stdenv.isAarch32 libffi;
 
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+  nativeBuildInputs = [ autoPatchelfHook ];
 
   # See: https://github.com/NixOS/patchelf/issues/10
   dontStrip = 1;
@@ -80,13 +57,6 @@ let result = stdenv.mkDerivation rec {
     cat <<EOF >> "$out/nix-support/setup-hook"
     if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
     EOF
-
-    # We cannot use -exec since wrapProgram is a function but not a command.
-    for bin in $( find "$out" -executable -type f ); do
-      if patchelf --print-interpreter "$bin" &> /dev/null; then
-        wrapProgram "$bin" --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
-      fi
-    done
   '';
 
   preFixup = ''


### PR DESCRIPTION
This reverts commit 714eca6967a0017b3228966871a9a3803ab3effb.

Closes https://github.com/NixOS/nixpkgs/issues/114495 (fixes openjdk15)

cc @taku0 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
