### PR TITLE
adoptopenjdk-bin, zulu, graalvm11-ce: do not wrap jspawnhelper

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -82,7 +82,10 @@ let result = stdenv.mkDerivation rec {
     EOF
 
     # We cannot use -exec since wrapProgram is a function but not a command.
-    for bin in $( find "$out" -executable -type f ); do
+    #
+    # jspawnhelper is executed from JVM, so it doesn't need to wrap it, and it
+    # breaks building OpenJDK (#114495).
+    for bin in $( find "$out" -executable -type f -not -name jspawnhelper ); do
       if patchelf --print-interpreter "$bin" &> /dev/null; then
         wrapProgram "$bin" --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
       fi

--- a/pkgs/development/compilers/graalvm/community-edition.nix
+++ b/pkgs/development/compilers/graalvm/community-edition.nix
@@ -189,7 +189,10 @@ let
         preFixup = ''
           # We cannot use -exec since wrapProgram is a function but not a
           # command.
-          for bin in $( find "$out" -executable -type f -not -path '*/languages/ruby/lib/gems/*' ); do
+          #
+          # jspawnhelper is executed from JVM, so it doesn't need to wrap it,
+          # and it breaks building OpenJDK (#114495).
+          for bin in $( find "$out" -executable -type f -not -path '*/languages/ruby/lib/gems/*' -not -name jspawnhelper ); do
             if patchelf --print-interpreter "$bin" &> /dev/null || head -n 1 "$bin" | grep '^#!' -q; then
               wrapProgram "$bin" \
                 --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -81,7 +81,10 @@ in stdenv.mkDerivation {
     EOF
   '' + lib.optionalString stdenv.isLinux ''
     # We cannot use -exec since wrapProgram is a function but not a command.
-    for bin in $( find "$out" -executable -type f ); do
+    #
+    # jspawnhelper is executed from JVM, so it doesn't need to wrap it, and it
+    # breaks building OpenJDK (#114495).
+    for bin in $( find "$out" -executable -type f -not -name jspawnhelper ); do
       wrapProgram "$bin" --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
     done
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #114495.

Note that OpenJDK 8 does not have jspawnhelper.

We can build `openjdk15` now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
