### PR TITLE
treewide/php-packages: Drop pkgs from arguments to packages

### DIFF
--- a/pkgs/development/php-packages/box/default.nix
+++ b/pkgs/development/php-packages/box/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, lib, php }:
 let
   pname = "box";
   version = "2.7.5";
@@ -12,7 +12,7 @@ mkDerivation {
   };
 
   phases = [ "installPhase" ];
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/development/php-packages/composer/2.0.nix
+++ b/pkgs/development/php-packages/composer/2.0.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, unzip, lib, php }:
 let
   pname = "composer";
   version = "2.0.11";
@@ -13,17 +13,17 @@ mkDerivation {
 
   dontUnpack = true;
 
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
     install -D $src $out/libexec/composer/composer.phar
     makeWrapper ${php}/bin/php $out/bin/composer \
       --add-flags "$out/libexec/composer/composer.phar" \
-      --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.unzip ]}
+      --prefix PATH : ${lib.makeBinPath [ unzip ]}
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "Dependency Manager for PHP";
     license = licenses.mit;
     homepage = "https://getcomposer.org/";

--- a/pkgs/development/php-packages/composer/default.nix
+++ b/pkgs/development/php-packages/composer/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, unzip, lib, php }:
 let
   pname = "composer";
   version = "1.10.15";
@@ -13,17 +13,17 @@ mkDerivation {
 
   dontUnpack = true;
 
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
     install -D $src $out/libexec/composer/composer.phar
     makeWrapper ${php}/bin/php $out/bin/composer \
       --add-flags "$out/libexec/composer/composer.phar" \
-      --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.unzip ]}
+      --prefix PATH : ${lib.makeBinPath [ unzip ]}
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "Dependency Manager for PHP";
     license = licenses.mit;
     homepage = "https://getcomposer.org/";

--- a/pkgs/development/php-packages/couchbase/default.nix
+++ b/pkgs/development/php-packages/couchbase/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pkgs, php }:
+{ lib, buildPecl, fetchFromGitHub, writeText, libcouchbase, zlib, php }:
 let
   pname = "couchbase";
   version = "2.6.2";
@@ -6,7 +6,7 @@ in
 buildPecl {
   inherit pname version;
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "couchbase";
     repo = "php-couchbase";
     rev = "v${version}";
@@ -16,12 +16,12 @@ buildPecl {
   configureFlags = [ "--with-couchbase" ];
   broken = lib.versionAtLeast php.version "8.0";
 
-  buildInputs = with pkgs; [ libcouchbase zlib ];
+  buildInputs = [ libcouchbase zlib ];
   internalDeps = [] ++ lib.optionals (lib.versionOlder php.version "8.0") [ php.extensions.json ];
   peclDeps = [ php.extensions.igbinary ];
 
   patches = [
-    (pkgs.writeText "php-couchbase.patch" ''
+    (writeText "php-couchbase.patch" ''
       --- a/config.m4
       +++ b/config.m4
       @@ -9,7 +9,7 @@ if test "$PHP_COUCHBASE" != "no"; then
@@ -29,7 +29,7 @@ buildPecl {
          else
            AC_MSG_CHECKING(for libcouchbase in default path)
       -    for i in /usr/local /usr; do
-      +    for i in ${pkgs.libcouchbase}; do
+      +    for i in ${libcouchbase}; do
              if test -r $i/include/libcouchbase/couchbase.h; then
                LIBCOUCHBASE_DIR=$i
                AC_MSG_RESULT(found in $i)

--- a/pkgs/development/php-packages/event/default.nix
+++ b/pkgs/development/php-packages/event/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pkgs, php }:
+{ buildPecl, lib, php, pkg-config, openssl, libevent }:
 buildPecl {
   pname = "event";
 
@@ -6,7 +6,7 @@ buildPecl {
   sha256 = "1ws4l014z52vb23xbsfj6viwkf7fmh462af639xgbp0n6syf77dq";
 
   configureFlags = [
-    "--with-event-libevent-dir=${pkgs.libevent.dev}"
+    "--with-event-libevent-dir=${libevent.dev}"
     "--with-event-core"
     "--with-event-extra"
     "--with-event-pthreads"
@@ -18,11 +18,11 @@ buildPecl {
       ':'
   '';
 
-  nativeBuildInputs = [ pkgs.pkg-config ];
-  buildInputs = with pkgs; [ openssl libevent ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl libevent ];
   internalDeps = [ php.extensions.sockets ];
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = ''
       This is an extension to efficiently schedule I/O, time and signal based
       events using the best I/O notification mechanism available for specific platform.

--- a/pkgs/development/php-packages/imagick/default.nix
+++ b/pkgs/development/php-packages/imagick/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, fetchpatch, lib, pkgs, pcre' }:
+{ buildPecl, fetchpatch, lib, imagemagick7, pkg-config, pcre' }:
 
 buildPecl {
   pname = "imagick";
@@ -19,8 +19,8 @@ buildPecl {
     })
   ];
 
-  configureFlags = [ "--with-imagick=${pkgs.imagemagick7.dev}" ];
-  nativeBuildInputs = [ pkgs.pkg-config ];
+  configureFlags = [ "--with-imagick=${imagemagick7.dev}" ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ pcre' ];
 
   meta.maintainers = lib.teams.php.members;

--- a/pkgs/development/php-packages/maxminddb/default.nix
+++ b/pkgs/development/php-packages/maxminddb/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pkgs }:
+{ buildPecl, lib, fetchFromGitHub, libmaxminddb }:
 let
   pname = "maxminddb";
   version = "1.10.0";
@@ -6,17 +6,17 @@ in
 buildPecl {
   inherit pname version;
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "maxmind";
     repo = "MaxMind-DB-Reader-php";
     rev = "v${version}";
     sha256 = "sha256-2SnajDdO5uAYcuVpEbOuFlZzMxwo/EqFtUSr9XxT0KQ=";
   };
 
-  buildInputs = [ pkgs.libmaxminddb ];
+  buildInputs = [ libmaxminddb ];
   sourceRoot = "source/ext";
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "C extension that is a drop-in replacement for MaxMind\\Db\\Reader";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ ajs124 das_j ] ++ teams.php.members;

--- a/pkgs/development/php-packages/memcached/default.nix
+++ b/pkgs/development/php-packages/memcached/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, fetchgit, php, pkgs }:
+{ buildPecl, lib, fetchgit, php, cyrus_sasl, zlib, pkg-config, libmemcached }:
 let
   pname = "memcached";
   version = "3.1.5";
@@ -19,12 +19,12 @@ buildPecl {
   ];
 
   configureFlags = [
-    "--with-zlib-dir=${pkgs.zlib.dev}"
-    "--with-libmemcached-dir=${pkgs.libmemcached}"
+    "--with-zlib-dir=${zlib.dev}"
+    "--with-libmemcached-dir=${libmemcached}"
   ];
 
-  nativeBuildInputs = [ pkgs.pkg-config ];
-  buildInputs = with pkgs; [ cyrus_sasl zlib ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ cyrus_sasl zlib ];
 
   meta.maintainers = lib.teams.php.members;
 }

--- a/pkgs/development/php-packages/mongodb/default.nix
+++ b/pkgs/development/php-packages/mongodb/default.nix
@@ -1,4 +1,5 @@
-{ buildPecl, lib, pkgs, pcre' }:
+{ stdenv, buildPecl, lib, pcre', pkg-config, cyrus_sasl, icu64
+, openssl, snappy, zlib, darwin }:
 
 buildPecl {
   pname = "mongodb";
@@ -6,15 +7,15 @@ buildPecl {
   version = "1.9.0";
   sha256 = "16mbw3p80qxsj86nmjbfch8wv6jaq8wbz4rlpmixvhj9nwbp37hs";
 
-  nativeBuildInputs = [ pkgs.pkg-config ];
-  buildInputs = with pkgs; [
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
     cyrus_sasl
     icu64
     openssl
     snappy
     zlib
     pcre'
-  ] ++ lib.optional (pkgs.stdenv.isDarwin) pkgs.darwin.apple_sdk.frameworks.Security;
+  ] ++ lib.optionals (stdenv.isDarwin) darwin.apple_sdk.frameworks.Security;
 
   meta.maintainers = lib.teams.php.members;
 }

--- a/pkgs/development/php-packages/oci8/default.nix
+++ b/pkgs/development/php-packages/oci8/default.nix
@@ -1,14 +1,14 @@
-{ buildPecl, lib, pkgs, version, sha256 }:
+{ buildPecl, lib, version, sha256, oracle-instantclient }:
 buildPecl {
   pname = "oci8";
 
   inherit version sha256;
 
-  buildInputs = [ pkgs.oracle-instantclient ];
-  configureFlags = [ "--with-oci8=shared,instantclient,${pkgs.oracle-instantclient.lib}/lib" ];
+  buildInputs = [ oracle-instantclient ];
+  configureFlags = [ "--with-oci8=shared,instantclient,${oracle-instantclient.lib}/lib" ];
 
   postPatch = ''
-    sed -i -e 's|OCISDKMANINC=`.*$|OCISDKMANINC="${pkgs.oracle-instantclient.dev}/include"|' config.m4
+    sed -i -e 's|OCISDKMANINC=`.*$|OCISDKMANINC="${oracle-instantclient.dev}/include"|' config.m4
   '';
 
   meta.maintainers = lib.teams.php.members;

--- a/pkgs/development/php-packages/pdlib/default.nix
+++ b/pkgs/development/php-packages/pdlib/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pkgs }:
+{ buildPecl, fetchFromGitHub, lib, pkg-config, dlib }:
 let
   pname = "pdlib";
   version = "1.0.2";
@@ -6,15 +6,15 @@ in
 buildPecl {
   inherit pname version;
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "goodspb";
     repo = "pdlib";
     rev = "v${version}";
     sha256 = "0qnmqwlw5vb2rvliap4iz9val6mal4qqixcw69pwskdw5jka6v5i";
   };
 
-  nativeBuildInputs = [ pkgs.pkg-config ];
-  buildInputs = [ (pkgs.dlib.override { guiSupport = true; }) ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ (dlib.override { guiSupport = true; }) ];
 
   meta = with lib; {
     description = "A PHP extension for Dlib";

--- a/pkgs/development/php-packages/pdo_sqlsrv/default.nix
+++ b/pkgs/development/php-packages/pdo_sqlsrv/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pkgs, php }:
+{ stdenv, buildPecl, lib, libiconv, unixODBC, php }:
 
 buildPecl {
   pname = "pdo_sqlsrv";
@@ -8,7 +8,7 @@ buildPecl {
 
   internalDeps = [ php.extensions.pdo ];
 
-  buildInputs = [ pkgs.unixODBC ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
+  buildInputs = [ unixODBC ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   meta.maintainers = lib.teams.php.members;
 }

--- a/pkgs/development/php-packages/php-cs-fixer/default.nix
+++ b/pkgs/development/php-packages/php-cs-fixer/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, lib, php }:
 let
   pname = "php-cs-fixer";
   version = "2.18.2";
@@ -12,7 +12,7 @@ mkDerivation {
   };
 
   phases = [ "installPhase" ];
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -21,7 +21,7 @@ mkDerivation {
       --add-flags "$out/libexec/php-cs-fixer/php-cs-fixer.phar"
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "A tool to automatically fix PHP coding standards issues";
     license = licenses.mit;
     homepage = "http://cs.sensiolabs.org/";

--- a/pkgs/development/php-packages/php-parallel-lint/default.nix
+++ b/pkgs/development/php-packages/php-parallel-lint/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchFromGitHub, pkgs, lib, php }:
+{ mkDerivation, fetchFromGitHub, makeWrapper, lib, php }:
 let
   pname = "php-parallel-lint";
   version = "1.0.0";
@@ -14,7 +14,7 @@ mkDerivation {
   };
 
   nativeBuildInputs = [
-    pkgs.makeWrapper
+    makeWrapper
     php.packages.composer
     php.packages.box
   ];
@@ -31,7 +31,7 @@ mkDerivation {
       --add-flags "$out/libexec/php-parallel-lint/php-parallel-lint.phar"
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "Tool to check syntax of PHP files faster than serial check with fancier output";
     license = licenses.bsd2;
     homepage = "https://github.com/JakubOnderka/PHP-Parallel-Lint";

--- a/pkgs/development/php-packages/php_excel/default.nix
+++ b/pkgs/development/php-packages/php_excel/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, fetchurl, lib, pkgs }:
+{ buildPecl, fetchurl, lib, libxl }:
 let
   pname = "php_excel";
   phpVersion = "php7";
@@ -12,12 +12,12 @@ buildPecl {
     sha256 = "0dpvih9gpiyh1ml22zi7hi6kslkilzby00z1p8x248idylldzs2n";
   };
 
-  buildInputs = with pkgs; [ libxl ];
+  buildInputs = [ libxl ];
 
   configureFlags = [
     "--with-excel"
-    "--with-libxl-incdir=${pkgs.libxl}/include_c"
-    "--with-libxl-libdir=${pkgs.libxl}/lib"
+    "--with-libxl-incdir=${libxl}/include_c"
+    "--with-libxl-libdir=${libxl}/lib"
   ];
 
   meta.maintainers = lib.teams.php.members;

--- a/pkgs/development/php-packages/phpcbf/default.nix
+++ b/pkgs/development/php-packages/phpcbf/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, lib, php, makeWrapper }:
 let
   pname = "phpcbf";
   version = "3.5.8";
@@ -12,7 +12,7 @@ mkDerivation {
   };
 
   phases = [ "installPhase" ];
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -21,7 +21,7 @@ mkDerivation {
       --add-flags "$out/libexec/phpcbf/phpcbf.phar"
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "PHP coding standard beautifier and fixer";
     license = licenses.bsd3;
     homepage = "https://squizlabs.github.io/PHP_CodeSniffer/";

--- a/pkgs/development/php-packages/phpcs/default.nix
+++ b/pkgs/development/php-packages/phpcs/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, lib, php }:
 let
   pname = "phpcs";
   version = "3.5.8";
@@ -12,7 +12,7 @@ mkDerivation {
   };
 
   phases = [ "installPhase" ];
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -21,7 +21,7 @@ mkDerivation {
       --add-flags "$out/libexec/phpcs/phpcs.phar"
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "PHP coding standard tool";
     license = licenses.bsd3;
     homepage = "https://squizlabs.github.io/PHP_CodeSniffer/";

--- a/pkgs/development/php-packages/phpmd/default.nix
+++ b/pkgs/development/php-packages/phpmd/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, lib, php }:
 let
   pname = "phpmd";
   version = "2.8.2";
@@ -8,13 +8,13 @@ in
 mkDerivation {
   inherit pname version;
 
-  src = pkgs.fetchurl {
+  src = fetchurl {
     url = "https://github.com/phpmd/phpmd/releases/download/${version}/phpmd.phar";
     sha256 = "1i8qgzxniw5d8zjpypalm384y7qfczapfq70xmg129laq6xiqlqb";
   };
 
   phases = [ "installPhase" ];
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -23,7 +23,7 @@ mkDerivation {
       --add-flags "$out/libexec/phpmd/phpmd.phar"
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "PHP code quality analyzer";
     license = licenses.bsd3;
     homepage = "https://phpmd.org/";

--- a/pkgs/development/php-packages/phpstan/default.nix
+++ b/pkgs/development/php-packages/phpstan/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, lib, php }:
 let
   pname = "phpstan";
   version = "0.12.78";
@@ -6,13 +6,13 @@ in
 mkDerivation {
   inherit pname version;
 
-  src = pkgs.fetchurl {
+  src = fetchurl {
     url = "https://github.com/phpstan/phpstan/releases/download/${version}/phpstan.phar";
     sha256 = "sha256-YPCh6HAVuFf2rJhUj/uzfqkWKN+Jd2iPfugSiTh65zc=";
   };
 
   phases = [ "installPhase" ];
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -21,7 +21,7 @@ mkDerivation {
       --add-flags "$out/libexec/phpstan/phpstan.phar"
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "PHP Static Analysis Tool";
     longDescription = ''
       PHPStan focuses on finding errors in your code without actually

--- a/pkgs/development/php-packages/psalm/default.nix
+++ b/pkgs/development/php-packages/psalm/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, lib, php }:
 let
   pname = "psalm";
   version = "4.6.1";
@@ -12,7 +12,7 @@ mkDerivation {
   };
 
   phases = [ "installPhase" ];
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -21,7 +21,7 @@ mkDerivation {
       --add-flags "$out/libexec/psalm/psalm.phar"
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "A static analysis tool for finding errors in PHP applications";
     license = licenses.mit;
     homepage = "https://github.com/vimeo/psalm";

--- a/pkgs/development/php-packages/psysh/default.nix
+++ b/pkgs/development/php-packages/psysh/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, pkgs, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, lib, php }:
 let
   pname = "psysh";
   version = "0.10.4";
@@ -12,7 +12,7 @@ mkDerivation {
   };
 
   phases = [ "installPhase" ];
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -21,7 +21,7 @@ mkDerivation {
     wrapProgram $out/bin/psysh --prefix PATH : "${lib.makeBinPath [ php ]}"
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "PsySH is a runtime developer console, interactive debugger and REPL for PHP.";
     license = licenses.mit;
     homepage = "https://psysh.org/";

--- a/pkgs/development/php-packages/rdkafka/default.nix
+++ b/pkgs/development/php-packages/rdkafka/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pkgs, pcre' }:
+{ buildPecl, lib, rdkafka, pcre' }:
 
 buildPecl {
   pname = "rdkafka";
@@ -6,11 +6,11 @@ buildPecl {
   version = "5.0.0";
   sha256 = "sha256-Qy+6rkPczhdxFbDhcuzmUTLMPUXYZ0HaheDBhkh4FXs=";
 
-  buildInputs = [ pkgs.rdkafka pcre' ];
+  buildInputs = [ rdkafka pcre' ];
 
   postPhpize = ''
     substituteInPlace configure \
-      --replace 'SEARCH_PATH="/usr/local /usr"' 'SEARCH_PATH=${pkgs.rdkafka}'
+      --replace 'SEARCH_PATH="/usr/local /usr"' 'SEARCH_PATH=${rdkafka}'
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/smbclient/default.nix
+++ b/pkgs/development/php-packages/smbclient/default.nix
@@ -1,14 +1,14 @@
-{ buildPecl, lib, pkgs }:
+{ buildPecl, lib, samba, pkg-config }:
 buildPecl {
   pname = "smbclient";
   version = "1.0.5";
   sha256 = "sha256-cNvTa1qzYrlhuX4oNehXt+XKqmqfonyomW/usQdQQO0=";
 
   # TODO: remove this when upstream merges a fix - https://github.com/eduardok/libsmbclient-php/pull/66
-  LIBSMBCLIENT_INCDIR = "${pkgs.samba.dev}/include/samba-4.0";
+  LIBSMBCLIENT_INCDIR = "${samba.dev}/include/samba-4.0";
 
-  nativeBuildInputs = [ pkgs.pkg-config ];
-  buildInputs = [ pkgs.samba ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ samba ];
 
   meta.maintainers = lib.teams.php.members;
 }

--- a/pkgs/development/php-packages/sqlsrv/default.nix
+++ b/pkgs/development/php-packages/sqlsrv/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pkgs }:
+{ stdenv, buildPecl, lib, unixODBC, libiconv }:
 
 buildPecl {
   pname = "sqlsrv";
@@ -7,10 +7,8 @@ buildPecl {
   sha256 = "1css440b4qrbblmcswd5wdr2v1rjxlj2iicbmvjq9fg81028w40a";
 
   buildInputs = [
-    pkgs.unixODBC
-  ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-    pkgs.libiconv
-  ];
+    unixODBC
+  ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   meta.maintainers = lib.teams.php.members;
 }

--- a/pkgs/development/php-packages/yaml/default.nix
+++ b/pkgs/development/php-packages/yaml/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pkgs }:
+{ buildPecl, lib, pkg-config, libyaml }:
 
 buildPecl {
   pname = "yaml";
@@ -6,9 +6,9 @@ buildPecl {
   version = "2.2.1";
   sha256 = "sha256-4XrQTnUuJf0Jm93S350m3+8YPI0AxBebydei4cl9eBk=";
 
-  configureFlags = [ "--with-yaml=${pkgs.libyaml}" ];
+  configureFlags = [ "--with-yaml=${libyaml}" ];
 
-  nativeBuildInputs = [ pkgs.pkg-config ];
+  nativeBuildInputs = [ pkg-config ];
 
   meta.maintainers = lib.teams.php.members;
 }


### PR DESCRIPTION
###### Motivation for this change
It was suggested to a previous PR to clean this up, so here it comes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
