### PR TITLE
flite: improve cross-compilation support

### DIFF
--- a/pkgs/development/libraries/flite/default.nix
+++ b/pkgs/development/libraries/flite/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, alsaLib }:
+{ lib, stdenv, fetchFromGitHub, alsaLib, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "flite";
@@ -12,6 +12,16 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = lib.optionals stdenv.isLinux [ alsaLib ];
+
+  # https://github.com/festvox/flite/pull/60.
+  # Replaces `ar` with `$(AR)` in config/common_make_rules.
+  # Improves cross-compilation compatibility.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/festvox/flite/commit/54c65164840777326bbb83517568e38a128122ef.patch";
+      sha256 = "sha256-hvKzdX7adiqd9D+9DbnfNdqEULg1Hhqe1xElYxNM1B8=";
+    })
+  ];
 
   configureFlags = [
     "--enable-shared"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Flite has a hardcoded reference to `ar`. I've sent in a PR to the upstream project and want to apply the patch here already for the time being. If the PR is accepted and a new release is cut, we can remove this patch again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've also tested building using `nix build .#pkgsCross.aarch64-multiplatform.flite` (on master, not on staging -> presumably that shouldn't matter, but I've started a build to be sure).