### PR TITLE
python3Packages.aiohttp: 3.7.3 -> 3.7.4

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -3,81 +3,76 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, async-timeout
 , attrs
 , chardet
-, multidict
-, async-timeout
-, yarl
 , idna-ssl
+, multidict
 , typing-extensions
-, pytestrunner
-, pytestCheckHook
-, gunicorn
+, yarl
 , async_generator
-, pytest_xdist
-, pytestcov
-, pytest-mock
-, trustme
 , brotlipy
 , freezegun
-, isPy38
+, gunicorn
+, pytest-mock
+, pytest-xdist
+, pytestCheckHook
 , re-assert
+, trustme
 }:
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "3.7.3";
-  # https://github.com/aio-libs/aiohttp/issues/4525 python3.8 failures
-  disabled = pythonOlder "3.5";
+  version = "3.7.4";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9c1a81af067e72261c9cbe33ea792893e83bc6aa987bfbd6fdc1e5e7b22777c4";
+    sha256 = "1pn79h8fng4xi5gl1f6saw31nxgmgyxl41yf3vba1l21673yr12x";
   };
 
-  checkInputs = [
-    pytestrunner pytestCheckHook gunicorn async_generator pytest_xdist
-    pytest-mock pytestcov trustme brotlipy freezegun
-    re-assert
-  ];
+  postPatch = ''
+    substituteInPlace setup.cfg --replace " --cov=aiohttp" ""
+  '';
 
   propagatedBuildInputs = [
+    async-timeout
     attrs
     chardet
     multidict
-    async-timeout
     typing-extensions
     yarl
   ] ++ lib.optionals (pythonOlder "3.7") [
     idna-ssl
   ];
 
+  checkInputs = [
+    async_generator
+    brotlipy
+    freezegun
+    gunicorn
+    pytest-mock
+    pytest-xdist
+    pytestCheckHook
+    re-assert
+    trustme
+  ];
+
+  pytestFlagsArray = [
+    "-n auto"
+  ];
+
   disabledTests = [
-    # disable tests which attempt to do loopback connections
-    "get_valid_log_format_exc"
-    "test_access_logger_atoms"
-    "aiohttp_request_coroutine"
-    "server_close_keepalive_connection"
-    "connector"
-    "client_disconnect"
-    "handle_keepalive_on_closed_connection"
-    "proxy_https_bad_response"
-    "partially_applied_handler"
-    "middleware"
+    # Disable tests that require network access
     "test_mark_formdata_as_processed"
-    # no longer compatible with pytest>=6
-    "aiohttp_plugin_async_fixture"
   ] ++ lib.optionals stdenv.is32bit [
     "test_cookiejar"
-  ] ++ lib.optionals isPy38 [
-    # Python 3.8  https://github.com/aio-libs/aiohttp/issues/4525
-    "test_read_boundary_with_incomplete_chunk"
-    "test_read_incomplete_chunk"
-    "test_request_tracing_exception"
   ] ++ lib.optionals stdenv.isDarwin [
-    "test_addresses"  # https://github.com/aio-libs/aiohttp/issues/3572
+    "test_addresses"  # https://github.com/aio-libs/aiohttp/issues/3572, remove >= v4.0.0
     "test_close"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   # aiohttp in current folder shadows installed version
   # Probably because we run `python -m pytest` instead of `pytest` in the hook.


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst#374-2021-02-25

Clean up package, reenable tests, allow local networking for darwin for
loopback network tests, actually enable xdist, disable coverage.

Fixes: CVE-2021-21330

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
