### PR TITLE
openjfx-modular-sdk, openjfx-sdk: add OpenJFX SDK

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk11-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? openjfx-modular-sdk.meta.available, openjfx-modular-sdk
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
@@ -61,7 +61,7 @@ let
       "--with-stdc++lib=dynamic"
     ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
       ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx-modular-sdk}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/12.nix
+++ b/pkgs/development/compilers/openjdk/12.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk11, fetchpatch
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? openjfx-modular-sdk.meta.available, openjfx-modular-sdk
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
@@ -71,7 +71,7 @@ let
       "--with-stdc++lib=dynamic"
     ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
       ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx-modular-sdk}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/13.nix
+++ b/pkgs/development/compilers/openjdk/13.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk13-bootstrap, fetchpatch
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? openjfx-modular-sdk.meta.available, openjfx-modular-sdk
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
@@ -71,7 +71,7 @@ let
       "--with-stdc++lib=dynamic"
     ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
       ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx-modular-sdk}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/14.nix
+++ b/pkgs/development/compilers/openjdk/14.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk14-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? openjfx-modular-sdk.meta.available, openjfx-modular-sdk
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
@@ -66,7 +66,7 @@ let
       "--with-stdc++lib=dynamic"
     ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
       ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx-modular-sdk}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/15.nix
+++ b/pkgs/development/compilers/openjdk/15.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk15-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? openjfx-modular-sdk.meta.available, openjfx-modular-sdk
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
@@ -66,7 +66,7 @@ let
       "--with-stdc++lib=dynamic"
     ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
       ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx-modular-sdk}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/16.nix
+++ b/pkgs/development/compilers/openjdk/16.nix
@@ -4,7 +4,7 @@
 , libXi, libXinerama, libXcursor, libXrandr, fontconfig, openjdk16-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? openjfx-modular-sdk.meta.available, openjfx-modular-sdk
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
@@ -72,7 +72,7 @@ let
       "--with-stdc++lib=dynamic"
     ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
       ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx-modular-sdk}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -116,7 +116,7 @@ in {
 
     meta = with lib; {
       homepage = "http://openjdk.java.net/projects/openjfx/";
-      license = licenses.gpl2;
+      license = licenses.gpl2Classpath;
       description = "The next-generation Java client toolkit; unpacked SDK";
       maintainers = with maintainers; [ abbradar ];
       platforms = [ "i686-linux" "x86_64-linux" ];
@@ -132,7 +132,7 @@ in {
 
     meta = with lib; {
       homepage = "http://openjdk.java.net/projects/openjfx/";
-      license = licenses.gpl2;
+      license = licenses.gpl2Classpath;
       description = "The next-generation Java client toolkit; packed SDK";
       maintainers = with maintainers; [ abbradar ];
       platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -115,7 +115,7 @@ in {
     passthru.deps = deps;
 
     meta = with lib; {
-      homepage = "http://openjdk.java.net/projects/openjfx/";
+      homepage = "https://openjdk.java.net/projects/openjfx/";
       license = licenses.gpl2Classpath;
       description = "The next-generation Java client toolkit; unpacked SDK";
       maintainers = with maintainers; [ abbradar ];
@@ -131,7 +131,7 @@ in {
     '';
 
     meta = with lib; {
-      homepage = "http://openjdk.java.net/projects/openjfx/";
+      homepage = "https://openjdk.java.net/projects/openjfx/";
       license = licenses.gpl2Classpath;
       description = "The next-generation Java client toolkit; packed SDK";
       maintainers = with maintainers; [ abbradar ];

--- a/pkgs/development/compilers/openjdk/openjfx/16.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/16.nix
@@ -116,7 +116,7 @@ in {
 
     meta = with lib; {
       homepage = "http://openjdk.java.net/projects/openjfx/";
-      license = licenses.gpl2;
+      license = licenses.gpl2Classpath;
       description = "The next-generation Java client toolkit; unpacked SDK";
       maintainers = with maintainers; [ abbradar ];
       platforms = [ "i686-linux" "x86_64-linux" ];
@@ -132,7 +132,7 @@ in {
 
     meta = with lib; {
       homepage = "http://openjdk.java.net/projects/openjfx/";
-      license = licenses.gpl2;
+      license = licenses.gpl2Classpath;
       description = "The next-generation Java client toolkit; packed SDK";
       maintainers = with maintainers; [ abbradar ];
       platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/development/compilers/openjdk/openjfx/16.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/16.nix
@@ -115,7 +115,7 @@ in {
     passthru.deps = deps;
 
     meta = with lib; {
-      homepage = "http://openjdk.java.net/projects/openjfx/";
+      homepage = "https://openjdk.java.net/projects/openjfx/";
       license = licenses.gpl2Classpath;
       description = "The next-generation Java client toolkit; unpacked SDK";
       maintainers = with maintainers; [ abbradar ];
@@ -131,7 +131,7 @@ in {
     '';
 
     meta = with lib; {
-      homepage = "http://openjdk.java.net/projects/openjfx/";
+      homepage = "https://openjdk.java.net/projects/openjfx/";
       license = licenses.gpl2Classpath;
       description = "The next-generation Java client toolkit; packed SDK";
       maintainers = with maintainers; [ abbradar ];

--- a/pkgs/development/compilers/openjdk/openjfx/add_ffmpeg_to_libgstreamer-lite.patch
+++ b/pkgs/development/compilers/openjdk/openjfx/add_ffmpeg_to_libgstreamer-lite.patch
@@ -1,0 +1,13 @@
+--- jfx/modules/javafx.media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile	2021-02-23 15:16:56.445630283 +0900
++++ jfx/modules/javafx.media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile.new	2021-02-23 20:01:34.798745570 +0900
+@@ -73,8 +73,8 @@
+            -I$(SRCBASE_DIR)/gst-plugins-good/gst/isomp4   \
+            -I$(SRCBASE_DIR)/gst-plugins-bad/gst-libs
+ 
+-PACKAGES_INCLUDES := $(shell pkg-config --cflags alsa glib-2.0)
+-PACKAGES_LIBS := $(shell pkg-config --libs alsa glib-2.0 gobject-2.0 gmodule-2.0 gthread-2.0)
++PACKAGES_INCLUDES := $(shell pkg-config --cflags alsa glib-2.0 libavcodec libavformat)
++PACKAGES_LIBS := $(shell pkg-config --libs alsa glib-2.0 gobject-2.0 gmodule-2.0 gthread-2.0 libavcodec libavformat)
+ 
+ LDFLAGS = -L$(BUILD_DIR) -lm $(PACKAGES_LIBS) \
+           -z relro \

--- a/pkgs/development/compilers/openjdk/openjfx/add_gtk_to_libglass.patch
+++ b/pkgs/development/compilers/openjdk/openjfx/add_gtk_to_libglass.patch
@@ -1,0 +1,14 @@
+--- a/buildSrc/linux.gradle
++++ b/buildSrc/linux.gradle
+@@ -225,9 +225,9 @@
+ LINUX.glass.glass = [:]
+ LINUX.glass.glass.nativeSource = ft_gtk_launcher.getFiles()
+ LINUX.glass.glass.compiler = compiler
+-LINUX.glass.glass.ccFlags = [cppFlags, "-Werror"].flatten()
++LINUX.glass.glass.ccFlags = [cppFlags, "-Werror", gtk3CCFlags].flatten()
+ LINUX.glass.glass.linker = linker
+-LINUX.glass.glass.linkFlags = IS_STATIC_BUILD? linkFlags : [linkFlags, "-lX11", "-ldl"].flatten()
++LINUX.glass.glass.linkFlags = IS_STATIC_BUILD? linkFlags : [linkFlags, "-lX11", "-ldl", gtk3LinkFlags].flatten()
+ LINUX.glass.glass.lib = "glass"
+ 
+ LINUX.glass.glassgtk2 = [:]

--- a/pkgs/development/compilers/openjdk/openjfx/add_gtk_to_libglass_11.patch
+++ b/pkgs/development/compilers/openjdk/openjfx/add_gtk_to_libglass_11.patch
@@ -1,0 +1,14 @@
+--- a/buildSrc/linux.gradle
++++ b/buildSrc/linux.gradle
+@@ -225,9 +225,9 @@
+ LINUX.glass.glass = [:]
+ LINUX.glass.glass.nativeSource = ft_gtk_launcher.getFiles()
+ LINUX.glass.glass.compiler = compiler
+-LINUX.glass.glass.ccFlags = [ccFlags, gtk2CCFlags,  "-Werror"].flatten()
++LINUX.glass.glass.ccFlags = [ccFlags, gtk3CCFlags,  "-Werror"].flatten()
+ LINUX.glass.glass.linker = linker
+-LINUX.glass.glass.linkFlags = [linkFlags, "-lX11", "-ldl" ].flatten()
++LINUX.glass.glass.linkFlags = [linkFlags, "-lX11", "-ldl", gtk3LinkFlags ].flatten()
+ LINUX.glass.glass.lib = "glass"
+ 
+ LINUX.glass.glassgtk2 = [:]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10765,9 +10765,16 @@ in
 
   hugs = callPackage ../development/interpreters/hugs { };
 
-  openjfx11 = callPackage ../development/compilers/openjdk/openjfx/11.nix { };
+  openjfx11-packages = callPackages ../development/compilers/openjdk/openjfx/11.nix {};
+  openjfx11-modular-sdk = openjfx11-packages.modular-sdk;
+  openjfx11-sdk = openjfx11-packages.sdk;
 
-  openjfx15 = callPackage ../development/compilers/openjdk/openjfx/15.nix { };
+  openjfx16-packages = callPackages ../development/compilers/openjdk/openjfx/16.nix {};
+  openjfx16-modular-sdk = openjfx16-packages.modular-sdk;
+  openjfx16-sdk = openjfx16-packages.sdk;
+
+  openjfx-modular-sdk = openjfx11-modular-sdk;
+  openjfx-sdk = openjfx11-sdk;
 
   openjdk8-bootstrap =
     if adoptopenjdk-hotspot-bin-8.meta.available then
@@ -10807,7 +10814,7 @@ in
       callPackage ../development/compilers/openjdk/darwin/11.nix { }
     else
       callPackage ../development/compilers/openjdk/11.nix {
-        openjfx = openjfx11;
+        openjfx-modular-sdk = openjfx11-modular-sdk;
         inherit (gnome2) GConf gnome_vfs;
       };
 
@@ -10823,23 +10830,23 @@ in
     else
       /* adoptopenjdk not available for i686, so fall back to our old builds of 12, 13, & 14 for bootstrapping */
       callPackage ../development/compilers/openjdk/15.nix {
-        openjfx = openjfx11; /* need this despite next line :-( */
+        openjfx-modular-sdk = openjfx11-modular-sdk; /* need this despite next line :-( */
         enableJavaFX = false;
         headless = true;
         inherit (gnome2) GConf gnome_vfs;
         openjdk15-bootstrap = callPackage ../development/compilers/openjdk/14.nix {
-          openjfx = openjfx11; /* need this despite next line :-( */
+          openjfx-modular-sdk = openjfx11-modular-sdk; /* need this despite next line :-( */
           enableJavaFX = false;
           headless = true;
           inherit (gnome2) GConf gnome_vfs;
           openjdk14-bootstrap = callPackage ../development/compilers/openjdk/13.nix {
-            openjfx = openjfx11; /* need this despite next line :-( */
+            openjfx-modular-sdk = openjfx11-modular-sdk; /* need this despite next line :-( */
             enableJavaFX = false;
             headless = true;
             inherit (gnome2) GConf gnome_vfs;
             openjdk13-bootstrap = callPackage ../development/compilers/openjdk/12.nix {
               stdenv = gcc8Stdenv; /* build segfaults with gcc9 or newer, so use gcc8 like Debian does */
-              openjfx = openjfx11; /* need this despite next line :-( */
+              openjfx-modular-sdk = openjfx11-modular-sdk; /* need this despite next line :-( */
               enableJavaFX = false;
               headless = true;
               inherit (gnome2) GConf gnome_vfs;
@@ -10857,7 +10864,7 @@ in
       callPackage ../development/compilers/openjdk/darwin { }
     else
       callPackage ../development/compilers/openjdk/16.nix {
-        openjfx = openjfx15;
+        openjfx-modular-sdk = openjfx16-modular-sdk;
         inherit (gnome2) GConf gnome_vfs;
       };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`openjfx-sdk` consists with JAR files and .so libraries for JavaFX (OpenJFX) modules.  This can be used with `adoptopenjdk-bin`, `zulu`, and `graalvm11-ce` like this:

```
javac --module-path path/to/javafx-sdk/lib/ \
  --add-modules javafx.graphics,javafx.controls,javafx.media,javafx.web JavaSample.java

java --module-path path/to/javafx-sdk/lib/ \
  --add-modules javafx.graphics,javafx.controls,javafx.media,javafx.web JavaSample
```

Existing `openjfx`, which is used to build `openjdk`, is renamed to `openjfx-modular-sdk` for consistency.

This patch also enables `openjdk` to run JavaFX apps with `MediaPlayer`.

See also #106716.

###### How to test

To test this PR, try https://gist.github.com/taku0/2c52b0b13876fb892a69c92c81e8f019.

This opens JavaFX windows with `adoptopenjdk-bin` (11 and 15), `zulu`, `graalvm11-ce`, and `openjdk` (11 and 15).
Clicking `Hello, JavaFX!` should play a movie.
Closing windows labeled `Hello, Swing!` terminates the application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
