### PR TITLE
python3Packages.python-gammu: init at 3.1

### DIFF
--- a/pkgs/development/python-modules/python-gammu/default.nix
+++ b/pkgs/development/python-modules/python-gammu/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+  #, pytestCheckHook
+, pythonOlder
+, pkg-config
+, gammu
+}:
+
+buildPythonPackage rec {
+  pname = "python-gammu";
+  version = "3.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "gammu";
+    repo = pname;
+    rev = version;
+    sha256 = "1hw2mfrps6wqfyi40p5mp9r59n1ick6pj4hw5njz0k822pbb33p0";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gammu ];
+
+  # Check with the next release if tests could be run with pytest
+  # checkInputs = [ pytestCheckHook ];
+  # Don't run tests for now
+  doCheck = false;
+  pythonImportsCheck = [ "gammu" ];
+
+  meta = with lib; {
+    description = "Python bindings for Gammu";
+    homepage = "https://github.com/gammu/python-gammu/";
+    license = with licenses; [ gpl2Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -751,7 +751,7 @@
     "smartthings" = ps: with ps; [ aiohttp-cors hass-nabucasa ]; # missing inputs: pysmartapp pysmartthings
     "smarty" = ps: with ps; [ ]; # missing inputs: pysmarty
     "smhi" = ps: with ps; [ ]; # missing inputs: smhi-pkg
-    "sms" = ps: with ps; [ ]; # missing inputs: python-gammu
+    "sms" = ps: with ps; [ python-gammu ];
     "smtp" = ps: with ps; [ ];
     "snapcast" = ps: with ps; [ snapcast ];
     "snips" = ps: with ps; [ aiohttp-cors paho-mqtt ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6361,6 +6361,8 @@ in {
 
   python-frontmatter = callPackage ../development/python-modules/python-frontmatter { };
 
+  python-gammu = callPackage ../development/python-modules/python-gammu { };
+
   python-gitlab = callPackage ../development/python-modules/python-gitlab { };
 
   python-gnupg = callPackage ../development/python-modules/python-gnupg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python bindings for Gammu

https://github.com/gammu/python-gammu/

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
