### PR TITLE
herbstluftwm: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -1,44 +1,42 @@
-{ lib, stdenv, fetchurl, cmake, pkg-config, python3, libX11, libXext, libXinerama, libXrandr, asciidoc
+{ lib, stdenv, fetchurl, cmake, pkg-config, python3, libX11, libXext, libXinerama, libXrandr, libXft, freetype, asciidoc-full
 , xdotool, xorgserver, xsetroot, xterm, runtimeShell
 , nixosTests }:
 
-# Doc generation is disabled by default when cross compiling because asciidoc
-# dependency is broken when cross compiling for now
-
-let
-  cross = stdenv.buildPlatform != stdenv.targetPlatform;
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "herbstluftwm";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchurl {
     url = "https://herbstluftwm.org/tarballs/herbstluftwm-${version}.tar.gz";
-    sha256 = "0r4qaklv97qcq8p0pnz4f2zqg69vfai6c2qi1ydi2kz24xqjf5hy";
+    sha256 = "0avfhr68f6fjnafjdcyxcx7dkg38f2nadmhpj971qyqzfq2f6i38";
   };
 
   outputs = [
     "out"
-    "doc" # share/doc exists with examples even without generated html documentation
-  ] ++ lib.optionals (!cross) [
+    "doc"
     "man"
   ];
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_SYSCONF_PREFIX=${placeholder "out"}/etc"
-  ] ++ lib.optional cross "-DWITH_DOCUMENTATION=OFF";
+  ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    python3
-  ] ++ lib.optional (!cross) asciidoc;
+  ];
+
+  depsBuildBuild = [
+    asciidoc-full
+  ];
 
   buildInputs = [
     libX11
     libXext
     libXinerama
     libXrandr
+    libXft
+    freetype
   ];
 
   patches = [
@@ -75,6 +73,9 @@ in stdenv.mkDerivation rec {
   '';
 
   pytestFlagsArray = [ "../tests" ];
+  disabledTests = [
+    "test_title_different_letters_are_drawn"
+  ];
 
   passthru = {
     tests.herbstluftwm = nixosTests.herbstluftwm;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22800,9 +22800,7 @@ in
 
   herbe = callPackage ../applications/misc/herbe { };
 
-  herbstluftwm = callPackage ../applications/window-managers/herbstluftwm {
-    asciidoc = asciidoc-full;
-  };
+  herbstluftwm = callPackage ../applications/window-managers/herbstluftwm { };
 
   hercules = callPackage ../applications/virtualization/hercules { };
 


### PR DESCRIPTION
###### Motivation for this change

New release.

###### Things done

This release introduces window titles and now depends on freetype and libXft.

I disabled the test `test_title_different_letters_are_drawn` for now because it is broken in sandboxed build, probably because of font issue. The NixOS test passse and the screenshot contains a title. I'm using this release for a couple of days now without any issue.

I also fixed the build of the documentation when cross-compiling. It was an instance of #49526 issue + using `nativeBuildInputs` instead of `depsBuildBuild`.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
