### PR TITLE
 python3Packages.python-awair: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/development/python-modules/aws-adfs/default.nix
+++ b/pkgs/development/python-modules/aws-adfs/default.nix
@@ -1,6 +1,19 @@
-{ lib, buildPythonPackage, fetchPypi
-, pytest, pytestrunner, pytestcov, mock, glibcLocales, lxml, botocore
-, requests, requests-kerberos, click, configparser, fido2, isPy27 }:
+{ lib
+, botocore
+, buildPythonPackage
+, click
+, configparser
+, fetchPypi
+, fido2
+, glibcLocales
+, isPy27
+, lxml
+, mock
+, pyopenssl
+, pytestCheckHook
+, requests
+, requests-kerberos
+}:
 
 buildPythonPackage rec {
   pname = "aws-adfs";
@@ -12,8 +25,25 @@ buildPythonPackage rec {
     sha256 = "6a78bd31477ea9988166215ae86abcbfe1413bee20373ecdf0dd170b7290db55";
   };
 
+  propagatedBuildInputs = [
+    botocore
+    click
+    configparser
+    fido2
+    lxml
+    pyopenssl
+    requests
+    requests-kerberos
+  ];
+
+  checkInputs = [
+    glibcLocales
+    mock
+    pytestCheckHook
+  ];
+
   # Relax version constraint
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/coverage < 4/coverage/' setup.py
   '';
 
@@ -22,9 +52,6 @@ buildPythonPackage rec {
 
   # Required for python3 tests, along with glibcLocales
   LC_ALL = "en_US.UTF-8";
-
-  checkInputs = [ glibcLocales pytest pytestrunner pytestcov mock ];
-  propagatedBuildInputs = [ botocore lxml requests requests-kerberos click configparser fido2 ];
 
   pythonImportsCheck = [ "aws_adfs" ];
 

--- a/pkgs/development/python-modules/docloud/default.nix
+++ b/pkgs/development/python-modules/docloud/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , requests
+, six
 }:
 
 buildPythonPackage rec {
@@ -15,6 +16,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     requests
+    six
   ];
 
   # Pypi's tarball doesn't contain tests. Source not available.

--- a/pkgs/development/python-modules/flask-limiter/default.nix
+++ b/pkgs/development/python-modules/flask-limiter/default.nix
@@ -1,15 +1,59 @@
-{ lib, fetchPypi, buildPythonPackage, flask, limits }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flask
+, flask-restful
+, hiro
+, limits
+, mock
+, ordereddict
+, pymemcache
+, pytestCheckHook
+, redis
+}:
 
 buildPythonPackage rec {
   pname = "Flask-Limiter";
   version = "1.4";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "021279c905a1e24f181377ab3be711be7541734b494f4e6db2b8edeba7601e48";
+  src = fetchFromGitHub {
+    owner = "alisaifee";
+    repo = "flask-limiter";
+    rev = version;
+    sha256 = "1k1b4b3s1acphqnar0y5g747bh1y7w35gcl5g819idq2a5vqnass";
   };
 
   propagatedBuildInputs = [ flask limits ];
+
+  checkInputs = [
+    pytestCheckHook
+    hiro
+    mock
+    redis
+    flask-restful
+    pymemcache
+    ordereddict
+  ];
+
+  postPatch = ''
+    sed -i "/--cov/d" pytest.ini
+  '';
+
+  # Some tests requires a local Redis instance
+  disabledTests = [
+    "test_fallback_to_memory"
+    "test_reset_unsupported"
+    "test_constructor_arguments_over_config"
+    "test_fallback_to_memory_config"
+    "test_fallback_to_memory_backoff_check"
+    "test_fallback_to_memory_with_global_override"
+    "test_custom_key_prefix"
+    "test_redis_request_slower_than_fixed_window"
+    "test_redis_request_slower_than_moving_window"
+    "test_custom_key_prefix_with_headers"
+  ];
+
+  pythonImportsCheck = [ "flask_limiter" ];
 
   meta = with lib; {
     description = "Rate limiting for flask applications";

--- a/pkgs/development/python-modules/gradient/default.nix
+++ b/pkgs/development/python-modules/gradient/default.nix
@@ -1,8 +1,23 @@
-{ lib, fetchPypi, buildPythonPackage
-, attrs, boto3, requests, gradient_statsd, terminaltables
-, click-completion , click-didyoumean, click-help-colors
-, colorama, requests_toolbelt, gradient-utils, halo, progressbar2
-, marshmallow, pyyaml, websocket_client
+{ lib
+, attrs
+, boto3
+, buildPythonPackage
+, click-completion
+, click-didyoumean
+, click-help-colors
+, colorama
+, fetchPypi
+, gradient_statsd
+, gradient-utils
+, halo
+, marshmallow
+, progressbar2
+, pyopenssl
+, pyyaml
+, requests
+, requests_toolbelt
+, terminaltables
+, websocket_client
 }:
 
 buildPythonPackage rec {
@@ -21,11 +36,26 @@ buildPythonPackage rec {
       --replace 'PyYAML==' 'PyYAML>=' \
       --replace 'marshmallow<' 'marshmallow>=' \
       --replace 'websocket-client==' 'websocket-client>='
-   '';
+  '';
 
-  propagatedBuildInputs = [ attrs boto3 requests gradient_statsd terminaltables
-    click-completion click-didyoumean click-help-colors requests_toolbelt
-    colorama gradient-utils halo marshmallow progressbar2 pyyaml websocket_client
+  propagatedBuildInputs = [
+    attrs
+    boto3
+    click-completion
+    click-didyoumean
+    click-help-colors
+    colorama
+    gradient_statsd
+    gradient-utils
+    halo
+    marshmallow
+    progressbar2
+    pyopenssl
+    pyyaml
+    requests
+    requests_toolbelt
+    terminaltables
+    websocket_client
   ];
 
   # tries to use /homeless-shelter to mimic container usage, etc
@@ -33,9 +63,9 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "The command line interface for Gradient";
-    homepage    = "https://github.com/Paperspace/gradient-cli";
-    license     = licenses.isc;
-    platforms   = platforms.unix;
+    homepage = "https://github.com/Paperspace/gradient-cli";
+    license = licenses.isc;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/development/python-modules/ntlm-auth/default.nix
+++ b/pkgs/development/python-modules/ntlm-auth/default.nix
@@ -1,10 +1,10 @@
 { lib
 , buildPythonPackage
+, cryptography
 , fetchFromGitHub
 , mock
-, pytest
+, pytestCheckHook
 , requests
-, unittest2
 , six
 }:
 
@@ -19,13 +19,18 @@ buildPythonPackage rec {
     sha256 = "00dpf5bfsy07frsjihv1k10zmwcyq4bvkilbxha7h6nlwpcm2409";
   };
 
-  checkInputs = [ mock pytest requests unittest2 ];
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [
+    cryptography
+    six
+  ];
 
-  # Functional tests require networking
-  checkPhase = ''
-    py.test --ignore=tests/functional/test_iis.py
-  '';
+  checkInputs = [
+    mock
+    pytestCheckHook
+    requests
+  ];
+
+  pythonImportsCheck = [ "ntlm_auth" ];
 
   meta = with lib; {
     description = "Calculates NTLM Authentication codes";

--- a/pkgs/development/python-modules/pymemcache/default.nix
+++ b/pkgs/development/python-modules/pymemcache/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, future
+, mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pymemcache";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "pinterest";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xkw76y4059jg2a902wlpk6psyh2g4x6j6vlj9gzd5vqb7ihg2y7";
+  };
+
+  checkInputs = [
+    future
+    mock
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    sed -i "/--cov/d" setup.cfg
+  '';
+
+  disabledTests = [
+    # python-memcached is not available (last release in 2017)
+    "TestClientSocketConnect"
+  ];
+
+  pythonImportsCheck = [ "pymemcache" ];
+
+  meta = with lib; {
+    description = "Python memcached client";
+    homepage = "https://pymemcache.readthedocs.io/";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/python-awair/default.nix
+++ b/pkgs/development/python-modules/python-awair/default.nix
@@ -2,7 +2,7 @@
 , aiohttp
 , buildPythonPackage
 , fetchFromGitHub
-, poetry
+, poetry-core
 , pytest-aiohttp
 , pytestCheckHook
 , pythonOlder
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "python-awair";
-  version = "0.2.1";
+  version = "0.2.2";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
@@ -20,10 +20,10 @@ buildPythonPackage rec {
     owner = "ahayworth";
     repo = "python_awair";
     rev = version;
-    sha256 = "1fqjigc1a0lr9q6bjjq3j8pa39wg1cbkb0l67w94a0i4dkdfri8r";
+    sha256 = "sha256-5+s1aSvt+rXyumvf/qZ58Uvmq0p45mu23Djbwgih3qI=";
   };
 
-  nativeBuildInputs = [ poetry ];
+  nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [
     aiohttp

--- a/pkgs/development/python-modules/requests-kerberos/default.nix
+++ b/pkgs/development/python-modules/requests-kerberos/default.nix
@@ -1,4 +1,12 @@
-{ lib, fetchFromGitHub, buildPythonPackage, requests, pykerberos, mock }:
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, cryptography
+, requests
+, pykerberos
+, pytestCheckHook
+, mock
+}:
 
 buildPythonPackage rec {
   pname = "requests-kerberos";
@@ -12,16 +20,26 @@ buildPythonPackage rec {
     sha256 = "1qw96aw84nljh9cip372mfv50p1yyirfgigavvavgpc3c5g278s6";
   };
 
-  checkInputs = [ mock ];
-  propagatedBuildInputs = [ requests pykerberos ];
+  propagatedBuildInputs = [
+    cryptography
+    requests
+    pykerberos
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
 
   # they have a setup.py which mentions a test suite that doesn't exist...
   patches = [ ./fix_setup.patch ];
 
+  pythonImportsCheck = [ "requests_kerberos" ];
+
   meta = with lib; {
-    description = "An authentication handler for using Kerberos with Python Requests.";
-    homepage    = "https://github.com/requests/requests-kerberos";
-    license     = licenses.isc;
+    description = "An authentication handler for using Kerberos with Python Requests";
+    homepage = "https://github.com/requests/requests-kerberos";
+    license = licenses.isc;
     maintainers = with maintainers; [ catern ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5956,6 +5956,8 @@ in {
 
   pymeeus = callPackage ../development/python-modules/pymeeus { };
 
+  pymemcache = callPackage ../development/python-modules/pymemcache { };
+
   pymemoize = callPackage ../development/python-modules/pymemoize { };
 
   pyment = callPackage ../development/python-modules/pyment { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.2.2

Enable tests of `Flask-Limiter` that is required by `vcrpy` and pulled-in for the tests of `python-awair`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
