### PR TITLE
python3Packages.watchdog: fix flaky test on macOS

### DIFF
--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , argh
 , pathtools
 , pyyaml
@@ -11,12 +12,20 @@
 
 buildPythonPackage rec {
   pname = "watchdog";
-  version = "2.0.0";
+  version = "2.0.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-/UtWz74NDZxPxDGs7KdXAKfxLTc33C6csuwrpkloBCU=";
+    sha256 = "sha256-Uy/t2ZPnVVRnH6o2zQTFgM7T+uCEJUp3mvu9iq8AVms=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Fix test flakiness on Apple Silicon, remove after upgrade to 2.0.6.
+      url = "https://github.com/gorakhargosh/watchdog/commit/331fd7c2c819663be39bc146e78ce67553f265fa.patch";
+      sha256 = "sha256-pLkZmbPN3qRNHs53OP0HIyDxqYCPPo6yOcBLD3aO2YE=";
+    })
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin
     [ pkgs.darwin.apple_sdk.frameworks.CoreServices ];


### PR DESCRIPTION
###### Motivation for this change

This makes builds more reliable on Apple Silicon (#105026).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).