### PR TITLE
erlang: 23.1.4 -> 23.2.6, 22.3 -> 22.3.4.16, 21.3.8.3 -> 21.3.8.21

### DIFF
--- a/pkgs/development/interpreters/erlang/R21.nix
+++ b/pkgs/development/interpreters/erlang/R21.nix
@@ -1,8 +1,8 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "21.3.8.3";
-  sha256 = "1szybirrcpqsl2nmlmpbkxjqnm6i7l7bma87m5cpwi0kpvlxwmcw";
+  version = "21.3.8.21";
+  sha256 = "sha256-zQCs2hOA66jxAaxl/B42EKCejAktIav2rpVQCNyKCh4=";
 
   prePatch = ''
     substituteInPlace configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"

--- a/pkgs/development/interpreters/erlang/R21.nix
+++ b/pkgs/development/interpreters/erlang/R21.nix
@@ -3,8 +3,4 @@
 mkDerivation {
   version = "21.3.8.21";
   sha256 = "sha256-zQCs2hOA66jxAaxl/B42EKCejAktIav2rpVQCNyKCh4=";
-
-  prePatch = ''
-    substituteInPlace configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"
-  '';
 }

--- a/pkgs/development/interpreters/erlang/R22.nix
+++ b/pkgs/development/interpreters/erlang/R22.nix
@@ -3,8 +3,8 @@
 # How to obtain `sha256`:
 # nix-prefetch-url --unpack https://github.com/erlang/otp/archive/OTP-${version}.tar.gz
 mkDerivation {
-  version = "22.3";
-  sha256 = "0srbyncgnr1kp0rrviq14ia3h795b3gk0iws5ishv6rphcq1rs27";
+  version = "22.3.4.16";
+  sha256 = "sha256-V0RwEPfjnHtEzShNh6Q49yGC5fbt2mNR4xy6f6iWvck=";
 
   prePatch = ''
     substituteInPlace make/configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"

--- a/pkgs/development/interpreters/erlang/R22.nix
+++ b/pkgs/development/interpreters/erlang/R22.nix
@@ -5,9 +5,4 @@
 mkDerivation {
   version = "22.3.4.16";
   sha256 = "sha256-V0RwEPfjnHtEzShNh6Q49yGC5fbt2mNR4xy6f6iWvck=";
-
-  prePatch = ''
-    substituteInPlace make/configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"
-    substituteInPlace erts/configure.in --replace '-Wl,-no_weak_imports' ""
-  '';
 }

--- a/pkgs/development/interpreters/erlang/R23.nix
+++ b/pkgs/development/interpreters/erlang/R23.nix
@@ -3,8 +3,8 @@
 # How to obtain `sha256`:
 # nix-prefetch-url --unpack https://github.com/erlang/otp/archive/OTP-${version}.tar.gz
 mkDerivation {
-  version = "23.1.4";
-  sha256 = "16ssxmrgjgvzg06aa1l4wz9rrdjfy39k22amgabxwb5if1g8bg8z";
+  version = "23.2.6";
+  sha256 = "sha256-G930sNbr8h5ryI/IE+J6OKhR5ij68ZhGo1YIEjSOwGU=";
 
   prePatch = ''
     substituteInPlace make/configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"

--- a/pkgs/development/interpreters/erlang/R23.nix
+++ b/pkgs/development/interpreters/erlang/R23.nix
@@ -5,9 +5,4 @@
 mkDerivation {
   version = "23.2.6";
   sha256 = "sha256-G930sNbr8h5ryI/IE+J6OKhR5ij68ZhGo1YIEjSOwGU=";
-
-  prePatch = ''
-    substituteInPlace make/configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"
-    substituteInPlace erts/configure.in --replace '-Wl,-no_weak_imports' ""
-  '';
 }

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -64,13 +64,6 @@ in stdenv.mkDerivation ({
   # On some machines, parallel build reliably crashes on `GEN    asn1ct_eval_ext.erl` step
   enableParallelBuilding = parallelBuild;
 
-  # Clang 4 (rightfully) thinks signed comparisons of pointers with NULL are nonsense
-  prePatch = ''
-    substituteInPlace lib/wx/c_src/wxe_impl.cpp --replace 'temp > NULL' 'temp != NULL'
-
-    ${prePatch}
-  '';
-
   postPatch = ''
     patchShebangs make
 
@@ -132,6 +125,7 @@ in stdenv.mkDerivation ({
 // optionalAttrs (preUnpack != "")      { inherit preUnpack; }
 // optionalAttrs (postUnpack != "")     { inherit postUnpack; }
 // optionalAttrs (patches != [])        { inherit patches; }
+// optionalAttrs (prePatch != "")       { inherit prePatch; }
 // optionalAttrs (patchPhase != "")     { inherit patchPhase; }
 // optionalAttrs (configurePhase != "") { inherit configurePhase; }
 // optionalAttrs (preConfigure != "")   { inherit preConfigure; }

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -57,7 +57,7 @@ in stdenv.mkDerivation ({
     ++ optionals odbcSupport odbcPackages
     ++ optionals javacSupport javacPackages
     ++ optional withSystemd systemd
-    ++ optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ AGL Carbon Cocoa ]);
+    ++ optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ AGL Carbon Cocoa WebKit ]);
 
   debugInfo = enableDebugInfo;
 

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -57,7 +57,7 @@ in stdenv.mkDerivation ({
     ++ optionals odbcSupport odbcPackages
     ++ optionals javacSupport javacPackages
     ++ optional withSystemd systemd
-    ++ optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ Carbon Cocoa ]);
+    ++ optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ AGL Carbon Cocoa ]);
 
   debugInfo = enableDebugInfo;
 


### PR DESCRIPTION
###### Motivation for this change

Bumping versions to enable `aarch64-darwin` support in #105026.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).