### PR TITLE
python3Packages.pandas: fix scipy coo_matrix test

### DIFF
--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -34,6 +34,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "06vhk75hmzgv1sfbjzgnsw9x10h7y6bd6s6z7d6lfnn7wcgc83zi";
   };
+  # See https://github.com/scipy/scipy/issues/13585 and https://github.com/pandas-dev/pandas/pull/40020
+  patches = [ ./fix-tests.patch ];
 
   nativeBuildInputs = [ cython ];
   buildInputs = lib.optional stdenv.isDarwin libcxx;
@@ -58,16 +60,6 @@ buildPythonPackage rec {
   # doesn't work with -Werror,-Wunused-command-line-argument
   # https://github.com/NixOS/nixpkgs/issues/39687
   hardeningDisable = lib.optional stdenv.cc.isClang "strictoverflow";
-
-  # For OSX, we need to add a dependency on libcxx, which provides
-  # `complex.h` and other libraries that pandas depends on to build.
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    cpp_sdk="${libcxx}/include/c++/v1";
-    echo "Adding $cpp_sdk to the setup.py common_include variable"
-    substituteInPlace setup.py \
-      --replace "['pandas/src/klib', 'pandas/src']" \
-                "['pandas/src/klib', 'pandas/src', '$cpp_sdk']"
-  '';
 
   # Parallel Cythonization is broken in Python 3.8 on Darwin. Fixed in the next
   # release. https://github.com/pandas-dev/pandas/pull/30862

--- a/pkgs/development/python-modules/pandas/fix-tests.patch
+++ b/pkgs/development/python-modules/pandas/fix-tests.patch
@@ -1,0 +1,12 @@
+diff --color -ur a/pandas/tests/arrays/sparse/test_array.py b/pandas/tests/arrays/sparse/test_array.py
+--- a/pandas/tests/arrays/sparse/test_array.py	2020-12-07 12:42:08.000000000 +0100
++++ b/pandas/tests/arrays/sparse/test_array.py	2021-02-27 21:48:16.483903149 +0100
+@@ -1188,7 +1188,7 @@
+         row = [0, 3, 1, 0]
+         col = [0, 3, 1, 2]
+         data = [4, 5, 7, 9]
+-        sp_array = scipy.sparse.coo_matrix((data, (row, col)))
++        sp_array = scipy.sparse.coo_matrix((data, (row, col)), dtype="int")
+         result = pd.Series.sparse.from_coo(sp_array)
+ 
+         index = pd.MultiIndex.from_arrays([[0, 0, 1, 3], [0, 2, 1, 3]])


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/114502

###### Things done
Adapted the patch from https://github.com/pandas-dev/pandas/pull/40020 to panda 1.1.5.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
