### PR TITLE
php: various fixes

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -22,7 +22,9 @@ let
 
   php = cfg.phpPackage.override { apacheHttpd = pkg; };
 
-  phpMajorVersion = lib.versions.major (lib.getVersion php);
+  phpModuleName = let
+    majorVersion = lib.versions.major (lib.getVersion php);
+  in (if majorVersion == "8" then "php" else "php${majorVersion}");
 
   mod_perl = pkgs.apacheHttpdPackages.mod_perl.override { apacheHttpd = pkg; };
 
@@ -63,7 +65,7 @@ let
     ++ optional enableSSL "ssl"
     ++ optional enableUserDir "userdir"
     ++ optional cfg.enableMellon { name = "auth_mellon"; path = "${pkgs.apacheHttpdPackages.mod_auth_mellon}/modules/mod_auth_mellon.so"; }
-    ++ optional cfg.enablePHP { name = "php${phpMajorVersion}"; path = "${php}/modules/libphp${phpMajorVersion}.so"; }
+    ++ optional cfg.enablePHP { name = phpModuleName; path = "${php}/modules/lib${phpModuleName}.so"; }
     ++ optional cfg.enablePerl { name = "perl"; path = "${mod_perl}/modules/mod_perl.so"; }
     ++ cfg.extraModules;
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -307,6 +307,9 @@ in
   pgjwt = handleTest ./pgjwt.nix {};
   pgmanage = handleTest ./pgmanage.nix {};
   php = handleTest ./php {};
+  php73 = handleTest ./php { php = pkgs.php73; };
+  php74 = handleTest ./php { php = pkgs.php74; };
+  php80 = handleTest ./php { php = pkgs.php80; };
   pinnwand = handleTest ./pinnwand.nix {};
   plasma5 = handleTest ./plasma5.nix {};
   pleroma = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./pleroma.nix {};

--- a/nixos/tests/php/default.nix
+++ b/nixos/tests/php/default.nix
@@ -1,8 +1,9 @@
-{ system ? builtins.currentSystem,
-  config ? {},
-  pkgs ? import ../../.. { inherit system config; }
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? import ../../.. { inherit system config; }
+, php ? pkgs.php
 }: {
-  fpm = import ./fpm.nix { inherit system pkgs; };
-  httpd = import ./httpd.nix { inherit system pkgs; };
-  pcre = import ./pcre.nix { inherit system pkgs; };
+  fpm = import ./fpm.nix { inherit system pkgs php; };
+  httpd = import ./httpd.nix { inherit system pkgs php; };
+  pcre = import ./pcre.nix { inherit system pkgs php; };
 }

--- a/nixos/tests/php/fpm.nix
+++ b/nixos/tests/php/fpm.nix
@@ -1,5 +1,5 @@
-import ../make-test-python.nix ({pkgs, lib, ...}: {
-  name = "php-fpm-nginx-test";
+import ../make-test-python.nix ({pkgs, lib, php, ...}: {
+  name = "php-${php.version}-fpm-nginx-test";
   meta.maintainers = lib.teams.php.members;
 
   machine = { config, lib, pkgs, ... }: {
@@ -25,6 +25,7 @@ import ../make-test-python.nix ({pkgs, lib, ...}: {
 
     services.phpfpm.pools."foobar" = {
       user = "nginx";
+      phpPackage = php;
       settings = {
         "listen.group" = "nginx";
         "listen.mode" = "0600";
@@ -44,7 +45,7 @@ import ../make-test-python.nix ({pkgs, lib, ...}: {
 
     # Check so we get an evaluated PHP back
     response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/")
-    assert "PHP Version ${pkgs.php.version}" in response, "PHP version not detected"
+    assert "PHP Version ${php.version}" in response, "PHP version not detected"
 
     # Check so we have database and some other extensions loaded
     for ext in ["json", "opcache", "pdo_mysql", "pdo_pgsql", "pdo_sqlite"]:

--- a/nixos/tests/php/httpd.nix
+++ b/nixos/tests/php/httpd.nix
@@ -1,5 +1,5 @@
-import ../make-test-python.nix ({pkgs, lib, ...}: {
-  name = "php-httpd-test";
+import ../make-test-python.nix ({pkgs, lib, php, ...}: {
+  name = "php-${php.version}-httpd-test";
   meta.maintainers = lib.teams.php.members;
 
   machine = { config, lib, pkgs, ... }: {
@@ -14,6 +14,7 @@ import ../make-test-python.nix ({pkgs, lib, ...}: {
           index = "index.php index.html";
         };
       };
+      phpPackage = php;
       enablePHP = true;
     };
   };
@@ -22,7 +23,7 @@ import ../make-test-python.nix ({pkgs, lib, ...}: {
 
     # Check so we get an evaluated PHP back
     response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/")
-    assert "PHP Version ${pkgs.php.version}" in response, "PHP version not detected"
+    assert "PHP Version ${php.version}" in response, "PHP version not detected"
 
     # Check so we have database and some other extensions loaded
     for ext in ["json", "opcache", "pdo_mysql", "pdo_pgsql", "pdo_sqlite"]:

--- a/nixos/tests/php/pcre.nix
+++ b/nixos/tests/php/pcre.nix
@@ -1,7 +1,7 @@
 let
   testString = "can-use-subgroups";
-in import ../make-test-python.nix ({lib, ...}: {
-  name = "php-httpd-pcre-jit-test";
+in import ../make-test-python.nix ({lib, php, ...}: {
+  name = "php-${php.version}-httpd-pcre-jit-test";
   meta.maintainers = lib.teams.php.members;
 
   machine = { lib, pkgs, ... }: {
@@ -9,6 +9,7 @@ in import ../make-test-python.nix ({lib, ...}: {
     services.httpd = {
       enable = true;
       adminAddr = "please@dont.contact";
+      phpPackage = php;
       enablePHP = true;
       phpOptions = "pcre.jit = true";
       extraConfig = let

--- a/pkgs/build-support/build-pecl.nix
+++ b/pkgs/build-support/build-pecl.nix
@@ -16,10 +16,10 @@
 }@args:
 
 stdenv.mkDerivation (args // {
-  name = "php-${pname}-${version}";
+  pname = "php-${php.version}-${pname}";
   extensionName = pname;
 
-  inherit src;
+  inherit version src;
 
   nativeBuildInputs = [ autoreconfHook re2c ] ++ nativeBuildInputs;
   buildInputs = [ php ] ++ peclDeps ++ buildInputs;

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -112,7 +112,8 @@ let
                   withExtensions = mkWithExtensions allArgs allExtensionFunctions;
                   phpIni = "${phpWithExtensions}/lib/php.ini";
                   unwrapped = php;
-                  tests = nixosTests.php;
+                  # Select the right php tests for the php version
+                  tests = nixosTests."php${lib.strings.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor php.version)}";
                   inherit (php-packages) extensions buildPecl;
                   packages = php-packages.tools;
                   meta = php.meta // {

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -5,7 +5,7 @@
 
 let
   generic =
-    { callPackage, lib, stdenv, nixosTests, config, fetchurl, makeWrapper
+    { callPackage, lib, stdenv, nixosTests, fetchurl, makeWrapper
     , symlinkJoin, writeText, autoconf, automake, bison, flex, libtool
     , pkg-config, re2c, apacheHttpd, libargon2, libxml2, pcre, pcre2
     , systemd, system-sendmail, valgrind, xcbuild
@@ -97,7 +97,7 @@ let
                     (enabledExtensions ++ (getDepsRecursively enabledExtensions)));
 
               extNames = map getExtName enabledExtensions;
-              extraInit = writeText "php.ini" ''
+              extraInit = writeText "php-extra-init-${version}.ini" ''
                 ${lib.concatStringsSep "\n"
                   (lib.textClosureList extensionTexts extNames)}
                 ${extraConfig}
@@ -121,7 +121,7 @@ let
                 };
                 paths = [ php ];
                 postBuild = ''
-                  cp ${extraInit} $out/lib/php.ini
+                  ln -s ${extraInit} $out/lib/php.ini
 
                   wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11380,9 +11380,10 @@ in
   #
   # Set default PHP interpreter, extensions and packages
   php = php74;
-  phpExtensions = php74Extensions;
-  phpPackages = php74Packages;
+  phpExtensions = php.extensions;
+  phpPackages = php.packages;
 
+  # Import PHP80 interpreter, extensions and packages
   php80 = callPackage ../development/interpreters/php/8.0.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -16,7 +16,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   # Wrap mkDerivation to prepend pname with "php-" to make names consistent
   # with how buildPecl does it and make the file easier to overview.
   mkDerivation = { pname, ... }@args: pkgs.stdenv.mkDerivation (args // {
-    pname = "php-${pname}";
+    pname = "php-${php.version}-${pname}";
   });
 
   pcre' = if (lib.versionAtLeast php.version "7.3") then pcre2 else pcre;


### PR DESCRIPTION
###### Motivation for this change
 - Changes some `pname`'s, shouldn't break anything, just making things more descriptive by including the php version number as well in the pname to make it easy to identify which version of php said package or extension is built for.
 - Adds a missing comment to all-packages list and reduce the version hardcoding in all-packages list
 - Rename the extra init file and include version in it as well, then symlink it instead of copying it.
 - Declare php versions in all tests to make it possible to override the php version used in the tests
 - Declare the tests separately for each PHP version
 - Include the tests for the right PHP version in the `php.tests` attribute to run the tests for each version of php
 - Fix usage of `php80` with apache httpd because it simply didn't work due to naming and method naming change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
