### PR TITLE
mons: rewrite xrandr path

### DIFF
--- a/pkgs/tools/misc/mons/default.nix
+++ b/pkgs/tools/misc/mons/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     description = "POSIX Shell script to quickly manage 2-monitors display";
     homepage = "https://github.com/Ventto/mons.git";
     license = licenses.mit;
-    maintainers = [ maintainers.mschneider ];
+    maintainers = with maintainers; [ mschneider thiagokokada ];
   };
 }

--- a/pkgs/tools/misc/mons/default.nix
+++ b/pkgs/tools/misc/mons/default.nix
@@ -12,6 +12,16 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Substitute xrandr path with @xrandr@ so we can replace it with
+    # real path in substituteInPlace
+    ./xrandr.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace mons.sh --replace '@xrandr@' '${xrandr}/bin/xrandr'
+  '';
+
   nativeBuildInputs = [ help2man ];
   makeFlags = [
     "DESTDIR=$(out)"

--- a/pkgs/tools/misc/mons/xrandr.patch
+++ b/pkgs/tools/misc/mons/xrandr.patch
@@ -1,0 +1,14 @@
+diff --git a/mons.sh b/mons.sh
+index b86ce5c..feb0f33 100755
+--- a/mons.sh
++++ b/mons.sh
+@@ -151,8 +151,7 @@ main() {
+     # =============================
+ 
+     [ -z "$DISPLAY" ]  && { echo 'DISPLAY: no variable set.';  exit 1; }
+-    command -vp xrandr >/dev/null 2>&1 || { echo 'xrandr: command not found.'; exit 1; }
+-    XRANDR="$(command -pv xrandr)"
++    XRANDR="@xrandr@"
+ 
+     # =============================
+     #      Argument Checking


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`mons` tries to detect if `xrandr` is installed in the `PATH`, failing otherwise. However, this is not the way that packages are generally packaged in nixpkgs.

This commit changes it to hardcode the path of `xrandr` explicitly instead of depending of `xrandr` being declared in `PATH`.

Also adding myself as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
