### PR TITLE
xorg.xorgproto: 2020.1 -> 2021.3

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2679,11 +2679,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xorgproto = callPackage ({ stdenv, pkg-config, fetchurl, libXt }: stdenv.mkDerivation {
-    name = "xorgproto-2020.1";
+    name = "xorgproto-2021.3";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/proto/xorgproto-2020.1.tar.bz2";
-      sha256 = "1llrnrkq6iprgiqakmwlv89745s9h02xsiaq0xn3fnh377qm78al";
+      url = "mirror://xorg/individual/proto/xorgproto-2021.3.tar.bz2";
+      sha256 = "0dypp7cvjf0rvwa7cn1zp7djw5ynhs1rwk9p0r1vczbwzha2nwsc";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -211,7 +211,7 @@ mirror://xorg/individual/lib/libXxf86misc-1.0.4.tar.bz2
 mirror://xorg/individual/lib/libXxf86vm-1.1.4.tar.bz2
 mirror://xorg/individual/lib/xtrans-1.4.0.tar.bz2
 mirror://xorg/individual/proto/xcb-proto-1.14.1.tar.xz
-mirror://xorg/individual/proto/xorgproto-2020.1.tar.bz2
+mirror://xorg/individual/proto/xorgproto-2021.3.tar.bz2
 mirror://xorg/individual/util/gccmakedep-1.0.3.tar.bz2
 mirror://xorg/individual/util/imake-1.0.8.tar.bz2
 mirror://xorg/individual/util/lndir-1.0.3.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-February/003072.html
https://lists.x.org/archives/xorg-announce/2021-February/003073.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).