### PR TITLE
nix: fix "common.sh: line 94: unshare: command not found"

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -40,7 +40,7 @@ common =
       outputs = [ "out" "dev" "man" "doc" ];
 
       nativeBuildInputs =
-        [ pkg-config utillinux ]
+        [ pkg-config util-linux ]
         ++ lib.optionals is24
           [ autoreconfHook
             autoconf-archive

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -10,7 +10,7 @@ let
 
 common =
   { lib, stdenv, perl, curl, bzip2, sqlite, openssl ? null, xz
-  , bash, coreutils, gzip, gnutar
+  , bash, coreutils, utillinux, gzip, gnutar
   , pkg-config, boehmgc, perlPackages, libsodium, brotli, boost, editline, nlohmann_json
   , autoreconfHook, autoconf-archive, bison, flex
   , jq, libarchive
@@ -40,7 +40,7 @@ common =
       outputs = [ "out" "dev" "man" "doc" ];
 
       nativeBuildInputs =
-        [ pkg-config ]
+        [ pkg-config utillinux ]
         ++ lib.optionals is24
           [ autoreconfHook
             autoconf-archive

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -10,7 +10,7 @@ let
 
 common =
   { lib, stdenv, perl, curl, bzip2, sqlite, openssl ? null, xz
-  , bash, coreutils, utillinux, gzip, gnutar
+  , bash, coreutils, util-linux, gzip, gnutar
   , pkg-config, boehmgc, perlPackages, libsodium, brotli, boost, editline, nlohmann_json
   , autoreconfHook, autoconf-archive, bison, flex
   , jq, libarchive


### PR DESCRIPTION
See
https://github.com/NixOS/nixpkgs/pull/111871#issuecomment-773351871
https://github.com/NixOS/nixpkgs/pull/95742#issuecomment-675472428
https://github.com/NixOS/nixpkgs/issues/56106#issuecomment-492375471