### PR TITLE
python3Packages.grpcio: remove cctools from build inputs

### DIFF
--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , buildPythonPackage
-, darwin
 , grpc
 , six
 , protobuf
@@ -20,8 +19,7 @@ buildPythonPackage rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ cython pkg-config ]
-    ++ lib.optional stdenv.isDarwin darwin.cctools;
+  nativeBuildInputs = [ cython pkg-config ];
 
   buildInputs = [ c-ares openssl zlib ];
   propagatedBuildInputs = [ six protobuf ]


### PR DESCRIPTION
###### Motivation for this change

This fixes `aarch64-darwin` build in #105026. Without this the `strip` in `PATH` is the one from `darwin.cctools`, which doesn't preserve code signatures, resulting in code that cannot run and pass `pythonImportsCheckPhase`.

The dependency on cctools was introduced in #44902 in 2018, but it doesn't seem to be necessary on `x86_64-darwin` today.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64 and x86_64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).