### PR TITLE
nix-direnv: fix NIX_BIN_PREFIX substitution in built direnvrc

### DIFF
--- a/pkgs/tools/misc/nix-direnv/default.nix
+++ b/pkgs/tools/misc/nix-direnv/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, gnugrep, nix }:
+{ lib, stdenv, fetchFromGitHub, gnugrep, nix, nixFlakes }:
 
 stdenv.mkDerivation rec {
   pname = "nix-direnv";
@@ -14,9 +14,8 @@ stdenv.mkDerivation rec {
   # Substitute instead of wrapping because the resulting file is
   # getting sourced, not executed:
   postPatch = ''
-    substituteInPlace direnvrc \
-      --replace "\''${NIX_BIN_PREFIX:-}" "\''${NIX_BIN_PREFIX:-${nix}/bin/}" \
-      --replace "grep" "${gnugrep}/bin/grep"
+    sed -i "1a NIX_BIN_PREFIX=${nixFlakes}/bin/" direnvrc
+    substituteInPlace direnvrc --replace "grep" "${gnugrep}/bin/grep"
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

* Reason: statically set `${NIX_BIN_PREFIX}` within generated `direnvrc`.
* Before it only replaced the `-z ${NIX_BIN_PREFIX:-}` check
  which therefore never was `true`. So, also `NIX_BIN_PREFIX` never got
  set such that its usage later always failed execution with
  `NIX_BIN_PREFIX: unbound variable`. With the fix, the line containing
  the check will no long be replaced.
* Solves https://github.com/nix-community/nix-direnv/issues/70

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on `nix-darwin`
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
