### PR TITLE
libxcrypt: init at 4.4.18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2417,6 +2417,16 @@
     githubId = 6806011;
     name = "Robert Schütz";
   };
+  dottedmag = {
+    email = "dottedmag@dottedmag.net";
+    github = "dottedmag";
+    githubId = 16120;
+    name = "Misha Gusarov";
+    keys = [{
+      longkeyid = "rsa4096/0x9D20F6503E338888";
+      fingerprint = "A8DF 1326 9E5D 9A38 E57C  FAC2 9D20 F650 3E33 8888";
+    }];
+  };
   doublec = {
     email = "chris.double@double.co.nz";
     github = "doublec";

--- a/pkgs/development/libraries/libxcrypt/default.nix
+++ b/pkgs/development/libraries/libxcrypt/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, pkg-config, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "libxcrypt";
+  version = "4.4.18";
+
+  src = fetchFromGitHub {
+    owner = "besser82";
+    repo = "libxcrypt";
+    rev = "v${version}";
+    sha256 = "4015bf1b3a2aab31da5a544424be36c1a0f0ffc1eaa219c0e7b048e4cdcbbfe1";
+  };
+
+  preConfigure = ''
+    patchShebangs autogen.sh
+    ./autogen.sh
+  '';
+
+  nativeBuildInputs = [ autoconf automake libtool pkg-config perl ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Extended crypt library for descrypt, md5crypt, bcrypt, and others";
+    homepage = "https://github.com/besser82/libxcrypt/";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ dottedmag ];
+    license = licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15778,6 +15778,8 @@ in
 
   libx86 = callPackage ../development/libraries/libx86 {};
 
+  libxcrypt = callPackage ../development/libraries/libxcrypt { };
+
   libxdg_basedir = callPackage ../development/libraries/libxdg-basedir { };
 
   libxkbcommon = libxkbcommon_8;


### PR DESCRIPTION
Closes #114632

###### Motivation for this change

A first step towards using `libxcrypt` as the implementation of `crypt(3)` and related functions on NixOS.

Full plan is at https://github.com/NixOS/nixpkgs/issues/112371

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
