### PR TITLE
wine{Unstable,Staging}: 6.2 -> 6.3

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,9 +44,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.2";
+    version = "6.3";
     url = "https://dl.winehq.org/wine/source/6.x/wine-${version}.tar.xz";
-    sha256 = "sha256-tmCWCaOrzGrZJ83WXHQL4BFiuAFSPg97qf1mkYALvxk=";
+    sha256 = "sha256-aCp3wf0S9WNHyiCA2F/hfe8bZV0yQdlFgvh1kdnQzDs=";
     inherit (stable) mono gecko32 gecko64;
 
     patches = [
@@ -58,7 +58,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-swhd5gTIWTz8eEk6f78iXG8bmA3y4ynO0/wBm0/Kimk=";
+    sha256 = "sha256-Fok0jdGBQtH84PL6LVnuCR7ZVSUIHECqPUI/2lLXs44=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

`nixpkgs-review` is always a bit unstable for me, but I built staging and unstable and used staging to run my usual Windows applications - no problems there.

```
$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev wine-6.3"
[...]
11 packages updated:
lutris lutris lutris-original pipelight winePackages.unstable (6.2 → 6.3) wineUnstable (6.2 → 6.3) winePackages.staging (6.2-staging → 6.3-staging) wineStaging (6.2-staging → 6.3-staging) wine-staging (6.2-staging → 6.3-staging) wineWowPackages.unstable (6.2 → 6.3) wineWowPackages.staging (6.2-staging → 6.3-staging)
[...]
9 packages built:
lutris lutris-free lutris-unwrapped pipelight wineStaging winePackages.staging wineUnstable wineWowPackages.staging wineWowPackages.unstable
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
