### PR TITLE
perlPackages: make meta.position point to the right location

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -10,8 +10,6 @@ assert attrs?pname -> !(attrs?name);
  else
   (x: x))
 toPerlModule(stdenv.mkDerivation (
-  (
-  lib.recursiveUpdate
   {
     outputs = [ "out" "devdoc" ];
 
@@ -31,11 +29,13 @@ toPerlModule(stdenv.mkDerivation (
     # https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0/pod/perldelta.pod#Removal-of-the-current-directory-%28%22.%22%29-from-@INC
     PERL_USE_UNSAFE_INC = "1";
 
-    meta.homepage = "https://metacpan.org/release/${lib.getName attrs}"; # TODO: phase-out `attrs.name`
-    meta.platforms = perl.meta.platforms;
+    meta = {
+      homepage = "https://metacpan.org/release/${lib.getName attrs}"; # TODO: phase-out `attrs.name`
+      platforms = perl.meta.platforms;
+    } // (attrs.meta or {});
   }
-  attrs
-  )
+  //
+  (builtins.removeAttrs attrs [ "meta" ])
   //
   {
     pname = "perl${perl.version}-${lib.getName attrs}"; # TODO: phase-out `attrs.name`


### PR DESCRIPTION
Currently on master `meta.position` points to `lib/attrsets.nix:362` for
all perlPackages. The culprit turns out to be `lib.recursiveUpdate` which
does the heavy lifting of merging the meta set provided in
perl-packages.nix and the preset values for homepage and platforms.
This function internally uses `lib.zipAttrsWithNames`.

The fix is just removing `lib.recursiveUpdate` and merging the meta set
manually because the rest of the stuff we are looking to merge in
buildPerlPackage is not nested.

Note that this fix only corrects the situation for perlPackages that set
meta.description: If meta.description is missing, stdenv.mkDerivation
tries to find name and version which are currently always redefined in
buildPerlPackage, so meta.position will point to
`pkgs/development/perl-modules/generic/default.nix` in those cases.
However the removal of the `name` and `version` redefinitions there are
a pending TODO, so this should fix itself at some point. Also it is
entirely possible to just add descriptions for the remaining
perlPackages without one (which wouldn't be good anyways)!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
