### PR TITLE
nixos/lxd: cleanup and misc fixes

### DIFF
--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -74,6 +74,17 @@ in {
           for details.
         '';
       };
+
+      startTimeout = mkOption {
+        type = types.int;
+        default = 600;
+        apply = toString;
+        description = ''
+          Time to wait (in seconds) for LXD to become ready to process requests.
+          If LXD does not reply within the configured time, lxd.service will be
+          considered failed and systemd will attempt to restart it.
+        '';
+      };
     };
   };
 
@@ -120,7 +131,7 @@ in {
 
       serviceConfig = {
         ExecStart = "@${cfg.package}/bin/lxd lxd --group lxd";
-        ExecStartPost = "${cfg.package}/bin/lxd waitready --timeout=600";
+        ExecStartPost = "${cfg.package}/bin/lxd waitready --timeout=${cfg.startTimeout}";
         ExecStop = "${cfg.package}/bin/lxd shutdown";
 
         KillMode = "process"; # when stopping, leave the containers alone
@@ -130,7 +141,7 @@ in {
         TasksMax = "infinity";
 
         Restart = "on-failure";
-        TimeoutStartSec = "600s";
+        TimeoutStartSec = "${cfg.startTimeout}s";
         TimeoutStopSec = "30s";
 
         # By default, `lxd` loads configuration files from hard-coded


### PR DESCRIPTION
###### Motivation for this change

Mainly removing udev-settle as part of https://github.com/NixOS/nixpkgs/issues/73095.
Changes:

- Actually use the zfsSupport option
- Add documentation URI to lxd.service
- Add lxd.socket to enable socket activatation
- Add proper dependencies and remove systemd-udev-settle from lxd.service
- Set up /var/lib/lxc/rootfs using systemd.tmpfiles
- Configure safe start and shutdown of lxd.service
- Configure restart on failures of lxd.service

###### Things done

- [x] Tested via `nixosTests.lxd nixosTests.lxd-nftables`
- [x] Tested socket activation works (via `lxc list`)
- [x] Tested starting/stopping lxd.service works
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
