### PR TITLE
qtwebkit: Fix build with icu 68

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -99,6 +99,7 @@ let
         sha256 = "0h8ymfnwgkjkwaankr3iifiscsvngqpwb91yygndx344qdiw9y0n";
       })
       ./qtwebkit.patch
+      ./qtwebkit-icu68.patch
 
       ./qtwebkit-darwin-no-readline.patch
       ./qtwebkit-darwin-no-qos-classes.patch

--- a/pkgs/development/libraries/qt-5/5.12/qtwebkit-icu68.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebkit-icu68.patch
@@ -1,0 +1,170 @@
+Regressed by https://github.com/unicode-org/icu/commit/c3fe7e09d844
+
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:31:
+Source/WebCore/platform/text/TextCodecICU.cpp:311:42: error: use of undeclared identifier 'TRUE'
+        ucnv_setFallback(m_converterICU, TRUE);
+                                         ^
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:40:
+In file included from Source/WebCore/platform/text/icu/UTextProvider.cpp:27:
+Source/WebCore/platform/text/icu/UTextProvider.h:83:28: error: use of undeclared identifier 'TRUE'
+            isAccessible = TRUE;
+                           ^
+Source/WebCore/platform/text/icu/UTextProvider.h:88:28: error: use of undeclared identifier 'FALSE'
+            isAccessible = FALSE;
+                           ^
+Source/WebCore/platform/text/icu/UTextProvider.h:97:28: error: use of undeclared identifier 'TRUE'
+            isAccessible = TRUE;
+                           ^
+Source/WebCore/platform/text/icu/UTextProvider.h:102:28: error: use of undeclared identifier 'FALSE'
+            isAccessible = FALSE;
+                           ^
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:41:
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:103:20: error: use of undeclared identifier 'TRUE'
+            return TRUE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:108:20: error: use of undeclared identifier 'FALSE'
+            return FALSE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:114:20: error: use of undeclared identifier 'TRUE'
+            return TRUE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:119:20: error: use of undeclared identifier 'FALSE'
+            return FALSE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:147:12: error: use of undeclared identifier 'TRUE'
+    return TRUE;
+           ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:339:16: error: use of undeclared identifier 'FALSE'
+        return FALSE;
+               ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:359:12: error: use of undeclared identifier 'TRUE'
+    return TRUE;
+           ^
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:42:
+Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp:128:16: error: use of undeclared identifier 'FALSE'
+        return FALSE;
+               ^
+Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp:148:12: error: use of undeclared identifier 'TRUE'
+    return TRUE;
+           ^
+
+--- a/Source/WebCore/platform/text/TextCodecICU.cpp
++++ b/Source/WebCore/platform/text/TextCodecICU.cpp
+@@ -308,7 +308,7 @@ void TextCodecICU::createICUConverter() const
+     m_converterICU = ucnv_open(m_canonicalConverterName, &err);
+     ASSERT(U_SUCCESS(err));
+     if (m_converterICU)
+-        ucnv_setFallback(m_converterICU, TRUE);
++        ucnv_setFallback(m_converterICU, true);
+ }
+ 
+ int TextCodecICU::decodeToBuffer(UChar* target, UChar* targetLimit, const char*& source, const char* sourceLimit, int32_t* offsets, bool flush, UErrorCode& err)
+--- a/Source/WebCore/platform/text/icu/UTextProvider.h
++++ b/Source/WebCore/platform/text/icu/UTextProvider.h
+@@ -80,12 +80,12 @@ inline bool uTextAccessInChunkOrOutOfRange(UText* text
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < std::numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex >= nativeLength && text->chunkNativeLimit == nativeLength) {
+             text->chunkOffset = text->chunkLength;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     } else {
+@@ -94,12 +94,12 @@ inline bool uTextAccessInChunkOrOutOfRange(UText* text
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < std::numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex <= 0 && !text->chunkNativeStart) {
+             text->chunkOffset = 0;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     }
+--- a/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
++++ b/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
+@@ -100,23 +100,23 @@ static UBool uTextLatin1Access(UText* uText, int64_t i
+         if (index < uText->chunkNativeLimit && index >= uText->chunkNativeStart) {
+             // Already inside the buffer. Set the new offset.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return TRUE;
++            return true;
+         }
+         if (index >= length && uText->chunkNativeLimit == length) {
+             // Off the end of the buffer, but we can't get it.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return FALSE;
++            return false;
+         }
+     } else {
+         if (index <= uText->chunkNativeLimit && index > uText->chunkNativeStart) {
+             // Already inside the buffer. Set the new offset.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return TRUE;
++            return true;
+         }
+         if (!index && !uText->chunkNativeStart) {
+             // Already at the beginning; can't go any farther.
+             uText->chunkOffset = 0;
+-            return FALSE;
++            return false;
+         }
+     }
+     
+@@ -144,7 +144,7 @@ static UBool uTextLatin1Access(UText* uText, int64_t i
+ 
+     uText->nativeIndexingLimit = uText->chunkLength;
+ 
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextLatin1Extract(UText* uText, int64_t start, int64_t limit, UChar* dest, int32_t destCapacity, UErrorCode* status)
+@@ -336,7 +336,7 @@ static int64_t uTextLatin1ContextAwareNativeLength(UTe
+ static UBool uTextLatin1ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = uTextLatin1ContextAwareNativeLength(text);
+     UBool isAccessible;
+     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -356,7 +356,7 @@ static UBool uTextLatin1ContextAwareAccess(UText* text
+         ASSERT(newContext == UTextProviderContext::PriorContext);
+         textLatin1ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextLatin1ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)
+--- a/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
++++ b/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
+@@ -125,7 +125,7 @@ static inline int64_t uTextUTF16ContextAwareNativeLeng
+ static UBool uTextUTF16ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = uTextUTF16ContextAwareNativeLength(text);
+     UBool isAccessible;
+     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -145,7 +145,7 @@ static UBool uTextUTF16ContextAwareAccess(UText* text,
+         ASSERT(newContext == UTextProviderContext::PriorContext);
+         textUTF16ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextUTF16ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -112,6 +112,7 @@ let
         sha256 = "0h8ymfnwgkjkwaankr3iifiscsvngqpwb91yygndx344qdiw9y0n";
       })
       ./qtwebkit.patch
+      ./qtwebkit-icu68.patch
     ] ++ optionals stdenv.isDarwin [
       ./qtwebkit-darwin-no-readline.patch
       ./qtwebkit-darwin-no-qos-classes.patch

--- a/pkgs/development/libraries/qt-5/5.14/qtwebkit-icu68.patch
+++ b/pkgs/development/libraries/qt-5/5.14/qtwebkit-icu68.patch
@@ -1,0 +1,170 @@
+Regressed by https://github.com/unicode-org/icu/commit/c3fe7e09d844
+
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:31:
+Source/WebCore/platform/text/TextCodecICU.cpp:311:42: error: use of undeclared identifier 'TRUE'
+        ucnv_setFallback(m_converterICU, TRUE);
+                                         ^
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:40:
+In file included from Source/WebCore/platform/text/icu/UTextProvider.cpp:27:
+Source/WebCore/platform/text/icu/UTextProvider.h:83:28: error: use of undeclared identifier 'TRUE'
+            isAccessible = TRUE;
+                           ^
+Source/WebCore/platform/text/icu/UTextProvider.h:88:28: error: use of undeclared identifier 'FALSE'
+            isAccessible = FALSE;
+                           ^
+Source/WebCore/platform/text/icu/UTextProvider.h:97:28: error: use of undeclared identifier 'TRUE'
+            isAccessible = TRUE;
+                           ^
+Source/WebCore/platform/text/icu/UTextProvider.h:102:28: error: use of undeclared identifier 'FALSE'
+            isAccessible = FALSE;
+                           ^
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:41:
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:103:20: error: use of undeclared identifier 'TRUE'
+            return TRUE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:108:20: error: use of undeclared identifier 'FALSE'
+            return FALSE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:114:20: error: use of undeclared identifier 'TRUE'
+            return TRUE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:119:20: error: use of undeclared identifier 'FALSE'
+            return FALSE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:147:12: error: use of undeclared identifier 'TRUE'
+    return TRUE;
+           ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:339:16: error: use of undeclared identifier 'FALSE'
+        return FALSE;
+               ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:359:12: error: use of undeclared identifier 'TRUE'
+    return TRUE;
+           ^
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:42:
+Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp:128:16: error: use of undeclared identifier 'FALSE'
+        return FALSE;
+               ^
+Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp:148:12: error: use of undeclared identifier 'TRUE'
+    return TRUE;
+           ^
+
+--- a/Source/WebCore/platform/text/TextCodecICU.cpp
++++ b/Source/WebCore/platform/text/TextCodecICU.cpp
+@@ -308,7 +308,7 @@ void TextCodecICU::createICUConverter() const
+     m_converterICU = ucnv_open(m_canonicalConverterName, &err);
+     ASSERT(U_SUCCESS(err));
+     if (m_converterICU)
+-        ucnv_setFallback(m_converterICU, TRUE);
++        ucnv_setFallback(m_converterICU, true);
+ }
+ 
+ int TextCodecICU::decodeToBuffer(UChar* target, UChar* targetLimit, const char*& source, const char* sourceLimit, int32_t* offsets, bool flush, UErrorCode& err)
+--- a/Source/WebCore/platform/text/icu/UTextProvider.h
++++ b/Source/WebCore/platform/text/icu/UTextProvider.h
+@@ -80,12 +80,12 @@ inline bool uTextAccessInChunkOrOutOfRange(UText* text
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < std::numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex >= nativeLength && text->chunkNativeLimit == nativeLength) {
+             text->chunkOffset = text->chunkLength;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     } else {
+@@ -94,12 +94,12 @@ inline bool uTextAccessInChunkOrOutOfRange(UText* text
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < std::numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex <= 0 && !text->chunkNativeStart) {
+             text->chunkOffset = 0;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     }
+--- a/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
++++ b/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
+@@ -100,23 +100,23 @@ static UBool uTextLatin1Access(UText* uText, int64_t i
+         if (index < uText->chunkNativeLimit && index >= uText->chunkNativeStart) {
+             // Already inside the buffer. Set the new offset.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return TRUE;
++            return true;
+         }
+         if (index >= length && uText->chunkNativeLimit == length) {
+             // Off the end of the buffer, but we can't get it.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return FALSE;
++            return false;
+         }
+     } else {
+         if (index <= uText->chunkNativeLimit && index > uText->chunkNativeStart) {
+             // Already inside the buffer. Set the new offset.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return TRUE;
++            return true;
+         }
+         if (!index && !uText->chunkNativeStart) {
+             // Already at the beginning; can't go any farther.
+             uText->chunkOffset = 0;
+-            return FALSE;
++            return false;
+         }
+     }
+     
+@@ -144,7 +144,7 @@ static UBool uTextLatin1Access(UText* uText, int64_t i
+ 
+     uText->nativeIndexingLimit = uText->chunkLength;
+ 
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextLatin1Extract(UText* uText, int64_t start, int64_t limit, UChar* dest, int32_t destCapacity, UErrorCode* status)
+@@ -336,7 +336,7 @@ static int64_t uTextLatin1ContextAwareNativeLength(UTe
+ static UBool uTextLatin1ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = uTextLatin1ContextAwareNativeLength(text);
+     UBool isAccessible;
+     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -356,7 +356,7 @@ static UBool uTextLatin1ContextAwareAccess(UText* text
+         ASSERT(newContext == UTextProviderContext::PriorContext);
+         textLatin1ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextLatin1ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)
+--- a/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
++++ b/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
+@@ -125,7 +125,7 @@ static inline int64_t uTextUTF16ContextAwareNativeLeng
+ static UBool uTextUTF16ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = uTextUTF16ContextAwareNativeLength(text);
+     UBool isAccessible;
+     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -145,7 +145,7 @@ static UBool uTextUTF16ContextAwareAccess(UText* text,
+         ASSERT(newContext == UTextProviderContext::PriorContext);
+         textUTF16ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextUTF16ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -95,6 +95,7 @@ let
         sha256 = "0h8ymfnwgkjkwaankr3iifiscsvngqpwb91yygndx344qdiw9y0n";
       })
       ./qtwebkit.patch
+      ./qtwebkit-icu68.patch
     ] ++ optionals stdenv.isDarwin [
       ./qtwebkit-darwin-no-readline.patch
       ./qtwebkit-darwin-no-qos-classes.patch

--- a/pkgs/development/libraries/qt-5/5.15/qtwebkit-icu68.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtwebkit-icu68.patch
@@ -1,0 +1,170 @@
+Regressed by https://github.com/unicode-org/icu/commit/c3fe7e09d844
+
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:31:
+Source/WebCore/platform/text/TextCodecICU.cpp:311:42: error: use of undeclared identifier 'TRUE'
+        ucnv_setFallback(m_converterICU, TRUE);
+                                         ^
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:40:
+In file included from Source/WebCore/platform/text/icu/UTextProvider.cpp:27:
+Source/WebCore/platform/text/icu/UTextProvider.h:83:28: error: use of undeclared identifier 'TRUE'
+            isAccessible = TRUE;
+                           ^
+Source/WebCore/platform/text/icu/UTextProvider.h:88:28: error: use of undeclared identifier 'FALSE'
+            isAccessible = FALSE;
+                           ^
+Source/WebCore/platform/text/icu/UTextProvider.h:97:28: error: use of undeclared identifier 'TRUE'
+            isAccessible = TRUE;
+                           ^
+Source/WebCore/platform/text/icu/UTextProvider.h:102:28: error: use of undeclared identifier 'FALSE'
+            isAccessible = FALSE;
+                           ^
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:41:
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:103:20: error: use of undeclared identifier 'TRUE'
+            return TRUE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:108:20: error: use of undeclared identifier 'FALSE'
+            return FALSE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:114:20: error: use of undeclared identifier 'TRUE'
+            return TRUE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:119:20: error: use of undeclared identifier 'FALSE'
+            return FALSE;
+                   ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:147:12: error: use of undeclared identifier 'TRUE'
+    return TRUE;
+           ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:339:16: error: use of undeclared identifier 'FALSE'
+        return FALSE;
+               ^
+Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp:359:12: error: use of undeclared identifier 'TRUE'
+    return TRUE;
+           ^
+In file included from Source/WebCore/platform/text/TextAllInOne.cpp:42:
+Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp:128:16: error: use of undeclared identifier 'FALSE'
+        return FALSE;
+               ^
+Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp:148:12: error: use of undeclared identifier 'TRUE'
+    return TRUE;
+           ^
+
+--- a/Source/WebCore/platform/text/TextCodecICU.cpp
++++ b/Source/WebCore/platform/text/TextCodecICU.cpp
+@@ -308,7 +308,7 @@ void TextCodecICU::createICUConverter() const
+     m_converterICU = ucnv_open(m_canonicalConverterName, &err);
+     ASSERT(U_SUCCESS(err));
+     if (m_converterICU)
+-        ucnv_setFallback(m_converterICU, TRUE);
++        ucnv_setFallback(m_converterICU, true);
+ }
+ 
+ int TextCodecICU::decodeToBuffer(UChar* target, UChar* targetLimit, const char*& source, const char* sourceLimit, int32_t* offsets, bool flush, UErrorCode& err)
+--- a/Source/WebCore/platform/text/icu/UTextProvider.h
++++ b/Source/WebCore/platform/text/icu/UTextProvider.h
+@@ -80,12 +80,12 @@ inline bool uTextAccessInChunkOrOutOfRange(UText* text
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < std::numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex >= nativeLength && text->chunkNativeLimit == nativeLength) {
+             text->chunkOffset = text->chunkLength;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     } else {
+@@ -94,12 +94,12 @@ inline bool uTextAccessInChunkOrOutOfRange(UText* text
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < std::numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex <= 0 && !text->chunkNativeStart) {
+             text->chunkOffset = 0;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     }
+--- a/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
++++ b/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
+@@ -100,23 +100,23 @@ static UBool uTextLatin1Access(UText* uText, int64_t i
+         if (index < uText->chunkNativeLimit && index >= uText->chunkNativeStart) {
+             // Already inside the buffer. Set the new offset.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return TRUE;
++            return true;
+         }
+         if (index >= length && uText->chunkNativeLimit == length) {
+             // Off the end of the buffer, but we can't get it.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return FALSE;
++            return false;
+         }
+     } else {
+         if (index <= uText->chunkNativeLimit && index > uText->chunkNativeStart) {
+             // Already inside the buffer. Set the new offset.
+             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
+-            return TRUE;
++            return true;
+         }
+         if (!index && !uText->chunkNativeStart) {
+             // Already at the beginning; can't go any farther.
+             uText->chunkOffset = 0;
+-            return FALSE;
++            return false;
+         }
+     }
+     
+@@ -144,7 +144,7 @@ static UBool uTextLatin1Access(UText* uText, int64_t i
+ 
+     uText->nativeIndexingLimit = uText->chunkLength;
+ 
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextLatin1Extract(UText* uText, int64_t start, int64_t limit, UChar* dest, int32_t destCapacity, UErrorCode* status)
+@@ -336,7 +336,7 @@ static int64_t uTextLatin1ContextAwareNativeLength(UTe
+ static UBool uTextLatin1ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = uTextLatin1ContextAwareNativeLength(text);
+     UBool isAccessible;
+     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -356,7 +356,7 @@ static UBool uTextLatin1ContextAwareAccess(UText* text
+         ASSERT(newContext == UTextProviderContext::PriorContext);
+         textLatin1ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextLatin1ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)
+--- a/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
++++ b/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
+@@ -125,7 +125,7 @@ static inline int64_t uTextUTF16ContextAwareNativeLeng
+ static UBool uTextUTF16ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = uTextUTF16ContextAwareNativeLength(text);
+     UBool isAccessible;
+     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -145,7 +145,7 @@ static UBool uTextUTF16ContextAwareAccess(UText* text,
+         ASSERT(newContext == UTextProviderContext::PriorContext);
+         textUTF16ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static int32_t uTextUTF16ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Qtwebkit currently doesn't build on master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
