### PR TITLE
nawk: 20180827 -> unstable-2021-02-15, fix noweb and nawk cross-complation

### DIFF
--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gawk, groff, icon-lang ? null }:
+{ lib, stdenv, fetchFromGitHub, nawk, groff, icon-lang }:
 
-let noweb = stdenv.mkDerivation rec {
+lib.fix (noweb: stdenv.mkDerivation rec {
   pname = "noweb";
   version = "2.12";
 
@@ -11,25 +11,28 @@ let noweb = stdenv.mkDerivation rec {
     sha256 = "1160i2ghgzqvnb44kgwd6s3p4jnk9668rmc15jlcwl7pdf3xqm95";
   };
 
-  patches = [ ./no-FAQ.patch ];
+  sourceRoot = "source/src";
+
+  patches = [
+    # Remove FAQ
+    ./no-FAQ.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace 'strip' '${stdenv.cc.targetPrefix}strip'
+  '';
 
   nativeBuildInputs = [ groff ] ++ lib.optionals (!isNull icon-lang) [ icon-lang ];
+  buildInputs = [ nawk ];
 
   preBuild = ''
     mkdir -p "$out/lib/noweb"
-    cd src
   '';
 
   makeFlags = lib.optionals (!isNull icon-lang) [
     "LIBSRC=icon"
     "ICONC=icont"
-  ] ++ lib.optionals stdenv.isDarwin [
-    "CC=clang"
-  ];
-
-
-  installFlags = [
-  ];
+  ] ++ [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   preInstall = ''
     mkdir -p "$tex/tex/latex/noweb"
@@ -50,11 +53,11 @@ let noweb = stdenv.mkDerivation rec {
     for f in $out/bin/no{index,roff,roots,untangle,web} \
              $out/lib/noweb/to{ascii,html,roff,tex} \
              $out/lib/noweb/{bt,empty}defn \
-             $out/lib/noweb/{noidx,unmarkup}; do
+             $out/lib/noweb/{noidx,pipedocs,unmarkup}; do
         # NOTE: substituteInPlace breaks Icon binaries, so make sure the script
         #       uses (n)awk before calling.
         if grep -q nawk "$f"; then
-            substituteInPlace "$f" --replace "nawk" "${gawk}/bin/awk"
+            substituteInPlace "$f" --replace "nawk" "${nawk}/bin/awk"
         fi
     done
 
@@ -77,4 +80,4 @@ let noweb = stdenv.mkDerivation rec {
     maintainers = with maintainers; [ yurrriq ];
     platforms = with platforms; linux ++ darwin;
   };
-}; in noweb
+})

--- a/pkgs/development/tools/literate-programming/noweb/no-FAQ.patch
+++ b/pkgs/development/tools/literate-programming/noweb/no-FAQ.patch
@@ -1,5 +1,5 @@
---- a/src/Makefile	2006-06-12 22:14:20.000000000 +0200
-+++ b/src/Makefile	2010-06-17 11:30:11.804018145 +0200
+--- a/Makefile	2006-06-12 22:14:20.000000000 +0200
++++ b/Makefile	2010-06-17 11:30:11.804018145 +0200
 @@ -198,7 +198,7 @@
  	(cd elisp; ci -l $(CINAME) $(CIMSG) *.el)
  	ci -l $(CINAME) $(CIMSG) Makefile.nw INSTALL INSTALL.DOS README FAQ COPYRIGHT nwmake *.nw

--- a/pkgs/tools/text/nawk/default.nix
+++ b/pkgs/tools/text/nawk/default.nix
@@ -1,26 +1,28 @@
-{ lib, stdenv, fetchFromGitHub, yacc }:
+{ lib, stdenv, fetchFromGitHub, bison, buildPackages }:
 
 stdenv.mkDerivation rec {
   pname = "nawk";
-  version = "20180827";
+  version = "unstable-2021-02-15";
 
   src = fetchFromGitHub {
     owner = "onetrueawk";
     repo = "awk";
-    rev = version;
-    sha256 = "0qcsxhcwg6g3c0zxmbipqa8d8d5n8zxrq0hymb8yavsaz103fcl6";
+    rev = "c0f4e97e4561ff42544e92512bbaf3d7d1f6a671";
+    sha256 = "kQCvItpSJnDJMDvlB8ruY+i0KdjmAphRDqCKw8f0m/8=";
   };
 
-  nativeBuildInputs = [ yacc ];
-
-  patchPhase = ''
-    substituteInPlace ./makefile \
-    --replace "YACC = yacc -d -S" ""
-  '';
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ bison ];
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "HOSTCC=${if stdenv.buildPlatform.isDarwin then "clang" else "cc"}"
+  ];
 
   installPhase = ''
+    runHook preInstall
     install -Dm755 a.out "$out/bin/nawk"
     install -Dm644 awk.1 "$out/share/man/man1/nawk.1"
+    runHook postInstall
   '';
 
   meta = {
@@ -33,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.cs.princeton.edu/~bwk/btl.mirror/";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.konimex ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Fix cross-compilation of noweb and nawk. Test with

```ShellSession
$ nix build .#pkgsCross.raspberryPi.noweb
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
