### PR TITLE
gnustep.(base|gui): fix icu 68 compatibility

### DIFF
--- a/pkgs/desktops/gnustep/base/default.nix
+++ b/pkgs/desktops/gnustep/base/default.nix
@@ -1,7 +1,7 @@
 { aspell, audiofile
 , gsmakeDerivation
 , cups
-, fetchurl
+, fetchurl, fetchpatch
 , gmp, gnutls
 , libffi, binutils-unwrapped
 , libjpeg, libtiff, libpng, giflib, libungif
@@ -33,7 +33,13 @@ gsmakeDerivation {
     portaudio
     libiberty
   ];
-  patches = [ ./fixup-paths.patch ];
+  patches = [
+    ./fixup-paths.patch
+    (fetchpatch {  # for icu68 compatibility, remove with next update(?)
+      url = "https://github.com/gnustep/libs-base/commit/06fa7792a51cb970e5d010a393cb88eb127830d7.patch";
+      sha256 = "150n1sa34av9ywc04j36jvj7ic9x6pgr123rbn2mx5fj76q23852";
+    })
+  ];
 
   meta = {
     description = "An implementation of AppKit and Foundation libraries of OPENSTEP and Cocoa";

--- a/pkgs/desktops/gnustep/gui/default.nix
+++ b/pkgs/desktops/gnustep/gui/default.nix
@@ -1,4 +1,4 @@
-{ gsmakeDerivation, fetchurl, base }:
+{ gsmakeDerivation, fetchurl, fetchpatch, base }:
 let
   version = "0.28.0";
 in
@@ -9,7 +9,13 @@ gsmakeDerivation {
     sha256 = "05wk8kbl75qj0jgawgyv9sp98wsgz5vl1s0d51sads0p0kk2sv8z";
   };
   buildInputs = [ base ];
-  patches = [ ./fixup-all.patch ];
+  patches = [
+    ./fixup-all.patch
+    (fetchpatch {  # for icu68 compatibility, remove with next update(?)
+      url = "https://github.com/gnustep/libs-gui/commit/05572b2d01713f5caf07f334f17ab639be8a1cff.patch";
+      sha256 = "04z287dk8jf3hdwzk8bpnv49qai2dcdlh824yc9bczq291pjy2xc";
+    })
+  ];
   meta = {
     description = "A GUI class library of GNUstep";
   };


### PR DESCRIPTION
###### Motivation for this change
Doesn't compile on master after #107774 / https://github.com/unicode-org/icu/commit/c3fe7e09d844

We could also stick with icu 67.x instead.

cc @marsam (please tell me if I should stop pinging you on these)

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (sogo)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
