### PR TITLE
pleroma-bot: init at 0.8.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8039,6 +8039,12 @@
     githubId = 3708689;
     name = "Roberto Di Remigio";
   };
+  robertoszek = {
+    email = "robertoszek@robertoszek.xyz";
+    github = "robertoszek";
+    githubId = 1080963;
+    name = "Roberto";
+  };
   robgssp = {
     email = "robgssp@gmail.com";
     github = "robgssp";

--- a/pkgs/development/python-modules/pleroma-bot/default.nix
+++ b/pkgs/development/python-modules/pleroma-bot/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, requests-mock
+, oauthlib
+, requests_oauthlib
+, requests
+, pyaml
+}:
+
+buildPythonPackage rec {
+  pname = "pleroma-bot";
+  version = "0.8.6";
+
+  src = fetchFromGitHub {
+    owner = "robertoszek";
+    repo = "pleroma-bot";
+    rev = version;
+    sha256 = "1q0xhgqq41zbqiawpd4kbdx41zhwxxp5ipn1c2rc8d7pjyb5p75w";
+  };
+
+  propagatedBuildInputs = [ pyaml requests requests_oauthlib oauthlib ];
+  checkInputs = [ pytestCheckHook requests-mock ];
+
+  pythonImportsCheck = [ "pleroma_bot" ];
+
+  meta = with lib; {
+    homepage = "https://robertoszek.github.io/pleroma-bot/";
+    description = "Bot for mirroring one or multiple Twitter accounts in Pleroma/Mastodon";
+    license = licenses.mit;
+    maintainers = with maintainers; [ robertoszek ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24041,6 +24041,8 @@ in
      stdenv = stdenv_32bit;
   };
 
+  pleroma-bot = python3Packages.callPackage ../development/python-modules/pleroma-bot { };
+
   polybar = callPackage ../applications/misc/polybar { };
 
   polybarFull = callPackage ../applications/misc/polybar {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
