### PR TITLE
gnome-tour: fix build

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-tour/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-tour/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , rustPlatform
 , gettext
 , meson
@@ -15,9 +16,11 @@
 , gnome3
 , libhandy
 , librsvg
+, rustc
+, cargo
 }:
 
-rustPlatform.buildRustPackage rec {
+stdenv.mkDerivation rec {
   pname = "gnome-tour";
   version = "3.38.0";
 
@@ -30,6 +33,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     appstream-glib
+    cargo
     desktop-file-utils
     gettext
     glib # glib-compile-resources
@@ -37,6 +41,8 @@ rustPlatform.buildRustPackage rec {
     ninja
     pkg-config
     python3
+    rustPlatform.cargoSetupHook
+    rustc
     wrapGAppsHook
   ];
 
@@ -47,12 +53,6 @@ rustPlatform.buildRustPackage rec {
     libhandy
     librsvg
   ];
-
-  # Don't use buildRustPackage phases, only use it for rust deps setup
-  configurePhase = null;
-  buildPhase = null;
-  checkPhase = null;
-  installPhase = null;
 
   postPatch = ''
     chmod +x build-aux/meson_post_install.py


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/114659

There might be other packages broken, so I'm going to see if the gnome test builds locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
