### PR TITLE
tecla: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/tecla/default.nix
+++ b/pkgs/development/libraries/tecla/default.nix
@@ -8,6 +8,11 @@ stdenv.mkDerivation rec {
     sha256 = "06pfq5wa8d25i9bdjkp4xhms5101dsrbg82riz7rz1a0a32pqxgj";
   };
 
+  postPatch = ''
+    substituteInPlace install-sh \
+      --replace "stripprog=" "stripprog=\$STRIP # "
+  '';
+
   meta = {
     homepage = "https://www.astro.caltech.edu/~mcs/tecla/";
     description = "Command-line editing library";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This small patch helps cross-compilation for tecla, which is a stepping stone to be able to cross-compile libbladeRF and rtl-433 in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
   - python2.7-requests doesn't build, but apparantly that's known: https://github.com/NixOS/nixpkgs/pull/106599/files#diff-857098592df0045379db0f24793dbed58feb22b927b2ef88d3a9106fa0d67692R69
   - tamarin-prover doesn't build (also seems known: https://github.com/NixOS/nixpkgs/pull/110038#issuecomment-786315376)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>6 packages failed to build:</summary>
  <ul>
    <li>gr-ais (gnuradio-ais)</li>
    <li>gr-gsm (gnuradio-gsm)</li>
    <li>gr-osmosdr (gnuradio-osmosdr)</li>
    <li>gnuradio-with-packages</li>
    <li>qradiolink</li>
    <li>tamarin-prover</li>
  </ul>
</details>
<details>
  <summary>14 packages built:</summary>
  <ul>
    <li>cubicsdr</li>
    <li>dump1090</li>
    <li>gqrx</li>
    <li>libbladeRF</li>
    <li>maude</li>
    <li>python37Packages.soapysdr-with-plugins</li>
    <li>python38Packages.soapysdr-with-plugins</li>
    <li>python39Packages.soapysdr-with-plugins</li>
    <li>rtl_433</li>
    <li>sdrangel</li>
    <li>soapybladerf</li>
    <li>soapysdr-with-plugins</li>
    <li>tecla</li>
    <li>welle-io</li>
  </ul>
</details>

Building the cross package (for aarch64): `nix build .#pkgsCross.aarch64-multiplatform.tecla`.
