### PR TITLE
newsflash: use cargoSetupHook instead of buildRustPackage

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6065,7 +6065,7 @@
     name = "Celine Mercier";
   };
   metadark = {
-    email = "kira.bruneau@gmail.com";
+    email = "kira.bruneau@pm.me";
     name = "Kira Bruneau";
     github = "metadark";
     githubId = 382041;

--- a/pkgs/applications/networking/feedreaders/newsflash/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsflash/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , rustPlatform
 , fetchFromGitLab
 , meson
@@ -17,7 +18,7 @@
 , gst_all_1
 }:
 
-rustPlatform.buildRustPackage rec {
+stdenv.mkDerivation rec {
   pname = "newsflash";
   version = "1.3.0";
 
@@ -28,7 +29,11 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Vu8PXdnayrglAFVfO+WZTzk4Qrb/3uqzQIwClnRHto8=";
   };
 
-  cargoHash = "sha256-dWumQi/Bk7w2C8zVVExxguWchZU+K2qTC02otsiK9jA=";
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-dWumQi/Bk7w2C8zVVExxguWchZU+K2qTC02otsiK9jA=";
+  };
 
   patches = [
     # Post install tries to generate an icon cache & update the
@@ -54,7 +59,11 @@ rustPlatform.buildRustPackage rec {
 
     # Provides glib-compile-resources to compile gresources
     glib
-  ];
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
 
   buildInputs = [
     gtk3
@@ -75,13 +84,6 @@ rustPlatform.buildRustPackage rec {
     gst-plugins-good
     gst-plugins-bad
   ]);
-
-  # Unset default rust phases to use meson & ninja instead
-  configurePhase = null;
-  buildPhase = null;
-  checkPhase = null;
-  installPhase = null;
-  installCheckPhase = null;
 
   meta = with lib; {
     description = "A modern feed reader designed for the GNOME desktop";


### PR DESCRIPTION
###### Motivation for this change
The new `cargoSetupHook` makes it easier to work with mixed projects. In this case meson & ninja + rust.

See https://github.com/NixOS/nixpkgs/pull/114669#issuecomment-787470564
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@collares @worldofpeace @danieldk