### PR TITLE
bashup-events: fix nixpkgs-hammering warnings

### DIFF
--- a/pkgs/development/libraries/bashup-events/generic.nix
+++ b/pkgs/development/libraries/bashup-events/generic.nix
@@ -1,8 +1,6 @@
 {
   # general
   lib
-, callPackage
-, runCommand
 , resholvePackage
 , bash
 , shellcheck
@@ -46,7 +44,9 @@ resholvePackage rec {
   inherit src;
 
   installPhase = ''
+    runHook preInstall
     install -Dt $out/bin bashup.events
+    runHook postInstall
   '';
 
   inherit doCheck;
@@ -54,9 +54,11 @@ resholvePackage rec {
 
   # check based on https://github.com/bashup/events/blob/master/.dkrc
   checkPhase = ''
+    runHook preCheck
     SHELLCHECK_OPTS='-e SC2016,SC2145' ${shellcheck}/bin/shellcheck ./bashup.events
     ${bash}/bin/bash -n ./bashup.events
     ${bash}/bin/bash ./bashup.events
+    runHook postCheck
   '';
 
   solutions = {
@@ -70,7 +72,11 @@ resholvePackage rec {
 
   inherit doInstallCheck;
   installCheckInputs = [ bash ];
-  installCheckPhase = installCheck "${bash}/bin/bash";
+  installCheckPhase = ''
+    runHook preInstallCheck
+    ${installCheck "${bash}/bin/bash"}
+    runHook postInstallCheck
+  '';
 
   meta = with lib; {
     inherit branch;


### PR DESCRIPTION
###### Motivation for this change
Fixing nixpkgs-hammering warnings that I noticed in a @SuperSandro2000 [review comment](https://github.com/NixOS/nixpkgs/pull/114528#issuecomment-787442392) on a different PR that triggered a rebuild of these.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
