### PR TITLE
.*gopass.*: remove platform from buildGoModule

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -60,7 +60,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = with maintainers; [ andir rvolosatovs ];
     changelog = "https://github.com/gopasspw/gopass/blob/v${version}/CHANGELOG.md";
-    platforms = platforms.unix;
 
     longDescription = ''
       gopass is a rewrite of the pass password manager in Go with the aim of

--- a/pkgs/tools/security/gopass/git-credential.nix
+++ b/pkgs/tools/security/gopass/git-credential.nix
@@ -37,6 +37,5 @@ buildGoModule rec {
     homepage = "https://github.com/gopasspw/git-credential-gopass";
     license = licenses.mit;
     maintainers = with maintainers; [ benneti ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/security/gopass/jsonapi.nix
+++ b/pkgs/tools/security/gopass/jsonapi.nix
@@ -38,6 +38,5 @@ buildGoModule rec {
     homepage = "https://www.gopass.pw/";
     license = licenses.mit;
     maintainers = with maintainers; [ maxhbr ];
-    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
per suggestion from @SuperSandro2000 remove the redundant meta.platform in gopass, gopass-jsonapi, git-credential-gopass.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
