### PR TITLE
llvmPackages_11.libcxx: backport block.h fix from llvm12

### DIFF
--- a/pkgs/development/compilers/llvm/11/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/11/libc++/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetch, cmake, python3, libcxxabi, llvm, fixDarwinDylibNames, version
+{ lib, stdenv, fetch, fetchpatch, cmake, python3, libcxxabi, llvm, fixDarwinDylibNames, version
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
 
@@ -15,7 +15,14 @@ stdenv.mkDerivation {
     mv llvm-* llvm
   '';
 
-  patches = lib.optional stdenv.hostPlatform.isMusl ../../libcxx-0001-musl-hacks.patch;
+  patches = [
+    (fetchpatch {
+      # Backported from LLVM 12, avoids clashes with commonly used "block.h" header.
+      url = "https://github.com/llvm/llvm-project/commit/19bc9ea480b60b607a3e303f20c7a3a2ea553369.patch";
+      sha256 = "sha256-aWa66ogmPkG0xHzSfcpD0qZyZQcNKwLV44js4eiun78=";
+      stripLen = 1;
+    })
+  ] ++ lib.optional stdenv.hostPlatform.isMusl ../../libcxx-0001-musl-hacks.patch;
 
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
     patchShebangs utils/cat_files.py


### PR DESCRIPTION
###### Motivation for this change

As a concrete example, this fixes graphviz compilation:

* https://gitlab.com/graphviz/graphviz/-/issues/1785

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).