### PR TITLE
python3Packages.elmax: init at 0.1.0

### DIFF
--- a/pkgs/development/python-modules/elmax/default.nix
+++ b/pkgs/development/python-modules/elmax/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, httpx
+, poetry-core
+, pythonOlder
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "elmax";
+  version = "0.1.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-ecosystem";
+    repo = "python-elmax";
+    rev = version;
+    sha256 = "0np3ixw8khrzb7hd8ly8xv349vnas0myfv9s0ahic58r1l9lcwa4";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    httpx
+    yarl
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "elmax" ];
+
+  meta = with lib; {
+    description = "Python API client for the Elmax Cloud services";
+    homepage = "https://github.com/home-assistant-ecosystem/python-elmax";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2061,6 +2061,8 @@ in {
 
   eliot = callPackage ../development/python-modules/eliot { };
 
+  elmax = callPackage ../development/python-modules/elmax { };
+
   emailthreads = callPackage ../development/python-modules/emailthreads { };
 
   email_validator = callPackage ../development/python-modules/email-validator { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API client for the Elmax Cloud services

https://github.com/home-assistant-ecosystem/python-elmax

This will become a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
