### PR TITLE
ocamlPackages.base: 0.14.0 → 0.14.1

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -158,7 +158,8 @@ rec {
 
   base = janePackage {
     pname = "base";
-    hash = "1d5ynzzq58g9qammhba5dasrg734p9vndq28a7kg80bdxb8gh3kp";
+    version = "0.14.1";
+    hash = "1hizjxmiqlj2zzkwplzjamw9rbnl0kh44sxgjpzdij99qnfkzylf";
     minimumOCamlVersion = "4.07";
     meta.description = "Full standard library replacement for OCaml";
     buildInputs = [ dune-configurator ];


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.12

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
