### PR TITLE
python3Packages.httpx: 0.16.1 -> 0.17.0

### DIFF
--- a/pkgs/development/python-modules/elmax/default.nix
+++ b/pkgs/development/python-modules/elmax/default.nix
@@ -9,15 +9,15 @@
 
 buildPythonPackage rec {
   pname = "elmax";
-  version = "0.1.0";
+  version = "0.1.1";
   format = "pyproject";
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "home-assistant-ecosystem";
     repo = "python-elmax";
     rev = version;
-    sha256 = "0np3ixw8khrzb7hd8ly8xv349vnas0myfv9s0ahic58r1l9lcwa4";
+    sha256 = "sha256-vDISJ/CVOjpM+GPF2TCm3/AMFTWTM0b/+ZPCpAEvNvY=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "httpx";
-  version = "0.16.1";
+  version = "0.17.0";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "00gmq45fckcqkj910bvd7pyqz1mvgsdvz4s0k7dzbnc5czzq1f4a";
+    sha256 = "sha256-pRdhPAxKZOVbRhOm4881Dn+IRtpX5T3oFuYdtWp3cgY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pytest-httpx/default.nix
+++ b/pkgs/development/python-modules/pytest-httpx/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "pytest-httpx";
-  version = "0.10.1";
+  version = "0.11.0";
 
   src = fetchPypi {
     inherit version;
     pname = "pytest_httpx";
     extension = "tar.gz";
-    sha256 = "13ld6nnsc3f7i4zl4qm1jh358z0awr6xfk05azwgngmjb7jmcz0a";
+    sha256 = "sha256-koyrYudZfWRYeK4nP9SLGvEd0xlf017FyZ2FN8CV0Ys=";
   };
 
   propagatedBuildInputs = [ httpx pytest ];

--- a/pkgs/development/python-modules/pytest-httpx/default.nix
+++ b/pkgs/development/python-modules/pytest-httpx/default.nix
@@ -1,20 +1,33 @@
-{ lib, buildPythonPackage, fetchPypi, httpx, pytest }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, httpx
+, pytest
+, pytest-asyncio
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pytest-httpx";
   version = "0.11.0";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "pytest_httpx";
-    extension = "tar.gz";
-    sha256 = "sha256-koyrYudZfWRYeK4nP9SLGvEd0xlf017FyZ2FN8CV0Ys=";
+  src = fetchFromGitHub {
+    owner = "Colin-b";
+    repo = "pytest_httpx";
+    rev = "v${version}";
+    sha256 = "08idd3y6khxjqkn46diqvkjvsl4w4pxhl6z1hspbkrj0pqwf9isi";
   };
 
-  propagatedBuildInputs = [ httpx pytest ];
+  propagatedBuildInputs = [
+    httpx
+    pytest
+  ];
 
-  # not in pypi tarball
-  doCheck = false;
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
   pythonImportsCheck = [ "pytest_httpx" ];
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -87,6 +87,7 @@ in with py.pkgs; buildPythonApplication rec {
       --replace "bcrypt==3.1.7" "bcrypt>=3.1.7" \
       --replace "awesomeversion==21.2.2" "awesomeversion>=21.2.2" \
       --replace "cryptography==3.2" "cryptography" \
+      --replace "httpx==0.16.1" "httpx>=0.16.1" \
       --replace "pip>=8.0.3,<20.3" "pip" \
       --replace "pytz>=2020.5" "pytz>=2020.4" \
       --replace "pyyaml==5.4.1" "pyyaml" \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.17.0

Change log: https://github.com/encode/httpx/releases/tag/0.17.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
