### PR TITLE
cryptopp: run configure.sh before make

### DIFF
--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -21,6 +21,14 @@ stdenv.mkDerivation rec {
     substituteInPlace GNUmakefile \
         --replace "AR = libtool" "AR = ar" \
         --replace "ARFLAGS = -static -o" "ARFLAGS = -cru"
+
+    # See https://github.com/weidai11/cryptopp/issues/1011
+    substituteInPlace GNUmakefile \
+      --replace "ZOPT = -O0" "ZOPT ="
+  '';
+
+  preConfigure = ''
+    sh TestScripts/configure.sh
   '';
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];


### PR DESCRIPTION
###### Motivation for this change

This prevents failure on `aarch64-darwin`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).