### PR TITLE
dwarf-fortress: 0.47.04 -> 0.47.05

### DIFF
--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -40,7 +40,7 @@ let
   # The latest Dwarf Fortress version. Maintainers: when a new version comes
   # out, ensure that (unfuck|dfhack|twbt) are all up to date before changing
   # this.
-  latestVersion = "0.47.04";
+  latestVersion = "0.47.05";
 
   # Converts a version to a package name.
   versionToName = version: "dwarf-fortress_${lib.replaceStrings ["."] ["_"] version}";

--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -71,6 +71,13 @@ let
       xmlRev = "036b662a1bbc96b4911f3cbe74dfa1243b6459bc";
       prerelease = false;
     };
+    "0.47.05" = {
+      dfHackRelease = "0.47.05-r1";
+      sha256 = "sha256-B0iv7fpIcnaO8sx9wPqI7/WuyLK15p8UYlYIcF5F5bw=";
+      xmlRev = "11c379ffd31255f2a1415d98106114a46245e1c3";
+      prerelease = false;
+    };
+
   };
 
   release =

--- a/pkgs/games/dwarf-fortress/game.json
+++ b/pkgs/games/dwarf-fortress/game.json
@@ -121,5 +121,19 @@
     "legacy_s": "19ai7lvxx0y3iha9qrbl5krric547rzs6vm4ibk8x61vv97jrbd8",
     "legacy32": "0lli6s1g7yj3p3h26ajgq3h619n88qn6s7amyz6z8w7hyzfi7wij",
     "legacy32_s": "1wzxbzgln9pmsk2nchrl94d2yd09xdgynmjl4qwcaqzkrnf3sfqc"
+  },
+  "0.47.05": {
+    "linux": "18zwmz2nsgwjxbr2yd9jcrgw6l5b481hh1848cgn5nfpnzdscx5c",
+    "linux32": "1jbav7ghsjsxd6cdp6f2x5qn83zc8707dqan5sp73fp6mbj2jasl",
+    "osx": "092z1vhc5sbdc5irggdz5ai7rxifmg4yhy33aicpsjcnvcmajydw",
+    "osx32": "0lpbwfiagp0zp280aw3fmj8938w5fc5r9gibzk2h86jy63ps29ww",
+    "win": "0bbk7j3d4h2wn9hmbsbbbbr0ajf3ddlprxfaajfbnbiyv72cpn9s",
+    "win_s": "0nl7c9dpfx7jjpy7y52z8h3kiy4cpax1m58apbcfyy95an4jz8s4",
+    "win32": "08ka1lklly82h4mr770y9p0a21x9dx6jqvjgxdsxj5979f26il1v",
+    "win32_s": "06w844zxzx3lfykibgkk4gbg4xymnqraj1ikv4mzlv31l727a1x4",
+    "legacy": "042a0gbad3cp5dwhnrzg3vr9w48b8ybqgxgw5i9rk4c1i0gjjpw2",
+    "legacy_s": "1rb7h8lzlsjs08rvhhl3nwbrpj54zijijp4y0qdp4vyzsig6nisk",
+    "legacy32": "0ayw09x9smihh8qp5pdvr6vvhwkvcqz36h3lh4g1b5kzxj7g9cyf",
+    "legacy32_s": "10gfxlysfs9gyi1mv52idp5xk45g9h517g2jq4a8cqp2j7594v9c"
   }
 }

--- a/pkgs/games/dwarf-fortress/game.nix
+++ b/pkgs/games/dwarf-fortress/game.nix
@@ -52,7 +52,8 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "dwarf-fortress-${dfVersion}";
+  pname = "dwarf-fortress";
+  version = dfVersion;
 
   src = fetchurl {
     url = "${homepage}df_${baseVersion}_${patchVersion}_${dfPlatform}.tar.bz2";

--- a/pkgs/games/dwarf-fortress/themes/themes.json
+++ b/pkgs/games/dwarf-fortress/themes/themes.json
@@ -1,8 +1,8 @@
 [
   {
     "name": "afro-graphics",
-    "version": "47.04",
-    "sha256": "1x1ir0qi3g8wgzwm1pnrkrqb6lhnjq87vs30l8kva6y5wr4sz7q0"
+    "version": "47.05",
+    "sha256": "0gqrxb4bbx1h93xjz4ygd7yp8g5barj2zc6y7xvr94ww8b9a2r28"
   },
   {
     "name": "autoreiv",
@@ -21,13 +21,13 @@
   },
   {
     "name": "gemset",
-    "version": "47.04",
-    "sha256": "015nkkdnpykhz6a1n8qi3wgap19a4wavz4n2xbvfa4g770lcjd92"
+    "version": "47.05",
+    "sha256": "1ivsbj71w3zwxnaz0405xhqhn4yzdfziijc0s0vmbmcphhhqnjaj"
   },
   {
     "name": "ironhand",
-    "version": "47.04",
-    "sha256": "0x3hi1isgc2cv7c3qz87rm7ik0kbd748djpnghvjdqpj3a0n1ih2"
+    "version": "47.05",
+    "sha256": "003yrwishkzf6nvr6xlldbnd3x7rf5ds7l91mc0npdq1lcl0br9w"
   },
   {
     "name": "jolly-bastion",
@@ -36,33 +36,33 @@
   },
   {
     "name": "mayday",
-    "version": "47.04a",
-    "sha256": "1hpj40762n81grsddg3nc5jxc0bqmy2xamxvsgxzb2bx0b7akz0w"
+    "version": "47.05",
+    "sha256": "17sdvr9a98xx5r2nrr3m4jlddvlb4h6qlch8r23g9g4mj0hsifnj"
   },
   {
     "name": "meph",
-    "version": "47.04_v5.5.0_V1.1.2",
-    "sha256": "0q8hfm66rag61qd2hab7lsr4nyg52bn1hvy6bl7z6kv4yj5cra50"
+    "version": "47.05_v5.5.1-V",
+    "sha256": "1kiqxiqw686dii5x7zav2nsw15csg0grv4h8hrb764rl4fw6x9nl"
   },
   {
     "name": "obsidian",
-    "version": "47.04a",
-    "sha256": "0y5kmj362i9y8w1n5d1nx80yq88c0xqps9i02gvnls6r421a4nms"
+    "version": "47.05",
+    "sha256": "1dkwdwm52fsj4gqqqr5vppbsk8a4kd3i7d3qawawgl0qn6q139xs"
   },
   {
     "name": "phoebus",
-    "version": "47.04a",
-    "sha256": "1ihbqs5a3b8pydbcynblvgw2bxkgr9hhpmgjlji7a7zvz8m6h6pw"
+    "version": "47.05",
+    "sha256": "18pn3dqyk9hp82gva92c6y3vk52s366rrx74rdnvahswdr5dmq4d"
   },
   {
     "name": "rally-ho",
-    "version": "47.04",
-    "sha256": "0pmvpfbj07ll674lw7mjgkb4kgjk4mxr82fjq4ppvwrnzx6vi2g0"
+    "version": "47.05",
+    "sha256": "1h3jqq0yq2rbzbl70sq85lgdpwswczpay16kqfwq1n8zdisl4gqn"
   },
   {
     "name": "spacefox",
-    "version": "47.04",
-    "sha256": "0sk3k5bcpfl2xind4vfrgzbcqqbw0mg47pm3d3h44vi6hl3bdaqj"
+    "version": "47.05a",
+    "sha256": "1y1rbsxr1m0mb2k02q6gh24c4nyqc9lw98dvfckp2bzc5f9cx3ks"
   },
   {
     "name": "taffer",
@@ -76,8 +76,8 @@
   },
   {
     "name": "vettlingr",
-    "version": "1.4a",
-    "sha256": "1p4y0dm52rb49dnmcnivddlsd94m4gr1pxn04fpjbrvck22klgpj"
+    "version": "47.05",
+    "sha256": "0s1vy3ssp1hk8f6wlkz09xy5v747dpbsgw5vi6i1mq3lnlcy68vq"
   },
   {
     "name": "wanderlust",

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -50,6 +50,12 @@ let
       sha256 = "092dgp8fh1j4nqr9wbzn89ib1nhscclr8m91lfxsvg0mgn7j8xlv";
       prerelease = true;
     };
+    "0.47.05" = {
+      twbtRelease = "6.xx";
+      dfhackRelease = "0.47.05-beta1";
+      sha256 = "sha256-Y6G0qBMHvotp/oyiqANlzXZVklL270dhskd135PnE9Q=";
+      prerelease = true;
+    };
   };
 
   release =

--- a/pkgs/games/dwarf-fortress/unfuck.nix
+++ b/pkgs/games/dwarf-fortress/unfuck.nix
@@ -12,6 +12,7 @@
 , ncurses
 , glib
 , gtk2
+, gtk3
 , libsndfile
 , zlib
 , dfVersion
@@ -58,6 +59,10 @@ let
       unfuckRelease = "0.47.04";
       sha256 = "1wa990xbsyiiz7abq153xmafvvk1dmgz33rp907d005kzl1z86i9";
     };
+    "0.47.05" = {
+      unfuckRelease = "0.47.04";
+      sha256 = "1wa990xbsyiiz7abq153xmafvvk1dmgz33rp907d005kzl1z86i9";
+    };
   };
 
   release =
@@ -90,11 +95,16 @@ stdenv.mkDerivation {
     glew
     openalSoft
     ncurses
-    gtk2
     libsndfile
     zlib
     libGL
-  ];
+  ]
+  # switched to gtk3 in 0.47.05
+  ++ (if lib.versionOlder release.unfuckRelease "0.47.05" then [
+    gtk2
+  ] else [
+    gtk3
+  ]);
 
   # Don't strip unused symbols; dfhack hooks into some of them.
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change
Can't get the game to launch without seg faulting

maybe @shazow @bbigras  you could help?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
