### PR TITLE
cargo-play: init at 0.5.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-play/default.nix
+++ b/pkgs/development/tools/rust/cargo-play/default.nix
@@ -1,0 +1,25 @@
+{ fetchFromGitHub, lib, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-play";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "fanzeyi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "01r00akfmvpzp924yqqybd9s0pwiwxy8vklsg4m9ypzljc3nlv02";
+  };
+
+  cargoSha256 = "0fvsdyivq5991ka6avh12aqdkjx0myk61kmzlr19p2vlfpg70q07";
+
+  # some tests require internet access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Run your rust code without setting up cargo";
+    homepage = "https://github.com/fanzeyi/cargo-play";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10849,6 +10849,7 @@ in
   cargo-make = callPackage ../development/tools/rust/cargo-make {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
+  cargo-play = callPackage ../development/tools/rust/cargo-play { };
   cargo-raze = callPackage ../development/tools/rust/cargo-raze {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`cargo-play` is a tool to help you running your Rust code file without manually setting up a Cargo project.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
