### PR TITLE
[staging] cargo/hooks: allow hooks to be disabled

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -32,4 +32,6 @@ cargoBuildHook() {
     echo "Finished cargoBuildHook"
 }
 
-buildPhase=cargoBuildHook
+if [ -z "${dontCargoBuild-}" ] && [ -z "${buildPhase-}" ]; then
+  buildPhase=cargoBuildHook
+fi

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -36,6 +36,6 @@ cargoCheckHook() {
     runHook postCheck
 }
 
-if [ -z "${checkPhase-}" ]; then
+if [ -z "${dontCargoCheck-}" ] && [ -z "${checkPhase-}" ]; then
   checkPhase=cargoCheckHook
 fi

--- a/pkgs/build-support/rust/hooks/cargo-install-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-install-hook.sh
@@ -43,7 +43,7 @@ cargoInstallHook() {
 }
 
 
-if [ -z "${installPhase-}" ]; then
+if [ -z "${dontCargoInstall-}" ] && [ -z "${installPhase-}" ]; then
   installPhase=cargoInstallHook
   postBuildHooks+=(cargoInstallPostBuildHook)
 fi

--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -77,7 +77,9 @@ cargoSetupPostPatchHook() {
     echo "Finished cargoSetupPostPatchHook"
 }
 
-postUnpackHooks+=(cargoSetupPostUnpackHook)
+if [ -z "${dontCargoSetupPostUnpack-}" ]; then
+  postUnpackHooks+=(cargoSetupPostUnpackHook)
+fi
 
 if [ -z ${cargoVendorDir-} ]; then
   postPatchHooks+=(cargoSetupPostPatchHook)


### PR DESCRIPTION
###### Motivation for this change
For `gnome-tour` we want meson to do the build, however, there was no way to conditionally disable the buildRustPackage hooks

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
