### PR TITLE
urserver: 3.6.0.745 -> 3.9.0.2465

### DIFF
--- a/pkgs/servers/urserver/default.nix
+++ b/pkgs/servers/urserver/default.nix
@@ -9,15 +9,16 @@
 
 stdenv.mkDerivation rec {
   pname = "urserver";
-  version = "3.6.0.745";
+  version = "3.9.0.2465";
 
   src = fetchurl {
-    url = "https://www.unifiedremote.com/static/builds/server/linux-x64/745/urserver-${version}.tar.gz";
-    sha256 = "1ib9317bg9n4knwnlbrn1wfkyrjalj8js3a6h7zlcl8h8xc0szc8";
+    url = "https://www.unifiedremote.com/static/builds/server/linux-x64/${builtins.elemAt (builtins.splitVersion version) 3}/urserver-${version}.tar.gz";
+    sha256 = "sha256-3DIroodWCMbq1fzPjhuGLk/2fY/qFxFISLzjkjJ4i90=";
   };
 
   nativeBuildInputs = [
     autoPatchelfHook
+    makeWrapper
   ];
 
   buildInputs = [
@@ -25,7 +26,6 @@ stdenv.mkDerivation rec {
     bluez
     libX11
     libXtst
-    makeWrapper
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

New upstream release, has apparently been available for some time, but I missed it.

###### Things done

Also tested that it still runs as a service, and still does the things I used it for.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
