### PR TITLE
cargo-criterion: init at 1.0.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-criterion/default.nix
+++ b/pkgs/development/tools/rust/cargo-criterion/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-criterion";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "bheisler";
+    repo = pname;
+    rev = version;
+    sha256 = "0czagclrn4yhlvlh06wsyiybz69r7mmk3182fywzn9vd0xlclxpi";
+  };
+
+  cargoSha256 = "sha256-XZuZ81hB/GQDopJyfSkxQiehSwJz7VWoJR6/m3WLil8=";
+
+  meta = with lib; {
+    description = "Cargo extension for running Criterion.rs benchmarks";
+    homepage = "https://github.com/bheisler/cargo-criterion";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ humancalico ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10869,6 +10869,7 @@ in
   cargo-c = callPackage ../development/tools/rust/cargo-c {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
+  cargo-criterion = callPackage ../development/tools/rust/cargo-criterion { };
   cargo-deb = callPackage ../tools/package-management/cargo-deb {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
Signed-off-by: Akshat Agarwal <humancalico@disroot.org>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
