### PR TITLE
nixos/rl-2105: add hookification of buildRustPackage

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -745,6 +745,40 @@ self: super:
      once during the time when the timer was inactive.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <literal>rustPlatform.buildRustPackage</literal> function is split into several hooks:
+     <package>cargoSetupHook</package> to set up vendoring for Cargo-based projects,
+     <package>cargoBuildHook</package> to build a project using Cargo,
+     <package>cargoInstallHook</package> to install a project using Cargo, and
+     <package>cargoCheckHook</package> to run tests in Cargo-based projects. With this change,
+     mixed-language projects can use the relevant hooks within builders other than
+     <literal>buildRustPackage</literal>. However, these changes also required several API changes to
+     <literal>buildRustPackage</literal> itself:
+
+     <itemizedlist>
+      <listitem>
+       <para>
+        The <literal>target</literal> argument was removed. Instead, <literal>buildRustPackage</literal>
+        will always use the same target as the C/C++ compiler that is used.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        The <literal>cargoParallelTestThreads</literal> argument was removed. Parallel tests are
+        now disabled through <literal>dontUseCargoParallelTests</literal>.
+       </para>
+      </listitem>
+     </itemizedlist>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The <literal>rustPlatform.maturinBuildHook</literal> hook was added. This hook can be used
+     with <literal>buildPythonPackage</literal> to build Python packages that are written in Rust
+     and use Maturin as their build tool.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
