### PR TITLE
python3Packages.ldaptor: 20.1.1 -> 21.2.0

### DIFF
--- a/pkgs/development/python-modules/ldaptor/default.nix
+++ b/pkgs/development/python-modules/ldaptor/default.nix
@@ -8,25 +8,23 @@
 , service-identity
 , zope_interface
 , isPy3k
-, pythonAtLeast
 , python
 }:
 
 buildPythonPackage rec {
   pname = "ldaptor";
-  version = "20.1.1";
+  version = "21.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "778f45d68a0b5d63a892c804c05e57b464413a41d8ae52f92ae569321473ab67";
+    sha256 = "sha256-jEnrGTddSqs+W4NYYGFODLF+VrtaIOGHSAj6W+xno1g=";
   };
 
   propagatedBuildInputs = [
     twisted passlib pyopenssl pyparsing service-identity zope_interface
   ];
 
-  # https://github.com/twisted/ldaptor/pull/210
-  disabled = !isPy3k || pythonAtLeast "3.9";
+  disabled = !isPy3k;
 
   checkPhase = ''
     ${python.interpreter} -m twisted.trial ldaptor


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Support for Python 3.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
