### PR TITLE
brltty: 6.1 -> 6.3; nixos/brltty: use upstream units

### DIFF
--- a/nixos/modules/services/hardware/brltty.nix
+++ b/nixos/modules/services/hardware/brltty.nix
@@ -5,6 +5,19 @@ with lib;
 let
   cfg = config.services.brltty;
 
+  targets = [
+    "default.target" "multi-user.target"
+    "rescue.target" "emergency.target"
+  ];
+
+  genApiKey = pkgs.writers.writeDash "generate-brlapi-key" ''
+    if ! test -f /etc/brlapi.key; then
+      echo -n generating brlapi key...
+      ${pkgs.brltty}/bin/brltty-genkey -f /etc/brlapi.key
+      echo done
+    fi
+  '';
+
 in {
 
   options = {
@@ -18,33 +31,27 @@ in {
   };
 
   config = mkIf cfg.enable {
-
-    systemd.services.brltty = {
-      description = "Braille Device Support";
-      unitConfig = {
-        Documentation = "http://mielke.cc/brltty/";
-        DefaultDependencies = "no";
-        RequiresMountsFor = "${pkgs.brltty}/var/lib/brltty";
-      };
-      serviceConfig = {
-        ExecStart = "${pkgs.brltty}/bin/brltty --no-daemon";
-        Type = "notify";
-        TimeoutStartSec = 5;
-        TimeoutStopSec = 10;
-        Restart = "always";
-        RestartSec = 30;
-        Nice = -10;
-        OOMScoreAdjust = -900;
-        ProtectHome = "read-only";
-        ProtectSystem = "full";
-        SystemCallArchitectures = "native";
-      };
-      wants = [ "systemd-udev-settle.service" ];
-      after = [ "local-fs.target" "systemd-udev-settle.service" ];
-      before = [ "sysinit.target" ];
-      wantedBy = [ "sysinit.target" ];
+    users.users.brltty = {
+      description = "BRLTTY daemon user";
+      group = "brltty";
+    };
+    users.groups = {
+      brltty = { };
+      brlapi = { };
     };
 
+    systemd.services."brltty@".serviceConfig =
+      { ExecStartPre = "!${genApiKey}"; };
+
+    # Install all upstream-provided files
+    systemd.packages = [ pkgs.brltty ];
+    systemd.tmpfiles.packages = [ pkgs.brltty ];
+    services.udev.packages = [ pkgs.brltty ];
+    environment.systemPackages = [ pkgs.brltty ];
+
+    # Add missing WantedBys (see issue #81138)
+    systemd.paths.brltty.wantedBy = targets;
+    systemd.paths."brltty@".wantedBy = targets;
   };
 
 }

--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -1,10 +1,8 @@
 { lib, stdenv, fetchurl, pkg-config, python3, bluez
 , tcl, acl, kmod, coreutils, shadow
-, alsaSupport ? stdenv.isLinux, alsaLib ? null
-, systemdSupport ? stdenv.isLinux, systemd ? null }:
-
-assert alsaSupport -> alsaLib != null;
-assert systemdSupport -> systemd != null;
+, alsaSupport ? stdenv.isLinux, alsaLib
+, systemdSupport ? stdenv.isLinux, systemd
+}:
 
 stdenv.mkDerivation rec {
   pname = "brltty";

--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, python3, bluez
+, tcl, acl, kmod, coreutils, shadow
 , alsaSupport ? stdenv.isLinux, alsaLib ? null
 , systemdSupport ? stdenv.isLinux, systemd ? null }:
 
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "14psxwlvgyi2fj1zh8rfykyjcjaya8xa7yg574bxd8y8n49n8hvb";
   };
 
-  nativeBuildInputs = [ pkg-config python3.pkgs.cython ];
+  nativeBuildInputs = [ pkg-config python3.pkgs.cython tcl ];
   buildInputs = [ bluez ]
     ++ lib.optional alsaSupport alsaLib
     ++ lib.optional systemdSupport systemd;
@@ -33,11 +34,53 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
   };
 
-  makeFlags = [ "PYTHON_PREFIX=$(out)" ];
-
-  preConfigurePhases = [ "preConfigure" ];
+  makeFlags = [
+    "PYTHON_PREFIX=$(out)"
+    "SYSTEMD_UNITS_DIRECTORY=$(out)/lib/systemd/system"
+    "SYSTEMD_USERS_DIRECTORY=$(out)/lib/sysusers.d"
+    "SYSTEMD_FILES_DIRECTORY=$(out)/lib/tmpfiles.d"
+    "UDEV_LIBRARY_DIRECTORY=$(out)/lib/udev"
+    "POLKIT_POLICY_DIR=$(out)/share/polkit-1/actions"
+    "POLKIT_RULE_DIR=$(out)/share/polkit-1/rules.d"
+  ];
+  configureFlags = [
+    "--with-writable-directory=/run/brltty"
+    "--with-updatable-directory=/var/lib/brltty"
+    "--with-api-socket-path=/var/lib/BrlAPI"
+  ];
+  installFlags = [ "install-systemd" "install-udev" "install-polkit" ];
 
   preConfigure = ''
     substituteInPlace configure --replace /sbin/ldconfig ldconfig
+
+    # Some script needs a working tclsh shebang
+    patchShebangs .
+
+    # Skip impure operations
+    substituteInPlace Programs/Makefile.in    \
+      --replace install-writable-directory "" \
+      --replace install-apisoc-directory ""   \
+      --replace install-api-key ""
+  '';
+
+  postInstall = ''
+    # Rewrite absolute paths
+    substituteInPlace $out/bin/brltty-mkuser \
+      --replace '/sbin/nologin' '${shadow}/bin/nologin'
+    (
+      cd $out/lib
+      substituteInPlace systemd/system/brltty@.service \
+        --replace '/usr/lib' "$out/lib" \
+        --replace '/sbin/modprobe' '${kmod}/bin/modprobe'
+      substituteInPlace systemd/system/brltty-device@.service \
+        --replace '/usr/bin/true' '${coreutils}/bin/true'
+      substituteInPlace udev/rules.d/90-brltty-uinput.rules \
+        --replace '/usr/bin/setfacl' '${acl}/bin/setfacl'
+      substituteInPlace tmpfiles.d/brltty.conf \
+        --replace "$out/etc" '/etc'
+
+      # Remove unused commands from udev rules
+      sed '/initctl/d' -i udev/rules.d/90-brltty-device.rules
+    )
   '';
 }

--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
       Some speech capability has also been incorporated.
     '';
     homepage = "https://brltty.app";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.bramd ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -6,11 +6,12 @@ assert alsaSupport -> alsaLib != null;
 assert systemdSupport -> systemd != null;
 
 stdenv.mkDerivation rec {
-  name = "brltty-6.1";
+  pname = "brltty";
+  version = "6.3";
 
   src = fetchurl {
-    url = "http://brltty.com/archive/${name}.tar.gz";
-    sha256 = "0nk54chr7z2w579vyiak9xk2avhnvrx7x2l5sk8nyw2zplchkx9q";
+    url = "https://brltty.app/archive/${pname}-${version}.tar.gz";
+    sha256 = "14psxwlvgyi2fj1zh8rfykyjcjaya8xa7yg574bxd8y8n49n8hvb";
   };
 
   nativeBuildInputs = [ pkg-config python3.pkgs.cython ];
@@ -26,7 +27,7 @@ stdenv.mkDerivation rec {
       It drives the braille display, and provides complete screen review functionality.
       Some speech capability has also been incorporated.
     '';
-    homepage = "http://www.brltty.com/";
+    homepage = "https://brltty.app";
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.bramd ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
###### Motivation for this change

Removing systemd-udev-settle as part of #73095.

Upstream has been providing a very thoroughly designed set of systemd units,
udev and polkit rules. With these the brltty daemon is activated
asynchronously via udev, runs as a dedicated user with runtime and state
directories set up using systemd-tmpfiles.

This is much better than the current unit, which runs a single instance
as root and pulls in systemd-udev-settle to wait for the hardware.

###### Things done

- [x] Find someone with a braille display to test this
- [x] Build brltty
- [x] Build a system with `services.brltty.enable = true;` 
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
