### PR TITLE
crate2nix: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/development/tools/rust/crate2nix/default.nix
+++ b/pkgs/development/tools/rust/crate2nix/default.nix
@@ -10,17 +10,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "crate2nix";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub
     {
       owner = "kolloch";
       repo = pname;
       rev = version;
-      sha256 = "sha256-pqg1BsEq3kGmUzt1zpQvXgdnRcIsiuIyvtUBi3VxtZ4=";
+      sha256 = "sha256-dB8wa3CQFw8ckD420zpBGw4TnsLrHqXf+ff/WuhPsVM=";
     } + "/crate2nix";
 
-  cargoSha256 = "sha256-dAMWrGNMleQ3lDbG46Hr4qvCyxR+QcPOUZw9r2/CxV4=";
+  cargoSha256 = "sha256-6V0ifH63/s5XLo4BCexPtvlUH0UQPHFW8YHF8OCH3ik=";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change

- https://github.com/kolloch/crate2nix/issues/164
- https://github.com/kolloch/crate2nix/issues/168

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` ***(is only `crate2nix`)***
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
      ***346 kB***
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
