### PR TITLE
sage: adapt eclib test expected output, revert cypari2 update

### DIFF
--- a/pkgs/applications/science/math/sage/patches/eclib-20210223-test-formatting.patch
+++ b/pkgs/applications/science/math/sage/patches/eclib-20210223-test-formatting.patch
@@ -1,0 +1,131 @@
+diff --git a/src/sage/libs/eclib/interface.py b/src/sage/libs/eclib/interface.py
+index e898456720..6b98c12328 100644
+--- a/src/sage/libs/eclib/interface.py
++++ b/src/sage/libs/eclib/interface.py
+@@ -758,78 +758,78 @@ class mwrank_MordellWeil(SageObject):
+ 
+         sage: EQ = mwrank_MordellWeil(E, verbose=True)
+         sage: EQ.search(1)
+-        P1 = [0:1:0]     is torsion point, order 1
+-        P1 = [-3:0:1]     is generator number 1
+-        saturating up to 20...Checking 2-saturation
++        P1 = [0:1:0]         is torsion point, order 1
++        P1 = [-3:0:1]         is generator number 1
++        saturating up to 20...Checking 2-saturation...
+         Points have successfully been 2-saturated (max q used = 7)
+-        Checking 3-saturation
++        Checking 3-saturation...
+         Points have successfully been 3-saturated (max q used = 7)
+-        Checking 5-saturation
++        Checking 5-saturation...
+         Points have successfully been 5-saturated (max q used = 23)
+-        Checking 7-saturation
++        Checking 7-saturation...
+         Points have successfully been 7-saturated (max q used = 41)
+-        Checking 11-saturation
++        Checking 11-saturation...
+         Points have successfully been 11-saturated (max q used = 17)
+-        Checking 13-saturation
++        Checking 13-saturation...
+         Points have successfully been 13-saturated (max q used = 43)
+-        Checking 17-saturation
++        Checking 17-saturation...
+         Points have successfully been 17-saturated (max q used = 31)
+-        Checking 19-saturation
++        Checking 19-saturation...
+         Points have successfully been 19-saturated (max q used = 37)
+         done
+-        P2 = [-2:3:1]     is generator number 2
+-        saturating up to 20...Checking 2-saturation
++        P2 = [-2:3:1]         is generator number 2
++        saturating up to 20...Checking 2-saturation...
+         possible kernel vector = [1,1]
+         This point may be in 2E(Q): [14:-52:1]
+         ...and it is!
+         Replacing old generator #1 with new generator [1:-1:1]
+         Points have successfully been 2-saturated (max q used = 7)
+         Index gain = 2^1
+-        Checking 3-saturation
++        Checking 3-saturation...
+         Points have successfully been 3-saturated (max q used = 13)
+-        Checking 5-saturation
++        Checking 5-saturation...
+         Points have successfully been 5-saturated (max q used = 67)
+-        Checking 7-saturation
++        Checking 7-saturation...
+         Points have successfully been 7-saturated (max q used = 53)
+-        Checking 11-saturation
++        Checking 11-saturation...
+         Points have successfully been 11-saturated (max q used = 73)
+-        Checking 13-saturation
++        Checking 13-saturation...
+         Points have successfully been 13-saturated (max q used = 103)
+-        Checking 17-saturation
++        Checking 17-saturation...
+         Points have successfully been 17-saturated (max q used = 113)
+-        Checking 19-saturation
++        Checking 19-saturation...
+         Points have successfully been 19-saturated (max q used = 47)
+         done (index = 2).
+         Gained index 2, new generators = [ [1:-1:1] [-2:3:1] ]
+-        P3 = [-14:25:8]   is generator number 3
+-        saturating up to 20...Checking 2-saturation
++        P3 = [-14:25:8]       is generator number 3
++        saturating up to 20...Checking 2-saturation...
+         Points have successfully been 2-saturated (max q used = 11)
+-        Checking 3-saturation
++        Checking 3-saturation...
+         Points have successfully been 3-saturated (max q used = 13)
+-        Checking 5-saturation
++        Checking 5-saturation...
+         Points have successfully been 5-saturated (max q used = 71)
+-        Checking 7-saturation
++        Checking 7-saturation...
+         Points have successfully been 7-saturated (max q used = 101)
+-        Checking 11-saturation
++        Checking 11-saturation...
+         Points have successfully been 11-saturated (max q used = 127)
+-        Checking 13-saturation
++        Checking 13-saturation...
+         Points have successfully been 13-saturated (max q used = 151)
+-        Checking 17-saturation
++        Checking 17-saturation...
+         Points have successfully been 17-saturated (max q used = 139)
+-        Checking 19-saturation
++        Checking 19-saturation...
+         Points have successfully been 19-saturated (max q used = 179)
+         done (index = 1).
+-        P4 = [-1:3:1]    = -1*P1 + -1*P2 + -1*P3 (mod torsion)
+-        P4 = [0:2:1]     = 2*P1 + 0*P2 + 1*P3 (mod torsion)
+-        P4 = [2:13:8]    = -3*P1 + 1*P2 + -1*P3 (mod torsion)
+-        P4 = [1:0:1]     = -1*P1 + 0*P2 + 0*P3 (mod torsion)
+-        P4 = [2:0:1]     = -1*P1 + 1*P2 + 0*P3 (mod torsion)
+-        P4 = [18:7:8]    = -2*P1 + -1*P2 + -1*P3 (mod torsion)
+-        P4 = [3:3:1]     = 1*P1 + 0*P2 + 1*P3 (mod torsion)
+-        P4 = [4:6:1]     = 0*P1 + -1*P2 + -1*P3 (mod torsion)
+-        P4 = [36:69:64]  = 1*P1 + -2*P2 + 0*P3 (mod torsion)
+-        P4 = [68:-25:64]         = -2*P1 + -1*P2 + -2*P3 (mod torsion)
+-        P4 = [12:35:27]  = 1*P1 + -1*P2 + -1*P3 (mod torsion)
++        P4 = [-1:3:1]        = -1*P1 + -1*P2 + -1*P3 (mod torsion)
++        P4 = [0:2:1]         = 2*P1 + 0*P2 + 1*P3 (mod torsion)
++        P4 = [2:13:8]        = -3*P1 + 1*P2 + -1*P3 (mod torsion)
++        P4 = [1:0:1]         = -1*P1 + 0*P2 + 0*P3 (mod torsion)
++        P4 = [2:0:1]         = -1*P1 + 1*P2 + 0*P3 (mod torsion)
++        P4 = [18:7:8]        = -2*P1 + -1*P2 + -1*P3 (mod torsion)
++        P4 = [3:3:1]         = 1*P1 + 0*P2 + 1*P3 (mod torsion)
++        P4 = [4:6:1]         = 0*P1 + -1*P2 + -1*P3 (mod torsion)
++        P4 = [36:69:64]      = 1*P1 + -2*P2 + 0*P3 (mod torsion)
++        P4 = [68:-25:64]     = -2*P1 + -1*P2 + -2*P3 (mod torsion)
++        P4 = [12:35:27]      = 1*P1 + -1*P2 + -1*P3 (mod torsion)
+         sage: EQ
+         Subgroup of Mordell-Weil group: [[1:-1:1], [-2:3:1], [-14:25:8]]
+ 
+@@ -1076,7 +1076,7 @@ class mwrank_MordellWeil(SageObject):
+             sage: EQ.search(1)
+             P1 = [0:1:0]         is torsion point, order 1
+             P1 = [-3:0:1]         is generator number 1
+-            saturating up to 20...Checking 2-saturation
++            saturating up to 20...Checking 2-saturation...
+             ...
+             P4 = [12:35:27]      = 1*P1 + -1*P2 + -1*P3 (mod torsion)
+             sage: EQ

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -112,6 +112,9 @@ stdenv.mkDerivation rec {
 
     # workaround until we use sage's fork of threejs, which contains a "version" file
     ./patches/dont-grep-threejs-version-from-minified-js.patch
+
+    # updated eclib output has punctuation changes and tidier whitespace
+    ./patches/eclib-20210223-test-formatting.patch
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -11,11 +11,11 @@
 buildPythonPackage rec {
   pname = "cypari2";
   # upgrade may break sage, please test the sage build or ping @timokau on upgrade
-  version = "2.1.2";
+  version = "2.1.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "03cd45edab8716ebbfdb754e65fea72e873c73dc91aec098fe4a01e35324ac7a";
+    sha256 = "df1ef62e771ec36e5a456f5fc8b51bc6745b70f0efdd0c7a30c3f0b5f1fb93db";
   };
 
   # This differs slightly from the default python installPhase in that it pip-installs


### PR DESCRIPTION
###### Motivation for this change
eclib was updated in #114425, but the test output changed slightly. Upstream is still on eclib 20190909, so I cannot just import an upstream patch.

Should unbreak sage. I've verified that the test outputs are the same up to minor formatting changes.