### PR TITLE
umr: init at unstable-2021-02-18

### DIFF
--- a/pkgs/development/misc/umr/default.nix
+++ b/pkgs/development/misc/umr/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchgit, bash-completion, cmake, pkg-config
+, libdrm, libpciaccess, llvmPackages, ncurses
+}:
+
+stdenv.mkDerivation rec {
+  pname = "umr";
+  version = "unstable-2021-02-18";
+
+  src = fetchgit {
+    url = "https://gitlab.freedesktop.org/tomstdenis/umr";
+    rev = "79e17f8f2807ed707fc1be369d0aad536f6dbc97";
+    sha256 = "IwTkHEuJ82hngPjFVIihU2rSolLBqHxQTNsP8puYPaY=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    bash-completion
+    libdrm
+    libpciaccess
+    llvmPackages.llvm
+    ncurses
+  ];
+
+  # Remove static libraries (there are no dynamic libraries in there)
+  postInstall = ''
+    rm -r $out/lib
+  '';
+
+  meta = with lib; {
+    description = "A userspace debugging and diagnostic tool for AMD GPUs";
+    homepage = "https://gitlab.freedesktop.org/tomstdenis/umr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Flakebi ];
+    platforms = platforms.linux;
+ };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11731,6 +11731,10 @@ in
   pharo-spur64 = assert stdenv.is64bit; pharo-vms.spur64;
   pharo-launcher = callPackage ../development/pharo/launcher { };
 
+  umr = callPackage ../development/misc/umr {
+    llvmPackages = llvmPackages_latest;
+  };
+
   srandrd = callPackage ../tools/X11/srandrd { };
 
   srecord = callPackage ../development/tools/misc/srecord { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://gitlab.freedesktop.org/tomstdenis/umr

umr is a userspace debugging and diagnostic tool for AMD GPUs using
the AMDGPU kernel driver with limited support for driverless debugging
(via PCI direct access).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @danieldk @acowley