### PR TITLE
python3Packages.pymediaroom: init at 0.6.4.1

### DIFF
--- a/pkgs/development/python-modules/pymediaroom/default.nix
+++ b/pkgs/development/python-modules/pymediaroom/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, async-timeout
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "pymediaroom";
+  version = "0.6.4.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "dgomes";
+    repo = pname;
+    rev = version;
+    sha256 = "1klf2dxd8rlq3n4b9m03lzwcsasn9vi6m3hzrjqhqnprhrnp0xmy";
+  };
+
+  propagatedBuildInputs = [
+    async-timeout
+    xmltodict
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pymediaroom" ];
+
+  meta = with lib; {
+    description = "Python Remote Control for Mediaroom STB";
+    homepage = "https://github.com/dgomes/pymediaroom";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -480,7 +480,7 @@
     "media_extractor" = ps: with ps; [ aiohttp-cors youtube-dl-light ];
     "media_player" = ps: with ps; [ aiohttp-cors ];
     "media_source" = ps: with ps; [ aiohttp-cors ];
-    "mediaroom" = ps: with ps; [ ]; # missing inputs: pymediaroom
+    "mediaroom" = ps: with ps; [ pymediaroom ];
     "melcloud" = ps: with ps; [ ]; # missing inputs: pymelcloud
     "melissa" = ps: with ps; [ ]; # missing inputs: py-melissa-climate
     "meraki" = ps: with ps; [ aiohttp-cors ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5704,6 +5704,8 @@ in {
 
   pymediainfo = callPackage ../development/python-modules/pymediainfo { };
 
+  pymediaroom = callPackage ../development/python-modules/pymediaroom { };
+
   pymeeus = callPackage ../development/python-modules/pymeeus { };
 
   pymemoize = callPackage ../development/python-modules/pymemoize { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python Remote Control for Mediaroom STB

https://github.com/dgomes/pymediaroom

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
