### PR TITLE
python3Packages.aiopylgtv: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/aiopylgtv/default.nix
+++ b/pkgs/development/python-modules/aiopylgtv/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, pythonOlder
+, sqlitedict
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "aiopylgtv";
+  version = "0.4.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "bendavid";
+    repo = pname;
+    rev = version;
+    sha256 = "0x0xcnlz42arsp53zlq5wyv9pwif1in8j2pv48gh0pkdnz9s86b6";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    sqlitedict
+    websockets
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "aiopylgtv" ];
+
+  meta = with lib; {
+    description = "Python library to control webOS based LG TV units";
+    homepage = "https://github.com/bendavid/aiopylgtv";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -924,7 +924,7 @@
     "waze_travel_time" = ps: with ps; [ WazeRouteCalculator ];
     "weather" = ps: with ps; [ ];
     "webhook" = ps: with ps; [ aiohttp-cors ];
-    "webostv" = ps: with ps; [ ]; # missing inputs: aiopylgtv
+    "webostv" = ps: with ps; [ aiopylgtv ];
     "websocket_api" = ps: with ps; [ aiohttp-cors ];
     "wemo" = ps: with ps; [ ]; # missing inputs: pywemo
     "whois" = ps: with ps; [ python-whois ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -284,6 +284,8 @@ in {
 
   aiopulse = callPackage ../development/python-modules/aiopulse { };
 
+  aiopylgtv = callPackage ../development/python-modules/aiopylgtv { };
+
   aiorecollect = callPackage ../development/python-modules/aiorecollect { };
 
   aioredis = callPackage ../development/python-modules/aioredis { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to control webOS based LG TV units

https://github.com/bendavid/aiopylgtv

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
