### PR TITLE
Revert "minecraft: 2.2.1441 → 2.2.1867"

### DIFF
--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -88,11 +88,11 @@ in
 stdenv.mkDerivation rec {
   pname = "minecraft-launcher";
 
-  version = "2.2.1867";
+  version = "2.2.1441";
 
   src = fetchurl {
     url = "https://launcher.mojang.com/download/linux/x86_64/minecraft-launcher_${version}.tar.gz";
-    sha256 = "1gpagrinam595153jbxwagcq20ij2dk8nn6zajy2iyqmj12y66ay";
+    sha256 = "03q579hvxnsh7d00j6lmfh53rixdpf33xb5zlz7659pvb9j5w0cm";
   };
 
   icon = fetchurl {


### PR DESCRIPTION
Reverts NixOS/nixpkgs#114134

Temporary fix for #114732

/cc @ronthecookie 