### PR TITLE
nixos/anbox: remove systemd-udev-settle

### DIFF
--- a/nixos/modules/virtualisation/anbox.nix
+++ b/nixos/modules/virtualisation/anbox.nix
@@ -98,7 +98,6 @@ in
       environment.XDG_RUNTIME_DIR="${anboxloc}";
 
       wantedBy = [ "multi-user.target" ];
-      after = [ "systemd-udev-settle.service" ];
       preStart = let
         initsh = pkgs.writeText "nixos-init" (''
           #!/system/bin/sh


### PR DESCRIPTION
###### Motivation for this change

Remove systemd-udev-settle as part of #73095.

The anbox session manager seems to start without issues when
systemd-udev-settle is masked or the dependency removed.

Tested with:

    $ nix-build nixos/ -A vm --arg configuration '
      {
        virtualisation.anbox.enable = true;
        users.users.root.hashedPassword = "";
      }'

###### Things done

- [x] Tested anbox-container-manager.service starts at boot
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
