### PR TITLE
python3Packages.w3lib: Fix build failure with Python 3.8.8

### DIFF
--- a/pkgs/development/python-modules/w3lib/default.nix
+++ b/pkgs/development/python-modules/w3lib/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , six
 , pytest
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -13,6 +14,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1pv02lvvmgz2qb61vz1jkjc04fgm4hpfvaj5zm4i3mjp64hd1mha";
   };
+
+  patches = [
+    # Remove test broken by Python CVE-2021-23336 fix
+    (fetchpatch {
+      url = "https://github.com/scrapy/w3lib/pull/165/commits/78054f19bfe20555792b0f336b423921fe88b994.patch";
+      sha256 = "1fb40gk2dk6rlap7nxm5sii3id054plx0yq2gkzcs10gpv1a8vpc";
+    })
+  ];
 
   buildInputs = [ six pytest ];
 


### PR DESCRIPTION
###### Motivation for this change

In Python 3.6.13, 3.7.10, 3.8.8, and 3.9.2, `urllib.parse.parse_qsl` no longer treats ; as a separator by default to fix CVE-2021-23336 (https://bugs.python.org/issue42967). This broke one of the tests for w3lib (https://github.com/scrapy/w3lib/issues/164).

https://hydra.nixos.org/build/137332382

```
======================================================================
FAIL: test_add_or_replace_parameter (tests.test_url.UrlTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/w3lib-1.22.0/tests/test_url.py", line 303, in test_add_or_replace_parameter
    self.assertEqual(add_or_replace_parameter(url, 'arg1', 'v3'),
AssertionError: 'http://domain/test?arg1=v3' != 'http://domain/test?arg1=v3&arg2=v2'
- http://domain/test?arg1=v3
+ http://domain/test?arg1=v3&arg2=v2
?                           ++++++++


----------------------------------------------------------------------
Ran 146 tests in 0.411s

FAILED (failures=1)
Test failed: <unittest.runner.TextTestResult run=146 errors=0 failures=1>
error: Test failed: <unittest.runner.TextTestResult run=146 errors=0 failures=1>
builder for '/nix/store/cbnn0n3wk35556fbhsblhr37674lcj1j-python3.8-w3lib-1.22.0.drv' failed with exit code 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
