### PR TITLE
brutespray: 1.6.8 -> 1.7.0

### DIFF
--- a/pkgs/tools/security/brutespray/default.nix
+++ b/pkgs/tools/security/brutespray/default.nix
@@ -1,14 +1,20 @@
-{ lib, stdenv, python3, fetchFromGitHub, makeWrapper, medusa }:
+{ lib
+, stdenv
+, python3
+, fetchFromGitHub
+, makeWrapper
+, medusa
+}:
 
 stdenv.mkDerivation rec {
   pname = "brutespray";
-  version = "1.6.8";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "x90skysn3k";
     repo = pname;
-    rev = "brutespray-${version}";
-    sha256 = "1pi4d5vcvvjsby39dq995dlhpxdicmfhqsiw23hr25m38ccfm3rh";
+    rev = "${pname}-${version}";
+    sha256 = "0lkm3fvx35ml5jh4ykjr2srq8qfajkmxwp4qfcn9xi58khk3asq3";
   };
 
   postPatch = ''
@@ -33,7 +39,11 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/x90skysn3k/brutespray";
-    description = "Brute-Forcing from Nmap output - Automatically attempts default creds on found services";
+    description = "Tool to do brute-forcing from Nmap output";
+    longDescription = ''
+      This tool automatically attempts default credentials on found services
+      directly from Nmap output.
+    '';
     license = licenses.mit;
     maintainers = with maintainers; [ ma27 ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.7.0

Change log: https://github.com/x90skysn3k/brutespray/blob/master/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
