### PR TITLE
fcitx: wrap with xmodmap in PATH

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/unwrapped.nix
+++ b/pkgs/tools/inputmethods/fcitx/unwrapped.nix
@@ -2,7 +2,7 @@
 , libxml2, enchant2, isocodes, icu, libpthreadstubs
 , pango, cairo, libxkbfile, libXau, libXdmcp, libxkbcommon
 , dbus, gtk2, gtk3, qt4, extra-cmake-modules
-, xkeyboard_config, pcre, libuuid
+, xkeyboard_config, pcre, libuuid, xorg, makeWrapper
 , withPinyin ? true
 , fetchFromGitLab
 }:
@@ -68,7 +68,12 @@ stdenv.mkDerivation rec {
     patchShebangs cmake/
   '';
 
-  nativeBuildInputs = [ cmake extra-cmake-modules intltool pkg-config pcre ];
+  postInstall = ''
+    wrapProgram $out/bin/fcitx \
+      --prefix PATH : "${xorg.xmodmap}/bin"
+  '';
+
+  nativeBuildInputs = [ cmake extra-cmake-modules intltool pkg-config pcre makeWrapper ];
 
   buildInputs = [
     xkeyboard_config enchant2 gettext isocodes icu libpthreadstubs libXau libXdmcp libxkbfile


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

fcitx contains functionality to execute xmodmap when changing the
layout, which triggers if `~/.Xmodmap` is present. However, this breaks
if xmodmap isn't present in fcitx's PATH.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).