### PR TITLE
vms-empire: 1.15 -> 1.16

### DIFF
--- a/pkgs/games/vms-empire/default.nix
+++ b/pkgs/games/vms-empire/default.nix
@@ -1,26 +1,50 @@
-{ lib, stdenv, fetchurl, ncurses, xmlto }:
+{ lib
+, stdenv
+, fetchurl
+, ncurses
+, xmlto
+, docbook_xml_dtd_44
+, docbook_xsl
+, installShellFiles
+}:
 
 stdenv.mkDerivation rec {
   pname = "vms-empire";
-  version = "1.15";
+  version = "1.16";
 
   src = fetchurl{
-    url = "http://www.catb.org/~esr/vms-empire/${pname}-${version}.tar.gz";
-    sha256 = "1vcpglkimcljb8s1dp6lzr5a0vbfxmh6xf37cmb8rf9wc3pghgn3";
+    url = "http://www.catb.org/~esr/${pname}/${pname}-${version}.tar.gz";
+    hash = "sha256-XETIbt/qVU+TpamPc2WQynqqUuZqkTUnItBprjg+gPk=";
   };
 
-  buildInputs =
-  [ ncurses xmlto ];
+  nativeBuildInputs = [ installShellFiles ];
+  buildInputs = [
+    ncurses
+    xmlto
+    docbook_xml_dtd_44
+    docbook_xsl
+  ];
 
-  patchPhase = ''
-    sed -i -e 's|^install: empire\.6 uninstall|install: empire.6|' -e 's|usr/||g' Makefile
+  postBuild = ''
+    xmlto man vms-empire.xml
+    xmlto html-nochunks vms-empire.xml
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D vms-empire -t ${placeholder "out"}/bin/
+    install -D vms-empire.html -t ${placeholder "out"}/share/doc/${pname}/
+    install -D vms-empire.desktop -t ${placeholder "out"}/share/applications/
+    install -D vms-empire.png -t ${placeholder "out"}/share/icons/hicolor/48x48/apps/
+    install -D vms-empire.xml -t ${placeholder "out"}/share/appdata/
+    installManPage empire.6
+    runHook postInstall
   '';
 
   hardeningDisable = [ "format" ];
 
-  makeFlags = [ "DESTDIR=$(out)" ];
-
   meta = with lib; {
+    homepage = "http://catb.org/~esr/vms-empire/";
     description = "The ancestor of all expand/explore/exploit/exterminate games";
     longDescription = ''
       Empire is a simulation of a full-scale war between two emperors, the
@@ -30,11 +54,8 @@ stdenv.mkDerivation rec {
       expand/explore/exploit/exterminate games, including Civilization and
       Master of Orion.
     '';
-    homepage = "http://catb.org/~esr/vms-empire/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.AndersonTorres ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }
-
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
