### PR TITLE
haskellPackages.qtah*: Fix build and mark as unbroken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -120,6 +120,11 @@ self: super: {
     extraLibraries = [ pkgs.blas ];
   });
 
+  # Requires wrapQtAppsHook
+  qtah-cpp-qt5 = overrideCabal super.qtah-cpp-qt5 (drv: {
+    buildDepends = [ pkgs.qt5.wrapQtAppsHook ];
+  });
+
   # The Haddock phase fails for one reason or another.
   deepseq-magic = dontHaddock super.deepseq-magic;
   feldspar-signal = dontHaddock super.feldspar-signal; # https://github.com/markus-git/feldspar-signal/issues/1

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6127,7 +6127,6 @@ broken-packages:
   - haskell-reflect
   - haskell-rules
   - haskell-spacegoo
-  - haskell-src
   - haskell-src-exts-observe
   - haskell-src-exts-prisms
   - haskell-src-exts-qq
@@ -6623,10 +6622,6 @@ broken-packages:
   - hopencl
   - HOpenCV
   - hopfield
-  - hoppy-docs
-  - hoppy-generator
-  - hoppy-runtime
-  - hoppy-std
   - hops
   - hoq
   - horizon
@@ -9254,10 +9249,6 @@ broken-packages:
   - qr-imager
   - qr-repa
   - qsem
-  - qtah-cpp-qt5
-  - qtah-examples
-  - qtah-generator
-  - qtah-qt5
   - QuadEdge
   - QuadTree
   - quantfin


### PR DESCRIPTION
Fixes qtah* packages

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
