### PR TITLE
gnome-passwordsafe: 3.99.2 -> 5.0

### DIFF
--- a/pkgs/applications/misc/gnome-passwordsafe/default.nix
+++ b/pkgs/applications/misc/gnome-passwordsafe/default.nix
@@ -4,8 +4,8 @@
 , pkg-config
 , gettext
 , fetchFromGitLab
-, python3
-, libhandy_0
+, python3Packages
+, libhandy
 , libpwquality
 , wrapGAppsHook
 , gtk3
@@ -15,9 +15,9 @@
 , desktop-file-utils
 , appstream-glib }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "gnome-passwordsafe";
-  version = "3.99.2";
+  version = "5.0";
   format = "other";
   strictDeps = false; # https://github.com/NixOS/nixpkgs/issues/56943
 
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "World";
     repo = "PasswordSafe";
     rev = version;
-    sha256 = "0pi2l4gwf8paxm858mxrcsk5nr0c0zw5ycax40mghndb6b1qmmhf";
+    sha256 = "8EFKLNK7rZlYL2g/7FmaC5r5hcdblsnod/aB8NYiBvY=";
   };
 
   nativeBuildInputs = [
@@ -44,26 +44,13 @@ python3.pkgs.buildPythonApplication rec {
     gtk3
     glib
     gdk-pixbuf
-    libhandy_0
+    libhandy
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     pygobject3
     construct
-
-    # pykeepass 3.2.1 changed some exception types, and is not backwards compatible.
-    # Remove override once the MR is merged upstream.
-    # https://gitlab.gnome.org/World/PasswordSafe/-/merge_requests/79
-    (pykeepass.overridePythonAttrs (old: rec {
-      version = "3.2.0";
-      src = fetchPypi {
-        pname = "pykeepass";
-        inherit version;
-        sha256 = "1ysjn92bixq8wkwhlbhrjj9z0h80qnlnj7ks5478ndkzdw5gxvm1";
-      };
-      propagatedBuildInputs = old.propagatedBuildInputs ++ [ pycryptodome ];
-    }))
-
+    pykeepass
   ] ++ [
     libpwquality # using the python bindings
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update gnome-passwordsafe to latest release.

###### Things done
Update rev, remove pykeepass override.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
