### PR TITLE
factorio-headless-experimental, factorio-experimental: 1.1.25 -> 1.1.26

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.25.tar.xz",
+        "name": "factorio_alpha_x64-1.1.26.tar.xz",
         "needsAuth": true,
-        "sha256": "1xz03xr144grf5pa194j8pvyniiw77lsidkl32wha9x85fln5jhi",
+        "sha256": "0wv1yv5v77h09nk2skfabqmxys40d806x09kac3jja1lhhr4hzl2",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.25/alpha/linux64",
-        "version": "1.1.25"
+        "url": "https://factorio.com/get-download/1.1.26/alpha/linux64",
+        "version": "1.1.26"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.1.25.tar.xz",
@@ -20,12 +20,12 @@
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.25.tar.xz",
+        "name": "factorio_demo_x64-1.1.26.tar.xz",
         "needsAuth": false,
-        "sha256": "1v3rpi9cfx4bg4jqq3h8zwknb5wsidk3lf3qkf55kf4xw6fnkzcj",
+        "sha256": "1b6rjyhjvdhdb0d3drjpjc1v8398amcz8wmh3d84gl3aafflfl1x",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.25/demo/linux64",
-        "version": "1.1.25"
+        "url": "https://factorio.com/get-download/1.1.26/demo/linux64",
+        "version": "1.1.26"
       },
       "stable": {
         "name": "factorio_demo_x64-1.1.25.tar.xz",
@@ -38,12 +38,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.25.tar.xz",
+        "name": "factorio_headless_x64-1.1.26.tar.xz",
         "needsAuth": false,
-        "sha256": "0xirxdf41sdsgcknvhdfg6rm12bwmg86bl4ml6ap1skifk8dlia1",
+        "sha256": "08hnyycwsj6srp2kcvnh5rixlcifk17r2814fr1g7jbdx7rp14mj",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.25/headless/linux64",
-        "version": "1.1.25"
+        "url": "https://factorio.com/get-download/1.1.26/headless/linux64",
+        "version": "1.1.26"
       },
       "stable": {
         "name": "factorio_headless_x64-1.1.25.tar.xz",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://forums.factorio.com/viewtopic.php?t=96561&p=539516

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
