### PR TITLE
terraform-docs: 0.9.1 -> 0.11.2

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-docs/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-docs/default.nix
@@ -1,16 +1,18 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
-buildGoPackage rec {
+{ lib, buildGoModule, fetchFromGitHub }:
+buildGoModule rec {
   pname = "terraform-docs";
-  version = "0.9.1";
-
-  goPackagePath = "github.com/segmentio/${pname}";
+  version = "0.11.2";
 
   src = fetchFromGitHub {
-    owner  = "segmentio";
-    repo   = pname;
-    rev    = "v${version}";
-    sha256 = "00sfzdqhf8g85m03r6mbzfas5vvc67iq7syb8ljcgxg8l1knxnjx";
+    owner = "terraform-docs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-x2YTd4ZnimTRkFWbwFp4qz6BymD6ESVxBy6YE+QqQ6k=";
   };
+
+  vendorSha256 = "sha256-drfhfY03Ao0fqleBdzbAnPsE4kVrJMcUbec0txaEIP0=";
+
+  subPackages = [ "." ];
 
   preBuild = ''
     buildFlagsArray+=("-ldflags" "-X main.version=${version}")
@@ -18,7 +20,7 @@ buildGoPackage rec {
 
   meta = with lib; {
     description = "A utility to generate documentation from Terraform modules in various output formats";
-    homepage = "https://github.com/segmentio/terraform-docs/";
+    homepage = "https://github.com/terraform-docs/terraform-docs/";
     license = licenses.mit;
     maintainers = with maintainers; [ zimbatm ];
   };


### PR DESCRIPTION
###### Motivation for this change

0.9.1 has been out of date for a while now, so this change brings
terraform-docs inline with the current version 0.11.2.

The owner of the repository has changed from segmentio to terraform-docs
since the last pull request.

This commit also introduces the use of `buildGoModule` in place of
`buildGoPackage`, so that we can avoid generating a `deps.nix` file for
module dependencies.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
