### PR TITLE
[staging] python3Packages.virtualenv: don't add fish as a checkInput

### DIFF
--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -5,7 +5,6 @@
 , distlib
 , fetchPypi
 , filelock
-, fish
 , flaky
 , importlib-metadata
 , importlib-resources
@@ -56,7 +55,6 @@ buildPythonPackage rec {
 
   checkInputs = [
     cython
-    fish
     flaky
     pytest-freezegun
     pytest-mock


### PR DESCRIPTION
Otherwise, everything that touches fish is a mass-rebuild. Not ideal.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Before:

```
$ nix why-depends .#zookeeper_mq .#fish | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g"
/nix/store/rxq97l655gyi1hz3y01gwkx360ds67dp-zookeeper_mt-3.6.2.drv
└───/: …29.2.drv",["out"]),("/nix/store/cxc8g9yq9199rnsy6g69pksldwqxllal-zookeeper-3.6.2.drv",["out"]),(…
    → /nix/store/cxc8g9yq9199rnsy6g69pksldwqxllal-zookeeper-3.6.2.drv
    └───/: …8.32.drv",["out"]),("/nix/store/19nmzd6mbpys75v6jv2cnby2icmfsb6a-openjdk-8u272-b10.drv",["jre"])…
        → /nix/store/19nmzd6mbpys75v6jv2cnby2icmfsb6a-openjdk-8u272-b10.drv
        └───/: ….2.0.drv",["dev"]),("/nix/store/6ylf14zaiwhjw8vb8s35s12cpz7l51ck-liberation-fonts-2.1.0.drv",["o…
            → /nix/store/6ylf14zaiwhjw8vb8s35s12cpz7l51ck-liberation-fonts-2.1.0.drv
            └───/: …1107.drv",["out"]),("/nix/store/syvrgy0dnw3v533n9pd9dw0j91wygfl2-python3.8-fonttools-4.21.1.drv"…
                → /nix/store/syvrgy0dnw3v533n9pd9dw0j91wygfl2-python3.8-fonttools-4.21.1.drv
                └───/: …hook.drv",["out"]),("/nix/store/m7cghcc9d9myzrafzhprq3wqxbp1gzfw-python3.8-pytest-randomly-3.5.0…
                    → /nix/store/m7cghcc9d9myzrafzhprq3wqxbp1gzfw-python3.8-pytest-randomly-3.5.0.drv
                    └───/: …hook.drv",["out"]),("/nix/store/q511c5bz6yms2gdknf41zgdi4zi64gqs-python3.8-Faker-5.5.1.drv",["ou…
                        → /nix/store/q511c5bz6yms2gdknf41zgdi4zi64gqs-python3.8-Faker-5.5.1.drv
                        └───/: …hook.drv",["out"]),("/nix/store/7fckx39pb5mvd0m4am7i8qjpmcw6sqsh-python3.8-validators-0.18.1.drv…
                            → /nix/store/7fckx39pb5mvd0m4am7i8qjpmcw6sqsh-python3.8-validators-0.18.1.drv
                            └───/: …hook.drv",["out"]),("/nix/store/ksj7k6lil4ikngc542qx8z3y2jcvg1rx-python3.8-isort-5.6.4.drv",["ou…
                                → /nix/store/ksj7k6lil4ikngc542qx8z3y2jcvg1rx-python3.8-isort-5.6.4.drv
                                └───/: …hook.drv",["out"]),("/nix/store/m4jp3wi3jq830wml9xmvklz7jfm128r5-python3.8-poetry-core-1.0.0.drv…
                                    → /nix/store/m4jp3wi3jq830wml9xmvklz7jfm128r5-python3.8-poetry-core-1.0.0.drv
                                    └───/: …hook.drv",["out"]),("/nix/store/lhfzhn8b6b3k6hcks6xdcjzh4kz8girx-python3.8-virtualenv-20.2.1.drv…
                                        → /nix/store/lhfzhn8b6b3k6hcks6xdcjzh4kz8girx-python3.8-virtualenv-20.2.1.drv
                                        └───/: ….8.8.drv",["out"]),("/nix/store/fqw1j73l37abgmxjyyzrdfy40h4a37iw-fish-3.1.2.drv",["out"]),("/nix…
                                            → /nix/store/fqw1j73l37abgmxjyyzrdfy40h4a37iw-fish-3.1.2.drv
```

After:

```
'/nix/store/c2ss141qady409v26p8brshvgsibqyqy-zookeeper_mt-3.6.2.drv' does not depend on '/nix/store/fqw1j73l37abgmxjyyzrdfy40h4a37iw-fish-3.1.2.drv'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).