### PR TITLE
darwin: introduce darwinArch, apply in {cc,bintools}-wrappers

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -107,6 +107,11 @@ rec {
           powerpc64le = "ppc64le";
         }.${final.parsed.cpu.name} or final.parsed.cpu.name;
 
+      darwinArch = {
+        armv7a  = "armv7";
+        aarch64 = "arm64";
+      }.${final.parsed.cpu.name} or final.parsed.cpu.name;
+
       emulator = pkgs: let
         qemu-user = pkgs.qemu.override {
           smartcardSupport = false;

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -305,6 +305,10 @@ stdenv.mkDerivation {
       done
     ''
 
+    + optionalString stdenv.targetPlatform.isDarwin ''
+      echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/libc-ldflags
+    ''
+
     + ''
       for flags in "$out/nix-support"/*flags*; do
         substituteInPlace "$flags" --replace $'\n' ' '

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -481,6 +481,10 @@ stdenv.mkDerivation {
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
     ''
 
+    + optionalString stdenv.targetPlatform.isDarwin ''
+      echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/cc-cflags
+    ''
+
     ##
     ## Extra custom steps
     ##

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -50,9 +50,6 @@ cmakeConfigurePhase() {
     # because we usually do not package the framework
     cmakeFlags="-DCMAKE_FIND_FRAMEWORK=LAST $cmakeFlags"
 
-    # on macOS i686 was only relevant for 10.5 or earlier.
-    cmakeFlags="-DCMAKE_OSX_ARCHITECTURES=x86_64 $cmakeFlags"
-
     # we never want to use the global macOS SDK
     cmakeFlags="-DCMAKE_OSX_SYSROOT= $cmakeFlags"
 

--- a/pkgs/os-specific/darwin/xcode/sdk-pkgs.nix
+++ b/pkgs/os-specific/darwin/xcode/sdk-pkgs.nix
@@ -14,12 +14,6 @@ let
 
 minSdkVersion = targetPlatform.minSdkVersion or "9.0";
 
-iosPlatformArch = { parsed, ... }: {
-  armv7a  = "armv7";
-  aarch64 = "arm64";
-  x86_64  = "x86_64";
-}.${parsed.cpu.name};
-
 in
 
 rec {
@@ -35,9 +29,7 @@ rec {
   binutils = wrapBintoolsWith {
     libc = targetIosSdkPkgs.libraries;
     bintools = binutils-unwrapped;
-    extraBuildCommands = ''
-      echo "-arch ${iosPlatformArch targetPlatform}" >> $out/nix-support/libc-ldflags
-    '' + lib.optionalString (sdk.platform == "iPhoneSimulator") ''
+    extraBuildCommands = lib.optionalString (sdk.platform == "iPhoneSimulator") ''
       echo "-platform_version ios-sim ${minSdkVersion} ${sdk.version}" >> $out/nix-support/libc-ldflags
     '' + lib.optionalString (sdk.platform == "iPhoneOS") ''
       echo "-platform_version ios ${minSdkVersion} ${sdk.version}" >> $out/nix-support/libc-ldflags
@@ -52,7 +44,7 @@ rec {
     extraBuildCommands = ''
       tr '\n' ' ' < $out/nix-support/cc-cflags > cc-cflags.tmp
       mv cc-cflags.tmp $out/nix-support/cc-cflags
-      echo "-target ${targetPlatform.config} -arch ${iosPlatformArch targetPlatform}" >> $out/nix-support/cc-cflags
+      echo "-target ${targetPlatform.config}" >> $out/nix-support/cc-cflags
       echo "-isystem ${sdk}/usr/include${lib.optionalString (lib.versionAtLeast "10" sdk.version) " -isystem ${sdk}/usr/include/c++/4.2.1/ -stdlib=libstdc++"}" >> $out/nix-support/cc-cflags
     '' + lib.optionalString (sdk.platform == "iPhoneSimulator") ''
       echo "-mios-simulator-version-min=${minSdkVersion}" >> $out/nix-support/cc-cflags

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -251,6 +251,7 @@ in rec {
                lib.optional (!stdenv.hostPlatform.isRedox) stdenv.hostPlatform.uname.system)}"]
           ++ lib.optional (stdenv.hostPlatform.uname.processor != null) "-DCMAKE_SYSTEM_PROCESSOR=${stdenv.hostPlatform.uname.processor}"
           ++ lib.optional (stdenv.hostPlatform.uname.release != null) "-DCMAKE_SYSTEM_VERSION=${stdenv.hostPlatform.release}"
+          ++ lib.optional (stdenv.hostPlatform.isDarwin) "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
           ++ lib.optional (stdenv.buildPlatform.uname.system != null) "-DCMAKE_HOST_SYSTEM_NAME=${stdenv.buildPlatform.uname.system}"
           ++ lib.optional (stdenv.buildPlatform.uname.processor != null) "-DCMAKE_HOST_SYSTEM_PROCESSOR=${stdenv.buildPlatform.uname.processor}"
           ++ lib.optional (stdenv.buildPlatform.uname.release != null) "-DCMAKE_HOST_SYSTEM_VERSION=${stdenv.buildPlatform.uname.release}";


### PR DESCRIPTION
###### Motivation for this change

Extracted out of #105026. This, as well as #111988, try to make the darwin {cc,bintools}-wrappers use the correct flags for the target platform. A version of these flags previously existed only in the xcode wrapper.

Tested only as part of #105026. It changes the compiler and linker flags for all darwin packages, so there's a potential for a lot of breakage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
