### PR TITLE
hyper: add required libraries to library path

### DIFF
--- a/pkgs/applications/terminal-emulators/hyper/default.nix
+++ b/pkgs/applications/terminal-emulators/hyper/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, lib, fetchurl, dpkg, atk, glib, pango, gdk-pixbuf, gnome2, gtk2, cairo
+{ stdenv, lib, fetchurl, dpkg, atk, glib, pango, gdk-pixbuf, gnome2, gtk3, cairo
 , freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr
 , libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver
-, libxcb, nss, nspr, alsaLib, cups, expat, udev, libpulseaudio }:
+, libxcb, nss, nspr, alsaLib, cups, expat, udev, libpulseaudio, at-spi2-atk }:
 
 let
   libPath = lib.makeLibraryPath [
-    stdenv.cc.cc gtk2 gnome2.GConf atk glib pango gdk-pixbuf cairo freetype fontconfig dbus
+    stdenv.cc.cc gtk3 gnome2.GConf atk glib pango gdk-pixbuf cairo freetype fontconfig dbus
     libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes libxcb
     libXrender libX11 libXtst libXScrnSaver nss nspr alsaLib cups expat udev libpulseaudio
+    at-spi2-atk
   ];
 in
 stdenv.mkDerivation rec {
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
     mv opt "$out/"
     ln -s "$out/opt/Hyper/hyper" "$out/bin/hyper"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:\$ORIGIN" "$out/opt/Hyper/hyper"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:$out/opt/Hyper:\$ORIGIN" "$out/opt/Hyper/hyper"
     mv usr/* "$out/"
   '';
   dontPatchELF = true;


### PR DESCRIPTION
###### Motivation for this change

hyper was unable to run and resulted in the following error:

```
/nix/store/n7y10kx18wpw3asm4zhansw819kdfznx-hyper-3.0.2/bin/hyper: error while loading shared libraries: libgtk-3.so.0: cannot open shared object file: No such file or directory
```

ldd showed:

```
ldd /nix/store/n7y10kx18wpw3asm4zhansw819kdfznx-hyper-3.0.2/bin/hyper
...
	libnode.so => not found
...
	libgtk-3.so.0 => not found
	libgdk-3.so.0 => not found
...
	libatk-bridge-2.0.so.0 => not found
...
	libffmpeg.so => not found
...
```

I added the missing libraries and also added $out/opt/hyper to the library path to make sure it can find libnode and libffmpeg.

After these changes hyper was able to run on my system.

I also run nixfmt, so the file was formatted accordingly.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
