### PR TITLE
catatonit: init at 0.1.5, fix podman --init

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -118,8 +118,9 @@ in
       [network]
       cni_plugin_dirs = ["${pkgs.cni-plugins}/bin/"]
 
-      ${lib.optionalString (cfg.ociSeccompBpfHook.enable == true) ''
       [engine]
+      init_path = "${pkgs.catatonit}/bin/catatonit"
+      ${lib.optionalString (cfg.ociSeccompBpfHook.enable) ''
       hooks_dir = [
         "${config.boot.kernelPackages.oci-seccomp-bpf-hook}",
       ]

--- a/nixos/tests/podman.nix
+++ b/nixos/tests/podman.nix
@@ -96,6 +96,15 @@ import ./make-test-python.nix (
           podman.succeed(su_cmd("podman ps | grep sleeping"))
           podman.succeed(su_cmd("podman stop sleeping"))
           podman.succeed(su_cmd("podman rm sleeping"))
+
+      with subtest("Run container with init"):
+          podman.succeed(
+              "tar cv -C ${pkgs.pkgsStatic.busybox} . | podman import - busybox"
+          )
+          pid = podman.succeed("podman run --rm busybox readlink /proc/self").strip()
+          assert pid == "1"
+          pid = podman.succeed("podman run --rm --init busybox readlink /proc/self").strip()
+          assert pid == "2"
     '';
   }
 )

--- a/pkgs/applications/virtualization/catatonit/default.nix
+++ b/pkgs/applications/virtualization/catatonit/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, glibc }:
+
+stdenv.mkDerivation rec {
+  pname = "catatonit";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "openSUSE";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "ciJ1MI7jr5P2PgxIykQ+BiwNUO8lQHGt0+U8CNbc5bI=";
+  };
+
+  patches = [
+    # Fix compilation with musl
+    (fetchpatch {
+      url = "https://github.com/openSUSE/catatonit/commit/75014b1c3099245b7d0f44f24d7f6dc4888a45fd.patch";
+      sha256 = "sha256-9VMNUT1U90ocjvE7EXYfLxuodDwTXXHYg89qqa5Jq0g=";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isMusl) [ glibc glibc.static ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    readelf -d $out/bin/catatonit | grep 'There is no dynamic section in this file.'
+  '';
+
+  meta = with lib; {
+    description = "A container init that is so simple it's effectively brain-dead";
+    homepage = "https://github.com/openSUSE/catatonit";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ erosennin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/virtualization/catatonit/default.nix
+++ b/pkgs/applications/virtualization/catatonit/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, glibc }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, glibc, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "catatonit";
@@ -27,11 +27,13 @@ stdenv.mkDerivation rec {
     readelf -d $out/bin/catatonit | grep 'There is no dynamic section in this file.'
   '';
 
+  passthru.tests = { inherit (nixosTests) podman; };
+
   meta = with lib; {
     description = "A container init that is so simple it's effectively brain-dead";
     homepage = "https://github.com/openSUSE/catatonit";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ erosennin ];
+    maintainers = with maintainers; [ erosennin ] ++ teams.podman.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -197,6 +197,8 @@ in
     inherit (python3Packages) sphinx;
   };
 
+  catatonit = callPackage ../applications/virtualization/catatonit { };
+
   cen64 = callPackage ../misc/emulators/cen64 { };
 
   cereal = callPackage ../development/libraries/cereal { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Podman uses [catatonit](https://github.com/openSUSE/catatonit) as the default container-init with `podman run --init`. It is currently broken on NixOS:

```
$ podman run --init busybox
Error: container-init binary not found on the host: stat /usr/libexec/podman/catatonit: no such file or directory
```

The idea is to add catatonit to nixpkgs, then patch podman to use `${catatonit}/bin/catatonit` instead of ` /usr/libexec/podman/catatonit`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
