### PR TITLE
ffmpeg: 4.3.1 -> 4.3.2

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -246,11 +246,6 @@ stdenv.mkDerivation rec {
 
   # this should go away in the next release
   patches = [
-    (fetchpatch {
-      url = "https://git.videolan.org/?p=ffmpeg.git;a=patch;h=7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315";
-      sha256 = "sha256-dqpmpDFETTuWHWolMoLaubU4BeDEuQaBNA0wmzL1f8o=";
-      name = "fix_libsrt.patch";
-    })
     # Patch ffmpeg for svt-av1 until version 4.4
     (fetchpatch {
       url = "https://raw.githubusercontent.com/AOMediaCodec/SVT-AV1/v0.8.4/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch";

--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -5,8 +5,8 @@
 }@args:
 
 callPackage ./generic.nix (rec {
-  version = "4.3.1";
+  version = "4.3.2";
   branch = "4.3";
-  sha256 = "1nghcpm2r9ir2h6xpqfn9381jq6aiwlkwlnyplxywvkbjiisr97l";
+  sha256 = "0flik4y7c5kchj65p3p908mk1dsncqgzjdvzysjs12rmf1m6sfmb";
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
 } // args)


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2020-35964
https://nvd.nist.gov/vuln/detail/CVE-2020-35965

Closes https://github.com/NixOS/nixpkgs/issues/109157

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).