### PR TITLE
mrsh: 2020-11-04 -> 2021-01-10

### DIFF
--- a/pkgs/shells/mrsh/default.nix
+++ b/pkgs/shells/mrsh/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, readline }:
 
 stdenv.mkDerivation rec {
-  pname   = "mrsh";
-  version = "2020-11-04";
+  pname = "mrsh-unstable";
+  version = "2021-01-10";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = "mrsh";
-    rev = "1738e41b2a35e5f99b9a1300a5f687478458226a";
-    sha256 = "08gak5261d4sd6b2w2kscmdwa4gwcp5drgfyb3swyrj9cl0nlcbn";
+    rev = "9f9884083831ea1f94bdda5151c5df3888932849";
+    sha256 = "0vvdwzw3fq74lwgmy6xxkk01sd68fzhsw84c750lm1dma22xhjci";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config ];
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ matthiasbeyer ];
     platforms = platforms.unix;
-    broken = stdenv.isDarwin;
+  };
+
+  passthru = {
+    shellPath = "/bin/mrsh";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
