### PR TITLE
emacs26: Drop unsupported package

### DIFF
--- a/pkgs/applications/editors/emacs/26.nix
+++ b/pkgs/applications/editors/emacs/26.nix
@@ -1,7 +1,0 @@
-import ./generic.nix (rec {
-  version = "26.3";
-  sha256 = "119ldpk7sgn9jlpyngv5y4z3i7bb8q3xp4p0qqi7i5nq39syd42d";
-  patches = [
-    ./tramp-detect-wrapped-gvfsd-26.patch
-  ];
-})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -166,9 +166,7 @@ mapAliases ({
   emacsPackagesNgGen = emacsPackagesFor; # added 2018-08-18
   emacsPackagesNgFor = emacsPackagesFor; # added 2019-08-07
   emacsPackagesNg = emacs.pkgs; # added 2019-08-07
-  emacs26Packages = emacs26.pkgs; # added 2020-12-18
   emacs27Packages = emacs27.pkgs; # added 2020-12-18
-  emacs26WithPackages = emacs26.pkgs.withPackages; # added 2020-12-18
   emacs27WithPackages = emacs27.pkgs.withPackages; # added 2020-12-18
   emacsWithPackages = emacs.pkgs.withPackages; # added 2020-12-18
   emacsPackages = emacs.pkgs; # added 2020-12-18

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21978,25 +21978,6 @@ in
     withGTK3 = false;
   }));
 
-  emacs26 = callPackage ../applications/editors/emacs/26.nix {
-    # use override to enable additional features
-    libXaw = xorg.libXaw;
-    Xaw3d = null;
-    gconf = null;
-    alsaLib = null;
-    imagemagick = null;
-    acl = null;
-    gpm = null;
-    inherit (darwin.apple_sdk.frameworks) AppKit GSS ImageIO;
-  };
-
-  emacs26-nox = lowPrio (appendToName "nox" (emacs26.override {
-    withX = false;
-    withNS = false;
-    withGTK2 = false;
-    withGTK3 = false;
-  }));
-
   emacsMacport = callPackage ../applications/editors/emacs/macport.nix {
     inherit (darwin.apple_sdk.frameworks)
       AppKit Carbon Cocoa IOKit OSAKit Quartz QuartzCore WebKit

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -34,7 +34,6 @@
     "nvidiaPackages"
     "sourceHanPackages"
     "atomPackages"
-    "emacs26.pkgs"
     "emacs27.pkgs"
     "steamPackages"
     "ut2004Packages"


### PR DESCRIPTION
###### Motivation for this change
Emacs 26 is not supported by upstream and 27 has had plenty of time to stabilise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @turboMaCk who previously showed some interest in emacs26.