### PR TITLE
Build julia 1.5 on macos

### DIFF
--- a/pkgs/development/compilers/julia/1.5.nix
+++ b/pkgs/development/compilers/julia/1.5.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, fetchzip, fetchFromGitHub
 # build tools
 , gfortran, m4, makeWrapper, patchelf, perl, which, python2
-, cmake
+, cmake, unzip
 # libjulia dependencies
 , libunwind, readline, utf8proc, zlib
 # standard library dependencies
@@ -12,7 +12,7 @@
 , CoreServices, ApplicationServices
 }:
 
-assert (!blas.isILP64) && (!lapack.isILP64);
+# assert (!blas.isILP64) && (!lapack.isILP64);
 
 with lib;
 
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     zlib
   ] ++ lib.optionals stdenv.isDarwin [CoreServices ApplicationServices];
 
-  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which cmake ];
+  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which cmake unzip ];
 
   makeFlags =
     let
@@ -89,8 +89,8 @@ stdenv.mkDerivation rec {
       "prefix=$(out)"
       "SHELL=${stdenv.shell}"
 
-      "USE_SYSTEM_BLAS=1"
-      "USE_BLAS64=${if blas.isILP64 then "1" else "0"}"
+      "USE_SYSTEM_BLAS=0"
+      # "USE_BLAS64=${if blas.isILP64 then "1" else "0"}"
 
       "USE_SYSTEM_LAPACK=1"
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

julia 1.5.3 does not build macos.

Please do NOT merge as I have commented some things out and hard-coded other things. I'd appreciate some help on what I should do :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
