### PR TITLE
pothos: init at 0.7.1

### DIFF
--- a/pkgs/applications/radio/pothos/default.nix
+++ b/pkgs/applications/radio/pothos/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, pkg-config
+, doxygen
+, wrapQtAppsHook
+, pcre
+, poco
+, qtbase
+, qtsvg
+, libsForQt5
+, nlohmann_json
+, soapysdr-with-plugins
+, portaudio
+, alsaLib
+, muparserx
+, python3
+}:
+
+mkDerivation rec {
+  pname = "pothos";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "PothosCore";
+    rev = "pothos-${version}";
+    sha256 = "038c3ipvf4sgj0zhm3vcj07ymsva4ds6v89y43f5d3p4n8zc2rsg";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # spuce's CMakeLists.txt uses QT5_USE_Modules, which does not seem to work on Nix
+    ./spuce.patch
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config doxygen wrapQtAppsHook ];
+
+  buildInputs = [
+    pcre poco qtbase qtsvg libsForQt5.qwt nlohmann_json
+    soapysdr-with-plugins portaudio alsaLib muparserx python3
+  ];
+
+  postInstall = ''
+    install -Dm644 $out/share/Pothos/Desktop/pothos-flow.desktop $out/share/applications/pothos-flow.desktop
+    install -Dm644 $out/share/Pothos/Desktop/pothos-flow-16.png $out/share/icons/hicolor/16x16/apps/pothos-flow.png
+    install -Dm644 $out/share/Pothos/Desktop/pothos-flow-22.png $out/share/icons/hicolor/22x22/apps/pothos-flow.png
+    install -Dm644 $out/share/Pothos/Desktop/pothos-flow-32.png $out/share/icons/hicolor/32x32/apps/pothos-flow.png
+    install -Dm644 $out/share/Pothos/Desktop/pothos-flow-48.png $out/share/icons/hicolor/48x48/apps/pothos-flow.png
+    install -Dm644 $out/share/Pothos/Desktop/pothos-flow-64.png $out/share/icons/hicolor/64x64/apps/pothos-flow.png
+    install -Dm644 $out/share/Pothos/Desktop/pothos-flow-128.png $out/share/icons/hicolor/128x128/apps/pothos-flow.png
+    install -Dm644 $out/share/Pothos/Desktop/pothos-flow.xml $out/share/mime/application/pothos-flow.xml
+    rm -r $out/share/Pothos/Desktop
+  '';
+
+  dontWrapQtApps = true;
+  preFixup = ''
+    # PothosUtil does not need to be wrapped
+    wrapQtApp $out/bin/PothosFlow
+    wrapQtApp $out/bin/spuce_fir_plot
+    wrapQtApp $out/bin/spuce_iir_plot
+    wrapQtApp $out/bin/spuce_other_plot
+    wrapQtApp $out/bin/spuce_window_plot
+  '';
+
+  meta = with lib; {
+    description = "The Pothos data-flow framework";
+    homepage = "https://github.com/pothosware/PothosCore/wiki";
+    license = licenses.boost;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ eduardosm ];
+  };
+}

--- a/pkgs/applications/radio/pothos/spuce.patch
+++ b/pkgs/applications/radio/pothos/spuce.patch
@@ -1,0 +1,101 @@
+diff --git a/spuce/qt_fir/CMakeLists.txt b/spuce/qt_fir/CMakeLists.txt
+index fa2e580..e32113c 100644
+--- a/spuce/qt_fir/CMakeLists.txt
++++ b/spuce/qt_fir/CMakeLists.txt
+@@ -6,7 +6,7 @@ Message("Project spuce fir_plot")
+ set(CMAKE_INCLUDE_CURRENT_DIR ON)
+ set(CMAKE_AUTOMOC ON)
+ 
+-FIND_PACKAGE(Qt5 REQUIRED Gui Core Widgets)
++FIND_PACKAGE(Qt5 REQUIRED Gui Core Widgets PrintSupport)
+ 
+ set(SOURCES
+ 	make_filter.cpp 
+@@ -27,11 +27,7 @@ set_property(TARGET spuce_fir PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+ set_property(TARGET spuce_fir_plot PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+ set_property(TARGET spuce_fir_plot PROPERTY CXX_STANDARD 11)
+ 
+-TARGET_LINK_LIBRARIES(spuce_fir_plot spuce_fir ${QT_LIBRARIES} spuce)
+-QT5_USE_Modules(spuce_fir_plot Gui)
+-QT5_USE_Modules(spuce_fir_plot Core)
+-QT5_USE_Modules(spuce_fir_plot Widgets)
+-QT5_USE_Modules(spuce_fir_plot PrintSupport)
++TARGET_LINK_LIBRARIES(spuce_fir_plot spuce_fir ${QT_LIBRARIES} spuce Qt::Gui Qt::Core Qt::Widgets Qt::PrintSupport)
+ 
+ INSTALL(TARGETS spuce_fir_plot DESTINATION bin)
+ 
+diff --git a/spuce/qt_iir/CMakeLists.txt b/spuce/qt_iir/CMakeLists.txt
+index 4717226..debb5f9 100644
+--- a/spuce/qt_iir/CMakeLists.txt
++++ b/spuce/qt_iir/CMakeLists.txt
+@@ -6,7 +6,7 @@ Message("Project spuce iir_plot")
+ set(CMAKE_INCLUDE_CURRENT_DIR ON)
+ set(CMAKE_AUTOMOC ON)
+ 
+-FIND_PACKAGE(Qt5 REQUIRED Gui Core Widgets)
++FIND_PACKAGE(Qt5 REQUIRED Gui Core Widgets PrintSupport)
+ 
+ set(SOURCES
+ 	make_filter.cpp 	
+@@ -27,10 +27,6 @@ set_property(TARGET spuce_iir PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+ set_property(TARGET spuce_iir_plot PROPERTY CXX_STANDARD 11)
+ set_property(TARGET spuce_iir_plot PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+ 
+-TARGET_LINK_LIBRARIES(spuce_iir_plot spuce_iir ${QT_LIBRARIES} spuce)
+-QT5_USE_Modules(spuce_iir_plot Gui)
+-QT5_USE_Modules(spuce_iir_plot Core)
+-QT5_USE_Modules(spuce_iir_plot Widgets)
+-QT5_USE_Modules(spuce_iir_plot PrintSupport)
++TARGET_LINK_LIBRARIES(spuce_iir_plot spuce_iir ${QT_LIBRARIES} spuce Qt::Gui Qt::Core Qt::Widgets Qt::PrintSupport)
+ 
+ INSTALL(TARGETS spuce_iir_plot DESTINATION bin)
+diff --git a/spuce/qt_other/CMakeLists.txt b/spuce/qt_other/CMakeLists.txt
+index 29c270d..e1ed778 100644
+--- a/spuce/qt_other/CMakeLists.txt
++++ b/spuce/qt_other/CMakeLists.txt
+@@ -6,7 +6,7 @@ Message("Project spuce window_plot")
+ set(CMAKE_INCLUDE_CURRENT_DIR ON)
+ set(CMAKE_AUTOMOC ON)
+ 
+-FIND_PACKAGE(Qt5 REQUIRED Gui Core Widgets)
++FIND_PACKAGE(Qt5 REQUIRED Gui Core Widgets PrintSupport)
+ 
+ set(SOURCES	make_filter.cpp)
+ ADD_LIBRARY(spuce_other STATIC ${SOURCES})
+@@ -23,10 +23,6 @@ ADD_EXECUTABLE(spuce_other_plot ${other_plot_SOURCES} ${other_plot_HEADERS_MOC})
+ set_property(TARGET spuce_other_plot PROPERTY CXX_STANDARD 11)
+ set_property(TARGET spuce_other_plot PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+ 
+-TARGET_LINK_LIBRARIES(spuce_other_plot spuce_other ${QT_LIBRARIES} spuce)
+-QT5_USE_Modules(spuce_other_plot Gui)
+-QT5_USE_Modules(spuce_other_plot Core)
+-QT5_USE_Modules(spuce_other_plot Widgets)
+-QT5_USE_Modules(spuce_other_plot PrintSupport)
++TARGET_LINK_LIBRARIES(spuce_other_plot spuce_other ${QT_LIBRARIES} spuce Qt::Gui Qt::Core Qt::Widgets Qt::PrintSupport)
+ 
+ INSTALL(TARGETS spuce_other_plot DESTINATION bin)
+diff --git a/spuce/qt_window/CMakeLists.txt b/spuce/qt_window/CMakeLists.txt
+index e95c85b..4a77ab8 100644
+--- a/spuce/qt_window/CMakeLists.txt
++++ b/spuce/qt_window/CMakeLists.txt
+@@ -6,7 +6,7 @@ Message("Project spuce window_plot")
+ set(CMAKE_INCLUDE_CURRENT_DIR ON)
+ set(CMAKE_AUTOMOC ON)
+ 
+-FIND_PACKAGE(Qt5 REQUIRED Gui Core Widgets)
++FIND_PACKAGE(Qt5 REQUIRED Gui Core Widgets PrintSupport)
+ 
+ set(SOURCES	make_filter.cpp)
+ 
+@@ -25,10 +25,6 @@ set_property(TARGET spuce_window_plot PROPERTY CXX_STANDARD 11)
+ set_property(TARGET spuce_win PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+ set_property(TARGET spuce_window_plot PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+ 
+-TARGET_LINK_LIBRARIES(spuce_window_plot spuce_win ${QT_LIBRARIES} spuce)
+-QT5_USE_Modules(spuce_window_plot Gui)
+-QT5_USE_Modules(spuce_window_plot Core)
+-QT5_USE_Modules(spuce_window_plot Widgets)
+-QT5_USE_Modules(spuce_window_plot PrintSupport)
++TARGET_LINK_LIBRARIES(spuce_window_plot spuce_win ${QT_LIBRARIES} spuce Qt::Gui Qt::Core Qt::Widgets Qt::PrintSupport)
+ 
+ INSTALL(TARGETS spuce_window_plot DESTINATION bin)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24589,6 +24589,8 @@ in
 
   ponymix = callPackage ../applications/audio/ponymix { };
 
+  pothos = libsForQt5.callPackage ../applications/radio/pothos { };
+
   potrace = callPackage ../applications/graphics/potrace {};
 
   posterazor = callPackage ../applications/misc/posterazor { };


### PR DESCRIPTION
Adds the [Pothos data-flow framework](https://github.com/pothosware/PothosCore/wiki)

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
