### PR TITLE
s5cmd: init at 1.2.1

### DIFF
--- a/pkgs/tools/networking/s5cmd/default.nix
+++ b/pkgs/tools/networking/s5cmd/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "s5cmd";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "peak";
+    repo = "s5cmd";
+    rev = "v${version}";
+    sha256 = "sha256-09vBYwnTfLIuu2SPP7DYB+U6sUkQffglIOHNn4+47qQ=";
+  };
+
+  vendorSha256 = null;
+
+  meta = with lib; {
+    homepage = "https://github.com/peak/s5cmd";
+    description = "Parallel S3 and local filesystem execution tool";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tomberek ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7722,6 +7722,8 @@ in
 
   s4cmd = callPackage ../tools/networking/s4cmd { };
 
+  s5cmd = callPackage ../tools/networking/s5cmd { };
+
   s3gof3r = callPackage ../tools/networking/s3gof3r { };
 
   s6-dns = skawarePackages.s6-dns;


### PR DESCRIPTION
###### Motivation for this change
Go-based parallel s3 tool

###### Things done
package with buidGoModule. s5cmd has a vendor directory, so set vendorSha256 to `null`.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
