### PR TITLE
claws-mail-gtk3: re-enable fancy plugin

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -34,6 +34,7 @@
 , enablePluginBsfilter ? true
 , enablePluginClamd ? true
 , enablePluginDillo ? true
+, enablePluginFancy ? useGtk3, libsoup, webkitgtk
 , enablePluginFetchInfo ? true
 , enablePluginLibravatar ? enablePluginRavatar
 , enablePluginLitehtmlViewer ? true, gumbo
@@ -87,6 +88,7 @@ let
     { flags = [ "dbus" ]; enabled = enableDbus; deps = [ dbus dbus-glib ]; }
     { flags = [ "dillo-plugin" ]; enabled = enablePluginDillo; }
     { flags = [ "enchant" ]; enabled = enableEnchant; deps = [ enchant ]; }
+    { flags = [ "fancy-plugin" ]; enabled = enablePluginFancy; deps = [ libsoup webkitgtk ]; }
     { flags = [ "fetchinfo-plugin" ]; enabled = enablePluginFetchInfo; }
     { flags = [ "gnutls" ]; enabled = enableGnuTLS; deps = [ gnutls ]; }
     { flags = [ "ldap" ]; enabled = enableLdap; deps = [ openldap ]; }
@@ -153,7 +155,6 @@ in stdenv.mkDerivation rec {
       "--disable-jpilot"   # Missing jpilot library
 
       "--disable-gdata-plugin" # Complains about missing libgdata, even when provided
-      "--disable-fancy-plugin" # Missing libwebkit-1.0 library
     ] ++
     (map (feature: map (flag: strings.enableFeature feature.enabled flag) feature.flags) features);
 


### PR DESCRIPTION
###### Motivation for this change

It was inadvertently disabled by #113663.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
