### PR TITLE
calls: 0.2.0 -> 0.3.1, callaudiod: 0.0.4 -> 0.1.0

### DIFF
--- a/pkgs/applications/audio/callaudiod/default.nix
+++ b/pkgs/applications/audio/callaudiod/default.nix
@@ -11,14 +11,14 @@
 
 stdenv.mkDerivation rec {
   pname = "callaudiod";
-  version = "0.0.4";
+  version = "0.1.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.com";
     owner = "mobian1";
     repo = pname;
     rev = version;
-    sha256 = "07k7xp5a9c4d4lq7amaj6cg6b3gsd77x9wvf7nzcf4vpaph4yiyj";
+    sha256 = "087589z45xvldn2m1g79y0xbwzylwkjmfk83s5xjixyq0wqmfppd";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/calls/default.nix
+++ b/pkgs/applications/networking/calls/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitLab
 , meson
 , ninja
-, cmake
 , pkg-config
 , libhandy
 , modemmanager
@@ -15,6 +14,7 @@
 , evolution-data-server
 , folks
 , desktop-file-utils
+, appstream-glib
 , libpeas
 , dbus
 , vala
@@ -24,14 +24,14 @@
 
 stdenv.mkDerivation rec {
   pname = "calls";
-  version = "0.2.0";
+  version = "0.3.1";
 
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1qmjdhnr95dawccw1ss8hc3lk0cypj86xg2amjq7avzn86ryd76l";
+    sha256 = "0igap5ynq269xqaky6fqhdg2dpsvxa008z953ywa4s5b5g5dk3dd";
   };
 
   nativeBuildInputs = [
@@ -39,8 +39,8 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     desktop-file-utils
+    appstream-glib
     vala
-    cmake
     wrapGAppsHook
   ];
 
@@ -73,6 +73,7 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     runHook preCheck
     NO_AT_BRIDGE=1 \
+    XDG_DATA_DIRS=${folks}/share/gsettings-schemas/${folks.name} \
     xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       meson test --print-errorlogs

--- a/pkgs/applications/networking/calls/default.nix
+++ b/pkgs/applications/networking/calls/default.nix
@@ -12,6 +12,7 @@
 , feedbackd
 , callaudiod
 , evolution-data-server
+, glib
 , folks
 , desktop-file-utils
 , appstream-glib
@@ -20,6 +21,10 @@
 , vala
 , wrapGAppsHook
 , xvfb_run
+, gtk-doc
+, docbook-xsl-nons
+, docbook_xml_dtd_43
+, gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
@@ -34,6 +39,8 @@ stdenv.mkDerivation rec {
     sha256 = "0igap5ynq269xqaky6fqhdg2dpsvxa008z953ywa4s5b5g5dk3dd";
   };
 
+  outputs = [ "out" "devdoc" ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -42,6 +49,9 @@ stdenv.mkDerivation rec {
     appstream-glib
     vala
     wrapGAppsHook
+    gtk-doc
+    docbook-xsl-nons
+    docbook_xml_dtd_43
   ];
 
   buildInputs = [
@@ -62,10 +72,10 @@ stdenv.mkDerivation rec {
     xvfb_run
   ];
 
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
+
   mesonFlags = [
-    # docs fail to build
-    # https://source.puri.sm/Librem5/calls/issues/99
-    "-Dgtk_doc=false"
+    "-Dgtk_doc=true"
   ];
 
   doCheck = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update callaudiod and calls. There was an api change in callaudiod, so both need to be updated at the same time, or calls won't build.

closes #111865 , both updates need to be in one PR
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
