### PR TITLE
steam: continuation of #114024 with missing edits

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -17,6 +17,7 @@ in {
   config = mkIf cfg.enable {
     hardware.opengl = { # this fixes the "glXChooseVisual failed" bug, context: https://github.com/NixOS/nixpkgs/issues/47932
       enable = true;
+      driSupport = true;
       driSupport32Bit = true;
     };
 

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -140,6 +140,7 @@ in buildFHSUserEnv rec {
 
     # dependencies for mesa drivers, needed inside pressure-vessel
     mesa.drivers
+    vulkan-loader
     expat
     wayland
     xlibs.libxcb

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -233,7 +233,14 @@ in buildFHSUserEnv rec {
     libvdpau
   ] ++ steamPackages.steam-runtime-wrapped.overridePkgs) ++ extraLibraries pkgs;
 
-  extraBuildCommands = if (!nativeOnly) then ''
+  extraBuildCommands = ''
+    if [ -f $out/usr/share/vulkan/icd.d/nvidia_icd.json ]; then
+      cp $out/usr/share/vulkan/icd.d/nvidia_icd{,32}.json
+      nvidia32Lib=$(realpath $out/lib32/libGLX_nvidia.so.0 | cut -d'/' -f-4)
+      escapedNvidia32Lib="''${nvidia32Lib//\//\\\/}"
+      sed -i "s/\/nix\/store\/.*\/lib\/libGLX_nvidia\.so\.0/$escapedNvidia32Lib\/lib\/libGLX_nvidia\.so\.0/g" $out/usr/share/vulkan/icd.d/nvidia_icd32.json
+    fi
+  '' + (if (!nativeOnly) then ''
     mkdir -p steamrt
     ln -s ../lib/steam-runtime steamrt/${steam-runtime-wrapped.arch}
     ${lib.optionalString (steam-runtime-wrapped-i686 != null) ''
@@ -246,7 +253,7 @@ in buildFHSUserEnv rec {
     ${lib.optionalString (steam-runtime-wrapped-i686 != null) ''
       ln -s /usr/lib32/libbz2.so usr/lib32/libbz2.so.1.0
     ''}
-  '';
+  '');
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

With the predecessor to this PR, #114024, pressure-vessel was mostly fixed, but there were a few missing packages and files that made the games not work sometimes. Credits to @starcraft66 for finding the problems and being very helpful while fixing them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
