### PR TITLE
librepcb: fix use of wrapQtApp

### DIFF
--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -33,10 +33,6 @@ stdenv.mkDerivation rec {
       --replace 'GIT_COMMIT_SHA' 'GIT_COMMIT_SHA="\\\"${src.rev}\\\"" # '
   '';
 
-  preFixup = ''
-    wrapQtApp $out/bin/librepcb
-  '';
-
   meta = with lib; {
     description = "A free EDA software to develop printed circuit boards";
     homepage    = "https://librepcb.org/";

--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -18,26 +18,25 @@ stdenv.mkDerivation rec {
   buildInputs = [ qtbase ];
 
   qmakeFlags = ["-r"];
-  enableParallelBuilding = true;
+
+  # the build system tries to use 'git' at build time to find the HEAD hash.
+  # that's a no-no, so replace it with a quick hack. NOTE: the # adds a comment
+  # at the end of the line to remove the git call.
+  postPatch = ''
+    substituteInPlace ./libs/librepcb/common/common.pro \
+      --replace 'GIT_COMMIT_SHA' 'GIT_COMMIT_SHA="\\\"${src.rev}\\\"" # '
+  '';
 
   postInstall = ''
     mkdir -p $out/share/librepcb/fontobene
     cp share/librepcb/fontobene/newstroke.bene $out/share/librepcb/fontobene/
   '';
 
-  # the build system tries to use 'git' at build time to find the HEAD hash.
-  # that's a no-no, so replace it with a quick hack. NOTE: the # adds a comment
-  # at the end of the line to remove the git call.
-  patchPhase = ''
-    substituteInPlace ./libs/librepcb/common/common.pro \
-      --replace 'GIT_COMMIT_SHA' 'GIT_COMMIT_SHA="\\\"${src.rev}\\\"" # '
-  '';
-
   meta = with lib; {
     description = "A free EDA software to develop printed circuit boards";
     homepage    = "https://librepcb.org/";
     maintainers = with maintainers; [ luz thoughtpolice ];
-    license     = licenses.gpl3;
+    license     = licenses.gpl3Plus;
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Executables are automatically wrapped when wrapQtAppsHook is included, so using wrapQtApp will have them wrapped twice.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
