### PR TITLE
python3Packages.glasgow: unstable-2020-06-29 -> unstable-2021-03-02

### DIFF
--- a/pkgs/development/python-modules/glasgow/default.nix
+++ b/pkgs/development/python-modules/glasgow/default.nix
@@ -2,7 +2,8 @@
 , buildPythonPackage
 , fetchFromGitHub
 , setuptools
-, setuptools_scm
+, setuptools-scm
+, pythonOlder
 , sdcc
 , nmigen
 , fx2
@@ -18,18 +19,19 @@
 
 buildPythonPackage rec {
   pname = "glasgow";
-  version = "unstable-2020-06-29";
+  version = "unstable-2021-03-02";
+  disabled = pythonOlder "3.7";
   # python software/setup.py --version
-  realVersion = "0.1.dev1352+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.1.dev1660+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "GlasgowEmbedded";
     repo = "glasgow";
-    rev = "f885790d7927b893e631c33744622d6ebc18b5e3";
-    sha256 = "sha256-fSorSEa5K09aPEOk4XPWOFRxYl1KGVy29jOBqIvs2hk=";
+    rev = "41c48bbcee284d024e4249a81419fbbae674cf40";
+    sha256 = "1fg8ps228930d70bczwmcwnrd1gvm02a58mxbpn8pyakwbwwa6hq";
   };
 
-  nativeBuildInputs = [ setuptools_scm sdcc ];
+  nativeBuildInputs = [ setuptools-scm sdcc ];
 
   propagatedBuildInputs = [
     setuptools


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to new upstream state

Fix for build failure detected in #114860

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
