### PR TITLE
treewide: Fix various tools wrappers "with packages"

### DIFF
--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -36,8 +36,9 @@ lib.makeOverridable
 , # Shell commands to run after building the symlink tree.
   postBuild ? ""
 
-, # Additional inputs. Handy e.g. if using makeWrapper in `postBuild`.
-  buildInputs ? []
+# Additional inputs
+, nativeBuildInputs ? [] # Handy e.g. if using makeWrapper in `postBuild`.
+, buildInputs ? []
 
 , passthru ? {}
 , meta ? {}
@@ -53,7 +54,8 @@ in
 runCommand name
   rec {
     inherit manifest ignoreCollisions checkCollisionContents passthru
-            meta pathsToLink extraPrefix postBuild buildInputs;
+            meta pathsToLink extraPrefix postBuild
+            nativeBuildInputs buildInputs;
     pkgs = builtins.toJSON (map (drv: {
       paths =
         # First add the usual output(s): respect if user has chosen explicitly,

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -57,9 +57,8 @@ symlinkJoin {
   # as a dedicated drv attribute, like `compiler-name`
   name = ghc.name + "-with-packages";
   paths = paths ++ [ghc];
+  nativeBuildInputs = [ makeWrapper ];
   postBuild = ''
-    . ${makeWrapper}/nix-support/setup-hook
-
     # wrap compiler executables with correct env variables
 
     for prg in ${ghcCommand} ${ghcCommand}i ${ghcCommand}-${ghc.version} ${ghcCommand}i-${ghc.version}; do

--- a/pkgs/development/interpreters/octave/build-env.nix
+++ b/pkgs/development/interpreters/octave/build-env.nix
@@ -20,17 +20,14 @@ in buildEnv {
   inherit ignoreCollisions;
   extraOutputsToInstall = [ "out" ] ++ extraOutputsToInstall;
 
-  buildInputs = [ makeWrapper texinfo wrapOctave ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ texinfo wrapOctave ];
 
   # During "build" we must first unlink the /share symlink to octave's /share
   # Then, we can re-symlink the all of octave/share, except for /share/octave
   # in env/share/octave, re-symlink everything from octave/share/octave and then
   # perform the pkg install.
   postBuild = ''
-      . "${makeWrapper}/nix-support/setup-hook"
-      # The `makeWrapper` used here is the one defined in
-      # ${makeWrapper}/nix-support/setup-hook
-
       if [ -L "$out/bin" ]; then
          unlink $out/bin
          mkdir -p "$out/bin"

--- a/pkgs/development/interpreters/perl/wrapper.nix
+++ b/pkgs/development/interpreters/perl/wrapper.nix
@@ -17,11 +17,10 @@ let
     inherit ignoreCollisions;
     extraOutputsToInstall = [ "out" ] ++ extraOutputsToInstall;
 
+    nativeBuildInputs = [ makeWrapper ];
+
     # we create wrapper for the binaries in the different packages
     postBuild = ''
-
-      . "${makeWrapper}/nix-support/setup-hook"
-
       if [ -L "$out/bin" ]; then
           unlink "$out/bin"
       fi

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -1,10 +1,15 @@
-{ lib, stdenv, python, buildEnv, makeWrapper
+{ lib, stdenv, buildEnv, makeWrapper
+
+# manually pased
+, python
+, requiredPythonModules
+
+# extra opts
 , extraLibs ? []
 , extraOutputsToInstall ? []
 , postBuild ? ""
 , ignoreCollisions ? false
 , permitUserSite ? false
-, requiredPythonModules
 # Wrap executables with the given argument.
 , makeWrapperArgs ? []
 , }:
@@ -22,9 +27,9 @@ let
     inherit ignoreCollisions;
     extraOutputsToInstall = [ "out" ] ++ extraOutputsToInstall;
 
-    postBuild = ''
-      . "${makeWrapper}/nix-support/setup-hook"
+    nativeBuildInputs = [ makeWrapper ];
 
+    postBuild = ''
       if [ -L "$out/bin" ]; then
           unlink "$out/bin"
       fi


### PR DESCRIPTION
###### Motivation for this change

Fixes #114687. See each commit message for minor details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
