### PR TITLE
nix-output-monitor: Add nom-build script

### DIFF
--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -1,15 +1,16 @@
 { mkDerivation, ansi-terminal, async, attoparsec, base, containers
 , cassava, directory, HUnit, mtl, nix-derivation, process, relude, lib
 , stm, terminal-size, text, time, unix, wcwidth, fetchFromGitHub
+, expect, runtimeShell
 }:
-mkDerivation {
+mkDerivation rec {
   pname = "nix-output-monitor";
   version = "1.0.1.1";
   src = fetchFromGitHub {
     owner = "maralorn";
     repo = "nix-output-monitor";
     sha256 = "1wi1gsl5q1sy7k6k5wxhwpwzki7rghhbsyzm84hnw6h93w6401ax";
-    rev = "v1.0.1.1";
+    rev = "v${version}";
   };
   isLibrary = true;
   isExecutable = true;
@@ -25,6 +26,13 @@ mkDerivation {
     ansi-terminal async attoparsec base containers directory HUnit mtl
     nix-derivation process relude stm text time unix
   ];
+  postInstall = ''
+    cat > $out/bin/nom-build << EOF
+    #!${runtimeShell}
+    ${expect}/bin/unbuffer nix-build "\$@" 2>&1 | exec $out/bin/nom
+    EOF
+    chmod a+x $out/bin/nom-build
+  '';
   homepage = "https://github.com/maralorn/nix-output-monitor";
   description = "Parses output of nix-build to show additional information";
   license = lib.licenses.agpl3Plus;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

By popular demand we present `nom-build` it's exactly like `nix-build` but with more `nom`.

Credits to @lilyball for the idea:
https://discourse.nixos.org/t/announcing-the-nix-output-monitor/11672/6

My bash in nixpkgs foo is not very strong, so I appreciate any style critique.

\cc @mweinelt 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
