### PR TITLE
serf: use latest scons

### DIFF
--- a/pkgs/development/libraries/serf/default.nix
+++ b/pkgs/development/libraries/serf/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, apr, sconsPackages, openssl, aprutil, zlib, kerberos
+{ lib, stdenv, fetchurl, apr, scons, openssl, aprutil, zlib, kerberos
 , pkg-config, libiconv }:
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1k47gbgpp52049andr28y28nbwh9m36bbb0g8p0aka3pqlhjv72l";
   };
 
-  nativeBuildInputs = [ pkg-config sconsPackages.scons_3_1_2 ];
+  nativeBuildInputs = [ pkg-config scons ];
   buildInputs = [ apr openssl aprutil zlib libiconv ]
     ++ lib.optional (!stdenv.isCygwin) kerberos;
 

--- a/pkgs/development/libraries/serf/scons.patch
+++ b/pkgs/development/libraries/serf/scons.patch
@@ -1,7 +1,16 @@
 diff --git a/SConstruct b/SConstruct
-index 4358a23..0d862e7 100644
+index 4358a23..6ce7776 100644
 --- a/SConstruct
 +++ b/SConstruct
+@@ -55,7 +55,7 @@ def RawListVariable(key, help, default):
+ # To be used to ensure a PREFIX directory is only created when installing.
+ def createPathIsDirCreateWithTarget(target):
+   def my_validator(key, val, env):
+-    build_targets = (map(str, BUILD_TARGETS))
++    build_targets = (list(map(str, BUILD_TARGETS)))
+     if target in build_targets:
+       return PathVariable.PathIsDirCreate(key, val, env)
+     else:
 @@ -155,6 +155,7 @@ if sys.platform == 'win32':
  env = Environment(variables=opts,
                    tools=('default', 'textfile',),
@@ -10,3 +19,25 @@ index 4358a23..0d862e7 100644
                    )
  
  env.Append(BUILDERS = {
+@@ -163,9 +164,9 @@ env.Append(BUILDERS = {
+               suffix='.def', src_suffix='.h')
+   })
+ 
+-match = re.search('SERF_MAJOR_VERSION ([0-9]+).*'
+-                  'SERF_MINOR_VERSION ([0-9]+).*'
+-                  'SERF_PATCH_VERSION ([0-9]+)',
++match = re.search(b'SERF_MAJOR_VERSION ([0-9]+).*'
++                  b'SERF_MINOR_VERSION ([0-9]+).*'
++                  b'SERF_PATCH_VERSION ([0-9]+)',
+                   env.File('serf.h').get_contents(),
+                   re.DOTALL)
+ MAJOR, MINOR, PATCH = [int(x) for x in match.groups()]
+@@ -183,7 +184,7 @@ CALLOUT_OKAY = not (env.GetOption('clean') or env.GetOption('help'))
+ 
+ unknown = opts.UnknownVariables()
+ if unknown:
+-  print 'Warning: Used unknown variables:', ', '.join(unknown.keys())
++  print('Warning: Used unknown variables:', ', '.join(list(unknown.keys())))
+ 
+ apr = str(env['APR'])
+ apu = str(env['APU'])


### PR DESCRIPTION
###### Motivation for this change
scons_3_1_2 depends on python2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
