### PR TITLE
pythonPackages.rfcat: init at 1.9.5

### DIFF
--- a/pkgs/development/python-modules/rfcat/default.nix
+++ b/pkgs/development/python-modules/rfcat/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, future
+, ipython
+, numpy
+, pyserial
+, pyusb
+, hostPlatform
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "rfcat";
+  version = "1.9.5";
+
+  src = fetchFromGitHub {
+    owner = "atlas0fd00m";
+    repo = "rfcat";
+    rev = "v${version}";
+    sha256 = "1mmr7g7ma70sk6vl851430nqnd7zxsk7yb0xngwrdx9z7fbz2ck0";
+  };
+
+  propagatedBuildInputs = [
+    future
+    ipython
+    numpy
+    pyserial
+    pyusb
+  ];
+
+  postInstall = lib.optionalString hostPlatform.isLinux ''
+    mkdir -p $out/etc/udev/rules.d
+    cp etc/udev/rules.d/20-rfcat.rules $out/etc/udev/rules.d
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "rflib" ];
+
+  meta = with lib; {
+    description = "Swiss Army knife of sub-GHz ISM band radio";
+    homepage = "https://github.com/atlas0fd00m/rfcat";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ trepetti ];
+    changelog = "https://github.com/atlas0fd00m/rfcat/releases/tag/v${version}";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6726,6 +6726,8 @@ in {
 
   rfc7464 = callPackage ../development/python-modules/rfc7464 { };
 
+  rfcat = callPackage ../development/python-modules/rfcat { };
+
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl { });
 
   rich = callPackage ../development/python-modules/rich { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add rfcat: the Swiss Army knife of sub-GHz ISM band radio. Useful for RF protocol debugging and compatible with the popular YARD Stick One from Great Scott Gadgets. Tested on Python 2.7 and 3.8.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
