### PR TITLE
nixos/lxd: fixup of 4adcb006

### DIFF
--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -97,7 +97,7 @@ in {
     # does a bunch of unrelated things.
     systemd.tmpfiles.rules = [ "d /var/lib/lxc/rootfs 0755 root root -" ];
 
-    security.apparmor.packages = [ pkgs.lxcPackage ];
+    security.apparmor.packages = [ cfg.lxcPackage ];
     security.apparmor.profiles = [
       "${cfg.lxcPackage}/etc/apparmor.d/lxc-containers"
       "${cfg.lxcPackage}/etc/apparmor.d/usr.bin.lxc-start"


### PR DESCRIPTION
###### Motivation for this change
Fix broken evaluation due to stupid typo.

###### Things done

- [x] Tested `virtualisation.lxd.enable = true;`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Lillecarl
