### PR TITLE
nvmet-cli: init at 0.7

### DIFF
--- a/pkgs/os-specific/linux/nvmet-cli/default.nix
+++ b/pkgs/os-specific/linux/nvmet-cli/default.nix
@@ -1,0 +1,25 @@
+{ lib, python3Packages, fetchurl }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "nvmet-cli";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "ftp://ftp.infradead.org/pub/nvmetcli/nvmetcli-${version}.tar.gz";
+    sha256 = "051y1b9w46azy35118154c353v3mhjkdzh6h59brdgn5054hayj2";
+  };
+
+  buildInputs = with python3Packages; [ nose2 ];
+
+  propagatedBuildInputs = with python3Packages; [ configshell ];
+
+  # This package requires the `nvmet` kernel module to be loaded for tests.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "NVMe target CLI";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ hoverbear ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19819,6 +19819,8 @@ in
 
   nvme-cli = callPackage ../os-specific/linux/nvme-cli { };
 
+  nvmet-cli = callPackage ../os-specific/linux/nvmet-cli { };
+
   system76-firmware = callPackage ../os-specific/linux/firmware/system76-firmware { };
 
   open-vm-tools = callPackage ../applications/virtualization/open-vm-tools { };


### PR DESCRIPTION
###### Motivation for this change

Introduce `nvmet-cli` from http://git.infradead.org/users/hch/nvmetcli.git.

This tool allows users to configure NVMe targets. This is useful for configuring devices  for NVMe-oF. It is often used with [`nvme-cli`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/nvme-cli/default.nix) 

This tool is described in Red Hat access documents for RHEL8: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/managing_storage_devices/index

It is present in RHEL8.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
