### PR TITLE
xdg-desktop-portal-kde: drop unused python dependency

### DIFF
--- a/pkgs/desktops/plasma-5/xdg-desktop-portal-kde.nix
+++ b/pkgs/desktops/plasma-5/xdg-desktop-portal-kde.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation, lib,
-  extra-cmake-modules, gettext, kdoctools, python,
+  extra-cmake-modules, gettext, kdoctools,
   cups, epoxy, mesa, pcre, pipewire, wayland, wayland-protocols,
   kcoreaddons, knotifications, kwayland, kwidgetsaddons, kwindowsystem,
   kirigami2, kdeclarative, plasma-framework, plasma-wayland-protocols, kio,
@@ -10,7 +10,7 @@
 mkDerivation {
   name = "xdg-desktop-portal-kde";
   meta.broken = lib.versionOlder qtbase.version "5.15.0";
-  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python ];
+  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools ];
   buildInputs = [
     cups epoxy mesa pcre pipewire wayland wayland-protocols
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
