### PR TITLE
libproxy: 0.4.15 -> 0.4.17

### DIFF
--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -3,10 +3,9 @@
 , pkg-config
 , cmake
 , zlib
-, fetchpatch
 , dbus
 , networkmanager
-, spidermonkey_60
+, spidermonkey_68
 , pcre
 , gsettings-desktop-schemas
 , glib
@@ -19,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libproxy";
-  version = "0.4.15";
+  version = "0.4.17";
 
   src = fetchFromGitHub {
     owner = "libproxy";
     repo = "libproxy";
     rev = version;
-    sha256 = "10swd3x576pinx33iwsbd4h15fbh2snmfxzcmab4c56nb08qlbrs";
+    sha256 = "0v8q4ln0pd5231kidpi8wpwh0chcjwcmawcki53czlpdrc09z96r";
   };
 
   outputs = [ "out" "dev" "py3" ];
@@ -46,7 +45,7 @@ stdenv.mkDerivation rec {
     JavaScriptCore
   ] else [
     glib
-    spidermonkey_60
+    spidermonkey_68
     dbus
     networkmanager
   ]);
@@ -55,38 +54,6 @@ stdenv.mkDerivation rec {
     "-DWITH_MOZJS=ON"
     "-DWITH_PYTHON2=OFF"
     "-DPYTHON3_SITEPKG_DIR=${placeholder "py3"}/${python3.sitePackages}"
-  ];
-
-  patches = [
-    # Make build with spidermonkey_60
-    (fetchpatch {
-      url = "https://github.com/libproxy/libproxy/pull/86.patch";
-      sha256 = "17c06ilinrnzr7xnnmw9pc6zrncyaxcdd6r6k1ah5p156skbykfs";
-    })
-    (fetchpatch {
-      url = "https://github.com/libproxy/libproxy/pull/87.patch";
-      sha256 = "0sagzfwm16f33inbkwsp88w9wmrd034rjmw0y8d122f7k1qfx6zc";
-    })
-    (fetchpatch {
-      url = "https://github.com/libproxy/libproxy/pull/95.patch";
-      sha256 = "18vyr6wlis9zfwml86606jpgb9mss01l9aj31iiciml8p857aixi";
-    })
-    (fetchpatch {
-      name = "CVE-2020-25219.patch";
-      url = "https://github.com/libproxy/libproxy/commit/a83dae404feac517695c23ff43ce1e116e2bfbe0.patch";
-      sha256 = "0wdh9qjq99aw0jnf2840237i3hagqzy42s09hz9chfgrw8pyr72k";
-    })
-    (fetchpatch {
-      name = "CVE-2020-26154.patch";
-      url = "https://github.com/libproxy/libproxy/commit/4411b523545b22022b4be7d0cac25aa170ae1d3e.patch";
-      sha256 = "0pdy9sw49lxpaiwq073cisk0npir5bkch70nimdmpszxwp3fv1d8";
-    })
-
-  ] ++ lib.optionals stdenv.isDarwin [
-    (fetchpatch {
-      url = "https://github.com/libproxy/libproxy/commit/44158f03f8522116758d335688ed840dfcb50ac8.patch";
-      sha256 = "0axfvb6j7gcys6fkwi9dkn006imhvm3kqr83gpwban8419n0q5v1";
-    })
   ];
 
   postFixup = lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
###### Motivation for this change
https://github.com/libproxy/libproxy/blob/0.4.17/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
