### PR TITLE
kodi: fix build for wayland and gbm

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -231,7 +231,6 @@ in stdenv.mkDerivation {
 
     cmakeFlags = [
       "-DAPP_RENDER_SYSTEM=${if useGbm then "gles" else "gl"}"
-      "-DCORE_PLATFORM_NAME=${lib.concatStringsSep " " kodi_platforms}"
       "-Dlibdvdcss_URL=${libdvdcss.src}"
       "-Dlibdvdnav_URL=${libdvdnav.src}"
       "-Dlibdvdread_URL=${libdvdread.src}"
@@ -251,9 +250,11 @@ in stdenv.mkDerivation {
     # I'm guessing there is a thing waiting to time out
     doCheck = false;
 
-    # Need these tools on the build system when cross compiling,
-    # hacky, but have found no other way.
-    preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    preConfigure = ''
+      cmakeFlagsArray+=("-DCORE_PLATFORM_NAME=${lib.concatStringsSep " " kodi_platforms}")
+    '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+      # Need these tools on the build system when cross compiling,
+      # hacky, but have found no other way.
       CXX=${stdenv.cc.targetPrefix}c++ LD=ld make -C tools/depends/native/JsonSchemaBuilder
       cmakeFlags+=" -DWITH_JSONSCHEMABUILDER=$PWD/tools/depends/native/JsonSchemaBuilder/bin"
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix broken `kodi` build for multiple `platform` values (whenever more than one value is chosen from `gbm`, `wayland`, and `x11`): https://github.com/NixOS/nixpkgs/pull/105417#issuecomment-787439213

ping @minijackson for testing `kodi-wayland`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
