### PR TITLE
darwin.bootstrap_cmds: use correct arch in "mig"

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/bootstrap_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/bootstrap_cmds/default.nix
@@ -1,4 +1,4 @@
-{ lib, appleDerivation, yacc, flex }:
+{ lib, stdenv, appleDerivation, yacc, flex }:
 
 appleDerivation {
   nativeBuildInputs = [ yacc flex ];
@@ -26,7 +26,7 @@ appleDerivation {
     cp migcom.1 $out/share/man/man1
 
     substituteInPlace $out/bin/mig \
-      --replace 'arch=`/usr/bin/arch`' 'arch=i386' \
+      --replace 'arch=`/usr/bin/arch`' 'arch=${stdenv.targetPlatform.darwinArch}' \
       --replace '/usr/bin/' "" \
       --replace '/bin/rmdir' "rmdir" \
       --replace 'C=''${MIGCC}' "C=cc"


### PR DESCRIPTION
###### Motivation for this change

Fix darwin stdenv in staging after breaking it in #114817 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
