### PR TITLE
python3Packages.curio: fix another flaky test

### DIFF
--- a/pkgs/development/python-modules/curio/default.nix
+++ b/pkgs/development/python-modules/curio/default.nix
@@ -24,6 +24,11 @@ buildPythonPackage rec {
       url = "https://github.com/dabeaz/curio/commit/132376724bbfaa0a52d3d63d0791aa4ac1eb6f5f.patch";
       sha256 = "sha256-AxO0xRcR9l9/NKEJFwyZIoYcyZxpqOhpdNaeaYokVb4=";
     })
+    # Same as above
+    (fetchpatch {
+      url = "https://github.com/dabeaz/curio/commit/8ac2f12a2cdacbc750b01fc7459cee8879bc1ee3.patch";
+      sha256 = "sha256-2Si3fuDLrI09QuzJd1TrE0QY02G9e9m+1eHFTB/MrWU=";
+    })
   ];
 
   disabled = !isPy3k;


### PR DESCRIPTION
###### Motivation for this change

This needs to go into staging as it builds upon #114255. It mainly helps #105026.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).