### PR TITLE
lib/modules: provide a better error message when "imports" contains a list

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -23,6 +23,7 @@ let
     isAttrs
     isBool
     isFunction
+    isList
     isString
     length
     mapAttrs
@@ -188,6 +189,9 @@ rec {
       loadModule = args: fallbackFile: fallbackKey: m:
         if isFunction m || isAttrs m then
           unifyModuleSyntax fallbackFile fallbackKey (applyIfFunction fallbackKey m args)
+        else if isList m then
+          let defs = [{ file = fallbackFile; value = m; }]; in
+          throw "Module imports can't be nested lists. Perhaps you meant to remove one level of lists? Definitions: ${showDefs defs}"
         else unifyModuleSyntax (toString m) (toString m) (applyIfFunction (toString m) (import m) args);
 
       /*


### PR DESCRIPTION
###### Motivation for this change

A user had a problem with their NixOS configuration because they had an `imports = [ [ ./path ] ]` with a nested list.

When the `imports` option of a module contains a nested list, a very cryptic error message is printed:

``` text
error: --- TypeError ---
at: (150:89) in file: /nix/store/bxl3kwj11yj2dxs35q58s7m1x87c0i7h-source/lib/modules.nix

   149|           unifyModuleSyntax fallbackFile fallbackKey (applyIfFunction fallbackKey m args)
   150|         else unifyModuleSyntax (toString m) (toString m) (applyIfFunction (toString m) (import m) args);
      |                                                                                         ^
   151| 

cannot coerce a list to a string
--- show-trace ---
```

This PR simply checks whether a to-be-loaded module is actually a list and throws an error with a more "helpful" error message:

![image](https://user-images.githubusercontent.com/20448408/109762498-ad835480-7bbe-11eb-9e59-9ec039ab80d4.png)

with the (very simplified) configuration:

``` nix
{ ... }:

{
  imports = [ [ "lol" "ok" ] ];
}
```

This new error message should be improved but it's fairly better now than it was before.
Ideally, it should show the faulty line with the a link to the line:column.

###### Things done

Sorry if this PR doesn't follow the guidelines for changes to the lib.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
