### PR TITLE
crun: 0.17 -> 0.18

### DIFF
--- a/pkgs/applications/virtualization/crun/default.nix
+++ b/pkgs/applications/virtualization/crun/default.nix
@@ -12,6 +12,7 @@
 , nixosTests
 , criu
 , system
+, fetchpatch
 }:
 
 let
@@ -37,15 +38,23 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "crun";
-  version = "0.17";
+  version = "0.18";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = pname;
     rev = version;
-    sha256 = "sha256-OdB7UXLG99ErbfSCvq87LxBy5EYkUvTfyQNG70RFbl4=";
+    sha256 = "sha256-VjMpfj2qUQdhqdnLpZsYigfo2sM7gNl0GrE4nitp13g=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # For 0.18 some tests switched to static builds, this was reverted after 0.18 was released
+    (fetchpatch {
+      url = "https://github.com/containers/crun/commit/d26579bfe56aa36dd522745d47a661ce8c70d4e7.patch";
+      sha256 = "1xmc0wj0j2xcg0915vxn0pplc4s94rpmw0s5g8cyf8dshfl283f9";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook go-md2man pkg-config python3 ];
 


### PR DESCRIPTION
https://github.com/containers/crun/releases/tag/0.18

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
