### PR TITLE
kdeApplications.kamoso: init at 20.12.1

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -91,6 +91,7 @@ let
       kalarm = callPackage ./kalarm.nix {};
       kalarmcal = callPackage ./kalarmcal.nix {};
       kalzium = callPackage ./kalzium.nix {};
+      kamoso = callPackage ./kamoso.nix {};
       kapman = callPackage ./kapman.nix {};
       kapptemplate = callPackage ./kapptemplate.nix { };
       kate = callPackage ./kate.nix {};

--- a/pkgs/applications/kde/kamoso.nix
+++ b/pkgs/applications/kde/kamoso.nix
@@ -1,0 +1,41 @@
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, kdoctools
+, wrapQtAppsHook
+, qtdeclarative
+, qtgraphicaleffects
+, qtquickcontrols2
+, kirigami2
+, kpurpose
+, gst_all_1
+, pcre
+}:
+
+let
+  gst = with gst_all_1; [ gstreamer gst-libav gst-plugins-base gst-plugins-good gst-plugins-bad ];
+
+in
+mkDerivation {
+  pname = "kamoso";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapQtAppsHook ];
+  buildInputs = [ pcre ] ++ gst;
+  propagatedBuildInputs = [
+    qtdeclarative
+    qtgraphicaleffects
+    qtquickcontrols2
+    kirigami2
+    kpurpose
+  ];
+
+  cmakeFlags = [
+    "-DOpenGL_GL_PREFERENCE=GLVND"
+    "-DGSTREAMER_VIDEO_INCLUDE_DIR=${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0"
+  ];
+
+  qtWrapperArgs = [
+    "--prefix GST_PLUGIN_PATH : ${lib.makeSearchPath "lib/gstreamer-1.0" gst}"
+  ];
+
+  meta.license = with lib.licenses; [ lgpl21Only gpl3Only ];
+}


### PR DESCRIPTION
###### Motivation for this change

Needed to see if my webcam was working properly. While it works here (with kdeapps 20.08 as well), there are no guarantees regarding the quality of the subject(s).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
