### PR TITLE
python3Packages.poetry-core: 1.0.0 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -1,25 +1,29 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, filelock
 , flit-core
-, toml
-, pep517
-, packaging
-, isPy3k
-, typing
-, pythonOlder
 , importlib-metadata
+, isPy3k
+, packaging
+, pep517
+, pytest-mock
+, pytest-xdist
+, pytestCheckHook
+, pythonOlder
+, toml
+, typing
 }:
 
 buildPythonPackage rec {
   pname = "build";
-  version = "0.1.0";
+  version = "0.3.0";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1d6m21lijwm04g50nwgsgj7x3vhblzw7jv05ah8psqgzk20bbch8";
+    sha256 = "sha256-DrlbLI13DXxMm5LGjCJ8NQu/ZfPsg1UazpCXwYzBX90=";
   };
 
   nativeBuildInputs = [
@@ -36,8 +40,25 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
-  # No tests in archive
-  doCheck = false;
+  checkInputs = [
+    filelock
+    pytestCheckHook
+    pytest-mock
+    pytest-xdist
+  ];
+
+  disabledTests = [
+    "test_isolation"
+    "test_isolated_environment_install"
+    "test_default_pip_is_never_too_old"
+    "test_build_isolated - StopIteration"
+    "test_build_raises_build_exception"
+    "test_build_raises_build_backend_exception"
+    "test_projectbuilder.py"
+    "test_projectbuilder.py"
+  ];
+
+  pythonImportsCheck = [ "build" ];
 
   meta = with lib; {
     description = "Simple, correct PEP517 package builder";

--- a/pkgs/development/python-modules/check-manifest/default.nix
+++ b/pkgs/development/python-modules/check-manifest/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pep517, toml, mock, breezy, git, build }:
+{ lib, buildPythonPackage, fetchPypi, pep517, toml, mock, breezy, git, build, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "check-manifest";
@@ -16,7 +16,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ build pep517 toml ];
 
-  checkInputs = [ mock breezy git ];
+  checkInputs = [ mock breezy git pytestCheckHook ];
+
+  pythonImportsCheck = [ "check_manifest" ];
+
 
   meta = with lib; {
     homepage = "https://github.com/mgedmin/check-manifest";

--- a/pkgs/development/python-modules/check-manifest/default.nix
+++ b/pkgs/development/python-modules/check-manifest/default.nix
@@ -1,4 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, pep517, toml, mock, breezy, git, build, pytestCheckHook }:
+{ lib
+, breezy
+, build
+, buildPythonPackage
+, fetchPypi
+, git
+, mock
+, pep517
+, pytestCheckHook
+, toml
+}:
 
 buildPythonPackage rec {
   pname = "check-manifest";
@@ -14,12 +24,20 @@ buildPythonPackage rec {
     substituteInPlace tests.py --replace "test_build_sdist" "no_test_build_sdist"
   '';
 
-  propagatedBuildInputs = [ build pep517 toml ];
+  propagatedBuildInputs = [
+    build
+    pep517
+    toml
+  ];
 
-  checkInputs = [ mock breezy git pytestCheckHook ];
+  checkInputs = [
+    breezy
+    git
+    mock
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "check_manifest" ];
-
 
   meta = with lib; {
     homepage = "https://github.com/mgedmin/check-manifest";

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "poetry-core";
-  version = "1.0.0";
+  version = "1.0.2";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = pname;
     rev = version;
-    sha256 = "02pqkwzbg43xz2zsw8q7m0sfkj8wbw07in83gy0bk0znhljhp0vw";
+    sha256 = "sha256-OE6oc/3HYrMmgPnINxvSZ27m8YeZk5Gnn9ok8GlSIZ0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.0.2

Change log:
- https://github.com/python-poetry/poetry-core/releases/tag/1.0.2
- https://github.com/python-poetry/poetry-core/releases/tag/1.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
