### PR TITLE
isrcsubmit: init at 2.1.0

### DIFF
--- a/pkgs/tools/audio/isrcsubmit/default.nix
+++ b/pkgs/tools/audio/isrcsubmit/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "isrcsubmit";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "JonnyJD";
+    repo = "musicbrainz-isrcsubmit";
+    rev = "v${version}";
+    sha256 = "1lqs4jl2xv1zxmf0xsihk9rxzx2awq87g51vd7y3cq1vhj1icxqa";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ musicbrainzngs discid ];
+
+  meta = with lib; {
+    # drutil is required on Darwin, which does not seem to be available in nixpkgs
+    broken = stdenv.isDarwin;
+    description = "Script to submit ISRCs from disc to MusicBrainz";
+    license = licenses.gpl3Plus;
+    homepage = "http://jonnyjd.github.io/musicbrainz-isrcsubmit/";
+    maintainers = with maintainers; [ eduardosm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5402,6 +5402,8 @@ in
 
   ispike = callPackage ../development/libraries/science/robotics/ispike { };
 
+  isrcsubmit = callPackage ../tools/audio/isrcsubmit { };
+
   isync = callPackage ../tools/networking/isync {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
