### PR TITLE
strace: assert isLinux to avoid eval error on darwin 

### DIFF
--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -1,5 +1,9 @@
 { lib, stdenv, fetchurl, perl, libunwind, buildPackages }:
 
+# libunwind does not have the supportsHost attribute on darwin, thus
+# when this package is evaluated it causes an evaluation error
+assert stdenv.isLinux;
+
 stdenv.mkDerivation rec {
   pname = "strace";
   version = "5.11";


### PR DESCRIPTION
###### Motivation for this change
While running queries about `buildInputs`, I ran into an evaluation error in strace that cannot be caught with `tryEval` on darwin. This PR adds an assert that the system is Linux before continuing evaluation.

#### Before
```ShellSession                                                                                                                                                                       
$ nix repl '<nixpkgs>'
Welcome to Nix version 2.4pre20210207_fd6eaa1. Type :? for help.

Loading '<nixpkgs>'...
Added 13459 variables.

nix-repl> strace.buildInputs      
error: attribute 'supportsHost' missing

       at /nix/store/56ghaiixmzzfy0yvm0c8brjrw73zka1y-nixpkgs-21.05pre271547.a964d7094a3/nixpkgs/pkgs/development/tools/misc/strace/default.nix:15:46:

           14|
           15|   buildInputs = [ perl.out ] ++ lib.optional libunwind.supportsHost libunwind; # support -k
             |                                              ^
           16|

nix-repl> 
```
### After
```ShellSession
Welcome to Nix version 2.4pre20210207_fd6eaa1. Type :? for help.

Loading '.'...
Added 13503 variables.

nix-repl> strace
error: assertion '(stdenv).isLinux' failed

       at /Users/siraben/Git/forks/nixpkgs/pkgs/development/tools/misc/strace/default.nix:3:1:

            2|
            3| assert stdenv.isLinux;
             | ^
            4|
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
