### PR TITLE
treewide: fix or enable darwin build for many packages

### DIFF
--- a/pkgs/development/compilers/4th/default.nix
+++ b/pkgs/development/compilers/4th/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "-C sources"
-    "CC=${stdenv.cc}/bin/cc"
+    "CC=${stdenv.cc.targetPrefix}cc"
   ];
 
   preInstall = ''
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     description = "A portable Forth compiler";
     homepage = "https://thebeez.home.xs4all.nl/4tH/index.html";
     license = licenses.lgpl3;
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/compilers/arachne-pnr/default.nix
+++ b/pkgs/development/compilers/arachne-pnr/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/cseed/arachne-pnr";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ shell thoughtpolice ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/compilers/gprolog/default.nix
+++ b/pkgs/development/compilers/gprolog/default.nix
@@ -63,6 +63,6 @@ stdenv.mkDerivation rec {
     '';
 
     maintainers = [ lib.maintainers.peti ];
-    platforms = lib.platforms.gnu ++ lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/compilers/miranda/default.nix
+++ b/pkgs/development/compilers/miranda/default.nix
@@ -70,5 +70,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.cs.kent.ac.uk/people/staff/dat/miranda/";
     license = licenses.bsd2;
     maintainers = with maintainers; [ siraben ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/compilers/muon/default.nix
+++ b/pkgs/development/compilers/muon/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     mkdir -p $out/bin $out/share/mu
     cp -r lib $out/share/mu
-    gcc -O3 -o $out/bin/mu-unwrapped bootstrap/mu64.c
+    ${stdenv.cc.targetPrefix}cc -o $out/bin/mu-unwrapped bootstrap/mu64.c
   '';
 
   installPhase = ''
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/nickmqb/muon";
     license = licenses.mit;
     maintainers = with maintainers; [ Br1ght0ne ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/compilers/rasm/default.nix
+++ b/pkgs/development/compilers/rasm/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
       # according to official documentation
-      cc rasm_v*.c -O2 -lm -lrt -o rasm
+      ${stdenv.cc.targetPrefix}cc rasm_v*.c -O2 -lm -o rasm
   '';
 
   installPhase = ''
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     # use -n option to display all licenses
     license = licenses.mit; # expat version
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/compilers/serpent/default.nix
+++ b/pkgs/development/compilers/serpent/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation {
     sha256 = "1bns9wgn5i1ahj19qx7v1wwdy8ca3q3pigxwznm5nywsw7s7lqxs";
   };
 
+  postPatch = ''
+    substituteInPlace Makefile --replace 'g++' '${stdenv.cc.targetPrefix}c++'
+  '';
+
   installPhase = ''
     mkdir -p $out/bin
     mv serpent $out/bin
@@ -33,6 +37,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/ethereum/wiki/wiki/Serpent";
     license = with licenses; [ wtfpl ];
     maintainers = with maintainers; [ chris-martin ];
-    platforms = with platforms; linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/science/math/QuadProgpp/default.nix
+++ b/pkgs/development/libraries/science/math/QuadProgpp/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ ];
 
   meta = with lib; {
     homepage = "https://github.com/liuq/QuadProgpp";
@@ -22,6 +21,6 @@ stdenv.mkDerivation rec {
       Goldfarb-Idnani active-set dual method.
     '';
     maintainers = with maintainers; [ ];
-    platforms = with platforms; linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/misc/0x0/default.nix
+++ b/pkgs/tools/misc/0x0/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation {
     homepage = "https://gitlab.com/somasis/scripts/";
     maintainers = [ maintainers.ar1a ];
     license = licenses.unlicense;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/system/snooze/default.nix
+++ b/pkgs/tools/system/snooze/default.nix
@@ -14,6 +14,6 @@ stdenv.mkDerivation rec {
     description = "Tool for waiting until a particular time and then running a command";
     maintainers = with maintainers; [ kaction ];
     license = licenses.cc0;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/text/mpage/default.nix
+++ b/pkgs/tools/text/mpage/default.nix
@@ -7,8 +7,9 @@ stdenv.mkDerivation rec {
     sha256 = "1zn37r5xrvjgjbw2bdkc0r7s6q8b1krmcryzj0yf0dyxbx79rasi";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "Makefile" -e "s|^ *PREFIX *=.*$|PREFIX = $out|g"
+    substituteInPlace Makefile --replace 'gcc' '${stdenv.cc.targetPrefix}cc'
   '';
 
   meta = {
@@ -24,6 +25,6 @@ stdenv.mkDerivation rec {
 
     license = "liberal";  # a non-copyleft license, see `Copyright' file
     homepage = "http://www.mesa.nl/pub/mpage/";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/text/numdiff/default.nix
+++ b/pkgs/tools/text/numdiff/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, libintl }:
 
 
 stdenv.mkDerivation rec {
@@ -9,6 +9,9 @@ stdenv.mkDerivation rec {
     url = "mirror://savannah/numdiff/numdiff-${version}.tar.gz";
     sha256 = "1vzmjh8mhwwysn4x4m2vif7q2k8i19x8azq7pzmkwwj4g48lla47";
   };
+
+  buildInputs = [ libintl ];
+
   meta = with lib; {
     description = ''
       A little program that can be used to compare putatively similar files
@@ -18,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.nongnu.org/numdiff/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [];
-    platforms = platforms.gnu ++ platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/text/uni2ascii/default.nix
+++ b/pkgs/tools/text/uni2ascii/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     similar ASCII characters, e.g. by stripping diacritics.
     '';
     maintainers = with lib.maintainers; [ goibhniu ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/text/yaml-merge/default.nix
+++ b/pkgs/tools/text/yaml-merge/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     description = "Merge YAML data files";
     homepage = "https://github.com/abbradar/yaml-merge";
     license = licenses.bsd2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ abbradar ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This is going to be one of many PRs. I created a [query script](https://github.com/siraben/nixpkgs/commit/b3c5aa660d43d2c22d38bf8d14c0e3bca8495ea6) to be able to find packages with no buildInputs that don't have darwin in the `meta.platforms`. Sometimes this was due to a lack of having a `meta.platforms` at all, but in many cases simply expanding the `meta.platforms` to include darwin fixed the issue. Otherwise I had to do minor changes to get it to build (hence why I chose packages with `buildInputs = []`).

Over 1000 packages were returned by my script and so it would be better to do this in small PRs at a time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
