### PR TITLE
python3Packages.ge25519: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/bitlist/default.nix
+++ b/pkgs/development/python-modules/bitlist/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, parts
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "bitlist";
+  version = "0.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04dz64r21a39p8wph5qlhvs5y873qgk6xxjlzw8n695b8jm3ixir";
+  };
+
+  propagatedBuildInputs = [
+    parts
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    nose
+  ];
+
+  pythonImportsCheck = [ "bitlist" ];
+
+  meta = with lib; {
+    description = "Python library for working with little-endian list representation of bit strings";
+    homepage = "https://github.com/lapets/bitlist";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/fe25519/default.nix
+++ b/pkgs/development/python-modules/fe25519/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, bitlist
+, buildPythonPackage
+, fetchPypi
+, fountains
+, parts
+, nose
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "fe25519";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1m85qvw9dwxk81mv9k45c9n75pk8wqn70qkinqh56h5zv56vgq24";
+  };
+
+  propagatedBuildInputs = [
+    bitlist
+    fountains
+    parts
+  ];
+
+  checkInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "fe25519" ];
+
+  meta = with lib; {
+    description = "Python field operations for Curve25519's prime";
+    homepage = "https://github.com/BjoernMHaase/fe25519";
+    license = with licenses; [ cc0 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/fountains/default.nix
+++ b/pkgs/development/python-modules/fountains/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, bitlist
+}:
+
+buildPythonPackage rec {
+  pname = "fountains";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0jk5y099g6ggaq5lwp0jlg4asyhcdxnl3him3ibmzc1k9nnknp30";
+  };
+
+  propagatedBuildInputs = [
+    bitlist
+  ];
+
+  # Project has no test
+  doCheck = false;
+  pythonImportsCheck = [ "fountains" ];
+
+  meta = with lib; {
+    description = "Python library for generating and embedding data for unit testing";
+    homepage = "https://github.com/reity/fountains";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/ge25519/default.nix
+++ b/pkgs/development/python-modules/ge25519/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, bitlist
+, buildPythonPackage
+, fe25519
+, fetchPypi
+, fountains
+, nose
+, parts
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ge25519";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wgv0vqg8iv9y5d7if14gmcgslwd5zzgk322w9jaxdfbndldddik";
+  };
+
+  propagatedBuildInputs = [
+    fe25519
+    parts
+    bitlist
+    fountains
+  ];
+
+  checkInputs = [
+    nose
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "ge25519" ];
+
+  meta = with lib; {
+    description = "Python implementation of Ed25519 group elements and operations";
+    homepage = "https://github.com/nthparty/ge25519";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/parts/default.nix
+++ b/pkgs/development/python-modules/parts/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "parts";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ym238hxwsw15ivvf6gzmkmla08b9hwhdyc3v6rs55wga9j3a4db";
+  };
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "parts" ];
+
+  meta = with lib; {
+    description = "Python library for common list functions related to partitioning lists";
+    homepage = "https://github.com/lapets/parts";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2230,6 +2230,8 @@ in {
 
   fdint = callPackage ../development/python-modules/fdint { };
 
+  fe25519 = callPackage ../development/python-modules/fe25519 { };
+
   feedgen = callPackage ../development/python-modules/feedgen { };
 
   feedgenerator = callPackage ../development/python-modules/feedgenerator { inherit (pkgs) glibcLocales; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4751,6 +4751,8 @@ in {
 
   partd = callPackage ../development/python-modules/partd { };
 
+  parts = callPackage ../development/python-modules/parts { };
+
   parver = callPackage ../development/python-modules/parver { };
   arpeggio = callPackage ../development/python-modules/arpeggio { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2530,6 +2530,8 @@ in {
 
   gdrivefs = callPackage ../development/python-modules/gdrivefs { };
 
+  ge25519 = callPackage ../development/python-modules/ge25519 { };
+
   geant4 = disabledIf (!isPy3k) (toPythonModule (pkgs.geant4.override {
     enablePython = true;
     python3 = python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2446,6 +2446,8 @@ in {
   foundationdb60 = callPackage ../servers/foundationdb/python.nix { foundationdb = pkgs.foundationdb60; };
   foundationdb61 = callPackage ../servers/foundationdb/python.nix { foundationdb = pkgs.foundationdb61; };
 
+  fountains = callPackage ../development/python-modules/fountains { };
+
   foxdot = callPackage ../development/python-modules/foxdot { };
 
   fpdf = callPackage ../development/python-modules/fpdf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -979,6 +979,8 @@ in {
 
   bitcoin-price-api = callPackage ../development/python-modules/bitcoin-price-api { };
 
+  bitlist = callPackage ../development/python-modules/bitlist { };
+
   bitmath = callPackage ../development/python-modules/bitmath { };
 
   bitstring = callPackage ../development/python-modules/bitstring { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python implementation of Ed25519 group elements and operations

https://github.com/nthparty/ge25519

This is a dependency of the latest `aiocoap` release. For easier processing the update of `aiocoap` is splitted. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
