### PR TITLE
go-mockery: init at 2.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3071,6 +3071,12 @@
     githubId = 1276854;
     name = "Florian Peter";
   };
+  fbrs = {
+    email = "yuuki@protonmail.com";
+    github = "cideM";
+    githubId = 4246921;
+    name = "Florian Beeres";
+  };
   fdns = {
     email = "fdns02@gmail.com";
     github = "fdns";

--- a/pkgs/development/tools/go-mockery/default.nix
+++ b/pkgs/development/tools/go-mockery/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-mockery";
+  version = "2.5.1";
+
+  src = fetchFromGitHub {
+    owner = "vektra";
+    repo = "mockery";
+    rev = "v${version}";
+    sha256 = "5W5WGWqxpZzOqk1VOlLeggIqfneRb7s7ZT5faNEhDos=";
+  };
+
+  vendorSha256 = "//V3ia3YP1hPgC1ipScURZ5uXU4A2keoG6dGuwaPBcA=";
+
+  meta = with lib; {
+    homepage = "https://github.com/vektra/mockery";
+    description = "A mock code autogenerator for Golang";
+    maintainers = with maintainers; [ fbrs ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19895,6 +19895,8 @@ in
 
   go-migrate = callPackage ../development/tools/go-migrate { };
 
+  go-mockery = callPackage ../development/tools/go-mockery { };
+
   gomacro = callPackage ../development/tools/gomacro { };
 
   gomodifytags = callPackage ../development/tools/gomodifytags { };


### PR DESCRIPTION
Also added myself as  `fbrs` to list of maintainers

<details>
<summary>Using the added package to verify it works</summary>

```shell
~/foo
$ nix-shell -p go gotools gopls
these 3 paths will be fetched (124.33 MiB download, 567.76 MiB unpacked):
  /nix/store/5cjd962ig8azhp45l7h95hl4jzkyzqv0-go-1.15.8
  /nix/store/fmc862521n4ssh2naklkz7agp2fjd8c4-gopls-0.4.4
  /nix/store/fyw7qcni6p6py0xlrxamydq1904hrbbg-gotools-unstable-2020-04-21
copying path '/nix/store/5cjd962ig8azhp45l7h95hl4jzkyzqv0-go-1.15.8' from 'https://cache.nixos.org'...
copying path '/nix/store/fmc862521n4ssh2naklkz7agp2fjd8c4-gopls-0.4.4' from 'https://cache.nixos.org'...
copying path '/nix/store/fyw7qcni6p6py0xlrxamydq1904hrbbg-gotools-unstable-2020-04-21' from 'https://cache.nixos.org'...

[nix-shell:~/foo]$ go mod init foo
go: creating new go.mod: module foo

[nix-shell:~/foo]$ nvim main.go

[nix-shell:~/foo]$ ~/nixpkgs/result/bin/mockery --name Foo --inpackage
03 Mar 21 16:07 CET INF Starting mockery dry-run=false version=0.0.0-dev
03 Mar 21 16:07 CET INF Walking dry-run=false version=0.0.0-dev
03 Mar 21 16:07 CET INF Generating mock dry-run=false interface=Foo qualified-name=foo version=0.0.0-dev

[nix-shell:~/foo]$ ls
go.mod  main.go  mock_Foo.go

[nix-shell:~/foo]$ cat mock_Foo.go
// Code generated by mockery v0.0.0-dev. DO NOT EDIT.

package main

import mock "github.com/stretchr/testify/mock"

// MockFoo is an autogenerated mock type for the Foo type
type MockFoo struct {
        mock.Mock
}

// Foo provides a mock function with given fields:
func (_m *MockFoo) Foo() string {
        ret := _m.Called()

        var r0 string
        if rf, ok := ret.Get(0).(func() string); ok {
                r0 = rf()
        } else {
                r0 = ret.Get(0).(string)
        }

        return r0
}
```
</details>

###### Motivation for this change

Package is a CLI tool for generating interface mocks and as such I think it's a good fit, in the same sense as `go-migrate` for example.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
