### PR TITLE
mycrypto: Fix crash when opening FileChooser dialog

### DIFF
--- a/pkgs/applications/blockchains/mycrypto/default.nix
+++ b/pkgs/applications/blockchains/mycrypto/default.nix
@@ -1,5 +1,5 @@
 { lib, appimageTools, fetchurl, makeDesktopItem
-, gsettings-desktop-schemas, gtk2
+, gsettings-desktop-schemas, gtk3
 }:
 
 let
@@ -30,7 +30,7 @@ in appimageTools.wrapType2 rec {
   inherit name src;
 
   profile = ''
-    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk2}/share/gsettings-schemas/${gtk2.name}:$XDG_DATA_DIRS
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
   '';
 
   multiPkgs = null; # no p32bit needed


### PR DESCRIPTION
###### Motivation for this change
The program crashed when it tried to open a FileChooser dialog because the `org.gtk.Settings.FileChooser.gschema.xml` was not provided: the derivation tried to load gsettings-schemas from `gtk2`, but they are part of `gtk3`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
