### PR TITLE
drone-runner-exec: init at unstable-2020-04-19

### DIFF
--- a/pkgs/development/tools/continuous-integration/drone-runner-exec/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-runner-exec/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , buildGoModule
 , fetchFromGitHub
 }:

--- a/pkgs/development/tools/continuous-integration/drone-runner-exec/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-runner-exec/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "drone-runner-exec";
+  version = "2020-04-19";
+
+  src = fetchFromGitHub {
+    owner = "drone-runners";
+    repo = "drone-runner-exec";
+    rev = "c0a612ef2bdfdc6d261dfbbbb005c887a0c3668d";
+    sha256 = "sha256-0UIJwpC5Y2TQqyZf6C6neICYBZdLQBWAZ8/K1l6KVRs=";
+  };
+
+  vendorSha256 = "sha256-ypYuQKxRhRQGX1HtaWt6F6BD9vBpD8AJwx/4esLrJsw=";
+
+  meta = with lib; {
+    description = "Drone pipeline runner that executes builds directly on the host machine";
+    homepage = "https://github.com/drone-runners/drone-runner-exec";
+    # https://polyformproject.org/licenses/small-business/1.0.0/
+    license = licenses.unfree;
+    maintainers = with maintainers; [ mic92 ];
+  };
+}

--- a/pkgs/development/tools/continuous-integration/drone-runner-exec/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-runner-exec/default.nix
@@ -6,7 +6,7 @@
 
 buildGoModule rec {
   pname = "drone-runner-exec";
-  version = "2020-04-19";
+  version = "unstable-2020-04-19";
 
   src = fetchFromGitHub {
     owner = "drone-runners";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3751,6 +3751,8 @@ in
 
   drone-cli = callPackage ../development/tools/continuous-integration/drone-cli { };
 
+  drone-runner-exec = callPackage ../development/tools/continuous-integration/drone-runner-exec { };
+
   dropbear = callPackage ../tools/networking/dropbear { };
 
   dsview = libsForQt5.callPackage ../applications/science/electronics/dsview { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
