### PR TITLE
rustPlatform.buildRustPackage: support debug builds

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -9,6 +9,10 @@ cargoBuildHook() {
         pushd "${buildAndTestSubdir}"
     fi
 
+    if [ "${cargoBuildType}" != "debug" ]; then
+        cargoBuildProfileFlag="--${cargoBuildType}"
+    fi
+
     (
     set -x
     env \
@@ -19,7 +23,7 @@ cargoBuildHook() {
       cargo build -j $NIX_BUILD_CORES \
         --target @rustTargetPlatformSpec@ \
         --frozen \
-        --${cargoBuildType} \
+        ${cargoBuildProfileFlag} \
         ${cargoBuildFlags}
     )
 

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -16,7 +16,11 @@ cargoCheckHook() {
         threads=1
     fi
 
-    argstr="--${cargoCheckType} --target @rustTargetPlatformSpec@ --frozen ${cargoTestFlags}";
+    if [ "${cargoBuildType}" != "debug" ]; then
+        cargoBuildProfileFlag="--${cargoBuildType}"
+    fi
+
+    argstr="${cargoBuildProfileFlag} --target @rustTargetPlatformSpec@ --frozen ${cargoTestFlags}";
 
     (
         set -x


### PR DESCRIPTION
###### Motivation for this change

Permits the `rustPlatform.buildRustPackage` system to handle `debug` builds.

On `master` right now, the following fails:

```shell
git apply <<EOF
diff --git a/pkgs/tools/text/ripgrep/default.nix b/pkgs/tools/text/ripgrep/default.nix
index 8c9eef9cc3d..2c6511e887f 100644
--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -21,6 +21,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "03wf9r2csi6jpa7v5sw5lpxkrk4wfzwmzx7k3991q3bdjzcwnnwp";
+  buildType = "debug";
 
   cargoBuildFlags = lib.optional withPCRE2 "--features pcre2";

EOF
nix build -f . ripgrep
```

The result is:

```shell
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------- nix
builder for '/nix/store/6lszgmplakcwmss3dhvc5xd0wxxvryyq-ripgrep-12.1.1.drv' failed with exit code 1; last 10 log lines:
  configuring
  building
  Executing cargoBuildHook
  ++ env CC_x86_64-unknown-linux-gnu=/nix/store/ca37d3qrydh0wpw40kswsx30j8dyzxh2-gcc-wrapper-10.2.0/bin/cc CXX_x86_64-unknown-linux-gnu=/nix/store/ca37d3qrydh0wpw40kswsx30j8dyzxh2-gcc-wrapper-10.2.0/bin/c++ CC_x86_64-unknown-linux-gnu=/nix/store/ca37d3qrydh0wpw40kswsx30j8dyzxh2-gcc-wrapper-10.2.0/bin/cc CXX_x86_64-unknown-linux-gnu=/nix/store/ca37d3qrydh0wpw40kswsx30j8dyzxh2-gcc-wrapper-10.2.0/bin/c++ cargo build -j 32 --target x86_64-unknown-linux-gnu --frozen --debug --features pcre2
  error: Found argument '--debug' which wasn't expected, or isn't valid in this context
  
  USAGE:
      cargo build --frozen --jobs <N> --target <TRIPLE>...
  
  For more information try --help
```

On this branch, the command above succeeds. This is because we no longer pass the non-existing `--debug` command. Rust does not have a `--debug` build option, by default builds are in debug.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
