### PR TITLE
kakoune.cr: init at unstable-2021-04-30

### DIFF
--- a/pkgs/applications/editors/kakoune.cr/default.nix
+++ b/pkgs/applications/editors/kakoune.cr/default.nix
@@ -1,0 +1,49 @@
+{ bat, crystal, fd, fzf, fetchFromGitHub, fetchurl, jq, kakoune, lib, stdenv }:
+let
+  icon = fetchurl {
+    url = "https://github.com/mawww/kakoune/raw/master/doc/kakoune_logo.svg";
+    sha256 = "1x9gdrnrqgzvr1ixr6s8ff6cvz01yp2xdh5ad6nbh6p2d094h617";
+    name = "kakoune.svg";
+  };
+
+in crystal.buildCrystalPackage rec {
+  pname = "kakoune-cr";
+  version = "unstable-2021-04-30";
+
+  propagatedUserEnvPkgs = [ bat fd fzf jq ];
+  doInstallCheck = false;
+
+  src = fetchFromGitHub {
+    repo = "kakoune.cr";
+    owner = "alexherbo2";
+    rev = "c0bfd9e76a972359098af9f1957ab681e3a54318";
+    sha256 = "sha256-acqC5RT9duI/zmE5Nk7COI2sQzvi0lkmLJ8orvBOL7c=";
+  };
+
+  crystalBinaries.kcr.src = "src/cli.cr";
+
+  format = "shards";
+  shardsFile = ./shards.nix;
+  lockFile = ./shard.lock;
+
+  preConfigure = ''
+    substituteInPlace src/version.cr --replace \
+    '`git describe --tags --always`' \
+    '"${version}"'
+  '';
+
+  postInstall = ''
+    install -Dm555 share/kcr/commands/*/kcr-* -t $out/bin
+    install -Dm444 ${icon} -t $out/share/icons/hicolor/scalable/apps/${icon.name}
+    install -Dm444 share/kcr/applications/kakoune.desktop -t $out/share/applications
+    cp -r share/kcr $out/share/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/alexherbo2/kakoune.cr";
+    description = "A command-line tool for Kakoune";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ loewenheim ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/editors/kakoune.cr/shard.lock
+++ b/pkgs/applications/editors/kakoune.cr/shard.lock
@@ -1,0 +1,10 @@
+version: 2.0
+shards:
+  fifo:
+    git: https://github.com/alexherbo2/fifo.cr.git
+    version: 0.1.0+git.commit.a5df8025fd3ab182ae2511d525f708cbbe0ed43a
+
+  rsub:
+    git: https://github.com/alexherbo2/rsub.cr.git
+    version: 0.1.0+git.commit.fb52b9e80fafef84afd79aee37240068913861fa
+

--- a/pkgs/applications/editors/kakoune.cr/shards.nix
+++ b/pkgs/applications/editors/kakoune.cr/shards.nix
@@ -1,0 +1,14 @@
+{
+  fifo = {
+    owner = "alexherbo2";
+    repo = "fifo.cr";
+    rev = "a5df8025fd3ab182ae2511d525f708cbbe0ed43a";
+    sha256 = "14n80wm3n36fpp7apih3bymsvrj0w5x7wg8a8j0b4rzydap8mljg";
+  };
+  rsub = {
+    owner = "alexherbo2";
+    repo = "rsub.cr";
+    rev = "fb52b9e80fafef84afd79aee37240068913861fa";
+    sha256 = "13l8jiskmm0w9yw4rj41jwv3iix04m5zbny727wxyghxfwk6wxfx";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6043,6 +6043,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  kakoune-cr = callPackage ../applications/editors/kakoune.cr { };
+
   kbdd = callPackage ../applications/window-managers/kbdd { };
 
   kbs2 = callPackage ../tools/security/kbs2 {


### PR DESCRIPTION
###### Motivation for this change
I would like to have [kakoune.cr](https://github.com/alexherbo2/kakoune.cr) in `nixpkgs`.

This is still a draft; it doesn't build for reasons that are a mystery to me. To be more concrete, when it gets to the building phase, this happens:
```shell
Resolving dependencies
Could not find commit a5df8025fd3ab182ae2511d525f708cbbe0ed43a for shard "fifo" in the repository https://github.com/alexherbo2/fifo.cr.git
```
I don't understand what "could not find commit" is supposed to mean. As far as I can tell it's set up exactly like `crystal2nix`, which builds without issue.

@alexherbo2 @manveru @peterhoeg 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
