### PR TITLE
tree-sitter: 0.18.2 -> 0.19.3

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -1,9 +1,21 @@
-{ lib, stdenv
-, fetchgit, fetchFromGitHub, fetchurl
-, writeShellScript, runCommand, which, formats
-, rustPlatform, jq, nix-prefetch-git, xe, curl, emscripten
+{ lib
+, stdenv
+, fetchgit
+, fetchFromGitHub
+, fetchurl
+, writeShellScript
+, runCommand
+, which
+, formats
+, rustPlatform
+, jq
+, nix-prefetch-git
+, xe
+, curl
+, emscripten
 , Security
 , callPackage
+, linkFarm
 
 , enableShared ? !stdenv.hostPlatform.isStatic
 , enableStatic ? stdenv.hostPlatform.isStatic
@@ -16,9 +28,9 @@ let
   # 1) change all these hashes
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
   # 3) run the ./result script that is output by that (it updates ./grammars)
-  version = "0.18.2";
-  sha256 = "1kh3bqn28nal3mmwszbih8hbq25vxy3zd45pzj904yf0ds5ql684";
-  cargoSha256 = "06jbn4ai5lrxzv51vfjzjs7kgxw4nh2vbafc93gma4k14gggyygc";
+  version = "0.19.3";
+  sha256 = "0zd1p9x32bwdc5cdqr0x8i9fpcykk1zczb8zdjawrrr92465d26y";
+  cargoSha256 = "0mlrbl85x1x2ynwrps94mxn95rjj1r7gb3vdivfaxqv1xvp25m41";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";
@@ -32,35 +44,35 @@ let
     inherit writeShellScript nix-prefetch-git curl jq xe src formats lib;
   };
 
-  fetchGrammar = (v: fetchgit {inherit (v) url rev sha256 fetchSubmodules; });
+  fetchGrammar = (v: fetchgit { inherit (v) url rev sha256 fetchSubmodules; });
 
   grammars =
-    runCommand "grammars" {} (''
-       mkdir $out
-     '' + (lib.concatStrings (lib.mapAttrsToList
-            (name: grammar: "ln -s ${fetchGrammar grammar} $out/${name}\n")
-            (import ./grammars))));
+    runCommand "grammars" { } (''
+      mkdir $out
+    '' + (lib.concatStrings (lib.mapAttrsToList
+      (name: grammar: "ln -s ${fetchGrammar grammar} $out/${name}\n")
+      (import ./grammars))));
 
-  builtGrammars = let
-    change = name: grammar:
-      callPackage ./grammar.nix {} {
-        language = name;
-        inherit version;
-        source = fetchGrammar grammar;
-      };
-  in
-    lib.mapAttrs change (removeAttrs (import ./grammars) [
-      # TODO these don't have parser.c in the same place as others.
-      # They might require more elaborate builds?
-      #  /nix/…/src/parser.c: No such file or directory
-      "tree-sitter-typescript"
-      #  /nix/…/src/parser.c: No such file or directory
-      "tree-sitter-ocaml"
-      # /nix/…/src/parser.c:1:10: fatal error: tree_sitter/parser.h: No such file or directory
-      "tree-sitter-razor"
-    ]);
+  builtGrammars =
+    let
+      change = name: grammar:
+        callPackage ./grammar.nix { } {
+          language = name;
+          inherit version;
+          source = fetchGrammar grammar;
+          location = if grammar ? location then grammar.location else null;
+        };
+      grammars' = (import ./grammars);
+      grammars = grammars' //
+        { tree-sitter-ocaml = grammars'.tree-sitter-ocaml // { location = "ocaml"; }; } //
+        { tree-sitter-ocaml-interface = grammars'.tree-sitter-ocaml // { location = "interface"; }; } //
+        { tree-sitter-typescript = grammars'.tree-sitter-typescript // { location = "typescript"; }; } //
+        { tree-sitter-tsx = grammars'.tree-sitter-typescript // { location = "tsx"; }; };
+    in
+    lib.mapAttrs change grammars;
 
-in rustPlatform.buildRustPackage {
+in
+rustPlatform.buildRustPackage {
   pname = "tree-sitter";
   inherit src version cargoSha256;
 
@@ -99,8 +111,7 @@ in rustPlatform.buildRustPackage {
     updater = {
       inherit update-all-grammars;
     };
-    inherit grammars;
-    inherit builtGrammars;
+    inherit grammars builtGrammars;
 
     tests = {
       # make sure all grammars build

--- a/pkgs/development/tools/parsing/tree-sitter/grammar.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar.nix
@@ -11,6 +11,7 @@
 , version
   # source for the language grammar
 , source
+, location ? null
 }:
 
 stdenv.mkDerivation {
@@ -18,12 +19,18 @@ stdenv.mkDerivation {
   pname = "${language}-grammar";
   inherit version;
 
-  src = source;
+  src =
+    if location == null
+    then
+      source
+    else
+      "${source}/${location}"
+  ;
 
   buildInputs = [ tree-sitter ];
 
   dontUnpack = true;
-  configurePhase= ":";
+  configurePhase = ":";
   buildPhase = ''
     runHook preBuild
     scanner_cc="$src/src/scanner.cc"

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -6,6 +6,7 @@
   tree-sitter-cpp = (builtins.fromJSON (builtins.readFile ./tree-sitter-cpp.json));
   tree-sitter-css = (builtins.fromJSON (builtins.readFile ./tree-sitter-css.json));
   tree-sitter-embedded-template = (builtins.fromJSON (builtins.readFile ./tree-sitter-embedded-template.json));
+  tree-sitter-fennel = (builtins.fromJSON (builtins.readFile ./tree-sitter-fennel.json));
   tree-sitter-fluent = (builtins.fromJSON (builtins.readFile ./tree-sitter-fluent.json));
   tree-sitter-go = (builtins.fromJSON (builtins.readFile ./tree-sitter-go.json));
   tree-sitter-haskell = (builtins.fromJSON (builtins.readFile ./tree-sitter-haskell.json));
@@ -16,17 +17,19 @@
   tree-sitter-json = (builtins.fromJSON (builtins.readFile ./tree-sitter-json.json));
   tree-sitter-julia = (builtins.fromJSON (builtins.readFile ./tree-sitter-julia.json));
   tree-sitter-lua = (builtins.fromJSON (builtins.readFile ./tree-sitter-lua.json));
+  tree-sitter-markdown = (builtins.fromJSON (builtins.readFile ./tree-sitter-markdown.json));
   tree-sitter-nix = (builtins.fromJSON (builtins.readFile ./tree-sitter-nix.json));
   tree-sitter-ocaml = (builtins.fromJSON (builtins.readFile ./tree-sitter-ocaml.json));
   tree-sitter-php = (builtins.fromJSON (builtins.readFile ./tree-sitter-php.json));
   tree-sitter-python = (builtins.fromJSON (builtins.readFile ./tree-sitter-python.json));
   tree-sitter-ql = (builtins.fromJSON (builtins.readFile ./tree-sitter-ql.json));
-  tree-sitter-razor = (builtins.fromJSON (builtins.readFile ./tree-sitter-razor.json));
   tree-sitter-regex = (builtins.fromJSON (builtins.readFile ./tree-sitter-regex.json));
   tree-sitter-ruby = (builtins.fromJSON (builtins.readFile ./tree-sitter-ruby.json));
   tree-sitter-rust = (builtins.fromJSON (builtins.readFile ./tree-sitter-rust.json));
   tree-sitter-scala = (builtins.fromJSON (builtins.readFile ./tree-sitter-scala.json));
+  tree-sitter-svelte = (builtins.fromJSON (builtins.readFile ./tree-sitter-svelte.json));
   tree-sitter-swift = (builtins.fromJSON (builtins.readFile ./tree-sitter-swift.json));
   tree-sitter-typescript = (builtins.fromJSON (builtins.readFile ./tree-sitter-typescript.json));
   tree-sitter-verilog = (builtins.fromJSON (builtins.readFile ./tree-sitter-verilog.json));
+  tree-sitter-yaml = (builtins.fromJSON (builtins.readFile ./tree-sitter-yaml.json));
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bash.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bash.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-bash",
-  "rev": "e213464b5062017dc058cfb7effe2fc7a2eebb04",
-  "date": "2020-03-02T14:55:46+01:00",
-  "path": "/nix/store/napdz7i4k0gz469zsszdlvr5hmj8y7i9-tree-sitter-bash",
-  "sha256": "0wz9rmpd36g88l2hhy1xl3i5d6a6di1jlw11qkvccgg16kb9p4h7",
+  "rev": "b6667bed364733c8a8f8e5973749f86cfa04ba2a",
+  "date": "2021-03-04T14:15:26-08:00",
+  "path": "/nix/store/nvlvdv02wdy4dq4w19bvzq6nlkgvpj20-tree-sitter-bash",
+  "sha256": "18c030bb65r50i6z37iy7jb9z9i8i36y7b08dbc9bchdifqsijs5",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "21ec3c3deb4365085aa353fadbc6a616d7769f9f",
-  "date": "2021-02-18T09:41:56-08:00",
-  "path": "/nix/store/8172rv05dvvlyp4cfmr2b41g4a20vlcf-tree-sitter-c-sharp",
-  "sha256": "1cc0ss09bfv2xy77bpcmy6y2hqis7a8xby9afcaxcn5llj593ynj",
+  "rev": "70fd2cba742506903589b5e046c32e0e3e06404a",
+  "date": "2021-03-03T17:18:54-08:00",
+  "path": "/nix/store/m0pzbb0vg0fm9nycj05ay0yldzp7qwbi-tree-sitter-c-sharp",
+  "sha256": "12jj66rsn1klsk24yj0ymgsqwy7lc5kb3nkj7griip8rmi3kgy41",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "fa408bc9e77f4b770bd1db984ca00c901ddf95fc",
-  "date": "2021-02-24T11:13:22-08:00",
-  "path": "/nix/store/8rlr93kjsvbpc8vgfxw02vcaprlfmprq-tree-sitter-c",
-  "sha256": "03nb8nlnkfw8p8bi4grfyh31l6419sk7ak2hnkpnnjs0y0gqb7jm",
+  "rev": "5aa0bbbfc41868a3727b7a89a90e9f52e0964b2b",
+  "date": "2021-03-03T17:00:36-08:00",
+  "path": "/nix/store/2wa64ii39p31wpngvqk4ni8z8ws29r2g-tree-sitter-c",
+  "sha256": "1diys8yigvhm4ppbmp3a473yxjg2d5lk11y0ay7qprcz7233lakv",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "3bfe046f3967fef92ebb33f8cd58c3ff373d5e56",
-  "date": "2021-02-25T11:55:19-08:00",
-  "path": "/nix/store/m2sd8ic8j3dayfa0zz0shc2pjaamahpf-tree-sitter-cpp",
-  "sha256": "052imxj6920ia002pzgwj2rg75xq3xpa80w8sjdq4mnlksy8v7g6",
+  "rev": "05cf2030e5415e9e931f620f0924107f73976796",
+  "date": "2021-03-04T10:01:34-08:00",
+  "path": "/nix/store/fraya34acwl9i3cxpml9hwzfkyc8vs89-tree-sitter-cpp",
+  "sha256": "08ywv6n80sa541rr08bqz4zyg7byvjcabp68lvxmcahjk8xzcgwk",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-css",
-  "rev": "e882c98b5e62d864f7f9e4d855b19b6050c897a8",
-  "date": "2021-02-12T10:45:27-08:00",
-  "path": "/nix/store/g368rqak07i91ddma16pkccp63y2s5yv-tree-sitter-css",
-  "sha256": "0firlbl81vxnw5dp31inabizjhqc37rnbvwf05668qpfjl9gc03z",
+  "rev": "94e10230939e702b4fa3fa2cb5c3bc7173b95d07",
+  "date": "2021-03-04T15:25:23-08:00",
+  "path": "/nix/store/0q3y4zhphdcc54qijbx2pdp8li9idk64-tree-sitter-css",
+  "sha256": "0y90nsfbh13mf33yahbk7zklbv7124rpm0v19qydz6nv1f9hpywd",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-embedded-template",
-  "rev": "872f037009ae700e3d4c3f83284af8f51c184dd4",
-  "date": "2021-02-05T09:53:39-08:00",
-  "path": "/nix/store/qg1lmgjrvjxg05bf7dczx5my9r83rxyb-tree-sitter-embedded-template",
-  "sha256": "0iffxki8pqavvi0cyndgyr4gp0f4zcdbv7gn7ar4sp17pksk5ss6",
+  "rev": "1c03594a44df1fc2020b989d503cb084abd5fd01",
+  "date": "2021-03-04T10:06:18-08:00",
+  "path": "/nix/store/09b9drfnywcy1i8wlw6slnn76ch40kqk-tree-sitter-embedded-template",
+  "sha256": "0c9l4i6kwb29zp05h616y3vk2hhcfc8bhdf9m436bk47pfy2zabg",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/travonted/tree-sitter-fennel",
+  "rev": "5aad9d1f490b7fc8a847a5b260f23396c56024f5",
+  "date": "2020-11-03T09:22:17-05:00",
+  "path": "/nix/store/gsxg67brk198201h70lip7miwny084sy-tree-sitter-fennel",
+  "sha256": "1imv5nwmhsyxwq7b9z4qz72lfva40wgybdkmq0gbbfbszl9a9bgl",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "dadfd9c9aab2630632e61cfce645c13c35aa092f",
-  "date": "2020-10-27T13:42:16-04:00",
-  "path": "/nix/store/91a8w265vjc955hyp7cqvpm8ks9zcmqv-tree-sitter-go",
-  "sha256": "1pwbzkg7s0l2fhr4p1rpcldjcpxbkaqsm3q81543almc75k38x8w",
+  "rev": "e41dd569d91eb58725baa7089c34fc3d785b2978",
+  "date": "2021-03-03T17:11:05-08:00",
+  "path": "/nix/store/87n5nl5p1fnmwgy0zshz90vyvha6b7mn-tree-sitter-go",
+  "sha256": "0nxs47vd2fc2fr0qlxq496y852rwg39flhg334s7dlyq7d3lcx4x",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "2a0aa1cb5f1b787a4056a29fa0791e87846e33fb",
-  "date": "2018-11-03T09:56:20-07:00",
-  "path": "/nix/store/9xszs4xi51qr72laxr67zxnh8y2br0gy-tree-sitter-haskell",
-  "sha256": "0z0nfip5m0yrjgm49j5nld7jkgyjdmps101xhbng39pwfnh1av83",
+  "rev": "24cf84ff618e96528882c67c8740fadcd6c4a921",
+  "date": "2021-03-06T17:58:27+01:00",
+  "path": "/nix/store/46hpbz06d1p5n0rp6z3iwy2lpwrn8kgl-tree-sitter-haskell",
+  "sha256": "1l004x1z9g1p8313ipvrf581vr2wi82qcwc0281kg083m2z4535p",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-html",
-  "rev": "7f442e1c6163d450c69c75c7a621badc3a0ea98f",
-  "date": "2020-07-20T12:46:52-07:00",
-  "path": "/nix/store/qklk97krsas1kjbh8dp6ii1gj9sqz8h9-tree-sitter-html",
-  "sha256": "0z249nnxlal8g6zbrys6kb80vksgcw2j5nd737m6yna2h5bhl126",
+  "rev": "d93af487cc75120c89257195e6be46c999c6ba18",
+  "date": "2021-03-04T14:11:18-08:00",
+  "path": "/nix/store/26yjfh6v17n4ajs9ln7x25sf1m3ijcjg-tree-sitter-html",
+  "sha256": "1hg7vbcy7bir6b8x11v0a4x0glvqnsqc3i2ixiarbxmycbgl3axy",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "16c07a726c34c9925b3e28716b2d6d60e3643252",
-  "date": "2021-02-11T09:32:05-08:00",
-  "path": "/nix/store/1b64g1a3cvq1hspys9z2z1lsawg2b9m2-tree-sitter-java",
-  "sha256": "1rag75r71cp8cvkf4f3wj911jppypziri19zysyy3pgzhznqy4zd",
+  "rev": "7ad106e81963b4d5c0aff99b93d16dc577fa3bc8",
+  "date": "2021-03-05T16:03:00-08:00",
+  "path": "/nix/store/ax9m7v0pv7q7xsnrjlfdpljs4f6xi2z3-tree-sitter-java",
+  "sha256": "1594mrhqcdfs8b7wmwpzcwna4m3ra8cbzq162flwrhcsb3w0rr9w",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "37af80d372ae9e2f5adc2c6321d5a34294dc348b",
-  "date": "2021-02-24T09:50:29-08:00",
-  "path": "/nix/store/y8jbjblicw2c65kil2y4d6vdn9r9h9w5-tree-sitter-javascript",
-  "sha256": "0cr75184abpg95bl6wgkqn7ay849bjsib48m9pdb5jrly1idw6n2",
+  "rev": "b3e7667995c065be724d10b69fbc3d0177ccef0b",
+  "date": "2021-03-08T13:12:59-08:00",
+  "path": "/nix/store/1y3nirw7bbnld4qy7ysm20bq0x9403wz-tree-sitter-javascript",
+  "sha256": "0bzyq5x8x1r34fzy1f05yqdlz51b1i1jmyssm0i571n9n6142s3j",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsdoc.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsdoc.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-jsdoc",
-  "rev": "77e7785739ad3e90c3de8ed5a55418a5fd2b8225",
-  "date": "2020-05-14T14:58:51-07:00",
-  "path": "/nix/store/3wp3hff203z15fvbnizcqzic1pjxmpg4-tree-sitter-jsdoc",
-  "sha256": "0i2ac7i0vs46668q56dpmd9c02vcyy3f8rh4i0dbvd3rvihifbgc",
+  "rev": "189a6a4829beb9cdbe837260653b4a3dfb0cc3db",
+  "date": "2021-03-04T14:39:14-08:00",
+  "path": "/nix/store/dpm11vziss6jbgp3dxvmgkb0dgg1ygc8-tree-sitter-jsdoc",
+  "sha256": "0qpsy234p30j6955wpjlaqwbr21bi56p0ln5vhrd84s99ac7s6b6",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-json",
-  "rev": "d3976b27df8622ed17bef6dd5e358b398e73c676",
-  "date": "2020-05-14T14:59:27-07:00",
-  "path": "/nix/store/ds2wnlrh289rsnjx828h3jy1706g3x21-tree-sitter-json",
-  "sha256": "1cbhsmzbjni0mynjcai6gshhg16nls82v9lcihxf350dz57f7sax",
+  "rev": "89607925e8989f2638cc935b8de7e44ac3c91907",
+  "date": "2021-03-04T14:55:58-08:00",
+  "path": "/nix/store/xpykb8mr4xarh6finzkz71z2bpqm8k26-tree-sitter-json",
+  "sha256": "06pjh31bv9ja9hlnykk257a6zh8bsxg2fqa54al7qk1r4n9ksnff",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-julia",
-  "rev": "6a0863f1ce3fcf6f99dc0addb7886dcbd27c5a48",
-  "date": "2020-09-08T19:39:52-07:00",
-  "path": "/nix/store/xn5nii9mi2aw7xdabyxlglha2vk12h1w-tree-sitter-julia",
-  "sha256": "07ds4wzgvnkgkq07izdglkk8lgpqrylvrs96afnwxi56bnzs8sbv",
+  "rev": "0ba7a24b062b671263ae08e707e9e94383b25bb7",
+  "date": "2021-03-04T14:52:13-08:00",
+  "path": "/nix/store/2ni8p1cgyrkn1mcccl4zqdpkfm63a10m-tree-sitter-julia",
+  "sha256": "1pbnmvhy2gq4vg1b0sjzmjm4s2gsgdjh7h01yj8qrrqbcl29c463",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
-  "url": "https://github.com/nvim-treesitter/tree-sitter-lua",
-  "rev": "97b757ad3546d68dc1131e6ffb9b1d2a750eea29",
-  "date": "2020-11-25T21:23:57+01:00",
-  "path": "/nix/store/irz0dikk9dahkayi41chcznqq1i3wr84-tree-sitter-lua",
-  "sha256": "1nhg139vk3xm6ip4mhr29z0rprfg4q417z2vlvkz3m9wp8gppzls",
+  "url": "https://github.com/Azganoth/tree-sitter-lua",
+  "rev": "a943944ec09c5e96f455bb166079de4ef3534457",
+  "date": "2020-12-27T00:15:24-03:00",
+  "path": "/nix/store/6glr8p3x58pva0nn586dk5jwb3bpgqrj-tree-sitter-lua",
+  "sha256": "0pm6wwb3kv73bfvvshdmvazcb1is5x1z6jwr31gz0niln18nqvpb",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/ikatyang/tree-sitter-markdown",
+  "rev": "5a139bed455268a06410471bf48b19d11abdd367",
+  "date": "2021-01-24T15:17:18+08:00",
+  "path": "/nix/store/125cbxcqvwyq8b7kvmg7wxjjz16s2jvw-tree-sitter-markdown",
+  "sha256": "072b4nnpymrh90y4dk18kr8l1g7m83r3gvp6v0ad9f9dnq47fgax",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ocaml",
-  "rev": "4ec9ee414dadc2b6e7325a9f8124d02f6cd8c250",
-  "date": "2020-09-18T02:13:40+02:00",
-  "path": "/nix/store/dszjdnwnbziqxav2khs85026msm6fasz-tree-sitter-ocaml",
-  "sha256": "0wy85940fhmrnz7c1gk6xkipm8ixzalq5q4i7mcc6wnjiiwq60gx",
+  "rev": "19a8d2aab425c4c4c8dc6a882e67c37010620c3b",
+  "date": "2021-03-08T16:57:09-08:00",
+  "path": "/nix/store/y8jsf6vp278svqm4c6xnl4i6vanslrkk-tree-sitter-ocaml",
+  "sha256": "0c5wjanka87bhha0aq3m5p448apxhv8hndlqvhly6qafj99jp85i",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "b0c0367d4b7058921fdc4ba11e257441a64ab809",
-  "date": "2020-07-29T16:56:25-07:00",
-  "path": "/nix/store/la06yzcv5w1dpp31s4clllkfic8rs98a-tree-sitter-php",
-  "sha256": "0a47rr1d5dg70kfvk257g7mhpcwslv6prxc7012spxcrfiwbx89l",
+  "rev": "ba231f9844e5a1bf60e1cb72c34c0a431239585a",
+  "date": "2021-03-03T17:17:11-08:00",
+  "path": "/nix/store/cn06h14pgq3psjq3ms0yvdm3x1wwbc1j-tree-sitter-php",
+  "sha256": "1xaml64b7cx3hn6x35bbgar8cp7ccxkwvxddjdvyj5nzfx1id8y3",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "3196e288650992bca2399dda15ac703c342a22bb",
-  "date": "2021-01-19T11:31:59-08:00",
-  "path": "/nix/store/0y394nsknvjxpxnsfscab531mivnzhap-tree-sitter-python",
-  "sha256": "0fbkyysz0qsjqzqznwgf52wsgb10h8agc4p68zafiibwlp72gd09",
+  "rev": "dd98afca32aaceff9025f9e85031ac50bee8b08b",
+  "date": "2021-03-05T16:00:15-08:00",
+  "path": "/nix/store/6sbmzgva73fhgqhsdrg5zy7vbs9lzll9-tree-sitter-python",
+  "sha256": "01ykryrv1nn2y8dcbl64d31h1ipz2569ywzjp10pd93h1s6czpnl",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ql",
-  "rev": "f3738c138ba753eed5da386c7321cb139d185d39",
-  "date": "2021-02-19T10:26:41+00:00",
-  "path": "/nix/store/dww93fp6psaw4lhiwyn8qajq8mvsyv5s-tree-sitter-ql",
-  "sha256": "15wqyf0q9arr4jh0dfjr5200rghy989wvf311cffma7706ngmgxb",
+  "rev": "965948cce9a94a710b1339851e0919471ad5ee2c",
+  "date": "2021-03-04T14:34:34-08:00",
+  "path": "/nix/store/4hi59c856ii2b79nv2wjib6qbp3hk24i-tree-sitter-ql",
+  "sha256": "01y1fzclwlaffx0rzg49h7kyvhhm25fba0w362n2y8hgjp3imgmg",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-regex",
-  "rev": "be2e415b5716615530234d179dc27c32b7a1d86b",
-  "date": "2020-05-14T15:05:54-07:00",
-  "path": "/nix/store/acbcq9lgh5pf6hq3329fa253yfvaj6ji-tree-sitter-regex",
-  "sha256": "0qxbafbwfj64bwhj3455jgkidpdzqwrlsqm3rckq2pi75flnkv42",
+  "rev": "3041aa3472d16fd94c6a9e15b741dbfecd9b714e",
+  "date": "2021-03-04T14:37:27-08:00",
+  "path": "/nix/store/7d200fzyx2rkbbgf47g5ismvd4id0fqy-tree-sitter-regex",
+  "sha256": "0jah3apalvp7966sjzdrka2n7f83h64sd56nbq2lzmrxgv98rxmg",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "f86d90cce578e28c824afdcdbdca7d031b88c0b0",
-  "date": "2020-11-02T20:49:49-08:00",
-  "path": "/nix/store/gs0hhb1dlgmv0y60zyyz7ki30yvpddfx-tree-sitter-ruby",
-  "sha256": "1n1irdjfmv27p5ia2vqzv8zfsq19pxi0as0wrkb7z7s1lqr1gwrb",
+  "rev": "fe6a2d634da0e16b11b5aa255cc3df568a4572fd",
+  "date": "2021-03-03T16:54:30-08:00",
+  "path": "/nix/store/ragrvqj7hm98r74v5b3fljvc47gd3nhj-tree-sitter-ruby",
+  "sha256": "0m3h4928rbs300wcb6776h9r88hi32rybbhcaf6rdympl5nzi83v",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "ab7f7962073fec96e0b64fbd1697263fe2c79281",
-  "date": "2021-02-16T21:17:08-08:00",
-  "path": "/nix/store/zy2sccixlk8lwkqamikz03j42s13ndjp-tree-sitter-rust",
-  "sha256": "06zmbwgsvyaz0wgja8r3ir06z67gix7i62zj0k3bbng6smdnhp9w",
+  "rev": "20f064bd758f94b8f47ce5a21e4383c7349ca182",
+  "date": "2021-03-04T14:06:14-08:00",
+  "path": "/nix/store/za0yxqjjp9vxgwrp014qwv2v2qffl0di-tree-sitter-rust",
+  "sha256": "118vkhv7n3sw8y9pi0987cgdcd74sjqwviijw01mhnk3bkyczi3l",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "211bb726bb5857f872247b600c7c1808e641a8d4",
-  "date": "2020-07-13T13:31:00-07:00",
-  "path": "/nix/store/6q66gzabxazr2581dgp4pp5wwyk2p6mw-tree-sitter-scala",
-  "sha256": "096ps5za8gxmq61gdd3xdk8cif07vb4v8asls2kdwm6jazm82777",
+  "rev": "262797b1dfe0303818c2418c0a88f6be65f37245",
+  "date": "2021-03-04T15:02:28-08:00",
+  "path": "/nix/store/vc5fr00vqx5nf17r9grdwb11wci3xrkm-tree-sitter-scala",
+  "sha256": "1zf3b1x1s94dgzjbc6l8ind5fd1mmny3893d4bqc63h4qp0n0bp3",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/Himujjal/tree-sitter-svelte",
+  "rev": "a96899bd1ab6a18e3837f232fd688af69e3a8071",
+  "date": "2021-03-09T15:14:24+05:30",
+  "path": "/nix/store/nlpf6gilkk19aw7pk1kbys2alhnqagqj-tree-sitter-svelte",
+  "sha256": "04virfsiqqhh3gc3cmcjd4s1zn9wdxi47m55x938napaqiaw29nx",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "543cbe44f16189f7f1b739cf268d70f373d94b87",
-  "date": "2021-02-25T11:54:57-08:00",
-  "path": "/nix/store/liyi8hkl55dcbs1wc4w2jw4zf717bb29-tree-sitter-typescript",
-  "sha256": "0ljhkhi8fp38l1n6wam7l8bdqxr95d0c1mf7i6p1gb6xrjzssik0",
+  "rev": "7e119621b1d2ab1873ba14d8702f62458df70409",
+  "date": "2021-03-08T13:23:30-08:00",
+  "path": "/nix/store/k7vam1w5c2r0hhxy0bgpmj65bw5wnh96-tree-sitter-typescript",
+  "sha256": "1fv6q1bc0j6b89skz7x2ibi6bxx0ijrb676y23aahycvz2p8x4z0",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/ikatyang/tree-sitter-yaml",
+  "rev": "ab0ce67ce98f8d9cc0224ebab49c64d01fedc1a1",
+  "date": "2021-01-01T21:13:43+08:00",
+  "path": "/nix/store/3vnhqr4l2hb0ank13avj8af4qbni5szw-tree-sitter-yaml",
+  "sha256": "14f0abv68cjkwdcjjwa1nzjpwp6w59cj5v4m5h5h3jxi96z65459",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -2,6 +2,9 @@
 , curl, jq, xe
 , src }:
 
+# Grammar list:
+# https://github.com/tree-sitter/tree-sitter/blob/master/docs/index.md
+
 let
   # Grammars we want to fetch from the tree-sitter github orga
   knownTreeSitterOrgGrammarRepos = [
@@ -11,7 +14,6 @@ let
     "tree-sitter-json"
     "tree-sitter-cpp"
     "tree-sitter-ruby"
-    "tree-sitter-razor"
     "tree-sitter-go"
     "tree-sitter-c-sharp"
     "tree-sitter-python"
@@ -56,6 +58,8 @@ let
     "highlight-schema"
     # website
     "tree-sitter.github.io"
+    # not maintained
+    "tree-sitter-razor"
   ];
   ignoredTreeSitterOrgReposJson = jsonFile "ignored-tree-sitter-org-repos" ignoredTreeSitterOrgRepos;
 
@@ -68,8 +72,24 @@ let
       repo = "tree-sitter-nix";
     };
     "tree-sitter-lua" = {
-      orga = "nvim-treesitter";
+      orga = "Azganoth";
       repo = "tree-sitter-lua";
+    };
+    "tree-sitter-fennel" = {
+      orga = "travonted";
+      repo = "tree-sitter-fennel";
+    };
+    "tree-sitter-markdown" = {
+      orga = "ikatyang";
+      repo = "tree-sitter-markdown";
+    };
+    "tree-sitter-svelte" = {
+      orga = "Himujjal";
+      repo = "tree-sitter-svelte";
+    };
+    "tree-sitter-yaml" = {
+      orga = "ikatyang";
+      repo = "tree-sitter-yaml";
     };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update tree-sitter

Update the grammars and add `allGrammars` derivation.
`nix-build "<nixpkgs>" -A tree-sitter.allGrammars` will create a
derivation with symlinks to all the grammars


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
