### PR TITLE
cargo-cross: init at 0.2.1

### DIFF
--- a/pkgs/development/tools/rust/cargo-cross/default.nix
+++ b/pkgs/development/tools/rust/cargo-cross/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, fetchpatch
+, nix-update-script
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-cross";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "rust-embedded";
+    repo = "cross";
+    rev = "v${version}";
+    sha256 = "sha256:1py5w4kf612x4qxi190ilsrx0zzwdzk9i47ppvqblska1s47qa2w";
+  };
+
+  cargoSha256 = "sha256-3xSuTBcWRGn5HH7LnvwioeRWjehaPW1HCPjN5SUUVfo=";
+
+  cargoPatches = [
+    (fetchpatch {
+      url = "https://github.com/rust-embedded/cross/commit/e86ad2e5a55218395df7eaaf91900e22b809083c.patch";
+      sha256 = "sha256:1zrcj5fm3irmlrfkgb65kp2pjkry0rg5nn9pwsk9p0i6dpapjc7k";
+    })
+  ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with lib; {
+    description = "Zero setup cross compilation and cross testing";
+    homepage = "https://github.com/rust-embedded/cross";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ otavio ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10920,6 +10920,7 @@ in
   cargo-crev = callPackage ../development/tools/rust/cargo-crev {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-cross = callPackage ../development/tools/rust/cargo-cross { };
   cargo-deny = callPackage ../development/tools/rust/cargo-deny {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

A very handy tool to assist in cross compiling and test of Rust libraries and applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
