### PR TITLE
nix-output-monitor: 1.0.1.1 -> 1.0.2.0

### DIFF
--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -1,22 +1,23 @@
 { mkDerivation, ansi-terminal, async, attoparsec, base, containers
 , cassava, directory, HUnit, mtl, nix-derivation, process, relude, lib
 , stm, terminal-size, text, time, unix, wcwidth, fetchFromGitHub
-, expect, runtimeShell
+, lock-file, data-default, expect, runtimeShell
 }:
 mkDerivation rec {
   pname = "nix-output-monitor";
-  version = "1.0.1.1";
+  version = "1.0.2.0";
   src = fetchFromGitHub {
     owner = "maralorn";
     repo = "nix-output-monitor";
-    sha256 = "1wi1gsl5q1sy7k6k5wxhwpwzki7rghhbsyzm84hnw6h93w6401ax";
+    sha256 = "12spiddjy8xhbxdh89w46kg7p2asfa4qrldwb1kps178hdhjdrgz";
     rev = "v${version}";
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     ansi-terminal async attoparsec base cassava containers directory mtl
-    nix-derivation relude stm terminal-size text time unix wcwidth
+    nix-derivation relude stm terminal-size text time unix wcwidth lock-file
+    data-default
   ];
   executableHaskellDepends = [
     ansi-terminal async attoparsec base containers directory mtl


### PR DESCRIPTION
Package update with bugfixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
