### PR TITLE
stork: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1711,6 +1711,12 @@
     githubId = 2245737;
     name = "Christopher Mark Poole";
   };
+  chuahou = {
+    email = "human+github@chuahou.dev";
+    github = "chuahou";
+    githubId = 12386805;
+    name = "Chua Hou";
+  };
   chvp = {
     email = "nixpkgs@cvpetegem.be";
     github = "chvp";

--- a/pkgs/applications/misc/stork/default.nix
+++ b/pkgs/applications/misc/stork/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "stork";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jameslittle230";
+    repo = "stork";
+    rev = "v${version}";
+    sha256 = "sha256-pBJ9n1pQafXagQt9bnj4N1jriczr47QLtKiv+UjWgTg=";
+  };
+
+  cargoSha256 = "sha256-u8L4ZeST4ExYB2y8E+I49HCy41dOfhR1fgPpcVMVDuk=";
+
+  meta = with lib; {
+    description = "Impossibly fast web search, made for static sites";
+    homepage = "https://github.com/jameslittle230/stork";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ chuahou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29353,6 +29353,8 @@ in
 
   sndio = callPackage ../misc/sndio { };
 
+  stork = callPackage ../applications/misc/stork { };
+
   oclgrind = callPackage ../development/tools/analysis/oclgrind { };
 
   opkg = callPackage ../tools/package-management/opkg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This builds fine and all three commands work when tested on my own static site.

<details><summary>Run results</summary>

```
$ ../nixpkgs/result/bin/stork --build stork/config.toml
Index built, 137,496 bytes written to stork/index.st.
13,749 bytes/entry (average entry size is 2,156 bytes)
	0.023s to build index
	0.004s to write file
	0.027s total

$ ../nixpkgs/result/bin/stork --test stork/config.toml
Serving from http://127.0.0.1:1612
Press ctrl-C to exit.
^C%

$ ../nixpkgs/result/bin/stork --search stork/index.st "equality"
{
  "results": [
    {
      "entry": {
        "url": "[...]",
        "title": "Equational theories",
        "fields": {}
      },
      "excerpts": [
        {
          "text": "Syntactic equality [1.4] \\(\\alpha\\) -conversion [1.5] \\(\\beta\\) -conversion Capture-avoiding",
          "highlight_ranges": [
[...]
```

</details>

###### Motivation for this change

A useful Rust package to create an index for searches on static sites.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
