### PR TITLE
broadlink-cli: 0.15 -> 0.16

### DIFF
--- a/pkgs/tools/misc/broadlink-cli/default.nix
+++ b/pkgs/tools/misc/broadlink-cli/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "broadlink-cli";
-  version = "0.16";
+  version = "0.16.0";
 
   # the tools are available as part of the source distribution from GH but
   # not pypi, so we have to fetch them here.

--- a/pkgs/tools/misc/broadlink-cli/default.nix
+++ b/pkgs/tools/misc/broadlink-cli/default.nix
@@ -1,17 +1,16 @@
 { lib, python3Packages, fetchFromGitHub }:
 
-python3Packages.buildPythonApplication {
+python3Packages.buildPythonApplication rec {
   pname = "broadlink-cli";
-  inherit (python3Packages.broadlink) version;
+  version = "0.16";
 
   # the tools are available as part of the source distribution from GH but
   # not pypi, so we have to fetch them here.
   src = fetchFromGitHub {
     owner  = "mjg59";
     repo   = "python-broadlink";
-    # this rev is version 0.15.0
-    rev    = "99add9e6feea6e47be4f3a58783556d7838b759c";
-    sha256 = "1q1q62brvfjcb18i0j4ca5cxqzjwv1iywdrdby0yjqa4wm6ywq6b";
+    rev    = version;
+    sha256 = "sha256-fdwy58AopAcDp18APzvYionEbrKfTlH/yFpT1gG5iDs=";
   };
 
   format = "other";
@@ -23,8 +22,8 @@ python3Packages.buildPythonApplication {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 -t $out/bin cli/broadlink_{cli,discovery}
-    install -Dm644 -t $out/share/doc/broadlink cli/README.md
+    install -Dm555 -t $out/bin cli/broadlink_{cli,discovery}
+    install -Dm444 -t $out/share/doc/broadlink cli/README.md
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Motivation for this change

For some reason we were pinning the old release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
