### PR TITLE
treewide (darwin): fix or enable darwin build for many packages (2)

### DIFF
--- a/pkgs/development/interpreters/clips/default.nix
+++ b/pkgs/development/interpreters/clips/default.nix
@@ -3,18 +3,26 @@
 stdenv.mkDerivation rec {
   version = "6.31";
   pname = "clips";
+
   src = fetchurl {
     url = "mirror://sourceforge/clipsrules/CLIPS/${version}/clips_core_source_${
         builtins.replaceStrings [ "." ] [ "" ] version
       }.tar.gz";
     sha256 = "165k0z7dsv04q432sanmw0jxmxwf56cnhsdfw5ffjqxd3lzkjnv6";
   };
+
+  postPatch = ''
+    substituteInPlace core/makefile --replace 'gcc' '${stdenv.cc.targetPrefix}cc'
+  '';
+
   makeFlags = [ "-C" "core" ];
+
   installPhase = ''
     runHook preInstall
     install -D -t $out/bin core/clips
     runHook postInstall
   '';
+
   meta = with lib; {
     description = "A Tool for Building Expert Systems";
     homepage = "http://www.clipsrules.net/";
@@ -26,6 +34,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.publicDomain;
     maintainers = [ maintainers.league ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/boolstuff/default.nix
+++ b/pkgs/development/libraries/boolstuff/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     homepage = "${baseurl}/boolstuff.html";
     license = "GPL";
     maintainers = [ lib.maintainers.marcweber ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/libraries/cpptest/default.nix
+++ b/pkgs/development/libraries/cpptest/default.nix
@@ -13,6 +13,6 @@ stdenv.mkDerivation rec {
     description = "Simple C++ unit testing framework";
     maintainers = with maintainers; [ bosu ];
     license = lib.licenses.lgpl3;
-    platforms = with platforms; linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/cpputest/default.nix
+++ b/pkgs/development/libraries/cpputest/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://cpputest.github.io/";
     description = "Unit testing and mocking framework for C/C++";
-    platforms = platforms.linux ;
+    platforms = platforms.all;
     license = licenses.bsd3;
     maintainers = [ maintainers.juliendehos ];
   };

--- a/pkgs/development/tools/misc/direvent/default.nix
+++ b/pkgs/development/tools/misc/direvent/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     description = "Directory event monitoring daemon";
     homepage = "https://www.gnu.org.ua/software/direvent/";
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ puffnfresh ];
   };
 }

--- a/pkgs/misc/emulators/libdsk/default.nix
+++ b/pkgs/misc/emulators/libdsk/default.nix
@@ -14,6 +14,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.seasip.info/Unix/LibDsk/";
     license = licenses.gpl2Plus;
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/misc/emulators/mednafen/server.nix
+++ b/pkgs/misc/emulators/mednafen/server.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
     homepage = "https://mednafen.github.io/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ AndersonTorres ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/inputmethods/anthy/default.nix
+++ b/pkgs/tools/inputmethods/anthy/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://anthy.osdn.jp/";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ ericsagnes ];
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
   };
 
   src = fetchurl {

--- a/pkgs/tools/misc/agedu/default.nix
+++ b/pkgs/tools/misc/agedu/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation {
     homepage = "https://www.chiark.greenend.org.uk/~sgtatham/agedu/";
     license = licenses.mit;
     maintainers = with maintainers; [ symphorien ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/vimv/default.nix
+++ b/pkgs/tools/misc/vimv/default.nix
@@ -1,24 +1,27 @@
-{ lib, stdenv, bash, fetchFromGitHub }:
-stdenv.mkDerivation {
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation {
   pname = "vimv";
   version = "unstable-2019-10-31";
+
   src = fetchFromGitHub {
     owner = "thameera";
     repo = "vimv";
     rev = "4152496c1946f68a13c648fb7e583ef23dac4eb8";
     sha256 = "1fsrfx2gs6bqx7wk7pgcji2i2x4alqpsi66aif4kqvnpqfhcfzjd";
   };
-  phases = [ "installPhase" ];
+
   installPhase = ''
     install -d $out/bin
     install $src/vimv $out/bin/vimv
     patchShebangs $out/bin/vimv
   '';
+
   meta = with lib; {
     homepage = "https://github.com/thameera/vimv";
     description = "Batch-rename files using Vim";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = [ maintainers.kmein ];
   };
 }

--- a/pkgs/tools/networking/pcapfix/default.nix
+++ b/pkgs/tools/networking/pcapfix/default.nix
@@ -15,6 +15,6 @@ stdenv.mkDerivation rec {
     description = "Repair your broken pcap and pcapng files";
     license = licenses.gpl3;
     maintainers = [ maintainers.ehmry ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/aespipe/default.nix
+++ b/pkgs/tools/security/aespipe/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     homepage = "http://loop-aes.sourceforge.net/aespipe.README";
     license = licenses.gpl2;
     maintainers = [ maintainers.goibhniu ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/security/hashdeep/default.nix
+++ b/pkgs/tools/security/hashdeep/default.nix
@@ -17,6 +17,9 @@ stdenv.mkDerivation rec {
     description = "A set of cross-platform tools to compute hashes";
     homepage = "https://github.com/jessek/hashdeep";
     license = licenses.gpl2;
+    # Build fails on Darwin:
+    # > ./xml.h:103:82: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
+    # >     void xmlout(const std::string &tag,const int64_t value){ xmlprintf(tag,"","%"PRId64,value); }
     platforms = with platforms; linux ++ freebsd ++ openbsd;
     maintainers = [ maintainers.karantan ];
   };

--- a/pkgs/tools/system/loadwatch/default.nix
+++ b/pkgs/tools/system/loadwatch/default.nix
@@ -15,6 +15,6 @@ stdenv.mkDerivation {
     description = "Run a program using only idle cycles";
     license = licenses.gpl2;
     maintainers = with maintainers; [ woffs ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/text/cconv/default.nix
+++ b/pkgs/tools/text/cconv/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchurl, autoreconfHook }:
-let version = "0.6.3"; in
-  stdenv.mkDerivation {
+{ lib, stdenv, fetchurl, autoreconfHook, libiconv }:
+
+stdenv.mkDerivation rec {
   pname = "cconv";
-  inherit version;
+  version = "0.6.3";
 
   src = fetchurl {
     url = "https://github.com/xiaoyjy/cconv/archive/v${version}.tar.gz";
@@ -10,12 +10,13 @@ let version = "0.6.3"; in
   };
 
   nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ libiconv ];
 
   meta = with lib; {
     description = "A iconv based simplified-traditional chinese conversion tool";
     homepage = "https://github.com/xiaoyjy/cconv";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = [ maintainers.redfish64 ];
   };
 }

--- a/pkgs/tools/text/dadadodo/default.nix
+++ b/pkgs/tools/text/dadadodo/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1pzwp3mim58afjrc92yx65mmgr1c834s1v6z4f4gyihwjn8bn3if";
   };
 
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
   installPhase = ''
     mkdir -p $out/bin
     cp dadadodo $out/bin
@@ -20,6 +22,6 @@ stdenv.mkDerivation rec {
     description = "Markov chain-based text generator";
     homepage = "http://www.jwz.org/dadadodo";
     maintainers = with maintainers; [ pSub ];
-    platforms = with platforms; linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/text/dos2unix/default.nix
+++ b/pkgs/tools/text/dos2unix/default.nix
@@ -18,5 +18,6 @@ stdenv.mkDerivation rec {
     changelog = "https://sourceforge.net/p/dos2unix/dos2unix/ci/dos2unix-${version}/tree/dos2unix/NEWS.txt?format=raw";
     license = licenses.bsd2;
     maintainers = with maintainers; [ c0bw3b ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/text/fanficfare/default.nix
+++ b/pkgs/tools/text/fanficfare/default.nix
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication rec {
     description = "Tool for making eBooks from fanfiction web sites";
     homepage = "https://github.com/JimmXinu/FanFicFare";
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ dwarfmaster ];
   };
 }

--- a/pkgs/tools/text/podiff/default.nix
+++ b/pkgs/tools/text/podiff/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation {
     homepage = "http://puszcza.gnu.org.ua/software/podiff";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.goibhniu ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
See #114976 for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
