### PR TITLE
lmdbxx: switch to active fork, 0.9.14.0 -> 1.0.0; nheko: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -7,7 +7,6 @@
 , lmdb
 , lmdbxx
 , libsecret
-, tweeny
 , mkDerivation
 , qtbase
 , qtkeychain
@@ -26,17 +25,19 @@
 , voipSupport ? true
 , gst_all_1
 , libnice
+, screensharingSupport ? true
+, xorg
 }:
 
 mkDerivation rec {
   pname = "nheko";
-  version = "0.8.1";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "Nheko-Reborn";
     repo = "nheko";
     rev = "v${version}";
-    sha256 = "1v7k3ifzi05fdr06hmws1wkfl1bmhrnam3dbwahp086vkj0r8524";
+    sha256 = "0362hkbprc6jqlgmvzwxyvify4b1ldjakyqdz55m25xsypbpv2f3";
   };
 
   nativeBuildInputs = [
@@ -47,7 +48,6 @@ mkDerivation rec {
 
   buildInputs = [
     nlohmann_json
-    tweeny
     mtxclient
     olm
     boost17x
@@ -69,7 +69,8 @@ mkDerivation rec {
       (gst-plugins-good.override { qt5Support = true; })
       gst-plugins-bad
       libnice
-    ]);
+    ])
+    ++ lib.optional screensharingSupport xorg.libxcb;
 
   cmakeFlags = [
     "-DCOMPILE_QML=ON" # see https://github.com/Nheko-Reborn/nheko/issues/389

--- a/pkgs/development/libraries/lmdbxx/default.nix
+++ b/pkgs/development/libraries/lmdbxx/default.nix
@@ -1,26 +1,27 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, lmdb }:
+, lmdb
+}:
 
 stdenv.mkDerivation rec {
   pname = "lmdbxx";
-  version = "0.9.14.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "drycpp";
+    owner = "hoytech";
     repo = "lmdbxx";
     rev = version;
-    sha256 = "1jmb9wg2iqag6ps3z71bh72ymbcjrb6clwlkgrqf1sy80qwvlsn6";
+    sha256 = "12k5rz74d1l0skcks9apry1svkl96g9lf5dcgylgjmh7v1jm0b7c";
   };
 
   buildInputs = [ lmdb ];
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
-    homepage = "https://github.com/drycpp/lmdbxx#readme";
+    homepage = "https://github.com/hoytech/lmdbxx#readme";
     description = "C++11 wrapper for the LMDB embedded B+ tree database library";
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [ fgaz ];
   };
 }
-

--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mtxclient";
-  version = "0.4.1";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "Nheko-Reborn";
     repo = "mtxclient";
     rev = "v${version}";
-    sha256 = "1044zil3izhb3whhfjah7w0kg5mr3hys32cjffky681d3mb3wi5n";
+    sha256 = "1xznfx2bhw0ahwmkxm0rs05vz05ijk5k4190rj6qp3bvb9byiajh";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The original lmdbxx project is dead since 5 years. The fork was already adopted
by gentoo and by the downstream application nheko (still unreleased).

I'm waiting for the nheko release now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
