### PR TITLE
pleroma-otp: 2.2.2 -> 2.3.0

### DIFF
--- a/pkgs/servers/pleroma-otp/default.nix
+++ b/pkgs/servers/pleroma-otp/default.nix
@@ -12,19 +12,19 @@
 }:
 stdenv.mkDerivation {
   pname = "pleroma-otp";
-  version = "2.2.2";
+  version = "2.3.0";
 
   # To find the latest binary release stable link, have a look at
   # the CI pipeline for the latest commit of the stable branch
   # https://git.pleroma.social/pleroma/pleroma/-/tree/stable
   src = {
     aarch64-linux = fetchurl {
-      url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/175288/artifacts/download";
-      sha256 = "107kp5zqwq1lixk1cwkx4v7zpm0h248xzlm152aj36ghb43j2snw";
+      url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/182392/artifacts/download";
+      sha256 = "1drpd6xh7m2damxi5impb8jwvjl6m3qv5yxynl12i8g66vi3rbwf";
     };
     x86_64-linux = fetchurl {
-      url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/175284/artifacts/download";
-      sha256 = "1c6l04gga9iigm249ywwcrjg6wzy8iiid652mws3j9dnl71w2sim";
+      url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/182388/artifacts/download";
+      sha256 = "0glr0iiqmylwwsn5r946yqr9kx97j2zznrc0imyxm3j0vhz8xzl4";
     };
   }."${stdenv.hostPlatform.system}";
 


### PR DESCRIPTION
Changelog
==========

Security:
- Fixed client user agent leaking through MediaProxy

Removed:
- :auth, :enforce_oauth_admin_scope_usage configuration option.

Changed
- Breaking: Changed mix pleroma.user toggle_confirmed to mix pleroma.user confirm
- Breaking: Changed mix pleroma.user toggle_activated to mix pleroma.user activate/deactivate
- Polls now always return a voters_count, even if they are single-choice.
- Admin Emails: The ap id is used as the user link in emails now.
- Improved registration workflow for email confirmation and account approval modes.
- Search: When using Postgres 11+, Pleroma will use the websearch_to_tsvector function to parse search queries.
- Emoji: Support the full Unicode 13.1 set of Emoji for reactions, plus regional indicators.
- Deprecated Pleroma.Uploaders.S3, :public_endpoint. Now Pleroma.Upload, :base_url is the standard configuration key for all uploaders.
- Improved Apache webserver support: updated sample configuration, MediaProxy cache invalidation verified with the included sample script
- Improve OAuth 2.0 provider support. A missing fqn field was added to the response, but does not expose the user's email address.
- Provide redirect of external posts from /notice/:id to their original URL
- Admins no longer receive notifications for reports if they are the actor making the report.
- Improved Mailer configuration setting descriptions for AdminFE.
- Updated default avatar to look nicer.

Added

- Reports now generate notifications for admins and mods.
- Support for local-only statuses.
- Support pagination of blocks and mutes.
- Account backup.
- Configuration: Add :instance, autofollowing_nicknames setting to provide a way to make accounts automatically follow new users that register on the local Pleroma instance.
- Ability to view remote timelines, with ex. /api/v1/timelines/public?instance=lain.com and streams public:remote and public:remote:media.
- The site title is now injected as a title tag like preloads or metadata.
- Password reset tokens now are not accepted after a certain age.
- Mix tasks to help with displaying and removing ConfigDB entries. See mix pleroma.config.
- OAuth form improvements: users are remembered by their cookie, the CSS is overridable by the admin, and the style has been improved.
- OAuth improvements and fixes: more secure session-based authentication (by token that could be revoked anytime), ability to revoke belonging OAuth token from any client etc.
- Ability to set ActivityPub aliases for follower migration.
- Configurable background job limits for RichMedia (link previews) and MediaProxyWarmingPolicy
- Ability to define custom HTTP headers per each frontend
- MRF (NoEmptyPolicy): New MRF Policy which will deny empty statuses or statuses of only mentions from being created by local users
- New users will receive a simple email confirming their registration if no other emails will be dispatched. (e.g., Welcome, Confirmation, or Approval Required)

Fixed
- Users with is_discoverable field set to false (default value) will appear in in-service search results but be hidden from external services (search bots etc.).
- Streaming API: Posts and notifications are not dropped, when CLI task is executing.
- Creating incorrect IPv4 address-style HTTP links when encountering certain numbers.
- Reblog API Endpoint: Do not set visibility parameter to public by default and let CommonAPI to infer it from status, so a user can reblog their private status without explicitly setting reblog visibility to private.
- Tag URLs in statuses are now absolute
- Removed duplicate jobs to purge expired activities
- File extensions of some attachments were incorrectly changed. This feature has been disabled for now.
- Mix task pleroma.instance creates missing parent directories if the configuration or SQL output paths are changed.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
