### PR TITLE
deluge: shut up ngettext error on webui start

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -62,7 +62,7 @@ pythonPackages.buildPythonPackage rec {
   checkInputs = with pythonPackages; [
     pytestCheckHook
     pytest-twisted
-    pytestcov
+    pytest-cov
     mock
     mccabe
     pylint

--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,5 +1,15 @@
-{ lib, fetchurl, intltool, libtorrent-rasterbar, pythonPackages
-, gtk3, glib, gobject-introspection, librsvg, wrapGAppsHook }:
+{ lib
+, fetchurl
+, fetchpatch
+, intltool
+, libtorrent-rasterbar
+, pythonPackages
+, gtk3
+, glib
+, gobject-introspection
+, librsvg
+, wrapGAppsHook
+}:
 
 pythonPackages.buildPythonPackage rec {
   pname = "deluge";
@@ -10,28 +20,60 @@ pythonPackages.buildPythonPackage rec {
     sha256 = "14d8kn2pvr1qv8mwqrxmj85jycr73vwfqz12hzag0ararbkfhyky";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/deluge-torrent/deluge/commit/d6c96d629183e8bab2167ef56457f994017e7c85.patch";
+      sha256 = "sha256-slGMt2bgp36pjDztJUXFeZNbzdJsus0s9ARRD6IpNUw=";
+      name = "fix_ngettext_warning.patch";
+    })
+
+    (fetchpatch {
+      url = "https://github.com/deluge-torrent/deluge/commit/351664ec071daa04161577c6a1c949ed0f2c3206.patch";
+      sha256 = "sha256-ry1LFgMe9lys66xAvATcPqIa3rzBPWVnsf8FL1dXkHo=";
+      name = "fix_logging_on_py38.patch";
+    })
+  ];
+
   propagatedBuildInputs = with pythonPackages; [
-    twisted Mako chardet pyxdg pyopenssl service-identity
-    libtorrent-rasterbar.dev libtorrent-rasterbar.python setuptools
-    setproctitle pillow rencode six zope_interface
-    dbus-python pygobject3 pycairo
-    gtk3 gobject-introspection librsvg
+    twisted
+    Mako
+    chardet
+    pyxdg
+    pyopenssl
+    service-identity
+    libtorrent-rasterbar.dev
+    libtorrent-rasterbar.python
+    setuptools
+    setproctitle
+    pillow
+    rencode
+    six
+    zope_interface
+    dbus-python
+    pygobject3
+    pycairo
+    gtk3
+    gobject-introspection
+    librsvg
   ];
 
   nativeBuildInputs = [ intltool wrapGAppsHook glib ];
 
   checkInputs = with pythonPackages; [
-    pytest /* pytest-twisted */ pytestcov mock
-    mccabe pylint
+    pytestCheckHook
+    pytest-twisted
+    pytestcov
+    mock
+    mccabe
+    pylint
   ];
 
   doCheck = false; # until pytest-twisted is packaged
 
   postInstall = ''
-     mkdir -p $out/share/applications
-     cp -R deluge/ui/data/pixmaps $out/share/
-     cp -R deluge/ui/data/icons $out/share/
-     cp deluge/ui/data/share/applications/deluge.desktop $out/share/applications
+    mkdir -p $out/share
+    cp -R deluge/ui/data/{icons,pixmaps} $out/share/
+    install -Dm444 -t $out/share/applications deluge/ui/data/share/applications/deluge.desktop
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

deluge would complain loudly on start. Also patch the logger on py38.

Noise from `nixpkgs-fmt`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
