### PR TITLE
mailhog: fix --version output

### DIFF
--- a/pkgs/servers/mail/mailhog/default.nix
+++ b/pkgs/servers/mail/mailhog/default.nix
@@ -13,6 +13,8 @@ buildGoPackage rec {
     sha256 = "124216850572r1h0ii7ad6jd1cd5czcvkz7k2jzvjb4pv2kl8p3y";
   };
 
+  buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
+
   meta = with lib; {
     description = "Web and API based SMTP testing";
     homepage = "https://github.com/mailhog/MailHog";


### PR DESCRIPTION
###### Motivation for this change

```
# before
[nix-shell:~/github/nixpkgs]$ MailHog --version
MailHog version:

# after
[nix-shell:~/github/nixpkgs]$ MailHog --version
MailHog version: 1.0.1
```

MailHog Makefile https://github.com/mailhog/MailHog/blob/0441dd494b03c9255a9b8e90e3458ebb115eacff/Makefile#L9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
