### PR TITLE
update terraform-providers.{helm,kubernetes} to 2.0.2

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -504,9 +504,10 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/kubernetes",
     "repo": "terraform-provider-kubernetes",
-    "rev": "v1.13.3",
-    "sha256": "01hkbb81r3k630s3ww6379p66h1fsd5cd1dz14jm833nsr142c0i",
-    "version": "1.13.3"
+    "rev": "v2.0.2",
+    "sha256": "129aylw6hxa44syfnb0kkkihwvlaa6d1jnxrcbwkql6xxhn9zizf",
+    "vendorSha256": null,
+    "version": "2.0.2"
   },
   "kubernetes-alpha": {
     "owner": "hashicorp",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -398,10 +398,10 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/helm",
     "repo": "terraform-provider-helm",
-    "rev": "v1.3.2",
-    "sha256": "0mpbf03483jqrwd9cx4pdn2pcv4swfs5nbp021gaqr0jf1w970x6",
+    "rev": "v2.0.2",
+    "sha256": "119zvlkwa7ygwsjxxdl7z8cqb0c4m6gy21356jnsasf4c3557rrb",
     "vendorSha256": null,
-    "version": "1.3.2"
+    "version": "2.0.2"
   },
   "heroku": {
     "owner": "terraform-providers",

--- a/pkgs/applications/networking/cluster/terraform-providers/update-provider
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-provider
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p coreutils curl jq moreutils
+#! nix-shell -I nixpkgs=../../../../.. -i bash -p coreutils curl jq moreutils nix
 # shellcheck shell=bash
 # vim: ft=sh
 #
@@ -161,7 +161,8 @@ if [[ -z "$vendorSha256" ]]; then
       exit 1
     fi
     rm -f vendor_log.txt
-    vendorSha256=${BASH_REMATCH[1]}
+    # trim the results in case it they have a sha256: prefix or contain more than one line
+    vendorSha256=$(echo "${BASH_REMATCH[1]#sha256:}" | head -n 1)
     # Deal with nix unstable
     if [[ $vendorSha256 = sha256-* ]]; then
       vendorSha256=$(nix to-base32 "$vendorSha256")


### PR DESCRIPTION
###### Motivation for this change

I had a requirement for a newer version of both of these providers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
