### PR TITLE
dockerTools: fix build on Darwin

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -1,11 +1,11 @@
-{ lib, callPackage }:
+{ lib, callPackage, fetchFromGitHub }:
 
 with lib;
 
 rec {
   dockerGen = {
       version, rev, sha256
-      , mobyRev, mobySha256
+      , moby-src
       , runcRev, runcSha256
       , containerdRev, containerdSha256
       , tiniRev, tiniSha256, buildxSupport ? false
@@ -65,12 +65,7 @@ rec {
       inherit version;
       inherit docker-runc docker-containerd docker-proxy docker-tini;
 
-      src = fetchFromGitHub {
-        owner = "moby";
-        repo = "moby";
-        rev = mobyRev;
-        sha256 = mobySha256;
-      };
+      src = moby-src;
 
       goPackagePath = "github.com/docker/docker";
 
@@ -211,6 +206,9 @@ rec {
       maintainers = with maintainers; [ offline tailhook vdemeester periklis ];
       platforms = with platforms; linux ++ darwin;
     };
+
+    # Exposed for tarsum build on non-linux systems (build-support/docker/default.nix)
+    inherit moby-src;
   });
 
   # Get revisions from
@@ -219,8 +217,12 @@ rec {
     version = "20.10.2";
     rev = "v${version}";
     sha256 = "0z0hpm5hrqh7p8my8lmiwpym2shs48my6p0zv2cc34wym0hcly51";
-    mobyRev = "v${version}";
-    mobySha256 = "0c2zycpnwj4kh8m8xckv1raj3fx07q9bfaj46rr85jihm4p2dp5w";
+    moby-src = fetchFromGitHub {
+      owner = "moby";
+      repo = "moby";
+      rev = "v${version}";
+      sha256 = "0c2zycpnwj4kh8m8xckv1raj3fx07q9bfaj46rr85jihm4p2dp5w";
+    };
     runcRev = "ff819c7e9184c13b7c2607fe6c30ae19403a7aff"; # v1.0.0-rc92
     runcSha256 = "0r4zbxbs03xr639r7848282j1ybhibfdhnxyap9p76j5w8ixms94";
     containerdRev = "269548fa27e0089a8b8278fc4fc781d7f65a939b"; # v1.4.3

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -120,7 +120,7 @@ rec {
     export GOPATH=$(pwd)
     export GOCACHE="$TMPDIR/go-cache"
     mkdir -p src/github.com/docker/docker/pkg
-    ln -sT ${docker.moby.src}/pkg/tarsum src/github.com/docker/docker/pkg/tarsum
+    ln -sT ${docker.moby-src}/pkg/tarsum src/github.com/docker/docker/pkg/tarsum
     go build
 
     mkdir -p $out/bin


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/110665


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Following [Building and running Docker images](https://nixos.org/guides/building-and-running-docker-images.html) tutorial on macOS 11.2.1 and current master results in an error:
```sh
nix-build ./hello-docker.nix
error: attribute 'moby' missing, at /Users/osener/vcs/nixpkgs/pkgs/build-support/docker/default.nix:123:14
```

I traced it to `optionalAttrs (stdenv.isLinux)` declarations introduced in https://github.com/NixOS/nixpkgs/pull/109420 ([here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/virtualization/docker/default.nix#L63) and [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/virtualization/docker/default.nix#L122)) that prevents `moby` from being built on macOS. Per @quetz's comment, exposing the moby sources allows me to build Docker images on macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
