### PR TITLE
pcl: add wrapQt, remove broken and run nixpkgs-fmt

### DIFF
--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -1,22 +1,49 @@
-{ lib, stdenv, fetchFromGitHub, cmake
-, qhull, flann, boost, vtk, eigen, pkg-config, qtbase
-, libusb1, libpcap, libXt, libpng, Cocoa, AGL, OpenGL
+{ lib
+, stdenv
+, fetchFromGitHub
+, wrapQtAppsHook
+, cmake
+, qhull
+, flann
+, boost
+, vtk
+, eigen
+, pkg-config
+, qtbase
+, libusb1
+, libpcap
+, libXt
+, libpng
+, Cocoa
+, AGL
+, OpenGL
 }:
 
 stdenv.mkDerivation rec {
-  name = "pcl-1.11.1";
+  pname = "pcl";
+  version = "1.11.1";
 
   src = fetchFromGitHub {
     owner = "PointCloudLibrary";
     repo = "pcl";
-    rev = name;
+    rev = "${pname}-${version}";
     sha256 = "1cli2rxqsk6nxp36p5mgvvahjz8hm4fb68yi8cf9nw4ygbcvcwb1";
   };
 
-  nativeBuildInputs = [ pkg-config cmake ];
-  buildInputs = [ qhull flann boost eigen libusb1 libpcap
-                  libpng vtk qtbase libXt ]
-    ++ lib.optionals stdenv.isDarwin [ Cocoa AGL ];
+  nativeBuildInputs = [ pkg-config cmake wrapQtAppsHook ];
+  buildInputs = [
+    qhull
+    flann
+    boost
+    eigen
+    libusb1
+    libpcap
+    libpng
+    vtk
+    qtbase
+    libXt
+  ]
+  ++ lib.optionals stdenv.isDarwin [ Cocoa AGL ];
 
   cmakeFlags = lib.optionals stdenv.isDarwin [
     "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks"
@@ -24,10 +51,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://pointclouds.org/";
-    broken = lib.versionAtLeast qtbase.version "5.15";
     description = "Open project for 2D/3D image and point cloud processing";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [viric];
+    maintainers = with lib.maintainers; [ viric ];
     platforms = with lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION

###### Motivation for this change

Remove broken tag. 

Add wrapQt, this is new to me so not sure that I used it correctly. Another options was to disable wrapQt. 

Everything I've tested seems to work correctly. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
