### PR TITLE
linux_5_11: 5.11.2 -> 5.11.3

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-5.11.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.11.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.11.2";
+  version = "5.11.3";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "186ha9fsk2qvrjkq7yvpmml938byz92m8ykcvbw4w9pmp8y5njlh";
+    sha256 = "1znbn7n2jzm2rd7gsfj897lgrvaw48ljqfyza3166mw0nc5wfn1m";
   };
 } // (args.argsOverride or {}))


### PR DESCRIPTION
###### Motivation for this change
https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.11.3

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).