### PR TITLE
resholve: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -11,12 +11,12 @@
 , doCheck ? true
 }:
 let
-  version = "0.5.0";
+  version = "0.5.1";
   rSrc = fetchFromGitHub {
     owner = "abathur";
     repo = "resholve";
     rev = "v${version}";
-    hash = "sha256-dscmT0ss1buP56QzQtfs2HANr9oWWMxCS+fwBIKBxv4=";
+    hash = "sha256-+9MjvO1H+A3Ol2to5tWqdpNR7osQsYcbkX9avAqyrKw=";
   };
   deps = callPackage ./deps.nix {
     /*


### PR DESCRIPTION
_I don't know if it'll recur here, but when I ran `nixpkgs-review` I saw the bashup-events* packages built with resholvePackage fail (log: https://gist.github.com/abathur/1a0e44f852fec78190e5022132bc60df) due to an unrelated break down in shellcheck's dependency tree._

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
