### PR TITLE
renoise: 3.2.2 -> 3.3.1

### DIFF
--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -14,7 +14,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "renoise";
-  version = "3.2.2";
+  version = "3.3.1";
 
   src =
     if stdenv.hostPlatform.system == "x86_64-linux" then
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
               "https://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_Linux.tar.gz"
               "https://web.archive.org/web/https://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_Linux.tar.gz"
           ];
-          sha256 = "1v249kmyidx55kppk3sry7yg6hl1a91ixhnwz36h4y134fs7bkrl";
+          sha256 = "05baicks5dx278z2dx6h5n2vabsn64niwqssgys36xy469l9m1h0";
         }
         else
           releasePath


### PR DESCRIPTION
routine update

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
