### PR TITLE
python3Packages.pyrituals: init at 0.0.2

### DIFF
--- a/pkgs/development/python-modules/pyrituals/default.nix
+++ b/pkgs/development/python-modules/pyrituals/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyrituals";
+  version = "0.0.2";
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "milanmeu";
+    repo = pname;
+    rev = version;
+    sha256 = "0hrwhk3kpvdg78fgnvhmnnh3wprdv10j8jqjm4ly64chr8cdi6f2";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pyrituals" ];
+
+  meta = with lib; {
+    description = "Python wrapper for the Rituals Perfume Genie API";
+    homepage = "https://github.com/milanmeu/pyrituals";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5958,6 +5958,8 @@ in {
 
   pyrisco = callPackage ../development/python-modules/pyrisco { };
 
+  pyrituals = callPackage ../development/python-modules/pyrituals { };
+
   pyRFC3339 = callPackage ../development/python-modules/pyrfc3339 { };
 
   PyRMVtransport = callPackage ../development/python-modules/PyRMVtransport { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python wrapper for the Rituals Perfume Genie API

https://github.com/milanmeu/pyrituals

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
