### PR TITLE
ardour: add a videoSupport option, harvid: init at 0.8.3, xjadeo: init at 0.8.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6255,6 +6255,12 @@
     githubId = 1776903;
     name = "Andrew Abbott";
   };
+  mitchmindtree = {
+    email = "mail@mitchellnordine.com";
+    github = "mitchmindtree";
+    githubId = 4587373;
+    name = "Mitchell Nordine";
+  };
   mjanczyk = {
     email = "m@dragonvr.pl";
     github = "mjanczyk";

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -16,6 +16,7 @@
 , glibmm
 , graphviz
 , gtkmm2
+, harvid
 , itstool
 , libarchive
 , libjack2
@@ -35,6 +36,7 @@
 , lilv
 , lrdf
 , lv2
+, makeWrapper
 , pango
 , perl
 , pkg-config
@@ -49,6 +51,8 @@
 , taglib
 , vamp-plugin-sdk
 , wafHook
+, xjadeo
+, videoSupport ? false
 }:
 stdenv.mkDerivation rec {
   pname = "ardour";
@@ -70,6 +74,7 @@ stdenv.mkDerivation rec {
     doxygen
     graphviz # for dot
     itstool
+    makeWrapper
     perl
     pkg-config
     python3
@@ -121,7 +126,7 @@ stdenv.mkDerivation rec {
     suil
     taglib
     vamp-plugin-sdk
-  ];
+  ] ++ lib.optionals videoSupport [ harvid xjadeo ];
 
   wafConfigureFlags = [
     "--cxx11"
@@ -158,6 +163,10 @@ stdenv.mkDerivation rec {
         "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour6.png"
     done
     install -vDm 644 "ardour.1"* -t "$out/share/man/man1"
+  '' + lib.optionalString videoSupport ''
+    # `harvid` and `xjadeo` must be accessible in `PATH` for video to work.
+    wrapProgram "$out/bin/ardour6" \
+      --prefix PATH : "${lib.makeBinPath [ harvid xjadeo ]}"
   '';
 
   LINKFLAGS = "-lpthread";
@@ -176,6 +185,6 @@ stdenv.mkDerivation rec {
     homepage = "https://ardour.org/";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ goibhniu magnetophon ];
+    maintainers = with maintainers; [ goibhniu magnetophon mitchmindtree ];
   };
 }

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -183,7 +183,7 @@ stdenv.mkDerivation rec {
       https://community.ardour.org/donate
     '';
     homepage = "https://ardour.org/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ goibhniu magnetophon mitchmindtree ];
   };

--- a/pkgs/tools/video/harvid/default.nix
+++ b/pkgs/tools/video/harvid/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub, ffmpeg, libjpeg, libpng, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "harvid";
+  version = "0.8.3";
+
+  src = fetchFromGitHub {
+    owner = "x42";
+    repo = "harvid";
+    rev = "v${version}";
+    sha256 = "0l1plfsfh2ixhlzg3hqqvjj42z7g422718a9kgbh7b4p882n71x7";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ ffmpeg libjpeg libpng ];
+
+  makeFlags = [ "DESTDIR=$(out)" "libdir=\"/lib\"" ];
+
+  postInstall = ''
+    mkdir -p $out/bin
+    mv $out/usr/local/bin/* $out/bin
+    mv $out/usr/local/share $out/
+    rm -r $out/usr
+  '';
+
+  meta = with lib; {
+    description =
+      "Decodes still images from movie files and serves them via HTTP";
+    longDescription = ''
+      harvid's intended use-case is to efficiently provide frame-accurate data
+      and act as second level cache for rendering the video-timeline in Ardour,
+      but it is not limited to that: it has applications for any task that
+      requires a high-performance frame-accurate online image extraction
+      processor.
+    '';
+    homepage = "http://x42.github.io/harvid";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mitchmindtree ];
+  };
+}

--- a/pkgs/tools/video/xjadeo/default.nix
+++ b/pkgs/tools/video/xjadeo/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, autoreconfHook, fetchFromGitHub, ffmpeg, freetype, libGLU
+, libjack2, liblo, libX11, libXv, pkg-config, portmidi, xorg }:
+
+stdenv.mkDerivation rec {
+  pname = "xjadeo";
+  version = "0.8.10";
+
+  src = fetchFromGitHub {
+    owner = "x42";
+    repo = "xjadeo";
+    rev = "v${version}";
+    sha256 = "0dma4cjgbrpy16x63zvfr0xss4lryl0zw7nvixvhq2f6z8day1ds";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  buildInputs = [
+    ffmpeg
+    libjack2
+    libX11
+    xorg.libXext
+    xorg.libXpm
+    # The following are recommended in the README, but are seemingly
+    # unnecessary for a successful build. That said, the result of including
+    # these in the build process is possibly required at runtime in some cases,
+    # but I've not the time to test thoroughly for these cases. Should
+    # consider investigating and splitting these into options in the future.
+    freetype
+    libGLU
+    liblo
+    libXv
+    portmidi
+  ];
+
+  meta = with lib; {
+    description = "The X Jack Video Monitor";
+    longDescription = ''
+      Xjadeo is a software video player that displays a video-clip in sync with
+      an external time source (MTC, LTC, JACK-transport). Xjadeo is useful in
+      soundtrack composition, video monitoring or any task that requires to
+      synchronizing movie frames with external events.
+    '';
+    homepage = "http://xjadeo.sourceforge.net";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mitchmindtree ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1366,6 +1366,8 @@ in
 
   hakrawler = callPackage ../tools/security/hakrawler { };
 
+  harvid = callPackage ../tools/video/harvid { };
+
   hime = callPackage ../tools/inputmethods/hime {};
 
   hinit = haskell.lib.justStaticExecutables haskellPackages.hinit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1412,6 +1412,8 @@ in
 
   passExtensions = recurseIntoAttrs pass.extensions;
 
+  xjadeo = callPackage ../tools/video/xjadeo { };
+
   asc-key-to-qr-code-gif = callPackage ../tools/security/asc-key-to-qr-code-gif { };
 
   go-audit = callPackage ../tools/system/go-audit { };


### PR DESCRIPTION
##### Motivation

### Video support in Adour with `videoSupport`

This adds a `bool` option that, when set to `true`, enables video
timeline support for the Ardour DAW. This is commonly useful for
soundtrack composition, sound design for film, etc.

When enabled, `videoSupport` ensures that both `harvid` and `xjadeo` are
available to the `ardour6` exe via the PATH. `harvid` decodes the video
stream in real-time to produce still images (I think for thumbnail
support for the timeline?). `xjadeo` acts as a video monitoring window
that whose playback position is synchronised to the Ardour playhead.

`videoSupport` remains disabled by default, preserving the original
behaviour.

Video support can be added to ardour in your system or home
configuration package list with:

```
(ardour.override { videoSupport = true; })
```

### `harvid` and `xjadeo`

`harvid` decodes still images from movie files and serves them via HTTP.
`xjadeo` is an "X Jack Video Monitor".
Both executables must be available via `PATH` in order for ardour's video
timeline support to work. You can read more about both tools in their
respective `meta` attributes.

Tested builds of ardour both with and without `videoSupport` and both
appear to work nicely. Both `harvid` and `xjadeo` also appear to work
as intended from their respective CLIs.

---

##### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @cillianderoiste  @magnetophon, current maintainers of the ardour package.