### PR TITLE
evolution-data-server: enable phone number support

### DIFF
--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -1,8 +1,8 @@
 { fetchurl, lib, stdenv, substituteAll, pkg-config, gnome3, python3, gobject-introspection
-, intltool, libsoup, libxml2, libsecret, icu, sqlite, tzdata, libcanberra-gtk3, gcr
-, p11-kit, db, nspr, nss, libical, gperf, wrapGAppsHook, glib-networking, pcre
-, vala, cmake, ninja, kerberos, openldap, webkitgtk, libaccounts-glib, json-glib
-, glib, gtk3, gnome-online-accounts, libgweather, libgdata, gsettings-desktop-schemas }:
+, intltool, libsoup, libxml2, libsecret, icu, sqlite, tzdata, libcanberra-gtk3, gcr, p11-kit
+, db, nspr, nss, libical, gperf, wrapGAppsHook, glib-networking, pcre, vala, cmake, ninja
+, kerberos, openldap, webkitgtk, libaccounts-glib, json-glib, glib, gtk3, libphonenumber
+, gnome-online-accounts, libgweather, libgdata, gsettings-desktop-schemas, boost, protobuf }:
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     glib libsoup libxml2 gtk3 gnome-online-accounts
     gcr p11-kit libgweather libgdata libaccounts-glib json-glib
     icu sqlite kerberos openldap webkitgtk glib-networking
-    libcanberra-gtk3 pcre
+    libcanberra-gtk3 pcre libphonenumber boost protobuf
   ];
 
   propagatedBuildInputs = [ libsecret nss nspr libical db libsoup ];
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_INTROSPECTION=ON"
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DINCLUDE_INSTALL_DIR=${placeholder "dev"}/include"
+    "-DWITH_PHONENUMBER=ON"
   ];
 
   passthru = {

--- a/pkgs/development/libraries/folks/default.nix
+++ b/pkgs/development/libraries/folks/default.nix
@@ -1,6 +1,7 @@
 { fetchurl
 , lib, stdenv
 , pkg-config
+, fetchpatch
 , meson
 , ninja
 , glib
@@ -41,6 +42,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1f9b52vmwnq7s51vj26w2618dn2ph5g12ibbkbyk6fvxcgd7iryn";
   };
+
+  patches = [
+    # Fix tests with e-d-s linked with libphonenumber support
+    # https://gitlab.gnome.org/GNOME/folks/merge_requests/40
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/folks/commit/6d443480a137f6a6ff345b21bf3cb31066eefbcd.patch";
+      sha256 = "D/Y2g12TT0qrcH+iJ2umu4Hmp0EJ3Hoedh0H3aWI+HY=";
+    })
+  ];
 
   mesonFlags = [
     "-Ddocs=true"
@@ -91,6 +101,13 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
+
+  # Prevents e-d-s add-contacts-stress-test from timing out
+  checkPhase = ''
+    runHook preCheck
+    meson test --timeout-multiplier 4
+    runHook postCheck
+  '';
 
   postPatch = ''
     chmod +x meson_post_install.py


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
gnome-calls needs phone number support to match numbers to contacts. And this change will probably generally help with packaging gnome/librem phone packages, #88767.

###### Things done
Targeting staging due to gnome rebuilds - not sure if this is the right thing to do though.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
