### PR TITLE
python3Packages.pyplaato: init at 0.0.15

### DIFF
--- a/pkgs/development/python-modules/pyplaato/default.nix
+++ b/pkgs/development/python-modules/pyplaato/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, python-dateutil
+}:
+
+buildPythonPackage rec {
+  pname = "pyplaato";
+  version = "0.0.15";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nykbkv2fg1x5min07cbi44x6am48f5gw3mnyj7x2kpmj6sqfpqp";
+  };
+
+  propagatedBuildInputs = [ aiohttp python-dateutil ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pyplaato" ];
+
+  meta = with lib; {
+    description = "Python API client for fetching Plaato data";
+    homepage = "https://github.com/JohNan/pyplaato";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5868,6 +5868,8 @@ in {
 
   pypillowfight = callPackage ../development/python-modules/pypillowfight { };
 
+  pyplaato  = callPackage ../development/python-modules/pyplaato { };
+
   pyplatec = callPackage ../development/python-modules/pyplatec { };
 
   pypoppler = callPackage ../development/python-modules/pypoppler { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API client for fetching Plaato data

https://github.com/JohNan/pyplaato

This is a HOme Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
