### PR TITLE
python3Packages.pykmtronic: init at 0.0.2

### DIFF
--- a/pkgs/development/python-modules/pykmtronic/default.nix
+++ b/pkgs/development/python-modules/pykmtronic/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchPypi
+, lxml
+}:
+
+buildPythonPackage rec {
+  pname = "pykmtronic";
+  version = "0.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p0i7g4k8ggmzargdi3ch55id04j5qjlhv8hap2162gc77b16d59";
+  };
+
+  propagatedBuildInputs = [ aiohttp lxml ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pykmtronic" ];
+
+  meta = with lib; {
+    description = "Python client to interface with KM-Tronic web relays";
+    homepage = "https://github.com/dgomes/pykmtronic";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5642,6 +5642,8 @@ in {
 
   pykka = callPackage ../development/python-modules/pykka { };
 
+  pykmtronic = callPackage ../development/python-modules/pykmtronic { };
+
   pykwalify = callPackage ../development/python-modules/pykwalify { };
 
   pylacrosse = callPackage ../development/python-modules/pylacrosse { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client to interface with KM-Tronic web relays

https://github.com/dgomes/pykmtronic

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
