### PR TITLE
emacs.pkgs.pdf-tools: Fix darwin build

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -141,14 +141,18 @@ let
           buildInputs = old.buildInputs ++ [ pkgs.libpng pkgs.zlib pkgs.poppler ];
           preBuild = ''
             make server/epdfinfo
-            remove-references-to \
-              -t ${pkgs.stdenv.cc.libc.dev} \
-              -t ${pkgs.glib.dev} \
-              -t ${pkgs.libpng.dev} \
-              -t ${pkgs.poppler.dev} \
-              -t ${pkgs.zlib.dev} \
-              -t ${pkgs.cairo.dev} \
-              server/epdfinfo
+            remove-references-to ${lib.concatStringsSep " " (
+              map (output: "-t " + output) (
+                [
+                  pkgs.glib.dev
+                  pkgs.libpng.dev
+                  pkgs.poppler.dev
+                  pkgs.zlib.dev
+                  pkgs.cairo.dev
+                ]
+                ++ lib.optional pkgs.stdenv.isLinux pkgs.stdenv.cc.libc.dev
+              )
+            )} server/epdfinfo
           '';
           recipe = pkgs.writeText "recipe" ''
             (pdf-tools


### PR DESCRIPTION
###### Motivation for this change

As reported in https://github.com/NixOS/nixpkgs/pull/114484#discussion_r587722662

I haven't been able to test this on Darwin, but at least it now instantiates when setting `system = "x86_64-darwin"`.

cc @afontaine 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
