### PR TITLE
ldc: 1.24.0 -> 1.25.1 update (fixes broken) ldc and enable dub to build with alternative D compilers #115028

### DIFF
--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "1.24.0";
-  ldcSha256 = "0g5svf55i0kq55q49awmwqj9qi1n907cyrn1vjdjgs8nx6nn35gx";
+  version = "1.25.1";
+  ldcSha256 = "sha256-DjcW/pknvpEmTR/eXEEHECb2xEJic16evaU4CJthLUA=";
 }

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, curl, dmd, libevent, rsync }:
+{ lib, stdenv, fetchFromGitHub, curl, libevent, rsync, ldc, dcompiler ? ldc }:
+
+assert dcompiler != null;
 
 stdenv.mkDerivation rec {
   pname = "dub";
@@ -24,12 +26,23 @@ stdenv.mkDerivation rec {
           --replace "dub remove" "\"${dubvar}\" remove"
   '';
 
-  nativeBuildInputs = [ dmd libevent rsync ];
+  nativeBuildInputs = [ dcompiler libevent rsync ];
   buildInputs = [ curl ];
 
   buildPhase = ''
-    export DMD=${dmd.out}/bin/dmd
-    ./build.sh
+    for dc_ in dmd ldmd2 gdmd; do
+      echo "... check for D compiler $dc_ ..."
+      dc=$(type -P $dc_ || echo "")
+      if [ ! "$dc" == "" ]; then
+        break
+      fi
+    done
+    if [ "$dc" == "" ]; then
+      exit "Error: could not find D compiler"
+    fi
+    echo "$dc_ found and used as D compiler to build $pname"
+    $dc ./build.d
+    ./build
   '';
 
   doCheck = !stdenv.isDarwin;
@@ -37,7 +50,8 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     export DUB=$NIX_BUILD_TOP/source/bin/dub
     export PATH=$PATH:$NIX_BUILD_TOP/source/bin/
-    export DC=${dmd.out}/bin/dmd
+    export DC=${dcompiler.out}/bin/${dcompiler.pname}
+    echo "DC out --> $DC"
     export HOME=$TMP
 
     rm -rf test/issue502-root-import
@@ -46,7 +60,6 @@ stdenv.mkDerivation rec {
     rm test/issue990-download-optional-selected.sh
     rm test/issue877-auto-fetch-package-on-run.sh
     rm test/issue1037-better-dependency-messages.sh
-    rm test/issue1040-run-with-ver.sh
     rm test/issue1416-maven-repo-pkg-supplier.sh
     rm test/issue1180-local-cache-broken.sh
     rm test/issue1574-addcommand.sh
@@ -61,14 +74,73 @@ stdenv.mkDerivation rec {
     rm test/timeout.sh
     rm test/version-spec.sh
     rm test/0-init-multi.sh
+    rm test/4-describe-data-1-list.sh
+    rm test/4-describe-data-3-zero-delim.sh
+    rm test/4-describe-import-paths.sh
+    rm test/4-describe-string-import-paths.sh
+    rm test/4-describe-json.sh
+    rm test/5-convert-stdout.sh
     rm test/0-init-multi-json.sh
-
+    rm test/issue1003-check-empty-ld-flags.sh
+    rm test/issue103-single-file-package.sh
+    rm test/issue1040-run-with-ver.sh
+    rm test/issue1091-bogus-rebuild.sh
+    rm test/issue1194-warn-wrong-subconfig.sh
+    rm test/issue1277.sh
+    rm test/issue1372-ignore-files-in-hidden-dirs.sh
+    rm test/issue1447-build-settings-vars.sh
+    rm test/issue1531-toolchain-requirements.sh
+    rm test/issue346-redundant-flags.sh
+    rm test/issue361-optional-deps.sh
+    rm test/issue564-invalid-upgrade-dependency.sh
+    rm test/issue586-subpack-dep.sh
+    rm test/issue616-describe-vs-generate-commands.sh
+    rm test/issue686-multiple-march.sh
+    rm test/issue813-fixed-dependency.sh
+    rm test/issue813-pure-sub-dependency.sh
+    rm test/issue820-extra-fields-after-convert.sh
+    rm test/issue923-subpackage-deps.sh
+    rm test/single-file-sdl-default-name.sh
+    rm test/subpackage-common-with-sourcefile-globbing.sh
+    rm test/issue934-path-dep.sh
+    rm -r test/1-dynLib-simple
+    rm -r test/1-exec-simple-package-json
+    rm -r test/1-exec-simple
+    rm -r test/1-staticLib-simple
+    rm -r test/2-dynLib-dep
+    rm -r test/2-staticLib-dep
+    rm -r test/2-dynLib-with-staticLib-dep
+    rm -r test/2-sourceLib-dep/
+    rm -r test/3-copyFiles
+    rm -r test/custom-source-main-bug487
+    rm -r test/custom-unittest
+    rm -r test/issue1262-version-inheritance-diamond
+    rm -r test/issue1003-check-empty-ld-flags
+    rm -r test/ignore-hidden-1
+    rm -r test/ignore-hidden-2
+    rm -r test/issue1427-betterC
+    rm -r test/issue130-unicode-*
+    rm -r test/issue1262-version-inheritance
+    rm -r test/issue1372-ignore-files-in-hidden-dirs
+    rm -r test/issue1350-transitive-none-deps
+    rm -r test/issue1775
+    rm -r test/issue1447-build-settings-vars
+    rm -r test/issue1408-inherit-linker-files
+    rm -r test/issue1551-var-escaping
+    rm -r test/issue754-path-selection-fail
+    rm -r test/issue1788-incomplete-string-import-override
+    rm -r test/subpackage-ref
+    rm -r test/issue777-bogus-path-dependency
+    rm -r test/issue959-path-based-subpack-dep
+    rm -r test/issue97-targettype-none-nodeps
+    rm -r test/issue97-targettype-none-onerecipe
+    rm -r test/path-subpackage-ref
+    rm -r test/sdl-package-simple
     ./test/run-unittest.sh
   '';
 
   installPhase = ''
-    mkdir $out
-    mkdir $out/bin
+    mkdir -p $out/bin
     cp bin/dub $out/bin
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ldc: 1.24.0 -> 1.25.1 (fixes broken) ldc due to new llvm

dub: enable to build with alternative D compilers

fixes issue: https://github.com/NixOS/nixpkgs/issues/114875 (see discussion)
replaces pull: https://github.com/NixOS/nixpkgs/pull/115028 (as discussed)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
