### PR TITLE
python3Packages.pymazda: init at 0.0.9

### DIFF
--- a/pkgs/development/python-modules/pymazda/default.nix
+++ b/pkgs/development/python-modules/pymazda/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchPypi
+, pycryptodome
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pymazda";
+  version = "0.0.9";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15kygabjlxmy3g5kj48ixqdwaz8qrfzxj8ii27cidsp2fq8ph165";
+  };
+
+  propagatedBuildInputs = [ aiohttp pycryptodome ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pymazda" ];
+
+  meta = with lib; {
+    description = "Python client for interacting with the MyMazda API";
+    homepage = "https://github.com/bdr99/pymazda";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5718,6 +5718,8 @@ in {
 
   pymavlink = callPackage ../development/python-modules/pymavlink { };
 
+  pymazda = callPackage ../development/python-modules/pymazda { };
+
   pymbolic = callPackage ../development/python-modules/pymbolic { };
 
   pymc3 = callPackage ../development/python-modules/pymc3 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for interacting with the MyMazda API

https://github.com/bdr99/pymazda

This is a Home Assistant dpendency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
