### PR TITLE
python3Packages.python-smarttub: init at 0.0.19

### DIFF
--- a/pkgs/development/python-modules/python-smarttub/default.nix
+++ b/pkgs/development/python-modules/python-smarttub/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, aiohttp
+, aresponses
+, buildPythonPackage
+, fetchFromGitHub
+, inflection
+, pyjwt
+, pytest-asyncio
+, pytestCheckHook
+, python-dateutil
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "python-smarttub";
+  version = "0.0.19";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "mdz";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "01i4pvgvpl7inwhy53c6b34pi5zvfiv2scn507j8jdg5cjs04g80";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    inflection
+    pyjwt
+    python-dateutil
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "smarttub" ];
+
+  meta = with lib; {
+    description = "Python API for SmartTub enabled hot tubs";
+    homepage = "https://github.com/mdz/python-smarttub";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6519,6 +6519,8 @@ in {
 
   python-slugify = callPackage ../development/python-modules/python-slugify { };
 
+  python-smarttub = callPackage ../development/python-modules/python-smarttub { };
+
   python-snap7 = callPackage ../development/python-modules/python-snap7 {
     inherit (pkgs) snap7;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API for SmartTub enabled hot tubs

https://github.com/mdz/python-smarttub

This is a Home Assistant dependency

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
