### PR TITLE
python3Packages.openwrt-ubus-rpc: init at 0.0.3

### DIFF
--- a/pkgs/development/python-modules/openwrt-ubus-rpc/default.nix
+++ b/pkgs/development/python-modules/openwrt-ubus-rpc/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "openwrt-ubus-rpc";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "Noltari";
+    repo = "python-ubus-rpc";
+    rev = version;
+    sha256 = "19scncc1w9ar3pw4yrw24akjgm74n2m7y308hzl1i360daf5p21k";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    urllib3
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "openwrt.ubus" ];
+
+  meta = with lib; {
+    description = "Python API for OpenWrt ubus RPC";
+    homepage = "https://github.com/Noltari/python-ubus-rpc";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4635,6 +4635,8 @@ in {
 
   openwrt-luci-rpc = disabledIf (!isPy3k) (callPackage ../development/python-modules/openwrt-luci-rpc { });
 
+  openwrt-ubus-rpc = callPackage ../development/python-modules/openwrt-ubus-rpc { };
+
   opt-einsum = if isPy27 then
     callPackage ../development/python-modules/opt-einsum/2.nix { }
   else


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API for OpenWrt ubus RPC

https://github.com/Noltari/python-ubus-rpc

This is a Home Assistant dependency

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
