### PR TITLE
[20.09] nextcloud: init at 21.0.0

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -605,6 +605,14 @@ in {
               access_log off;
             '';
           };
+          "= /" = {
+            priority = 100;
+            extraConfig = ''
+              if ( $http_user_agent ~ ^DavClnt ) {
+                return 302 /remote.php/webdav/$is_args$args;
+              }
+            '';
+          };
           "/" = {
             priority = 900;
             extraConfig = "rewrite ^ /index.php;";
@@ -622,6 +630,9 @@ in {
               }
               location = /.well-known/caldav {
                 return 301 /remote.php/dav;
+              }
+              location ~ ^/\.well-known/(?!acme-challenge|pki-validation) {
+                return 301 /index.php$request_uri;
               }
               try_files $uri $uri/ =404;
             '';

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -264,6 +264,24 @@ in {
           may be served via HTTPS.
         '';
       };
+
+      defaultPhoneRegion = mkOption {
+        default = null;
+        type = types.nullOr types.str;
+        example = "DE";
+        description = ''
+          <warning>
+           <para>This option exists since Nextcloud 21! If older versions are used,
+            this will throw an eval-error!</para>
+          </warning>
+
+          <link xlink:href="https://www.iso.org/iso-3166-country-codes.html">ISO 3611-1</link>
+          country codes for automatic phone-number detection without a country code.
+
+          With e.g. <literal>DE</literal> set, the <literal>+49</literal> can be omitted for
+          phone-numbers.
+        '';
+      };
     };
 
     caching = {
@@ -328,6 +346,9 @@ in {
         { assertion = ((acfg.adminpass != null || acfg.adminpassFile != null)
             && !(acfg.adminpass != null && acfg.adminpassFile != null));
           message = "Please specify exactly one of adminpass or adminpassFile";
+        }
+        { assertion = versionOlder cfg.package.version "21" -> cfg.config.defaultPhoneRegion == null;
+          message = "The `defaultPhoneRegion'-setting is only supported for Nextcloud >=21!";
         }
       ];
 
@@ -434,6 +455,7 @@ in {
               'dbtype' => '${c.dbtype}',
               'trusted_domains' => ${writePhpArrary ([ cfg.hostName ] ++ c.extraTrustedDomains)},
               'trusted_proxies' => ${writePhpArrary (c.trustedProxies)},
+              ${optionalString (c.defaultPhoneRegion != null) "'default_phone_region' => '${c.defaultPhoneRegion}',"}
             ];
           '';
           occInstallCmd = let

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -26,7 +26,10 @@ let
     upload_max_filesize = cfg.maxUploadSize;
     post_max_size = cfg.maxUploadSize;
     memory_limit = cfg.maxUploadSize;
-  } // cfg.phpOptions;
+  } // cfg.phpOptions
+    // optionalAttrs cfg.caching.apcu {
+      "apc.enable_cli" = "1";
+    };
   phpOptionsStr = toKeyValue phpOptions;
 
   occ = pkgs.writeScriptBin "nextcloud-occ" ''

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -85,7 +85,7 @@ in {
     package = mkOption {
       type = types.package;
       description = "Which package to use for the Nextcloud instance.";
-      relatedPackages = [ "nextcloud18" "nextcloud19" "nextcloud20" ];
+      relatedPackages = [ "nextcloud18" "nextcloud19" "nextcloud20" "nextcloud21" ];
     };
 
     maxUploadSize = mkOption {
@@ -362,9 +362,10 @@ in {
           support upgrades that skip multiple versions (i.e. an upgrade from 17 to 19 isn't
           possible, but an upgrade from 18 to 19).
         '')
-        ++ (optional (versionOlder cfg.package.version "20") ''
+        ++ (optional (versionOlder cfg.package.version "21") ''
           The latest Nextcloud release is v20 which can be installed by setting
-          `services.nextcloud.package` to `pkgs.nextcloud20`.
+          `services.nextcloud.package` to `pkgs.nextcloud21`. Please note that if you're
+          on `pkgs.nextcloud19`, you'll have to install `pkgs.nextcloud20` first.
         '');
 
       services.nextcloud.package = with pkgs;

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -387,7 +387,7 @@ in {
           possible, but an upgrade from 18 to 19).
         '')
         ++ (optional (versionOlder cfg.package.version "21") ''
-          The latest Nextcloud release is v20 which can be installed by setting
+          The latest Nextcloud release is v21 which can be installed by setting
           `services.nextcloud.package` to `pkgs.nextcloud21`. Please note that if you're
           on `pkgs.nextcloud19`, you'll have to install `pkgs.nextcloud20` first.
         '');

--- a/nixos/modules/services/web-apps/nextcloud.xml
+++ b/nixos/modules/services/web-apps/nextcloud.xml
@@ -12,7 +12,7 @@
  </para>
  <para>
   The current default by NixOS is <package>nextcloud19</package> though it's recommended
-  to upgrade to the latest version, <package>nextcloud20</package>.
+  to upgrade to the latest version, <package>nextcloud21</package>.
  </para>
  <section xml:id="module-services-nextcloud-basic-usage">
   <title>Basic usage</title>

--- a/nixos/modules/services/web-apps/nextcloud.xml
+++ b/nixos/modules/services/web-apps/nextcloud.xml
@@ -12,7 +12,8 @@
  </para>
  <para>
   The current default by NixOS is <package>nextcloud19</package> though it's recommended
-  to upgrade to the latest version, <package>nextcloud21</package>.
+  to upgrade to the latest version, <package>nextcloud21</package>. Please note that it's necessary
+  to install <package>nextcloud20</package> first!
  </para>
  <section xml:id="module-services-nextcloud-basic-usage">
   <title>Basic usage</title>

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -61,4 +61,9 @@ in {
     version = "20.0.7";
     sha256 = "sha256-jO2Ct3K/CvZ9W+EyPkD5d0KbwKK8yGQJXvx4dnUAtys=";
   };
+
+  nextcloud21 = generic {
+    version = "21.0.0";
+    sha256 = "sha256-zq2u72doWhGvxbI7Coa6PHvQp7E41dHswFJiODZV8fA=";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5713,7 +5713,7 @@ in
   grocy = callPackage ../servers/grocy { };
 
   inherit (callPackage ../servers/nextcloud {})
-    nextcloud17 nextcloud18 nextcloud19 nextcloud20;
+    nextcloud17 nextcloud18 nextcloud19 nextcloud20 nextcloud21;
 
   nextcloud-client = libsForQt5.callPackage ../applications/networking/nextcloud-client { };
 


### PR DESCRIPTION

###### Motivation for this change

Partial backport of #113958.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
