### PR TITLE
Updates Home Assistant dependencies (aiohttp-3.7.4)

### DIFF
--- a/pkgs/development/python-modules/aioambient/default.nix
+++ b/pkgs/development/python-modules/aioambient/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "aioambient";
-  version = "1.2.3";
+  version = "1.2.4";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "1jg93rjn1gxc66qmipw4z1c09l8hgfsydacjgkfjq7vg547lragp";
+    sha256 = "sha256-uqvM5F0rpw+xeCXYl4lGMt3r0ugPsUmSvujmTJ9HABk=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/aioflo/default.nix
+++ b/pkgs/development/python-modules/aioflo/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "aioflo";
-  version = "0.4.2";
+  version = "0.4.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "1ppsinmjph6snj7s4hg28p3qa67kpkadc98ikjjg6w65vcm3dlaz";
+    sha256 = "sha256-Dap3yjFIS+k/LLNg+vmYmiFQCOEPNp27p0GCMpn/edA=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/aioguardian/default.nix
+++ b/pkgs/development/python-modules/aioguardian/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "aioguardian";
-  version = "1.0.4";
+  version = "1.0.7";
   disabled = pythonAtLeast "3.9";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "1cbxcsxh9c8r2zx3lsjdns26sm2qmlwnqgah2sfzbgp1lay23vvq";
+    sha256 = "sha256-KMhq86hcqoYloS/6VHsl+3KVEZBbN97ABrZlmEr32Z8=";
   };
 
   format = "pyproject";

--- a/pkgs/development/python-modules/aiorecollect/default.nix
+++ b/pkgs/development/python-modules/aiorecollect/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "aiorecollect";
-  version = "1.0.2";
+  version = "1.0.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "0dlz8zmqcn6g6000lfgcy5krpfafzdzrznmk6iwra65wcs7l9392";
+    sha256 = "sha256-S4HL8vJS/dTKsR5egKRSHqZYPClcET5Le06euHPyIkU=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pyairvisual/default.nix
+++ b/pkgs/development/python-modules/pyairvisual/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "pyairvisual";
-  version = "5.0.6";
+  version = "5.0.7";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "sha256-7u8AwIr1Ah/7zCfXFwj/C/CaD/B3uLRkZ8Gf6d18Xp0=";
+    sha256 = "sha256-r/AJl36dv6+C92tc3kpX4/VzG69qdh4ERCyQxDOHdVU=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pyflunearyou/default.nix
+++ b/pkgs/development/python-modules/pyflunearyou/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "pyflunearyou";
-  version = "2.0.0";
+  version = "2.0.1";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "18vxwfyvicbx8idpa0h0alp4ygnwfph6g4kq93hfm0fc94gi6h94";
+    sha256 = "sha256-2a4OKPmy9tFLJqRg9bEXqrbr3RKVHmKPSYDrtAEqvdo=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pyiqvia/default.nix
+++ b/pkgs/development/python-modules/pyiqvia/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pyiqvia";
-  version = "0.3.2";
+  version = "0.3.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "089lah23939m523jmjkaw2li0fikp2nswxznfvzwnr6wjpp3m9as";
+    sha256 = "sha256-XYWoHKa/yq7MtGVM6eVgLtR2E3VmqsjX3TNcQcd7dEQ=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pyopenuv/default.nix
+++ b/pkgs/development/python-modules/pyopenuv/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "pyopenuv";
-  version = "2.0.1";
+  version = "2.0.2";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "1pzdcy65gndrlyhrwyc1rwsh8n4w79wla8n9fr13m00vac3cqkl0";
+    sha256 = "sha256-QVgNwu/NXSV9nbRN0POBCdKCv6xdp4uSEzFAiHkhVaQ=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pytile/default.nix
+++ b/pkgs/development/python-modules/pytile/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "pytile";
-  version = "5.1.1";
+  version = "5.2.1";
   disabled = pythonAtLeast "3.9";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "sha256-bVoFTaK/Alemtc5I+Z/M9y/FWczvJ+P86R0DMD89/BM=";
+    sha256 = "sha256-/QaIMNImeZuAocxU9dfDoudcgJEkjv1doo7KR9TrwzQ=";
   };
 
   format = "pyproject";

--- a/pkgs/development/python-modules/regenmaschine/default.nix
+++ b/pkgs/development/python-modules/regenmaschine/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "regenmaschine";
-  version = "3.1.1";
+  version = "3.1.2";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "0m6i7vspp8ssdk2k32kznql1j8gkp300kzb7pk67hzvpijdy3mca";
+    sha256 = "sha256-lARti3Sb/jh7h8x+lFLqkM/BlL6XmELm46owsL041Cw=";
   };
 
   nativeBuildInputs = [ poetry-core ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Those package updates are only needed because their requirements says `aiohttp>=3.7.4`. Currently `aiohttp-3.7.4` is only available in `staging`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
