### PR TITLE
mypy: 0.790 → 0.812

### DIFF
--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -1,22 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, buildPythonPackage, typed-ast, psutil, isPy3k
+{ lib, stdenv, fetchPypi, buildPythonPackage, typed-ast, psutil, isPy3k
 , mypy-extensions
 , typing-extensions
-, fetchpatch
 }:
 buildPythonPackage rec {
   pname = "mypy";
-  version = "0.790";
+  version = "0.812";
   disabled = !isPy3k;
 
-  # Fetch 0.790 from GitHub temporarily because mypyc.analysis is missing from
-  # the Pip package (see also https://github.com/python/mypy/issues/9584). It
-  # should be possible to move back to Pypi for the next release.
-  src = fetchFromGitHub {
-    owner = "python";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0zq3lpdf9hphcklk40wz444h8w3dkhwa12mqba5j9lmg11klnhz7";
-    fetchSubmodules = true;
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "069i9qnfanp7dn8df1vspnqb0flvsszzn22v00vj08nzlnd061yd";
   };
 
   propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];
@@ -32,23 +25,6 @@ buildPythonPackage rec {
     "mypy.report"
     "mypyc"
     "mypyc.analysis"
-  ];
-
-  # These three patches are required to make compilation with mypyc work for
-  # 0.790, see also https://github.com/python/mypy/issues/9584.
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/python/mypy/commit/f6522ae646a8d87ce10549f29fcf961dc014f154.patch";
-      sha256 = "0d3jp4d0b7vdc0prk07grhajsy7x3wcynn2xysnszawiww93bfrh";
-    })
-    (fetchpatch {
-      url = "https://github.com/python/mypy/commit/acd603496237a78b109ca9d89991539633cbbb99.patch";
-      sha256 = "0ry1rxpz2ws7zzrmq09pra9dlzxb84zhs8kxwf5xii1k1bgmrljr";
-    })
-    (fetchpatch {
-      url = "https://github.com/python/mypy/commit/81818b23b5d53f31caf3515d6f0b54e3c018d790.patch";
-      sha256 = "002y24kfscywkw4mz9lndsps543j4xhr2kcnfbrqr4i0yxlvdbca";
-    })
   ];
 
   # Compile mypy with mypyc, which makes mypy about 4 times faster. The compiled


### PR DESCRIPTION
###### Motivation for this change

Upgrade mypy from 0.790 to 0.812.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
