### PR TITLE
zstxtns-utils: init at 0.0.3

### DIFF
--- a/pkgs/tools/text/zstxtns-utils/default.nix
+++ b/pkgs/tools/text/zstxtns-utils/default.nix
@@ -1,0 +1,41 @@
+{ bash
+, coreutils
+, fetchurl
+, gnugrep
+, lib
+, makeWrapper
+, moreutils
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zstxtns-utils";
+  version = "0.0.3";
+
+  src = fetchurl {
+    url = "https://ytrizja.de/distfiles/zstxtns-utils-${version}.tar.gz";
+    sha256 = "I/Gm7vHUr29NClYWQ1kwu8HrNZpdLXfE/nutTNoqcdU=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash coreutils gnugrep moreutils ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D -t $out/bin zstxtns-merge zstxtns-unmerge
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/zstxtns-merge --prefix PATH ":" "${lib.makeBinPath [coreutils gnugrep moreutils]}"
+    wrapProgram $out/bin/zstxtns-unmerge --prefix PATH ":" "${lib.makeBinPath [coreutils gnugrep]}"
+  '';
+
+  meta = with lib; {
+    description = "utilities to deal with text based name service databases";
+    homepage = "https://ytrizja.de/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zseri ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9393,6 +9393,8 @@ in
 
   zs-apc-spdu-ctl = callPackage ../tools/networking/zs-apc-spdu-ctl { };
 
+  zstxtns-utils = callPackage ../tools/text/zstxtns-utils { };
+
   zsh-autoenv = callPackage ../tools/misc/zsh-autoenv { };
 
   zsh-autopair = callPackage ../shells/zsh/zsh-autopair { };


### PR DESCRIPTION
###### Motivation for this change

Adding a utility I use on some servers and workplace machines to merge text databases (e.g. `/etc/passwd`, `/etc/group`) from multiple sources.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
