### PR TITLE
pyupgrade: init at 2.10.0

### DIFF
--- a/pkgs/development/python-modules/pyupgrade/default.nix
+++ b/pkgs/development/python-modules/pyupgrade/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, lib
+, pytestCheckHook
+, tokenize-rt
+}:
+
+buildPythonPackage rec {
+  pname = "pyupgrade";
+  version = "2.10.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "asottile";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-XYeqyyfwtS7dHLxeVvmcifW6UCOlnSMxqF1vxezBjT8=";
+  };
+
+  checkInputs =  [ pytestCheckHook ];
+
+  propagatedBuildInputs = [ tokenize-rt ];
+
+  meta = with lib; {
+    description = "A tool to automatically upgrade syntax for newer versions of the language";
+    homepage    = "https://github.com/asottile/pyupgrade";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/development/python-modules/tokenize-rt/default.nix
+++ b/pkgs/development/python-modules/tokenize-rt/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, lib
+, fetchFromGitHub
+, isPy27
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "tokenize-rt";
+  version = "4.1.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "asottile";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-9qamHk2IZRmgGNFlYkSRks6mRVNlYfetpK/7rsfK9tc=";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "A wrapper around the stdlib `tokenize` which roundtrips";
+    homepage = "https://github.com/asottile/tokenize-rt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29430,6 +29430,8 @@ in
 
   pyload = callPackage ../applications/networking/pyload {};
 
+  pyupgrade = with python3Packages; toPythonApplication pyupgrade;
+
   pwntools = with python3Packages; toPythonApplication pwntools;
 
   uae = callPackage ../misc/emulators/uae { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7974,6 +7974,8 @@ in {
 
   tokenizers = disabledIf (!isPy3k) (toPythonModule (callPackage ../development/python-modules/tokenizers { }));
 
+  tokenize-rt = disabledIf (!isPy3k) (toPythonModule (callPackage ../development/python-modules/tokenize-rt { }));
+
   tokenlib = callPackage ../development/python-modules/tokenlib { };
 
   tokenserver = callPackage ../development/python-modules/tokenserver { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6638,6 +6638,8 @@ in {
 
   pyupdate = callPackage ../development/python-modules/pyupdate { };
 
+  pyupgrade = callPackage ../development/python-modules/pyupgrade { };
+
   pyusb = callPackage ../development/python-modules/pyusb { libusb1 = pkgs.libusb1; };
 
   pyutil = callPackage ../development/python-modules/pyutil { };


### PR DESCRIPTION
###### Motivation for this change
I need these packages at work.

###### Things done
```
- python3Packages.tokenize-rt: init at 4.1.0
- pyupgrade: init at 2.10.0
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
