### PR TITLE
libtorch-bin: 1.7.1 -> 1.8.0

### DIFF
--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -18,7 +18,7 @@ let
   # this derivation. However, we should ensure on version bumps
   # that the CUDA toolkit for `passthru.tests` is still
   # up-to-date.
-  version = "1.7.1";
+  version = "1.8.0";
   device = if cudaSupport then "cuda" else "cpu";
   srcs = import ./binary-hashes.nix version;
   unavailable = throw "libtorch is not available for this platform";

--- a/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
+++ b/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
@@ -1,14 +1,14 @@
 version: {
   x86_64-darwin-cpu = {
     url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-${version}.zip";
-    sha256 = "0n93r7bq6wjjxkczp8r5pjm1nvl75wns5higsvh7gsir0j6k7b5b";
+    hash = "sha256-V1lbztMB09wyWjdiJrwVwJ00DT8Kihy/TC2cKmdBLIE=";
   };
   x86_64-linux-cpu = {
     url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-${version}%2Bcpu.zip";
-    sha256 = "0gpcj90nxyc69p53jiqwamd4gi7wzssk29csxfsyxsrzg3h36s7z";
+    hash = "sha256-xBaNyI7eiQnSArHMITonrQQLZnZCZK/SWKOTWnxzdpc=";
   };
   x86_64-linux-cuda = {
     url = "https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-${version}.zip";
-    sha256 = "01z61ryrflq306x7ay97k2fqc2q2z9c4c1zcnjfzr6412vg4fjb8";
+    hash = "sha256-rNEyE4+jfeX7cU0aNYd5b0pZGYT0PNPnDnS1PIsrMeM=";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog:

https://github.com/pytorch/pytorch/releases/tag/v1.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
