### PR TITLE
uroboros: init at 20210304-9bed95b

### DIFF
--- a/pkgs/tools/system/uroboros/default.nix
+++ b/pkgs/tools/system/uroboros/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "uroboros";
+  version = "20210304-${lib.strings.substring 0 7 rev}";
+  rev = "9bed95bb4cc44cfd043e8ac192e788df379c7a44";
+
+  src = fetchFromGitHub {
+    owner = "evilsocket";
+    repo = pname;
+    inherit rev;
+    sha256 = "1a1bc2za2ppb7j7ibhykgxwivwmx7yq0593255jd55gl60r0l7i4";
+  };
+
+  vendorSha256 = "1ml3x00zzkwj1f76a4wk2y8z4bxjhadf2p1li96qjpnc8fgfd50l";
+
+  meta = with lib; {
+    description = "Tool for monitoring and profiling single processes";
+    homepage = "https://github.com/evilsocket/uroboros";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25625,6 +25625,8 @@ in
 
   urh = callPackage ../applications/radio/urh { };
 
+  uroboros = callPackage ../tools/system/uroboros { };
+
   uuagc = haskell.lib.justStaticExecutables haskellPackages.uuagc;
 
   uucp = callPackage ../tools/misc/uucp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool for monitoring and profiling single processes

> While utilities like top, ps and htop provide great overall details, they often lack useful temporal representation for specific processes, such visual representation of the process data points can be used to profile, debug and generally monitor its good health. There are tools like psrecord that can record some of the activity of a process, but some graphical server is required for rendering, and it's neither complete nor realtime.
>
> Uroboros aims to fill this gap by providing a single tool to record, replay and render in realtime process runtime information in the terminal, without affecting the process performances like more invasive ptrace based solutions would do.

https://github.com/evilsocket/uroboros

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
