### PR TITLE
ocamlPackages.zarith: 1.11 → 1.12

### DIFF
--- a/pkgs/development/compilers/opa/default.nix
+++ b/pkgs/development/compilers/opa/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "1qs91rq9xrafv2mf2v415k8lv91ab3ycz0xkpjh1mng5ca3pjlf3";
   };
 
-  patches = [ ./ocaml-4.03.patch ];
+  patches = [ ./ocaml-4.03.patch ./ocaml-4.04.patch ];
 
   # Paths so the opa compiler code generation will use the same programs as were
   # used to build opa.

--- a/pkgs/development/compilers/opa/ocaml-4.04.patch
+++ b/pkgs/development/compilers/opa/ocaml-4.04.patch
@@ -1,0 +1,75 @@
+diff --git a/compiler/libbsl/bslLib.ml b/compiler/libbsl/bslLib.ml
+index b9f75bd1..171af065 100644
+--- a/compiler/libbsl/bslLib.ml
++++ b/compiler/libbsl/bslLib.ml
+@@ -726,7 +726,7 @@ struct
+       let root elt = !(elt.root)
+       let elt_name elt = elt.name
+       let elts e = e
+-      let children = List.map (fun e -> e.name, e)
++      let children m = List.map (fun e -> e.name, e) m
+       let is_root e = Path.is_root e.pwd
+ 
+       let parent e =
+diff --git a/compiler/passes/surfaceAstDependencies.ml b/compiler/passes/surfaceAstDependencies.ml
+index f4354a3f..81253d32 100644
+--- a/compiler/passes/surfaceAstDependencies.ml
++++ b/compiler/passes/surfaceAstDependencies.ml
+@@ -66,7 +66,6 @@ open SurfaceAst
+ 
+ (* shorthands *)
+ module SAH = SurfaceAstHelper
+-module C = SurfaceAstCons.ExprIdentCons
+ module D = SurfaceAstDecons
+ module S = SurfaceAst
+ 
+diff --git a/compiler/passes/surfaceAstPasses.ml b/compiler/passes/surfaceAstPasses.ml
+index 10edf5cb..00de59fa 100644
+--- a/compiler/passes/surfaceAstPasses.ml
++++ b/compiler/passes/surfaceAstPasses.ml
+@@ -25,7 +25,6 @@ open SurfaceAstPassesTypes
+ 
+ (* alias *)
+ module C = SurfaceAstCons.ExprIdentCons
+-module CS = SurfaceAstCons.StringCons
+ 
+ 
+ 
+diff --git a/compiler/qmlslicer/qmlSimpleSlicer.ml b/compiler/qmlslicer/qmlSimpleSlicer.ml
+index 2eebd96b..04ce77c8 100644
+--- a/compiler/qmlslicer/qmlSimpleSlicer.ml
++++ b/compiler/qmlslicer/qmlSimpleSlicer.ml
+@@ -17,7 +17,6 @@
+ *)
+ module Format = Base.Format
+ module List = Base.List
+-module String = Base.String
+ module Q = QmlAst
+ module Package = ObjectFiles.Package
+ 
+diff --git a/ocamllib/libbase/baseObj.mli b/ocamllib/libbase/baseObj.mli
+index da2d9736..82d72963 100644
+--- a/ocamllib/libbase/baseObj.mli
++++ b/ocamllib/libbase/baseObj.mli
+@@ -21,7 +21,7 @@ type t = Obj.t
+ external repr : 'a -> t = "%identity"
+ external obj : t -> 'a = "%identity"
+ external magic : 'a -> 'b = "%identity"
+-external is_block : t -> bool = "caml_obj_is_block"
++val [@inline always] is_block : t -> bool
+ external is_int : t -> bool = "%obj_is_int"
+ external tag : t -> int = "caml_obj_tag"
+ external set_tag : t -> int -> unit = "caml_obj_set_tag"
+diff --git a/ocamllib/libbase/baseString.ml b/ocamllib/libbase/baseString.ml
+index 640ce2fa..6931c608 100644
+--- a/ocamllib/libbase/baseString.ml
++++ b/ocamllib/libbase/baseString.ml
+@@ -20,7 +20,7 @@
+ (* depends *)
+ module Char = BaseChar
+ 
+-include Bytes
++include String
+ 
+ let compare_int (a:int) b = Pervasives.compare a b
+ 

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -1,31 +1,26 @@
-{ lib, stdenv, fetchurl
-, ocaml, findlib, pkg-config, perl
+{ lib, stdenv, fetchFromGitHub
+, ocaml, findlib, pkg-config
 , gmp
 }:
 
-let source =
-  if lib.versionAtLeast ocaml.version "4.02"
-  then {
-    version = "1.11";
-    url = "https://github.com/ocaml/Zarith/archive/release-1.11.tar.gz";
-    sha256 = "111n33flg4aq5xp5jfksqm4yyz6mzxx9ps9a4yl0dz8h189az5pr";
-  } else {
-    version = "1.3";
-    url = "http://forge.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz";
-    sha256 = "1mx3nxcn5h33qhx4gbg0hgvvydwlwdvdhqcnvfwnmf9jy3b8frll";
-  };
-in
+if !lib.versionAtLeast ocaml.version "4.04"
+then throw "zarith is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-zarith-${version}";
-  inherit (source) version;
-  src = fetchurl { inherit (source) url sha256; };
+  pname = "ocaml${ocaml.version}-zarith";
+  version = "1.12";
+  src = fetchFromGitHub {
+    owner = "ocaml";
+    repo = "Zarith";
+    rev = "release-${version}";
+    sha256 = "1jslm1rv1j0ya818yh23wf3bb6hz7qqj9pn5fwl45y9mqyqa01s9";
+  };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ocaml findlib perl ];
+  buildInputs = [ ocaml findlib ];
   propagatedBuildInputs = [ gmp ];
 
-  patchPhase = "patchShebangs ./z_pp.pl";
   dontAddPrefix = true;
   configureFlags = [ "-installdir ${placeholder "out"}/lib/ocaml/${ocaml.version}/site-lib" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10795,7 +10795,7 @@ in
   ocsigen-i18n = callPackage ../development/tools/ocaml/ocsigen-i18n { };
 
   opa = callPackage ../development/compilers/opa {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_03;
+    ocamlPackages = ocaml-ng.ocamlPackages_4_04;
   };
 
   opaline = callPackage ../development/tools/ocaml/opaline { };


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/ocaml/Zarith/releases/tag/release-1.12

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
