### PR TITLE
lorri: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -14,10 +14,10 @@
 
 let
   # Run `eval $(nix-build -A lorri.updater)` after updating the revision!
-  version = "1.2";
-  gitRev = "43a260c221d5dac4a44fd82271736c8444474eec";
-  sha256 = "0g6zq27dpr8bdan5xrqchybpbqwnhhc7x8sxbfygigbqd3xv9i6n";
-  cargoSha256 = "1zmlp14v7av0znmjyy2aq83lc74503p6r0l11l9iw7s3xad8rda4";
+  version = "1.3";
+  gitRev = "a26745e404c3a201fe98af4c000bb27f910542b1";
+  sha256 = "0gfkqvla2cphyhnl5xw19yf1v4pvwsvphr019y5r914cwqwnkb92";
+  cargoSha256 = "1a1alhpivlmxy8iv0ki7s0b8hf3hadashf81rzn207wn3yihsnaf";
 
 in (rustPlatform.buildRustPackage rec {
   pname = "lorri";
@@ -25,13 +25,13 @@ in (rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Your project's nix-env";
-    homepage = "https://github.com/target/lorri";
+    homepage = "https://github.com/nix-community/lorri";
     license = licenses.asl20;
     maintainers = with maintainers; [ grahamc Profpatsch ];
   };
 
   src = fetchFromGitHub {
-    owner = "target";
+    owner = "nix-community";
     repo = pname;
     rev = gitRev;
     inherit sha256;


### PR DESCRIPTION
We forked lorri to nix-community, so this release also moves us over
to the new official repository.

Release notes:

Fix the build loop.

Previously, any change (for example a direnv ping or a change in the
nix files) would add a new build invocation to the queue, and the
builds would all be done one after the other.

However, a new build will always use the newest state of the files
anyway, so the CPU time spent on all the other builds will be
wasted (and hog your processor).

Now lorri will only

    finish the current build (if running)
    schedule at maximum one additional build if requested

This should improve the resource use drastically in some situations.

---

Make lorri daemon exit with exit code 0 instead of 130/143 on
SIGINT or SIGTERM.

---

Add lorri self-upgrade branch sub-subcommand.
This enables us to point users to a branch name, in order to test out
fixes from repository branches.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
