### PR TITLE
ocamlPackages.asn1-combinators: 0.2.4 -> 0.2.5

### DIFF
--- a/pkgs/development/ocaml-modules/asn1-combinators/default.nix
+++ b/pkgs/development/ocaml-modules/asn1-combinators/default.nix
@@ -6,13 +6,13 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.05";
 
   pname = "asn1-combinators";
-  version = "0.2.4";
+  version = "0.2.5";
 
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v${version}/asn1-combinators-v${version}.tbz";
-    sha256 = "09rn5wwqhwg7x51b9ycl15s7007hgha6lwaz2bpw85fr70jq3i9r";
+    sha256 = "1pbcdwm12hnfpd1jv2b7cjfkj5r7h61xp2gr8dysb8waa455kwln";
   };
 
   propagatedBuildInputs = [ cstruct zarith bigarray-compat stdlib-shims ptime ];


### PR DESCRIPTION
Contains a single bug fix, resolving an integer overflow.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
