### PR TITLE
python3Packages.pandas: 1.1.5 → 1.2.3

### DIFF
--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -28,14 +28,12 @@
 
 buildPythonPackage rec {
   pname = "pandas";
-  version = "1.1.5";
+  version = "1.2.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "06vhk75hmzgv1sfbjzgnsw9x10h7y6bd6s6z7d6lfnn7wcgc83zi";
+    sha256 = "sha256-328QuFrveluyUlmtZRrRzB1rsJAAWVyrR+cYy6wlCx0=";
   };
-  # See https://github.com/scipy/scipy/issues/13585 and https://github.com/pandas-dev/pandas/pull/40020
-  patches = [ ./fix-tests.patch ];
 
   nativeBuildInputs = [ cython ];
   buildInputs = lib.optional stdenv.isDarwin libcxx;
@@ -104,6 +102,10 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     "test_locale"
     "test_clipboard"
+  ];
+
+  disabledTestPaths = [
+    "tests/io"
   ];
 
   # tests have relative paths, and need to reference compiled C extensions


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done



- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
