### PR TITLE
cython: 0.29.21 -> 0.29.22, backport Cython 3.0 trashcan support

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -49,6 +49,15 @@ in buildPythonPackage rec {
       url = "https://github.com/cython/cython/commit/28251032f86c266065e4976080230481b1a1bb29.patch";
       sha256 = "19rg7xs8gr90k3ya5c634bs8gww1sxyhdavv07cyd2k71afr83gy";
     })
+
+    # backport Cython 3.0 trashcan support (https://github.com/cython/cython/pull/2842) to 0.X series.
+    # it does not affect Python code unless the code explicitly uses the feature.
+    # trashcan support is needed to avoid stack overflows during object deallocation in sage (https://trac.sagemath.org/ticket/27267)
+    (fetchpatch {
+      name = "trashcan.patch";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/cython/patches/trashcan.patch?id=4569a839f070a1a38d5dbce2a4d19233d25aeed2";
+      sha256 = "sha256-+pOF1XNTEtNseLpqPzrc1Jfwt5hGx7doUoccIhNneYY=";
+    })
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -26,11 +26,11 @@ let
 
 in buildPythonPackage rec {
   pname = "Cython";
-  version = "0.29.21";
+  version = "0.29.22";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1bcwpra7c6k30yvic3sw2v3rq2dr40ypc4zqif6kr52mpn4wnyp5";
+    sha256 = "sha256-32uDx6bR2WfqiaKQPkqTE3djSil0WWUuRVFzTEgZVAY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Users of Sage [may get random stack overflows on large object deallocations without this patch](https://trac.sagemath.org/ticket/27267). It backports [Cython 3.0 trashcan support](https://github.com/cython/cython/pull/2842) to Cython 0.X.

This patch does not affect Python code unless the code explicitly uses the feature, which is both an argument for patching the global Cython (it's fairly safe) and for making sage use a modified Cython, since only a modified cypari2 will use this change. Just let me know if applying the patch globally is a bad idea, I won't be offended :) In fact, I didn't run nixpkgs-review because it rebuilds everything that uses Python.

(I can also just work around the Sage test failure instead of applying the patch at all, but users can still sporadically hit the problem during normal use.)

cc @omasanori @timokau This is causing the totallyreal.pyx aarch64 failure in the dependency update PR, I believe.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
