### PR TITLE
python3Packages.python-nmap: init at 0.6.4

### DIFF
--- a/pkgs/development/python-modules/python-nmap/default.nix
+++ b/pkgs/development/python-modules/python-nmap/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nmap
+}:
+
+buildPythonPackage rec {
+  pname = "python-nmap";
+  version = "0.6.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "013q2797d9sf6mrj7x1hqfcql5gqgg50zgiifp2yypfa4k8cwjsx";
+  };
+
+  propagatedBuildInputs = [ nmap ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "universal=3" "universal=1"
+  '';
+
+  # Tests requires sudo and performs scans
+  doCheck = false;
+  pythonImportsCheck = [ "nmap" ];
+
+  meta = with lib; {
+    description = "Python library which helps in using nmap";
+    longDescription = ''
+      python-nmap is a Python library which helps in using nmap port scanner. It
+      allows to easily manipulate nmap scan results and will be a perfect tool
+      for systems administrators who want to automatize scanning task and reports.
+      It also supports nmap script outputs.
+    '';
+    homepage = "http://xael.org/pages/python-nmap-en.html";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -549,7 +549,7 @@
     "niko_home_control" = ps: with ps; [ ]; # missing inputs: niko-home-control
     "nilu" = ps: with ps; [ ]; # missing inputs: niluclient
     "nissan_leaf" = ps: with ps; [ ]; # missing inputs: pycarwings2
-    "nmap_tracker" = ps: with ps; [ getmac ]; # missing inputs: python-nmap
+    "nmap_tracker" = ps: with ps; [ getmac python-nmap ];
     "nmbs" = ps: with ps; [ ]; # missing inputs: pyrail
     "no_ip" = ps: with ps; [ ];
     "noaa_tides" = ps: with ps; [ ]; # missing inputs: noaa-coops

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6493,6 +6493,8 @@ in {
       inherit (pkgs) pkg-config;
     };
 
+  python-nmap = callPackage ../development/python-modules/python-nmap { };
+
   python-nomad = callPackage ../development/python-modules/python-nomad { };
 
   python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
python-nmap is a Python library which helps in using nmap port scanner. It
allows to easily manipulate nmap scan results and will be a perfect tool
for systems administrators who want to automatize scanning task and reports.
It also supports nmap script outputs.

http://xael.org/pages/python-nmap-en.html

Related to #81418 and a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
