### PR TITLE
sieveshell: 0.6 -> 0.7

### DIFF
--- a/pkgs/development/python-modules/managesieve/default.nix
+++ b/pkgs/development/python-modules/managesieve/default.nix
@@ -1,8 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pytestrunner
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -14,11 +13,7 @@ buildPythonPackage rec {
     sha256 = "1dx0j8hhjwip1ackaj2m4hqrrx2iiv846ic4wa6ymrawwb8iq8m6";
   };
 
-  checkInputs = [ pytestrunner pytest ];
-
-  checkPhase = ''
-    pytest
-  '';
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "ManageSieve client library for remotely managing Sieve scripts";

--- a/pkgs/development/python-modules/managesieve/default.nix
+++ b/pkgs/development/python-modules/managesieve/default.nix
@@ -7,20 +7,24 @@
 
 buildPythonPackage rec {
   pname = "managesieve";
-  version = "0.6";
+  version = "0.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ee70e298e9b68eb81f93d52a1320a034fdc182f3927fdd551836fc93b0ed2c5f";
+    sha256 = "1dx0j8hhjwip1ackaj2m4hqrrx2iiv846ic4wa6ymrawwb8iq8m6";
   };
 
   checkInputs = [ pytestrunner pytest ];
 
+  checkPhase = ''
+    pytest
+  '';
+
   meta = with lib; {
     description = "ManageSieve client library for remotely managing Sieve scripts";
-    homepage    = "https://managesieve.readthedocs.io/";
-    # PSFL for the python module, GPLv3 for sieveshell
-    license     = with licenses; [ gpl3 psfl ];
+    homepage = "https://managesieve.readthedocs.io/";
+    # PSFL for the python module, GPLv3 only for sieveshell
+    license = with licenses; [ gpl3Only psfl ];
     maintainers = with maintainers; [ dadada ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

0.7 (2021-03-05)
----------------

:sieveshell:

   - For ``get`` and ``put`` expand ``~`` and ``~user`` constructions in
     `filename` . For ``put``, if script-name is not given, the file's
     basename is used.

:managesieve:
   - Fix error when constructing debug error message.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
