### PR TITLE
xdg-desktop-portal-wlr: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
@@ -1,20 +1,24 @@
 { lib, stdenv, fetchFromGitHub
 , meson, ninja, pkg-config, wayland-protocols
-, pipewire, wayland, elogind, systemd, libdrm }:
+, pipewire, wayland, systemd, libdrm }:
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal-wlr";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = pname;
     rev = "v${version}";
-    sha256 = "12k92h9dmn1fyn8nzxk69cyv0gnb7g9gj7a66mw5dcl5zqnl07nc";
+    sha256 = "1vjz0y3ib1xw25z8hl679l2p6g4zcg7b8fcd502bhmnqgwgdcsfx";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config wayland-protocols ];
-  buildInputs = [ pipewire wayland elogind systemd libdrm ];
+  buildInputs = [ pipewire wayland systemd libdrm ];
+
+  mesonFlags = [
+    "-Dsd-bus-provider=libsystemd"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/emersion/xdg-desktop-portal-wlr";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
