### PR TITLE
libfaketime: use date from nix store

### DIFF
--- a/pkgs/development/libraries/libfaketime/default.nix
+++ b/pkgs/development/libraries/libfaketime/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, perl }:
+{ lib, stdenv, fetchurl, perl, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "libfaketime";
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./no-date-in-gzip-man-page.patch
+    ./nix-store-date.patch
   ] ++ (lib.optionals stdenv.cc.isClang [
     # https://github.com/wolfcw/libfaketime/issues/277
     ./0001-Remove-unsupported-clang-flags.patch
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec {
       substituteInPlace $a \
         --replace /bin/bash ${stdenv.shell}
     done
+    substituteInPlace src/faketime.c --replace @DATE_CMD@ ${coreutils}/bin/date
   '';
 
   PREFIX = placeholder "out";

--- a/pkgs/development/libraries/libfaketime/nix-store-date.patch
+++ b/pkgs/development/libraries/libfaketime/nix-store-date.patch
@@ -1,0 +1,29 @@
+From abd7dd05b440e3dc9621a1579e4afb0267897d9c Mon Sep 17 00:00:00 2001
+From: Finn Behrens <me@kloenk.de>
+Date: Fri, 5 Mar 2021 21:58:57 +0100
+Subject: [PATCH] use nix date path
+
+---
+ src/faketime.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/src/faketime.c b/src/faketime.c
+index af618f2..48e47da 100644
+--- a/src/faketime.c
++++ b/src/faketime.c
+@@ -50,11 +50,7 @@
+ 
+ const char version[] = "0.9.9";
+ 
+-#ifdef __APPLE__
+-static const char *date_cmd = "gdate";
+-#else
+-static const char *date_cmd = "date";
+-#endif
++static const char *date_cmd = "@DATE_CMD@";
+ 
+ #define PATH_BUFSIZE 4096
+ 
+-- 
+2.24.3 (Apple Git-128)
+


### PR DESCRIPTION
###### Motivation for this change
This fixes the following error under Darwin:
~~~
faketime: Running (g)date failed: No such file or directory
Error: Timestamp to fake not recognized, please re-try with a different timestamp.
~~~

###### Things done
use the nix-store date for fake time

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @petabyteboy 
