### PR TITLE
python3Packages.py-cpuinfo: add sysctl to runtime dependencies

### DIFF
--- a/pkgs/development/python-modules/py-cpuinfo/default.nix
+++ b/pkgs/development/python-modules/py-cpuinfo/default.nix
@@ -1,7 +1,9 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , buildPythonPackage
 , pytestCheckHook
+, sysctl
 }:
 
 buildPythonPackage rec {
@@ -14,6 +16,13 @@ buildPythonPackage rec {
      rev = "v${version}";
      sha256 = "10qfaibyb2syiwiyv74l7d97vnmlk079qirgnw3ncklqjs0s3gbi";
   };
+
+  # On Darwin sysctl is used to read CPU information.
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace cpuinfo/cpuinfo.py \
+      --replace "len(_program_paths('sysctl')) > 0" "True" \
+      --replace "_run_and_get_stdout(['sysctl'" "_run_and_get_stdout(['${sysctl}/bin/sysctl'"
+  '';
 
   checkInputs = [
     pytestCheckHook


### PR DESCRIPTION
###### Motivation for this change

There is a test a new version that caught the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).