### PR TITLE
[20.09] apacheHttpdPackages.mod_auth_mellon: 0.13.1 -> 0.17.0

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
 
   pname = "mod_auth_mellon";
-  version = "0.13.1";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
-    owner = "UNINETT";
+    owner = "latchset";
     repo = "mod_auth_mellon";
     rev = "v${version}";
-    sha256 = "16b43y5a5p8g1287x04rv923230cy8dfs2j18cx6208n4bv4dvnk";
+    sha256 = "03bkvqkmqq72ff1a8cpvpcxngnlz1p6433y2fkkynpjfr19cna2s";
   };
 
   patches = [

--- a/pkgs/servers/http/apache-modules/mod_auth_mellon/fixdeps.patch
+++ b/pkgs/servers/http/apache-modules/mod_auth_mellon/fixdeps.patch
@@ -1,8 +1,23 @@
+diff --git a/Makefile.in b/Makefile.in
+index 1388c91..ab28982 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -42,7 +42,7 @@ DISTFILES=$(SRC) \
+ all:	mod_auth_mellon.la
+ 
+ mod_auth_mellon.la: $(SRC) auth_mellon.h auth_mellon_compat.h
+-	@APXS2@ -Wc,"-std=c99 @MELLON_CFLAGS@ @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@ @CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
++	@APXS2@ -Wc,"-std=c99 @MELLON_CFLAGS@ @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@ @CFLAGS@ @LIBXML2_CFLAGS@ @XMLSEC_CFLAGS@ @CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@ @LIBXML2_LIBS@ @XMLSEC_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
+ 
+ 
+ # Building configure (for distribution)
+diff --git a/configure.ac b/configure.ac
+index 421b952..e62768e 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -74,6 +74,16 @@ PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.12])
- AC_SUBST(GLIB_CFLAGS)
- AC_SUBST(GLIB_LIBS)
+@@ -91,6 +91,16 @@ AC_SUBST(GLIB_LIBS)
+ 
+ AC_SUBST(MELLON_CFLAGS)
  
 +#include <libxml/uri.h>
 +PKG_CHECK_MODULES(LIBXML2, libxml-2.0)
@@ -17,14 +32,3 @@
  # Test to see if we can include lasso/utils.h
  # AC_CHECK_HEADER won't work correctly unless we specifiy the include directories
  # found in the LASSO_CFLAGS. Save and restore CFLAGS and CPPFLAGS.
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -25,7 +25,7 @@
- all:	mod_auth_mellon.la
- 
- mod_auth_mellon.la: $(SRC) auth_mellon.h auth_mellon_compat.h
--	@APXS2@ -Wc,"-std=c99 @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@ @CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
-+	@APXS2@ -Wc,"-std=c99 @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@ @CFLAGS@ @LIBXML2_CFLAGS@ @XMLSEC_CFLAGS@ @CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@ @LIBXML2_LIBS@ @XMLSEC_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
- 
- 
- # Building configure (for distribution)


### PR DESCRIPTION
(cherry picked from commit 90649bacfbc4fd5a8d77f23135d34bc69ca10229)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Backport of https://github.com/NixOS/nixpkgs/pull/115135, closes https://github.com/NixOS/nixpkgs/issues/93102.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
