### PR TITLE
zs-wait4host: init at 0.3.2

### DIFF
--- a/pkgs/tools/networking/zs-wait4host/default.nix
+++ b/pkgs/tools/networking/zs-wait4host/default.nix
@@ -1,0 +1,36 @@
+{ bash, coreutils, fetchurl, fping, lib, stdenvNoCC }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "zs-wait4host";
+  version = "0.3.2";
+
+  src = fetchurl {
+    url = "https://ytrizja.de/distfiles/${pname}-${version}.tar.gz";
+    sha256 = "9F1264BDoGlRR7bWlRXhfyvxWio4ydShKmabUQEIz9I=";
+  };
+
+  buildInputs = [ bash coreutils fping ];
+
+  postPatch = ''
+    for i in zs-wait4host zs-wait4host-inf; do
+      substituteInPlace "$i" \
+        --replace '$(zs-guess-fping)' '${fping}/bin/fping' \
+        --replace ' sleep ' ' ${coreutils}/bin/sleep ' \
+        --replace '[ "$FPING" ] || exit 1' ""
+    done
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -t $out/bin zs-wait4host zs-wait4host-inf
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Wait for a host to come up/go down";
+    homepage = "https://ytrizja.de/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zseri ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9400,6 +9400,8 @@ in
 
   zs-apc-spdu-ctl = callPackage ../tools/networking/zs-apc-spdu-ctl { };
 
+  zs-wait4host = callPackage ../tools/networking/zs-wait4host { };
+
   zstxtns-utils = callPackage ../tools/text/zstxtns-utils { };
 
   zsh-autoenv = callPackage ../tools/misc/zsh-autoenv { };


### PR DESCRIPTION
###### Motivation for this change

Adding a utility I use on some servers and workplace machines to wait for other hosts to come up/down (checked via fping). This is a set of sh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
