### PR TITLE
python3Packages.trustme: skip disallowed w+x test on aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/trustme/default.nix
+++ b/pkgs/development/python-modules/trustme/default.nix
@@ -1,12 +1,13 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , isPy3k
 , cryptography
 , futures ? null
-, pytest
 , pyopenssl
 , service-identity
+, pytestCheckHook
 , idna
 }:
 
@@ -20,9 +21,9 @@ buildPythonPackage rec {
   };
 
   checkInputs = [
-    pytest
     pyopenssl
     service-identity
+    pytestCheckHook
   ];
 
   propagatedBuildInputs = [
@@ -32,9 +33,11 @@ buildPythonPackage rec {
     futures
   ];
 
-  checkPhase = ''
-    pytest
-  '';
+  # aarch64-darwin forbids W+X memory, but this tests depends on it:
+  # * https://github.com/pyca/pyopenssl/issues/873
+  disabledTests = lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+    "test_pyopenssl_end_to_end"
+  ];
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
###### Motivation for this change

Another one to help #105026.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).