### PR TITLE
[20.09] re2c: fix CVE-2018-21232

### DIFF
--- a/pkgs/development/tools/parsing/re2c/default.nix
+++ b/pkgs/development/tools/parsing/re2c/default.nix
@@ -13,6 +13,30 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
+      name = "CVE-2018-21232-part1.patch";
+      url = "https://github.com/skvadrik/re2c/commit/fd634998f813340768c333cdad638498602856e5.patch";
+      sha256 = "1blyg5lyhqd4ymisih65xl0g36ig71ijia4skkkd59rdvj78aiw6";
+    })
+
+    (fetchpatch {
+      name = "CVE-2018-21232-part2.patch";
+      url = "https://github.com/skvadrik/re2c/commit/7b5643476bd99c994c4f51b8143f942982d85521.patch";
+      sha256 = "0rhmgqrinpk49r9x75ygrs14lz72aw5ad5kr6qp9bdyl8gs082qp";
+    })
+
+    (fetchpatch {
+      name = "CVE-2018-21232-part3.patch";
+      url = "https://github.com/skvadrik/re2c/commit/4d9c809355b574f2a58eac119f5e076c48e4d1e2.patch";
+      sha256 = "0k86wg9icw1gkqpf7rq2w6xsq4caxw3rc0zfxf39liwa35027rai";
+    })
+
+    (fetchpatch {
+      name = "CVE-2018-21232-part4.patch";
+      url = "https://github.com/skvadrik/re2c/commit/89be91f3df00657261870adbc590209fdb2bc405.patch";
+      sha256 = "1aygy9va7jwby93chlskwg7z90fn07x5hym0gziwlkx8k900p3a3";
+    })
+
+    (fetchpatch {
       name = "CVE-2020-11958.patch";
       url = "https://github.com/skvadrik/re2c/commit/c4603ba5ce229db83a2a4fb93e6d4b4e3ec3776a.patch";
       sha256 = "1d95ahxk92g7k87sda9gxgmr3blyfzwd2y7h9jxj8zkd74knd9zh";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See #114391 for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
