### PR TITLE
Fix shebangs in auto-generated android toolchain scripts.

### DIFF
--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -14,6 +14,10 @@ deployAndroidPackage {
   patchInstructions = lib.optionalString (os == "linux") (''
     patchShebangs .
 
+    # Fix the shebangs of the auto-generated scripts.
+    substituteInPlace $(pwd)/build/tools/make_standalone_toolchain.py \
+      --replace '#!/bin/bash' '#!${pkgs.bash}/bin/bash'
+
   '' + lib.optionalString (builtins.compareVersions (lib.getVersion package) "21" > 0) ''
     patch -p1 \
       --no-backup-if-mismatch < ${./make_standalone_toolchain.py_18.patch} || true

--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -15,13 +15,13 @@ deployAndroidPackage {
     patchShebangs .
 
     # Fix the shebangs of the auto-generated scripts.
-    substituteInPlace $(pwd)/build/tools/make_standalone_toolchain.py \
+    substituteInPlace ./build/tools/make_standalone_toolchain.py \
       --replace '#!/bin/bash' '#!${pkgs.bash}/bin/bash'
 
   '' + lib.optionalString (builtins.compareVersions (lib.getVersion package) "21" > 0) ''
     patch -p1 \
       --no-backup-if-mismatch < ${./make_standalone_toolchain.py_18.patch} || true
-    wrapProgram $(pwd)/build/tools/make_standalone_toolchain.py --prefix PATH : "${runtime_paths}"
+    wrapProgram ./build/tools/make_standalone_toolchain.py --prefix PATH : "${runtime_paths}"
   '' + ''
 
     # TODO: allow this stuff


### PR DESCRIPTION
###### Motivation for this change

This PR patches the ``make_standalone_toolchain.py`` file that is shipped with Android NDK. The file is already modified explicitly [here](https://github.com/NixOS/nixpkgs/blob/6aa26c8623b5f91c5a7e9fd9c82ed08c3066b905/pkgs/development/mobile/androidenv/ndk-bundle/default.nix#L19) and implicitly [here](https://github.com/NixOS/nixpkgs/blob/6aa26c8623b5f91c5a7e9fd9c82ed08c3066b905/pkgs/development/mobile/androidenv/ndk-bundle/default.nix#L15).

The file is responsible for creating shell scripts on the fly. These scripts get a hardcoded shebang of ``#!/bin/bash``. This PR modifies this shebang in order to use ``{pkgs.bash}/bin/bash``.

The following derivation reproduces the issue & the fix

```nix
# DOESN'T WORK:
{ pkgs ? import (builtins.fetchTarball {
  name = "nixpkgs-unstable-2021-01-27";
  url =
    "https://github.com/NixOS/nixpkgs/archive/652b2d6dba246abd696bc6f2cb8b30032ed4fb56.tar.gz";
  sha256 = "1l5wk1y04gmv3zikyb9g04j8c5525h8q62ymhhm0b8p4ny27c962";
}) { config.android_sdk.accept_license = true; } }:
# WORKS:
#{ pkgs ? import (builtins.fetchTarball {
#  name = "rolfschr_colon_android-fix-shebang-in-make-standalone-toolchain";
#  url =
#    "https://github.com/NixOS/nixpkgs/archive/2985284ccbff8f9774079ce2d7f02cf328776705.tar.gz";
#  sha256 = "sha256:06bkbmi26k9wigsc2jan1j41lbx4vfln2bl4w9b9r0pfb8rbyxp7";
#}) { config.android_sdk.accept_license = true; } }:

with pkgs;

let
  sdk = pkgs.androidenv.composeAndroidPackages {
    buildToolsVersions = [ "28.0.3" ];
    platformVersions = [ "28" "29" ];
    abiVersions = [ "x86" "x86_64" "armeabi-v7a" ];
    includeNDK = true;
    ndkVersion = "22.0.7026061";
  };

  ndk = sdk.ndk-bundle;

  # Use stdenvNoCC because gcc should not interfere with the Android toolchain
  # (dist-build/android-build.sh respects a previuosly set CC env variable).
in stdenvNoCC.mkDerivation rec {
  name = "libsodium-android";
  src = pkgs.libsodium.src;

  dontConfigure = true;

  ARCHS = "armv7-a";

  buildPhase = ''
    export ANDROID_NDK_HOME=${ndk}/libexec/android-sdk/ndk-bundle

    for arch in ${ARCHS} ; do
      LIBSODIUM_FULL_BUILD=1 ./dist-build/android-''${arch}.sh
    done
  '';

  installPhase = ''
    mkdir $out
    for arch in ${ARCHS} ; do
     cp -r libsodium-android-''${arch} $out
    done
  '';

}
```

Building the non-working version will fail like so:

```bash
$ nix --keep-failed --print-build-logs build -f default.nix
...
libsodium-android> checking for arm-linux-androideabi-gcc... arm-linux-androideabi-clang
libsodium-android> checking whether the C compiler works... no
libsodium-android> configure: error: in `/build/libsodium-1.0.18':
libsodium-android> configure: error: C compiler cannot create executables
libsodium-android> See `config.log' for more details
builder for '/nix/store/sdjs930c311cy9zd52rgn15z135hmnrp-libsodium-android.drv' failed with exit code 1; last 10 log lines:
  checking whether GID '100' is supported by ustar format... yes
  checking how to create a ustar tar archive... gnutar
  checking whether make supports nested variables... (cached) yes
  checking whether to enable maintainer-specific portions of Makefiles... no
  checking whether make supports the include directive... yes (GNU style)
  checking for arm-linux-androideabi-gcc... arm-linux-androideabi-clang
  checking whether the C compiler works... no
  configure: error: in `/build/libsodium-1.0.18':
  configure: error: C compiler cannot create executables
  See `config.log' for more details
error: --- Error ------------------------------------------------------------------------------------ nix
build of '/nix/store/sdjs930c311cy9zd52rgn15z135hmnrp-libsodium-android.drv' failed

$ grep -A 1 -B 5 'bin/bash' /tmp/nix-build-libsodium-android.drv-0/libsodium-1.0.18/config.log
configure:3389: result: yes (GNU style)
configure:3400: checking for arm-linux-androideabi-gcc
configure:3427: result: arm-linux-androideabi-clang
configure:3696: checking for C compiler version
configure:3705: arm-linux-androideabi-clang --version >&5
./configure: /build/libsodium-1.0.18/android-toolchain-armv7-a/bin/arm-linux-androideabi-clang: /bin/bash: bad interpreter: No such file or directory
configure:3716: $? = 126
configure:3705: arm-linux-androideabi-clang -v >&5
./configure: /build/libsodium-1.0.18/android-toolchain-armv7-a/bin/arm-linux-androideabi-clang: /bin/bash: bad interpreter: No such file or directory
configure:3716: $? = 126
configure:3705: arm-linux-androideabi-clang -V >&5
./configure: /build/libsodium-1.0.18/android-toolchain-armv7-a/bin/arm-linux-androideabi-clang: /bin/bash: bad interpreter: No such file or directory
configure:3716: $? = 126
configure:3705: arm-linux-androideabi-clang -qversion >&5
./configure: /build/libsodium-1.0.18/android-toolchain-armv7-a/bin/arm-linux-androideabi-clang: /bin/bash: bad interpreter: No such file or directory
configure:3716: $? = 126
configure:3736: checking whether the C compiler works
configure:3758: arm-linux-androideabi-clang -Os -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -marm -march=armv7-a   conftest.c  >&5
./configure: /build/libsodium-1.0.18/android-toolchain-armv7-a/bin/arm-linux-androideabi-clang: /bin/bash: bad interpreter: No such file or directory
configure:3762: $? = 126
--
PTHREAD_LIBS=''
RANLIB=''
SAFECODE_HOME=''
SED=''
SET_MAKE=''
SHELL='/nix/store/dskh7v2h3ly3kdkfk3xmjlqql1zr0hnw-bash-4.4-p23/bin/bash'
SODIUM_LIBRARY_MINIMAL_DEF=''

```
The working version will produce the desired output just fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
