### PR TITLE
python3Packages.datasets: 1.1.2 -> 1.4.1

### DIFF
--- a/pkgs/development/python-modules/datasets/default.nix
+++ b/pkgs/development/python-modules/datasets/default.nix
@@ -3,6 +3,8 @@
 , fetchFromGitHub
 , dill
 , filelock
+, fsspec
+, huggingface-hub
 , multiprocess
 , numpy
 , pandas
@@ -14,18 +16,20 @@
 
 buildPythonPackage rec {
   pname = "datasets";
-  version = "1.1.2";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = pname;
     rev = version;
-    hash = "sha256-upXZ2rOfmjnJbDo6RMGeHv/fe10RQAf/zwDWWKdt6SA=";
+    hash = "sha256-is8TS84varARWyfeDTbQH0pcYFTk0PcEyK183emB4GE=";
   };
 
   propagatedBuildInputs = [
     dill
     filelock
+    fsspec
+    huggingface-hub
     multiprocess
     numpy
     pandas
@@ -36,7 +40,9 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace setup.py --replace '"tqdm>=4.27,<4.50.0"' '"tqdm>=4.27"'
+    substituteInPlace setup.py \
+      --replace '"tqdm>=4.27,<4.50.0"' '"tqdm>=4.27"' \
+      --replace "huggingface_hub==0.0.2" "huggingface_hub>=0.0.2"
   '';
 
   # Tests require pervasive internet access.

--- a/pkgs/development/python-modules/huggingface-hub/default.nix
+++ b/pkgs/development/python-modules/huggingface-hub/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pythonOlder
+, filelock
+, importlib-metadata
+, requests
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "huggingface-hub";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "huggingface_hub";
+    rev = "v${version}";
+    hash = "sha256-0DSgWmodeRmvGq2v3n86BzRx5Xdb8fIQh+G/2O2d+yo=";
+  };
+
+  propagatedBuildInputs = [
+    filelock
+    requests
+    tqdm
+  ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+
+  # Tests require network access.
+  doCheck = false;
+  pythonImportsCheck = [ "huggingface_hub" ];
+
+   meta = with lib; {
+    homepage = "https://github.com/huggingface/huggingface_hub";
+    description = "Download and publish models and other files on the huggingface.co hub";
+    changelog = "https://github.com/huggingface/huggingface_hub/releases/tag/${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3072,6 +3072,8 @@ in {
 
   hug = callPackage ../development/python-modules/hug { };
 
+  huggingface-hub = callPackage ../development/python-modules/huggingface-hub { };
+
   humanfriendly = callPackage ../development/python-modules/humanfriendly { };
 
   humanize = callPackage ../development/python-modules/humanize { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update datasets to 1.4.1.

https://github.com/huggingface/datasets/releases/tag/1.3.0
https://github.com/huggingface/datasets/releases/tag/1.4.0
https://github.com/huggingface/datasets/releases/tag/1.4.1

Since datasets now also requires Huggingface's hub package, this PR
also adds `python3Packages.huggingface_hub`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
