### PR TITLE
libsForQt5.mauikit: init at 1.2.1

### DIFF
--- a/pkgs/applications/misc/index-fm/default.nix
+++ b/pkgs/applications/misc/index-fm/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, breeze-icons
+, karchive
+, kcoreaddons
+, ki18n
+, kio
+, kirigami2
+, mauikit
+, qtmultimedia
+, qtquickcontrols2
+}:
+
+mkDerivation rec {
+  pname = "index";
+  version = "1.2.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "maui";
+    repo = "index-fm";
+    rev = "v${version}";
+    sha256 = "1v6z44c88cqgr3b758yq6l5d2zj1vhlnaq7v8rrhs7s5dsimzlx8";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    breeze-icons
+    karchive
+    kcoreaddons
+    ki18n
+    kio
+    kirigami2
+    mauikit
+    qtmultimedia
+    qtquickcontrols2
+  ];
+
+  meta = with lib; {
+    description = "Multi-platform file manager";
+    homepage = "https://invent.kde.org/maui/index-fm";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/libraries/mauikit/default.nix
+++ b/pkgs/development/libraries/mauikit/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, kio
+, qtbase
+, qtquickcontrols2
+, syntax-highlighting
+}:
+
+mkDerivation rec {
+  pname = "mauikit";
+  version = "1.2.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "maui";
+    repo = "mauikit";
+    rev = "v${version}";
+    sha256 = "1wimbpbn9yqqdcjd59x83z0mw2fycjz09py2rwimfi8ldmvi5lgy";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kio
+    qtquickcontrols2
+    syntax-highlighting
+  ];
+
+  meta = with lib; {
+    homepage = "https://mauikit.org/";
+    description = "Free and modular front-end framework for developing fast and compelling user experiences";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ dotlambda ];
+    broken = lib.versionOlder qtbase.version "5.14.0";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23224,6 +23224,8 @@ in
   # Impressive, formerly known as "KeyJNote".
   impressive = callPackage ../applications/office/impressive { };
 
+  index-fm = libsForQt5.callPackage ../applications/misc/index-fm { };
+
   inkcut = libsForQt5.callPackage ../applications/misc/inkcut { };
 
   inkscape = callPackage ../applications/graphics/inkscape {

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -115,6 +115,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeApplications // qt5 // 
 
   kpmcore = callPackage ../development/libraries/kpmcore { };
 
+  mauikit = callPackage ../development/libraries/mauikit { };
+
   mlt = callPackage ../development/libraries/mlt/qt-5.nix { };
 
   openbr = callPackage ../development/libraries/openbr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Maybe use it on my PinePhone one day.

Questions I have:
* Should I fetch the source from https://download.kde.org/stable/maui/ instead?
* Should I include all dependencies listed at https://invent.kde.org/maui/index-fm#dependencies even though it builds and runs fine without?
* Should I put stuff like `kirigami2` in `mauikit`'s `propagatedBuildInputs`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/qt-kde 