### PR TITLE
ocamlPackages: recurse into all ocamlPackages sets

### DIFF
--- a/pkgs/development/ocaml-modules/caqti/type-calendar.nix
+++ b/pkgs/development/ocaml-modules/caqti/type-calendar.nix
@@ -4,7 +4,7 @@ buildDunePackage {
   pname = "caqti-type-calendar";
   version = "1.2.0";
   useDune2 = true;
-  inherit (caqti) src;
+  inherit (caqti) minimumOCamlVersion src;
 
   propagatedBuildInputs = [ calendar caqti ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10843,10 +10843,10 @@ in
     ocamlPackages = ocaml-ng.ocamlPackages_4_05;
   };
 
-  ocaml-ng = callPackage ./ocaml-packages.nix { };
+  ocaml-ng = recurseIntoAttrs (callPackage ./ocaml-packages.nix { });
   ocaml = ocamlPackages.ocaml;
 
-  ocamlPackages = recurseIntoAttrs ocaml-ng.ocamlPackages;
+  ocamlPackages = ocaml-ng.ocamlPackages;
 
   ocaml-crunch = ocamlPackages.crunch.bin;
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -4,7 +4,7 @@ let
   liftJaneStreet = self: super: super.janeStreet // super;
 
   mkOcamlPackages = ocaml:
-    (lib.makeScope newScope (self: with self;
+    (lib.makeScope newScope (self: with self; (lib.recurseIntoAttrs
   {
     inherit ocaml;
 
@@ -1396,7 +1396,7 @@ let
 
     hol_light = callPackage ../applications/science/logic/hol_light { };
 
-  })).overrideScope' liftJaneStreet;
+  }))).overrideScope' liftJaneStreet;
 
 in let inherit (pkgs) callPackage; in rec
 {


### PR DESCRIPTION
When testing changes to ocamlPackages it can often be hard to notice
avoidable regressions in older ocamlPackages sets like the
increased minimumOCamlVersion bound of a checkInput causing a dependent
package to fail to evaluate in an older set altogether. By adding
lib.recurseIntoAttrs to all ocamlPackages sets, test tools and ofborg
will also evaluate older sets, making such problems noticeable more
easily.

Additionally Hydra will build these sets and offer prebuilt packages via
the binary caches. An open question is if the stress this will cause is
_really_ worth it for older ocaml versions where also a lot of hard to
fix build failures exist at the moment (as a side note, we could use the
comprehensive build report hydra would give us to go around and try to
fix these packages or mark them as broken). I think we should at least
set recurseIntoAttrs for the 4.08 package set and above. The current
situation where you have to compile the 4.12 and 4.11 compiler yourself
is just not acceptable in my opinion.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
