### PR TITLE
ponyc: 0.38.3 -> 0.39.0

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation (rec {
   pname = "ponyc";
-  version = "0.38.3";
+  version = "0.39.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "14kivmyphi7gbd7mgd4cnsiwl4cl7wih8kwzh7n79s2s4c5hj4ak";
+    sha256 = "0b93br66wdjk38yd0qvi4q9g42c2676lhsydaw5xwq6cx11bdaag";
 
 # Due to a bug in LLVM 9.x, ponyc has to include its own vendored patched
 # LLVM.  (The submodule is a specific tag in the LLVM source tree).
@@ -24,9 +24,9 @@ stdenv.mkDerivation (rec {
   };
 
   ponygbenchmark = fetchurl {
-    url = "https://github.com/google/benchmark/archive/v1.5.0.tar.gz";
-    sha256 = "06i2cr4rj126m1zfz0x1rbxv1mw1l7a11mzal5kqk56cdrdicsiw";
-    name = "v1.5.0.tar.gz";
+    url = "https://github.com/google/benchmark/archive/v1.5.2.tar.gz";
+    sha256 = "033hgsc76bcii1gwd8hdc7z1iqdnggk4f8cq0hzh98dsjsvxmjyw";
+    name = "v1.5.2.tar.gz";
   };
 
   nativeBuildInputs = [ cmake makeWrapper which ];
@@ -36,6 +36,7 @@ stdenv.mkDerivation (rec {
   # Sandbox disallows network access, so disabling problematic networking tests
   patches = [
     ./disable-tests.patch
+    ./fix-libstdcpp-path.patch
     (substituteAll {
       src = ./make-safe-for-sandbox.patch;
       googletest = fetchurl {
@@ -49,7 +50,7 @@ stdenv.mkDerivation (rec {
   postUnpack = ''
     mkdir -p source/build/build_libs/gbenchmark-prefix/src
     tar -C source/build/build_libs/gbenchmark-prefix/src -zxvf "$ponygbenchmark"
-    mv source/build/build_libs/gbenchmark-prefix/src/benchmark-1.5.0 \
+    mv source/build/build_libs/gbenchmark-prefix/src/benchmark-1.5.2 \
        source/build/build_libs/gbenchmark-prefix/src/benchmark
   '';
 

--- a/pkgs/development/compilers/ponyc/fix-libstdcpp-path.patch
+++ b/pkgs/development/compilers/ponyc/fix-libstdcpp-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libponyc/CMakeLists.txt b/src/libponyc/CMakeLists.txt
+index bf2c385e..11d0d619 100644
+--- a/src/libponyc/CMakeLists.txt
++++ b/src/libponyc/CMakeLists.txt
+@@ -136,7 +136,7 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")
+ else()
+     # add a rule to generate the standalone library if needed
+     add_custom_command(OUTPUT libponyc-standalone.a
+-        COMMAND cp `find /usr/lib/ -name 'libstdc++.a' -print -quit` libstdcpp.a
++        COMMAND cp `${CMAKE_CXX_COMPILER} --print-file-name='libstdc++.a'` libstdcpp.a
+         COMMAND echo "create libponyc-standalone.a" > standalone.mri
+         COMMAND echo "addlib ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a" >> standalone.mri
+         COMMAND echo "addlib libstdcpp.a" >> standalone.mri

--- a/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
+++ b/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
@@ -4,7 +4,7 @@
  endif()
  
  ExternalProject_Add(gbenchmark
--    URL https://github.com/google/benchmark/archive/v1.5.0.tar.gz
+-    URL https://github.com/google/benchmark/archive/v1.5.2.tar.gz
 +    SOURCE_DIR gbenchmark-prefix/src/benchmark
      CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=-fpic --no-warn-unused-cli
  )


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
