### PR TITLE
passphrase2pgp: init at 1.1.0

### DIFF
--- a/pkgs/tools/security/passphrase2pgp/default.nix
+++ b/pkgs/tools/security/passphrase2pgp/default.nix
@@ -1,0 +1,27 @@
+{ lib, pandoc, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "passphrase2pgp";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "skeeto";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Nje77tn55CKRU6igEA/6IquDhXVVQAdiez6nmN49di4";
+  };
+
+  vendorSha256 = "sha256-7q5nwkj4TP7VgHmV9YBbCB11yTPL7tK4gD+uN4Vw3Cs";
+
+  postInstall = ''
+    mkdir -p $out/share/doc/$name
+    cp README.md $out/share/doc/$name
+  '';
+
+  meta = with lib; {
+    description = "Predictable, passphrase-based PGP key generator";
+    homepage = "https://github.com/skeeto/passphrase2pgp";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1398,6 +1398,8 @@ in
 
   pass = callPackage ../tools/security/pass { };
 
+  passphrase2pgp = callPackage ../tools/security/passphrase2pgp { };
+
   pass-git-helper = python3Packages.callPackage ../applications/version-management/git-and-tools/pass-git-helper { };
 
   pass-nodmenu = callPackage ../tools/security/pass {


### PR DESCRIPTION
passphrase2pgp generates, in OpenPGP format, an EdDSA signing key and
Curve25519 encryption subkey entirely from a passphrase, essentially
allowing you to [store a backup of your PGP keys in your brain][blog].
At any time you can re-run the tool and re-enter the passphrase to
reproduce the original keys.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
