### PR TITLE
Dlang update

### DIFF
--- a/pkgs/applications/audio/cheesecutter/default.nix
+++ b/pkgs/applications/audio/cheesecutter/default.nix
@@ -8,13 +8,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "cheesecutter";
-  version = "unstable-2020-04-03";
+  version = "unstable-2021-02-27";
 
   src = fetchFromGitHub {
     owner = "theyamo";
     repo = "CheeseCutter";
-    rev = "68d6518f0e6249a2a5d122fc80201578337c1277";
-    sha256 = "0xspzjhc6cp3m0yd0mwxncg8n1wklizamxvidrnn21jgj3mnaq2q";
+    rev = "84450d3614b8fb2cabda87033baab7bedd5a5c98";
+    sha256 = "sha256:0q4a791nayya6n01l0f4kk497rdq6kiq0n72fqdpwqy138pfwydn";
   };
 
   patches = [

--- a/pkgs/applications/networking/sync/onedrive/default.nix
+++ b/pkgs/applications/networking/sync/onedrive/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "onedrive";
-  version = "2.4.7";
+  version = "2.4.10";
 
   src = fetchFromGitHub {
     owner = "abraunegg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "12g2z6c4f65y8cc7vyhk9nlg1mpbsmlsj7ghlny452qhr13m7qpn";
+    sha256 = "sha256:0dvxjkni66g82j9wr6yy07sn7d7yr7bbc0py89pxybvsbid88l65";
   };
 
   nativeBuildInputs = [ autoreconfHook ldc installShellFiles pkg-config ];

--- a/pkgs/applications/science/biology/sambamba/default.nix
+++ b/pkgs/applications/science/biology/sambamba/default.nix
@@ -1,18 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, python3, which, dmd, ldc, zlib }:
+{ lib, stdenv, fetchFromGitHub, python3, which, ldc, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "sambamba";
-  version = "0.7.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "biod";
     repo = "sambamba";
     rev = "v${version}";
-    sha256 = "0k5wy06zrbsc40x6answgz7rz2phadyqwlhi9nqxbfqanbg9kq20";
+    sha256 = "sha256:0kx5a0fmvv9ldz2hnh7qavgf7711kqc73zxf51k4cca4hr58zxr9";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ which python3 dmd ldc ];
+  nativeBuildInputs = [ which python3 ldc ];
   buildInputs = [ zlib ];
 
   # Upstream's install target is broken; copy manually

--- a/pkgs/applications/terminal-emulators/tilix/default.nix
+++ b/pkgs/applications/terminal-emulators/tilix/default.nix
@@ -5,7 +5,7 @@
 , ninja
 , python3
 , pkg-config
-, dmd
+, ldc
 , dconf
 , dbus
 , gsettings-desktop-schemas
@@ -16,17 +16,18 @@
 , glib
 , wrapGAppsHook
 , libunwind
+, appstream
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "tilix";
-  version = "unstable-2019-10-02";
+  version = "1.9.4";
 
   src = fetchFromGitHub {
     owner = "gnunn1";
     repo = "tilix";
-    rev = "ffcd31e3c0e1a560ce89468152d8726065e8fb1f";
-    sha256 = "1bzv7xiqhyblz1rw8ln4zpspmml49vnshn1zsv9di5q7kfgpqrgq";
+    rev = "${version}";
+    sha256 = "sha256:020gr4q7kmqq8vnsh8rw97gf1p2n1yq4d7ncyjjh9l13zkaxqqv9";
   };
 
   # Default upstream else LDC fails to link
@@ -36,12 +37,13 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     desktop-file-utils
-    dmd
+    ldc
     meson
     ninja
     pkg-config
     python3
     wrapGAppsHook
+    appstream
   ];
 
   buildInputs = [

--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -4,10 +4,10 @@
 , targetPackages, fetchpatch, bash
 , dmdBootstrap ? callPackage ./bootstrap.nix { }
 , HOST_DMD ? "${dmdBootstrap}/bin/dmd"
-, version ? "2.091.1"
-, dmdSha256 ? "0brz0n84jdkhr4sq4k91w48p739psbhbb1jk2pi9q60psmx353yr"
-, druntimeSha256 ? "0smgpmfriffh110ksski1s5j921kmxbc2zjy0dyj9ksyrxbzklbl"
-, phobosSha256 ? "1n00anajgibrfs1xzvrmag28hvbvkc0w1fwlimqbznvhf28rhrxs"
+, version ? "2.095.1"
+, dmdSha256 ? "sha256:0faca1y42a1h16aml4lb7z118mh9k9fjx3xlw3ki5f1h3ln91xhk"
+, druntimeSha256 ? "sha256:0ad4pa5llr9m9wqbvfv4yrcra4zz9qxlh5kx43mrv48f9bcxm2ha"
+, phobosSha256 ? "sha256:04w6jw4izix2vbw62j13wvz6q3pi7vivxnmxqj0g8904j5g0cxjl"
 }:
 
 let
@@ -53,18 +53,6 @@ stdenv.mkDerivation rec {
   })
   ];
 
-  patchFlags = [ "--directory=dmd" "-p1" "-F3" ];
-  patches = [
-    (fetchpatch {
-     url = "https://github.com/dlang/dmd/commit/4157298cf04f7aae9f701432afd1de7b7e05c30f.patch";
-     sha256 = "0v4xgqmrx5r8vbx5a4v88s0xnm23mam9nm99yfga7s2sxr0hi5p2";
-    })
-    (fetchpatch {
-     url = "https://github.com/dlang/dmd/commit/1b8a4c90b040bf2f0b68a2739de4991315580b13.patch";
-     sha256 = "1iih6aalv4fsw9mbrlrybhngkkchzzrzg7q8zl047w36c0x397cs";
-    })
-  ];
-
   sourceRoot = ".";
 
   # https://issues.dlang.org/show_bug.cgi?id=19553
@@ -76,6 +64,16 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
       substituteInPlace dmd/test/dshell/test6952.d --replace "/usr/bin/env bash" "${bash}/bin/bash"
+
+      rm dmd/test/runnable/gdb1.d
+      rm dmd/test/runnable/gdb10311.d
+      rm dmd/test/runnable/gdb14225.d
+      rm dmd/test/runnable/gdb14276.d
+      rm dmd/test/runnable/gdb14313.d
+      rm dmd/test/runnable/gdb14330.d
+      rm dmd/test/runnable/gdb15729.sh
+      rm dmd/test/runnable/gdb4149.d
+      rm dmd/test/runnable/gdb4181.d
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
       substituteInPlace phobos/std/socket.d --replace "assert(ih.addrList[0] == 0x7F_00_00_01);" ""

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "1.24.0";
-  ldcSha256 = "0g5svf55i0kq55q49awmwqj9qi1n907cyrn1vjdjgs8nx6nn35gx";
+  version = "1.25.1";
+  ldcSha256 = "sha256-DjcW/pknvpEmTR/eXEEHECb2xEJic16evaU4CJthLUA=";
 }

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, fetchpatch, atk, cairo, dmd, gdk-pixbuf, gnome3, gst_all_1, librsvg
+{ lib, stdenv, fetchzip, fetchpatch, atk, cairo, ldc, gdk-pixbuf, gnome3, gst_all_1, librsvg
 , glib, gtk3, gtksourceview4, libgda, libpeas, pango, pkg-config, which, vte }:
 
 let
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
     stripRoot = false;
   };
 
-  nativeBuildInputs = [ dmd pkg-config which ];
+  nativeBuildInputs = [ ldc pkg-config which ];
   propagatedBuildInputs = [
     atk cairo gdk-pixbuf glib gstreamer gst-plugins-base gtk3 gtksourceview4
     libgda libpeas librsvg pango vte

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, curl, dmd, libevent, rsync }:
+{ lib, stdenv, fetchFromGitHub, curl, libevent, rsync, ldc, dcompiler ? ldc }:
+
+assert dcompiler != null;
 
 stdenv.mkDerivation rec {
   pname = "dub";
@@ -24,12 +26,23 @@ stdenv.mkDerivation rec {
           --replace "dub remove" "\"${dubvar}\" remove"
   '';
 
-  nativeBuildInputs = [ dmd libevent rsync ];
+  nativeBuildInputs = [ dcompiler libevent rsync ];
   buildInputs = [ curl ];
 
   buildPhase = ''
-    export DMD=${dmd.out}/bin/dmd
-    ./build.sh
+    for dc_ in dmd ldmd2 gdmd; do
+      echo "... check for D compiler $dc_ ..."
+      dc=$(type -P $dc_ || echo "")
+      if [ ! "$dc" == "" ]; then
+        break
+      fi
+    done
+    if [ "$dc" == "" ]; then
+      exit "Error: could not find D compiler"
+    fi
+    echo "$dc_ found and used as D compiler to build $pname"
+    $dc ./build.d
+    ./build
   '';
 
   doCheck = !stdenv.isDarwin;
@@ -37,7 +50,8 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     export DUB=$NIX_BUILD_TOP/source/bin/dub
     export PATH=$PATH:$NIX_BUILD_TOP/source/bin/
-    export DC=${dmd.out}/bin/dmd
+    export DC=${dcompiler.out}/bin/${dcompiler.pname}
+    echo "DC out --> $DC"
     export HOME=$TMP
 
     rm -rf test/issue502-root-import
@@ -46,7 +60,6 @@ stdenv.mkDerivation rec {
     rm test/issue990-download-optional-selected.sh
     rm test/issue877-auto-fetch-package-on-run.sh
     rm test/issue1037-better-dependency-messages.sh
-    rm test/issue1040-run-with-ver.sh
     rm test/issue1416-maven-repo-pkg-supplier.sh
     rm test/issue1180-local-cache-broken.sh
     rm test/issue1574-addcommand.sh
@@ -62,13 +75,73 @@ stdenv.mkDerivation rec {
     rm test/version-spec.sh
     rm test/0-init-multi.sh
     rm test/0-init-multi-json.sh
+    rm test/4-describe-data-1-list.sh
+    rm test/4-describe-data-3-zero-delim.sh
+    rm test/4-describe-import-paths.sh
+    rm test/4-describe-string-import-paths.sh
+    rm test/4-describe-json.sh
+    rm test/5-convert-stdout.sh
+    rm test/issue1003-check-empty-ld-flags.sh
+    rm test/issue103-single-file-package.sh
+    rm test/issue1040-run-with-ver.sh
+    rm test/issue1091-bogus-rebuild.sh
+    rm test/issue1194-warn-wrong-subconfig.sh
+    rm test/issue1277.sh
+    rm test/issue1372-ignore-files-in-hidden-dirs.sh
+    rm test/issue1447-build-settings-vars.sh
+    rm test/issue1531-toolchain-requirements.sh
+    rm test/issue346-redundant-flags.sh
+    rm test/issue361-optional-deps.sh
+    rm test/issue564-invalid-upgrade-dependency.sh
+    rm test/issue586-subpack-dep.sh
+    rm test/issue616-describe-vs-generate-commands.sh
+    rm test/issue686-multiple-march.sh
+    rm test/issue813-fixed-dependency.sh
+    rm test/issue813-pure-sub-dependency.sh
+    rm test/issue820-extra-fields-after-convert.sh
+    rm test/issue923-subpackage-deps.sh
+    rm test/single-file-sdl-default-name.sh
+    rm test/subpackage-common-with-sourcefile-globbing.sh
+    rm test/issue934-path-dep.sh
+    rm -r test/1-dynLib-simple
+    rm -r test/1-exec-simple-package-json
+    rm -r test/1-exec-simple
+    rm -r test/1-staticLib-simple
+    rm -r test/2-dynLib-dep
+    rm -r test/2-staticLib-dep
+    rm -r test/2-dynLib-with-staticLib-dep
+    rm -r test/2-sourceLib-dep/
+    rm -r test/3-copyFiles
+    rm -r test/custom-source-main-bug487
+    rm -r test/custom-unittest
+    rm -r test/issue1262-version-inheritance-diamond
+    rm -r test/issue1003-check-empty-ld-flags
+    rm -r test/ignore-hidden-1
+    rm -r test/ignore-hidden-2
+    rm -r test/issue1427-betterC
+    rm -r test/issue130-unicode-*
+    rm -r test/issue1262-version-inheritance
+    rm -r test/issue1372-ignore-files-in-hidden-dirs
+    rm -r test/issue1350-transitive-none-deps
+    rm -r test/issue1775
+    rm -r test/issue1447-build-settings-vars
+    rm -r test/issue1408-inherit-linker-files
+    rm -r test/issue1551-var-escaping
+    rm -r test/issue754-path-selection-fail
+    rm -r test/issue1788-incomplete-string-import-override
+    rm -r test/subpackage-ref
+    rm -r test/issue777-bogus-path-dependency
+    rm -r test/issue959-path-based-subpack-dep
+    rm -r test/issue97-targettype-none-nodeps
+    rm -r test/issue97-targettype-none-onerecipe
+    rm -r test/path-subpackage-ref
+    rm -r test/sdl-package-simple
 
     ./test/run-unittest.sh
   '';
 
   installPhase = ''
-    mkdir $out
-    mkdir $out/bin
+    mkdir -p $out/bin
     cp bin/dub $out/bin
   '';
 

--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -1,22 +1,22 @@
-{stdenv, lib, fetchFromGitHub, dmd, curl}:
+{stdenv, lib, fetchFromGitHub, ldc, curl}:
 
 stdenv.mkDerivation rec {
   pname = "dtools";
-  version = "2.085.1";
+  version = "2.095.1";
 
   srcs = [
     (fetchFromGitHub {
       owner = "dlang";
       repo = "dmd";
       rev = "v${version}";
-      sha256 = "0ccidfcawrcwdpfjwjiln5xwr4ffp8i2hwx52p8zn3xmc5yxm660";
+      sha256 = "sha256:0faca1y42a1h16aml4lb7z118mh9k9fjx3xlw3ki5f1h3ln91xhk";
       name = "dmd";
     })
     (fetchFromGitHub {
       owner = "dlang";
       repo = "tools";
       rev = "v${version}";
-      sha256 = "1x85w4k2zqgv2bjbvhschxdc6kq8ygp89h499cy8rfqm6q23g0ws";
+      sha256 = "sha256:0rdfk3mh3fjrb0h8pr8skwlq6ac9hdl1fkrkdl7n1fa2806b740b";
       name = "dtools";
     })
   ];
@@ -27,14 +27,13 @@ stdenv.mkDerivation rec {
       mv dmd dtools
       cd dtools
 
-      substituteInPlace posix.mak --replace "\$(DMD) \$(DFLAGS) -unittest -main -run rdmd.d" ""
   '';
 
-  nativeBuildInputs = [ dmd ];
+  nativeBuildInputs = [ ldc ];
   buildInputs = [ curl ];
 
   makeCmd = ''
-    make -f posix.mak DMD_DIR=dmd DMD=${dmd.out}/bin/dmd CC=${stdenv.cc}/bin/cc
+    make -f posix.mak all DMD_DIR=dmd DMD=${ldc.out}/bin/ldmd2 CC=${stdenv.cc}/bin/cc
   '';
 
   buildPhase = ''

--- a/pkgs/development/tools/literate-programming/Literate/default.nix
+++ b/pkgs/development/tools/literate-programming/Literate/default.nix
@@ -1,16 +1,16 @@
-{ lib, stdenv, fetchgit, dmd, dub }:
+{ lib, stdenv, fetchgit, ldc, dub }:
 
 stdenv.mkDerivation {
   pname = "Literate";
-  version = "unstable-2020-09-02";
+  version = "unstable-2021-01-22";
 
   src = fetchgit {
     url = "https://github.com/zyedidia/Literate.git";
-    rev = "533991cca6ec7a608a778396d32d51b35182d944";
-    sha256 = "09h1as01z0fw0bj0kf1g9nlhvinya7sqq2x8qb6zmhvqqm6v4n49";
+    rev = "7004dffec0cff3068828514eca72172274fd3f7d";
+    sha256 = "0x4xgrdskybaa7ssv81grmwyc1k167v3nwj320jvp5l59xxlbcvs";
   };
 
-  buildInputs = [ dmd dub ];
+  buildInputs = [ ldc dub ];
 
   installPhase = "install -D bin/lit $out/bin/lit";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Fix dmd build
- Switch from dmd as the default D compiler to ldc for all dependent packages
- Added possibility to use another D compiler for dub like it was already done in https://github.com/NixOS/nixpkgs/pull/115133 by @ralph-amissah
- Update to newest version for dlang and related packages 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
