### PR TITLE
gnvim: fix install phase with Rust with custom target

### DIFF
--- a/pkgs/applications/editors/neovim/gnvim/default.nix
+++ b/pkgs/applications/editors/neovim/gnvim/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   # The default build script tries to get the version through Git, so we
   # replace it
-  prePatch = ''
+  postPatch = ''
     cat << EOF > build.rs
     use std::env;
     use std::fs::File;
@@ -31,13 +31,13 @@ rustPlatform.buildRustPackage rec {
         f.write_all(b"const VERSION: &str = \"${version}\";").unwrap();
     }
     EOF
+
+    # Install the binary ourselves, since the Makefile doesn't have the path
+    # containing the target architecture
+    sed -e "/target\/release/d" -i Makefile
   '';
 
-  buildPhase = ''
-    make build
-  '';
-
-  installPhase = ''
+  postInstall = ''
     make install PREFIX="${placeholder "out"}"
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

When building with `cargo build --release --target <arch> ...`, Rust installs the gnvim binary in `./taget/<arch>/release` instead of `./target/release`, which isn't taken into account by upstream's `Makefile`.

Normally, the project would have been compiled by using `make build`, but if I understood it correctly, the `buildPhase` is now overridden by the new hook system (https://github.com/NixOS/nixpkgs/pull/112804)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
