### PR TITLE
kitsas: init at 2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3677,6 +3677,12 @@
     githubId = 201997;
     name = "Eric Seidel";
   };
+  gspia = {
+    email = "iahogsp@gmail.com";
+    github = "gspia";
+    githubId = 3320792;
+    name = "gspia";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";

--- a/pkgs/applications/office/kitsas/default.nix
+++ b/pkgs/applications/office/kitsas/default.nix
@@ -1,0 +1,51 @@
+{ lib, mkDerivation, fetchFromGitHub, qmake, qtsvg, qtcreator, poppler, libzip, pkg-config }:
+
+mkDerivation rec {
+  pname = "kitsas";
+  version = "2.3";
+
+  src = fetchFromGitHub {
+    owner = "artoh";
+    repo = "kitupiikki";
+    rev = "v${version}";
+    sha256 = "1qac6cxkb45rs5pschsf2rvpa789g27shmrwpshwahqzhw42xvgl";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ qmake qtsvg poppler libzip ];
+
+  # We use a separate build-dir as otherwise ld seems to get confused between
+  # directory and executable name on buildPhase.
+  preConfigure = ''
+    mkdir build-linux
+    cd build-linux
+  '';
+
+  qmakeFlags = [
+    "../kitsas/kitsas.pro"
+    "-spec"
+    "linux-g++"
+    "CONFIG+=release"
+  ];
+
+  preFixup = ''
+    make clean
+    rm Makefile
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/applications
+    cp kitsas $out/bin
+    cp $src/kitsas.png $out/share/applications
+    cp $src/kitsas.desktop $out/share/applications
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/artoh/kitupiikki";
+    description = "An accounting tool suitable for Finnish associations and small business";
+    maintainers = with maintainers; [ gspia ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23796,6 +23796,8 @@ in
     ffmpeg = ffmpeg_2;
   };
 
+  kitsas = libsForQt5.callPackage ../applications/office/kitsas { };
+
   kiwix = libsForQt5.callPackage ../applications/misc/kiwix { };
 
   klayout = libsForQt5.callPackage ../applications/misc/klayout { };


### PR DESCRIPTION
kitsas: init at 2.3

###### Motivation for this change

This adds an accounting application called kitsas to the set of available applications. Kitsas is suitable for Finnish associations and small business.

This is my first packaged application and related pull request. (I have no exp on reviewing nixpkgs issues yet.) 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
