### PR TITLE
targetcli: 2.1.53 -> 2.1.54

### DIFF
--- a/pkgs/development/python-modules/configshell/default.nix
+++ b/pkgs/development/python-modules/configshell/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "configshell";
-  version = "1.1.28";
+  version = "1.1.29";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo = "${pname}-fb";
     rev = "v${version}";
-    sha256 = "1ym2hkvmmacgy21wnjwzyrcxyl3sx4bcx4hc51vf4lzcnj589l68";
+    sha256 = "0mjj3c9335sph8rhwww7j4zvhyk896fbmx887vibm89w3jpvjjr9";
   };
 
   propagatedBuildInputs = [ pyparsing six urwid ];

--- a/pkgs/os-specific/linux/targetcli/default.nix
+++ b/pkgs/os-specific/linux/targetcli/default.nix
@@ -2,13 +2,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "targetcli";
-  version = "2.1.53";
+  version = "2.1.54";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo = "${pname}-fb";
     rev = "v${version}";
-    sha256 = "1qrq7y5hnghzbxgrxgl153n8jlhw31kqjbr93jsvlvhz5b3ci750";
+    sha256 = "1kbbvx0lba96ynr5iwws9jpi319m4rzph4bmcj7yfb37k8mi161v";
   };
 
   propagatedBuildInputs = with python3.pkgs; [ configshell rtslib ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
