### PR TITLE
bitlbee-facebook: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, fetchpatch, stdenv, bitlbee, autoconf, automake, libtool, pkg-config, json-glib }:
+{ lib, fetchFromGitHub, stdenv, bitlbee, autoconf, automake, libtool, pkg-config, json-glib }:
 
 stdenv.mkDerivation rec {
   pname = "bitlbee-facebook";

--- a/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-facebook/default.nix
@@ -2,25 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "bitlbee-facebook";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "bitlbee";
     repo = "bitlbee-facebook";
-    sha256 = "1yjhjhk3jzjip13lq009vlg84lm2lzwhac5jy0aq3vkcz6rp94rc";
+    sha256 = "1qiiiq17ybylbhwgbwsvmshb517589r8yy5rsh1rfaylmlcxyy7z";
   };
-
-  # TODO: This patch should be included with the next release after v1.2.1
-  #       these lines should be removed when this happens.
-  patches = [
-    (fetchpatch {
-        name = "FB_ORCA_AGENT_version_bump.patch";
-        url = "https://github.com/bitlbee/bitlbee-facebook/commit/49ea312d98b0578b9b2c1ff759e2cfa820a41f4d.patch";
-        sha256 = "0nzyyg8pw4f2jcickcpxq7r2la5wgl7q6iz94lhzybrkhss5753d";
-      }
-    )
-  ];
 
   nativeBuildInputs = [ autoconf automake libtool pkg-config ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump. This drops the FB_ORCA_AGENT bump patch because it is included in the release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
