### PR TITLE
python3Packages.APScheduler: add setuptools

### DIFF
--- a/pkgs/development/python-modules/APScheduler/default.nix
+++ b/pkgs/development/python-modules/APScheduler/default.nix
@@ -15,6 +15,7 @@
 , tzlocal
 , funcsigs
 , futures
+, setuptools
 , isPy3k
 }:
 
@@ -47,11 +48,14 @@ buildPythonPackage rec {
     pytz
     tzlocal
     funcsigs
+    setuptools
   ] ++ lib.optional (!isPy3k) futures;
 
   checkPhase = ''
     py.test
   '';
+
+  pythonImportsCheck = [ "apscheduler" ];
 
   # Somehow it cannot find pytestcov
   doCheck = false;


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
APScheduler requires setuptools as a propagatedBuildInput

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Tested manually via a telegram bot that uses APScheduler as an indirect dependency