### PR TITLE
ocamlPackages.ctypes: 0.17.1 -> 0.18.0

### DIFF
--- a/pkgs/development/libraries/libbap/default.nix
+++ b/pkgs/development/libraries/libbap/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation {
     sha256 = "0m4spva3z6fgbwlg4zq53l5p227dic893q2qq65pvzxyf7k7nmil";
   };
 
+  postPatch = ''
+    substituteInPlace Makefile.in \
+      --replace "-linkpkg" "-thread -linkpkg"
+  '';
+
   nativeBuildInputs = [ autoreconfHook which ];
   buildInputs = [ ocaml bap findlib ctypes ];
 

--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, ocaml, findlib, libffi, pkg-config, ncurses, integers }:
+{ lib, stdenv, fetchzip, ocaml, findlib, libffi, pkg-config, ncurses, integers, bigarray-compat }:
 
 if !lib.versionAtLeast ocaml.version "4.02"
 then throw "ctypes is not available for OCaml ${ocaml.version}"
@@ -6,16 +6,16 @@ else
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-ctypes-${version}";
-  version = "0.17.1";
+  version = "0.18.0";
 
   src = fetchzip {
     url = "https://github.com/ocamllabs/ocaml-ctypes/archive/${version}.tar.gz";
-    sha256 = "16brmdnz7wi2z25qqhd5s5blyq4app6jbv6g9pa4vyg6h0nzbcys";
+    sha256 = "03zrbnl16m67ls0yfhq7a4k4238x6x6b3m456g4dw2yqwc153vks";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ ocaml findlib ncurses ];
-  propagatedBuildInputs = [ integers libffi ];
+  propagatedBuildInputs = [ integers libffi bigarray-compat ];
 
   buildPhase =  ''
      make XEN=false libffi.config ctypes-base ctypes-stubs

--- a/pkgs/development/ocaml-modules/janestreet/0.12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.12.nix
@@ -382,7 +382,12 @@ rec {
   async_ssl = janePackage {
     pname = "async_ssl";
     hash = "02ard8x5q5c42d9jdqmyzfx624yjq8cxxmvq3zb82hf6p8cc57ml";
-    meta.description = "An Async-pipe-based interface with OpenSSL";
+    meta = {
+      description = "An Async-pipe-based interface with OpenSSL";
+      # ctypes no longer works with dune 1
+      # dune 2 no longer supports jbuild
+      broken = true;
+    };
     propagatedBuildInputs = [ async ctypes openssl ];
   };
 

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -147,6 +147,11 @@ rec {
     meta.description = "Async wrappers for SSL";
     buildInputs = [ dune-configurator ];
     propagatedBuildInputs = [ async ctypes openssl ];
+    # in ctypes.foreign 0.18.0 threaded and unthreaded have been merged
+    postPatch = ''
+      substituteInPlace bindings/dune \
+        --replace "ctypes.foreign.threaded" "ctypes.foreign"
+    '';
   };
 
   async_unix = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -417,7 +417,12 @@ rec {
     pname = "async_ssl";
     hash = "1p83fzfla4rb820irdrz3f2hp8kq5zrhw47rqmfv6qydlca1bq64";
     propagatedBuildInputs = [ async ctypes openssl ];
-    meta.description = "Async wrappers for SSL";
+    meta = {
+      description = "Async wrappers for SSL";
+      # ctypes no longer works with dune 1
+      # dune 2 no longer supports jbuild
+      broken = true;
+    };
   };
 
   sexp_pretty = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/janePackage.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage.nix
@@ -14,6 +14,8 @@ buildDunePackage (args // {
     sha256 = hash;
   };
 
-  meta.license = lib.licenses.asl20;
-  meta.homepage = "https://github.com/janestreet/${pname}";
+  meta = {
+    license = lib.licenses.asl20;
+    homepage = "https://github.com/janestreet/${pname}";
+  } // args.meta;
 })

--- a/pkgs/development/ocaml-modules/janestreet/janePackage_0_12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage_0_12.nix
@@ -14,6 +14,8 @@ buildDunePackage (args // {
     sha256 = hash;
   };
 
-  meta.license = lib.licenses.mit;
-  meta.homepage = "https://github.com/janestreet/${pname}";
+  meta = {
+    license = lib.licenses.mit;
+    homepage = "https://github.com/janestreet/${pname}";
+  } // args.meta;
 })

--- a/pkgs/development/ocaml-modules/janestreet/janePackage_0_14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage_0_14.nix
@@ -22,6 +22,8 @@ buildDunePackage (args // {
 
   inherit doCheck;
 
-  meta.license = lib.licenses.mit;
-  meta.homepage = "https://github.com/janestreet/${pname}";
+  meta = {
+    license = lib.licenses.mit;
+    homepage = "https://github.com/janestreet/${pname}";
+  } // args.meta;
 })

--- a/pkgs/development/ocaml-modules/sodium/default.nix
+++ b/pkgs/development/ocaml-modules/sodium/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "124gpi1jhac46x05gp5viykyrafnlp03v1cmkl13c6pgcs8w04pv";
   };
 
+  patches = [
+    # ctypes.stubs no longer pulls in bigarray automatically
+    ./lib-gen-link-bigarray.patch
+  ];
+
   buildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ ctypes libsodium ];
 

--- a/pkgs/development/ocaml-modules/sodium/lib-gen-link-bigarray.patch
+++ b/pkgs/development/ocaml-modules/sodium/lib-gen-link-bigarray.patch
@@ -1,0 +1,7 @@
+diff --git a/lib_gen/_tags b/lib_gen/_tags
+index 7a7e632..7a4e0b7 100644
+--- a/lib_gen/_tags
++++ b/lib_gen/_tags
+@@ -1 +1 @@
+-<*.{ml,byte,native}>: package(ctypes.stubs)
++<*.{ml,byte,native}>: package(ctypes.stubs), package(bigarray)


### PR DESCRIPTION
<https://github.com/ocamllabs/ocaml-ctypes/blob/0.18.0/CHANGES.md#ctypes-0180>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
