### PR TITLE
ocamlPackages: Init ppx_cstubs at 0.6.1.1, add ppxlib 0.22.0, add ppx_deriving 5.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, bigarray-compat
+, containers
+, cppo
+, ctypes
+, integers
+, num
+, ppxlib
+, re
+}:
+
+buildDunePackage rec {
+  pname = "ppx_cstubs";
+  version = "0.6.1.1";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "fdopen";
+    repo = "ppx_cstubs";
+    rev = version;
+    sha256 = "0rgg78435ypi6ryhcq5ljkch4qjvra2jqjd47c2hhhcbwvi2ssxh";
+  };
+
+  buildInputs = [
+    bigarray-compat
+    containers
+    cppo
+    ctypes
+    integers
+    num
+    ppxlib
+    re
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/fdopen/ppx_cstubs";
+    description = "Preprocessor for easier stub generation with ocaml-ctypes";
+    license = licenses.mit;
+    maintainers = [ maintainers.osener ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -1,15 +1,28 @@
-{ lib, fetchurl, buildDunePackage
-, cppo, ppxlib, ppx_derivers, result, ounit, ocaml-migrate-parsetree
+{ lib
+, fetchurl
+, buildDunePackage
+, cppo
+, ppxlib
+, ppx_derivers
+, result
+, ounit
+, ocaml-migrate-parsetree
+, ocaml-migrate-parsetree-2-1
 }:
 
 let params =
-  if lib.versionAtLeast ppxlib.version "0.15"
-  then {
+  if lib.versionAtLeast ppxlib.version "0.20" then {
+    version = "5.2.1";
+    sha256 = "11h75dsbv3rs03pl67hdd3lbim7wjzh257ij9c75fcknbfr5ysz9";
+    useOMP2 = true;
+  } else if lib.versionAtLeast ppxlib.version "0.15" then {
     version = "5.1";
     sha256 = "1i64fd7qrfzbam5hfbl01r0sx4iihsahcwqj13smmrjlnwi3nkxh";
+    useOMP2 = false;
   } else {
     version = "5.0";
     sha256 = "0fkzrn4pdyvf1kl0nwvhqidq01pnq3ql8zk1jd56hb0cxaw851w3";
+    useOMP2 = false;
   }
 ; in
 
@@ -25,7 +38,13 @@ buildDunePackage rec {
   };
 
   buildInputs = [ ppxlib cppo ];
-  propagatedBuildInputs = [ ocaml-migrate-parsetree ppx_derivers result ];
+  propagatedBuildInputs = [
+    (if params.useOMP2
+    then ocaml-migrate-parsetree-2-1
+    else ocaml-migrate-parsetree)
+    ppx_derivers
+    result
+  ];
 
   doCheck = true;
   checkInputs = [ ounit ];

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -25,6 +25,10 @@ let param = {
     sha256 = "1ciy6va2gjrpjs02kha83pzh0x1gkmfsfsdgabbs1v14a8qgfibm";
     min_version = "4.07";
   };
+  "0.22.0" = {
+    sha256 = "0kf7lgcwygf6zlx7rwddqpqvasa6v7xiq0bqal8vxlib6lpg074q";
+    min_version = "4.07";
+  };
 }."${version}"; in
 
 if param ? max_version && lib.versionAtLeast ocaml.version param.max_version

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1001,6 +1001,10 @@ let
 
     ppx_cstruct = callPackage ../development/ocaml-modules/cstruct/ppx.nix { };
 
+    ppx_cstubs = callPackage ../development/ocaml-modules/ppx_cstubs {
+      ppxlib = ppxlib.override { version = "0.22.0"; };
+    };
+
     ppx_derivers = callPackage ../development/ocaml-modules/ppx_derivers {};
 
     ppx_deriving = callPackage ../development/ocaml-modules/ppx_deriving {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add new package [ppx_cstubs](https://github.com/fdopen/ppx_cstubs/), update its dependency ppxlib, and update ppx_deriving

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
