### PR TITLE
ruby: Use appropriate targetPlatform

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -50,7 +50,7 @@ let
       # - If you run:
       #     ruby -e "puts RbConfig::CONFIG['configure_args']"
       # - In:
-      #     $out/${passthru.libPath}/${stdenv.targetPlatform.system}/rbconfig.rb
+      #     $out/${passthru.libPath}/${stdenv.hostPlatform.system}/rbconfig.rb
       #   Or (usually):
       #     $(nix-build -A ruby)/lib/ruby/2.6.0/x86_64-linux/rbconfig.rb
       # - In $out/lib/libruby.so and/or $out/lib/libruby.dylib
@@ -175,7 +175,7 @@ let
                 $out/lib/libruby*
               ${removeReferencesTo}/bin/remove-references-to \
                 -t ${stdenv.cc} \
-                $out/${passthru.libPath}/${stdenv.targetPlatform.system}/rbconfig.rb
+                $out/${passthru.libPath}/${stdenv.hostPlatform.system}/rbconfig.rb
             ''
           }
           # Bundler tries to create this directory
@@ -187,7 +187,7 @@ let
           addRubyLibPath() {
             addToSearchPath RUBYLIB \$1/lib/ruby/site_ruby
             addToSearchPath RUBYLIB \$1/lib/ruby/site_ruby/${ver.libDir}
-            addToSearchPath RUBYLIB \$1/lib/ruby/site_ruby/${ver.libDir}/${stdenv.targetPlatform.system}
+            addToSearchPath RUBYLIB \$1/lib/ruby/site_ruby/${ver.libDir}/${stdenv.hostPlatform.system}
           }
 
           addEnvHooks "$hostOffset" addGemPath


### PR DESCRIPTION
###### Motivation for this change

I believe there is a small issue with the packaging of `ruby` with regards to cross-compiling. 

Using `stdenv.targetPlatform` gives the wrong platform in buildPackages.

E.g.:

```
 $ nix-diff --color never $(env -i nix-instantiate -A pkgs.ruby -A pkgs.pkgsCross.aarch64-multiplatform.buildPackages.ruby)
- /nix/store/w8wk99p4gadns35n2l0fr7wx56jlwnnx-ruby-2.6.6.drv:{out}
+ /nix/store/5ywj7nicjai6ji4g33yh6nvz1b5fq7xw-ruby-2.6.6.drv:{out}
• The input named `ruby-2.6.6` differs
  - /nix/store/4a6nag89dcxwdf32820z6dfwwpfgab8s-ruby-2.6.6.drv:{out}
  + /nix/store/40pakkdfv578zffx3y11qd5ckcp2xpzm-ruby-2.6.6.drv:{out}
  • The environments do not match:
      postInstall=''
          # Remove unnecessary groff reference from runtime closure, since it's big
          sed -i '/NROFF/d' $out/lib/ruby/*/*/rbconfig.rb

          # Bundler tries to create this directory
          mkdir -p $out/nix-support
          cat > $out/nix-support/setup-hook <<EOF
          addGemPath() {
            addToSearchPath GEM_PATH \$1/lib/ruby/gems/2.6.0
          }
          addRubyLibPath() {
            addToSearchPath RUBYLIB \$1/lib/ruby/site_ruby
            addToSearchPath RUBYLIB \$1/lib/ruby/site_ruby/2.6.0
            addToSearchPath RUBYLIB \$1/lib/ruby/site_ruby/2.6.0/←x86_←→aarch→64-linux
          }

          addEnvHooks "$hostOffset" addGemPath
          addEnvHooks "$hostOffset" addRubyLibPath
          EOF

          rbConfig=$(find $out/lib/ruby -name rbconfig.rb)
      ''
• Skipping environment comparison
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Things still cross-compile fine:

```
[nix-shell:~/.../mobile-nixos/nixpkgs]$ nix-build -A pkgs.pkgsCross.aarch64-multiplatform.ruby
/nix/store/lkin6q8magfdr1pjshpqr6caw0a2904s-ruby-2.6.6-aarch64-unknown-linux-gnu

[nix-shell:~/.../mobile-nixos/nixpkgs]$ file result/bin/ruby 
result/bin/ruby: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/zxlk54lmkzhmir0ylszl3qy732vrrvma-glibc-2.32-37-aarch64-unknown-linux-gnu/lib/ld-linux-aarch64.so.1, for GNU/Linux 2.6.32, not stripped

[nix-shell:~/.../mobile-nixos/nixpkgs]$ qemu-aarch64 result/bin/ruby --version
ruby 2.6.6p146 (2020-03-31) [aarch64-linux]
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
