### PR TITLE
nomachine-client: 7.0.211 -> 7.2.3

### DIFF
--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, file, fetchurl, makeWrapper,
   autoPatchelfHook, jsoncpp, libpulseaudio }:
 let
-  versionMajor = "7.0";
-  versionMinor = "211";
-  versionBuild_x86_64 = "4";
-  versionBuild_i686 = "4";
+  versionMajor = "7.2";
+  versionMinor = "3";
+  versionBuild_x86_64 = "8";
+  versionBuild_i686 = "8";
 in
   stdenv.mkDerivation rec {
     pname = "nomachine-client";
@@ -14,12 +14,12 @@ in
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
-          sha256 = "06habqsl5gp13sym519r3qp188qwqqfw8p48wcs4zj3kcri6fjz0";
+          sha256 = "1x60vmngq4927qvy6ljmyvwlz5lapilld3495w3y3jdllwd3dxp4";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
-          sha256 = "1y4lr95mwilwr7gqsxqvygq4w3dcp4cjh8m06wdi3avwdzrjkgj9";
+          sha256 = "0dx921g6w3gk0x4p771qqxbbi16vl11hmdzzwhfczrq90pgzrhks";
         }
       else
         throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";


### PR DESCRIPTION
###### Motivation for this change

Version upgrade.

Random FYI in case someone runs into the same problem of getting `cannot detect any display running` when trying to connect to a host, [`sudo /etc/NX/nxserver --addtoredis && sudo systemctl restart nxserver`](https://forums.nomachine.com/topic/no-available-sessions-on-this-server-after-upgrade-to-opensuse-leap-15-2#post-31438) on the host.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).