### PR TITLE
python3Packages.cairocffi: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/cairocffi/default.nix
+++ b/pkgs/development/python-modules/cairocffi/default.nix
@@ -12,6 +12,7 @@
 , glibcLocales
 , cairo
 , cffi
+, numpy
 , withXcffib ? false, xcffib
 , python
 , glib
@@ -19,8 +20,8 @@
 }@args:
 
 import ./generic.nix ({
-  version = "1.1.0";
-  sha256 = "1nq53f5jipgy9jgyfxp43j40qfbmrhgn1cj8bp5rrb3liy3wbh7i";
+  version = "1.2.0";
+  sha256 = "sha256-mpebUAxkyBef7ChvM36P5kTsovLNBYYM4LYtJfIuoUA=";
   dlopen_patch = ./dlopen-paths.patch;
   disabled = pythonOlder "3.5";
   inherit withXcffib;

--- a/pkgs/development/python-modules/cairocffi/generic.nix
+++ b/pkgs/development/python-modules/cairocffi/generic.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     fontDirectories = [ freefont_ttf ];
   };
 
-  checkInputs = [ pytest pytestrunner glibcLocales ];
+  checkInputs = [ numpy pytest pytestrunner glibcLocales ];
   propagatedBuildInputs = [ cairo cffi ] ++ lib.optional withXcffib xcffib;
 
   checkPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
