### PR TITLE
dpt-rp1-py: unstable-2018-10-16 -> 0.1.12

### DIFF
--- a/pkgs/tools/misc/dpt-rp1-py/default.nix
+++ b/pkgs/tools/misc/dpt-rp1-py/default.nix
@@ -1,22 +1,27 @@
 { lib, python3Packages, fetchFromGitHub }:
 python3Packages.buildPythonApplication rec {
   pname = "dpt-rp1-py";
-  version = "unstable-2018-10-16";
+  version = "0.1.12";
 
   src = fetchFromGitHub {
     owner = "janten";
     repo = pname;
-    rev = "4551b4432f8470de5f2ad9171105f731a6259395";
-    sha256 = "176y5j31aci1vpi8v6r5ki55432fbdsazh9bsyzr90im9zimkffl";
+    rev = "v${version}";
+    sha256 = "0xw853s5bx2lr57w6ldfjzi1ppc6px66zd7hzk8y2kg82q6bnasq";
   };
 
   doCheck = false;
 
   propagatedBuildInputs = with python3Packages; [
+    anytree
+    fusepy
     httpsig
-    requests
     pbkdf2
+    pyyaml
+    requests
+    tqdm
     urllib3
+    zeroconf
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR updates dpt-rp1-py to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
