### PR TITLE
kramdown-rfc2629: 1.2.13 -> 1.3.37

### DIFF
--- a/pkgs/tools/text/kramdown-rfc2629/Gemfile.lock
+++ b/pkgs/tools/text/kramdown-rfc2629/Gemfile.lock
@@ -2,9 +2,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     certified (1.0.0)
+    json_pure (2.5.1)
     kramdown (1.17.0)
-    kramdown-rfc2629 (1.2.13)
+    kramdown-rfc2629 (1.3.37)
       certified (~> 1.0)
+      json_pure (~> 2.0)
       kramdown (~> 1.17.0)
 
 PLATFORMS

--- a/pkgs/tools/text/kramdown-rfc2629/gemset.nix
+++ b/pkgs/tools/text/kramdown-rfc2629/gemset.nix
@@ -9,6 +9,16 @@
     };
     version = "1.0.0";
   };
+  json_pure = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "030hmc268wchqsccbjk41hvbyg99krpa72i3q0y3wwqzfh8hi736";
+      type = "gem";
+    };
+    version = "2.5.1";
+  };
   kramdown = {
     groups = ["default"];
     platforms = [];
@@ -20,14 +30,14 @@
     version = "1.17.0";
   };
   kramdown-rfc2629 = {
-    dependencies = ["certified" "kramdown"];
+    dependencies = ["certified" "json_pure" "kramdown"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0s53m46qlcdakik0czvx0p41mk46l9l36331cps8gpf364wf3l9d";
+      sha256 = "16m08q5bgib3i54bb9p3inrxb1xksiybs9zj1rnncq492gcqqv4j";
       type = "gem";
     };
-    version = "1.2.13";
+    version = "1.3.37";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update the package to the latest release.

Result of `nixpkgs-review pr 115309` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>kramdown-rfc2629</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
