### PR TITLE
bindfs: enable darwin

### DIFF
--- a/pkgs/tools/filesystems/bindfs/default.nix
+++ b/pkgs/tools/filesystems/bindfs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fuse, pkg-config }:
+{ lib, stdenv, fetchurl, fuse, pkg-config, osxfuse }:
 
 stdenv.mkDerivation rec {
   version = "1.15.1";
@@ -10,7 +10,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ fuse ];
+  buildInputs = if stdenv.isDarwin
+                then [ osxfuse ]
+                else [ fuse ];
   postFixup = ''
     ln -s $out/bin/bindfs $out/bin/mount.fuse.bindfs
   '';


### PR DESCRIPTION
###### Motivation for this change

Provide bindfs on macOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
