### PR TITLE
gxkb: init at 0.9.0

### DIFF
--- a/pkgs/applications/misc/gxkb/default.nix
+++ b/pkgs/applications/misc/gxkb/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ gtk3 libwnck3 libxklavier ] ++ lib.optional appindicatorSupport libayatana-appindicator-gtk3;
 
-  configureFlags = lib.optional appindicatorSupport  "--enable-appindicator=yes";
+  configureFlags = lib.optional appindicatorSupport "--enable-appindicator=yes";
   outputs = [ "out" "man" ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/gxkb/default.nix
+++ b/pkgs/applications/misc/gxkb/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, gtk3, libwnck3, libxklavier
+, appindicatorSupport ? true, libayatana-appindicator-gtk3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gxkb";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "zen-tools";
+    repo = "gxkb";
+    rev = "v${version}";
+    sha256 = "1fmppvpfz8rip71agsc464fdz423qw0xy8i3pcic14cy5gcwh069";
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  buildInputs = [ gtk3 libwnck3 libxklavier ] ++ lib.optional appindicatorSupport libayatana-appindicator-gtk3;
+
+  configureFlags = lib.optional appindicatorSupport  "--enable-appindicator=yes";
+  outputs = [ "out" "man" ];
+
+  meta = with lib; {
+    description = "X11 keyboard indicator and switcher";
+    homepage = "https://zen-tools.github.io/gxkb/";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.omgbebebe ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9083,6 +9083,8 @@ in
 
   xwallpaper = callPackage ../tools/X11/xwallpaper { };
 
+  gxkb = callPackage ../applications/misc/gxkb { };
+
   xxkb = callPackage ../applications/misc/xxkb { };
 
   ugarit = callPackage ../tools/backup/ugarit {


### PR DESCRIPTION
###### Motivation for this change
I want to use this lightweight layout switcher on daily basis

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
