### PR TITLE
ocamlPackages.hxd: 0.2.0 -> 0.3.1

### DIFF
--- a/pkgs/development/ocaml-modules/duff/default.nix
+++ b/pkgs/development/ocaml-modules/duff/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchurl, buildDunePackage, fetchpatch
 , stdlib-shims, bigarray-compat, fmt
 , alcotest, hxd, crowbar, bigstringaf
 }:
@@ -13,6 +13,14 @@ buildDunePackage rec {
     url = "https://github.com/mirage/duff/releases/download/v${version}/duff-v${version}.tbz";
     sha256 = "1lb67yxk93ifj94p1i3swjbnj5xy8j6xzs72bwvq6cffx5xykznm";
   };
+
+  patches = [
+    # compatibility with hxd >= 0.3.0
+    (fetchpatch {
+      url = "https://github.com/mirage/duff/commit/da0737975aaca313ee4ad9f1e46db1e969672a5b.patch";
+      sha256 = "0qbqzfn2rv867fjcd607cjbnvrfh8fzxlp9mn5r7jx5v83l0zjjq";
+    })
+  ];
 
   propagatedBuildInputs = [ stdlib-shims bigarray-compat fmt ];
 

--- a/pkgs/development/ocaml-modules/hxd/default.nix
+++ b/pkgs/development/ocaml-modules/hxd/default.nix
@@ -1,11 +1,11 @@
 { lib, buildDunePackage, fetchurl
-, dune-configurator, cmdliner, angstrom
-, rresult, stdlib-shims, fmt, fpath
+, dune-configurator, cmdliner
+, withLwt ? true, lwt
 }:
 
 buildDunePackage rec {
   pname = "hxd";
-  version = "0.2.0";
+  version = "0.3.1";
 
   useDune2 = true;
 
@@ -13,24 +13,25 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/dinosaure/hxd/releases/download/v${version}/hxd-v${version}.tbz";
-    sha256 = "1lyfrq058cc9x0c0hzsf3hv3ys0h8mxkwin9lldidlnj10izqf1l";
+    sha256 = "1c226c91e17cd329dec0c287bfd20f36302aa533069ff9c6ced32721f96b29bc";
   };
+
+  # ignore yes stderr output due to trapped SIGPIPE
+  postPatch = ''
+    sed -i 's|yes ".\+"|& 2> /dev/null|' test/*.t
+  '';
 
   nativeBuildInputs = [
     dune-configurator
   ];
 
+  propagatedBuildInputs = lib.optional withLwt lwt;
+
   buildInputs = [
     cmdliner
-    angstrom
-    rresult
-    fmt
-    fpath
   ];
 
-  propagatedBuildInputs = [
-    stdlib-shims
-  ];
+  doCheck = true;
 
   meta = with lib; {
     description = "Hexdump in OCaml";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
* <https://github.com/dinosaure/hxd/releases/tag/v0.3.1>
* <https://github.com/dinosaure/hxd/releases/tag/v0.3.0>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
