### PR TITLE
libgcrypt: remove upstreamed patch

### DIFF
--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -1,6 +1,4 @@
-{ lib, stdenv, fetchurl, gettext, libgpgerror, enableCapabilities ? false, libcap
-, buildPackages, fetchpatch
-}:
+{ lib, stdenv, fetchurl, gettext, libgpgerror, enableCapabilities ? false, libcap, buildPackages }:
 
 assert enableCapabilities -> stdenv.isLinux;
 
@@ -12,15 +10,6 @@ stdenv.mkDerivation rec {
     url = "mirror://gnupg/libgcrypt/${pname}-${version}.tar.bz2";
     sha256 = "sha256-ssENCRUTsnHkcXcnRgex/7o9lbGIu/qHl/lIrskFPFo=";
   };
-
-  patches = [
-    # fix build on 32bit musl
-    (fetchpatch {
-      name = "fix_building_with_disable-asm_on_x86.patch";
-      url = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commitdiff_plain;h=af23ab5c5482d625ff52e60606cf044e2b0106c8";
-      sha256 = "1m8apm8wra6fk89ggha4d0bba5absihm38zvb2khklqh9q5hj9jw";
-    })
-  ];
 
   outputs = [ "out" "dev" "info" ];
   outputBin = "dev";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
