### PR TITLE
cadaver: Fix building with current openssl

### DIFF
--- a/pkgs/tools/networking/cadaver/configure.patch
+++ b/pkgs/tools/networking/cadaver/configure.patch
@@ -1,0 +1,20 @@
+--- a/configure.orig
++++ b/configure
+@@ -9595,7 +9595,7 @@ fi
+ $as_echo "$ne_cv_lib_neon" >&6; }
+     if test "$ne_cv_lib_neon" = "yes"; then
+        ne_cv_lib_neonver=no
+-       for v in 27 28 29; do
++       for v in 27 28 29 30 31; do
+           case $ne_libver in
+           0.$v.*) ne_cv_lib_neonver=yes ;;
+           esac
+@@ -10328,7 +10328,7 @@ fi
+ $as_echo "$ne_cv_lib_neon" >&6; }
+     if test "$ne_cv_lib_neon" = "yes"; then
+        ne_cv_lib_neonver=no
+-       for v in 27 28 29; do
++       for v in 27 28 29 30 31; do
+           case $ne_libver in
+           0.$v.*) ne_cv_lib_neonver=yes ;;
+           esac

--- a/pkgs/tools/networking/cadaver/default.nix
+++ b/pkgs/tools/networking/cadaver/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, openssl, readline }:
+{ lib, stdenv, fetchurl, fetchpatch, neon, pkg-config, readline, zlib}:
 
 stdenv.mkDerivation rec {
   name = "cadaver-0.23.3";
@@ -14,11 +14,15 @@ stdenv.mkDerivation rec {
       name = "disable-sslv2.patch";
       sha256 = "1qx65hv584wdarks51yhd3y38g54affkphm5wz27xiz4nhmbssrr";
     })
+    # Cadaver also works with newer versions of neon than stated
+    # in the configure script
+    ./configure.patch
   ];
 
   configureFlags = [ "--with-ssl" "--with-readline" ];
 
-  buildInputs = [ openssl readline ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ neon readline zlib ];
 
   meta = with lib; {
     description = "A command-line WebDAV client";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3116,9 +3116,7 @@ in
 
   cabextract = callPackage ../tools/archivers/cabextract { };
 
-  cadaver = callPackage ../tools/networking/cadaver {
-    openssl = openssl_1_0_2;
-  };
+  cadaver = callPackage ../tools/networking/cadaver { };
 
   davix = callPackage ../tools/networking/davix { };
 


### PR DESCRIPTION
...by using the already-packaged (newer) version of neon as it is also done for
openSUSE[1].

[1] https://build.opensuse.org/package/show/openSUSE:Factory/cadaver

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This package was broken before, because it used an old version of openssl which has known vulnerabilities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@wavewave 