### PR TITLE
Hercules CI updates

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1533,6 +1533,11 @@ self: super: {
         );
   };
 
+  hercules-ci-cli = generateOptparseApplicativeCompletion "hci" (
+    # See hercules-ci-optparse-applicative in non-hackage-packages.nix.
+    addBuildDepend (unmarkBroken super.hercules-ci-cli) super.hercules-ci-optparse-applicative
+  );
+
   # 2020-12-05: http-client is fixed on too old version
   essence-of-live-coding-warp = super.essence-of-live-coding-warp.override {
     http-client = self.http-client_0_7_6;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1518,8 +1518,20 @@ self: super: {
   # Upstream issue: https://github.com/haskell-servant/servant-swagger/issues/129
   servant-swagger = dontCheck super.servant-swagger;
 
-  # 2020-11-27: cxx-options is broken in Cabal 3.2.0.0
-  hercules-ci-agent = addSetupDepend super.hercules-ci-agent self.Cabal_3_2_1_0;
+  hercules-ci-agent = super.hercules-ci-agent.override {
+    cachix =
+      # https://github.com/cachix/cachix/pull/361
+      (appendPatch
+        (addBuildDepend super.cachix super.hercules-ci-cnix-store)
+        (pkgs.fetchpatch {
+          name = "cachix-361.patch";
+          url = "https://patch-diff.githubusercontent.com/raw/cachix/cachix/pull/361.patch";
+          sha256 = "0wwlcpmnqmvk1css5f723dzgjvg4jr7i58ifhni5zg9h5iwycdfr";
+          stripLen = 1;
+          includes = ["*.cabal" "*.hs"];
+        })
+        );
+  };
 
   # 2020-12-05: http-client is fixed on too old version
   essence-of-live-coding-warp = super.essence-of-live-coding-warp.override {

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2785,8 +2785,12 @@ package-maintainers:
   roberth:
     - arion-compose
     - hercules-ci-agent
+    - hercules-ci-api
     - hercules-ci-api-agent
     - hercules-ci-api-core
+    - hercules-ci-cli
+    - hercules-ci-cnix-expr
+    - hercules-ci-cnix-store
   cdepillabout:
     - pretty-simple
     - spago

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -28,4 +28,8 @@ self: super: {
   graphql-parser = self.callPackage ../misc/haskell/hasura/graphql-parser {};
   # cabal2nix  --subpath server --maintainer offline --no-check --revision 1.2.1 https://github.com/hasura/graphql-engine.git
   graphql-engine = self.callPackage ../misc/haskell/hasura/graphql-engine {};
+
+  # Unofficial fork until PRs are merged https://github.com/pcapriotti/optparse-applicative/pulls/roberth
+  # cabal2nix --maintainer roberth https://github.com/hercules-ci/optparse-applicative.git > pkgs/development/misc/haskell/hercules-ci-optparse-applicative.nix
+  hercules-ci-optparse-applicative = self.callPackage ../misc/haskell/hercules-ci-optparse-applicative.nix {};
 }

--- a/pkgs/development/misc/haskell/hercules-ci-optparse-applicative.nix
+++ b/pkgs/development/misc/haskell/hercules-ci-optparse-applicative.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, ansi-wl-pprint, base, fetchgit, lib, process, QuickCheck
+, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "hercules-ci-optparse-applicative";
+  version = "0.16.1.0";
+  src = fetchgit {
+    url = "https://github.com/hercules-ci/optparse-applicative.git";
+    sha256 = "0v0r11jaav95im82if976256kncp0ji7nfdrlpbgmwxnkj1hxl48";
+    rev = "f9d1242f9889d2e09ff852db9dc2d231d9a3e8d8";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    ansi-wl-pprint base process transformers transformers-compat
+  ];
+  testHaskellDepends = [ base QuickCheck ];
+  homepage = "https://github.com/hercules-ci/optparse-applicative";
+  description = "Utilities and combinators for parsing command line options (fork)";
+  license = lib.licenses.bsd3;
+  maintainers = with lib.maintainers; [ roberth ];
+}

--- a/pkgs/development/tools/continuous-integration/hci/default.nix
+++ b/pkgs/development/tools/continuous-integration/hci/default.nix
@@ -1,0 +1,23 @@
+{ haskell, haskellPackages, lib, makeWrapper, runc, stdenv }:
+let
+  inherit (haskell.lib) overrideCabal addBuildDepends;
+  inherit (lib) makeBinPath;
+  bundledBins = lib.optional stdenv.isLinux runc;
+
+  pkg =
+    # justStaticExecutables is needed due to https://github.com/NixOS/nix/issues/2990
+    overrideCabal
+      (addBuildDepends (haskell.lib.justStaticExecutables haskellPackages.hercules-ci-cli) [ makeWrapper ])
+      (o: {
+        postInstall = ''
+          ${o.postInstall or ""}
+          mkdir -p $out/libexec
+          mv $out/bin/hci $out/libexec
+          makeWrapper $out/libexec/hci $out/bin/hci --prefix PATH : ${makeBinPath bundledBins}
+        '';
+      });
+in pkg // {
+    meta = pkg.meta // {
+      position = toString ./default.nix + ":1";
+    };
+  }

--- a/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
@@ -1,7 +1,9 @@
-{ gnutar, gzip, git, haskell, haskellPackages, lib, makeWrapper }:
+{ gnutar, gzip, git, haskell, haskellPackages, lib, makeWrapper, runc, stdenv }:
 let
   inherit (haskell.lib) overrideCabal addBuildDepends;
   inherit (lib) makeBinPath;
+  bundledBins = [ gnutar gzip git ] ++ lib.optional stdenv.isLinux runc;
+
   pkg =
     # justStaticExecutables is needed due to https://github.com/NixOS/nix/issues/2990
     overrideCabal
@@ -11,7 +13,7 @@ let
           ${o.postInstall or ""}
           mkdir -p $out/libexec
           mv $out/bin/hercules-ci-agent $out/libexec
-          makeWrapper $out/libexec/hercules-ci-agent $out/bin/hercules-ci-agent --prefix PATH : ${makeBinPath [ gnutar gzip git ]}
+          makeWrapper $out/libexec/hercules-ci-agent $out/bin/hercules-ci-agent --prefix PATH : ${makeBinPath bundledBins}
         '';
       });
 in pkg // {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13452,6 +13452,8 @@ in
 
   hercules-ci-agent = callPackage ../development/tools/continuous-integration/hercules-ci-agent { };
 
+  hci = callPackage ../development/tools/continuous-integration/hci { };
+
   niv = lib.getBin (haskell.lib.justStaticExecutables haskellPackages.niv);
 
   ormolu = haskellPackages.ormolu.bin;


### PR DESCRIPTION

###### Motivation for this change

- Unbreak the build
- Update hercules-ci-agent to 0.8.0
- First release of the `hci` command to run effects locally, manipulate state files and manage secrets

I've included the hackage updates, because iirc that's the correct workflow now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
