### PR TITLE
zstxtns-utils: use stdenvNoCC

### DIFF
--- a/pkgs/tools/text/zstxtns-utils/default.nix
+++ b/pkgs/tools/text/zstxtns-utils/default.nix
@@ -5,10 +5,10 @@
 , lib
 , makeWrapper
 , moreutils
-, stdenv
+, stdenvNoCC
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "zstxtns-utils";
   version = "0.0.3";
 


### PR DESCRIPTION
###### Motivation for this change

stdenv (with compiler, etc.) is not used in this package.
https://github.com/NixOS/nixpkgs/pull/115225#discussion_r588833299

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
