### PR TITLE
zz: unstable-2021-01-26 -> unstable-2021-03-07

### DIFF
--- a/pkgs/development/compilers/zz/default.nix
+++ b/pkgs/development/compilers/zz/default.nix
@@ -2,19 +2,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "zz";
-  version = "unstable-2021-01-26";
+  version = "unstable-2021-03-07";
 
-  # commit chosen by using the latest build from http://bin.zetz.it/
+  # when updating, choose commit of the latest build on http://bin.zetz.it/
   src = fetchFromGitHub {
     owner = "zetzit";
     repo = "zz";
-    rev = "0b5c52674e9adf795fbfb051d4dceef3126e669f";
-    sha256 = "0bb77ll1g5i6a04ybpgx6lqsb74xs4v4nyqm9j4j6x24407h8l89";
+    rev = "d3fc968ba2ae6668f930e39077f9a90aecb9fdc4";
+    sha256 = "18p17lgwq6rq1n76sj0dwb32bpxflfd7knky1v0sgmaxfpaq04y3";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
-  cargoSha256 = "1lf4k3n89w2797c1yrj1dp97y8a8d5hnixr1nwa2qcq1sxmm5rcg";
+  cargoSha256 = "0i3c459d4699z4dwvdw1495krdv3c2qpygrsw0cz3j0zd2n5gqj6";
 
   postPatch = ''
     # remove search path entry which would reference /build


### PR DESCRIPTION
Picking from current master for these fixes:

* makes module resolving via ZZ_MODULES_PATH deterministic
* no longer tries to write to /nix/store failing compilation

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
