### PR TITLE
dnsviz: init at 0.9.2

### DIFF
--- a/pkgs/tools/networking/dnsviz/default.nix
+++ b/pkgs/tools/networking/dnsviz/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, dnspython
+, m2crypto
+, pygraphviz
+}:
+
+buildPythonApplication rec {
+  pname = "dnsviz";
+  version = "0.9.2";
+
+  src = fetchFromGitHub {
+    owner = "dnsviz";
+    repo = "dnsviz";
+    rev = "v${version}";
+    sha256 = "sha256-tIxjlNtncZJSdfQelIR9fTohBDkyC0+YwEcs2gNfKec=";
+  };
+
+  patches = [
+    # override DNSVIZ_INSTALL_PREFIX with $out
+    ./fix-path.patch
+  ];
+
+  propagatedBuildInputs = [
+    dnspython
+    m2crypto
+    pygraphviz
+  ];
+
+  postPatch = ''
+    substituteInPlace dnsviz/config.py.in --replace '@out@' $out
+  '';
+
+  # Tests require network connection and /etc/resolv.conf
+  doCheck = false;
+
+  pythonImportsCheck = [ "dnsviz" ];
+
+  meta = with lib; {
+    description = "Tool suite for analyzing and visualizing DNS and DNSSEC behavior";
+    longDescription = ''
+      DNSViz is a tool suite for analysis and visualization of Domain Name System (DNS) behavior,
+      including its security extensions (DNSSEC).
+
+      This tool suite powers the Web-based analysis available at https://dnsviz.net/
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/tools/networking/dnsviz/fix-path.patch
+++ b/pkgs/tools/networking/dnsviz/fix-path.patch
@@ -1,0 +1,18 @@
+diff --git a/dnsviz/config.py.in b/dnsviz/config.py.in
+index 373fde2..007f0f1 100644
+--- a/dnsviz/config.py.in
++++ b/dnsviz/config.py.in
+@@ -26,12 +26,7 @@ from __future__ import unicode_literals
+ import os
+ import sys
+ 
+-_prefix = '__DNSVIZ_INSTALL_PREFIX__'
+-if (hasattr(sys, 'real_prefix') or hasattr(sys, 'base_prefix')) and \
+-        not _prefix:
+-    DNSVIZ_INSTALL_PREFIX = sys.prefix
+-else:
+-    DNSVIZ_INSTALL_PREFIX = _prefix
++DNSVIZ_INSTALL_PREFIX = "@out@"
+ DNSVIZ_SHARE_PATH = os.path.join(DNSVIZ_INSTALL_PREFIX, 'share', 'dnsviz')
+ JQUERY_PATH = __JQUERY_PATH__
+ JQUERY_UI_PATH = __JQUERY_UI_PATH__

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3663,6 +3663,8 @@ in
 
   dnstop = callPackage ../tools/networking/dnstop { };
 
+  dnsviz = python3Packages.callPackage ../tools/networking/dnsviz { };
+
   dnsx = callPackage ../tools/security/dnsx { };
 
   dhcp = callPackage ../tools/networking/dhcp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

[DNSViz](https://github.com/dnsviz/dnsviz) is a tool suite for analysis and visualization of Domain Name System (DNS) behavior, including its security extensions (DNSSEC). This tool suite powers the Web-based analysis available at https://dnsviz.net/.

###### Motivation for this change

Been using it for a few weeks for my personal machines and wanted to add it to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/cdphfhjb9b9fxim9l1if4gk6l2kv2jxq-dnsviz-0.9.2	  191017480
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
