### PR TITLE
ytfzf: init at 1.0.0

### DIFF
--- a/pkgs/tools/misc/ytfzf/default.nix
+++ b/pkgs/tools/misc/ytfzf/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, curl
+, dmenu
+, fzf
+, jq
+, mpv
+, youtube-dl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ytfzf";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "pystardust";
+    repo = "ytfzf";
+    rev = "v${version}";
+    sha256 = "09znixn8mpkxipv2x3nrfxr2i8g7y58v25qssqf092j9lh85sf9h";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  dontBuild = true;
+
+  # remove after next update
+  preInstall = ''
+    mkdir -p "$out/bin"
+  '';
+
+  postInstall = ''
+    wrapProgram "$out/bin/ytfzf" --prefix PATH : ${lib.makeBinPath [
+      curl dmenu fzf jq mpv youtube-dl
+    ]}
+  '';
+
+  meta = with lib; {
+    description = "A posix script to find and watch youtube videos from the terminal";
+    homepage = "https://github.com/pystardust/ytfzf";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9349,6 +9349,8 @@ in
 
   yeshup = callPackage ../tools/system/yeshup { };
 
+  ytfzf = callPackage ../tools/misc/ytfzf { };
+
   ytree = callPackage ../tools/misc/ytree { };
 
   yggdrasil = callPackage ../tools/networking/yggdrasil { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
