### PR TITLE
calamares: fix python modules

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -155,6 +155,7 @@
   ./programs/nm-applet.nix
   ./programs/npm.nix
   ./programs/oblogout.nix
+  ./programs/partition-manager.nix
   ./programs/plotinus.nix
   ./programs/proxychains.nix
   ./programs/qt5ct.nix

--- a/nixos/modules/programs/partition-manager.nix
+++ b/nixos/modules/programs/partition-manager.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta.maintainers = [ maintainers.oxalica ];
+
+  ###### interface
+  options = {
+    programs.partition-manager.enable = mkEnableOption "KDE Partition Manager";
+  };
+
+  ###### implementation
+  config = mkIf config.programs.partition-manager.enable {
+    services.dbus.packages = [ pkgs.libsForQt5.kpmcore ];
+    # `kpmcore` need to be installed to pull in polkit actions.
+    environment.systemPackages = [ pkgs.libsForQt5.kpmcore pkgs.partition-manager ];
+  };
+}

--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -1,25 +1,38 @@
-{ stdenv, lib, fetchurl, extra-cmake-modules
-, qtbase, kio
-, libatasmart, parted
-, util-linux }:
+{ stdenv, lib, fetchurl, fetchpatch, extra-cmake-modules
+, qca-qt5, kauth, kio, polkit-qt, qtbase
+, util-linux
+}:
 
 stdenv.mkDerivation rec {
   pname = "kpmcore";
-  version = "3.3.0";
+  # NOTE: When changing this version, also change the version of `partition-manager`.
+  version = "4.2.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.xz";
-    sha256 = "0s6v0jfrhjg31ri5p6h9n4w29jvasf5dj954j3vfpzl91lygmmmq";
+    hash = "sha256-MvW0CqvFZtzcJlya6DIpzorPbKJai6fxt7nKsKpJn54=";
   };
 
+  patches = [
+    # Fix build with `kcoreaddons` >= 5.77.0
+    (fetchpatch {
+      url = "https://github.com/KDE/kpmcore/commit/07e5a3ac2858e6d38cc698e0f740e7a693e9f302.patch";
+      sha256 = "sha256-LYzea888euo2HXM+acWaylSw28iwzOdZBvPBt/gjP1s=";
+    })
+    # Fix crash when `fstab` omits mount options.
+    (fetchpatch {
+      url = "https://github.com/KDE/kpmcore/commit/eea84fb60525803a789e55bb168afb968464c130.patch";
+      sha256 = "sha256-NJ3PvyRC6SKNSOlhJPrDDjepuw7IlAoufPgvml3fap0=";
+    })
+  ];
+
   buildInputs = [
-    qtbase
-    libatasmart
-    parted # we only need the library
-
+    qca-qt5
+    kauth
     kio
+    polkit-qt
 
-    util-linux # needs blkid (note that this is not provided by util-linux-compat)
+    util-linux # Needs blkid in configure script (note that this is not provided by util-linux-compat)
   ];
 
   nativeBuildInputs = [ extra-cmake-modules ];
@@ -27,8 +40,11 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   meta = with lib; {
-    maintainers = with lib.maintainers; [ peterhoeg ];
+    description = "KDE Partition Manager core library";
+    homepage = "https://invent.kde.org/system/kpmcore";
+    license = with licenses; [ cc-by-40 cc0 gpl3Plus mit ];
+    maintainers = with maintainers; [ peterhoeg oxalica ];
     # The build requires at least Qt 5.14:
-    broken = lib.versionOlder qtbase.version "5.14";
+    broken = versionOlder qtbase.version "5.14";
   };
 }

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -21,8 +21,6 @@ mkDerivation rec {
     qtquickcontrols qtsvg qttools qtwebengine.dev util-linux
   ];
 
-  enableParallelBuilding = false;
-
   cmakeFlags = [
     "-DPYTHON_LIBRARY=${python}/lib/lib${python.libPrefix}.so"
     "-DPYTHON_INCLUDE_DIR=${python}/include/${python.libPrefix}"

--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -1,30 +1,66 @@
-{ mkDerivation, fetchurl, lib
+{ mkDerivation, fetchurl, lib, makeWrapper
 , extra-cmake-modules, kdoctools, wrapGAppsHook, wrapQtAppsHook
 , kconfig, kcrash, kinit, kpmcore
-, eject, libatasmart , util-linux, qtbase
+, cryptsetup, lvm2, mdadm, smartmontools, systemdMinimal, util-linux
+, btrfs-progs, dosfstools, e2fsprogs, exfat, f2fs-tools, fatresize, hfsprogs
+, jfsutils, nilfs-utils, ntfs3g, reiser4progs, reiserfsprogs, udftools, xfsprogs, zfs
 }:
 
 let
-  pname = "partitionmanager";
+  # External programs are resolved by `partition-manager` and then
+  # invoked by `kpmcore_externalcommand` from `kpmcore` as root.
+  # So these packages should be in PATH of `partition-manager`.
+  # https://github.com/KDE/kpmcore/blob/06f15334ecfbe871730a90dbe2b694ba060ee998/src/util/externalcommand_whitelist.h
+  runtimeDeps = lib.makeBinPath [
+    cryptsetup
+    lvm2
+    mdadm
+    smartmontools
+    systemdMinimal
+    util-linux
+
+    btrfs-progs
+    dosfstools
+    e2fsprogs
+    exfat
+    f2fs-tools
+    fatresize
+    hfsprogs
+    jfsutils
+    nilfs-utils
+    ntfs3g
+    reiser4progs
+    reiserfsprogs
+    udftools
+    xfsprogs
+    zfs
+
+    # FIXME: Missing command: tune.exfat hfsck hformat fsck.nilfs2 {fsck,mkfs,debugfs,tunefs}.ocfs2
+  ];
+
 in mkDerivation rec {
-  name = "${pname}-${version}";
-  version = "3.3.1";
+  pname = "partitionmanager";
+  # NOTE: When changing this version, also change the version of `kpmcore`.
+  version = "4.2.0";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "0jhggb4xksb0k0mj752n6pz0xmccnbzlp984xydqbz3hkigra1si";
+    url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.xz";
+    hash = "sha256-6Qlt1c47Eek6TkWWBzTyBZYJ1jfhtwsC9X5q5h6IhPg=";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook wrapQtAppsHook ];
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook wrapQtAppsHook makeWrapper ];
 
-  # refer to kpmcore for the use of eject
-  buildInputs = [ eject libatasmart util-linux ];
   propagatedBuildInputs = [ kconfig kcrash kinit kpmcore ];
+
+  postFixup = ''
+    wrapProgram $out/bin/partitionmanager \
+      --prefix PATH : "${runtimeDeps}"
+  '';
 
   meta = with lib; {
     description = "KDE Partition Manager";
-    license = licenses.gpl2;
+    license = with licenses; [ cc-by-40 cc0 gpl3Plus lgpl3Plus mit ];
     homepage = "https://www.kde.org/applications/system/kdepartitionmanager/";
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg oxalica ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1838,7 +1838,7 @@ in
 
   calamares = libsForQt514.callPackage ../tools/misc/calamares {
     python = python3;
-    boost = pkgs.boost.override { python = python3; };
+    boost = pkgs.boost.override { enablePython = true; python = python3; };
   };
 
   candle = libsForQt5.callPackage ../applications/misc/candle { };


### PR DESCRIPTION
###### Motivation for this change

Calamares wants a boost with python support. It builds without it, but omits any python modules, which are a lot of the interesting ones. This PR also incorporates #114016, which is necessary to build calamares on master.

(As a side note, it's a shame that kpmcore runs on DBus now; as of a few weeks ago, it was possible to run Calamares without any reliance on the global system, which would have made it possible to use any system with Nix on it as a NixOS installer. Ah well.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
