### PR TITLE
palemoon: 29.0.1 -> 29.1.0

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -16,14 +16,14 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "29.0.1";
+  version = "29.1.0";
 
   src = fetchFromGitHub {
     githubBase = "repo.palemoon.org";
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "18flr64041cvffj6jbzx0njnynvyk3k5yljb446a4lwmksvd3nmq";
+    sha256 = "02blhk3v7gpnicd7s5l5fpqvdvj2279g3rq8xyhcd4sw6qnms8m6";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
http://www.palemoon.org/releasenotes.shtml
> This is a development, bugfix and security update.
> […]
> · Added required interaction with file/folder open dialog boxes on html file input elements on some operating systems to avoid malicious content tricking users into uploading sensitive files unintentionally (related to CVE-2021-23956).
> · Added a font sanity check to avoid triggering a potential vulnerability on unpatched Windows operating systems (related to CVE-2021-24093).
> · Security issues addressed: CVE-2021-23974, CVE-2021-23973 and several memory safety hazards that don't have CVE numbers.
> · Unified XUL Platform Mozilla Security Patch Summary: 4 fixed, 2 DiD, 19 not applicable.

Needs backport to stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
