### PR TITLE
neovim-qt-unwrapped: init at 2.16.1

### DIFF
--- a/pkgs/applications/editors/neovim/neovim-qt.nix
+++ b/pkgs/applications/editors/neovim/neovim-qt.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, mkDerivation, fetchFromGitHub, cmake, doxygen, makeWrapper
+, msgpack, neovim, pythonPackages, qtbase }:
+
+mkDerivation rec {
+  pname = "neovim-qt-unwrapped";
+  version = "0.2.16.1";
+
+  src = fetchFromGitHub {
+    owner  = "equalsraf";
+    repo   = "neovim-qt";
+    rev    = "v${version}";
+    sha256 = "0x5brrim3f21bzdmh6wyrhrislwpx1248wbx56csvic6v78hzqny";
+  };
+
+  cmakeFlags = [
+    "-DUSE_SYSTEM_MSGPACK=1"
+    "-DENABLE_TESTS=0"  # tests fail because xcb platform plugin is not found
+  ];
+
+  buildInputs = [
+    neovim.unwrapped # only used to generate help tags at build time
+    qtbase
+  ] ++ (with pythonPackages; [
+    jinja2 python msgpack
+  ]);
+
+  nativeBuildInputs = [ cmake doxygen ];
+
+  preCheck = ''
+    # The GUI tests require a running X server, disable them
+    sed -i ../test/CMakeLists.txt -e '/^add_xtest_gui/d'
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Neovim client library and GUI, in Qt5";
+    homepage = "https://github.com/equalsraf/neovim-qt";
+    license     = licenses.isc;
+    maintainers = with maintainers; [ peterhoeg ];
+    inherit (neovim.meta) platforms;
+  };
+}

--- a/pkgs/applications/editors/neovim/qt.nix
+++ b/pkgs/applications/editors/neovim/qt.nix
@@ -1,79 +1,38 @@
 { lib, stdenv, mkDerivation, fetchFromGitHub, cmake, doxygen, makeWrapper
-, msgpack, neovim, pythonPackages, qtbase }:
+, msgpack, neovim, pythonPackages, qtbase, neovim-qt-unwrapped }:
 
 let
-  unwrapped = mkDerivation rec {
-    pname = "neovim-qt-unwrapped";
-    version = "0.2.16.1";
-
-    src = fetchFromGitHub {
-      owner  = "equalsraf";
-      repo   = "neovim-qt";
-      rev    = "v${version}";
-      sha256 = "0x5brrim3f21bzdmh6wyrhrislwpx1248wbx56csvic6v78hzqny";
-    };
-
-    cmakeFlags = [
-      "-DUSE_SYSTEM_MSGPACK=1"
-      "-DENABLE_TESTS=0"  # tests fail because xcb platform plugin is not found
-    ];
-
-    buildInputs = [
-      neovim.unwrapped # only used to generate help tags at build time
-      qtbase
-    ] ++ (with pythonPackages; [
-      jinja2 python msgpack
-    ]);
-
-    nativeBuildInputs = [ cmake doxygen ];
-
-    preCheck = ''
-      # The GUI tests require a running X server, disable them
-      sed -i ../test/CMakeLists.txt \
-        -e '/^add_xtest_gui/d'
-    '';
-
-    doCheck = true;
-
-    meta = with lib; {
-      description = "Neovim client library and GUI, in Qt5";
-      homepage = "https://github.com/equalsraf/neovim-qt";
-      license     = licenses.isc;
-      maintainers = with maintainers; [ peterhoeg ];
-      inherit (neovim.meta) platforms;
-      inherit version;
-    };
-  };
+  unwrapped = neovim-qt-unwrapped;
 in
-  stdenv.mkDerivation {
-    pname = "neovim-qt";
-    version = unwrapped.version;
-    buildCommand = if stdenv.isDarwin then ''
-      mkdir -p $out/Applications
-      cp -r ${unwrapped}/bin/nvim-qt.app $out/Applications
+stdenv.mkDerivation {
+  pname = "neovim-qt";
+  version = unwrapped.version;
+  buildCommand = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+    cp -r ${unwrapped}/bin/nvim-qt.app $out/Applications
 
-      chmod -R a+w "$out/Applications/nvim-qt.app/Contents/MacOS"
-      wrapProgram "$out/Applications/nvim-qt.app/Contents/MacOS/nvim-qt" \
-        --prefix PATH : "${neovim}/bin"
-    '' else ''
-      makeWrapper '${unwrapped}/bin/nvim-qt' "$out/bin/nvim-qt" \
-        --prefix PATH : "${neovim}/bin"
+    chmod -R a+w $out/Applications/nvim-qt.app/Contents/MacOS
+    wrapProgram $out/Applications/nvim-qt.app/Contents/MacOS/nvim-qt \
+      --prefix PATH : ${neovim}/bin
+  '' else ''
+    makeWrapper ${unwrapped}/bin/nvim-qt $out/bin/nvim-qt \
+      --prefix PATH : ${neovim}/bin
 
-      # link .desktop file
-      mkdir -p "$out/share/pixmaps"
-      ln -s '${unwrapped}/share/applications' "$out/share/applications"
-      ln -s '${unwrapped}/share/pixmaps/nvim-qt.png' "$out/share/pixmaps/nvim-qt.png"
-    '';
+    # link .desktop file
+    mkdir -p $out/share/pixmaps
+    ln -s ${unwrapped}/share/applications $out/share/applications
+    ln -s ${unwrapped}/share/pixmaps/nvim-qt.png $out/share/pixmaps/nvim-qt.png
+  '';
 
-    preferLocalBuild = true;
+  preferLocalBuild = true;
 
-    nativeBuildInputs = [
-      makeWrapper
-    ];
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
-    passthru = {
-      inherit unwrapped;
-    };
+  passthru = {
+    inherit unwrapped;
+  };
 
-    inherit (unwrapped) meta;
-  }
+  inherit (unwrapped) meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25739,6 +25739,7 @@ in
   neovimUtils = callPackage ../applications/editors/neovim/utils.nix { };
   neovim = wrapNeovim neovim-unwrapped { };
 
+  neovim-qt-unwrapped = libsForQt5.callPackage ../applications/editors/neovim/neovim-qt.nix { };
   neovim-qt = libsForQt5.callPackage ../applications/editors/neovim/qt.nix { };
 
   olifant = callPackage ../applications/misc/olifant { };


### PR DESCRIPTION
more like a refactoring. It was already available but via neovim-qt.passthru.unwrapped. 

With home-manager, init.vim is already in the expected position so  wrapping neovim-qt with another neovim wrapper doesn't load my user config as expected. This should be backwards compatible (attribute name doesn't change, I just introduce a new one)

cc @peterhoeg
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
