### PR TITLE
hacpack: init at 1.36

### DIFF
--- a/pkgs/tools/compression/hacpack/default.nix
+++ b/pkgs/tools/compression/hacpack/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "hacpack";
+  version = "1.36";
+
+  src = fetchFromGitHub {
+    owner = "The-4n";
+    repo = "hacpack";
+    rev = "v${version}";
+    sha256 = "0d846l36w1n9rxv79fbyhl2zdbqhlgrvk21b9vzr9x77yki89ygs";
+  };
+
+  preConfigure = ''
+    mv config.mk.template config.mk
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./hacpack $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/The-4n/hacPack";
+    description = "Make and repack Nintendo Switch NCAs/NSPs";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.ivar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22899,6 +22899,8 @@ in
 
   hamster = callPackage ../applications/misc/hamster { };
 
+  hacpack = callPackage ../tools/compression/hacpack { };
+
   hashit = callPackage ../tools/misc/hashit { };
 
   hactool = callPackage ../tools/compression/hactool { };


### PR DESCRIPTION
###### Motivation for this change
Adds [hacpack](https://github.com/The-4n/hacPack), a program allowing you to repack NCA's.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
