### PR TITLE
pylint-flask-sqlalchemy: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/pylint-flask-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/pylint-flask-sqlalchemy/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchPypi
+, isPy3k
+, lib
+, pytestCheckHook
+, pylint-plugin-utils
+, flask_sqlalchemy
+}:
+
+buildPythonPackage rec {
+  pname = "pylint-flask-sqlalchemy";
+  version = "0.2.0";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "pylint_flask_sqlalchemy";
+    sha256 = "10dam2dm5kvz2wjbsi7zzrm7m7c8y3y3yf6q76xdhrd4l6mmpplf";
+  };
+
+  propagatedBuildInputs = [
+    pylint-plugin-utils
+    flask_sqlalchemy
+  ];
+
+  doCheck = false; # Tests are unfortunately broken
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Pylint plugin for improving code analysis when editing code using Flask-SQLAlchemy";
+    homepage = "https://gitlab.anybox.cloud/rboyer/pylint_flask_sqlalchemy";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ nomisiv ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5705,10 +5705,9 @@ in {
 
   pylint-flask = callPackage ../development/python-modules/pylint-flask { };
 
-  pylint = if isPy3k then
-    callPackage ../development/python-modules/pylint { }
-  else
-    callPackage ../development/python-modules/pylint/1.9.nix { };
+  pylint-flask-sqlalchemy = callPackage ../development/python-modules/pylint-flask-sqlalchemy { };
+
+  pylint = callPackage ../development/python-modules/pylint { };
 
   pylint-plugin-utils = callPackage ../development/python-modules/pylint-plugin-utils { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added pylint-flask-sqlalchemy, a python module which enables pylint to correctly lint flask-sqlachemy code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The package builds and is functional, at least on my machine. However I could not get the tests to complete, so I disabled them for now.