### PR TITLE
mopidy-local: 3.2.0 -> 3.2.1

### DIFF
--- a/pkgs/applications/audio/mopidy/local.nix
+++ b/pkgs/applications/audio/mopidy/local.nix
@@ -1,16 +1,15 @@
 { lib
 , mopidy
 , python3Packages
-, fetchpatch
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "Mopidy-Local";
-  version = "3.2.0";
+  version = "3.2.1";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "14f78sb3wkg83dg3xcqlq77dh059zzcwry5l9ilyhnmvmyrkhqx0";
+    sha256 = "18w39mxpv8p17whd6zfw5653d21q138f8xd6ili6ks2g2dbm25i9";
   };
 
   propagatedBuildInputs = [
@@ -20,14 +19,6 @@ python3Packages.buildPythonApplication rec {
 
   checkInputs = [
     python3Packages.pytestCheckHook
-  ];
-
-  patches = [
-    # Fix tests for Mopidy≥3.1.0. Remove with the next release.
-    (fetchpatch {
-      url = "https://github.com/mopidy/mopidy-local/commit/f1d7598d3a9587f0823acb97ecb615f4f4817fd2.patch";
-      sha256 = "193kd5zwsr0qpp2y8icdy13vqpglmjdm7x1rw5hliwyq18a34vjp";
-    })
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/mopidy/mopidy-local/releases/tag/v3.2.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I also tested building a custom Mopidy derivation with the `mopidy-local` extension enabled.