### PR TITLE
stdenv: Fix regression on ARM+static when enabling hardening

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -106,7 +106,12 @@ in rec {
                                       ++ depsTargetTarget ++ depsTargetTargetPropagated) == 0;
       dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || (stdenv.noCC or false);
       supportedHardeningFlags = [ "fortify" "stackprotector" "pie" "pic" "strictoverflow" "format" "relro" "bindnow" ];
-      defaultHardeningFlags = if stdenv.hostPlatform.isMusl
+                              # Musl-based platforms will keep "pie", other platforms will not.
+      defaultHardeningFlags = if stdenv.hostPlatform.isMusl &&
+                                # Except when:
+                                #    - static aarch64, where compilation works, but produces segfaulting dynamically linked binaries.
+                                #    - static armv7l, where compilation fails.
+                                !((stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isAarch32) && stdenv.hostPlatform.isStatic)
                               then supportedHardeningFlags
                               else lib.remove "pie" supportedHardeningFlags;
       enabledHardeningOptions =


### PR DESCRIPTION
###### Motivation for this change

4e9dc46dea0ef8cf15c567fa863796bb23099d0b re-enabled hardening for Musl,
which is good.

Though static builds for ARM fail in various ways

 - cross armv7l static does not build
 - cross aarch64 static produces segfaulting dynamically linked binaries
 - native aarch64 static also produces segfaulting dynamically linked binaries

It seems that for native x86_64-linux, static builds are fine though.

This works around the issue by removing PIE from the hardening flags,
keeping all other hardening flags. This is an improvement (I think) from
before 4e9dc46d.

Fixes #114953 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

In addition to manual testing, a WIP testing harness within Mobile NixOS was used to verify things work.

 - https://github.com/NixOS/mobile-nixos/pull/317

I eventually plan to fold this concept into Nixpkgs proper, but to expedite testing being actually ran it's happening on that side-project.