### PR TITLE
[20.09] Backport of #114723

### DIFF
--- a/pkgs/development/python-modules/soco/default.nix
+++ b/pkgs/development/python-modules/soco/default.nix
@@ -1,29 +1,76 @@
-{ lib, buildPythonPackage, fetchPypi, xmltodict, requests
-, toml
-
-# Test dependencies
-, pytest, pytestcov, coveralls, pylint, flake8, graphviz, mock, sphinx
+{ buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, graphviz
+, ifaddr
+, isPy27
+, lib
+, mock
+, nix-update-script
+, pytestCheckHook
+, requests
+, requests-mock
+, sphinx
 , sphinx_rtd_theme
+, toml
+, xmltodict
 }:
 
 buildPythonPackage rec {
   pname = "soco";
-  version = "0.19";
+  version = "0.21.2";
+  disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0dgca286vhrabm4r4jj545k895z6w2c70ars06vrjhf9cpgg7qck";
+  # N.B. We fetch from GitHub because the PyPI tarball doesn't contain the
+  # required files to run the tests.
+  src = fetchFromGitHub {
+    owner = "SoCo";
+    repo = "SoCo";
+    rev = "v${version}";
+    sha256 = "sha256-CCgkzUkt9YqTJt9tPBLmYXW6ZuRoMDd7xahYmNXgfM0=";
   };
 
-  propagatedBuildInputs = [ xmltodict requests toml ];
+  patches = [(fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/SoCo/SoCo/pull/811.patch";
+    sha256 = "sha256-GBd74c8zc25ROO411SZ9TTa+bi8yXJaaOQqY9FM1qj4=";
+  })];
+
+  # N.B. These exist because:
+  # 1. Upstream's pinning isn't well maintained, leaving dependency versions no
+  #    longer in nixpkgs.
+  # 2. There is no benefit for us to be running linting and coverage tests.
+  postPatch = ''
+    sed -i "/black/d" ./requirements-dev.txt
+    sed -i "/coveralls/d" ./requirements-dev.txt
+    sed -i "/flake8/d" ./requirements-dev.txt
+    sed -i "/pylint/d" ./requirements-dev.txt
+    sed -i "/pytest-cov/d" ./requirements-dev.txt
+  '';
+
+  propagatedBuildInputs = [
+    ifaddr
+    requests
+    toml
+    xmltodict
+  ];
+
   checkInputs = [
-    pytest pytestcov coveralls pylint flake8 graphviz mock sphinx
+    pytestCheckHook
+    graphviz
+    mock
+    requests-mock
+    sphinx
     sphinx_rtd_theme
   ];
 
-  meta = {
+  passthru.updateScript = nix-update-script {
+    attrPath = "python3Packages.${pname}";
+  };
+
+  meta = with lib; {
     homepage = "http://python-soco.com/";
     description = "A CLI and library to control Sonos speakers";
-    license = lib.licenses.mit;
+    license = licenses.mit;
+    maintainers = with maintainers; [ lovesegfault ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
(cherry picked from commit ee06463b2a4e54c8a8ce01a5bc6e0ca1018dbc5b)

Fixes #114886

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
