### PR TITLE
angelfish: init at 1.8.0

### DIFF
--- a/pkgs/applications/networking/browsers/angelfish/default.nix
+++ b/pkgs/applications/networking/browsers/angelfish/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, corrosion
+, extra-cmake-modules
+, kconfig
+, kcoreaddons
+, kdbusaddons
+, ki18n
+, kirigami2
+, knotifications
+, kpurpose
+, kwindowsystem
+, qtquickcontrols2
+, qtwebengine
+, rustPlatform
+}:
+
+mkDerivation rec {
+  pname = "angelfish";
+  version = "1.8.0";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "plasma-mobile";
+    repo = "angelfish";
+    rev = "v${version}";
+    sha256 = "0pj2kw7lmxh7diwdcmk24qxqslavhvf23r2i6h549gbllbzk219f";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    sha256 = "0cyrmhlg0kjr14842ckbjdljc2zc28al0y9i8w5l0qzr18krgc0m";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    corrosion
+    extra-cmake-modules
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  cmakeFlags = [
+    "-DRust_CARGO=${rustPlatform.rust.cargo}/bin/cargo"
+  ];
+
+  buildInputs = [
+    kconfig
+    kcoreaddons
+    kdbusaddons
+    ki18n
+    kirigami2
+    knotifications
+    kpurpose
+    kwindowsystem
+    qtquickcontrols2
+    qtwebengine
+  ];
+
+  meta = with lib; {
+    description = "Web browser for Plasma Mobile";
+    homepage = "https://apps.kde.org/en/mobile.angelfish";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/tools/build-managers/corrosion/cmake-install-full-dir.patch
+++ b/pkgs/development/tools/build-managers/corrosion/cmake-install-full-dir.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/CorrosionConfig.cmake.in b/cmake/CorrosionConfig.cmake.in
+index c042a00..491f53c 100644
+--- a/cmake/CorrosionConfig.cmake.in
++++ b/cmake/CorrosionConfig.cmake.in
+@@ -4,11 +4,11 @@ if (Corrosion_FOUND)
+     return()
+ endif()
+ 
+-list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/@CORROSION_INSTALL_PREFIX@@CMAKE_INSTALL_DATADIR@/cmake")
++list(APPEND CMAKE_MODULE_PATH "@CMAKE_INSTALL_FULL_DATADIR@/cmake")
+ 
+ add_executable(Corrosion::Generator IMPORTED GLOBAL)
+ set_property(
+     TARGET Corrosion::Generator
+-    PROPERTY IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/@CORROSION_INSTALL_PREFIX@@CMAKE_INSTALL_LIBEXECDIR@/corrosion-generator")
++    PROPERTY IMPORTED_LOCATION "@CMAKE_INSTALL_FULL_LIBEXECDIR@/corrosion-generator")
+ 
+ include(Corrosion)

--- a/pkgs/development/tools/build-managers/corrosion/default.nix
+++ b/pkgs/development/tools/build-managers/corrosion/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, rustPlatform
+}:
+
+stdenv.mkDerivation rec {
+  pname = "corrosion";
+  version = "unstable-2021-02-23";
+
+  src = fetchFromGitHub {
+    owner = "AndrewGaspar";
+    repo = "corrosion";
+    rev = "e6c35c7e55a59c8223577b5abc4d253b4a82898b";
+    sha256 = "0vq6g3ggnqiln0q8gsr8rr5rrdgpfcgfly79jwcygxrviw37m44d";
+  };
+
+  patches = [
+    # https://github.com/AndrewGaspar/corrosion/issues/84
+    ./cmake-install-full-dir.patch
+  ];
+
+  cargoRoot = "generator";
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    sourceRoot = "${src.name}/${cargoRoot}";
+    name = "${pname}-${version}";
+    sha256 = "1fsq8zzzq28fj2fh92wmg8kmdj4y10mcpdmlgxsygy5lbh4xs13f";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  cmakeFlags = [
+    "-DRust_CARGO=${rustPlatform.rust.cargo}/bin/cargo"
+
+    # tests cannot find cargo because Rust_CARGO is unset before tests
+    "-DCORROSION_BUILD_TESTS=OFF"
+  ];
+
+  meta = with lib; {
+    description = "Tool for integrating Rust into an existing CMake project";
+    homepage = "https://github.com/AndrewGaspar/corrosion";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12312,6 +12312,8 @@ in
 
   cookiecutter = with python3Packages; toPythonApplication cookiecutter;
 
+  corrosion = callPackage ../development/tools/build-managers/corrosion { };
+
   corundum = callPackage ../development/tools/corundum { };
 
   confluent-platform = callPackage ../servers/confluent-platform {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21602,6 +21602,8 @@ in
     });
   android-studio = androidStudioPackages.stable;
 
+  angelfish = libsForQt5.callPackage ../applications/networking/browsers/angelfish { };
+
   animbar = callPackage ../applications/graphics/animbar { };
 
   antfs-cli = callPackage ../applications/misc/antfs-cli {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Play around with Plasma Mobile.

The adblocking feature relies on Brave's adblock written in Rust.
That relies on [Corrosion](https://github.com/AndrewGaspar/corrosion). I fear I'm not knowledgable enough when it comes to Rust and CMake to package that myself, or rather patch it out and use our own hooks instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/qt-kde 
cc @danieldk 