### PR TITLE
python3Packages.phonemizer: update patch to fix tests

### DIFF
--- a/pkgs/development/python-modules/phonemizer/backend-paths.patch
+++ b/pkgs/development/python-modules/phonemizer/backend-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/phonemizer/backend/espeak.py b/phonemizer/backend/espeak.py
-index 387c11c..ceb5e7e 100644
+index b4712bf..5628fd5 100644
 --- a/phonemizer/backend/espeak.py
 +++ b/phonemizer/backend/espeak.py
-@@ -81,10 +81,7 @@ class BaseEspeakBackend(BaseBackend):
+@@ -82,10 +82,7 @@ class BaseEspeakBackend(BaseBackend):
          if _ESPEAK_DEFAULT_PATH:
              return _ESPEAK_DEFAULT_PATH
  
@@ -15,10 +15,10 @@ index 387c11c..ceb5e7e 100644
      @classmethod
      def is_available(cls):
 diff --git a/phonemizer/backend/festival.py b/phonemizer/backend/festival.py
-index b5bc56d..0833160 100644
+index 3037be5..684ffff 100644
 --- a/phonemizer/backend/festival.py
 +++ b/phonemizer/backend/festival.py
-@@ -78,7 +78,7 @@ class FestivalBackend(BaseBackend):
+@@ -80,7 +80,7 @@ class FestivalBackend(BaseBackend):
          if _FESTIVAL_DEFAULT_PATH:
              return _FESTIVAL_DEFAULT_PATH
  
@@ -27,3 +27,16 @@ index b5bc56d..0833160 100644
  
      @classmethod
      def is_available(cls):
+diff --git a/test/test_punctuation.py b/test/test_punctuation.py
+index 6ed642a..08060df 100644
+--- a/test/test_punctuation.py
++++ b/test/test_punctuation.py
+@@ -28,7 +28,7 @@ ESPEAK_143 = (EspeakBackend.version(as_tuple=True) >= (1, 49, 3))
+ ESPEAK_150 = (EspeakBackend.version(as_tuple=True) >= (1, 50))
+ 
+ # True if we are using festival>=2.5
+-FESTIVAL_25 = (FestivalBackend.version(as_tuple=True) >= (2, 5))
++FESTIVAL_25 = False
+ 
+ 
+ @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Broken by the last upgrade during last the python-unstable cycle.

We don't have festival packaged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
