### PR TITLE
trealla: init at 1.7.65

### DIFF
--- a/pkgs/development/interpreters/trealla/default.nix
+++ b/pkgs/development/interpreters/trealla/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, fetchFromGitHub, readline, openssl, withThread ? true, withSSL ? true, xxd }:
+
+stdenv.mkDerivation rec {
+  pname = "trealla";
+  version = "1.7.65";
+
+  src = fetchFromGitHub {
+    owner = "infradig";
+    repo = "trealla";
+    rev = "v${version}";
+    sha256 = "sha256-uCDACBwdiCeAwF6IZHz7s5pD83JXTP7jAQDjGld8tt0=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '-I/usr/local/include' "" \
+      --replace '-L/usr/local/lib' "" \
+      --replace 'GIT_VERSION :=' 'GIT_VERSION ?='
+  '';
+
+  makeFlags = [
+    "GIT_VERSION=\"v${version}\""
+    (lib.optionalString withThread "THREADS=1")
+    (lib.optionalString (!withSSL) "NOSSL=1")
+    (lib.optionalString stdenv.isDarwin "NOLDLIBS=1")
+  ];
+
+  nativeBuildInputs = [ xxd ];
+  buildInputs = [ readline openssl ];
+
+  installPhase = ''
+    install -Dm755 -t $out/bin tpl
+  '';
+
+  doCheck = true;
+  preCheck = ''
+    # Disable test 81 due to floating point error
+    rm tests/issues/test081.expected tests/issues/test081.pl
+  '';
+
+  meta = with lib; {
+    description = "A compact, efficient Prolog interpreter written in ANSI C";
+    homepage = "https://github.com/infradig/trealla";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11791,6 +11791,8 @@ in
 
   tclreadline = callPackage ../development/interpreters/tclreadline { };
 
+  trealla = callPackage ../development/interpreters/trealla { };
+
   wasm = ocamlPackages.wasm;
 
   proglodyte-wasm = callPackage ../development/interpreters/proglodyte-wasm { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
