### PR TITLE
libtorch-bin: switch to CUDA 11.1, remove static libraries

### DIFF
--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -8,8 +8,8 @@
 , fixDarwinDylibNames
 
 , cudaSupport
-, cudatoolkit_10_2
-, cudnn_cudatoolkit_10_2
+, cudatoolkit_11_1
+, cudnn_cudatoolkit_11_1
 }:
 
 let
@@ -109,8 +109,8 @@ in stdenv.mkDerivation {
 
   passthru.tests.cmake = callPackage ./test {
     inherit cudaSupport;
-    cudatoolkit = cudatoolkit_10_2;
-    cudnn = cudnn_cudatoolkit_10_2;
+    cudatoolkit = cudatoolkit_11_1;
+    cudnn = cudnn_cudatoolkit_11_1;
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -38,7 +38,7 @@ in stdenv.mkDerivation {
 
   installPhase = ''
     # Copy headers and CMake files.
-    install -Dm755 -t $dev/lib lib/*.a
+    mkdir -p $dev
     cp -r include $dev
     cp -r share $dev
 

--- a/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
+++ b/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
@@ -8,7 +8,7 @@ version: {
     hash = "sha256-xBaNyI7eiQnSArHMITonrQQLZnZCZK/SWKOTWnxzdpc=";
   };
   x86_64-linux-cuda = {
-    url = "https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-${version}.zip";
-    hash = "sha256-rNEyE4+jfeX7cU0aNYd5b0pZGYT0PNPnDnS1PIsrMeM=";
+    url = "https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-${version}%2Bcu111.zip";
+    hash = "sha256-uQ7ptOuzowJ0JSPIvJHyNotBfpsqAnxpMDLq7Vl6L00=";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Two small quality of life improvements:

- Switch from CUDA 10.2 build to CUDA 11.1. This enables support for
  some newer GPUs.
- Remove static libraries. These are included with the libtorch
  distribution, but are not usable for static linking anyway (they are incomplete).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
