### PR TITLE
pythonPackages.Babel: 2.7.0 -> 2.9.0

### DIFF
--- a/pkgs/development/python-modules/Babel/default.nix
+++ b/pkgs/development/python-modules/Babel/default.nix
@@ -1,38 +1,17 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, fetchpatch, pytz, pytest, freezegun, glibcLocales }:
+{ stdenv, lib, buildPythonPackage, fetchPypi, pytz, pytestCheckHook, freezegun }:
 
 buildPythonPackage rec {
   pname = "Babel";
-  version = "2.7.0";
+  version = "2.9.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28";
+    sha256 = "018yg7g2pa6vjixx1nx41cfispgfi0azzp0a1chlycbj8jsil0ys";
   };
-
-  patches = [
-    # The following 2 patches fix the test suite failing on nix < 2.3 with
-    # Python < 3 because those nix versions do not run in a pseudoterminal,
-    # which makes Python 2 not set the default encoding to UTF-8, and the
-    # Babel code crashes when printing a warning in that case.
-    # See #75676 and https://github.com/python-babel/babel/pull/691.
-    # It is important to fix this because otherwise Babel is not buildable
-    # with older nix versions (e.g. on machines used as --builders).
-    # TODO: Remove at release > 2.8.0.
-    (fetchpatch {
-      name = "Babel-Introduce-invariant-that-invalid_pofile-takes-unicode-line.patch";
-      url = "https://github.com/python-babel/babel/commit/f4f6653e6aa053724d2c6dc0ee71dcb928013352.patch";
-      sha256 = "1kyknwn9blspcf9yxmgdiaxdii1dnkblyhcflqwhxyl1mss1dxv5";
-    })
-    (fetchpatch {
-      name = "Babel-Fix-unicode-printing-error-on-Python-2-without-TTY.patch";
-      url = "https://github.com/python-babel/babel/commit/da7f31143847659b6b74d802618b03438aceb350.patch";
-      sha256 = "09yny8614knr8ngrrddmqzkxk70am135rccv2ncc6dji4xbqbfln";
-    })
-  ];
 
   propagatedBuildInputs = [ pytz ];
 
-  checkInputs = [ pytest freezegun ];
+  checkInputs = [ pytestCheckHook freezegun ];
 
   doCheck = !stdenv.isDarwin;
 


### PR DESCRIPTION
Update babel as the current release is over a year old and some packages
need >=2.8.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update babel as the current release is over a year old and a couple of packages i use
need >=2.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
