### PR TITLE
python3Packages.pytest-cid: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/pytest-cid/default.nix
+++ b/pkgs/development/python-modules/pytest-cid/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pythonOlder
+, py-cid
+, pytestCheckHook
+, pytest-cov
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-cid";
+  version = "1.1.1";
+  format = "flit";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "ntninja";
+    repo = pname;
+    rev = "1ff9ec43ac9eaf76352ea7e7a060cd081cb8b68a"; # Version has no git tag
+    sha256 = "sha256-H2RtMGYWukowTTfqZSx+hikxzkqw1v5bA4AfZfiVl8U=";
+  };
+
+  propagatedBuildInputs = [
+    py-cid
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-cov
+  ];
+
+  pythonImportsCheck = [ "pytest_cid" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/ntninja/pytest-cid";
+    description = "A simple wrapper around py-cid for easily writing tests involving CIDs in datastructures";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6249,6 +6249,8 @@ in {
 
   pytest-check = callPackage ../development/python-modules/pytest-check { };
 
+  pytest-cid = callPackage ../development/python-modules/pytest-cid { };
+
   pytest-click = callPackage ../development/python-modules/pytest-click { };
 
   pytest-cov = self.pytestcov; # self 2021-01-04


### PR DESCRIPTION
###### Motivation for this change
This adds pytest-cid from https://github.com/ntninja/pytest-cid.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).