### PR TITLE
stdenv: bootstrap riscv64-linux (Step 1)

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -81,6 +81,8 @@ let
     else if targetPlatform.system == "aarch64-linux"  then "${sharedLibraryLoader}/lib/ld-linux-aarch64.so.1"
     else if targetPlatform.system == "powerpc-linux"  then "${sharedLibraryLoader}/lib/ld.so.1"
     else if targetPlatform.isMips                     then "${sharedLibraryLoader}/lib/ld.so.1"
+    # `ld-linux-riscv{32,64}-<abi>.so.1`
+    else if targetPlatform.isRiscV                    then "${sharedLibraryLoader}/lib/ld-linux-riscv*.so.1"
     else if targetPlatform.isDarwin                   then "/usr/lib/dyld"
     else if targetPlatform.isFreeBSD                  then "/libexec/ld-elf.so.1"
     else if lib.hasSuffix "pc-gnu" targetPlatform.config then "ld.so.1"

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -279,6 +279,10 @@ in
         };
       };
     };
+
+    # `libtool` comes with obsolete config.sub/config.guess that don't recognize Risc-V.
+    extraNativeBuildInputs =
+      lib.optional (localSystem.isRiscV) prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
 
 

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -160,6 +160,11 @@ in with pkgs; rec {
         # pkgs/stdenv/linux/default.nix for the details.
         cp -d ${isl_0_20.out}/lib/libisl*.so* $out/lib
 
+      '' + lib.optionalString (stdenv.hostPlatform.isRiscV) ''
+        # libatomic is required on RiscV platform for C/C++ atomics and pthread
+        # even though they may be translated into native instructions.
+        cp -d ${bootGCC.out}/lib/libatomic.a* $out/lib
+
       '' + ''
         cp -d ${bzip2.out}/lib/libbz2.so* $out/lib
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix bootstrap packages and bootstrap `stdenv` on native `riscv64-linux` platform.

Related: #101651

**UPDATE  2021.11.27**

Rebased and fixed. Currently it doesn't contain bootstrap binary hashes. As suggested by @r-burns https://github.com/NixOS/nixpkgs/pull/115406#issuecomment-950109021, we should build it on Hydra for trusted binaries.

**UPDATE  2021.10.23**
Rebased and re-bootstrapped with [QEMU VM](https://github.com/NixOS/nixpkgs/issues/101651#issuecomment-852725823). Thanks @zhaofengli.

<details>
<summary>Previous attempt</summary>

Files ready to be uploaded to `tarballs.nixos.org`: (Currently on my cachix https://riscv64.cachix.org)
- /nix/store/yffnjz4sny3ygbm59wk69yk56ja0lyk8-busybox
  Nar hash: `sha256:d67bc5ef5c550bc1e2b86b27fe20b9ffadca42b9d104ae0f27957794be62ac5f`

- /nix/store/gaa783s4y4w14wyc94lh5pvbpyszbvhc-bootstrap-tools.tar.xz
  File hash: `sha256:541b51c0dcc4e9fb04652664ff03581c73c16e24198e4030c8ff205fc1114c3d`

###### Steps **I** did

1. Cross build bootstrap tools for `riscv64-linux`, with build platform `x86_64-linux`.
```shell
nix build -f pkgs/stdenv/linux/make-bootstrap-tools-cross.nix riscv64.build -o result-rv64-bootstrap-tools-stage0
```

2. Get hashes to fill `pkgs/stdenv/linux/bootstrap-files/riscv64.nix`.
   Then add fixed-output paths into store since our bootstrap file URLs are fake.
```shell
nix hash path --type sha256 --base16 ./result-rv64-bootstrap-tools-stage0/on-server/busybox
nix hash file --type sha256 --base16 ./result-rv64-bootstrap-tools-stage0/on-server/bootstrap-tools.tar.xz
# ... hashes to fill

nix store add-path ./result-rv64-bootstrap-tools-stage0/on-server/busybox
nix store add-file ./result-rv64-bootstrap-tools-stage0/on-server/bootstrap-tools.tar.xz
```

3. Setup a native `riscv64-linux` platform.
   ~For me, [HiFive-Unleashed](https://www.sifive.com/boards/hifive-unleashed) is used.
   Cross build `nix` for `riscv64-linux`, copy closures to the riscv64 platform, and setup `/nix` and `PATH` correctly.~
   I currently don't have any native machine, so I setup an QEMU VM for the bootstrap build.
   Note that some packages like `coreutils` must be built on native machine or QEMU VM, instead of binfmt (QEMU user mode), to pass all tests . See Notes 3 below.

4. Remote build native bootstrap tools on `riscv64-linux` with previous cross bootstrap tools.
```shell
nix build -f pkgs/stdenv/linux/make-bootstrap-tools.nix build --arg localSystem '{ system = "riscv64-linux"; }' -L --keep-going --builders 'ssh://rv64_machine_or_vm riscv64-linux - 4' -j0 -o result-rv64-bootstrap-tools-stage1
```

5. Update bootstrap file hashes to native ones in `pkgs/stdenv/linux/bootstrap-files/riscv64.nix`.
```shell
nix hash path --type sha256 --base16 ./result-rv64-bootstrap-tools-stage1/on-server/busybox
nix hash file --type sha256 --base16 ./result-rv64-bootstrap-tools-stage1/on-server/bootstrap-tools.tar.xz
# ... hashes to fill

nix store add-path ./result-rv64-bootstrap-tools-stage1/on-server/busybox
nix store add-file ./result-rv64-bootstrap-tools-stage1/on-server/bootstrap-tools.tar.xz
```

6. Bootstrap again to check if it works. But not update hashes this time.
```shell
nix build -f pkgs/stdenv/linux/make-bootstrap-tools.nix build --arg localSystem '{ system = "riscv64-linux"; }' -L --keep-going --builders 'ssh://rv64_machine_or_vm riscv64-linux - 4' -j0 -o result-rv64-bootstrap-tools-stage2
```

###### Notes

1. Bootstrap tools are currently using fake URLs. They should be uploaded first and updated to `tarballs.nixos.org` before merging this PR.
2. All intermediate and final store paths are available on <https://riscv64.cachix.org>.
3. Using `binfmt` instead of native riscv64 platform (or QEMU VM) will make few derivations like `coreutils` fail the `checkPhase` because of changed `argv[0]` and emulator behavior. Some tests expects a specific failure like "invalid cwd" from binary, but binfmt qemu fails before it which produces different error message.

4. ~`gcc10` uses PGO and therefore not deterministic (#108475). So bootstrap file hashs may also be not reproducible.~
5. `libatomic` is required for packages linking `pthread` or using `<atomic>` (like `xz`) during the bootstrap. ~But there is another way to avoid producing `libatomic` in bootstrap tools, but re-configure these packages to disable multi-threading before new `gcc` is built (like [what we do](https://github.com/NixOS/nixpkgs/blob/b2a42f017ff3308a4f6394bc949a8acb8e8c8be2/pkgs/stdenv/linux/default.nix#L210) with `perl`)
   I'm not sure which way is preferred.~
   I just added `libatomic` to bootstrap tools.
6. `bootstrap-tools-stage2` differs from `bootstrap-tools-stage1`. The differences are from glibc and gcc (cc1/cc1plus). 
   I believe it's caused by that `-frandom-seed` is based on `$out` (#102251), which is hashed from all drv inputs. Here between two bootstraps, the bootstrap tools should be functionally identical but have different hash, which changes `random-seed` of downstream packages.
   It should not be an issue though.

<details>
<summary><code>diff -r ./result-rv64-bootstrap-tools-stage{1,2}</code></summary>

```
Binary files ./result-rv64-bootstrap-tools-stage1/on-server/bootstrap-tools.tar.xz and ./result-rv64-bootstrap-tools-stage2/on-server/bootstrap-tools.tar.xz differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/bin/make and ./result-rv64-bootstrap-tools-stage2/pack/bin/make differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/crt1.o and ./result-rv64-bootstrap-tools-stage2/pack/lib/crt1.o differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/ld-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/ld-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/ld-linux-riscv64-lp64d.so.1 and ./result-rv64-bootstrap-tools-stage2/pack/lib/ld-linux-riscv64-lp64d.so.1 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libc-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libc-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libcrypt-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libcrypt-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libcrypt.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libcrypt.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libcrypt.so.1 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libcrypt.so.1 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libc.so.6 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libc.so.6 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libdl-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libdl-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libdl.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libdl.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libdl.so.2 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libdl.so.2 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libm-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libm-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libmemusage.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libmemusage.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libm.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libm.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libm.so.6 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libm.so.6 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnsl-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnsl-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnsl.so.1 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnsl.so.1 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_compat-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_compat-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_compat.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_compat.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_compat.so.2 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_compat.so.2 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_db-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_db-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_db.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_db.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_db.so.2 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_db.so.2 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_dns-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_dns-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_dns.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_dns.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_dns.so.2 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_dns.so.2 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_files-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_files-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_files.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_files.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_files.so.2 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_files.so.2 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_hesiod-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_hesiod-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_hesiod.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_hesiod.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libnss_hesiod.so.2 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libnss_hesiod.so.2 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libpthread-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libpthread-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libpthread.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libpthread.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libpthread.so.0 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libpthread.so.0 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libresolv-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libresolv-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libresolv.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libresolv.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libresolv.so.2 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libresolv.so.2 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/librt-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/librt-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/librt.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/librt.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/librt.so.1 and ./result-rv64-bootstrap-tools-stage2/pack/lib/librt.so.1 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libutil-2.33.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libutil-2.33.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libutil.so and ./result-rv64-bootstrap-tools-stage2/pack/lib/libutil.so differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/lib/libutil.so.1 and ./result-rv64-bootstrap-tools-stage2/pack/lib/libutil.so.1 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/libexec/gcc/riscv64-unknown-linux-gnu/10.3.0/cc1 and ./result-rv64-bootstrap-tools-stage2/pack/libexec/gcc/riscv64-unknown-linux-gnu/10.3.0/cc1 differ
Binary files ./result-rv64-bootstrap-tools-stage1/pack/libexec/gcc/riscv64-unknown-linux-gnu/10.3.0/cc1plus and ./result-rv64-bootstrap-tools-stage2/pack/libexec/gcc/riscv64-unknown-linux-gnu/10.3.0/cc1plus differ
```

</details>
</details>