### PR TITLE
networkmanagerapplet: 1.18.0 -> 1.20.0

### DIFF
--- a/pkgs/tools/networking/network-manager/applet/default.nix
+++ b/pkgs/tools/networking/network-manager/applet/default.nix
@@ -11,7 +11,6 @@
 , polkit
 , modemmanager
 , libnma
-, mobile-broadband-provider-info
 , glib-networking
 , gsettings-desktop-schemas
 , libgudev
@@ -51,6 +50,7 @@ stdenv.mkDerivation rec {
     libgudev
     modemmanager
     jansson
+    glib
     glib-networking
     libappindicator-gtk3
     gnome3.adwaita-icon-theme
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://gitlab.gnome.org/GNOME/network-manager-applet/";
     description = "NetworkManager control applet for GNOME";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ phreedom ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/networking/network-manager/applet/default.nix
+++ b/pkgs/tools/networking/network-manager/applet/default.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation rec {
   pname = "network-manager-applet";
-  version = "1.18.0";
+  version = "1.20.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "12xiy8g8qk18jvxvn78mvq03zvzp06bww49na765jjw0rq541fyx";
+    sha256 = "0lsjkbv66hn7acl2pg9h6hz4b700zzv4cjwrwjvy7043blw0bcla";
   };
 
   mesonFlags = [


### PR DESCRIPTION
###### Motivation for this change
Version bump.

Notably allows disabling/enabling wireguard connections, instead of just editing them (though until NM gets updated this is meaningless). Only tested in as far as running it in `--indicator` mode.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
