### PR TITLE
coqPackages.mathcomp: etc

### DIFF
--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -10,7 +10,7 @@
 # See the documentation at doc/languages-frameworks/coq.section.md.        #
 ############################################################################
 
-{ lib, ncurses, which, graphviz, lua,
+{ lib, ncurses, which, graphviz, lua, fetchzip,
   mkCoqDerivation, recurseIntoAttrs, withDoc ? false, single ? false,
   coqPackages, coq, ocamlPackages, version ? null }@args:
 with builtins // lib;
@@ -55,27 +55,47 @@ let
       derivation = mkCoqDerivation ({
         inherit version pname defaultVersion release releaseRev repo owner;
 
-        nativeBuildInputs = optional withDoc graphviz;
+        nativeBuildInputs = optionals withDoc [ graphviz lua ];
         mlPlugin = versions.isLe "8.6" coq.coq-version;
-        extraBuildInputs = [ ncurses which ] ++ optional withDoc lua;
+        extraBuildInputs = [ ncurses which ];
         propagatedBuildInputs = mathcomp-deps;
 
         buildFlags = optional withDoc "doc";
 
         preBuild = ''
           patchShebangs etc/utils/ssrcoqdep || true
+          patchShebangs etc/buildlibgraph || true
         '' + ''
           cd ${pkgpath}
         '' + optionalString (package == "all") pkgallMake;
-
-        installTargets = "install" + optionalString withDoc " doc";
 
         meta = {
           homepage    = "https://math-comp.github.io/";
           license     = licenses.cecill-b;
           maintainers = with maintainers; [ vbgl jwiegley cohencyril ];
         };
-      } // optionalAttrs (package != "single") { passthru = genAttrs packages mathcomp_; });
+      } // optionalAttrs (package != "single")
+        { passthru = genAttrs packages mathcomp_; }
+        // optionalAttrs withDoc {
+            htmldoc_template =
+              fetchzip {
+                url = "https://github.com/math-comp/math-comp.github.io/archive/doc-1.12.0.zip";
+                sha256 = "0y1352ha2yy6k2dl375sb1r68r1qi9dyyy7dyzj5lp9hxhhq69x8";
+              };
+            postBuild = ''
+              cp -rf _build_doc/* .
+              rm -rf _build_doc
+            '';
+            postInstall =
+              let tgt = "$out/share/coq/${coq.coq-version}/"; in
+              optionalString withDoc ''
+              mkdir -p ${tgt}
+              cp -r htmldoc ${tgt}
+              cp -r $htmldoc_template/htmldoc_template/* ${tgt}/htmldoc/
+            '';
+            buildTargets = "doc";
+            extraInstallFlags = [ "-f Makefile.coq" ];
+          });
     patched-derivation1 = derivation.overrideAttrs (o:
       optionalAttrs (o.pname != null && o.pname == "mathcomp-all" &&
          o.version != null && o.version != "dev" && versions.isLt "1.7" o.version)

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -84,7 +84,7 @@ let
               };
             postBuild = ''
               cp -rf _build_doc/* .
-              rm -rf _build_doc
+              rm -r _build_doc
             '';
             postInstall =
               let tgt = "$out/share/coq/${coq.coq-version}/"; in

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -63,8 +63,12 @@ let
         buildFlags = optional withDoc "doc";
 
         preBuild = ''
-          patchShebangs etc/utils/ssrcoqdep || true
-          patchShebangs etc/buildlibgraph || true
+          if [[ -f etc/utils/ssrcoqdep ]]
+          then patchShebangs etc/utils/ssrcoqdep
+          fi
+          if [[ -f etc/buildlibgraph ]]
+          then patchShebangs etc/buildlibgraph
+          fi
         '' + ''
           cd ${pkgpath}
         '' + optionalString (package == "all") pkgallMake;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The option `withDoc` was broken.
This PR fixes it and provide a correct generation of the doc for mathcomp.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).