### PR TITLE
glib: 2.66.4 -> 2.66.8

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -45,11 +45,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "glib";
-  version = "2.66.4";
+  version = "2.66.8";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "l9+GcOMvn9T3OSsJgOZh3WJQEgFdWDUNoeWOND9K+YQ=";
+    sha256 = "sha256-l7yH3ZE2VYmvXLv+oldIM66nobcYQP02Xs0oUsdrnIs=";
   };
 
   patches = optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/glib/schema-override-variable.patch
+++ b/pkgs/development/libraries/glib/schema-override-variable.patch
@@ -1,12 +1,14 @@
+diff --git a/gio/gsettingsschema.c b/gio/gsettingsschema.c
+index 1282c10a1..feadfe3aa 100644
 --- a/gio/gsettingsschema.c
 +++ b/gio/gsettingsschema.c
-@@ -352,6 +352,9 @@
+@@ -360,6 +360,9 @@ initialise_schema_sources (void)
  
        try_prepend_data_dir (g_get_user_data_dir ());
  
-+      if ((path = g_getenv ("NIX_GSETTINGS_OVERRIDES_DIR")) != NULL)
++      if (!is_setuid && (path = g_getenv ("NIX_GSETTINGS_OVERRIDES_DIR")) != NULL)
 +        try_prepend_dir (path);
 +
-       if ((path = g_getenv ("GSETTINGS_SCHEMA_DIR")) != NULL)
-         try_prepend_dir (path);
- 
+       /* Disallow loading extra schemas if running as setuid, as that could
+        * allow reading privileged files. */
+       if (!is_setuid && (path = g_getenv ("GSETTINGS_SCHEMA_DIR")) != NULL)


### PR DESCRIPTION
###### Motivation for this change
Maintenance version bump. Took rebasing the override patch as some safeties got added. I duplicated the setuid checking, but did not add multi-directory support, as it didn't seem necessary. Happy to fix the patch up if there's some preference.

I haven't "fully" tested this yet (read: actually running my system on it) as it's taking a while to rebuild everything.

https://ftp.fau.de/gnome/sources/glib/2.66/glib-2.66.5.news
https://ftp.fau.de/gnome/sources/glib/2.66/glib-2.66.6.news
https://ftp.fau.de/gnome/sources/glib/2.66/glib-2.66.7.news

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
