### PR TITLE
mindustry: 125.1 -> 126.1

### DIFF
--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -29,20 +29,20 @@ let
   # Note: when raising the version, ensure that all SNAPSHOT versions in
   # build.gradle are replaced by a fixed version
   # (the current one at the time of release) (see postPatch).
-  version = "125.1";
+  version = "126.1";
   buildVersion = makeBuildVersion version;
 
   Mindustry = fetchFromGitHub {
     owner = "Anuken";
     repo = "Mindustry";
     rev = "v${version}";
-    sha256 = "0p05ndxhl3zgwm4k9cbqclp995kvcjxxhmbkmpjvv7cphiw82hvw";
+    sha256 = "cyg4TofSSFLv8pM3zzvc0FxXMiTm+OIchBJF9PDQrkg=";
   };
   Arc = fetchFromGitHub {
     owner = "Anuken";
     repo = "Arc";
     rev = "v${version}";
-    sha256 = "1injdyxwgc9dn49zvr4qggsfrsslkvh5d53z3yv28ayx48qpsgxk";
+    sha256 = "uBIm82mt1etBB/HrNY6XGa7mmBfwd1E3RtqN8Rk5qeY=";
   };
   soloud = fetchFromGitHub {
     owner = "Anuken";
@@ -114,7 +114,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "0dk4w8h0kg0mgbn0ifmk29rw8aj917k3nf27qdf1lyr6wl8k7f8k";
+    outputHash = "Mw8LZ1iW6vn4RkBBs8SWHp6mo2Bhj7tMZjLbyuJUqSI=";
   };
 
 in


### PR DESCRIPTION
packr doesn't seem to have been updated (since 2019-10-23)
soloud is not updated since the last version bump (still at b33dfc5)

###### Motivation for this change

Mindustry has a new update.

https://github.com/Anuken/Mindustry/releases/tag/v126.1

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
    - [x] mindustry-wayland crashes, but I guess that's normal since I'm not using wayland (see log below)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<details><summary>Crash log of mindustry-wayland (see above)</summary>

```
[E] java.lang.ExceptionInInitializerError
        at arc.backend.sdl.SdlGL20.glGetString(SdlGL20.java:36)
        at arc.backend.sdl.SdlGraphics.<init>(SdlGraphics.java:37)
        at arc.backend.sdl.SdlApplication.<init>(SdlApplication.java:34)
        at mindustry.desktop.DesktopLauncher.main(DesktopLauncher.java:36)
Caused by: arc.util.ArcRuntimeException: GLEW failed to initialize: Missing GL version
        at arc.backend.sdl.jni.SDLGL.<clinit>(SDLGL.java:109)
        ... 4 more

[E] Failed to save local crash report.: java.lang.NullPointerException: Cannot invoke "mindustry.mod.Mods.list()" because "mindustry.Vars.mods" is null
        at mindustry.net.CrashSender.createReport(CrashSender.java:29)
        at mindustry.net.CrashSender.send(CrashSender.java:92)
        at mindustry.desktop.DesktopLauncher.handleCrash(DesktopLauncher.java:186)
        at mindustry.desktop.DesktopLauncher.main(DesktopLauncher.java:44)

[I] Sending crash report.
java.net.ConnectException: Connection refused
        at java.base/sun.nio.ch.Net.pollConnect(Native Method)
        at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:660)
        at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:549)
        at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:597)
        at java.base/java.net.Socket.connect(Socket.java:648)
        at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:177)
        at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:474)
        at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:569)
        at java.base/sun.net.www.http.HttpClient.<init>(HttpClient.java:242)
        at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:341)
        at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:362)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1261)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1194)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1082)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:1016)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getOutputStream0(HttpURLConnection.java:1375)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getOutputStream(HttpURLConnection.java:1350)
        at arc.util.NetJavaImpl.lambda$http$0(NetJavaImpl.java:67)
        at arc.util.async.AsyncExecutor.lambda$submit$2(AsyncExecutor.java:31)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
        at java.base/java.lang.Thread.run(Thread.java:832)
```

</details>


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>mindustry</li>
    <li>mindustry-server</li>
    <li>mindustry-wayland</li>
  </ul>
</details>
