### PR TITLE
vimPlugin.nvim-treesitter: Add withPlugins

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -76,6 +76,8 @@
 
   # fruzzy dependency
 , nim
+  # nvim-treesitter
+, tree-sitter
 }:
 
 self: super: {
@@ -332,6 +334,33 @@ self: super: {
 
   nvim-lsputils = super.nvim-lsputils.overrideAttrs (old: {
     dependencies = with super; [ popfix ];
+  });
+
+  # Usage:
+  # pkgs.vimPlugins.nvim-treesitter.withPlugins (p: [ p.tree-sitter-c p.tree-sitter-java ... ])
+  # or for all grammars:
+  # pkgs.vimPlugins.nvim-treesitter.withPlugins (p: builtins.attrValues p)
+  nvim-treesitter = super.nvim-treesitter.overrideAttrs (old: {
+    passthru.withPlugins =
+      grammarFn: self.nvim-treesitter.overrideAttrs (_: {
+        postPatch =
+          let
+            grammars = grammarFn tree-sitter.builtGrammars;
+            symLinks = map
+              (drv:
+                let
+                  name = lib.strings.getName drv;
+                  # The plugin expects the parsers to have a specific name, e.g.:
+                  # https://github.com/nvim-treesitter/nvim-treesitter/blob/9d57216c0d94c9823c0d971caeaffb3b261e527e/lua/nvim-treesitter/parsers.lua#L37
+                  linkName = (lib.strings.removePrefix "tree-sitter-" (lib.strings.removeSuffix "-grammar" name)) + stdenv.hostPlatform.extensions.sharedLibrary;
+                in
+                "ln -s ${drv}/parser parser/${linkName}")
+              grammars;
+          in
+          ''
+            ${lib.concatStringsSep "\n" symLinks}
+          '';
+      });
   });
 
   fzf-vim = super.fzf-vim.overrideAttrs (old: {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add `withPlugins` function to passthru attribute set. It allows to install nvim-treesitter with tree-sitter grammars.

Usage example:
```nix
pkgs.vimPlugins.nvim-treesitter.withPlugins (p: [ p.tree-sitter-c p.tree-sitter-java ... ])
# or for all grammars:
pkgs.vimPlugins.nvim-treesitter.withPlugins (p: builtins.attrValues p)
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
