### PR TITLE
zsh-clipboard: init at 1.0

### DIFF
--- a/pkgs/shells/zsh/zsh-clipboard/clipboard.plugin.zsh
+++ b/pkgs/shells/zsh/zsh-clipboard/clipboard.plugin.zsh
@@ -1,0 +1,40 @@
+_cb-yank() {
+  AA=$(clippaste 2>/dev/null) && CUTBUFFER="$AA"
+  zle yank
+}
+_cb-kill-line() {
+  zle kill-line
+  printf "%s" "$CUTBUFFER" | clipcopy 2>/dev/null
+}
+_cb-kill-whole-line() {
+  zle kill-whole-line
+  printf "%s" "$CUTBUFFER" | clipcopy 2>/dev/null
+}
+_cb-kill-word() {
+  zle kill-word
+  printf "%s" "$CUTBUFFER" | clipcopy 2>/dev/null
+}
+_cb-backward-kill-word() {
+  zle backward-kill-word
+  printf "%s" "$CUTBUFFER" | clipcopy 2>/dev/null
+}
+_cb-copy-region-as-kill() {
+  ## https://unix.stackexchange.com/questions/19947/
+  zle copy-region-as-kill
+  zle set-mark-command -n -1
+  printf "%s" "$CUTBUFFER" | clipcopy 2>/dev/null
+}
+
+zle -N _cb-yank
+zle -N _cb-kill-line
+zle -N _cb-kill-whole-line
+zle -N _cb-kill-word
+zle -N _cb-backward-kill-word
+zle -N _cb-copy-region-as-kill
+
+bindkey '^y'   _cb-yank
+bindkey '^k'   _cb-kill-line
+bindkey '^u'   _cb-kill-whole-line
+bindkey '\ed'  _cb-kill-word
+bindkey '\e^?' _cb-backward-kill-word
+bindkey '\ew'  _cb-copy-region-as-kill

--- a/pkgs/shells/zsh/zsh-clipboard/default.nix
+++ b/pkgs/shells/zsh/zsh-clipboard/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "zsh-clipboard";
+  version = "1.0";
+
+  src = ./.;
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -D -m0444 -t $out/share/zsh/plugins/clipboard ./clipboard.plugin.zsh
+  '';
+
+  meta = with lib; {
+    description = "Ohmyzsh plugin that integrates kill-ring with system clipboard";
+    longDescription = ''
+      Ohmyzsh plugin that integrates kill-ring with system clipboard.
+
+      Key bindings for C-y, C-k, C-u, M-d, M-backspace and M-w are rebound.
+      Behaviour of these keys should not be changed.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ bb2020 ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/shells/zsh/zsh-clipboard/default.nix
+++ b/pkgs/shells/zsh/zsh-clipboard/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [ bb2020 ];
-    platforms = with platforms; unix;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9405,6 +9405,8 @@ in
 
   zsh-bd = callPackage ../shells/zsh/zsh-bd { };
 
+  zsh-clipboard = callPackage ../shells/zsh/zsh-clipboard { };
+
   zsh-git-prompt = callPackage ../shells/zsh/zsh-git-prompt { };
 
   zsh-history = callPackage ../shells/zsh/zsh-history { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A simple `ohmyzsh` plugin for `zsh` clipboard integration. I've put source code in the package itself, I hope this is allowed.
It can be installed like this:
```
programs.zsh.ohMyZsh = {
  customPkgs = [ pkgs.zsh-clipboard ];
  plugins = [ "clipboard" ];
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
