### PR TITLE
python3Packages.docker: 4.4.3 -> 4.4.4

### DIFF
--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -1,8 +1,11 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, isPy27
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy27
 , backports_ssl_match_hostname
 , mock
 , paramiko
-, pytest
 , pytestCheckHook
 , requests
 , six
@@ -11,11 +14,11 @@
 
 buildPythonPackage rec {
   pname = "docker";
-  version = "4.4.3";
+  version = "4.4.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "de5753b7f6486dd541a98393e423e387579b8974a5068748b83f852cc76a89d6";
+    sha256 = "d3393c878f575d3a9ca3b94471a3c89a6d960b35feb92f033c0de36cc9d934db";
   };
 
   nativeBuildInputs = lib.optional isPy27 mock;
@@ -32,8 +35,9 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [ "tests/unit" ];
+
   # Deselect socket tests on Darwin because it hits the path length limit for a Unix domain socket
-  disabledTests = lib.optionals stdenv.isDarwin [ "stream_response" "socket_file" ];
+  disabledTests = lib.optionals stdenv.isDarwin [ "api_test" "stream_response" "socket_file" ];
 
   dontUseSetuptoolsCheck = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- version update
- fix darwin build by disabling failing test; if not disabled they fail with:

```
E           requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=59516): Max retries exceeded with url: /v1.39/tty (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x1123da220>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
```

the same issue was present in the version 4.4.3 of the package on Darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
