### PR TITLE
cjdns-tools: init at 21.1

### DIFF
--- a/pkgs/tools/admin/cjdns-tools/default.nix
+++ b/pkgs/tools/admin/cjdns-tools/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, cjdns
+, nodejs
+, makeWrapper
+, lib
+}:
+
+stdenv.mkDerivation {
+  pname = "cjdns-tools";
+  version = cjdns.version;
+
+  src = cjdns.src;
+
+  buildInputs = [
+    nodejs
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    patchShebangs tools
+
+    sed -e "s|'password': 'NONE'|'password': Fs.readFileSync('/etc/cjdns.keys').toString().split('\\\\n').map(v => v.split('=')).filter(v => v[0] === 'CJDNS_ADMIN_PASSWORD').map(v => v[1])[0]|g" \
+      -i tools/lib/cjdnsadmin/cjdnsadmin.js
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cat ${./wrapper.sh} | sed "s|@@out@@|$out|g" > $out/bin/cjdns-tools
+    chmod +x $out/bin/cjdns-tools
+
+    cp -r tools $out/tools
+    find $out/tools -maxdepth 1 -type f -exec chmod -v a+x {} \;
+    cp -r node_modules $out/node_modules
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/cjdelisle/cjdns";
+    description = "Tools for cjdns managment";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ mkg20001 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/admin/cjdns-tools/wrapper.sh
+++ b/pkgs/tools/admin/cjdns-tools/wrapper.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+export PATH="@@out@@/tools:$PATH"
+
+set -eo pipefail
+
+if ! cat /etc/cjdns.keys >/dev/null 2>&1; then
+  echo "ERROR: No permission to read /etc/cjdns.keys (use sudo)" >&2
+  exit 1
+fi
+
+if [[ -z $1 ]]; then
+  echo "Cjdns admin"
+
+  echo "Usage: $0 <command> <args..>"
+
+  echo
+  echo "Commands:" $(find @@out@@/tools -maxdepth 1 -type f | sed -r "s|.+/||g")
+
+  _sh=$(which sh)
+  PATH="@@out@@/tools" PS1="cjdns\$ " "$_sh"
+else
+  if [[ ! -e @@out@@/tools/$1 ]]; then
+    echo "ERROR: '$1' is not a valid tool" >&2
+    exit 2
+  else
+    "$@"
+  fi
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3194,6 +3194,7 @@ in
   };
 
   cjdns = callPackage ../tools/networking/cjdns { };
+  cjdns-tools = callPackage ../tools/admin/cjdns-tools { };
 
   cjson = callPackage ../development/libraries/cjson { };
 


### PR DESCRIPTION
This adds cjdns-tools which is exposing the tools from
$cjdns/tools/ under a command named cjdns-tools
(so for ex cjdns "ping" is accessible as cjdns-tools ping <ip>)

Additionally patches cjdns tools to read admin pw from /etc/cjdns.keys

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
