### PR TITLE
pre-commit: 2.7.1 -> 2.11.0

### DIFF
--- a/pkgs/development/python-modules/pre-commit/default.nix
+++ b/pkgs/development/python-modules/pre-commit/default.nix
@@ -2,7 +2,6 @@
 , aspy-yaml
 , cached-property
 , cfgv
-, futures
 , identify
 , importlib-metadata
 , importlib-resources
@@ -16,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "pre-commit";
-  version = "2.7.1";
+  version = "2.11.0";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit version;
     pname = "pre_commit";
-    sha256 = "0w2a104yhbw1z92rcwpq0gdjsxvr2bwx5ry5xhlf2psnfkjx6ky5";
+    sha256 = "15f1chxrbmfcajk1ngk3jvf6jjbigb5dg66wnn7phmlywaawpy06";
   };
 
   patches = [

--- a/pkgs/development/python-modules/pre-commit/languages-use-the-hardcoded-path-to-python-binaries.patch
+++ b/pkgs/development/python-modules/pre-commit/languages-use-the-hardcoded-path-to-python-binaries.patch
@@ -12,15 +12,15 @@ index 26f4919..4885ec1 100644
          if version != C.DEFAULT:
              cmd.extend(['-n', version])
 diff --git a/pre_commit/languages/python.py b/pre_commit/languages/python.py
-index e17376e..0c1d2ab 100644
+index 43b7280..f0f2338 100644
 --- a/pre_commit/languages/python.py
 +++ b/pre_commit/languages/python.py
-@@ -204,7 +204,7 @@ def install_environment(
+@@ -192,7 +192,7 @@ def install_environment(
+         additional_dependencies: Sequence[str],
  ) -> None:
      envdir = prefix.path(helpers.environment_dir(ENVIRONMENT_DIR, version))
+-    venv_cmd = [sys.executable, '-mvirtualenv', envdir]
++    venv_cmd = ['@virtualenv@/bin/virtualenv', envdir]
      python = norm_version(version)
--    venv_cmd = (sys.executable, '-mvirtualenv', envdir, '-p', python)
-+    venv_cmd = ('@virtualenv@/bin/virtualenv', envdir, '-p', python)
-     install_cmd = ('python', '-mpip', 'install', '.', *additional_dependencies)
-
-     with clean_path_on_failure(envdir):
+     if python is not None:
+         venv_cmd.extend(('-p', python))


### PR DESCRIPTION
###### Motivation for this change

Version upgrade, `isort` wanted a newer version of `pre-commit`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).