### PR TITLE
python3Packages.fakeredis: init at 1.4.5

### DIFF
--- a/pkgs/development/python-modules/fakeredis/default.nix
+++ b/pkgs/development/python-modules/fakeredis/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, aioredis
+, async_generator
+, buildPythonPackage
+, fetchPypi
+, hypothesis
+, lupa
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, redis
+, six
+, sortedcontainers
+}:
+
+buildPythonPackage rec {
+  pname = "fakeredis";
+  version = "1.4.5";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0slb23zxn47a4z8b7jq7gq40g4zsn52y9h29zdqs29b85394gjq1";
+  };
+
+  propagatedBuildInputs = [
+    aioredis
+    lupa
+    redis
+    six
+    sortedcontainers
+  ];
+
+  checkInputs = [
+    async_generator
+    hypothesis
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "fakeredis" ];
+
+  meta = with lib; {
+    description = "Fake implementation of Redis API";
+    homepage = "https://github.com/jamesls/fakeredis";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/lupa/default.nix
+++ b/pkgs/development/python-modules/lupa/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, cython
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "lupa";
+  version = "1.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13ifv0nxbf70xg69sp49j484m8cnid7rgh8f94pgfb50dj01vqd3";
+  };
+
+  nativeBuildInputs = [ cython ];
+
+  pythonImportsCheck = [ "lupa" ];
+
+  meta = with lib; {
+    description = "Lua in Python";
+    homepage = "https://github.com/scoder/lupa";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2213,9 +2213,11 @@ in {
 
   fake_factory = callPackage ../development/python-modules/fake_factory { };
 
+  fake-useragent = callPackage ../development/python-modules/fake-useragent { };
+
   faker = callPackage ../development/python-modules/faker { };
 
-  fake-useragent = callPackage ../development/python-modules/fake-useragent { };
+  fakeredis = callPackage ../development/python-modules/fakeredis { };
 
   falcon = callPackage ../development/python-modules/falcon { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3927,6 +3927,8 @@ in {
 
   luftdaten = callPackage ../development/python-modules/luftdaten { };
 
+  lupa = callPackage ../development/python-modules/lupa { };
+
   lxc = callPackage ../development/python-modules/lxc { };
 
   lxml = callPackage ../development/python-modules/lxml { inherit (pkgs) libxml2 libxslt zlib; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fake implementation of Redis API

https://github.com/jamesls/fakeredis

This is a test requirement for `sentry-sdk`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
