### PR TITLE
zcash: 4.1.1 -> 4.3.0

### DIFF
--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -1,6 +1,7 @@
-{ rust, rustPlatform, stdenv, lib, fetchFromGitHub, autoreconfHook, makeWrapper, fetchpatch
-, cargo, pkg-config, bash, curl, coreutils, boost174, db62, hexdump, libsodium, libevent
-, utf8cpp, util-linux, withWallet ? true, withDaemon ? true, withUtils ? true
+{ rust, rustPlatform, stdenv, lib, fetchFromGitHub, autoreconfHook, makeWrapper
+, fetchpatch, cargo, pkg-config, curl, coreutils, boost174, db62, hexdump
+, libsodium, libevent, utf8cpp, util-linux, withWallet ? true, withDaemon ? true
+, withUtils ? true
 }:
 
 rustPlatform.buildRustPackage.override { stdenv = stdenv; } rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26682,7 +26682,7 @@ in
 
   wownero = callPackage ../applications/blockchains/wownero.nix {};
 
-  zcash = callPackage ../applications/blockchains/zcash { };
+  zcash = callPackage ../applications/blockchains/zcash { stdenv = llvmPackages_11.stdenv; };
 
   openethereum = callPackage ../applications/blockchains/openethereum { };
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade Zcash to 4.3.0. NB: the `-j` flag is not properly passed to make, for unknown reason(s) (Raspberry Pi 4). It does seem to be properly passed to rust.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
