### PR TITLE
[haskell-updates] haskell-language-server: 0.9.0 -> 1.0.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1413,17 +1413,20 @@ self: super: {
   # https://github.com/haskell/haskell-language-server/issues/611
   haskell-language-server = dontCheck super.haskell-language-server;
 
-  # 2021-02-11: Jailbreaking because of syntax error on bound revision
-  hls-explicit-imports-plugin = doJailbreak super.hls-explicit-imports-plugin;
+  # 2021-03-09: Overrides because nightly is to old for hls 1.0.0
+  lsp-test = doDistribute (dontCheck self.lsp-test_0_13_0_0);
 
-  # 2021-02-08: Overrides because nightly is to old for hls 0.9.0
-  lsp-test = doDistribute (dontCheck self.lsp-test_0_11_0_7);
-  haskell-lsp = doDistribute self.haskell-lsp_0_23_0_0;
-  haskell-lsp-types = doDistribute self.haskell-lsp-types_0_23_0_0;
+  # 2021-03-09: Golden tests seem to be missing in hackage release:
+  # https://github.com/haskell/haskell-language-server/issues/1536
+  hls-tactics-plugin = dontCheck super.hls-tactics-plugin;
 
   # 1. test requires internet
   # 2. dependency shake-bench hasn't been published yet so we also need unmarkBroken and doDistribute
   ghcide = doDistribute (unmarkBroken (dontCheck super.ghcide));
+
+  # 2020-03-09: Tests broken in hackage release, fixed on upstream
+  # https://github.com/wz1000/HieDb/issues/30
+  hiedb = dontCheck super.hiedb;
 
   data-tree-print = doJailbreak super.data-tree-print;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -73,14 +73,7 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  # Don't update yet to remain compatible with haskell-language-server-0.9.0.
-  - ghcide < 0.7.4
-  - hls-class-plugin < 1
-  - hls-explicit-imports-plugin < 0.1.0.1
-  - hls-haddock-comments-plugin < 1
-  - hls-plugin-api < 0.7.1.0
-  - hls-retrie-plugin < 0.1.1.1
-  - hls-tactics-plugin < 1
+
   # Stackage Nightly 2021-03-06
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
@@ -6456,7 +6449,6 @@ broken-packages:
   - hid-examples
   - hidden-char
   - hie-core
-  - hiedb
   - hieraclus
   - hierarchical-clustering-diagrams
   - hierarchical-exceptions


### PR DESCRIPTION
Adapt overrides for newest hls version. :tada: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
