### PR TITLE
home-assistant: 2021.3.2 -> 2021.3.3

### DIFF
--- a/pkgs/development/python-modules/HAP-python/default.nix
+++ b/pkgs/development/python-modules/HAP-python/default.nix
@@ -1,11 +1,13 @@
 { lib
 , buildPythonPackage
+, base36
 , cryptography
 , curve25519-donna
 , ecdsa
 , ed25519
 , fetchFromGitHub
 , h11
+, pyqrcode
 , pytest-asyncio
 , pytest-timeout
 , pytestCheckHook
@@ -15,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "HAP-python";
-  version = "3.3.2";
+  version = "3.4.0";
   disabled = pythonOlder "3.5";
 
   # pypi package does not include tests
@@ -23,15 +25,17 @@ buildPythonPackage rec {
     owner = "ikalchev";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-oDTyFIhf7oogYyh9LpmVtagi1kDXLCc/7c2UH1dL2Sg=";
+    sha256 = "0mkrs3fwiyp4am9fx1dnhd9h7rphfwymr46khw40xavrfb5jmsa7";
   };
 
   propagatedBuildInputs = [
+    base36
     cryptography
     curve25519-donna
     ecdsa
     ed25519
     h11
+    pyqrcode
     zeroconf
   ];
 
@@ -41,35 +45,19 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  # Disable tests requiring network access
+  disabledTestPaths = [
+    "tests/test_accessory_driver.py"
+    "tests/test_hap_handler.py"
+    "tests/test_hap_protocol.py"
+  ];
+
   disabledTests = [
-    # Disable tests needing network
-    "camera"
-    "pair"
-    "test_async_subscribe_client_topic"
-    "test_auto_add_aid_mac"
-    "test_connection_management"
-    "test_crypto_failure_closes_connection"
-    "test_empty_encrypted_data"
-    "test_external_zeroconf"
-    "test_get_accessories"
-    "test_get_characteristics"
-    "test_handle_set_handle_set"
-    "test_handle_snapshot_encrypted_non_existant_accessory"
-    "test_http_11_keep_alive"
-    "test_http10_close"
-    "test_mdns_service_info"
-    "test_mixing_service_char_callbacks_partial_failure"
-    "test_not_standalone_aid"
-    "test_persist"
-    "test_push_event"
-    "test_send_events"
-    "test_service_callbacks"
-    "test_set_characteristics_with_crypto"
-    "test_setup_endpoints"
-    "test_start"
-    "test_upgrade_to_encrypted"
+    "test_persist_and_load"
+    "test_we_can_connect"
+    "test_idle_connection_cleanup"
     "test_we_can_start_stop"
-    "test_xhm_uri"
+    "test_push_event"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pymysensors/default.nix
+++ b/pkgs/development/python-modules/pymysensors/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "pymysensors";
-  version = "0.20.1";
+  version = "0.21.0";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "theolind";
     repo = pname;
     rev = version;
-    sha256 = "1hz3551ydsmd23havd0dljmvkhzjnmd28k41ws60s8ms3gzlzqfy";
+    sha256 = "1k75gwvyzslyjr3cdx8b74fb302k2i7bda4q92rb75rhgp4gch55";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pytile/default.nix
+++ b/pkgs/development/python-modules/pytile/default.nix
@@ -13,17 +13,21 @@
 
 buildPythonPackage rec {
   pname = "pytile";
-  version = "5.1.1";
+  version = "5.2.1";
   disabled = pythonAtLeast "3.9";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "sha256-bVoFTaK/Alemtc5I+Z/M9y/FWczvJ+P86R0DMD89/BM=";
+    sha256 = "0d63xga4gjlfl9fzv3i4j605rrx2qgbzam6cl609ny96s8q8h1px";
   };
 
   format = "pyproject";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace 'aiohttp = "^3.7.4"' 'aiohttp = "^3.7.3"'
+  '';
 
   nativeBuildInputs = [ poetry-core ];
 

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.3.2";
+  version = "2021.3.3";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];
@@ -609,7 +609,7 @@
     "otp" = ps: with ps; [ pyotp ];
     "ovo_energy" = ps: with ps; [ ]; # missing inputs: ovoenergy
     "owntracks" = ps: with ps; [ pynacl aiohttp-cors hass-nabucasa paho-mqtt ];
-    "ozw" = ps: with ps; [ aiohttp-cors homeassistant-pyozw paho-mqtt pydispatcher python-openzwave-mqtt ];
+    "ozw" = ps: with ps; [ aiohttp-cors paho-mqtt python-openzwave-mqtt ];
     "panasonic_bluray" = ps: with ps; [ ]; # missing inputs: panacotta
     "panasonic_viera" = ps: with ps; [ ]; # missing inputs: panasonic_viera
     "pandora" = ps: with ps; [ pexpect ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -66,7 +66,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.3.2";
+  hassVersion = "2021.3.3";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -85,7 +85,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "09z2sds9my4vq0vmryjpzi7fv787zjfikfkd711d34c140bgcjch";
+    sha256 = "0kfvjpzz6ynw8bwd91nm0aiw1pkrmaydwf1r93dnwi8rmzq10zpb";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20210302.5";
+  version = "20210302.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-+SKXLOuvMYfNyR++uQMMY4M5deRgm2w3AhMM/DP470k=";
+    sha256 = "sha256-h3jCqfAPg+z6vsdLm5Pdr+7PCEWW58GCG9viIz3Mi64=";
   };
 
   # there is nothing to strip in this package


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/2021.3.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
      Outdated dependencies      
┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┓
┃ Package    ┃ Current ┃ Wanted ┃
┡━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━┩
│ sentry-sdk │ 0.19.5  │ 0.20.3 │
└────────────┴─────────┴────────┘
```