### PR TITLE
shards: 0.13 -> 0.14

### DIFF
--- a/pkgs/development/tools/build-managers/shards/default.nix
+++ b/pkgs/development/tools/build-managers/shards/default.nix
@@ -43,11 +43,11 @@ rec {
     crystal = crystal_0_34;
   };
 
-  shards_0_13 = generic {
-    version = "0.12.0";
-    sha256 = "0dginczw1gc5qlb9k4b6ldxzqz8n97jrrnjvj3mm9wcdbc9j6h3c";
+  shards_0_14 = generic {
+    version = "0.14.0";
+    sha256 = "sha256-HEyGXoGkQvLrk672/ekmBxnR1eRM//GwRPd/19LM8Wo=";
     crystal = crystal_0_36;
   };
 
-  shards = shards_0_13;
+  shards = shards_0_14;
 }

--- a/pkgs/development/tools/build-managers/shards/shards.nix
+++ b/pkgs/development/tools/build-managers/shards/shards.nix
@@ -2,7 +2,7 @@
   molinillo = {
     owner = "crystal-lang";
     repo = "crystal-molinillo";
-    rev = "v0.1.0";
-    sha256 = "0rs0w59m6ccsgkdxfy3xv6alxsziy9sy9smz71cz0dnyvlzlnaxj";
+    rev = "v0.2.0";
+    sha256 = "0pzi8pbrjn03zgk3kbha2kqqq0crmr8gy98dr05kisafvbghzwnh";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12967,7 +12967,7 @@ in
 
   inherit (callPackage ../development/tools/build-managers/shards { })
     shards_0_11
-    shards_0_13
+    shards_0_14
     shards;
 
   shellcheck = callPackage ../development/tools/shellcheck {};


### PR DESCRIPTION
###### Motivation for this change

Been using it here for a while.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Cc @NixOS/crystal-lang 