### PR TITLE
php80: fix on darwin

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -399,7 +399,7 @@ lib.makeScope pkgs.newScope (self: with self; {
       # oci8 (7.4, 7.3, 7.2)
       # odbc (7.4, 7.3, 7.2)
       { name = "opcache";
-        buildInputs = [ pcre' ] ++ lib.optionals (lib.versionAtLeast php.version "8.0") [
+        buildInputs = [ pcre' ] ++ lib.optionals (!stdenv.isDarwin && lib.versionAtLeast php.version "8.0") [
           valgrind.dev
         ];
         patches = lib.optionals (lib.versionOlder php.version "7.4") [
@@ -419,7 +419,9 @@ lib.makeScope pkgs.newScope (self: with self; {
              #include "zend_accelerator_util_funcs.h"
           '') ];
         zendExtension = true;
-        doCheck = !(lib.versionOlder php.version "7.4"); }
+        doCheck = !(lib.versionOlder php.version "7.4");
+        # Tests launch the builtin webserver.
+        __darwinAllowLocalNetworking = true; }
       { name = "openssl";
         buildInputs = [ openssl ];
         configureFlags = [ "--with-openssl" ];


### PR DESCRIPTION
###### Motivation for this change

Similar to #101840. Valgrind is marked broken on Darwin, and PHP 8 specifically has an additional Valgrind dependency through opcache. This PR removes that dependency in the Darwin build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
