### PR TITLE
kustomize: 3.10.0 -> 4.0.5

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -2,9 +2,9 @@
 
 buildGoModule rec {
   pname = "kustomize";
-  version = "3.10.0";
-  # rev is the 3.9.3 commit, mainly for kustomize version command output
-  rev = "602ad8aa98e2e17f6c9119e027a09757e63c8bec";
+  version = "4.0.5";
+  # rev is the commit of the tag, mainly for kustomize version command output
+  rev = "9e8e7a7fe99ec9fbf801463e8607928322fc5245";
 
   buildFlagsArray = let t = "sigs.k8s.io/kustomize/api/provenance"; in
     ''
@@ -17,13 +17,16 @@ buildGoModule rec {
     owner = "kubernetes-sigs";
     repo = pname;
     rev = "kustomize/v${version}";
-    sha256 = "1qr0mi83df8d9qd2svyr1h26pg97qi67nnygrkydnp8an28k48hi";
+    sha256 = "sha256-rv65sDr6V6hEYgIRxS1OSu9txmW75F7/YGAy/zRXGyY=";
   };
+
+  # TODO: Remove once https://github.com/kubernetes-sigs/kustomize/pull/3708 got merged.
+  doCheck = false;
 
   # avoid finding test and development commands
   sourceRoot = "source/kustomize";
 
-  vendorSha256 = "0p2j8mm7jpladpm6v3451g38n5bax0g368dk5h5r5gmkr6srxdy4";
+  vendorSha256 = "sha256-lLUi0vD7uyfDR4HjDiosoTU0NbfQTY7ewZGm38ZT9nU=";
 
   meta = with lib; {
     description = "Customization of kubernetes YAML configurations";


### PR DESCRIPTION


###### Motivation for this change

Update kustomize to the latest version
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @carlosdagos @vdemeester @periklis @zaninime @Chili-Man