### PR TITLE
stdenv/darwin: allow brotli reference from curl

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -322,7 +322,7 @@ in rec {
         libxml2 gettext sharutils gmp libarchive ncurses pkg-config libedit groff
         openssh sqlite sed serf openldap db cyrus-sasl expat apr-util subversion xz
         findfreetype libssh curl cmake autoconf automake libtool ed cpio coreutils
-        libssh2 nghttp2 libkrb5 ninja;
+        libssh2 nghttp2 libkrb5 ninja brotli;
 
       llvmPackages_7 = super.llvmPackages_7 // (let
         tools = super.llvmPackages_7.tools.extend (_: _: {
@@ -359,7 +359,7 @@ in rec {
       [ bootstrapTools ] ++
       (with pkgs; [
         xz.bin xz.out libcxx libcxxabi llvmPackages_7.compiler-rt
-        llvmPackages_7.clang-unwrapped zlib libxml2.out curl.out openssl.out
+        llvmPackages_7.clang-unwrapped zlib libxml2.out curl.out brotli.lib openssl.out
         libssh2.out nghttp2.lib libkrb5 coreutils gnugrep pcre.out gmp libiconv
       ]) ++
       (with pkgs.darwin; [ dyld Libsystem CF ICU locale ]);
@@ -411,7 +411,7 @@ in rec {
       [ bootstrapTools ] ++
       (with pkgs; [
         xz.bin xz.out bash libcxx libcxxabi llvmPackages_7.compiler-rt
-        llvmPackages_7.clang-unwrapped zlib libxml2.out curl.out openssl.out
+        llvmPackages_7.clang-unwrapped zlib libxml2.out curl.out brotli.lib openssl.out
         libssh2.out nghttp2.lib libkrb5 coreutils gnugrep pcre.out gmp libiconv
       ]) ++
       (with pkgs.darwin; [ dyld ICU Libsystem locale ]);
@@ -533,7 +533,7 @@ in rec {
       gzip ncurses.out ncurses.dev ncurses.man gnused bash gawk
       gnugrep llvmPackages.clang-unwrapped llvmPackages.clang-unwrapped.lib patch pcre.out gettext
       binutils.bintools darwin.binutils darwin.binutils.bintools
-      curl.out openssl.out libssh2.out nghttp2.lib libkrb5
+      curl.out brotli.lib openssl.out libssh2.out nghttp2.lib libkrb5
       cc.expand-response-params libxml2.out
     ]) ++ (with pkgs.darwin; [
       dyld Libsystem CF cctools ICU libiconv locale libtapi


### PR DESCRIPTION
Brotli is recently a default dependency of curl in nixpkgs.

See e3d19670a0f6b012aac5e05b50951d8a991ba143 in #112947

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix darwin stdenv build.

Stage 2 now references brotli:

```
$ nix why-depends --all /nix/store/4x2440ns4gzyknaa70lzrk832vsn3djv-bootstrap-stage2-stdenv-darwin   /nix/store/qvv2xw5da22lfgbj1zq4hhvh286i74f7-brotli-1.0.9-lib
/nix/store/4x2440ns4gzyknaa70lzrk832vsn3djv-bootstrap-stage2-stdenv-darwin
╚═══setup: ….defaultBuildInputs="/nix/store/irylbhn1qz80fyqlcjcxl0jaqm2yr328-swift-corefoundation".# Don't p…
    => /nix/store/irylbhn1qz80fyqlcjcxl0jaqm2yr328-swift-corefoundation
    ╚═══Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation: ….h.................../nix/store/1ycixpvd73ys8lzpkf2562pdxz5dxfp6-curl-7.74.0/lib/libcurl.4.dylib…
        => /nix/store/1ycixpvd73ys8lzpkf2562pdxz5dxfp6-curl-7.74.0
        ╚═══lib/libcurl.4.dylib: ….p.................../nix/store/qvv2xw5da22lfgbj1zq4hhvh286i74f7-brotli-1.0.9-lib/lib/libbrotlid…
            => /nix/store/qvv2xw5da22lfgbj1zq4hhvh286i74f7-brotli-1.0.9-lib
```

Comparing master and this branch (shameless plug for [my stdenv analyser](https://github.com/thefloweringash/analyse-stdenv)), the new builds by stage are:

- libidn-1.36.drv at stages 1 and 4
- brotli-1.0.9.drv at stages 1 and 4

And libidn doesn't appear in the closure of curl, so can be omitted here.

This isn't the only solution, we could use `curlMinimal` in stage1 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
