### PR TITLE
fishPlugins.fzf-fish: init at 5.6

### DIFF
--- a/pkgs/shells/fish/plugins/clownfish.nix
+++ b/pkgs/shells/fish/plugins/clownfish.nix
@@ -1,0 +1,20 @@
+{ lib, buildFishPlugin, fetchFromGitHub }:
+
+buildFishPlugin {
+  pname = "clownfish";
+  version = "unstable-2021-01-17";
+
+  src = fetchFromGitHub {
+    owner = "IlanCosman";
+    repo = "clownfish";
+    rev = "a0db28d8280d05561b8f48c0465480725feeca4c";
+    sha256 = "04xvikyrdm6yxh588vbpwvm04fas76pa7sigsaqrip7yh021xxab";
+  };
+
+  meta = with lib; {
+    description = "Fish function to mock the behaviour of commands";
+    homepage = "https://github.com/IlanCosman/clownfish";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -4,6 +4,8 @@ lib.makeScope newScope (self: with self; {
 
   buildFishPlugin = callPackage ./build-fish-plugin.nix { };
 
+  clownfish = callPackage ./clownfish.nix { };
+
   fishtape = callPackage ./fishtape.nix { };
 
   foreign-env = callPackage ./foreign-env { };

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -6,7 +6,10 @@ lib.makeScope newScope (self: with self; {
 
   clownfish = callPackage ./clownfish.nix { };
 
+  # Fishtape 2.x and 3.x aren't compatible,
+  # but both versions are used in the tests of different other plugins.
   fishtape = callPackage ./fishtape.nix { };
+  fishtape_3 = callPackage ./fishtape_3.nix { };
 
   foreign-env = callPackage ./foreign-env { };
 

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -13,6 +13,8 @@ lib.makeScope newScope (self: with self; {
 
   foreign-env = callPackage ./foreign-env { };
 
+  fzf-fish = callPackage ./fzf-fish.nix { };
+
   pure = callPackage ./pure.nix { };
 
 })

--- a/pkgs/shells/fish/plugins/fishtape_3.nix
+++ b/pkgs/shells/fish/plugins/fishtape_3.nix
@@ -1,0 +1,25 @@
+{ lib, buildFishPlugin, fetchFromGitHub }:
+
+buildFishPlugin rec {
+  pname = "fishtape";
+  version = "3.0.1";
+
+  src = fetchFromGitHub {
+    owner = "jorgebucaran";
+    repo = "fishtape";
+    rev = version;
+    sha256 = "072a3qbk1lpxw53bxp91drsffylx8fbywhss3x0jbnayn9m8i7aa";
+  };
+
+  checkFunctionDirs = [ "./functions" ]; # fishtape is introspective
+  checkPhase = ''
+    fishtape tests/*.fish
+  '';
+
+  meta = with lib; {
+    description = "100% pure-Fish test runner";
+    homepage = "https://github.com/jorgebucaran/fishtape";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/shells/fish/plugins/fzf-fish.nix
+++ b/pkgs/shells/fish/plugins/fzf-fish.nix
@@ -1,0 +1,34 @@
+{ lib, buildFishPlugin, fetchFromGitHub, fzf, clownfish, fishtape_3 }:
+
+buildFishPlugin rec {
+  pname = "fzf.fish";
+  version = "5.6";
+
+  src = fetchFromGitHub {
+    owner = "PatrickF1";
+    repo = "fzf.fish";
+    rev = "v${version}";
+    sha256 = "1b280n8bh00n4vkm19zrn84km52296ljlm1zhz95jgaiwymf2x73";
+  };
+
+  checkInputs = [ fzf ];
+  checkPlugins = [ clownfish fishtape_3 ];
+  checkFunctionDirs = [ "./functions" ];
+  checkPhase = ''
+    # Disable git tests which inspect the project's git repo, which isn't
+    # possible since we strip the impure .git from our build input
+    rm -r tests/*git*
+
+    # Disable tests that are failing, probably because of our wrappers
+    rm -r tests/search_shell_variables
+
+    fishtape tests/*/*.fish
+  '';
+
+  meta = with lib; {
+    description = "Augment your fish command line with fzf key bindings";
+    homepage = "https://github.com/PatrickF1/fzf.fish";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pacien ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This adds a package for the fzf.fish fish plugin.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
