### PR TITLE
python3Packages.nose-timer: 1.0.0 -> 1.0.1, python3Packages.parameterized: 0.7.5 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/nose-timer/default.nix
+++ b/pkgs/development/python-modules/nose-timer/default.nix
@@ -1,20 +1,44 @@
-{ buildPythonPackage, fetchPypi, lib, nose, }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nose
+, mock
+, parameterized
+, termcolor
+}:
 
 buildPythonPackage rec {
   pname = "nose-timer";
-  version = "1.0.0";
+  version = "1.0.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "09hwjwbczi06bfqgiylb2yxs5h88jdl26zi1fdqxdzvamrkksf2c";
+  src = fetchFromGitHub {
+    owner = "mahmoudimus";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xsai2l5i1av62y9y0q63wy2zk27klmf2jizgghhxg2y8nfa8x3x";
   };
 
   propagatedBuildInputs = [ nose ];
 
+  checkInputs = [
+    mock
+    nose
+    parameterized
+    termcolor
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    nosetests --verbosity 2 tests
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "nosetimer" ];
+
   meta = with lib; {
+    description = "A timer plugin for nosetests";
     homepage = "https://github.com/mahmoudimus/nose-timer";
     license = licenses.mit;
-    description = "A timer plugin for nosetests (how much time does every test take?)";
     maintainers = with maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/parameterized/default.nix
+++ b/pkgs/development/python-modules/parameterized/default.nix
@@ -1,28 +1,40 @@
-{ lib, fetchPypi, buildPythonPackage, nose, mock, glibcLocales, isPy3k, isPy38 }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, glibcLocales
+, isPy3k
+, mock
+, nose
+}:
 
 buildPythonPackage rec {
   pname = "parameterized";
-  version = "0.7.5";
+  version = "0.8.1";
+  disable = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b5e6af67b9e49485e30125b1c8f031ffa81a265ca08bfa73f31551bf03cf68c4";
+    sha256 = "sha256-Qbv/N9YYZDD3f5ANd35btqJJKKHEb7HeaS+LUriDO1w=";
   };
 
-  # Tests require some python3-isms but code works without.
-  # python38 is not fully supported yet
-  doCheck = isPy3k && (!isPy38);
-
-  checkInputs = [ nose mock glibcLocales ];
+  checkInputs = [
+    nose
+    mock
+    glibcLocales
+  ];
 
   checkPhase = ''
+    runHook preCheck
     LC_ALL="en_US.UTF-8" nosetests -v
+    runHook postCheck
   '';
+
+  pythonImportsCheck = [ "parameterized" ];
 
   meta = with lib; {
     description = "Parameterized testing with any Python test framework";
-    homepage = "https://pypi.python.org/pypi/parameterized";
-    license = licenses.bsd3;
+    homepage = "https://github.com/wolever/parameterized";
+    license = licenses.bsd2;
     maintainers = with maintainers; [ ma27 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update nose-timer to latest upstream release 1.0.1.
Update parameterized to latest upstream release 0.8.1

Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
