### PR TITLE
lxqt.lxqt-policykit: fix missing buildInput polkit

### DIFF
--- a/pkgs/desktops/lxqt/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-policykit/default.nix
@@ -8,6 +8,7 @@
 , qttools
 , qtx11extras
 , qtsvg
+, polkit
 , polkit-qt
 , kwindowsystem
 , liblxqt
@@ -38,6 +39,7 @@ mkDerivation rec {
     qttools
     qtx11extras
     qtsvg
+    polkit
     polkit-qt
     kwindowsystem
     liblxqt


### PR DESCRIPTION
###### Motivation for this change

The `lxqt-policykit` derivation is currently failing due to pkg-config not being able to locate the module `polkit-agent-1` provided by `polkit`. This PR adds `polkit` to the `buildInputs` of `lxqt-policykit`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
