### PR TITLE
sent: enable on darwin

### DIFF
--- a/pkgs/applications/misc/sent/default.nix
+++ b/pkgs/applications/misc/sent/default.nix
@@ -2,10 +2,11 @@
 , patches ? [] }:
 
 stdenv.mkDerivation rec {
-  name = "sent-1";
+  pname = "sent";
+  version = "1";
 
   src = fetchurl {
-    url = "https://dl.suckless.org/tools/${name}.tar.gz";
+    url = "https://dl.suckless.org/tools/sent-${version}.tar.gz";
     sha256 = "0cxysz5lp25mgww73jl0mgip68x7iyvialyzdbriyaff269xxwvv";
   };
 
@@ -26,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "A simple plaintext presentation tool";
     homepage = "https://tools.suckless.org/sent/";
     license = licenses.isc;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ pSub ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Enable on darwin.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
