### PR TITLE
tfk8s: init at 0.1.0

### DIFF
--- a/pkgs/tools/misc/tfk8s/default.nix
+++ b/pkgs/tools/misc/tfk8s/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "tfk8s";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jrhouston";
+    repo = "tfk8s";
+    rev = version;
+    sha256 = "sha256-JzTWbkICOIfsHgMvpXz4bIWaXKKDAD8INSorMvnXiBw=";
+  };
+
+  vendorSha256 = "sha256-r0c3y+nRc/hCTAT31DasQjxZN86BT8jnJmsLM7Ugrq4=";
+  runVend = true;
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-s"
+    "-w"
+    "-X main.toolVersion=${version}"
+    "-X main.builtBy=nixpkgs"
+  ];
+
+  meta = with lib; {
+    description = "An utility to convert Kubernetes YAML manifests to Terraform's HCL format.";
+    license = licenses.mit;
+    longDescription = ''
+      tfk8s is a tool that makes it easier to work with the Terraform Kubernetes Provider.
+      If you want to copy examples from the Kubernetes documentation or migrate existing YAML manifests and use them with Terraform without having to convert YAML to HCL by hand, this tool is for you.
+      Features:
+      * Convert a YAML file containing multiple manifests.
+      * Strip out server side fields when piping kubectl get $R -o yaml | tfk8s --strip
+    '';
+    homepage = "https://github.com/jrhouston/tfk8s/";
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -755,6 +755,8 @@ in
 
   metapixel = callPackage ../tools/graphics/metapixel { };
 
+  tfk8s = callPackage ../tools/misc/tfk8s { };
+
   xtrt = callPackage ../tools/archivers/xtrt { };
 
   yabridge = callPackage ../tools/audio/yabridge {


### PR DESCRIPTION
TFK8S is a tool to convert YAML files to HCL (Terraform).

Tested in my x86_64 and aarch64 (RockPro64) hosts.

I have used this package with success for my needs. Hope it proves useful to other Terraform users.

I appreciate all the kindness of reviewers for reviewing this proposal.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).