### PR TITLE
systemd: Handle template overrides

### DIFF
--- a/nixos/modules/system/boot/systemd-lib.nix
+++ b/nixos/modules/system/boot/systemd-lib.nix
@@ -182,7 +182,18 @@ in rec {
       # upstream unit.
       for i in ${toString (mapAttrsToList (n: v: v.unit) units)}; do
         fn=$(basename $i/*)
-        if [ -e $out/$fn ]; then
+
+        case $fn in
+          # if file name is a template specialization, use the template's name
+          *@?*.service)
+            # remove @foo.service and replace it with @.service
+            ofn="''${fn%@*.service}@.service"
+            ;;
+          *)
+            ofn="$fn"
+        esac
+
+        if [ -e $out/$ofn ]; then
           if [ "$(readlink -f $i/$fn)" = /dev/null ]; then
             ln -sfn /dev/null $out/$fn
           else

--- a/nixos/tests/systemd-template-override.nix
+++ b/nixos/tests/systemd-template-override.nix
@@ -1,0 +1,41 @@
+import ./make-test-python.nix {
+  name = "systemd-template-override";
+
+  machine = { pkgs, lib, ... }: let
+    touchTmp = pkgs.writeTextFile {
+      name = "touch-tmp@.service";
+      text = ''
+        [Service]
+        Type=oneshot
+        ExecStart=${pkgs.coreutils}/bin/touch /tmp/%I
+      '';
+      destination = "/etc/systemd/system/touch-tmp@.service";
+    };
+  in {
+    systemd.packages = [ touchTmp ];
+
+    systemd.services."touch-tmp@forbidden" = {
+      serviceConfig.ExecStart = [ "" ''
+        ${pkgs.coreutils}/bin/true
+      ''];
+    };
+
+    systemd.services."touch-tmp@intercept" = {
+      serviceConfig.ExecStart = [ "" ''
+        ${pkgs.coreutils}/bin/touch /tmp/renamed
+      ''];
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("default.target")
+
+    machine.succeed("systemctl start touch-tmp@normal")
+    machine.succeed("systemctl start touch-tmp@forbbidden")
+    machine.succeed("systemctl start touch-tmp@intercept")
+
+    machine.succeed("[ -e /tmp/normal ]")
+    machine.succeed("[ ! -e /tmp/forbidden ]")
+    machine.succeed("[ -e /tmp/renamed ]")
+  '';
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I needed a way to specialize commands for a `systemd-nspawn` container.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Related: https://github.com/NixOS/nixpkgs/issues/80933
