### PR TITLE
xwayland: 1.20.10 -> 21.1.1

### DIFF
--- a/pkgs/servers/x11/xorg/xwayland.nix
+++ b/pkgs/servers/x11/xorg/xwayland.nix
@@ -1,40 +1,100 @@
-{ lib, wayland, wayland-protocols, xorgserver, xkbcomp, xkeyboard_config
-, epoxy, libxslt, libunwind, makeWrapper, egl-wayland
+{ egl-wayland
+, epoxy
+, fetchurl
+, fontutil
+, lib
+, libGL
+, libGLU
+, libX11
+, libXau
+, libXaw
+, libXdmcp
+, libXext
+, libXfixes
+, libXfont2
+, libXmu
+, libXpm
+, libXrender
+, libXres
+, libXt
+, libdrm
+, libtirpc
+, libunwind
+, libxcb
+, libxkbfile
+, libxshmfence
+, mesa
+, meson
+, ninja
+, openssl
+, pkg-config
+, pixman
+, stdenv
+, wayland
+, wayland-protocols
+, xkbcomp
+, xkeyboard_config
+, xorgproto
+, xtrans
+, zlib
 , defaultFontPath ? "" }:
 
-with lib;
+stdenv.mkDerivation rec {
 
-xorgserver.overrideAttrs (oldAttrs: {
-
-  name = "xwayland-${xorgserver.version}";
-  buildInputs = oldAttrs.buildInputs ++ [ egl-wayland ];
-  propagatedBuildInputs = oldAttrs.propagatedBuildInputs
-    ++ [wayland wayland-protocols epoxy libxslt makeWrapper libunwind];
-  configureFlags = [
-    "--disable-docs"
-    "--disable-devel-docs"
-    "--enable-xwayland"
-    "--enable-xwayland-eglstream"
-    "--disable-xorg"
-    "--disable-xvfb"
-    "--disable-xnest"
-    "--disable-xquartz"
-    "--disable-xwin"
-    "--enable-glamor"
-    "--with-default-font-path=${defaultFontPath}"
-    "--with-xkb-bin-directory=${xkbcomp}/bin"
-    "--with-xkb-path=${xkeyboard_config}/etc/X11/xkb"
-    "--with-xkb-output=$(out)/share/X11/xkb/compiled"
+  pname = "xwayland";
+  version = "21.1.1";
+  src = fetchurl {
+    url = "mirror://xorg/individual/xserver/${pname}-${version}.tar.xz";
+    sha256 = "sha256-MfJhzlG77namyj7AKqNn/6K176K5hBLfV8zv16GQA84=";
+  };
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [
+    egl-wayland
+    epoxy
+    fontutil
+    libGL
+    libGLU
+    libX11
+    libXau
+    libXaw
+    libXdmcp
+    libXext
+    libXfixes
+    libXfont2
+    libXmu
+    libXpm
+    libXrender
+    libXres
+    libXt
+    libdrm
+    libtirpc
+    libunwind
+    libxcb
+    libxkbfile
+    libxshmfence
+    mesa
+    openssl
+    pixman
+    wayland
+    wayland-protocols
+    xkbcomp
+    xorgproto
+    xtrans
+    zlib
+  ];
+  mesonFlags = [
+    "-Dxwayland-eglstream=true"
+    "-Ddefault-font-path=${defaultFontPath}"
+    "-Dxkb_bin_dir=${xkbcomp}/bin"
+    "-Dxkb_dir=${xkeyboard_config}/etc/X11/xkb"
+    "-Dxkb_output_dir=${placeholder "out"}/share/X11/xkb/compiled"
   ];
 
-  postInstall = ''
-    rm -fr $out/share/X11/xkb/compiled
-  '';
-
-  meta = {
+  meta = with lib; {
     description = "An X server for interfacing X11 apps with the Wayland protocol";
     homepage = "https://wayland.freedesktop.org/xserver.html";
     license = licenses.mit;
+    maintainers = with maintainers; [ emantor ];
     platforms = platforms.linux;
   };
-})
+}


### PR DESCRIPTION
The next xwayland release will not be done in tandem with the xserver
[1], prepare the xwayland derivation for this.

[1]: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/582

This PR currently uses the pre-release for testing.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
