### PR TITLE
pika-backup: init at 0.2.1

### DIFF
--- a/pkgs/applications/backup/pika-backup/borg-path.patch
+++ b/pkgs/applications/backup/pika-backup/borg-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/borg/utils.rs b/src/borg/utils.rs
+index 4e30913..30d7d6f 100644
+--- a/src/borg/utils.rs
++++ b/src/borg/utils.rs
+@@ -223,7 +223,7 @@ impl BorgCall {
+     }
+ 
+     pub fn cmd(&self) -> Command {
+-        let mut cmd = Command::new("borg");
++        let mut cmd = Command::new("@borg@");
+ 
+         cmd.args(self.args())
+             .stderr(Stdio::piped())

--- a/pkgs/applications/backup/pika-backup/default.nix
+++ b/pkgs/applications/backup/pika-backup/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, rustPlatform
+, substituteAll
+, desktop-file-utils
+, meson
+, ninja
+, pkg-config
+, python3
+, wrapGAppsHook
+, borgbackup
+, dbus
+, gdk-pixbuf
+, glib
+, gtk3
+, libhandy
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pika-backup";
+  version = "0.2.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
+    repo = "pika-backup";
+    rev = "v${version}";
+    sha256 = "0fm6vwpw0pa98v2yn8p3818rrlv9lk3pmgnal1b2kh52im5ll7m8";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    sha256 = "1f5s6a0wjrs2spsicirhbvb5xlz9iflwsaqchij9k02hfcsr308y";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./borg-path.patch;
+      borg = "${borgbackup}/bin/borg";
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs build-aux
+  '';
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    python3
+    wrapGAppsHook
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  buildInputs = [
+    dbus
+    gdk-pixbuf
+    glib
+    gtk3
+    libhandy
+  ];
+
+  meta = with lib; {
+    description = "Simple backups based on borg";
+    homepage = "https://wiki.gnome.org/Apps/PikaBackup";
+    changelog = "https://gitlab.gnome.org/World/pika-backup/-/blob/v${version}/CHANGELOG.md";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24584,6 +24584,8 @@ in
 
   pidgin-window-merge = callPackage ../applications/networking/instant-messengers/pidgin-plugins/window-merge { };
 
+  pika-backup = callPackage ../applications/backup/pika-backup { };
+
   purple-discord = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-discord { };
 
   purple-hangouts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-hangouts { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@danieldk Thanks for https://github.com/NixOS/nixpkgs/pull/112804!
cc @NixOS/gnome 