### PR TITLE
bundlerEnv: Allow overriding bundler

### DIFF
--- a/pkgs/development/ruby-modules/bundler-env/default.nix
+++ b/pkgs/development/ruby-modules/bundler-env/default.nix
@@ -23,7 +23,7 @@
 let
   inherit (import ../bundled-common/functions.nix {inherit lib ruby gemConfig groups; }) genStubsScript;
 
-  basicEnv = (callPackage ../bundled-common {}) (args // { inherit pname name; mainGemName = pname; });
+  basicEnv = (callPackage ../bundled-common { inherit bundler; }) (args // { inherit pname name; mainGemName = pname; });
 
   inherit (basicEnv) envPaths;
   # Idea here is a mkDerivation that gen-bin-stubs new stubs "as specified" -


### PR DESCRIPTION
###### Motivation for this change

Prior to this it doesn't seem to be possible to customize the version of
bundler used in a bundlerEnv app. This change allows something like the
following:

```nix
let bundler = pkgs.buildRubyGem rec {
  gemName="bundler";
  name="bundler-2.2.11";
  version="2.2.11";
  source.sha256="1izx6wsjdm6mnbxazgz1z5qbhwrrisbq0np2nmx4ij6lrqjy18jf";
};
in pkgs.bundlerEnv { inherit bundler; }{
  name="test";
  gemdir=./.;
}
```

to use bundler 2.2.11 rather than the 2.1.5 default.

(As a one-liner test from the nixpkgs repo:

```shell
nix-shell -I nixpkgs=./ -p 'let bundler = pkgs.buildRubyGem rec {gemName="bundler"; name="bundler-2.2.11"; version="2.2.11"; source.sha256="1izx6wsjdm6mnbxazgz1z5qbhwrrisbq0np2nmx4ij6lrqjy18jf";}; in pkgs.bundlerEnv.override {inherit bundler;} {name="test"; gemdir=./pkgs/development/tools/sass; }' --pure --run "bundler --version"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
