### PR TITLE
open-policy-agent: 0.26.0 -> 0.27.0

### DIFF
--- a/pkgs/development/tools/open-policy-agent/default.nix
+++ b/pkgs/development/tools/open-policy-agent/default.nix
@@ -2,23 +2,30 @@
 
 buildGoModule rec {
   pname = "open-policy-agent";
-  version = "0.26.0";
+  version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "opa";
     rev = "v${version}";
-    sha256 = "sha256-bkWfRmcUPNYeUucrbh9xAqmLg7RxEEQGa2DQdN2S6Po=";
+    sha256 = "sha256-WMCd7+SUpKagoutBqI98KnoOd/UwJqFrSh0RAJQvuSo=";
   };
 
   vendorSha256 = null;
 
   subPackages = [ "." ];
 
-  buildFlagsArray = [
-    "-ldflags="
-    "-X github.com/open-policy-agent/opa/version.Version=${version}"
-  ];
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-s -w -X github.com/open-policy-agent/opa/version.Version=${version}")
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/opa --help
+    $out/bin/opa version | grep "Version: ${version}"
+    runHook postInstallCheck
+  '';
 
   meta = with lib; {
     description = "General-purpose policy engine";
@@ -30,6 +37,6 @@ buildGoModule rec {
     '';
     homepage = "https://www.openpolicyagent.org";
     license = licenses.asl20;
-    maintainers = with maintainers; [ lewo ];
+    maintainers = with maintainers; [ lewo jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump open-policy-agent to 0.27.0

Also:

- Set buildFlagsArray using bash
- use -s and -w to minify the result
  - Before: 18 MB
  - After: 16 MB
- Add @06kellyjac as a maintainer

@nlewo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
