### PR TITLE
emacs: do not use project package from elpa for emacs >= 28

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-packages.nix
@@ -53,6 +53,9 @@ self: let
       seq = if lib.versionAtLeast self.emacs.version "27"
             then null
             else super.seq;
+      project = if lib.versionAtLeast self.emacs.version "28"
+                then null
+                else super.project;
     };
 
     elpaPackages = super // overrides;


### PR DESCRIPTION
The `project` package bundled with Emacs 28 is newer than the one
provided by GNU ELPA. This may or may not change in the future.

For now it is definitely the case and since the package is under heavy
development a lot of features are missing in the one on GNU ELPA which in
turn is newer than the one that comes bundled with Emacs 27.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Some features are missing/broken in the GNU ELPA project package when used together with Emacs 28.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
