### PR TITLE
mcfgthreads: enable cross-compiling on Darwin

### DIFF
--- a/pkgs/os-specific/windows/mcfgthreads/default.nix
+++ b/pkgs/os-specific/windows/mcfgthreads/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation {
     rm -r "$sourceRoot/debug" "$sourceRoot/release"
   '';
 
+  postPatch = ''
+    substituteInPlace Makefile.am --replace '-Werror' ''
+  '';
+
   nativeBuildInputs = [
     autoreconfHook
   ];


### PR DESCRIPTION
This PR fixes issue #97214. I want to build a Windows-targetting cross compiler on Darwin. However, compilation of `mcfgthreads` fails, because clang shows warnings with this codebase and the build system uses `-Werror`.

I think `-Werror` is problematic in release code, so I boldly removed it for all platforms. With this change, I can successfully build a Windows-cross-compiler on Darwin.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).