### PR TITLE
renoise: Add desktop item

### DIFF
--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
         }
         else
           releasePath
-    else throw "Platform is not supported by Renoise";
+    else throw "Platform is not supported. Use instalation native to your platform https://www.renoise.com/";
 
   buildInputs = [ alsaLib libjack2 libX11 libXcursor libXext libXrandr ];
 
@@ -47,6 +47,16 @@ stdenv.mkDerivation rec {
 
     mkdir $out/bin
     ln -s $out/renoise $out/bin/renoise
+
+    # Desktop item
+    mkdir -p $out/share/applications
+    cp -r Installer/renoise.desktop $out/share/applications/renoise.desktop
+
+    # Desktop item icons
+    mkdir -p $out/share/icons/hicolor/{48x48,64x64,128x128}/apps
+    cp Installer/renoise-48.png $out/share/icons/hicolor/48x48/apps/renoise.png
+    cp Installer/renoise-64.png $out/share/icons/hicolor/64x64/apps/renoise.png
+    cp Installer/renoise-128.png $out/share/icons/hicolor/128x128/apps/renoise.png
   '';
 
   postFixup = ''
@@ -61,6 +71,9 @@ stdenv.mkDerivation rec {
         --set-rpath $out/lib \
         $path
     done
+
+    substituteInPlace $out/share/applications/renoise.desktop \
+      --replace Exec=renoise Exec=$out/bin/renoise
   '';
 
   meta = {

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -54,9 +54,7 @@ stdenv.mkDerivation rec {
 
     # Desktop item icons
     mkdir -p $out/share/icons/hicolor/{48x48,64x64,128x128}/apps
-    cp Installer/renoise-48.png $out/share/icons/hicolor/48x48/apps/renoise.png
-    cp Installer/renoise-64.png $out/share/icons/hicolor/64x64/apps/renoise.png
-    cp Installer/renoise-128.png $out/share/icons/hicolor/128x128/apps/renoise.png
+    cp Installer/renoise-{48,64,128}.png $out/share/icons/hicolor/{48x48,64x64,128x128}/apps/renoise.png
   '';
 
   postFixup = ''


### PR DESCRIPTION
Adds desktop item to renoise.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
