### PR TITLE
nemo-qml-plugin-dbus: 2.1.23 -> 2.1.24

### DIFF
--- a/pkgs/development/libraries/nemo-qml-plugin-dbus/default.nix
+++ b/pkgs/development/libraries/nemo-qml-plugin-dbus/default.nix
@@ -2,14 +2,14 @@
 
 mkDerivation rec {
   pname = "nemo-qml-plugin-dbus";
-  version = "2.1.23";
+  version = "2.1.24";
 
   src = fetchFromGitLab {
     domain = "git.sailfishos.org";
     owner = "mer-core";
     repo = "nemo-qml-plugin-dbus";
     rev = version;
-    sha256 = "0ww478ds7a6h4naa7vslj6ckn9cpsgcml0q7qardkzmdmxsrv1ag";
+    sha256 = "1ilg929456d3k0xkvxa5r4k7i4kkw9i8kgah5xx1yq0d9wka0l77";
   };
 
   nativeBuildInputs = [ qmake ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
