### PR TITLE
zstd: 1.4.8 -> 1.4.9

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zstd";
-  version = "1.4.8";
+  version = "1.4.9";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "zstd";
     rev = "v${version}";
-    sha256 = "018zgigp5xlrb4mgshgrvns0cfbhhcg89cifbjj4rv6s3n9riphw";
+    sha256 = "18alxnym54gswsmsr5ra82q4k1q5fyzsyx0jykb2sk2nkpvx7334";
   };
 
   nativeBuildInputs = [ cmake ]
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optional stdenv.hostPlatform.isUnix bash;
 
   patches = [
+    # This patches makes sure we do not attempt to use the MD5 implementation
+    # of the host platform when running the tests
     ./playtests-darwin.patch
   ] # This I didn't upstream because if you use posix threads with MinGW it will
     # work fine, and I'm not sure how to write the condition.

--- a/pkgs/tools/compression/zstd/playtests-darwin.patch
+++ b/pkgs/tools/compression/zstd/playtests-darwin.patch
@@ -1,18 +1,28 @@
 --- a/tests/playTests.sh
 +++ b/tests/playTests.sh
-@@ -109,5 +109,2 @@ esac
+@@ -112,17 +112,10 @@ case "$OS" in
+ esac
+ 
  case "$UNAME" in
 -  Darwin) MD5SUM="md5 -r" ;;
 -  FreeBSD) MD5SUM="gmd5sum" ;;
+-  NetBSD) MD5SUM="md5 -n" ;;
 -  OpenBSD) MD5SUM="md5" ;;
    *) MD5SUM="md5sum" ;;
-@@ -116,5 +113,2 @@ esac
+ esac
+ 
  MTIME="stat -c %Y"
 -case "$UNAME" in
--    Darwin | FreeBSD | OpenBSD) MTIME="stat -f %m" ;;
+-    Darwin | FreeBSD | OpenBSD | NetBSD) MTIME="stat -f %m" ;;
 -esac
  
-@@ -752,3 +746,2 @@ zstd -d --rm dirTestDict/*.zst -D tmpDictC  # note : use internal checksum by de
+ DIFF="diff"
+ case "$UNAME" in
+@@ -842,7 +835,6 @@ $MD5SUM dirTestDict/* > tmph1
+ zstd -f --rm dirTestDict/* -D tmpDictC
+ zstd -d --rm dirTestDict/*.zst -D tmpDictC  # note : use internal checksum by default
  case "$UNAME" in
 -  Darwin) println "md5sum -c not supported on OS-X : test skipped" ;;  # not compatible with OS-X's md5
    *) $MD5SUM -c tmph1 ;;
+ esac
+ rm -rf dirTestDict


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-24032.

Changelog: https://github.com/facebook/zstd/releases/tag/v1.4.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
