### PR TITLE
pdfslicer: init at 1.8.8

### DIFF
--- a/pkgs/applications/misc/pdfslicer/default.nix
+++ b/pkgs/applications/misc/pdfslicer/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gettext
+, intltool
+, pkg-config
+, wrapGAppsHook
+, gtkmm3
+, libuuid
+, poppler
+, qpdf
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pdfslicer";
+  version = "1.8.8";
+
+  src = fetchFromGitHub {
+    owner = "junrrein";
+    repo = "pdfslicer";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "0sja0ddd9c8wjjpzk2ag8q1lxpj09adgmhd7wnsylincqnj2jyls";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    intltool
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtkmm3
+    libuuid
+    poppler
+    qpdf
+  ];
+
+  meta = with lib; {
+    description = "A simple application to extract, merge, rotate and reorder pages of PDF documents";
+    homepage = "https://junrrein.github.io/pdfslicer/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24494,6 +24494,8 @@ in
     wxGTK = wxGTK30-gtk3;
   };
 
+  pdfslicer = callPackage ../applications/misc/pdfslicer { };
+
   pekwm = callPackage ../applications/window-managers/pekwm { };
 
   pencil = callPackage ../applications/graphics/pencil {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
