### PR TITLE
python3Packages.ansible-lint: fix failing test on deprecation warning

### DIFF
--- a/pkgs/development/python-modules/ansible-lint/default.nix
+++ b/pkgs/development/python-modules/ansible-lint/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   '';
 
   checkPhase = ''
-    pytest -k 'not test_run_playbook_github and not test_run_single_role_path_no_trailing_slash_script'
+    pytest -W ignore::DeprecationWarning -k 'not test_run_playbook_github and not test_run_single_role_path_no_trailing_slash_script'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Ignore the deprecation warning during test. The deprecation warning is
due to a recent version of pyyaml which [moved some of their packages](https://github.com/yaml/pyyaml/commit/89f608599d700bf2976bf9307f9f86565f27a80e)

This fixes #113807

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
