### PR TITLE
 openmpi: 4.0.5 -> 4.1.0 

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -18,7 +18,7 @@
 assert !cudaSupport || cudatoolkit != null;
 
 let
-  version = "4.0.5";
+  version = "4.1.0";
 
   cudatoolkit_joined = symlinkJoin {
     name = "${cudatoolkit.name}-unsplit";
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
 
   src = with lib.versions; fetchurl {
     url = "https://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "02f0r9d3xgs08svkmj8v7lzviyxqnkk4yd3z0wql550xnriki3y5";
+    sha256 = "sha256-c4Zvt3CQgZtqjIXLhTljjTfWh3RVglt04onWR6Of1bU=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, python, buildPythonPackage, mpi, openssh }:
+{ lib, fetchPypi, fetchpatch, python, buildPythonPackage, mpi, openssh }:
 
 buildPythonPackage rec {
   pname = "mpi4py";
@@ -8,6 +8,12 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "012d716c8b9ed1e513fcc4b18e5af16a8791f51e6d1716baccf988ad355c5a1f";
   };
+
+  patches = [ (fetchpatch {
+    name = "disable-broken-test"; # upstream patch
+    url = "https://github.com/mpi4py/mpi4py/commit/e13cc3ee59ec6ec2c6ee20e384e1e649d5027e8a.patch";
+    sha256 = "0iwknrhxnfmsqjj8ahpn50c8pcdyv9p3wmcqi1jhr4i5y7lnmvvx";
+  })];
 
   passthru = {
     inherit mpi;


### PR DESCRIPTION
###### Motivation for this change
cleanup of https://github.com/NixOS/nixpkgs/pull/110194

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
