### PR TITLE
keeweb: 1.16.7 → 1.17.0

### DIFF
--- a/pkgs/applications/misc/keeweb/default.nix
+++ b/pkgs/applications/misc/keeweb/default.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, fetchurl, appimageTools, undmg, libsecret }:
+{ lib, stdenv, fetchurl, appimageTools, undmg, libsecret, libxshmfence }:
 let
   inherit (stdenv.hostPlatform) system;
   throwSystem = throw "Unsupported system: ${system}";
 
   pname = "keeweb";
-  version = "1.16.7";
+  version = "1.17.0";
   name = "${pname}-${version}";
 
   suffix = {
@@ -16,9 +16,9 @@ let
   src = fetchurl {
     url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.${suffix}";
     sha256 = {
-      x86_64-linux = "0a4yh2jh9sph17mqqi62gm5jc4yffkysq6yiggyzz5f8xw4p315j";
-      x86_64-darwin = "0ix1apddqvz561pw5lx47x091wlfj27zh8k8v7kn5xvm09hswfkr";
-      aarch64-darwin = "0p0kql79kcb3w947g1ljhbj15b8aqrwcrbi0cknb12f6iq47lkz7";
+      x86_64-linux = "1c7zvwnd46d3lrlcdigv341flz44jl6mnvr6zqny5mfz221ynbj7";
+      x86_64-darwin = "1n4haxychm5jjhjnpncavjh0wr4dagqi78qfsx5gwlv86hzryzwy";
+      aarch64-darwin = "1j7z63cbfms02f2lhl949wy3lc376jw8kqmjfn9j949s0l5fanpb";
     }.${system} or throwSystem;
   };
 
@@ -29,6 +29,7 @@ let
   meta = with lib; {
     description = "Free cross-platform password manager compatible with KeePass";
     homepage = "https://keeweb.info/";
+    changelog = "https://github.com/keeweb/keeweb/blob/v${version}/release-notes.md";
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
     platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
@@ -37,7 +38,7 @@ let
   linux = appimageTools.wrapType2 rec {
     inherit name src meta;
 
-    extraPkgs = pkgs: with pkgs; [ libsecret ];
+    extraPkgs = pkgs: with pkgs; [ libsecret libxshmfence ];
 
     extraInstallCommands = ''
       mv $out/bin/{${name},${pname}}
@@ -54,11 +55,11 @@ let
 
     nativeBuildInputs = [ undmg ];
 
-    sourceRoot = "KeeWeb.app";
+    sourceRoot = ".";
 
     installPhase = ''
-      mkdir -p $out/Applications/KeeWeb.app
-      cp -R . $out/Applications/KeeWeb.app
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
     '';
   };
 in


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/keeweb/keeweb/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
