### PR TITLE
python38Packages.percol: python3 support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3991,6 +3991,12 @@
     githubId = 61913481;
     name = "Mat Marini";
   };
+  illustris = {
+    email = "me@illustris.tech";
+    github = "illustris";
+    githubId = 3948275;
+    name = "Harikrishnan R";
+  };
   ilya-fedin = {
     email = "fedin-ilja2010@ya.ru";
     github = "ilya-fedin";

--- a/pkgs/development/python-modules/cmigemo/default.nix
+++ b/pkgs/development/python-modules/cmigemo/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchPypi, six, cmigemo, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "cmigemo";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09j68kvcskav2cqb7pj12caksmj4wh2lhjp0csq00xpn0wqal4vk";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  preConfigure = ''
+    export LDFLAGS="-L${cmigemo}/lib"
+    export CPPFLAGS="-I${cmigemo}/include"
+    export LD_LIBRARY_PATH="${cmigemo}/lib"
+  '';
+
+  postPatch = ''
+    sed -i 's~dict_path_base = "/usr/share/cmigemo"~dict_path_base = "/${cmigemo}/share/migemo"~g' test/test_cmigemo.py
+  '';
+
+  checkInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "test/" ];
+
+  pythonImportsCheck = [ "cmigemo" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mooz/python-cmigemo";
+    description = "A pure python binding for C/Migemo";
+    license = licenses.mit;
+    maintainers = with maintainers; [ illustris ];
+  };
+}

--- a/pkgs/development/python-modules/percol/default.nix
+++ b/pkgs/development/python-modules/percol/default.nix
@@ -1,25 +1,26 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k
-, six
-}:
+{ lib, buildPythonPackage, fetchFromGitHub, cmigemo }:
 
 buildPythonPackage rec {
   pname = "percol";
-  version = "0.2.1";
-  disabled = isPy3k;
+  version = "unstable-2019-07-24";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "7a649c6fae61635519d12a6bcacc742241aad1bff3230baef2cedd693ed9cfe8";
+  src = fetchFromGitHub {
+    owner = "mooz";
+    repo = "percol";
+    rev = "4b28037e328da3d0fe8165c11b800cbaddcb525e";
+    sha256 = "07sq3517wzn04j2dzlmczmcvx3w6r7xnzz3634zgf1zi6dbr2a3g";
   };
 
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [ cmigemo ];
+
+  # package has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "percol" ];
 
   meta = with lib; {
     homepage = "https://github.com/mooz/percol";
     description = "Adds flavor of interactive filtering to the traditional pipe concept of shell";
     license = licenses.mit;
     maintainers = with maintainers; [ koral ];
-    broken = true; # missing cmigemo package which is missing libmigemo.so
-    # also doesn't support python3
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1387,6 +1387,10 @@ in {
 
   cmdtest = callPackage ../development/python-modules/cmdtest { };
 
+  cmigemo = callPackage ../development/python-modules/cmigemo {
+    inherit (pkgs) cmigemo;
+  };
+
   cmsis-svd = callPackage ../development/python-modules/cmsis-svd { };
 
   cntk = callPackage ../development/python-modules/cntk { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The percol package is currently marked as broken on python3

###### Things done
- Add the [python-cmigemo](https://pypi.org/project/cmigemo/) package from pypi
- Update percol from 0.1.0 to git rev. 4b28037

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
