### PR TITLE
klipper: fixup build on i686

### DIFF
--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -12,8 +12,14 @@ stdenv.mkDerivation rec {
     owner = "KevinOConnor";
     repo = "klipper";
     rev = "ef4d9c3abd30ae8a485020fd9ff2fb4529a143b3";
-    sha256 = "puAkSGL0DD0JUWejPdzr7zKIW2UP2soBBtgm2msUKzA=";
+    sha256 = "sha256-puAkSGL0DD0JUWejPdzr7zKIW2UP2soBBtgm2msUKzA=";
   };
+
+  # We have no LTO on i686 since commit 22284b0
+  postPatch = lib.optional stdenv.isi686 ''
+    substituteInPlace chelper/__init__.py \
+      --replace "-flto -fwhole-program " ""
+  '';
 
   sourceRoot = "source/klippy";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
We have no LTO here since commit 22284b0. This fixes the build for klipper which was referencing it in its build script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
