### PR TITLE
cudnnPackages: Remove statically linked .a files.

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -8,6 +8,14 @@
 , cudatoolkit
 , fetchurl
 , addOpenGLRunpath
+, # The distributed version of CUDNN includes both dynamically liked .so files,
+  # as well as statically linked .a files.  However, CUDNN is quite large
+  # (multiple gigabytes), so you can save some space in your nix store by
+  # removing the statically linked libraries if you are not using them.
+  #
+  # Setting this to true removes the statically linked .a files.
+  # Setting this to false keeps these statically linked .a files.
+  removeStatic ? false
 }:
 
 stdenv.mkDerivation {
@@ -23,6 +31,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ addOpenGLRunpath ];
 
   installPhase = ''
+    runHook preInstall
+
     function fixRunPath {
       p=$(patchelf --print-rpath $1)
       patchelf --set-rpath "''${p:+$p:}${lib.makeLibraryPath [ stdenv.cc.cc ]}:\$ORIGIN/" $1
@@ -35,6 +45,10 @@ stdenv.mkDerivation {
     mkdir -p $out
     cp -a include $out/include
     cp -a lib64 $out/lib64
+  '' + lib.optionalString removeStatic ''
+    rm -f $out/lib64/*.a
+  '' + ''
+    runHook postInstall
   '';
 
   # Set RUNPATH so that libcuda in /run/opengl-driver(-32)/lib can be found.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The latest version of CUDNN is really huge.  It is distributed with both statically linked and dynamically linked libraries.

This PR adds an option to remove the statically linked libraries.  This is nice if you don't actually use the statically linked libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
