### PR TITLE
tipp10: unstable -> 3.2.1

### DIFF
--- a/pkgs/applications/misc/tipp10/default.nix
+++ b/pkgs/applications/misc/tipp10/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation rec {
   pname = "tipp10";
-  version = "unstable-20200616";
+  version = "3.2.1";
 
   src = fetchFromGitLab {
     owner = "tipp10";
     repo = "tipp10";
-    rev = "2dd6d45c8a91cff7075675d8875721456cdd5f1b";
-    sha256 = "16x51rv4r6cz5vsmrfbakqzbfxy456h82ibzacknp35f41cjdqq4";
+    rev = "v${version}";
+    sha256 = "4cxN2AnvYhZAMuA/qfmdLVICJNk6VCpRnfelbxYRvPg=";
   };
 
   nativeBuildInputs = [ cmake qttools ];
@@ -17,8 +17,8 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "Learn and train typing with the ten-finger system";
-    homepage = "https://gitlab.com/a_a/tipp10";
-    license = licenses.gpl2;
+    homepage = "https://gitlab.com/tipp10/tipp10";
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ petabyteboy ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tidiness.

###### Things done
Go to a stable version (which is almost literally the same as the previous unstable) and update metadata.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
