### PR TITLE
acousticbrainz-client: init at 0.1

### DIFF
--- a/pkgs/tools/audio/acousticbrainz-client/default.nix
+++ b/pkgs/tools/audio/acousticbrainz-client/default.nix
@@ -1,0 +1,41 @@
+{ lib, fetchFromGitHub, python3Packages, essentia-extractor }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "acousticbrainz-client";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "MTG";
+    repo = "acousticbrainz-client";
+    rev = version;
+    sha256 = "1g1nxh58939vysfxplrgdz366dlqnic05pkzbqh75m79brg4yrv1";
+  };
+
+  propagatedBuildInputs = [ essentia-extractor python3Packages.requests ];
+
+  postPatch = ''
+    # The installer needs the streaming_extractor_music binary in the source directoy,
+    # so we provide a symlink to it.
+    ln -s ${essentia-extractor}/bin/streaming_extractor_music streaming_extractor_music
+  '';
+
+  postInstall = ''
+    # The installer includes a copy of the streaming_extractor_music binary (not a symlink),
+    # which we don't need, because the wrapper adds ${essentia-extractor}/binary to PATH.
+    rm $out/bin/streaming_extractor_music
+  '';
+
+  # Tests seem to be broken, but the tool works
+  doCheck = false;
+
+  pythonImportsCheck = [ "abz" ];
+
+  meta = with lib; {
+    description = "A client to upload data to an AcousticBrainz server";
+    license = licenses.gpl3Plus;
+    homepage = "https://github.com/MTG/acousticbrainz-client";
+    # essentia-extractor is only available for those platforms
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ eduardosm ];
+  };
+}

--- a/pkgs/tools/audio/acousticbrainz-client/default.nix
+++ b/pkgs/tools/audio/acousticbrainz-client/default.nix
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
 
   postInstall = ''
     # The installer includes a copy of the streaming_extractor_music binary (not a symlink),
-    # which we don't need, because the wrapper adds ${essentia-extractor}/binary to PATH.
+    # which we don't need, because the wrapper adds essentia-extractor/binary to PATH.
     rm $out/bin/streaming_extractor_music
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -642,6 +642,8 @@ in
 
   acme-sh = callPackage ../tools/admin/acme.sh { };
 
+  acousticbrainz-client = callPackage ../tools/audio/acousticbrainz-client { };
+
   acoustidFingerprinter = callPackage ../tools/audio/acoustid-fingerprinter {
     ffmpeg = ffmpeg_2;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
