### PR TITLE
fselect: fix darwin build

### DIFF
--- a/pkgs/tools/misc/fselect/default.nix
+++ b/pkgs/tools/misc/fselect/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPlatform, installShellFiles }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform, installShellFiles, libiconv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "fselect";
@@ -14,6 +14,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-vVIanMkc0sPzu0L48oOh8wEEUOckR/AYkz81u4OR+fE=";
 
   nativeBuildInputs = [ installShellFiles ];
+  buildInputs = lib.optional stdenv.isDarwin libiconv;
 
   postInstall = ''
     installManPage docs/fselect.1


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds missing dependency to `libiconv`.

```
error: linking with `/nix/store/8i0yaj3r82kqcdbr453wzzijnszxg4gx-clang-wrapper-7.1.0/bin/cc` failed: exit code: 1
  |
  = note: "/nix/store/8i0yaj3r82kqcdbr453wzzijnszxg4gx-clang-wrapper-7.1.0/bin/cc" "-m64" "-arch" "x86_64" "-L" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.0.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.1.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.10.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.11.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.12.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.13.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.14.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.15.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.2.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.3.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.4.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.5.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.6.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.7.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.8.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.phf_macros.17r0ggj6-cgu.9.rcgu.o" "-o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libphf_macros-fbc96675ec501b5e.dylib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.4gkptsdo41top6ix.rcgu.o" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/phf_macros-fbc96675ec501b5e.ikf90dthb855245.rcgu.o" "-Wl,-dead_strip" "-dynamiclib" "-Wl,-dylib" "-nodefaultlibs" "-L" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps" "-L" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libsyn-e1d2d3a126484b3c.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libquote-d38858d5e98b3e3c.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libproc_macro2-355c8ebe19c2e2a9.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libunicode_xid-7a20af18a2e741cc.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libphf_generator-a6e2cfde9ad43652.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/librand-e874cf4fd8ce3cdf.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/librand_pcg-c33c22dc6ab926ee.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/librand_chacha-7f66423450184ab0.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libppv_lite86-60aafc4dda808b33.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/librand_core-a412870b33d823c8.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libgetrandom-8175e63f9e3bbb12.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/liblibc-d34007a8911180db.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libcfg_if-cf61b0c4241ec95c.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libphf_shared-27f66ced03e10c75.rlib" "/private/tmp/nix-build-fselect-0.7.3.drv-0/source/target/release/deps/libsiphasher-ea84e9da9ba37075.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libproc_macro-c8d8db58737923bc.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libstd-fbaf988a2238c9e9.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libpanic_unwind-36d71f5e021c8aaf.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libobject-52cb1c57d45328b2.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libaddr2line-0edee1f480609da6.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libgimli-a241224dc8ce7669.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_demangle-628cdeb90e459c83.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libhashbrown-e49deb3fce23ec92.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_alloc-55ee31d22782c712.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libunwind-9e5a42e709210026.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libcfg_if-a20fa459d060e810.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/liblibc-9e2d83706b05787b.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/liballoc-33c234d8842d07cd.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_std_workspace_core-d361a19a86808d70.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libcore-af0b48f873da4690.rlib" "/nix/store/l25lk4w9gqnmdply0xx1jrdw5a5mkbyd-rustc-1.49.0/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-dceff571bc8c7bda.rlib" "-liconv" "-lSystem" "-lresolv" "-lc" "-lm"
  = note: ld: library not found for -liconv
          clang-7: error: linker command failed with exit code 1 (use -v to see invocation)


error: aborting due to previous error

error: could not compile `phf_macros`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
builder for '/nix/store/yid5apw4izgk7rqda102x3s62zml1ssj-fselect-0.7.3.drv' failed with exit code 101
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
