### PR TITLE
nixos/stage-1: make cpio quiet

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -386,7 +386,7 @@ let
           ) config.boot.initrd.secrets)
          }
 
-        (cd "$tmp" && find . -print0 | sort -z | cpio -o -H newc -R +0:+0 --reproducible --null) | \
+        (cd "$tmp" && find . -print0 | sort -z | cpio --quiet -o -H newc -R +0:+0 --reproducible --null) | \
           ${compressorExe} ${lib.escapeShellArgs initialRamdisk.compressorArgs} >> "$1"
       '';
 


### PR DESCRIPTION
The use of `cpio` without the `--quiet` flag in `append-initrd-secrets` generates a lot of noise during bootloader installation:

```
building the system configuration...
updating GRUB 2 menu...
2 blocks
2 blocks
2 blocks
2 blocks
2 blocks
2 blocks
2 blocks
```

This PR adds the flag.