### PR TITLE
yabridge, yabridgectl: 3.0.1 -> 3.0.2

### DIFF
--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -56,14 +56,14 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "yabridge";
-  version = "3.0.1";
+  version = "3.0.2";
 
-  # NOTE: Also update yabridgectl's cargoSha256 when this is updated
+  # NOTE: Also update yabridgectl's cargoHash when this is updated
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = pname;
     rev = version;
-    hash = "sha256-BT8Qj8WvyRlBwSuIIlfWVhlG3RSv2sFnSskCcjPF/N0=";
+    hash = "sha256-3uZCYGqo9acpANy5tQl3U0LK6wuOzjQpfjHDvaPSGlI=";
   };
 
   # Unpack subproject sources

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -6,12 +6,12 @@ rustPlatform.buildRustPackage rec {
 
   src = yabridge.src;
   sourceRoot = "source/tools/yabridgectl";
-  cargoHash = "sha256-YSK1DWv9kb6kFUJ4UEhh6psKsVqwpFJjvjJgj2e4BAc=";
+  cargoHash = "sha256-mSp/IH7ZB7YSOBCFwNtHLYDz7CvWo2sO9VuPdqpl/u0=";
 
   patches = [
     # By default, yabridgectl locates libyabridge.so by using
-    # hard-coded distro-specific lib paths. This patch replaces those
-    # hard coded paths with lib paths from NIX_PROFILE.
+    # hard coded distro specific lib paths. This patch replaces those
+    # hard coded paths with lib paths from NIX_PROFILES.
     ./libyabridge-from-nix-profiles.patch
   ];
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version: https://github.com/robbert-vdh/yabridge/releases/tag/3.0.2

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  Works with stable wine (v6.0), fails with staging wine (v6.3):
  ```shell
  > yabridgectl sync
  Setting up VST2 and VST3 plugins using:
  - /home/kira/.nix-profile/lib/libyabridge-vst2.so
  - /home/kira/.nix-profile/lib/libyabridge-vst3.so

  Finished setting up 2 plugins using copies (0 new), skipped 0 non-plugin .dll files

  Warning: Could not run 'yabridge-host.exe'. Wine reported the following error:

      Or maybe the wrong wineserver is still running?

      This can happen when using a version of Wine that is much older than the version that has been used to compile yabridge with. Your current Wine version is '6.3 (Staging)'. See the troubleshooting section of the readme for more information on how to upgrade
      your installation of Wine.

      https://github.com/robbert-vdh/yabridge#troubleshooting-common-issues
  ```
  Although, this error is now also occurring in the current version of yabridge with wine staging 6.3. This wasn't an issue in version 6.2.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).