### PR TITLE
mpvScripts.thumbnail: init at unstable-2020-01-16

### DIFF
--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -1,0 +1,36 @@
+{ fetchFromGitHub, lib, python3, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "mpv_thumbnail_script";
+  version = "unstable-2020-01-16";
+
+  src = fetchFromGitHub {
+    owner = "theamm";
+    repo = pname;
+    rev = "682becf5b5115c2a206b4f0bdee413d4be8b5bef";
+    sha256 = "0dgfrb8ypc5vlq35kzn423fm6l6348ivl85vb6j3ccc9a51xprw3";
+  };
+
+  nativeBuildInputs = [ python3 ];
+
+  postPatch = ''
+    patchShebangs concat_files.py
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/mpv/scripts
+    cp mpv_thumbnail_script_{client_osc,server}.lua $out/share/mpv/scripts
+    runHook postInstall
+  '';
+
+  passthru.scriptName = "mpv_thumbnail_script_{client_osc,server}.lua";
+
+  meta = with lib; {
+    description = "A lua script to show preview thumbnails in mpv's OSC seekbar";
+    homepage = "https://github.com/theamm/mpv_thumbnail_script";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24018,6 +24018,7 @@ in
     mpvacious = callPackage ../applications/video/mpv/scripts/mpvacious.nix {};
     simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix {};
     sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix {};
+    thumbnail = callPackage ../applications/video/mpv/scripts/thumbnail.nix { };
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A lua script to show preview thumbnails in mpv's OSC seekbar


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
