### PR TITLE
linux: enable NVMe Multipath

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -772,6 +772,8 @@ let
       MLX4_EN_VXLAN = whenOlder "4.8" yes;
       MLX5_CORE_EN       = option yes;
 
+      NVME_MULTIPATH = whenAtLeast "4.15" yes;
+
       PSI = whenAtLeast "4.20" yes;
 
       MODVERSIONS        = whenOlder "4.9" yes;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Enable NVME_MULTIPATH so that a single /dev/nvmeXnY device will show
up for each NVMe namespaces, even if it is accessible through multiple
controllers. Can be disabled at boot with `nvme_core.multipath=0`.

This is default enabled in Debian [1], Ubuntu 20.04 [2] , Arch [3] and
Fedora 33 [4].

[1]: https://salsa.debian.org/kernel-team/linux/-/blob/debian/5.10.19-1/debian/config/config#L4362
[2]: https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/tree/debian.master/config/config.common.ubuntu?h=Ubuntu-5.4.0-67.75#n6722
[3]: https://git.archlinux.org/svntogit/packages.git/tree/trunk/config?h=packages/linux#n2423
[4]: https://src.fedoraproject.org/rpms/kernel/blob/f33/f/kernel-x86_64-fedora.config#_4338

The `multipath` option becomes available in this kernel module:
```
jteh@host:~/work/nixpkgs/result/lib/modules/5.10.21/kernel/drivers/nvme/host$ modinfo ./nvme-core.ko.xz
filename:       /home/jteh/work/nixpkgs/result/lib/modules/5.10.21/kernel/drivers/nvme/host/./nvme-core.ko.xz
version:        1.0
license:        GPL
srcversion:     908F75982125E2BC0E8FB31
depends:        t10-pi
retpoline:      Y
intree:         Y
name:           nvme_core
vermagic:       5.10.21 SMP mod_unload 
parm:           multipath:turn on native support for multiple controllers per subsystem (bool)
...
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
