### PR TITLE
lxqt-policykit: add required polkit buildinput

### DIFF
--- a/pkgs/desktops/lxqt/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-policykit/default.nix
@@ -9,6 +9,7 @@
 , qtx11extras
 , qtsvg
 , polkit-qt
+, polkit
 , kwindowsystem
 , liblxqt
 , libqtxdg
@@ -43,6 +44,7 @@ mkDerivation rec {
     liblxqt
     libqtxdg
     pcre
+    polkit
   ];
 
   passthru.updateScript = lxqtUpdateScript { inherit pname version src; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Build of lxqt.lxqt-policykit failed with the following error:

```
  --   No package 'polkit-agent-1' found
  CMake Error at /nix/store/cmq8c45600zjlv2prcwvpl161vgbmsmi-cmake-3.19.4/share/cmake-3.19/Modules/FindPkgConfig.cmake:553 (message):
    A required package was not found
  Call Stack (most recent call first):
    /nix/store/cmq8c45600zjlv2prcwvpl161vgbmsmi-cmake-3.19.4/share/cmake-3.19/Modules/FindPkgConfig.cmake:741 (_pkg_check_modules_internal)
    CMakeLists.txt:19 (pkg_check_modules)
  
  
  -- Configuring incomplete, errors occurred!
  See also "/build/source/build/CMakeFiles/CMakeOutput.log".

```

This PR resolves the build error.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
