### PR TITLE
powercap: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8267,6 +8267,12 @@
       fingerprint = "1401 1B63 393D 16C1 AA9C  C521 8526 B757 4A53 6236";
     }];
   };
+  rowanG077 = {
+    email = "goemansrowan@gmail.com";
+    github = "rowanG077";
+    githubId = 7439756;
+    name = "Rowan Goemans";
+  };
   royneary = {
     email = "christian@ulrich.earth";
     github = "royneary";

--- a/pkgs/os-specific/linux/powercap/default.nix
+++ b/pkgs/os-specific/linux/powercap/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "powercap";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "powercap";
+    repo = "powercap";
+    rev = "v${version}";
+    sha256 = "0f1sg1zsskcfralg9khwq7lmz25gvnyknza3bb0hmh1a9lw0jhdn";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=On"
+  ];
+
+  meta = with lib; {
+    description = "Tools and library to read/write to the Linux power capping framework (sysfs interface)";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rowanG077 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19429,6 +19429,8 @@ in
 
   power-calibrate = callPackage ../os-specific/linux/power-calibrate { };
 
+  powercap = callPackage ../os-specific/linux/powercap { };
+
   powerstat = callPackage ../os-specific/linux/powerstat { };
 
   smemstat = callPackage ../os-specific/linux/smemstat { };


### PR DESCRIPTION
###### Motivation for this change
Powercap was not packaged. This is a simple utility that allows setting power limits of components.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
