### PR TITLE
robo3t: 1.3.1 -> 1.4.3

### DIFF
--- a/pkgs/applications/misc/robo3t/default.nix
+++ b/pkgs/applications/misc/robo3t/default.nix
@@ -1,19 +1,23 @@
-{ lib, stdenv, fetchurl, zlib, glib, xorg, dbus, fontconfig, libGL,
+{ lib, stdenv, fetchurl, curl, zlib, glib, xorg, dbus, fontconfig, libGL,
   freetype, xkeyboard_config, makeDesktopItem, makeWrapper }:
+
+let
+  curlWithGnuTls = curl.override { gnutlsSupport = true; sslSupport = false; };
+in
 
 stdenv.mkDerivation rec {
   pname = "robo3t";
-  version = "1.3.1";
-  rev = "7419c406";
+  version = "1.4.3";
+  rev = "48f7dfd";
 
   src = fetchurl {
-    url = "https://download-test.robomongo.org/linux/robo3t-${version}-linux-x86_64-${rev}.tar.gz";
-    sha256 = "1mp5i8iahd4qkwgi5ix98hlg17ivw5da27n0drnr0wk458wn99hi";
+    url = "https://github.com/Studio3T/robomongo/releases/download/v${version}/robo3t-${version}-linux-x86_64-${rev}.tar.gz";
+    sha256 = "sha256-pH4q/O3bq45ZZn+s/12iScd0WbfkcLjK4MBdVCMXK00=";
   };
 
   icon = fetchurl {
-    url = "https://github.com/Studio3T/robomongo/raw/${version}/trash/install/linux/robomongo.png";
-    sha256 = "15li8536x600kkfkb3h6mw7y0f2ljkv951pc45dpiw036vldibv2";
+    url = "https://github.com/Studio3T/robomongo/raw/${rev}/install/macosx/robomongo.iconset/icon_128x128.png";
+    sha256 = "sha256-2PkUxBq2ow0wl09k8B6LJJUQ+y4GpnmoAeumKN1u5xg=";
   };
 
   desktopItem = makeDesktopItem {
@@ -43,6 +47,7 @@ stdenv.mkDerivation rec {
     fontconfig
     freetype
     libGL
+    curlWithGnuTls
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Bumping robo3t. Needed to add curl with gnutls as new  robo3t version needed `libcurl-gnutls.so.4` at startup. 
Replaced old, not working urls (`src`, `icon`) with github ones. 
[Robo3t release](https://github.com/Studio3T/robomongo/releases/tag/v1.4.3)
###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
