### PR TITLE
vimPlugins.fzfWrapper: place the fzf binary in the plugin's bin dir

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -91,9 +91,11 @@ self: super: {
   # plugin, since part of the fzf vim plugin is included in the main fzf
   # program.
   fzfWrapper = buildVimPluginFrom2Nix {
+    inherit (fzf) src version;
     pname = "fzf";
-    version = fzf.version;
-    src = fzf.src;
+    postInstall = ''
+      ln -s ${fzf}/bin/fzf $target/bin/fzf
+    '';
   };
 
   skim = buildVimPluginFrom2Nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The fzfWrapper is providing the fzf Vim plugin, but it's not providing the fzf binary which is required by the plugin. So the plugin fails to load fzf as seen below:

```
$ nix-shell -I nixpkgs=. --pure -p 'with import <nixpkgs> {}; neovim.override { configure.packages.fzf.start = with vimPlugins; [fzf-vim]; }' --run 'nvim +Files'
fzf executable not found. Download binary? (y/n)
```

The above issue no longer happens with this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @daplay

This fix should be backported to 20.09 because it's currently broken.