### PR TITLE
xmedcon: init at 0.21.0

### DIFF
--- a/pkgs/applications/science/medicine/xmedcon/default.nix
+++ b/pkgs/applications/science/medicine/xmedcon/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, lib
+, fetchurl
+, gtk3
+, glib
+, pkg-config
+, libpng
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xmedcon";
+  version = "0.21.0";
+
+  src = fetchurl {
+    url = "https://prdownloads.sourceforge.net/${pname}/${pname}-${version}.tar.bz2";
+    sha256 = "0yfnbrcil5i76z1wbg308pb1mnjbcxy6nih46qpqs038v1lhh4q8";
+  };
+
+  buildInputs = [
+    gtk3
+    glib
+    libpng
+    zlib
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = with lib; {
+    description = "An open source toolkit for medical image conversion ";
+    homepage = "https://xmedcon.sourceforge.io/Main/HomePage";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ arianvp flokli ];
+    platforms = with platforms; [ darwin linux ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28278,6 +28278,8 @@ in
 
   dcmtk = callPackage ../applications/science/medicine/dcmtk { };
 
+  xmedcon = callPackage ../applications/science/medicine/xmedcon { };
+
   ### SCIENCE/PHYSICS
 
   elmerfem = callPackage ../applications/science/physics/elmerfem {};


### PR DESCRIPTION
This allows reading DICOM images, including 3d stacks.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
