### PR TITLE
vscode-extensions.hashicorp.terraform: 2.8.0 -> 2.8.1

### DIFF
--- a/pkgs/misc/vscode-extensions/terraform/default.nix
+++ b/pkgs/misc/vscode-extensions/terraform/default.nix
@@ -3,13 +3,13 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "terraform";
     publisher = "hashicorp";
-    version = "2.8.0";
+    version = "2.8.1";
   };
 
   vsix = fetchurl {
     name = "${mktplcRef.publisher}-${mktplcRef.name}.zip";
     url = "https://github.com/hashicorp/vscode-terraform/releases/download/v${mktplcRef.version}/terraform-${mktplcRef.version}.vsix";
-    sha256 = "1ns40xaswqhngprlpf3ck59mj3kcxngr4jk0wkf16j3cvvskn0yy";
+    sha256 = "1pdpl8diqybqf68jvfk4kq9wg4k6c38811mh8iq12j4ba31cig9s";
   };
 
   patches = [ ./fix-terraform-ls.patch ];

--- a/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
+++ b/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
@@ -1,18 +1,17 @@
 diff --git a/out/extension.js b/out/extension.js
-index 375048c..fa5eff0 100644
+index 4a2c6a9..158fe28 100644
 --- a/out/extension.js
 +++ b/out/extension.js
-@@ -209,20 +209,7 @@ function pathToBinary() {
+@@ -215,19 +215,7 @@ function pathToBinary() {
          if (!_pathToBinaryPromise) {
              let command = vscodeUtils_1.config('terraform').get('languageServer.pathToBinary');
              if (!command) { // Skip install/upgrade if user has set custom binary path
 -                const installDir = `${extensionPath}/lsp`;
--                const installer = new languageServerInstaller_1.LanguageServerInstaller();
+-                const installer = new languageServerInstaller_1.LanguageServerInstaller(reporter);
 -                try {
 -                    yield installer.install(installDir);
 -                }
 -                catch (err) {
--                    vscode.window.showErrorMessage(err);
 -                    reporter.sendTelemetryException(err);
 -                    throw err;
 -                }
@@ -22,5 +21,5 @@ index 375048c..fa5eff0 100644
 -                command = `${installDir}/terraform-ls`;
 +                command = 'TERRAFORM-LS-PATH';
              }
-             _pathToBinaryPromise = Promise.resolve(command);
-         }
+             else {
+                 reporter.sendTelemetryEvent('usePathToBinary');


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
