### PR TITLE
octave.pkgs.sparsersb: remove librsb null override, unbreak

### DIFF
--- a/pkgs/development/octave-modules/sparsersb/default.nix
+++ b/pkgs/development/octave-modules/sparsersb/default.nix
@@ -13,7 +13,7 @@ buildOctavePackage rec {
     sha256 = "0nl7qppa1cm51188hqhbfswlih9hmy1yz7v0f5i07z0g0kbd62xw";
   };
 
-  buildInputs = [
+  propagatedBuildInputs = [
     librsb
   ];
 
@@ -22,7 +22,5 @@ buildOctavePackage rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ KarlJoad ];
     description = "Interface to the librsb package implementing the RSB sparse matrix format for fast shared-memory sparse matrix computations";
-    # Mark this way until KarlJoad builds librsb specifically for this package.
-    broken = true;
   };
 }

--- a/pkgs/top-level/octave-packages.nix
+++ b/pkgs/top-level/octave-packages.nix
@@ -179,11 +179,7 @@ makeScope newScope (self:
 
     sockets = callPackage ../development/octave-modules/sockets { };
 
-    sparsersb = callPackage ../development/octave-modules/sparsersb {
-      librsb = null;
-      # TODO: Package the librsb library to build this package.
-      # http://librsb.sourceforge.net/
-    };
+    sparsersb = callPackage ../development/octave-modules/sparsersb { };
 
     stk = callPackage ../development/octave-modules/stk { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
With librsb being merged into master (#112264), the Octave package sparsersb can now function.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
