### PR TITLE
python3Packages.dateparser: run tests

### DIFF
--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage rec {
   pname = "dateparser";
   version = "1.0.0";
 
+  disabled = !isPy3k;
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "159cc4e01a593706a15cd4e269a0b3345edf3aef8bf9278a57dac8adf5bf1e4a";

--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -1,19 +1,17 @@
-{ lib, fetchPypi, buildPythonPackage
-, nose
-, parameterized
-, mock
-, flake8
-, glibcLocales
-, six
-, jdatetime
-, dateutil
-, umalqurra
-, pytz
-, tzlocal
-, regex
-, ruamel_yaml
-, python
+{ lib
+, buildPythonPackage
 , isPy3k
+, fetchFromGitHub
+, dateutil
+, pytz
+, regex
+, tzlocal
+, hijri-converter
+, convertdate
+, parameterized
+, pytestCheckHook
+, GitPython
+, ruamel_yaml
 }:
 
 buildPythonPackage rec {
@@ -22,42 +20,36 @@ buildPythonPackage rec {
 
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "159cc4e01a593706a15cd4e269a0b3345edf3aef8bf9278a57dac8adf5bf1e4a";
+  src = fetchFromGitHub {
+    owner = "scrapinghub";
+    repo = "dateparser";
+    rev = "v${version}";
+    sha256 = "0i6ci14lqfsqrmaif57dyilrjbxzmbl98hps1b565gkiy1xqmjhl";
   };
-
-  checkInputs = [
-    flake8
-    nose
-    mock
-    parameterized
-    six
-    glibcLocales
-  ];
-  preCheck =''
-    # skip because of missing convertdate module, which is an extra requirement
-    rm tests/test_jalali.py
-  '';
-
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
-
-  # Strange
-  # AttributeError: 'module' object has no attribute 'config'
-  doCheck = false;
 
   propagatedBuildInputs = [
     # install_requires
     dateutil pytz regex tzlocal
     # extra_requires
-    jdatetime ruamel_yaml umalqurra
+    hijri-converter convertdate
   ];
+
+  checkInputs = [
+    parameterized
+    pytestCheckHook
+    GitPython
+    ruamel_yaml
+  ];
+
+  # Upstream only runs the tests in tests/ in CI, others use git clone
+  pytestFlagsArray = [ "tests" ];
+
+  pythonImportsCheck = [ "dateparser" ];
 
   meta = with lib; {
     description = "Date parsing library designed to parse dates from HTML pages";
     homepage = "https://github.com/scrapinghub/dateparser";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/115779#issuecomment-795892271

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
