### PR TITLE
renderizer: 2.0.9 -> 2.0.12

### DIFF
--- a/pkgs/development/tools/renderizer/default.nix
+++ b/pkgs/development/tools/renderizer/default.nix
@@ -2,18 +2,20 @@
 
 buildGoModule rec {
   pname = "renderizer";
-  version = "2.0.9";
+  version = "2.0.12";
 
   src = fetchFromGitHub {
     owner = "gomatic";
     repo = pname;
-    rev = version;
-    sha256 = "1bip12pcn8bqgph7vd7bzzadwbyqh80fx7gqciv9fchycwsj04rf";
+    rev = "v${version}";
+    sha256 = "sha256-Ji+wTTXLp17EYRIjUiVgd33ZeBdT8K2O8R2Ejq2Ll5I=";
   };
 
-  vendorSha256 = "13z357ww4j5bmmy8ag6d6gd5b2dib8kby73q8317pqnqzaxrrbcj";
+  buildFlagsArray = [
+    "-ldflags=-s -w -X main.version=${version} -X main.commitHash=${src.rev} -X main.date=19700101T000000"
+  ];
 
-  doCheck = false;
+  vendorSha256 = null;
 
   meta = with lib; {
     description = "CLI to render Go template text files";


### PR DESCRIPTION
###### Motivation for this change

- Update to latest version
- Run tests
- Fix version output

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
