### PR TITLE
cagebreak: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cagebreak";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "project-repo";
     repo = "cagebreak";
     rev = version;
-    hash = "sha256-P6zBVQEv+fKdverNIXhoEavu51uGKbSHx3Sh5FWsc2E=";
+    hash = "sha256-F7fqDVbJS6pVgmj6C1/l9PAaz5yzcYpaq6oc6a6v/Qk=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config wayland scdoc makeWrapper ];
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dxwayland=${lib.boolToString withXwayland}"
     "-Dversion_override=${version}"
+    "-Dman-pages=true"
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Update [cagebreak](https://github.com/project-repo/cagebreak) to 1.6.0.

Manpage are now also enabled.

Cagebreak is a Wayland TWM akin to ratpoison.

Fixed issues in 1.6.0:
- 24:
  > Cagebreak up to and including release 1.5.1 had an error, where the code
  > incremented a variable and not a pointer. This resulted in a bug in a
  > surface counting iterator.

- 25:
  > Cagebreak, beginning with release 1.5.0, when a keybinding containing an
  > output configuration is removed from the list of active keybindings, the
  > output configuration contained in this keybinding is destroyed in order to
  > prevent memory leaks. However, after an output configuration was applied,
  > it was inserted into the list of active output configurations and if it was
  > later destroyed, this led to a use-after-free memory corruption.
  >
  > Starting from release 1.6.0, output configurations are copied before being
  > inserted into the list of active output configurations and therefore remain
  > valid even if the original is freed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/marvin opt-in
/status needs_reviewer
