### PR TITLE
[20.09] keepassrpc: 1.8.0 -> 1.14.0

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keepassrpc/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keepassrpc/default.nix
@@ -1,13 +1,13 @@
 { stdenv, buildEnv, fetchurl, mono }:
 
 let
-  version = "1.8.0";
+  version = "1.14.0";
   drv = stdenv.mkDerivation {
     pname = "keepassrpc";
     inherit version;
     src = fetchurl {
       url    = "https://github.com/kee-org/keepassrpc/releases/download/v${version}/KeePassRPC.plgx";
-      sha256 = "1dclfpia559cqf78qw29zz235h1df5md4kgjv3bbi8y41wwmx7cd";
+      sha256 = "1c410cc93c0252e7cfdb02507b8172c13e18d12c97f08630b721d897dc9b8b24";
     };
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes #96799 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
