### PR TITLE
go-containerregistry: init at 0.4.1

### DIFF
--- a/pkgs/development/tools/go-containerregistry/default.nix
+++ b/pkgs/development/tools/go-containerregistry/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "A tool for interacting with remote images and registries";
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/google/go-containerregistry";
     license = licenses.apsl20;
     maintainers = with maintainers; [ yurrriq ];
   };

--- a/pkgs/development/tools/go-containerregistry/default.nix
+++ b/pkgs/development/tools/go-containerregistry/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-containerregistry";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-3mvGHAPKDUmrQkBKwlxnF6PG0ZpZDqlM9SMkCyC5ytE=";
+  };
+
+  vendorSha256 = null;
+
+  subPackages = [ "cmd/crane" "cmd/gcrane" ];
+
+  buildFlagsArray = [
+    "-ldflags=-s -w -X github.com/google/go-containerregistry/cmd/crane/cmd.Version=${version} -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version=${version}"
+  ];
+
+  # NOTE: no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A tool for interacting with remote images and registries";
+    inherit (src.meta) homepage;
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ yurrriq ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2403,6 +2403,8 @@ in
 
   go-chromecast = callPackage ../applications/video/go-chromecast { };
 
+  go-containerregistry = callPackage ../development/tools/go-containerregistry { };
+
   go-rice = callPackage ../tools/misc/go.rice {};
 
   go-2fa = callPackage ../tools/security/2fa {};


### PR DESCRIPTION
###### Motivation for this change

Add [go-containerregistry](https://github.com/google/go-containerregistry), which provides the `crane` and `gcrane` binaries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
   - [x] `crane`
   - [ ] `gcrane` (I don't use this or have easy access to a GCR registry)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
