### PR TITLE
m-cli: remove maintainer

### DIFF
--- a/pkgs/os-specific/darwin/m-cli/default.nix
+++ b/pkgs/os-specific/darwin/m-cli/default.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
 
     platforms = platforms.darwin;
-    maintainers = with maintainers; [ yurrriq ];
+    maintainers = with maintainers; [];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I haven't used Darwin much the last few years, and don't plan to any time soon. Someone might like to update this. There are several commits since v0.2.5, but now new tag.
