### PR TITLE
musescore: remove darwin maintainer

### DIFF
--- a/pkgs/applications/audio/musescore/darwin.nix
+++ b/pkgs/applications/audio/musescore/darwin.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     homepage = "https://musescore.org/";
     license = licenses.gpl2;
     platforms = platforms.darwin;
-    maintainers = with maintainers; [ yurrriq ];
+    maintainers = [];
     repositories.git = "https://github.com/musescore/MuseScore";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I haven't used Darwin much the last few years, and don't plan to any time soon. Someone might like to update this, but maybe it'd be better just to delete it. The latest version is 3.6.2, and this Darwin binary package is 2.1.