### PR TITLE
cutecom: install desktop file and man pages

### DIFF
--- a/pkgs/tools/misc/cutecom/default.nix
+++ b/pkgs/tools/misc/cutecom/default.nix
@@ -14,6 +14,14 @@ mkDerivation rec {
   buildInputs = [ qtbase qtserialport ];
   nativeBuildInputs = [ cmake ];
 
+  postInstall = ''
+    cd ..
+    mkdir -p "$out"/share/{applications,icons/hicolor/scalable/apps,man/man1}
+    cp cutecom.desktop "$out/share/applications"
+    cp images/cutecom.svg "$out/share/icons/hicolor/scalable/apps"
+    cp cutecom.1 "$out/share/man/man1"
+  '';
+
   meta = with lib; {
     description = "A graphical serial terminal";
     homepage = "https://gitlab.com/cutecom/cutecom/";

--- a/pkgs/tools/misc/cutecom/default.nix
+++ b/pkgs/tools/misc/cutecom/default.nix
@@ -11,11 +11,6 @@ mkDerivation rec {
     sha256 = "X8jeESt+x5PxK3rTNC1h1Tpvue2WH09QRnG2g1eMoEE=";
   };
 
-  preConfigure = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "#find_package(Serialport REQUIRED)" "find_package(Qt5SerialPort REQUIRED)"
-  '';
-
   buildInputs = [ qtbase qtserialport ];
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Cutecom's desktop file and man page were not installed. Also, there was a no longer needed `substituteInPlace` command.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @bennofs 