### PR TITLE
pythonPackages.{convertdate,vcrpy}: Drop support for Python 2.7

### DIFF
--- a/pkgs/development/python-modules/convertdate/default.nix
+++ b/pkgs/development/python-modules/convertdate/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, isPy27
 , fetchFromGitHub
 , pymeeus
 , pytz
@@ -9,6 +10,8 @@
 buildPythonPackage rec {
   pname = "convertdate";
   version = "2.3.0";
+
+  disabled = isPy27;
 
   # Tests are not available in the PyPI tarball so use GitHub instead.
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/vcrpy/default.nix
+++ b/pkgs/development/python-modules/vcrpy/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , lib
+, isPy27
 , six
 , fetchPypi
 , pyyaml
@@ -16,6 +17,8 @@
 buildPythonPackage rec {
   pname = "vcrpy";
   version = "4.1.1";
+
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
Extracted from https://github.com/NixOS/nixpkgs/pull/115779 where older versions compatible with Python 2.7 were introduced.

These cause a mass rebuild so in the interest of getting Nixops unbroken sooner rather than later I separated this from the Nixops unbreak PR.

Thank you @dotlambda!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
