### PR TITLE
Revert "google-play-music-desktop-player: drop"

### DIFF
--- a/pkgs/applications/audio/google-play-music-desktop-player/default.nix
+++ b/pkgs/applications/audio/google-play-music-desktop-player/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "https://www.googleplaymusicdesktopplayer.com/";
-    description = "A beautiful cross platform Desktop Player for Google Play Music";
+    description = "A beautiful cross platform Desktop Player for Google Play Music and YouTube Music";
     license = lib.licenses.mit;
     platforms = [ "x86_64-linux" ];
     maintainers = [ lib.maintainers.SuprDewd ];

--- a/pkgs/applications/audio/google-play-music-desktop-player/default.nix
+++ b/pkgs/applications/audio/google-play-music-desktop-player/default.nix
@@ -77,6 +77,6 @@ stdenv.mkDerivation {
     description = "A beautiful cross platform Desktop Player for Google Play Music and YouTube Music";
     license = lib.licenses.mit;
     platforms = [ "x86_64-linux" ];
-    maintainers = [ lib.maintainers.SuprDewd ];
+    maintainers = with lib.maintainers; [ anna328p SuprDewd ];
   };
 }

--- a/pkgs/applications/audio/google-play-music-desktop-player/default.nix
+++ b/pkgs/applications/audio/google-play-music-desktop-player/default.nix
@@ -1,0 +1,82 @@
+{ lib, stdenv, alsaLib, atk, at-spi2-atk, cairo, cups, dbus, dpkg, expat, fontconfig, freetype
+, fetchurl, GConf, gdk-pixbuf, glib, gtk2, gtk3, libpulseaudio, makeWrapper, nspr
+, nss, pango, udev, xorg
+}:
+
+let
+  version = "4.7.1";
+
+  deps = [
+    alsaLib
+    atk
+    at-spi2-atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    GConf
+    gdk-pixbuf
+    glib
+    gtk2
+    gtk3
+    libpulseaudio
+    nspr
+    nss
+    pango
+    stdenv.cc.cc
+    udev
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libXtst
+  ];
+
+in
+
+stdenv.mkDerivation {
+  pname = "google-play-music-desktop-player";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v${version}/google-play-music-desktop-player_${version}_amd64.deb";
+    sha256 = "1ljm9c5sv6wa7pa483yq03wq9j1h1jdh8363z5m2imz407yzgm5r";
+  };
+
+  dontBuild = true;
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  unpackPhase = ''
+    dpkg -x $src .
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./usr/share $out
+    cp -r ./usr/bin $out
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+             "$out/share/google-play-music-desktop-player/Google Play Music Desktop Player"
+
+    wrapProgram $out/bin/google-play-music-desktop-player \
+      --prefix LD_LIBRARY_PATH : "$out/share/google-play-music-desktop-player" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath deps}"
+  '';
+
+  meta = {
+    homepage = "https://www.googleplaymusicdesktopplayer.com/";
+    description = "A beautiful cross platform Desktop Player for Google Play Music";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ lib.maintainers.SuprDewd ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -262,7 +262,6 @@ mapAliases ({
   google-gflags = gflags; # added 2019-07-25
   google-music-scripts = throw "google-music-scripts has been removed because Google Play Music was discontinued"; # added 2021-03-07
   google-musicmanager = throw "google-musicmanager has been removed because Google Play Music was discontinued"; # added 2021-03-07
-  google-play-music-desktop-player = throw "google-play-music-desktop-player has been removed because Google Play Music was discontinued"; # added 2021-03-07
   googleAuthenticator = google-authenticator; # added 2016-10-16
   grantlee5 = libsForQt5.grantlee;  # added 2015-12-19
   gsettings_desktop_schemas = gsettings-desktop-schemas; # added 2018-02-25

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22849,6 +22849,10 @@ in
 
   google-chrome-dev = google-chrome.override { chromium = chromiumDev; channel = "dev"; };
 
+  google-play-music-desktop-player = callPackage ../applications/audio/google-play-music-desktop-player {
+    inherit (gnome2) GConf;
+  };
+
   gosmore = callPackage ../applications/misc/gosmore { };
 
   gpsbabel = libsForQt5.callPackage ../applications/misc/gpsbabel {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The package is still useful for YouTube Music.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
