### PR TITLE
async-profiler: init at 1.8.4

### DIFF
--- a/pkgs/development/tools/async-profiler/default.nix
+++ b/pkgs/development/tools/async-profiler/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub, jdk8 }:
+
+stdenv.mkDerivation rec {
+  pname = "async-profiler";
+  version = "1.8.4";
+
+  src = fetchFromGitHub {
+    owner = "jvm-profiling-tools";
+    repo = "async-profiler";
+    rev = "v${version}";
+    sha256 = "sha256-R/TFElytq3mBG+jKjb7XlFUqpXBpSZGfbscUdg2vevE=";
+  };
+
+  buildInputs = [ jdk8 ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D "$src/profiler.sh" "$out/bin/async-profiler"
+    install -D build/jattach "$out/bin/jattach"
+    install -D build/libasyncProfiler.so "$out/lib/libasyncProfiler.so"
+    install -D -t "$out/share/java/" build/*.jar
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    substituteInPlace $out/bin/async-profiler \
+      --replace 'JATTACH=$SCRIPT_DIR/build/jattach' \
+                'JATTACH=${placeholder "out"}/bin/jattach' \
+      --replace 'PROFILER=$SCRIPT_DIR/build/libasyncProfiler.so' \
+                'PROFILER=${placeholder "out"}/lib/libasyncProfiler.so'
+  '';
+
+  meta = with lib; {
+    description = "A low overhead sampling profiler for Java that does not suffer from Safepoint bias problem";
+    homepage    = "https://github.com/jvm-profiling-tools/async-profiler";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ mschuwalow ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1000,6 +1000,8 @@ in
 
   async = callPackage ../development/tools/async {};
 
+  async-profiler = callPackage ../development/tools/async-profiler { };
+
   atheme = callPackage ../servers/irc/atheme { };
 
   atinout = callPackage ../tools/networking/atinout { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
