### PR TITLE
pythonPackages.pystray: 0.16.0 -> 0.17.2

### DIFF
--- a/pkgs/development/python-modules/pystray/default.nix
+++ b/pkgs/development/python-modules/pystray/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonPackage rec {
   pname = "pystray";
-  version = "0.16.0";
+  version = "0.17.2";
 
   src = fetchFromGitHub {
     owner = "moses-palmer";
     repo = "pystray";
     rev = "v${version}";
-    sha256 = "0q5yqfm5mzffx9vnp9xcnclgjzgs0b7f50i9xmxn1m1iha1zawh1";
+    sha256 = "sha256-/dU+jwe/3qhypq7e5tawhJKzSryW7EIbmrpP+VLDvHA=";
   };
 
   propagatedBuildInputs = [ pillow xlib six ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release. 

Also tested my `jellyfin-mpv-shim` PR with the updated version (is currently the only application using `pystray`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/7krcaqmah0xsz93i4rc0a875cf3k16aj-python3.8-pystray-0.16.0	  131511728
/nix/store/a90cckynpg1lx497w8418c0d885dlzkj-python3.8-pystray-0.17.2	  131514096
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
