### PR TITLE
pythonPackages.pywebview: 3.3.1 -> 3.4

### DIFF
--- a/pkgs/development/python-modules/pywebview/default.nix
+++ b/pkgs/development/python-modules/pywebview/default.nix
@@ -1,25 +1,53 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
-, importlib-resources, pytest, xvfb_run }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, importlib-resources
+, pyqtwebengine
+, pytest
+, pythonOlder
+, qt5
+, xvfb_run
+}:
 
 buildPythonPackage rec {
   pname = "pywebview";
-  version = "3.3.1";
+  version = "3.4";
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "r0x0r";
     repo = "pywebview";
     rev = version;
-    sha256 = "015z7n0hdgkzn0p7aw1xsv6lwc260p8q67jx0zyd1zghnwyj8k79";
+    sha256 = "sha256-3JHwtw8oReolEl4k8cdt7GCVGNkfWWJN6EnZYHxzDO8=";
   };
 
-  propagatedBuildInputs = lib.optionals (pythonOlder "3.7") [ importlib-resources ];
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+  ];
 
-  checkInputs = [ pytest xvfb_run ];
+  propagatedBuildInputs = [
+    pyqtwebengine
+  ] ++ lib.optionals (pythonOlder "3.7") [ importlib-resources ];
+
+  checkInputs = [
+    pytest
+    xvfb_run
+  ];
 
   checkPhase = ''
+    # Cannot create directory /homeless-shelter/.... Error: FILE_ERROR_ACCESS_DENIED
+    export HOME=$TMPDIR
+    # QStandardPaths: XDG_RUNTIME_DIR not set
+    export XDG_RUNTIME_DIR=$HOME/xdg-runtime-dir
+
     pushd tests
+    substituteInPlace run.sh \
+      --replace "PYTHONPATH=.." "PYTHONPATH=$PYTHONPATH" \
+      --replace "pywebviewtest test_js_api.py::test_concurrent ''${PYTEST_OPTIONS}" "# skip flaky test_js_api.py::test_concurrent"
+
     patchShebangs run.sh
+    wrapQtApp run.sh
+
     xvfb-run -s '-screen 0 800x600x24' ./run.sh
     popd
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest release. Fixed the tests by adding `pyqtwebengine` (they fail but do not cause the build to fail ... now fixed by https://github.com/r0x0r/pywebview/commit/81d32b04e7bf5e63edb09cf7830473208d3bde12).

Also tested my jellyfin-mpv-shim PR with the updated version (is currently the only application using pywebview).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/fr39zy34lhxw1f2byzyf40cr9hhivcgi-python3.8-pywebview-3.3.1	  111240936
/nix/store/ly1axib4vga9q1d4pla0vpk1d74vg8gn-python3.8-pywebview-3.4	  714124656
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
