### PR TITLE
trace-cmd: 2.9-dev -> 2.9.1+2, kernelshark: 1.1 -> 1.2

### DIFF
--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -1,9 +1,13 @@
 { lib, stdenv, fetchgit, asciidoc, docbook_xsl, libxslt }:
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "trace-cmd";
-  version = "2.9-dev";
+  version = "2.9.1";
 
-  src = fetchgit (import ./src.nix);
+  src = fetchgit {
+    url    = "git://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
+    rev    = "trace-cmd-v${version}";
+    sha256 = "19c63a0qmcppm1456qf4k6a0d1agcvpa6jnbzrdcyc520yax6khw";
+  };
 
   patches = [ ./fix-Makefiles.patch ];
 

--- a/pkgs/os-specific/linux/trace-cmd/fix-Makefiles.patch
+++ b/pkgs/os-specific/linux/trace-cmd/fix-Makefiles.patch
@@ -1,30 +1,30 @@
 diff --git a/Makefile b/Makefile
-index bbdf15e..deb8ef7 100644
+index b034042..b8a06bc 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -288,7 +288,7 @@ libtraceevent.a: $(LIBTRACEEVENT_STATIC)
- libtracecmd.a: $(LIBTRACECMD_STATIC)
- libtracecmd.so: $(LIBTRACECMD_SHARED)
+@@ -338,6 +338,7 @@ libtracefs.a: $(LIBTRACEFS_STATIC)
+ libtracefs.so: $(LIBTRACEFS_SHARED)
  
--libs: $(LIBTRACECMD_SHARED) $(LIBTRACEEVENT_SHARED)
-+libs: $(LIBTRACECMD_SHARED) $(LIBTRACEEVENT_SHARED) $(LIBTRACECMD_STATIC) $(LIBTRACEEVENT_STATIC)
+ libs: $(LIBTRACECMD_SHARED) $(LIBTRACEEVENT_SHARED) $(LIBTRACEFS_SHARED)
++libs: $(LIBTRACECMD_STATIC) $(LIBTRACEEVENT_STATIC) $(LIBTRACEFS_STATIC)
  
- plugins: force $(obj)/lib/traceevent/plugins/traceevent_plugin_dir $(obj)/lib/traceevent/plugins/trace_python_dir
- 	$(Q)$(MAKE) -C $(src)/lib/traceevent/plugins
-@@ -344,6 +344,8 @@ install_gui: install_cmd gui
- install_libs: libs
+ test: force $(LIBTRACEEVENT_STATIC) $(LIBTRACEFS_STATIC) $(LIBTRACECMD_STATIC)
+ ifneq ($(CUNIT_INSTALLED),1)
+@@ -414,6 +415,9 @@ install_libs: libs
  	$(Q)$(call do_install,$(LIBTRACECMD_SHARED),$(libdir_SQ)/trace-cmd)
  	$(Q)$(call do_install,$(LIBTRACEEVENT_SHARED),$(libdir_SQ)/traceevent)
+ 	$(Q)$(call do_install,$(LIBTRACEFS_SHARED),$(libdir_SQ)/tracefs)
 +	$(Q)$(call do_install,$(LIBTRACECMD_STATIC),$(libdir_SQ)/trace-cmd)
 +	$(Q)$(call do_install,$(LIBTRACEEVENT_STATIC),$(libdir_SQ)/traceevent)
++	$(Q)$(call do_install,$(LIBTRACEFS_STATIC),$(libdir_SQ)/tracefs)
  	$(Q)$(call do_install,$(src)/include/traceevent/event-parse.h,$(includedir_SQ)/traceevent)
  	$(Q)$(call do_install,$(src)/include/traceevent/trace-seq.h,$(includedir_SQ)/traceevent)
  	$(Q)$(call do_install,$(src)/include/trace-cmd/trace-cmd.h,$(includedir_SQ)/trace-cmd)
 diff --git a/kernel-shark/src/CMakeLists.txt b/kernel-shark/src/CMakeLists.txt
-index e20a030..7fce165 100644
+index 457c100..687e150 100644
 --- a/kernel-shark/src/CMakeLists.txt
 +++ b/kernel-shark/src/CMakeLists.txt
-@@ -93,7 +93,7 @@ if (Qt5Widgets_FOUND AND Qt5Network_FOUND)
+@@ -92,7 +92,7 @@ if (Qt5Widgets_FOUND AND Qt5Network_FOUND)
              DESTINATION ${_INSTALL_PREFIX}/share/icons/${KS_APP_NAME})
  
      install(FILES "${KS_DIR}/org.freedesktop.kshark-record.policy"

--- a/pkgs/os-specific/linux/trace-cmd/kernelshark.nix
+++ b/pkgs/os-specific/linux/trace-cmd/kernelshark.nix
@@ -1,9 +1,13 @@
 { lib, mkDerivation, fetchgit, qtbase, cmake, asciidoc, docbook_xsl, json_c, mesa_glu, freeglut, trace-cmd, pkg-config }:
-mkDerivation {
+mkDerivation rec {
   pname = "kernelshark";
-  version = "1.1.0";
+  version = "1.2";
 
-  src = fetchgit (import ./src.nix);
+  src = fetchgit {
+    url    = "git://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
+    rev    = "kernelshark-v${version}";
+    sha256 = "0wzzm2imk9n94v96v6sbvbff6j47lz4qj0snhiyv3nj3slg0anvh";
+  };
 
   patches = [ ./fix-Makefiles.patch ];
 
@@ -21,6 +25,7 @@ mkDerivation {
     "-DTRACECMD_INCLUDE_DIR=${trace-cmd.dev}/include"
     "-DTRACECMD_LIBRARY=${trace-cmd.lib}/lib/trace-cmd/libtracecmd.a"
     "-DTRACEEVENT_LIBRARY=${trace-cmd.lib}/lib/traceevent/libtraceevent.a"
+    "-DTRACEFS_LIBRARY=${trace-cmd.lib}/lib/tracefs/libtracefs.a"
   ];
 
   preInstall = ''

--- a/pkgs/os-specific/linux/trace-cmd/src.nix
+++ b/pkgs/os-specific/linux/trace-cmd/src.nix
@@ -1,5 +1,0 @@
-{
-  url    = "git://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
-  rev    = "ab370b78b9278fe16657742d46cb95c0a65b47d5"; # branch: kernelshark-v1.1
-  sha256 = "0qngwc4qgadrkwlwpz73f12prdkx94kl0bg7g9hib95ipvsdmk1c";
-}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

KernelShark 1.1 in nixpkgs fails to build from source.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
