### PR TITLE
nixos/switch-to-configuration: don't try restart deleted sockets

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -243,9 +243,13 @@ while (my ($unit, $state) = each %{$activePrev}) {
                             foreach my $socket (@sockets) {
                                 if (defined $activePrev->{$socket}) {
                                     $unitsToStop{$socket} = 1;
-                                    $unitsToStart{$socket} = 1;
-                                    recordUnit($startListFile, $socket);
-                                    $socketActivated = 1;
+                                    # Only restart sockets that actually
+                                    # exist in new configuration:
+                                    if (-e "$out/etc/systemd/system/$socket") {
+                                        $unitsToStart{$socket} = 1;
+                                        recordUnit($startListFile, $socket);
+                                        $socketActivated = 1;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
We have some deployments where we can disable systemd socket for a service. 
In this case, switch-to-configuration will try to restart a systemd socket which unit no longer exist in the new configuration.
This patch fix this case, by checking that the socket still exists in the new configuration before trying to restart it.

Tested on nixos 20.09.