### PR TITLE
haskellPackages.hnix-store-core: unbreak build on darwin

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -215,8 +215,13 @@ self: super: {
   # 2020-06-05: HACK: does not pass own build suite - `dontCheck`
   hnix = generateOptparseApplicativeCompletion "hnix" (dontCheck super.hnix);
 
-  # https://github.com/haskell-nix/hnix-store/issues/127
-  hnix-store-core = addTestToolDepend super.hnix-store-core self.tasty-discover;
+  hnix-store-core = overrideCabal super.hnix-store-core (drv: {
+    # https://github.com/haskell-nix/hnix-store/issues/127
+    testToolDepends = (drv.testToolDepends or []) ++ [self.tasty-discover];
+    # Tests incorrectly assume the existence of /proc on Darwin.  Remove with
+    # next release. See: https://github.com/haskell-nix/hnix-store/issues/109
+    doCheck = !pkgs.stdenv.isDarwin;
+  });
 
   # Fails for non-obvious reasons while attempting to use doctest.
   search = dontCheck super.search;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Do not execute `hnix-store-core` tests on Darwin because it wrongly assumes the existence of /proc https://github.com/haskell-nix/hnix-store/issues/109


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
