### PR TITLE
fhs-userenv-bubblewrap: Add store path to readlink

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -95,7 +95,7 @@ let
       if [[ $path == '/etc' ]]; then
         :
       elif [[ -L $i ]]; then
-        symlinks+=(--symlink "$(readlink "$i")" "$path")
+        symlinks+=(--symlink "$(${coreutils}/bin/readlink "$i")" "$path")
         blacklist+=("$path")
       else
         ro_mounts+=(--ro-bind "$i" "$path")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[This](https://github.com/NixOS/nixpkgs/commit/df4761d45082d94f6a469bbcab71cee1e31719da#diff-13e68e7f90a4c9c68c723958f598a9e27c76ba887c388d0a49e75d67637c96b8) commit added a call to `readlink` from core utils, but expected it to be in the users path as the command was run. This patch hardcodes the store path into the script, so it can be run even without a suitable `PATH` set.

Found this out since I use `systemd-run` to start graphical programs in clean environments, which caused Steam to fail to start. All starts up fine on my machine after this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
