### PR TITLE
radarr: 0.2.0.1504 -> 3.0.2.4552

### DIFF
--- a/pkgs/servers/radarr/default.nix
+++ b/pkgs/servers/radarr/default.nix
@@ -1,12 +1,26 @@
-{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, makeWrapper }:
+{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, makeWrapper, icu, dotnetCorePackages, openssl, nixosTests }:
 
-stdenv.mkDerivation rec {
+let
+  os = if stdenv.isDarwin then "osx" else "linux";
+  arch = {
+    x86_64-linux = "x64";
+    aarch64-linux = "arm64";
+    x86_64-darwin = "x64";
+  }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  hash = {
+    x64-linux_hash = "sha256-bTh+Z5w5ZkL2iPteStqVcoFDGZIbpVjuXn20TZsfgtY=";
+    arm64-linux_hash = "sha256-aIzVSIRuGNiIFJPToXCQwYsbICKuPtwKATnQhkxvJuA=";
+    x64-osx_hash = "sha256-FxRSAJvRQya2x1kei6yRceGcyQ2mCaFveyeMGw0Jqw4=";
+  }."${arch}-${os}_hash";
+
+in stdenv.mkDerivation rec {
   pname = "radarr";
-  version = "0.2.0.1504";
+  version = "3.0.2.4552";
 
   src = fetchurl {
-    url = "https://github.com/Radarr/Radarr/releases/download/v${version}/Radarr.develop.${version}.linux.tar.gz";
-    sha256 = "1h7pqn39vxd0vr1fwrnvfpxv5vhh4zcr0s8h0zvgplay2z6b6bvb";
+    url = "https://github.com/Radarr/Radarr/releases/download/v${version}/Radarr.master.${version}.${os}-core-${arch}.tar.gz";
+    sha256 = hash;
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -15,17 +29,22 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
 
-    makeWrapper "${mono}/bin/mono" $out/bin/Radarr \
-      --add-flags "$out/share/${pname}-${version}/Radarr.exe" \
+    makeWrapper "${dotnetCorePackages.netcore_3_1}/bin/dotnet" $out/bin/Radarr \
+      --add-flags "$out/share/${pname}-${version}/Radarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
-          curl sqlite libmediainfo ]}
+        curl sqlite libmediainfo mono openssl icu ]}
   '';
+
+  passthru = {
+    updateScript = ./update.sh;
+    tests.smoke-test = nixosTests.radarr;
+  };
 
   meta = with lib; {
     description = "A Usenet/BitTorrent movie downloader";
     homepage = "https://radarr.video/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ edwtjo purcell ];
-    platforms = platforms.all;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/servers/radarr/update.sh
+++ b/pkgs/servers/radarr/update.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl nix-prefetch jq
+
+set -e
+
+dirname="$(dirname "$0")"
+
+updateHash()
+{
+    version=$1
+    arch=$2
+    os=$3
+
+    hashKey="${arch}-${os}_hash"
+
+    url="https://github.com/Radarr/Radarr/releases/download/v$version/Radarr.master.$version.$os-core-$arch.tar.gz"
+    hash=$(nix-prefetch-url --type sha256 $url)
+    sriHash="$(nix to-sri --type sha256 $hash)"
+
+    sed -i "s/$hashKey = \"[a-zA-Z0-9\/+-=]*\";/$hashKey = \"$sriHash\";/g" "$dirname/default.nix"
+}
+
+updateVersion()
+{
+    sed -i "s/version = \"[0-9.]*\";/version = \"$1\";/g" "$dirname/default.nix"
+}
+
+currentVersion=$(cd $dirname && nix eval --raw '(with import ../../.. {}; radarr.version)')
+
+latestTag=$(curl https://api.github.com/repos/Radarr/Radarr/releases/latest | jq -r ".tag_name")
+latestVersion="$(expr $latestTag : 'v\(.*\)')"
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "Radarr is up-to-date: ${currentVersion}"
+    exit 0
+fi
+
+updateVersion $latestVersion
+
+updateHash $latestVersion x64 linux
+updateHash $latestVersion arm64 linux
+updateHash $latestVersion x64 osx


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Inspired by https://github.com/NixOS/nixpkgs/pull/105356. I also changed the license to  gpl3-only, since I didn't find any note specifying version 3 or later being used.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
