### PR TITLE
jackett: 0.17.668 -> 0.17.677

### DIFF
--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -17,8 +17,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper "${dotnetCorePackages.netcore_3_1}/bin/dotnet" $out/bin/Jackett \
       --add-flags "$out/share/${pname}-${version}/jackett.dll" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
-          curl icu60 openssl zlib ]}
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ curl icu60 openssl zlib ]}
   '';
 
   passthru.tests = {

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, fetchurl, mono, makeWrapper, curl, icu60, openssl, zlib }:
+{ lib, stdenv, fetchurl, dotnetCorePackages, makeWrapper, curl, icu60, openssl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "jackett";
-  version = "0.17.668";
+  version = "0.17.671";
 
   src = fetchurl {
-    url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.Mono.tar.gz";
-    sha256 = "sha256-+cvUpWVpXEkW+d92aIOli+pNi+ZDHEbxDDQ67O6kOVA=";
+    url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxAMDx64.tar.gz";
+    sha256 = "19yhfyznkqdwj408hz5481lvaz7ri6sib7bsmh0lxg0mvx35rq9r";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -15,9 +15,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}
 
-    makeWrapper "${mono}/bin/mono" $out/bin/Jackett \
-      --add-flags "$out/share/${pname}-${version}/JackettConsole.exe" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ curl icu60 openssl zlib ]}
+    makeWrapper "${dotnetCorePackages.netcore_3_1}/bin/dotnet" $out/bin/Jackett \
+      --add-flags "$out/share/${pname}-${version}/jackett.dll" \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ 
+          curl icu60 openssl zlib ]}
   '';
 
   meta = with lib; {

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -1,12 +1,24 @@
 { lib, stdenv, fetchurl, dotnetCorePackages, makeWrapper, curl, icu60, openssl, zlib, nixosTests }:
 
-stdenv.mkDerivation rec {
+let
+  suffix = {
+    x86_64-linux = "LinuxAMDx64";
+    aarch64-linux = "LinuxARM64";
+    x86_64-darwin = "macOS";
+  }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  hash = {
+    x86_64-linux = "1mpm8kji4npc44cs51r75xxdq74gxxdnfffazlbgypcabcb46gzp";
+    aarch64-linux = "18slsjzqs52frmbq6a0c3zrpa5fgf9sfxmzbkrffllc8m54rhcjn";
+    x86_64-darwin = "161df7s2skg8wbd7kpbs9qhyka0ywqcbc44zpz4c16mvax0a6wls";
+  }."${stdenv.hostPlatform.system}";
+
+in stdenv.mkDerivation rec {
   pname = "jackett";
-  version = "0.17.671";
+  version = "0.17.677";
 
   src = fetchurl {
-    url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxAMDx64.tar.gz";
-    sha256 = "19yhfyznkqdwj408hz5481lvaz7ri6sib7bsmh0lxg0mvx35rq9r";
+    url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.${suffix}.tar.gz";
+    sha256 = hash;
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -29,6 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Jackett/Jackett/";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ edwtjo nyanloutre purcell ];
-    platforms = platforms.all;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, dotnetCorePackages, makeWrapper, curl, icu60, openssl, zlib }:
+{ lib, stdenv, fetchurl, dotnetCorePackages, makeWrapper, curl, icu60, openssl, zlib, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "jackett";
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ 
           curl icu60 openssl zlib ]}
   '';
+
+  passthru.tests = {
+    smoke-test = nixosTests.jackett;
+  };
 
   meta = with lib; {
     description = "API Support for your favorite torrent trackers";

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper "${dotnetCorePackages.netcore_3_1}/bin/dotnet" $out/bin/Jackett \
       --add-flags "$out/share/${pname}-${version}/jackett.dll" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ 
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
           curl icu60 openssl zlib ]}
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
I also replaced mono with dotnet core to fix a warning on the jackett webpage.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
