### PR TITLE
[20.09] nixUnstable: 2.4pre20201205_a5d85d0 -> 2.4pre20210308_1c0e3e4, hydra-unstable: 2020-10-20 -> 2021-03-10

### DIFF
--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -5,7 +5,7 @@
 , docbook_xsl, openssh, gnused, coreutils, findutils, gzip, lzma, gnutar
 , rpm, dpkg, cdrkit, pixz, lib, boost, autoreconfHook, src ? null, version ? null
 , migration ? false, patches ? []
-, tests ? {}
+, tests ? {}, mdbook
 }:
 
 with stdenv;
@@ -84,7 +84,7 @@ in stdenv.mkDerivation rec {
       perlDeps perl nix
       postgresql # for running the tests
       nlohmann_json
-      boost
+      boost mdbook
     ];
 
   hydraPath = lib.makeBinPath (

--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -84,7 +84,7 @@ in stdenv.mkDerivation rec {
       perlDeps perl nix
       postgresql # for running the tests
       nlohmann_json
-      boost mdbook
+      boost
     ];
 
   hydraPath = lib.makeBinPath (
@@ -92,7 +92,7 @@ in stdenv.mkDerivation rec {
       gzip bzip2 lzma gnutar unzip git gitAndTools.top-git mercurial /*darcs*/ gnused breezy
     ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig mdbook ];
 
   configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
 

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -24,12 +24,12 @@
   # so when having an older version, `pkgs.hydra-migration` should be deployed first.
 
   hydra-unstable = callPackage ./common.nix {
-    version = "2020-10-20";
+    version = "2021-03-10";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "79d34ed7c93af2daf32cf44ee0e3e0768f13f97c";
-      sha256 = "1lql899430137l6ghnhyz0ivkayy83fdr087ck2wq3gf1jv8pccj";
+      rev = "930f05c38eeac63ad6c3e3250de2667e2df2e96e";
+      sha256 = "06s2lg119p96i1j4rdbg3z097n25bgvq8ljdn4vcwcw3yz0lnswm";
     };
     nix = nixFlakes;
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -14,7 +14,7 @@ common =
   , pkgconfig, boehmgc, perlPackages, libsodium, brotli, boost, editline, nlohmann_json
   , autoreconfHook, autoconf-archive, bison, flex
   , jq, libarchive, libcpuid
-  , lowdown, mdbook
+  , lowdown_0_8, mdbook
   # Used by tests
   , gmock
   , busybox-sandbox-shell
@@ -45,7 +45,7 @@ common =
           [ autoreconfHook
             autoconf-archive
             bison flex
-            lowdown mdbook
+            lowdown_0_8 mdbook
             jq
            ];
 
@@ -54,7 +54,7 @@ common =
           brotli boost editline
         ]
         ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
-        ++ lib.optionals is24 [ libarchive gmock lowdown libcpuid ]
+        ++ lib.optionals is24 [ libarchive gmock lowdown_0_8 libcpuid ]
         ++ lib.optional withLibseccomp libseccomp
         ++ lib.optional withAWS
             ((aws-sdk-cpp.override {

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -13,7 +13,7 @@ common =
   , bash, coreutils, gzip, gnutar
   , pkgconfig, boehmgc, perlPackages, libsodium, brotli, boost, editline, nlohmann_json
   , autoreconfHook, autoconf-archive, bison, flex
-  , jq, libarchive
+  , jq, libarchive, libcpuid
   , lowdown, mdbook
   # Used by tests
   , gmock
@@ -54,7 +54,7 @@ common =
           brotli boost editline
         ]
         ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
-        ++ lib.optionals is24 [ libarchive gmock ]
+        ++ lib.optionals is24 [ libarchive gmock lowdown libcpuid ]
         ++ lib.optional withLibseccomp libseccomp
         ++ lib.optional withAWS
             ((aws-sdk-cpp.override {
@@ -207,23 +207,14 @@ in rec {
 
   nixUnstable = lib.lowPrio (callPackage common rec {
     name = "nix-2.4${suffix}";
-    suffix = "pre20201201_5a6ddb3";
+    suffix = "pre20210308_1c0e3e4";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "5a6ddb3de14a1684af6c793d663764d093fa7846";
-      sha256 = "0qhd3nxvqzszzsfvh89xhd239ycqb0kq2n0bzh9br78pcb60vj3g";
+      rev = "1c0e3e453d41b869e4ac7e25dc1c00c349a7c411";
+      sha256 = "17killwp42d25f17yq2jida64j7d0ipz6zish78iqi450yrd9wrd";
     };
-
-    patches = [
-      # Fix the ETag bug. PR merged. Remove when updating to >= 20210125
-      # https://github.com/NixOS/nixpkgs/pull/109309#issuecomment-768331750
-      (fetchpatch {
-        url = "https://github.com/NixOS/nix/commit/c5b42c5a42138329c6d02da0d8a53cb59c6077f4.patch";
-        sha256 = "sha256-d4RNOKMxa4NMbFgYcqWRv2ByHt8F/XUWV+6P9qHz7S4=";
-      })
-    ];
 
     inherit storeDir stateDir confDir boehmgc;
   });

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lowdown";
-  version = "0.7.4";
+  version = "0.7.5";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
-    sha512 = "2iw5x3lf5knnscp0ifgk50yj48p54cbd34h94qrxa9vdybg2nnipklrqmmqblf6l7qph98h7jvlyr99m5qlrki9lvjr1jcgbgp31pn0";
+    sha512 = "1wfbrydbk0f0blhg5my3m5gw8bspwh3rdg4w4mcalnrwpypzd4zrggc4aj3zm72c5jikx6pnjb2k9w1s075k84f6q8p8chlzb3s4qd2";
   };
 
   nativeBuildInputs = [ which ];

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lowdown";
-  version = "0.8.0";
+  version = "0.8.1";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
-    sha512 = "17w0hldlg7x0f4946bz1pmgkpp08dha3myz8pk0rx8n2lqlw76f3n9giq69kw82sgzg7qqy31sl9mxvgaxyf6hcdgmxnkr7h8d9xmak";
+    sha512 = "28kwj053lm3510cq7pg4rqx6linv5zphhm2h6r9icigclfq7j9ybnd7vqbn2v4ay0r8ghac5cjbqab5zy8cjlgllwhwsxg0dnk75x2i";
   };
 
   nativeBuildInputs = [ which ];

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lowdown";
-  version = "0.8.1";
+  version = "0.8.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
-    sha512 = "28kwj053lm3510cq7pg4rqx6linv5zphhm2h6r9icigclfq7j9ybnd7vqbn2v4ay0r8ghac5cjbqab5zy8cjlgllwhwsxg0dnk75x2i";
+    sha512 = "07xy6yjs24zkwrr06ly4ln5czvm3azw6iznx6m8gbrmzblkcp3gz1jcl9wclcyl8bs4xhgmyzkf5k67b95s0jndhyb9ap5zy6ixnias";
   };
 
   nativeBuildInputs = [ which ];

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lowdown";
-  version = "0.7.9";
+  version = "0.8.0";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
-    sha512 = "18q8i8lh8w127vzw697n0bzv4mchhna1p4s672hjvy39l3ls8rlj5nwq5npr5fry06yil62sjmq4652vw29r8l49wwk5j82a8l2nr7c";
+    sha512 = "17w0hldlg7x0f4946bz1pmgkpp08dha3myz8pk0rx8n2lqlw76f3n9giq69kw82sgzg7qqy31sl9mxvgaxyf6hcdgmxnkr7h8d9xmak";
   };
 
   nativeBuildInputs = [ which ];

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, which }:
 
-stdenv.mkDerivation rec {
+let base = version: sha512: stdenv.mkDerivation rec {
   pname = "lowdown";
-  version = "0.8.2";
+  inherit version;
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
-    sha512 = "07xy6yjs24zkwrr06ly4ln5czvm3azw6iznx6m8gbrmzblkcp3gz1jcl9wclcyl8bs4xhgmyzkf5k67b95s0jndhyb9ap5zy6ixnias";
+    inherit sha512;
   };
 
   nativeBuildInputs = [ which ];
@@ -26,5 +26,9 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.sternenseemann ];
     platforms = platforms.unix;
   };
+};
+in {
+  lowdown = base "0.7.3" "14mx22aqr9cmin4cyhrclhm0hly1i21j2dmsikfp1c87wl2kpn9xgxnix5r0iqh5dwjxdh591rfh21xjp0l11m0nl5wkpnn7wmq7g6b";
+  lowdown_0_8 = base "0.8.2" "07xy6yjs24zkwrr06ly4ln5czvm3azw6iznx6m8gbrmzblkcp3gz1jcl9wclcyl8bs4xhgmyzkf5k67b95s0jndhyb9ap5zy6ixnias";
 }
 

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lowdown";
-  version = "0.7.5";
+  version = "0.7.9";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
-    sha512 = "1wfbrydbk0f0blhg5my3m5gw8bspwh3rdg4w4mcalnrwpypzd4zrggc4aj3zm72c5jikx6pnjb2k9w1s075k84f6q8p8chlzb3s4qd2";
+    sha512 = "18q8i8lh8w127vzw697n0bzv4mchhna1p4s672hjvy39l3ls8rlj5nwq5npr5fry06yil62sjmq4652vw29r8l49wwk5j82a8l2nr7c";
   };
 
   nativeBuildInputs = [ which ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2155,7 +2155,7 @@ in
 
   long-shebang = callPackage ../misc/long-shebang {};
 
-  lowdown = callPackage ../tools/typesetting/lowdown { };
+  inherit (callPackage ../tools/typesetting/lowdown { }) lowdown lowdown_0_8;
 
   numatop = callPackage ../os-specific/linux/numatop { };
 


### PR DESCRIPTION

###### Motivation for this change

Backport of #114786.
Also had to backport most recent lowdown bumps to get Nix compiling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
