### PR TITLE
bazarr: 0.9.0.8 -> 0.9.2

### DIFF
--- a/pkgs/servers/bazarr/default.nix
+++ b/pkgs/servers/bazarr/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Subtitle manager for Sonarr and Radarr";
     homepage = "https://www.bazarr.media/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ xwvvvvwx ];
     platforms = platforms.all;
   };

--- a/pkgs/servers/bazarr/default.nix
+++ b/pkgs/servers/bazarr/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, lib, fetchurl, makeWrapper, python3, nixosTests }:
+{ stdenv, lib, fetchurl, makeWrapper, python3, unrar, ffmpeg, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "bazarr";
-  version = "0.9.0.8";
+  version = "0.9.2";
 
   src = fetchurl {
     url = "https://github.com/morpheus65535/bazarr/archive/v${version}.tar.gz";
-    sha256 = "sha256-Ecbx7FHpcEkcWBAKCtZPtQKX5ibvU4tajSJ5pyEboKc=";
+    sha256 = "16mh7v8z5ijr75pvavcj6225w6bg12qy1d1w9vm2d5axnfm3wfbk";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     makeWrapper "${(python3.withPackages (ps: [ps.lxml ps.numpy])).interpreter}" \
       $out/bin/bazarr \
       --add-flags "$out/src/bazarr.py" \
+      --suffix PATH : ${lib.makeBinPath [ unrar ffmpeg ]} \
   '';
 
   passthru.tests = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Bazarr now needs `unrar` and `ffmpeg` at runtime, if missing it will try to download them and crash. So I added them to path, tho I'm not sure if it's the correct way to do it.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
