### PR TITLE
multipath-tools: fix the service path to multipathd

### DIFF
--- a/pkgs/os-specific/linux/multipath-tools/default.nix
+++ b/pkgs/os-specific/linux/multipath-tools/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, perl, lvm2, libaio, gzip, readline, systemd, liburcu, json_c }:
+{ lib, stdenv, fetchurl, pkg-config, perl, lvm2, libaio, gzip, readline, systemd, liburcu, json_c, kmod }:
 
 stdenv.mkDerivation rec {
   pname = "multipath-tools";
@@ -16,7 +16,13 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    substituteInPlace libmultipath/Makefile --replace /usr/include/libdevmapper.h ${lib.getDev lvm2}/include/libdevmapper.h
+    substituteInPlace libmultipath/Makefile \
+      --replace /usr/include/libdevmapper.h ${lib.getDev lvm2}/include/libdevmapper.h
+
+    substituteInPlace multipathd/multipathd.service \
+      --replace /sbin/modprobe ${lib.getBin kmod}/sbin/modprobe \
+      --replace /sbin/multipathd "$out/bin/multipathd"
+
     sed -i -re '
       s,^( *#define +DEFAULT_MULTIPATHDIR\>).*,\1 "'"$out/lib/multipath"'",
     ' libmultipath/defaults.h


### PR DESCRIPTION
###### Motivation for this change

Allow using the upstream systemd units without redefining the units.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
