### PR TITLE
brave: support permanent cmd args

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -91,6 +91,7 @@ in
 stdenv.mkDerivation rec {
   pname = "brave";
   version = "1.26.67";
+  patches = [ ./user-flags.patch ];
 
   src = fetchurl {
     url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";

--- a/pkgs/applications/networking/browsers/brave/user-flags.patch
+++ b/pkgs/applications/networking/browsers/brave/user-flags.patch
@@ -1,0 +1,17 @@
+diff --git a/opt/brave.com/brave/brave-browser b/opt/brave.com/brave/brave-browser
+index 21bac37..a3b7234 100755
+--- a/opt/brave.com/brave/brave-browser
++++ b/opt/brave.com/brave/brave-browser
+@@ -45,4 +45,11 @@ exec < /dev/null
+ exec > >(exec cat)
+ exec 2> >(exec cat >&2)
+
+-"$HERE/brave" "$@" || true
++# Allow to set permanent command line flags
++XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
++BRAVE_USER_FLAGS_FILE="$XDG_CONFIG_HOME/brave-flags.conf"
++if [[ -f $BRAVE_USER_FLAGS_FILE ]]; then
++        USER_FLAGS="$(cat $BRAVE_USER_FLAGS_FILE | sed 's/#.*//')"
++fi
++
++$HERE/brave $@ $USER_FLAGS || true


### PR DESCRIPTION
###### Motivation for this change

To run Brave (or any Chromium based program) natively under Wayland, a command line argument has to be supplied:
`$ brave --enable-features=UseOzonePlatform --ozone-platform=wayland`
There seems to be no way to make this setting permanent. Our friends at Arch are running a small patch on the Brave binary wrapper which essentially created a config file to supply permanent command line arguments[0]. The Nix Chromium package has a more elaborate way which make command line arguments supplyable as a package attribute[1].

A general Brave/Wayland tracking issue can be found at https://github.com/NixOS/nixpkgs/issues/115956.

[0] https://wiki.archlinux.org/index.php/chromium#Making_flags_persistent
[1] https://github.com/NixOS/nixpkgs/blob/a3228bb6e8bdbb9900f30a11fe09006fdabf7b71/pkgs/applications/networking/browsers/chromium/default.nix#L20

For the general Brave/Wayland issue tracking, see https://github.com/NixOS/nixpkgs/issues/115956.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
