### PR TITLE
php.extensions.swoole: init at 4.6.4

### DIFF
--- a/pkgs/development/php-packages/swoole/default.nix
+++ b/pkgs/development/php-packages/swoole/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPecl, php, valgrind, pcre' }:
+
+buildPecl {
+  pname = "swoole";
+
+  version = "4.6.4";
+  sha256 = "0hgndnn27q7fbsb0nw6bfdg0kyy5di9vrmf7g53jc6lsnf73ha31";
+
+  buildInputs = [ valgrind pcre' ];
+  internalDeps = lib.optionals (lib.versionOlder php.version "7.4") [ php.extensions.hash ];
+
+  doCheck = true;
+  checkTarget = "tests";
+
+  meta = with lib; {
+    description = "Coroutine-based concurrency library for PHP";
+    license = licenses.asl20;
+    homepage = "https://www.swoole.co.uk/";
+    maintainers = teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -138,6 +138,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     sqlsrv = callPackage ../development/php-packages/sqlsrv { };
 
+    swoole = callPackage ../development/php-packages/swoole { };
+
     v8 = buildPecl {
       version = "0.2.2";
       pname = "v8";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
