### PR TITLE
python3Packages.altair: propagate jinja2 as buildInput

### DIFF
--- a/pkgs/development/python-modules/altair/default.nix
+++ b/pkgs/development/python-modules/altair/default.nix
@@ -33,17 +33,19 @@ buildPythonPackage rec {
     pandas
     six
     toolz
+    jinja2
   ] ++ lib.optionals (pythonOlder "3.5") [ typing ];
 
   checkInputs = [
     glibcLocales
     ipython
-    jinja2
     pytest
     recommonmark
     sphinx
     vega_datasets
   ];
+
+  pythonImportsCheck = [ "altair" ];
 
   checkPhase = ''
     export LANG=en_US.UTF-8


### PR DESCRIPTION


###### Motivation for this change

```
$ python3 -c 'import altair'                                                                                    
Traceback (most recent call last):                                                                                                   
  File "<string>", line 1, in <module>                                                                                               
  File "/nix/store/ycb8bpkh485zfilf8mbj1hyjb2c4fxx4-python3.8-altair-4.1.0/lib/python3.8/site-packages/altair/__init__.py", line 4, i
n <module>                                                                                                                           
    from .vegalite import *                                                                                                          
  File "/nix/store/ycb8bpkh485zfilf8mbj1hyjb2c4fxx4-python3.8-altair-4.1.0/lib/python3.8/site-packages/altair/vegalite/__init__.py", 
line 2, in <module>                                                                                                                  
    from .v4 import *                                                                                                                
  File "/nix/store/ycb8bpkh485zfilf8mbj1hyjb2c4fxx4-python3.8-altair-4.1.0/lib/python3.8/site-packages/altair/vegalite/v4/__init__.py
", line 2, in <module>                                                                                                               
    from .schema import *                                                                                                            
  File "/nix/store/ycb8bpkh485zfilf8mbj1hyjb2c4fxx4-python3.8-altair-4.1.0/lib/python3.8/site-packages/altair/vegalite/v4/schema/__in
it__.py", line 2, in <module>                                                                                                        
    from .core import *                                                                                                              
  File "/nix/store/ycb8bpkh485zfilf8mbj1hyjb2c4fxx4-python3.8-altair-4.1.0/lib/python3.8/site-packages/altair/vegalite/v4/schema/core
.py", line 4, in <module>                                                                                                            
    from altair.utils.schemapi import SchemaBase, Undefined, _subclasses                                                             
  File "/nix/store/ycb8bpkh485zfilf8mbj1hyjb2c4fxx4-python3.8-altair-4.1.0/lib/python3.8/site-packages/altair/utils/__init__.py", lin
e 13, in <module>                                                                                                                    
    from .html import spec_to_html                                                                                                   
  File "/nix/store/ycb8bpkh485zfilf8mbj1hyjb2c4fxx4-python3.8-altair-4.1.0/lib/python3.8/site-packages/altair/utils/html.py", line 2,
 in <module>                                                                                                                         
    import jinja2                                                                                                                    
ModuleNotFoundError: No module named 'jinja2'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
