### PR TITLE
mtd-utils: 2.1.1 -> 2.1.2 [fixes broken pkg]

### DIFF
--- a/pkgs/tools/filesystems/mtdutils/default.nix
+++ b/pkgs/tools/filesystems/mtdutils/default.nix
@@ -1,30 +1,28 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, cmocka, acl, libuuid, lzo, zlib, zstd }:
-
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, cmocka, acl, libuuid, lzo, zlib, zstd, lib }:
 stdenv.mkDerivation rec {
   pname = "mtd-utils";
-  version = "2.1.1";
+  version = "2.1.2";
 
   src = fetchurl {
     url = "ftp://ftp.infradead.org/pub/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "1lijl89l7hljx8xx70vrz9srd3h41v5gh4b0lvqnlv831yvyh5cd";
+    sha256 = "sha256-itTF80cW1AZGqihySi9WFtMlpvEZJU+RTiaXbx926dY=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ] ++ lib.optional doCheck cmocka;
+  nativeBuildInputs = [ autoreconfHook pkgconfig ] ++ lib.optional doCheck cmocka;
   buildInputs = [ acl libuuid lzo zlib zstd ];
 
-  configureFlags = [
-    (lib.enableFeature doCheck "unit-tests")
-    (lib.enableFeature doCheck "tests")
+  configureFlags = with lib; [
+    (enableFeature doCheck "unit-tests")
+    (enableFeature doCheck "tests")
   ];
-  enableParallelBuilding = true;
 
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
-  meta = {
+  meta = with lib; {
     description = "Tools for MTD filesystems";
-    license = lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     homepage = "http://www.linux-mtd.infradead.org/";
-    maintainers = with lib.maintainers; [ viric ];
-    platforms = with lib.platforms; linux;
+    maintainers = with maintainers; [ viric superherointj ];
+    platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
IGNORE THIS PR.

###### Motivation for this change
"mtd-utils" 2.1.1 was broken. Fixes it and upgrades it to latest.
The fix was to disable parallel builds. As I need this package for my use. I prefer it working serially than not working at all.

Edit: I have closed this PR because I was not using master but unstable in my git repository where I did the changes. Silly I know.