### PR TITLE
mtd-utils: 2.1.1 -> 2.1.2

### DIFF
--- a/pkgs/tools/filesystems/mtdutils/default.nix
+++ b/pkgs/tools/filesystems/mtdutils/default.nix
@@ -2,29 +2,28 @@
 
 stdenv.mkDerivation rec {
   pname = "mtd-utils";
-  version = "2.1.1";
+  version = "2.1.2";
 
   src = fetchurl {
     url = "ftp://ftp.infradead.org/pub/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "1lijl89l7hljx8xx70vrz9srd3h41v5gh4b0lvqnlv831yvyh5cd";
+    sha256 = "sha256-itTF80cW1AZGqihySi9WFtMlpvEZJU+RTiaXbx926dY=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ] ++ lib.optional doCheck cmocka;
   buildInputs = [ acl libuuid lzo zlib zstd ];
 
-  configureFlags = [
-    (lib.enableFeature doCheck "unit-tests")
-    (lib.enableFeature doCheck "tests")
+  configureFlags = with lib; [
+    (enableFeature doCheck "unit-tests")
+    (enableFeature doCheck "tests")
   ];
-  enableParallelBuilding = true;
 
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
-  meta = {
+  meta = with lib; {
     description = "Tools for MTD filesystems";
-    license = lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     homepage = "http://www.linux-mtd.infradead.org/";
-    maintainers = with lib.maintainers; [ viric ];
-    platforms = with lib.platforms; linux;
+    maintainers = with maintainers; [ viric superherointj ];
+    platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
Building "mtd-utils" outputs an error for me. Tested versions 2.1.1 & 2.1.2. Also tried aarch64. Same result. Sample:

Version 2.1.1 (aarch64):
```
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
builder for '/nix/store/8gq8s85xgr4qyzd6969mflcm5f1qnnas-mtd-utils-2.1.1.drv' failed with exit code 2; last 10 log lines:
  # ERROR: 0
  ============================================================================
  See ./test-suite.log
  Please report to linux-mtd@lists.infradead.org
  ============================================================================
  make[2]: *** [Makefile:4357: test-suite.log] Error 1
  make[2]: Leaving directory '/build/mtd-utils-2.1.1'
  make[1]: *** [Makefile:4465: check-TESTS] Error 2
  make[1]: Leaving directory '/build/mtd-utils-2.1.1'
  make: *** [Makefile:4684: check-am] Error 2
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
1 dependencies of derivation '/nix/store/kdnzy5z18h7q4g6nb38qzqchj7bnvzm5-system-path.drv' failed to build
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
1 dependencies of derivation '/nix/store/i2k0psqiq5fgirdb3psvkcy35hp40mf7-nixos-system-k2-21.05.19700101.dirty.drv' failed to build
```

Nix log: https://termbin.com/fbp2


Version 2.1.2 (x86_64):
```
error: builder for '/nix/store/a4c6627ynms5xv7grq6xzilmpwm0mz7a-mtd-utils-2.1.2.drv' failed with exit code 2;
       last 10 log lines:
       > # ERROR: 0
       > ============================================================================
       > See ./test-suite.log
       > Please report to linux-mtd@lists.infradead.org
       > ============================================================================
       > make[2]: *** [Makefile:4397: test-suite.log] Error 1
       > make[2]: Leaving directory '/build/mtd-utils-2.1.2'
       > make[1]: *** [Makefile:4505: check-TESTS] Error 2
       > make[1]: Leaving directory '/build/mtd-utils-2.1.2'
       > make: *** [Makefile:4724: check-am] Error 2
       For full logs, run 'nix log /nix/store/a4c6627ynms5xv7grq6xzilmpwm0mz7a-mtd-utils-2.1.2.drv'.
error: 1 dependencies of derivation '/nix/store/9pjv48qagxvfmlrc131m45khyivkn4g0-system-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/rsmh5mcdw14js87b7wj0kghh4y4wp32a-nixos-system-nixos-2700x-21.05.19700101.dirty.drv' failed to build
```

Nix log at: https://gist.github.com/superherointj/71876d93530213cd93775de42ad2249f

--

Proposed changes:
* Remove "enableParallelBuilding" to fix/workaround above error.
* Upgrade package to latest.
* Minor refactor/clean-up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
