### PR TITLE
tests.cuda.cuda-{,library-}sample_*: Init at supported CUDA toolkit versions

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6987,6 +6987,12 @@
     githubId = 3359345;
     name = "obadz";
   };
+  obsidian-systems-maintainence = {
+    name = "Obsidian Systems Maintenance";
+    email = "maintainer@obsidian.systems";
+    github = "obsidian-systems-maintenance";
+    githubId = 80847921;
+  };
   odi = {
     email = "oliver.dunkl@gmail.com";
     github = "odi";

--- a/pkgs/test/cuda/cuda-library-samples/default.nix
+++ b/pkgs/test/cuda/cuda-library-samples/default.nix
@@ -1,0 +1,35 @@
+{ callPackage
+, cudatoolkit_10_1, cudatoolkit_10_2
+, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2
+}:
+
+rec {
+
+  cuda-library-samples_cudatoolkit_10_1 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_10_1;
+  };
+
+  cuda-library-samples_cudatoolkit_10_2 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_10_2;
+  };
+
+  cuda-library-samples_cudatoolkit_10 =
+    cuda-library-samples_cudatoolkit_10_2;
+
+  ##
+
+  cuda-library-samples_cudatoolkit_11_0 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_0;
+  };
+
+  cuda-library-samples_cudatoolkit_11_1 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_1;
+  };
+
+  cuda-library-samples_cudatoolkit_11_2 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_2;
+  };
+
+  cuda-library-samples_cudatoolkit_11 =
+    cuda-library-samples_cudatoolkit_11_2;
+}

--- a/pkgs/test/cuda/cuda-library-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-library-samples/generic.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, fetchFromGitHub
+, cmake, addOpenGLRunpath
+, cudatoolkit
+}:
+
+let
+  rev = "5aab680905d853bce0dbad4c488e4f7e9f7b2302";
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "CUDALibrarySamples";
+    inherit rev;
+    sha256 = "0gwgbkq05ygrfgg5hk07lmap7n7ampxv0ha1axrv8qb748ph81xs";
+  };
+  commonAttrs = {
+    version = lib.strings.substring 0 7 rev + "-" + lib.versions.majorMinor cudatoolkit.version;
+    nativeBuildInputs = [ cmake addOpenGLRunpath ];
+    buildInputs = [ cudatoolkit ];
+    enableParallelBuilding = true;
+    postFixup = ''
+      for exe in $out/bin/*; do
+        addOpenGLRunpath $exe
+      done
+    '';
+    meta = {
+      description = "examples of using libraries using CUDA";
+      longDescription = ''
+        CUDA Library Samples contains examples demonstrating the use of
+        features in the math and image processing libraries cuBLAS, cuTENSOR,
+        cuSPARSE, cuSOLVER, cuFFT, cuRAND, NPP and nvJPEG.
+      '';
+      license = lib.licenses.bsd3;
+      maintainers = with lib.maintainers; [ obsidian-systems-maintainence ];
+    };
+  };
+in
+
+{
+  cublas = stdenv.mkDerivation (commonAttrs // {
+    pname = "cuda-library-samples-cublas";
+
+    src = "${src}/cuBLASLt";
+  });
+
+  cusolver = stdenv.mkDerivation (commonAttrs // {
+    pname = "cuda-library-samples-cusolver";
+
+    src = "${src}/cuSOLVER";
+
+    sourceRoot = "cuSOLVER/gesv";
+  });
+}

--- a/pkgs/test/cuda/cuda-samples/default.nix
+++ b/pkgs/test/cuda/cuda-samples/default.nix
@@ -1,0 +1,52 @@
+{ callPackage
+, cudatoolkit_9_2
+, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2
+, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2
+}:
+
+rec {
+  cuda-samples_cudatoolkit_9_2 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_9_2;
+    sha256 = "1ydankhyigcg99h0rqnmz1z4vc0sl6p9s1s0hbdxh5l1sx9141j6";
+  };
+
+  cuda-samples_cudatoolkit_9 = cuda-samples_cudatoolkit_9_2;
+
+  ##
+
+  cuda-samples_cudatoolkit_10_0 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_10_0;
+    sha256 = "1zvh4xsdyc59m87brpcmssxsjlp9dkynh4asnkcmc3g94f53l0jw";
+  };
+
+  cuda-samples_cudatoolkit_10_1 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_10_1;
+    sha256 = "1s8ka0hznrni36ajhzf2gqpdrl8kd8fi047qijxks5l2abc093qd";
+  };
+
+  cuda-samples_cudatoolkit_10_2 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_10_2;
+    sha256 = "01p1innzgh9siacpld6nsqimj8jkg93rk4gj8q4crn62pa5vhd94";
+  };
+
+  cuda-samples_cudatoolkit_10 = cuda-samples_cudatoolkit_10_2;
+
+  ##
+
+  cuda-samples_cudatoolkit_11_0 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_0;
+    sha256 = "1n3vjc8c7zdig2xgl5fppavrphqzhdiv9m9nk6smh4f99fwi0705";
+  };
+
+  cuda-samples_cudatoolkit_11_1 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_1;
+    sha256 = "1kjixk50i8y1bkiwbdn5lkv342crvkmbvy1xl5j3lsa1ica21kwh";
+  };
+
+  cuda-samples_cudatoolkit_11_2 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_2;
+    sha256 = "1p1qjvfbm28l933mmnln02rqrf0cy9kbpsyb488d1haiqzvrazl1";
+  };
+
+  cuda-samples_cudatoolkit_11 = cuda-samples_cudatoolkit_11_2;
+}

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, fetchFromGitHub
+, pkg-config, addOpenGLRunpath
+, sha256, cudatoolkit
+}:
+
+let
+  pname = "cuda-samples";
+  version = lib.versions.majorMinor cudatoolkit.version;
+in
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = pname;
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  nativeBuildInputs = [ pkg-config addOpenGLRunpath ];
+
+  buildInputs = [ cudatoolkit ];
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    export CUDA_PATH=${cudatoolkit}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin bin/${stdenv.hostPlatform.parsed.cpu.name}/${stdenv.hostPlatform.parsed.kernel.name}/release/*
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    for exe in $out/bin/*; do
+      addOpenGLRunpath $exe
+    done
+  '';
+
+  meta = {
+    description = "Samples for CUDA Developers which demonstrates features in CUDA Toolkit";
+    # CUDA itself is proprietary, but these sample apps are not.
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ obsidian-systems-maintainence ];
+  };
+}

--- a/pkgs/test/cuda/default.nix
+++ b/pkgs/test/cuda/default.nix
@@ -1,0 +1,16 @@
+{ callPackage }:
+
+rec {
+  cuda-samplesPackages = callPackage ./cuda-samples { };
+  inherit (cuda-samplesPackages)
+    cuda-samples_cudatoolkit_9
+    cuda-samples_cudatoolkit_9_2
+    cuda-samples_cudatoolkit_10
+    cuda-samples_cudatoolkit_10_0
+    cuda-samples_cudatoolkit_10_1
+    cuda-samples_cudatoolkit_10_2
+    cuda-samples_cudatoolkit_11
+    cuda-samples_cudatoolkit_11_0
+    cuda-samples_cudatoolkit_11_1
+    cuda-samples_cudatoolkit_11_2;
+}

--- a/pkgs/test/cuda/default.nix
+++ b/pkgs/test/cuda/default.nix
@@ -13,4 +13,14 @@ rec {
     cuda-samples_cudatoolkit_11_0
     cuda-samples_cudatoolkit_11_1
     cuda-samples_cudatoolkit_11_2;
+
+  cuda-library-samplesPackages = callPackage ./cuda-library-samples { };
+  inherit (cuda-library-samplesPackages)
+    cuda-library-samples_cudatoolkit_10
+    cuda-library-samples_cudatoolkit_10_1
+    cuda-library-samples_cudatoolkit_10_2
+    cuda-library-samples_cudatoolkit_11
+    cuda-library-samples_cudatoolkit_11_0
+    cuda-library-samples_cudatoolkit_11_1
+    cuda-library-samples_cudatoolkit_11_2;
 }

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -47,5 +47,7 @@ with pkgs;
 
   texlive = callPackage ./texlive {};
 
+  cuda = callPackage ./cuda { };
+
   writers = callPackage ../build-support/writers/test.nix {};
 }


### PR DESCRIPTION
###### Motivation for this change

Since CUDA is unfree, we won't actually use this when testing Nixpkgs
officially. But I want to include this as they are useful for users of
Nixpkgs trying to set up / debug a CUDA environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
