### PR TITLE
libwebsockets: improve cross-compilation support

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -20,7 +20,7 @@ let
       "-DLWS_WITH_PLUGINS=ON"
       "-DLWS_WITH_IPV6=ON"
       "-DLWS_WITH_SOCKS5=ON"
-    ];
+    ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON";
 
     NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-Wno-error=unused-but-set-variable";
 


### PR DESCRIPTION
Building works on aarch64-multiplatform:

- libwebsockets_3_1
- libwebsockets_3_2
- libwebsockets_4_0
- libwebsockets_4_1

This patch disables building the test applications for libmosquitto in case you're cross-compiling. I don't think they're that important and this is the easiest fix for enabling cross-compilation.

If anyone cares enough about the test applications and wants to use them in a cross scenario, they could properly patch this. I'd assume that a patch would be the same for all versions, since I've seen this error at least on `3.1` and `4.1`.

<details><summary>Error log without this patch</summary>

```
rick@nixos-asus:~/hobby/nixos-mobile-nixpkgs$ nix build https://github.com/nixos/nixpkgs/archive/master.tar.gz#pkgsCross.aarch64-multiplatform.libwebsockets_4_0
error: --- Error ----------------------------------------------------------------------------------------------- nix
builder for '/nix/store/lc966irnncjnppdnj4j6icpsbmkyjqvx-libwebsockets-4.0.21-aarch64-unknown-linux-gnu.drv' failed with exit code 2; last 10 log lines:
  -- Installing: /nix/store/z1h2gkdiqyqpp9fdpabf369pvqmrh387-libwebsockets-4.0.21-aarch64-unknown-linux-gnu/bin/libwebsockets-test-server-extpoll
  -- Installing: /nix/store/z1h2gkdiqyqpp9fdpabf369pvqmrh387-libwebsockets-4.0.21-aarch64-unknown-linux-gnu/bin/libwebsockets-test-lejp
  -- Installing: /nix/store/z1h2gkdiqyqpp9fdpabf369pvqmrh387-libwebsockets-4.0.21-aarch64-unknown-linux-gnu/bin/libwebsockets-test-client
  CMake Error at cmake_install.cmake:174 (file):
    file INSTALL cannot find
    "/build/source/build/libwebsockets-test-server.key.pem": No such file or
    directory.
  
  
  make: *** [Makefile:147: install] Error 1
```

</details>

###### Motivation for this change

libwebsockets is a dependency of mosquitto, and I tried cross-compiling mosquitto. It was easy to fix this dependency, so here we are.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note that I haven't actually tried running this (yet), but at least it compiles now, which is a step in the right direction IMO.