### PR TITLE
maturinBuildHook: specify python interpreter

### DIFF
--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -19,6 +19,7 @@ maturinBuildHook() {
         --target @rustTargetPlatformSpec@ \
         --manylinux off \
         --strip \
+        --interpreter $(command -v python) \
         --release \
         ${maturinBuildFlags-}
     )


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Pass absolute path to python interpreter to maturin, to work around a cross compilation issue under qemu user-mode emulation, fixes #115601

https://github.com/NixOS/nixpkgs/issues/115601#issuecomment-795645304

Can be tested by running something like:
```
OPTIONS="--option system aarch64-linux
         --option sandbox false
         --extra-platforms aarch64-linux"
nix build $OPTIONS -f . python38Packages.adblock
```
from an x86 machine with `boot.binfmt.emulatedSystems = [ "aarch64-linux" ];`

cc @danieldk 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
