### PR TITLE
dunst: fix 1.6.1 src and build

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -2,7 +2,7 @@
 , pkg-config, which, perl, libXrandr
 , cairo, dbus, systemd, gdk-pixbuf, glib, libX11, libXScrnSaver
 , gtk3, wayland, wayland-protocols
-, libXinerama, libnotify, pango, xorgproto, librsvg, dunstify ? false
+, libXinerama, libnotify, pango, xorgproto, librsvg
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "dunst-project";
     repo = "dunst";
     rev = "v${version}";
-    sha256 = "0irwkqcgwkqaylcpvqgh25gn2ysbdm2kydipxfzcq1ddj9ns6f9c";
+    sha256 = "0lga1kj2vjbj9g9rl93nivngjmk5fkxdxwal8w96x9whwk9jvdga";
   };
 
   nativeBuildInputs = [ perl pkg-config which systemd makeWrapper ];
@@ -29,15 +29,12 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "PREFIX=$(out)"
     "VERSION=$(version)"
+    "SYSCONFDIR=$(out)/etc"
     "SERVICEDIR_DBUS=$(out)/share/dbus-1/services"
     "SERVICEDIR_SYSTEMD=$(out)/lib/systemd/user"
   ];
 
-  buildFlags = if dunstify then [ "dunstify" ] else [];
-
-  postInstall = lib.optionalString dunstify ''
-    install -Dm755 dunstify $out/bin
-  '' + ''
+  postInstall = ''
     wrapProgram $out/bin/dunst \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
   '';


### PR DESCRIPTION
[The previous bump to version 1.6.1](https://github.com/NixOS/nixpkgs/pull/114327/files) left the sha256 of the src attribute
unchanged, and as a consequence, it still built the old version.
But since the make config injected the version number, the binary still
self-reported as 1.6.1, even though it was built from 1.5.0.

I found this because I tried for an hour to get the new progress bar feature to work without success, now I know why.

As a drive-by, I also removed the `dunstify` option, as it was no longer effective because make install now always includes it, as remarked in https://github.com/NixOS/nixpkgs/pull/93731#issuecomment-663864072.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
