### PR TITLE
google-chrome: add optional libva and vulkan support

### DIFF
--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -39,6 +39,9 @@
 
 , gsettings-desktop-schemas
 , gnome3
+
+# For video acceleration via VA-API (--enable-features=VaapiVideoDecoder)
+, libvaSupport ? true, libva
 }:
 
 with lib;
@@ -63,6 +66,7 @@ let
     kerberos libdrm mesa coreutils
     libxkbcommon wayland
   ] ++ optional pulseSupport libpulseaudio
+    ++ optional libvaSupport libva
     ++ [ gtk3 ];
 
   suffix = if channel != "stable" then "-" + channel else "";

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -42,6 +42,9 @@
 
 # For video acceleration via VA-API (--enable-features=VaapiVideoDecoder)
 , libvaSupport ? true, libva
+
+# For Vulkan support (--enable-features=Vulkan)
+, vulkanSupport ? true, vulkan-loader
 }:
 
 with lib;
@@ -67,6 +70,7 @@ let
     libxkbcommon wayland
   ] ++ optional pulseSupport libpulseaudio
     ++ optional libvaSupport libva
+    ++ optional vulkanSupport vulkan-loader
     ++ [ gtk3 ];
 
   suffix = if channel != "stable" then "-" + channel else "";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Chrome cannot do hardware video acceleration without libva in its search path. This just adds libva. Tested against a VP9 video looking at `chrome://media-internals` and `intel_gpu_top`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
