### PR TITLE
jruby: Fix JAVA_HOME to support proper jmod support

### DIFF
--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -23,7 +23,7 @@ jruby = stdenv.mkDerivation rec {
 
      for i in $out/bin/jruby{,.bash}; do
        wrapProgram $i \
-         --set JAVA_HOME ${jre}
+         --set JAVA_HOME ${jre.home}
      done
 
      ln -s $out/bin/jruby $out/bin/ruby


### PR DESCRIPTION
###### Motivation for this change

This is investigation I've done in support of https://github.com/jruby/jruby/issues/6608 where I noticed some funky issues with JRuby and module loading.

Looks like that JRuby expects JAVA_HOME to have a directory called `jmod`, which is consistent with the Java Module system.

Unfortunately, the top level directory for the `jre` or `jdk` /nix/store entry is not a valid JAVA_HOME since it is missing that directory.

Instead it's set within `lib/openjdk`, and there is a passthru variable set accordingly.

This fixes JRuby and follows many other derivations.

**A simple search in the code-base shows that there are many other packages that suffer this same bug.**

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @marsam @volth @Mic92 