### PR TITLE
spike: fix build and tests.

### DIFF
--- a/nixos/tests/spike.nix
+++ b/nixos/tests/spike.nix
@@ -17,6 +17,6 @@ in
     ''
       machine.wait_for_unit("multi-user.target")
       output = machine.succeed("spike -m64 $(which pk) $(which hello)")
-      assert output == "Hello, world!\n"
+      assert "Hello, world!" in output
     '';
 })

--- a/pkgs/applications/virtualization/spike/default.nix
+++ b/pkgs/applications/virtualization/spike/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, dtc, nixosTests }:
+{ lib, stdenv, fetchgit, dtc, nixosTests, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "spike";
@@ -13,7 +13,15 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ dtc ];
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  patches = [
+    # Add missing headers to fix build.
+    (fetchpatch {
+      url = "https://github.com/riscv/riscv-isa-sim/commit/b3855682c2d744c613d2ffd6b53e3f021ecea4f3.patch";
+      sha256 = "1v1mpp4iddf5n4h3kmj65g075m7xc31bxww7gldnmgl607ma7cnl";
+    })
+  ];
+
+  postPatch = ''
     patchShebangs scripts/*.sh
     patchShebangs tests/ebreak.py
   '';

--- a/pkgs/misc/riscv-pk/default.nix
+++ b/pkgs/misc/riscv-pk/default.nix
@@ -1,15 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, payload ? null }: let
-  rev = "e5846a2bc707eaa58dc8ab6a8d20a090c6ee8570";
-  sha256 = "1clynpp70fnbgsjgxx7xi0vrdrj1v0h8zpv0x26i324kp2gwylf4";
-  revCount = "438";
-  shortRev = "e5846a2";
-in stdenv.mkDerivation {
-  name = "riscv-pk-0.1pre${revCount}_${shortRev}";
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, payload ? null }:
+
+stdenv.mkDerivation rec {
+  pname = "riscv-pk";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "riscv";
     repo = "riscv-pk";
-    inherit rev sha256;
+    rev = "v${version}";
+    sha256 = "1cc0rz4q3a1zw8756b8yysw8lb5g4xbjajh5lvqbjix41hbdx6xz";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

Spike failed to build (https://hydra.nixos.org/build/137765306). This PR back-ports the necessary commit from upstream to fix the build.

For `nixos/tests/spike.nix` to run, `riscv-pk` needed to be updated along the way, and the test slightly adjusted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
