### PR TITLE
apple-music-electron: 1.5.2 -> 1.5.5

### DIFF
--- a/pkgs/applications/audio/apple-music-electron/default.nix
+++ b/pkgs/applications/audio/apple-music-electron/default.nix
@@ -1,12 +1,12 @@
 { appimageTools, lib, fetchurl }:
 let
   pname = "apple-music-electron";
-  version = "1.5.2";
+  version = "1.5.5";
   name = "Apple.Music-${version}";
 
   src = fetchurl {
-    url = "https://github.com/iiFir3z/Apple-Music-Electron/releases/download/${version}/${name}.AppImage";
-    sha256 = "1jl0wgwy6ajmfkzygwb7cm9m49nkhp3x6vd8kwmh6ccs3jy4ayp5";
+    url = "https://github.com/cryptofyre/Apple-Music-Electron/releases/download/v${version}/${name}.AppImage";
+    sha256 = "1gb6j3nvam9fcpsgiv56jccg9a4y14vzsyw11h3hckaigy90knpx";
   };
 
   appimageContents = appimageTools.extract { inherit name src; };

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -184,6 +184,7 @@ rec {
       # libraries not on the upstream include list, but nevertheless expected
       # by at least one appimage
       libtool.lib # for Synfigstudio
+      xorg.libxshmfence # for apple-music-electron
       at-spi2-core
     ];
   };


### PR DESCRIPTION
###### Motivation for this change
Fails with the following error without the change in `pkgs/build-support/appimage/default.nix`:
```
/nix/store/48a25nl0bpcya9pdajcwxdx4k9cjfzgr-Apple.Music-1.5.5-extracted/apple-music-electron: error while loading shared libraries: libxshmfence.so.1: cannot open shared object file: No such file or directory
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
