### PR TITLE
Improve zs-apc-spdu-ctl

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -193,6 +193,7 @@
   ./programs/xwayland.nix
   ./programs/yabar.nix
   ./programs/zmap.nix
+  ./programs/zs-apc-spdu.nix
   ./programs/zsh/oh-my-zsh.nix
   ./programs/zsh/zsh.nix
   ./programs/zsh/zsh-autoenv.nix

--- a/nixos/modules/programs/zs-apc-spdu.nix
+++ b/nixos/modules/programs/zs-apc-spdu.nix
@@ -1,0 +1,72 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.zs-apc-spdu;
+
+  hostOptions = {
+    host = mkOption {
+      type = types.str;
+      description = "Set the hostname or IP address of host";
+    };
+
+    apc = mkOption {
+      type = types.str;
+      default = "";
+      description = "Set the APC for this host";
+    };
+
+    outlets = mkOption {
+      type = with types; listOf ints.u8;
+      description = "Set the list of APC outlets which belong to this host";
+    };
+  };
+
+  optSetApc = apc: optionalString (apc != "") "apc ${apc}\n";
+  fmt_outlets = { outlets, ... }: concatStringsSep " " (builtins.map toString outlets);
+
+in {
+  meta.maintainers = with maintainers; [ zseri ];
+
+  options.programs.zs-apc-spdu = {
+    defaultApc = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        Set the default APC for all hosts in the default config for
+        <command>zs-apc-spdu-ctl</command>.
+      '';
+    };
+
+    hosts = mkOption {
+      type = with types; attrsOf (submodule { options = hostOptions; });
+      default = {};
+      description = ''
+        Set the default map of hosts. If empty, no config will be generated.
+        The key is the name which can be given to
+        <command>zs-apc-spdu-ctl</command> on the command line.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.hosts != {}) {
+    environment.systemPackages = [ pkgs.zs-apc-spdu-ctl ];
+
+    environment.etc."zs-apc-spdu.conf" = {
+      text = (optSetApc cfg.defaultApc)
+        + (concatStringsSep "\n\n"
+            (mapAttrsToList (key: value: ''
+              :${key}
+              host ${value.host}
+              ${optSetApc value.apc}outlets ${fmt_outlets value}
+            '') cfg.hosts)
+          );
+
+      # may contain sensitive information
+      # the user should set an appropriate group
+      mode = mkDefault "0440";
+      group = mkDefault "wheel";
+    };
+  };
+}

--- a/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
+++ b/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
@@ -7,7 +7,6 @@
 , stdenv
 }:
 
-# TODO: add a services entry for the /etc/zs-apc-spdu.conf file
 stdenv.mkDerivation rec {
   pname = "zs-apc-spdu-ctl";
   version = "0.0.2";


### PR DESCRIPTION
###### Motivation for this change

Allow generating the config via `programs.zs-apc-spdu`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
