### PR TITLE
vector: 0.10.0 -> 0.12.1

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -1,32 +1,24 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform
-, openssl, pkg-config, protobuf
-, Security, libiconv, rdkafka
-, tzdata
+{ stdenv, lib, fetchFromGitHub, rustPlatform, openssl, pkg-config, protobuf
+, Security, libiconv, rdkafka, tzdata, coreutils, CoreServices
 
 , features ?
-    ((if stdenv.isAarch64
-     then [ "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ]
-     else [ "leveldb" "leveldb/leveldb-sys-2" "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ])
-     ++
-     (lib.optional stdenv.targetPlatform.isUnix "unix")
-     ++
-     [ "sinks" "sources" "transforms" ])
-, coreutils
-, CoreServices
+       ([ "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ]
+    ++ (lib.optional stdenv.targetPlatform.isUnix "unix")
+    ++ [ "sinks" "sources" "transforms" ])
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "vector";
-  version = "0.10.0";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner  = "timberio";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "0q6x3fvwwh18iyznqlr09n3zppzgw9jaz973s8haz54hnxj16wx0";
+    sha256 = "02qbn9w9286ran8vjry9090r9ym9bj9xxvyzavw7gk53sg56m8gl";
   };
 
-  cargoSha256 = "Y/vDYXWQ65zZ86vTwP4aCZYCMZuqbz6tpfv4uRkFAzc=";
+  cargoSha256 = "0zynyc7vkdf5pzz4svymsn3w8r834hc5gqxm1jk6myidvnyh2xsp";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl protobuf rdkafka ]
                 ++ lib.optional stdenv.isDarwin [ Security libiconv coreutils CoreServices ];
@@ -35,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   PROTOC="${protobuf}/bin/protoc";
   PROTOC_INCLUDE="${protobuf}/include";
 
-  cargoBuildFlags = [ "--no-default-features" "--features" "${lib.concatStringsSep "," features}" ];
+  cargoBuildFlags = [ "--no-default-features" "--features" (lib.concatStringsSep "," features) ];
   checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features} -- --test-threads 1";
 
   # recent overhauls of DNS support in 0.9 mean that we try to resolve
@@ -49,14 +41,16 @@ rustPlatform.buildRustPackage rec {
   # nor do I know why it depends on rustc.
   # However, in order for the closure size to stay at a reasonable level,
   # transforms-geoip is patched out of Cargo.toml for now - unless explicitly asked for.
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./src/dns.rs \
-      --replace "#[test]" ""
+      --replace "#[tokio::test]" ""
 
     ${lib.optionalString (!builtins.elem "transforms-geoip" features) ''
         substituteInPlace ./Cargo.toml --replace '"transforms-geoip",' ""
     ''}
   '';
+
+  passthru = { inherit features; };
 
   meta = with lib; {
     description = "A high-performance logs, metrics, and events router";

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "vector";
-  version = "0.12.0";
+  version = "0.12.1";
 
   src = fetchFromGitHub {
     owner  = "timberio";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "02qbn9w9286ran8vjry9090r9ym9bj9xxvyzavw7gk53sg56m8gl";
+    sha256 = "0sw05472znxmggckxjbrl3b8ky8nsw42xmrsb41p8z4q0aw115fd";
   };
 
-  cargoSha256 = "0zynyc7vkdf5pzz4svymsn3w8r834hc5gqxm1jk6myidvnyh2xsp";
+  cargoSha256 = "0mfhrdqry6qrzfx5px1zqgfv5iqa186vl2yh290ibinkxy0x5fa9";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl protobuf rdkafka ]
                 ++ lib.optional stdenv.isDarwin [ Security libiconv coreutils CoreServices ];


### PR DESCRIPTION
As a minor regression, LevelDB support is currently compiled out. This is due to a few changes in the build infrastructure that now causes leveldb to be vendored when it shouldn't be, but should be fixable, I think.

This has to hit staging because Vector now requires Rust 1.50, due to it stabilizing some library APIs it uses.

Darwin is currently untested.

This supersedes both #113849 and #107557.

/cc @happysalada @rmcgibbo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
