### PR TITLE
wireshark: 3.4.3 -> 3.4.4

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config, pcre, perl, flex, bison, gettext, libpcap, libnl, c-ares
 , gnutls, libgcrypt, libgpgerror, geoip, openssl, lua5, python3, libcap, glib
-, libssh, nghttp2, zlib, cmake, fetchpatch, makeWrapper
+, libssh, nghttp2, zlib, cmake, makeWrapper
 , withQt ? true, qt5 ? null
 , ApplicationServices, SystemConfiguration, gmp
 }:
@@ -10,7 +10,7 @@ assert withQt  -> qt5  != null;
 with lib;
 
 let
-  version = "3.4.3";
+  version = "3.4.4";
   variant = if withQt then "qt" else "cli";
 
 in stdenv.mkDerivation {
@@ -20,7 +20,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
-    sha256 = "0ar6pxzrcpxdriz437d6ziwlhb8k5wlvrkalp3hgqwzwy1vwqrzl";
+    sha256 = "0aad3m8nh4i75dgjs68217135bzqmhmlgjklmpjh1ihmjwgd373j";
   };
 
   cmakeFlags = [
@@ -33,13 +33,11 @@ in stdenv.mkDerivation {
   # Avoid referencing -dev paths because of debug assertions.
   NIX_CFLAGS_COMPILE = [ "-DQT_NO_DEBUG" ];
 
-  nativeBuildInputs = [
-    bison cmake flex pkg-config
-  ] ++ optional withQt qt5.wrapQtAppsHook;
+  nativeBuildInputs = [ bison cmake flex makeWrapper pkg-config ] ++ optional withQt qt5.wrapQtAppsHook;
 
   buildInputs = [
     gettext pcre perl libpcap lua5 libssh nghttp2 openssl libgcrypt
-    libgpgerror gnutls geoip c-ares python3 glib zlib makeWrapper
+    libgpgerror gnutls geoip c-ares python3 glib zlib
   ] ++ optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
     ++ optionals stdenv.isLinux  [ libcap libnl ]
     ++ optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ]
@@ -96,7 +94,7 @@ in stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://www.wireshark.org/";
     description = "Powerful network protocol analyzer";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
 
     longDescription = ''
       Wireshark (formerly known as "Ethereal") is a powerful network


### PR DESCRIPTION
###### Motivation for this change
https://www.wireshark.org/docs/relnotes/wireshark-3.4.4.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).