### PR TITLE
aws-c-cal, aws-c-io: fix on big sur

### DIFF
--- a/pkgs/development/libraries/aws-c-cal/default.nix
+++ b/pkgs/development/libraries/aws-c-cal/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, aws-c-common, openssl, Security }:
+{ lib, stdenv, fetchFromGitHub, cmake, aws-c-common, openssl, Security, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "aws-c-cal";
@@ -11,9 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "04acra1mnzw9q7jycs5966akfbgnx96hkrq90nq0dhw8pvarlyv6";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/awslabs/aws-c-cal/commit/2169f11aae546e8aa7ed36c91ffc006a4e87aae8.patch";
+      sha256 = "16wxydw140s90z0601vn00xqvsn67bj9dfc80c69k8sib1r6901q";
+    })
+  ];
+
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ aws-c-common openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [ aws-c-common openssl ];
+
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"

--- a/pkgs/development/libraries/aws-c-io/default.nix
+++ b/pkgs/development/libraries/aws-c-io/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, aws-c-cal, aws-c-common, s2n-tls, Security }:
+{ lib, stdenv, fetchFromGitHub, cmake, aws-c-cal, aws-c-common, s2n-tls, Security, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "aws-c-io";
@@ -11,9 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "0lx72p9xmmnjkz4zkfb1lz0ibw0jsy52qpydhvn56bq85nv44rwx";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/matthewbauer/aws-c-io/commit/8c9b28a3ea2e9dc2892d9e1cdcb18b0d03b36c6d.patch";
+      sha256 = "16pcr413b0d8xyb360dq2b64a6533r5d7kdi34zrnbkr3xvz97f9";
+    })
+  ];
+
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ aws-c-cal aws-c-common s2n-tls] ++ lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [ aws-c-cal aws-c-common s2n-tls];
+
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"


### PR DESCRIPTION
We need to use -framework instead of hardcoding the Security library
found by CMake.
