### PR TITLE
tektoncd-cli: 0.16.0 -> 0.17.0

### DIFF
--- a/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
+++ b/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
@@ -2,23 +2,20 @@
 
 buildGoModule rec {
   pname = "tektoncd-cli";
-  version = "0.16.0";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "tektoncd";
     repo = "cli";
     rev = "v${version}";
-    sha256 = "sha256-IY9iJa4HcZ60jDPdP47jjC0FiOJesvf2vEENMAYVd4Q=";
+    sha256 = "sha256-IyYlmatgcVbUj1WCPAFVOIgn1iHM80P4ie6d1YD3ISM=";
   };
 
   vendorSha256 = null;
 
-  buildFlagsArray = [
-    "-ldflags="
-    "-s"
-    "-w"
-    "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=${version}"
-  ];
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-s -w -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=${version}")
+  '';
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -39,6 +36,15 @@ buildGoModule rec {
       --fish <($out/bin/tkn completion fish) \
       --zsh <($out/bin/tkn completion zsh)
   '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/tkn --help
+    $out/bin/tkn version | grep "Client version: ${version}"
+    runHook postInstallCheck
+  '';
+
 
   meta = with lib; {
     homepage = "https://tekton.dev";

--- a/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
+++ b/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
@@ -45,7 +45,6 @@ buildGoModule rec {
     runHook postInstallCheck
   '';
 
-
   meta = with lib; {
     homepage = "https://tekton.dev";
     changelog = "https://github.com/tektoncd/cli/releases/tag/v${version}";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump tektoncd-cli to `0.17.0`

Also:
- Set buildFlagsArray using bash
- Add installCheckPhase


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
