### PR TITLE
firefox-bin: 86.0 -> 86.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "86.0";
+  version = "86.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ach/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ach/firefox-86.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "96cf6afb631f36dd18f0d109bfc31abbff5960e7972b59e4fa51ac0c2c81f9ed";
+      sha256 = "b9006b2c0251ae2264a60be3763dcf9610f3a8569f2a05f266e59c8232400e8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/af/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/af/firefox-86.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "38d4588b8498917717ea58419a35751c6c3ae987372ee6a37590a7630eb68c35";
+      sha256 = "7f4268d613acee2e003fe8042dc2e969bd0f6f14b906b35ce6b8c727fbb13d76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/an/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/an/firefox-86.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "942c9cf4dc6f5baa6c5225a15a2856bd72c7366bcb6224b8ba5a1428cfd974f6";
+      sha256 = "8a892626b4f34413423f4da61d7e0099e215bc9e597092bbd625445e27998d17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ar/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ar/firefox-86.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "a616e3dfac2bcae832bc6538692a9d811604aadb71079641f77f9b3db105fabd";
+      sha256 = "c837e97ca8b46de448fbc9fd2120ffbb735474ade8a6f64f7ded8dbdfc4c7406";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ast/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ast/firefox-86.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "0e026de4affddbdf9e5915818c02acb018b214cd005c5122593e86e821919016";
+      sha256 = "8c3b990b899d70c46827ac5a7f32faf9cf44bfba195283bf47d277ccc8da8cbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/az/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/az/firefox-86.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "761e129a070f017b28ce51c1f96fa95be8d98e687b44e9e97d95d18db85ad9aa";
+      sha256 = "8fa2a9e6cb6c70fd92b43e2ae145956337f87dd21b468ac375a90a7d18551bce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/be/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/be/firefox-86.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "9e80115c8a78ab5ff3eec38e31c1ec29decba3660ebc95cb909aedf3db4390ab";
+      sha256 = "dddbf1e9eb8ecc928b534ef5fd77cb52edd0c67f68a522bbc377d5943cfaaa90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/bg/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/bg/firefox-86.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "b5149b21a8ae9b08ee3abfa2fdb894582e620464af36037c43c2cd0b6667c174";
+      sha256 = "c4eac8234b58f40b40ec5be3fc37817f768d35804f2f923b9d0effa5cf906782";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/bn/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/bn/firefox-86.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "0b5ed8e2859e54ce7d64ac8b0626c69229209cfadf14e8d55225272f702a6f8f";
+      sha256 = "41efed647c468ad3da21090e11a4bb861d26106471e0543c3709016d1ca2bd06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/br/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/br/firefox-86.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "7fb1cdb85510bb8e41f2ce5e856a0ef93c83c430bbe64079a2e3c362bd557ab0";
+      sha256 = "53076688c25034f02b3c30455fbdbea0287bfdd8d5100c0f5edb77ad32955f36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/bs/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/bs/firefox-86.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "2259ddd7f35d5a8d8830a429f0dec92da5ee101d5c42ff5d9f8ff003f76e5b8a";
+      sha256 = "304d9fa41a95f6abf61c16f765ec4651a159af0cabb09b1ce76f805d27746dc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ca-valencia/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ca-valencia/firefox-86.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "5214a48525eabc0ae4cda08e70ceba59b0e9fd51976d578f512b02fefbf48b8c";
+      sha256 = "e845d6cbff2cd88b9e1f7526e8aa9eac4aa53c116301ba861e1beb04f9deb4e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ca/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ca/firefox-86.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "250f4bf5659a04dfb20a651899a92bccd9d24c2e9d3186bb17acc4f452b0b648";
+      sha256 = "5159eb68a571fb035c4621cbeae9d7a88d40172876a00b3ab6512a8701f43f59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/cak/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/cak/firefox-86.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "959c3cf7aace0b80adc6ae2bedc578b74de66adf261de7b67654e0c57e6ee2f5";
+      sha256 = "efab62e54fa41a65d5989078ee594dc2c2e8c355bd656828321cc342cc167def";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/cs/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/cs/firefox-86.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "aaed7891e891ba8926ed5904a798e6201cbc355ba11c341546f779e0f2815abc";
+      sha256 = "1cc3e58c1c2790bd13346b752b2209bc8db08a9470960e06857913a70a7826dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/cy/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/cy/firefox-86.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "064c2419e8fd43e350e055d7bcd4ae1689c4f7667b51996be9037bc4d1c529a3";
+      sha256 = "230d79e979cdc350164fe37ea4ba84183db935ba973efab1ab14b56f0a12344f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/da/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/da/firefox-86.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "484f1bdd24689a7a7dd7a8b4556b2f32aeb50509aa3f9d645e151dbfaab9e71b";
+      sha256 = "04d50be5260cafde33729aca15cd9731f6fb1550da2db86719e6d672639607fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/de/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/de/firefox-86.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "12670011be25e5420a5721e23d1e37592e4d1ca9a2efac85db02545398454e65";
+      sha256 = "a4b5c447cb34b91ac5053153e73520d9f5fc8b06a390f5694cda6bc2131efe12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/dsb/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/dsb/firefox-86.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "2851664d7d9dd90f8e444e13b5c9f20bd6271b6e77ae857db1e3aa55429b8b83";
+      sha256 = "eea691c668126056cb1e4137cf4f6e8d40fe46f79a00c73ccd59723cfb63e404";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/el/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/el/firefox-86.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "ec24c6634f20da95f820623c32d92f492f2b939280a49e327a1f465b0046632f";
+      sha256 = "d6774ba0cdc0e89091cb57bc1669927f58ed9811617cfbd358567e2a85f977d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/en-CA/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/en-CA/firefox-86.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "6c5a19ac4ac5f174569483ee5c1f053e692efc189edfca7e78f9428f05454338";
+      sha256 = "8cb49ea8e3db760de1f3d97f1583f4219c3039d09632f5ef186311145aa2c3c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/en-GB/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/en-GB/firefox-86.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "919d6e6c731d53ade97bbb330cd2e425f70565c330233a86ffe9295ff3692001";
+      sha256 = "2ee2ead0c7765e9e5744dff5d7bdfe2ac890cb6859362426bf8244e393f1bb5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/en-US/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/en-US/firefox-86.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "c643dd519fe8b0b6d2d2241b5c241aa1b43ece397f49268865b4d1888c19173e";
+      sha256 = "d419da5168312f5d023481668fb4767a27799f02248b4ea90fef98a54ab73b86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/eo/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/eo/firefox-86.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "d20b007ba86bdfdd7aa4bdaae08b283107a4464d88a4a9fc34bd4c95781f48d3";
+      sha256 = "0b73a3695f0291c3afdc1635976e6129f94d72d9a9a422ebd3a0cfbbb9343697";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/es-AR/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/es-AR/firefox-86.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "3d4ed05801d31a92c072384e660d7b874be835edd3b6b37741b71bec32a0fa6f";
+      sha256 = "4fe2c2428ce205054d16ee33f432dd865e4d919b63f7c2f0a458bd5b80c9c0b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/es-CL/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/es-CL/firefox-86.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "8ec51d79baefe2808024c33105fd4c1a8e4f5061b72530a4c01bc8a23d6b6cd5";
+      sha256 = "f5d1850c5c10051b04a445001a2991e52a3c1b93002b3534030e85ee0a3c6b5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/es-ES/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/es-ES/firefox-86.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "38781952508f86d9b4aa7a0c4fae927494e207970e54ba1070943008283c2e23";
+      sha256 = "b99f0532bdc3ab04c421442cf0ea4c24db19a87104ad7d2eff51acb0a383b154";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/es-MX/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/es-MX/firefox-86.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "29817ccf3aad1e38f195f18ab628bca8f9bc4dcd931919cdd9d5d22c6461ce87";
+      sha256 = "56bc322d4c7c160fe1bf095039b5b6e31fcfa234bd5d66ba0995f22af49f5bae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/et/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/et/firefox-86.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d4ddde9103e9355a91186e0343315f99bf0eb53b2502abb80b8fcb1056ea82e2";
+      sha256 = "962dcd00ed62c5ca6ef86ede3e965e699f403435de9ce933457dac940141c293";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/eu/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/eu/firefox-86.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "85744b3d7e3bcd5de92ca4ec5a0ade8421689dda5a3c53e361656f3de3178a91";
+      sha256 = "2ba0643490d449ad39b07e98713f8693ecc16b368cc459a9ea89a35a1ed74978";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/fa/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/fa/firefox-86.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "60e6ebb40f1e11a61ad63d2543acd7d83cef58c0fd4dc22f1c553749a36e3fb8";
+      sha256 = "11566ef20d466b2930841f4fce2f92960ceeb1771b82449c274f6a4fcfb85e0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ff/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ff/firefox-86.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "878d7155fe73ff6585e8566399416361a39080cb54afd61448e1bd0e191046a0";
+      sha256 = "110cbb0d3662bbc73273535abd2846091bb16dda3c221a60a2f7023ef756f764";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/fi/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/fi/firefox-86.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "d02f24944f5bbd57273e05aa4fe701b375ad8d8905d0070ec9396a55d104203d";
+      sha256 = "decb87ed765911a9564e15dd97fc7e35164b0af1ab84167dcd598689c8972d30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/fr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/fr/firefox-86.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "ac6497f8a4bfa4e37798840bf4dc9b84463bf095074d2ba3c931e89a402a3fc8";
+      sha256 = "31fa08ae30af62b65b39c16718ee6c6f132cb157a92fc149a3d36870016abde1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/fy-NL/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/fy-NL/firefox-86.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "456ff8a1bed8769cd9fc05b29ed23edd29c48514dda4e73ac8e8663593cc3b4b";
+      sha256 = "f75d128c1c6a1b3171132f20f42aca2b798180e1d58f20e264d4defa0e4508d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ga-IE/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ga-IE/firefox-86.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "b0778c1217f9ee6e631c62ef024991212cb679a43394e07401a5f61ca2b88459";
+      sha256 = "9902efeb4b30b0935be5dec5a7f85c4ec659b8d8f236e012b2d1187a52f3b667";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/gd/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/gd/firefox-86.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "37eba79d0db2bf84faa2d89efa0c5b9b34f7fc732636f4b436a3e118792ba610";
+      sha256 = "42c779be313524a365dd59013f5486e79b0378d0dc4fe805b5a6769d44ac98d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/gl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/gl/firefox-86.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "ef06e70653f712c4ab594a00c4d571ba098db740ff508cf78e08e859123096dc";
+      sha256 = "cc5d2239946d4b01e31b6da4604a75862f501cc529aecd7962956d4af4dcc970";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/gn/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/gn/firefox-86.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "c7bbe33c8f839b24ee6928d74d5b0cff18918ab5f2a55e4b3bc1319049b19e4b";
+      sha256 = "4a94e0f10f9002721ac57e622da7ab43cd1788683288564e87f667069fdac427";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/gu-IN/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/gu-IN/firefox-86.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "71ceee81509cb6d505b836dd494eb9dba73857aa2c976ec1aab2fa57a50f1519";
+      sha256 = "f81a85e1bea666d339774e0cadd316fccf52752c11a0b5a53a82ac22d6d8dabf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/he/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/he/firefox-86.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "cca354d947d83c616035fdd64019b50d1bb86c3d01e05090eae2d07953ae566b";
+      sha256 = "347130466e2f42d06707d56e486b4f262874e50c36b69e2badcb7287ff73376b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/hi-IN/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hi-IN/firefox-86.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "a151d3a3d85f0cf96837f51b2a0df9a0a9652148dbcb53733025e15686451669";
+      sha256 = "9600a709b7e4b2bb8f0c57cde08627aff892341cd68edda563cb4d0366ca13f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/hr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hr/firefox-86.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "00e3301bef430e243c6516d5c94e0b5fe6e27ca58fd0192955423956395fb2d4";
+      sha256 = "bea906c0745f77fc99a830594a2eef1ce609b03596a93cefaaf49044edd483c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/hsb/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hsb/firefox-86.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "34c2666668499c8034e732565b244fc5b0cc7b0f544296be1e86942aa62b9167";
+      sha256 = "56bf66c8f38567771b57e9f6008b0e86845cd71873b8ee4aa2c056e2c47d3f9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/hu/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hu/firefox-86.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "d33f5467d9be5a2c6317a10fbd5285c4db7ed4191ceddc317d4ec923bd6ef7df";
+      sha256 = "e7da1098e56e1ad7e1baa3b6075defc6169e28306846c77c8f26c424c748f565";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/hy-AM/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hy-AM/firefox-86.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "a008343614e5fa43d8ce90ac5f2afc0bec98419d28efc191b836ce835b6f48a1";
+      sha256 = "ce3660bf256ed1cccb9c73d0c895907c68104f7f1cc28e7163363a060a747036";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ia/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ia/firefox-86.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "9140874f06ed6e135ae70fa40600b4e1e570b6dc6901191658870916f73d1c17";
+      sha256 = "b6ebccd0e4c84d71e7da95ae99d6fa2e1a95fe94d6ed200fbf23ea7ff22aff70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/id/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/id/firefox-86.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "c1dea9043a7f06708498acfda90a7b166b1f7bf839bf86dc2fbb90cf7a00269f";
+      sha256 = "7d6844743e6a3e56a29f9d5ee599850bdef09f449de70f14e03664c02bebb31a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/is/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/is/firefox-86.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "50a804f9b7dd594b8c449ce6dd137b5f2bce41ab29baa35f6a14977a5c7af486";
+      sha256 = "28bc14cf54090b9f52ae8fcbc7703f201407520e72f5aa6cd0b9f953d4db1777";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/it/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/it/firefox-86.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "3ea5e01722a7a03a5dc498977410fd2cde90352b026489669bcb7ebaa571ffdf";
+      sha256 = "1d1a9a7108ebcc0cb796dadbdd9ddf0d8943e5d21c6d56588f33c583e7517b8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ja/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ja/firefox-86.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "efac929a1ace0484b5bce056bbd3d3ff4f26f897d4b1739f128d1dfd91c3c375";
+      sha256 = "64342a2674eba04cda7f38e7382b7b2fa93efa1b5c555f0a01e6c59314913f31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ka/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ka/firefox-86.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "95261b88327b5b20739d8adb2a99bb0de5d1311099e2d3fc0999405fbc918ae6";
+      sha256 = "38fd38b9a257ba42928e72fed0c3047e000d2a603d37eba1d879ac1d3a87c371";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/kab/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/kab/firefox-86.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "f7b4f440f27ab9141b24f2673e4b850193744d1fc03451c2134a6890b4884f37";
+      sha256 = "24570eeeaf5129ce8891320efe6a77203a3eb213285c71c9f2312da1c1d15303";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/kk/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/kk/firefox-86.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "652aeb8d66ffb884983a043ff1d2ba10ff3a03aafe8cd55217a8f6a8068a3e59";
+      sha256 = "cbc294b8e6988e2e010d08608fd1a822f05cf54bb3b3d6772eea13f1a17ee491";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/km/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/km/firefox-86.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "39deb82ca935780959e4a0f71d85cee3b90c6228237a508b239ad2a1f5a35a07";
+      sha256 = "ba9acd0c686ea2ef2d6d8af279c6cd75852021d16aa9e6d8a0bb429de605d8fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/kn/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/kn/firefox-86.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "886370871c27c6637a74e4d8ced9ef2a9ec5062a8aae45fad5fea1dc358e38f4";
+      sha256 = "bba2d328021359961fc0bdf7f5676fe47d72476b4bdb54cd41b09506f49ef0c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ko/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ko/firefox-86.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "9acea882760a961e228344c2cac9dfdb8d40c6c4c874744a4f2fffc356f6499c";
+      sha256 = "983f9e165840452aae854b780a480c215f3e030801ff8184424d53b541e1c8b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/lij/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/lij/firefox-86.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "fd76e82cda32813d43d80ae4acaed5610882162d68e98b4ae47dd1ddc8487d82";
+      sha256 = "d57f27ef2a5ab4d8032cb823fa9cb6fc566baced92517dca8ed61560641af96d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/lt/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/lt/firefox-86.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "afcc203f0d080560364277e7cca0f4080c74011dfc0fe07c751124e341e5b729";
+      sha256 = "1866f926855aed60846004450b34fb341faddc992cfc603ad2b689019e888c8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/lv/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/lv/firefox-86.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "1b8a5cc4941d669f12593dc078d6658751609bd094a3704e9a9949341413ba9d";
+      sha256 = "ac79432c516df059b15737c1bb492a3eec6dcd5261a2ebe17698720ae7085cae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/mk/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/mk/firefox-86.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "72d374b828e3316f119d592bde6ebfe91ac4907d63cde43f6391d4be81119bc4";
+      sha256 = "5d9eefd2926d1554d1feb4526c460506315a805c7e149ca4f87e0ebcb24b3d12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/mr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/mr/firefox-86.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "17a2dec82a1d89fe74e71f924a21bb175cdb89d801ba50e5f0f0b4625fdabc1d";
+      sha256 = "a5095a4eeea48bea9c52b843023756a9912a979aa8441aa2160785287bdefd1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ms/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ms/firefox-86.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "9af2d0b5f81d573c8fed4ff54446b2f3a77080ccec5138b1d0e707fb1c37e164";
+      sha256 = "47b1bc88d7a5f3d0feddbdb0d9e30a5cd9e420b85f3fb360bd6429a4ca1e4bc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/my/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/my/firefox-86.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "3a2815eed7a1288991c769045614cc50ec3fed2810ff143652092cd32aef5e1b";
+      sha256 = "420e4b3ef4b31bd850374fdd4098e41d455d02ab2bbf52b5c575d28ea6350afe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/nb-NO/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/nb-NO/firefox-86.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "a8255d1dffb5dcba012a15d5b0f62b9e6e4e60720ae6dc139c23f77aaf6ea99e";
+      sha256 = "6f6656a5370de01fc90eeeab8088d69d71c2e55cd9793b285f0bb88b61d44131";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ne-NP/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ne-NP/firefox-86.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "e1c563748ae230a44939d27d7fa246e63ad49d242df236082af2eb0c38af8046";
+      sha256 = "e7ac9e8e6914624349fd4cbb230faa96eed54502ec8019cdf2032606654e4464";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/nl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/nl/firefox-86.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "56ab4fedc5c3a71b91693d33eb70f79ba3f0095dda66eae44e3e15f885491d5c";
+      sha256 = "a425e62f533d9e360ec2690946cd9ec5fa4f7da9ce6891558fb50a1bf3be6adc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/nn-NO/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/nn-NO/firefox-86.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "216e2d4434c66fd4361114467ed5e4635342ed53b74eae287d1d69ba63ac85d6";
+      sha256 = "69c939c97646fcd628fe3facd0643c2d43790d7997b902a921190b6269dbf88e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/oc/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/oc/firefox-86.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "0f6822824131d1709c09de64643a9f6e3b03e30741d079f66229efdfb5096e21";
+      sha256 = "6a4c2ace18b9e00ee25a4600e115af847d305e60d89335203209d5a519ce89fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/pa-IN/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/pa-IN/firefox-86.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "9a15f3ea177314500e72ef123ed9dc36bfb9e10b92e5ab20cdaa6e7e1fa3367f";
+      sha256 = "d81d8fda4acd4ccad2cae15a47123cecdd91afa66f93cd635ea13ed6af074fa8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/pl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/pl/firefox-86.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "18d19ed1597d3862d08d6daf52dd1bfb8f21c005f7cc44ce4d2e8177b4509aee";
+      sha256 = "cb4b300ff0e8e8b0d874dce5349202b8b29e5a4ff79ab6044df74a53f5c72dc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/pt-BR/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/pt-BR/firefox-86.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "287c3c117532b23e45d726d4541ee726056139e976bf43210f35b529834c3884";
+      sha256 = "654cc5d0a0e35823733e6c9d440c43e4483233a4423c6c9bcaf91cb8fcbeb5ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/pt-PT/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/pt-PT/firefox-86.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "26915b7725a325db052cbc165454c34f19e7a1346aa400b1306234707bccdf9b";
+      sha256 = "a944bf18dc7490ce80779af4cce82c20521b48ddb691ed5504d70075116af0d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/rm/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/rm/firefox-86.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "4d5c14e2607efc653f5cae75290332229286b5ee606da635871dc04e20495fc3";
+      sha256 = "674921eeca942cc77b08e8c33a273d327357d90df7be91140e468517a59a7cbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ro/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ro/firefox-86.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "a41bab63866e22712861a825aae272e3468470783f92c23117e1c116b9d66771";
+      sha256 = "8cbc8f6246455b6deae4a8e619f065ba218b59e711747033b08adffbed8498d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ru/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ru/firefox-86.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "edec67a8079f55c5f22b6928bf1d55a2e1d31aff931c9e41e503ff1b7acf2ecf";
+      sha256 = "6d2f6c1d4d8503ee78769c69c97a3cbefa6544a8a1ffb662f10460b6d78fa209";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/si/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/si/firefox-86.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "0357b913e6528214f30ff5ffd4a0f1c0e26bf079d3afdc166a82ee24e8c099ad";
+      sha256 = "af33afea872e8e2b8825a01d5fcbc40a5b7674813b60735855b5fd0b886c57ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/sk/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sk/firefox-86.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "5a38f953d93cf4cb8b4e2dbb0206fc0a9fa3262c55d91fa4cfc3a8605098403e";
+      sha256 = "7ecd39362865c864d6a5412bed20f8946019e3cb845923ce2ee30112d8e6444b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/sl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sl/firefox-86.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "0c2c41f6d7c3f72e56cb84c921207a606f959993ec6a3cc5619bbb894ce6ef8a";
+      sha256 = "93c000e695b37f389356d4f3c48c55de6839688826c507e0cf76fee105409dfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/son/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/son/firefox-86.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "cfdedeaacf244b3bc63343f76ed817a165a15b2a727f04327581cd373e76ac86";
+      sha256 = "25df54b6e83be77fa22622905d17667a5db613eca263582daffea9c0079031cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/sq/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sq/firefox-86.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "daac917a1e105b7871a0361db364558251b931898e08c36515c64269c760d6b4";
+      sha256 = "6c8eb230a6de1b5056e530bd76ef0d6f6f35ee29a9d814440c6c2a32460b2de1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/sr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sr/firefox-86.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c1993cabde0e7df92e45101bd62cd14a86d023763c48c18a7e00018dcfea282f";
+      sha256 = "a7b82f4383608dae512dd528068d9b4b2d4ca194f118098b328fd1b817bed14c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/sv-SE/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sv-SE/firefox-86.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "eb04be61ab3d029437f57dedbf1b66d0bfc6c0a9b29e41fe4fb7aec7b5ab47b0";
+      sha256 = "dd856d068f32271ad024649c945ea4665faabf81a4057a8c7efe4f1cce302eb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ta/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ta/firefox-86.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "fbd105183afb74dc7887dfe5cc0e518e96cb8bf79c53fc502d154bbaededacd7";
+      sha256 = "9cb7ec3e3150a3594ae1a460b70d81ce1ddb9fe42696710a0e7eb1baf7c5aa17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/te/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/te/firefox-86.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "e049b79ce8a81749caa83d6b42ae710414fe08ae2f28a2c1af7c7d47f83b24e0";
+      sha256 = "a3960a97ab3a7a28fe8c218457fe36a5f72827d602ebced3ff74d02f9941100a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/th/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/th/firefox-86.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "2b3ca062e1e53d5fca726e5c5a9eb7a3a639e4f6e7f5b455bf33e305eda475cc";
+      sha256 = "c342893afcc7b68ba09c8875a55bec4ef2a8c5af40c0ae96a13a662eb0d73115";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/tl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/tl/firefox-86.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "0fce4ea1fc379ab87c0f565c12f8ee16205108048d7fe89d7850802653247c16";
+      sha256 = "3b0de00b254c2d984bbece1d3ca3acaffdc316a44d7270f4cff4c35425310913";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/tr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/tr/firefox-86.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "e0a1c0a5d31225fb6af2b5b2c4d7386dc10d9c5c56081c1282615cc8d5da51ba";
+      sha256 = "db36a0260fe69a99d3c834e526a6bdd305334490dd3e644dbd8a48606487209e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/trs/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/trs/firefox-86.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "129d9b5d54cc807664a27fba1fd4f003430bdccf0385cbb53ea77517ce30879f";
+      sha256 = "94bc2723028e39d161bb7e95a27e9ce935671c80646674aecc871205a6c602ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/uk/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/uk/firefox-86.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "d50f3c3f21af6c805bc8c86f886af9f1be2b2d5cb5ad061a000633fa9b7e2641";
+      sha256 = "7ad9a53018e54fcdb860cacc5fad9eb34a08e879ab69d47af21eb31f3d6c2803";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/ur/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ur/firefox-86.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "ac9240e7896f695f48526ad275d887ddef7eb98aa3dd94800a1b4da081110876";
+      sha256 = "6d333e34bb8a332efbff91b9f7d69092b69e377c324693b765eb48b49a7ba108";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/uz/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/uz/firefox-86.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "94bd2d3f2f95e32381f6b945f4b1149f355dffcc27ec829fd0849ec4895a6da7";
+      sha256 = "5d111ce8b55637ab03c94fef0ed2e5737bbeee4f80a1ca4ff1847c2e9133c31d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/vi/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/vi/firefox-86.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "e7c8034074e6d1f8f6987321e24dffdbe8acfa11d6784b8c8d033e690a5ed145";
+      sha256 = "7fafefae0afc2142a01d7304cfeda60ce1f6302c29abe2d906391dcafea0f25a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/xh/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/xh/firefox-86.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "b8f0f3ee8aeeec6fdac5ee15cf688735809994c71cbe4f01b238a3cc1386006a";
+      sha256 = "0d177c264ec9b357be2e616fb02958b4c9d7c6baf292f3c76bbeae84fd2202bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/zh-CN/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/zh-CN/firefox-86.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "47b4f3411306839882f5755b3eb2038f9c7bfd1c2ae72927db54c4816c97217d";
+      sha256 = "2203d75b4a62bfe3cbb51c02665420700ea00686b7b9d4002b9a9a6ddca13f36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-x86_64/zh-TW/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/zh-TW/firefox-86.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "5fb11410c30a813fd0db58c928fb07c488405776308eacf64b238daa0fbffbc1";
+      sha256 = "7d19a8791c79c0bd9fa03ea568f896221cf6432c826f4a59f99ec78139966817";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ach/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ach/firefox-86.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "06d2dbe0f799d22e98b715528b54566b167a22db4d16d3ad60d84a6e6a8b9e5e";
+      sha256 = "caa9485d62e682e5b06e39528857975d1c862ef23e62c9f4147c5db4027c867f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/af/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/af/firefox-86.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "536fdd221aa5f872cc8028f39fcfa7b9eecfe09a215da3d50fbfa9e256a1394d";
+      sha256 = "ea114ce9ca7f2c4e5675d25224ffaf7805ec9361097ff47649bd4371937032f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/an/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/an/firefox-86.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "ba6eff6a355361862fc78879264965f5f1c0adebefe934d1b6d51994023d3bc4";
+      sha256 = "c022590875868195664c4920a3da7bec6bf9942a233190176827d603529a74f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ar/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ar/firefox-86.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "0b465097dcfd4f2a50eba984b0bb30fedceb1a409e2a98f22c45709cdd1117ae";
+      sha256 = "66ac4afbde7ed45e1d0239e3364c62f788ac26c8bd652b5c571a9f965ae632ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ast/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ast/firefox-86.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "614241f31f38a71782faf76f0a31cd81d2520523ff85d8a5dfee32a77e48829b";
+      sha256 = "3962d9728bc8a0fde06ab64d6da1f40328938db7689db7b402919191c5286f3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/az/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/az/firefox-86.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "4fd682f83c0eee3031c6e452d1c7cde3e54d0e52bb8316b0e2224360665d4fc4";
+      sha256 = "84e786225936123aec5c0f2bb27df9dafcd1ceb2e50e8235749dbc081adfd4eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/be/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/be/firefox-86.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "c15417c21f42212337bd921c869b05124a720c6d8730e4a16d30ddd9c10aca97";
+      sha256 = "0cfac785cbb8f0c179788dca2a54484473cdfd5e0618894665bbc70d4c2e36f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/bg/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/bg/firefox-86.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "fda51760d2dfa07d559673605120a34706f8a6546dc4e673dab55b71cbc501ec";
+      sha256 = "8c99908f307fa77fe6e92e58d26ea295471e6421181218fd0ca022c767e1f5f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/bn/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/bn/firefox-86.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "f61419c6dd7b20cbdc48cb0faf51cc831fa90f37a721a162bf32753d85a40aff";
+      sha256 = "28b303305691ea7f8228580135acde6c17d745719a96e82c60b8d6738fdf2bde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/br/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/br/firefox-86.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "7d60c5f6be2270e9b40612dfb1072ab5d29bd02d070f463f1df915f8d13873d3";
+      sha256 = "83a76a0e7dad03453178dbb3a792aab03500359b623851b9a6ec9a4c1e0af084";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/bs/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/bs/firefox-86.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "4707568c61df2d2050e3f1c18d3a2dee1c5bcfd091f32bd615f2e75ed06949fc";
+      sha256 = "0700c7d655136ac51134a6da9def1747a27d84ee21b523dfcc6f30042f9b8632";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ca-valencia/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ca-valencia/firefox-86.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "fe52cf8f5f531143ef28e728753610b442443de53f34a4a8d6318d5124a10caf";
+      sha256 = "d7738e186c6bd3f4a35c53bc6cf39876ad7774a45bbb3a44529c322f48a490b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ca/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ca/firefox-86.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "8e6baa8ac94878448f65598042d47b9789352fba55d4e4f91cbe319f9676780e";
+      sha256 = "ca63b150369c02a048ddbfaaa2f2faeb2729fb46086937c97a93d684975e2837";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/cak/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/cak/firefox-86.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "006a887bfaea07c40ee0f67ebccb1aa538f56e28f625cf2b085242c26ebe7bf0";
+      sha256 = "2a8a8ebe18dce87a021c71e87e2815b227b03e3251d141f044c083d7a4c942dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/cs/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/cs/firefox-86.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "27f1c5634e101d3681885a8d2d572b73f8c9db2215e4836a6cd71fbcd0a5b8dc";
+      sha256 = "5e60175642fa8260c4125b90412564fbd49b8f91ca204c30dc687108273184db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/cy/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/cy/firefox-86.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "9e56e8f88baae2a4c99ae12041ed9c766dedc99b7ffd75bffbba92a7c19d98b9";
+      sha256 = "ee6e49cc30f01f5604cdb317801ced10c24809ed64f6505f44b6a33cb359641a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/da/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/da/firefox-86.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "eb317f12d74ac8b636c87dfe9c1cb0ce267a15ffeedb79956e1c15e971d1b7e4";
+      sha256 = "8c447626d889aa067bd758a56e4dce720f01192e283c7e01997c6f85f0265f89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/de/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/de/firefox-86.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "8a736a3a9c257f2b4509e3ec2f74259f655369159981cfedf8468de9cb1fb22a";
+      sha256 = "12d52ecbf5c4b9313c3e9cb61a353f812319142c6b20594f7fbee01a339d98ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/dsb/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/dsb/firefox-86.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "a8fbd4dd6d1172f67744e9283efb6cb644421cb07e3568cae0d3c68c479d653b";
+      sha256 = "5064e20ca27adaf48d5c4041c12db3738c95b9143f667ddbc28230ef9387b28e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/el/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/el/firefox-86.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "59baec30ea1d8e30982f52279003b6e1be0148c02f38fdf283325c53ad900ee5";
+      sha256 = "a625d2caf3be1a5039a90c3515d1598b5acb87a4e4df4e0ea22f0a63b0405ae7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/en-CA/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/en-CA/firefox-86.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "a4e0ea60acf339a61c19272170d2efdb4f519325bf2f71bcbf82af70ca304af0";
+      sha256 = "cc1c18c8d4d53495fc4236c95b353bbe40c3de16ded002b2bb991a824fc67210";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/en-GB/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/en-GB/firefox-86.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6c82da02a7560977faad1ca3d4c3973d08583fc0ce75e1de6e5aee2c9d372b38";
+      sha256 = "c76f7607b28bfee12eebf2aae7590fea71ed2a4f3bb0ce3903f0331187640122";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/en-US/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/en-US/firefox-86.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "eeec3b446c30c65d4af72d04d58c6d5ddb04c13e871a5351921a737f7e1cf234";
+      sha256 = "fe6bb788d3c5264943ae5a287cee691f6aea8b3502f11e386f6d723a08dc545f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/eo/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/eo/firefox-86.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "4cbb1144cadfd901082829f8e67e311c51df96ecd08aa2082772421d6445f2fa";
+      sha256 = "39af3debe06726ddd02a4914bfecda2d023d9445e7c735e8974ad73f45955298";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/es-AR/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/es-AR/firefox-86.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "c875473caefc7e18a4f7a0a3e7d44ce659a2271fc1b21d435a70c921092b8af4";
+      sha256 = "2d66f2f28958157da1dfda56827f5330f6d7b9fb192899b2ad60ecd6d18e9505";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/es-CL/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/es-CL/firefox-86.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "d1bf9c2a1df028b5d6eca5b41c975afc6378701c6f33d888b46511da5ce5e498";
+      sha256 = "cb69afb6ac3b47721176934047ec9ab3b1127b7d36da7b9ae9af9aec72bb8289";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/es-ES/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/es-ES/firefox-86.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "5ee1967bc61259869441f61061fec2f24ee3a4179c64b245768387e94acafdce";
+      sha256 = "3c0ae2ce17078ef568ac71d5cf8ceb0769fdb8298ce17c58468cf57ab7a95af8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/es-MX/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/es-MX/firefox-86.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "6b4669581f26a18fbd0bda8d605b9d22b3aa98eb193ea81f7ebce1db4d39a263";
+      sha256 = "cd07a75c8c96ac8d31cb988d9d394e5e2eb9bb6cfd6df33d6e60d38a6406a4a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/et/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/et/firefox-86.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "0c41ec2c1df4cbd295d349a7b6ad7a7e974662319d4a1d458e9f6bd31c4830c0";
+      sha256 = "cced1ea2d54c9d305b61ff1d1025aaa5f23bfe86fca3b0e915f2dcde1384d042";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/eu/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/eu/firefox-86.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "e7bb380e013f5cf35edba5b698a5e3fafd7af63593c663e0029e2754f6854b4f";
+      sha256 = "9105eebe6f606292b82eda26eb68b399dd13e1756f1ca88395f0b7714089ea4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/fa/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/fa/firefox-86.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "d2601f3b84b31d9852a3f2ec35ae8b43f8640da18976f5f4c8a77cf7ad360a22";
+      sha256 = "9956fc5949d1e111265dfcd71373d8ada4cb2f554b9ffa2dbda0c430296ece56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ff/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ff/firefox-86.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "a13ee0463fc23cff51f88072d527a6b758fd313276cc7e5f3c8a0c4c8d5f5404";
+      sha256 = "02a6a2f711db26b74094744e9f198ddc05a1188fef0fa330949e9e5056c7ffba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/fi/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/fi/firefox-86.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "76a153c9e398eb259c69b30d15782b7d7a9ebd156283f1034c20182cd72e13f7";
+      sha256 = "368c2a59f1446d61a7a27892ddaaa5f933cbbcb9e3f238db5f9e9cb77873e37c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/fr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/fr/firefox-86.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "6f5d6e07251f75d6355f52558f2734d2788bb87e1e53ccfb800e03173094f765";
+      sha256 = "d543125a0e0402245064dc763eafcb3b00237c217a929b04f44db6755319ae2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/fy-NL/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/fy-NL/firefox-86.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "785a30a785e55158c7251e623683350ed4840bb4b6f002d34cdee82d91b33d10";
+      sha256 = "ad28252c39eac70b9ce15631c65dfe520950d36212a547587978c635bf835187";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ga-IE/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ga-IE/firefox-86.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "f32f8a0e5f0b5fd2a1dd147b32880605186a4b9435e39a53fc87f42eb8706979";
+      sha256 = "a16c0117757cadacc408f95a81e38b7f7e9489a4b6ceef30b8a65796fa6a2ca2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/gd/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/gd/firefox-86.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2893dd13353b3504a00e02f65f0b2a0a72dd43771148d45cca271aa752a0c520";
+      sha256 = "83b61f8e5801607f7b71fe2fa5fd7aede2cd56e4b46b25057935afb23f28ba01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/gl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/gl/firefox-86.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "b5bcf0eff53f6bda0e394be3e483c3f314d962a919473492a7d1005b6976b861";
+      sha256 = "a603031b44679e8e9dfa14c2094690c786b4ded18d736bb16d683e978346fefe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/gn/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/gn/firefox-86.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "c979d766174b2e4df72de6a375084b509e879f11a13c1972c97b5ba0accb67d7";
+      sha256 = "5146bded3c264c6a77a9e4e9a1c5523e63858eed5077e8ded56d52b94fafa7fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/gu-IN/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/gu-IN/firefox-86.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "0e053f93d56a8fd9c07bfef4e93f1f338f951f519be669f5ff18157ca4216025";
+      sha256 = "d177f05815889cd026879d6ddb3c03d3c62bb3b2787ca68a97902671977400e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/he/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/he/firefox-86.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "05435889024f622f69d82a0007c19b50b1842f2cfa558748b39859a94a7addaf";
+      sha256 = "c3534b56a9fb43e959c8c6055f6af0c1ce9e512bee8786fa4a1028ba0813cd73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/hi-IN/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hi-IN/firefox-86.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "7fb87408064c024305295c38938c42b34a0c627b177cacb00ed9e79a0ff974c8";
+      sha256 = "a4885b1515cee1352bd534de17742af432502169d8cf2f34426950a5482647cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/hr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hr/firefox-86.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "924141a867793aa4fb3d2b87b75c1d60cc39bb3a3591eaaf6ee3381fcf28fcc6";
+      sha256 = "1d9d49b4360efa296ec8b6750aaf8e09a24d749e3694d30dca446480b350a733";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/hsb/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hsb/firefox-86.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "7ce0f09c144462f9c94dc6805165543d12afbf0e44e327dae4554fecf272601e";
+      sha256 = "65b890ced9ffc672d92d8fe998ff4f5deb485f22ec4d1525525fac81ed30c2e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/hu/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hu/firefox-86.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "8997e6d5620e0f565939cd8f127c4e86da0c46828c66fab7333073c3cbb8054e";
+      sha256 = "90e32c53ad910ecce1558c99f10514775b72efc207451e9c61127051c92fe450";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/hy-AM/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hy-AM/firefox-86.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "aeff6c4b8c7d164b63bf22808ea234236f893e6da2b3d9142f95d89e9ec7178e";
+      sha256 = "02c1dc969487809e432f4053b39b996ffcf51c81c7827146d3cd7a25ff050abf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ia/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ia/firefox-86.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "0590e0469ac2e562325d786dcb68e2ca2111aa8ae1ff3717ef8db2259e6ec149";
+      sha256 = "81d027c3facbe67258151046d9aa53a7d832d1a120aa671532524c87b79efe80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/id/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/id/firefox-86.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "ef8dc62e52df3e6b1d37aea5f9b9a214a26e51ef9fd378f56ac8b2245de54613";
+      sha256 = "7a54acb6b8f14cac3d2a7e21fba5990dbaab9d4efef8d2a55642ff120905cbd9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/is/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/is/firefox-86.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "aeabfd51aa160ba259850b7fac88829f81bcc0dd8ccc9168c7add07ce0d4efc3";
+      sha256 = "c1611ebeceaf431883e5dd61b15aef2954007feaea3cc7503573216ba4cbcb0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/it/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/it/firefox-86.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "c6069c0a86344af00150be03cb0f2c26984b713ad386352f5a10b39b79b13cac";
+      sha256 = "76042e19b820c69b1d7d39f3be87069142a4fb6c0327b8f67f78b87821454cc9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ja/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ja/firefox-86.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "9be7b40e66723583b17657ea805919955dda703957ba21d541baa22390a1befe";
+      sha256 = "6e2d8fe15275935a02e3f07ebf14b61f657a35cdff262d50e3a0f10e3ff587be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ka/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ka/firefox-86.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "2e8a57b44b3bec627793f46df84f7f25ab0aedd0f8b1f08202c75cc58d7e14c1";
+      sha256 = "93f59b3150795ee6a1d5cd446cd0147f5ccee359939fcecae63a262f28eea0ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/kab/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/kab/firefox-86.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "5777a6b5eb3055ab2c93f98bc597343f13bff7d0a846809d24c97e9ba1a0ca7d";
+      sha256 = "d71c30914f32b0f5f25c1492e94d0a397997f946f1ff58c85997d9c6c55ddd4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/kk/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/kk/firefox-86.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "84a8fbf2a859d81aae2aae6bc95f12a8e2982cff77090072a01d28daccbf21f9";
+      sha256 = "9c3b1b80d46c75526c5c9b53229e74aa7cb7219a3110218ecbd099e1d05037ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/km/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/km/firefox-86.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "55982f15b467ddea6203fbcf98081496d0e313d3cd281f807d2bb75b4e79077e";
+      sha256 = "95b59cdaa6caeb5cfbcfc673faed614650dbd44458c79684ca7f2ee4ef678e4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/kn/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/kn/firefox-86.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "18aedab4f324448da412ddebd1da9b01be51edcd5052c9455672a763ae1f673b";
+      sha256 = "31d79f5609140fb213e19b60d638811ef576bb3db8be533aa92a02ffd22d4df5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ko/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ko/firefox-86.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "5baa361fb97a76d12bfbf5b87c092cbe8079d34dd08842dae9def133383f587a";
+      sha256 = "f05215e9004a651b239475bf02de19709fb2ceacd99f0da22ba4ae91dfd899f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/lij/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/lij/firefox-86.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "35bf3aeba596135231b1ddff2e2550ab2a3e0c5bc796d7b628c5f78ac46ce40f";
+      sha256 = "309ce372ace38efc2cd907df32d18fad97e8fe66728c52efcbc36a36e91163f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/lt/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/lt/firefox-86.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "eedf7ba2cf4634ab18c2f2926266845a29c9bce8ba747554d413b276445b9eb1";
+      sha256 = "1426fae07194ec4dde7fd797631cbb561726af5b1c255b72c13a96b54034a440";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/lv/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/lv/firefox-86.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "a1c5f04c16f6d50a0797e466d6a8836de40219567f04928cda7f64d967d8afa7";
+      sha256 = "48be4205b0d9ba8de2545a73950a4c2836db3d046707ae5db7e2cba0dadaa3a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/mk/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/mk/firefox-86.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "8de29502640b51ac9f586ae7713903612911cf01cd7aecb6d74175a816cce6a3";
+      sha256 = "6cc5019e2d41510a67cec8850451fa16e868da753dceb8a38a0cec893814f07a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/mr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/mr/firefox-86.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "f4cb4ddcac3b5ede422e54c69c05902506be788b45a79cfee6e21a0b7b8c3ca5";
+      sha256 = "ba73c1ceac1ad36912f6367a23bcdc4455627d16f2bb589cde4abb5304b06d67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ms/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ms/firefox-86.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "aa09b472e21b453f6875e25dc7922ca062934527a306f3b338cd32636076c021";
+      sha256 = "09935a83eb75eb9f89847d9b279c5728c524bef37d063969ec3e44346ef74c12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/my/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/my/firefox-86.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "4a4ad99aac0614aa25fd77c4c740c49f509db2333c37f797018362b15f38d1d4";
+      sha256 = "55b7adcbe1bb47dc49e1d51d99fa3b3a9aa3028a56fe2c53848ec9591503360a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/nb-NO/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/nb-NO/firefox-86.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "45814c2d731cd8435a92c31e9311c333d4357dc38e9196fbc24358289004df8b";
+      sha256 = "87e7f1d1ecb402f9484e40078a3460b18aa41d88f0bedf61edeb937474ab3e69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ne-NP/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ne-NP/firefox-86.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "008ecc3d7bf7932a320b6ec12404a5259032930539a65e60f8aa2f98f9018524";
+      sha256 = "0c5e84344df03c41ab835c3af847772d13fe48d3395fc2aeef020eab04f76baa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/nl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/nl/firefox-86.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "0202adc844602502b48d078a665b1e9012c65172deda406ac9db972e05456fc7";
+      sha256 = "75f54fc189ee6f43277066a2600bd340375fa5820e64dc340a3ac93a1f0a6ea0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/nn-NO/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/nn-NO/firefox-86.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "28f34c957628178a112ad6a7c16d9dd20e58bc3a9068fb1e59ef5e656ac8f02f";
+      sha256 = "e1dd0adfc33ac73890d849c685d3072a8bfbe6ad3b5ad0bcfa0a04c9ec817c1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/oc/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/oc/firefox-86.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "4645cc6de115ff73444dfa4165a82b3ba1b0adbe3c4eff6fd854c9ec594a7bbb";
+      sha256 = "2eea8f40976373fa98d7d32c016dbf0e05fb8f53f3c0f038a087220ea91999a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/pa-IN/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/pa-IN/firefox-86.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "3fbe8e5c7b4fb420a6a6c62475bd01fead342d7431578b96f391a829cf184be4";
+      sha256 = "03c1dface09201be51bd8df92a420b67ce885a712231754dec5e42a4e5cb8cd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/pl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/pl/firefox-86.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "6850d14c02c152fb6252b08a111ff6bccbaee6a6ff76a99c018b497a8a014ab0";
+      sha256 = "1d4fad5713d1b6606551aa9b9527c4919e548fc9fb50b921404609dd7a43c76f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/pt-BR/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/pt-BR/firefox-86.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "a0aac09a39302df30a48c54e64ae422166eb781ef349dbc58927e077310fae5f";
+      sha256 = "53defe8219ee88152a542e24526a3bb9d75e0117e606a3e976d798f441acd64e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/pt-PT/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/pt-PT/firefox-86.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "e577444bd6ef376b0277cc2181bf50bc1ac3e377bed171f30616f536fa2d516b";
+      sha256 = "d91483eca2e1972ce6a0ac97b0393a9cf28a36eb1e923cd863d37b8fc66f4edd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/rm/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/rm/firefox-86.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "2a4f5f35caa3ec5b9f20c1160dd038ce3d689593650771c3e63246cc53b23cfe";
+      sha256 = "926234371843aae60cc81886ab7ebaca7bceb6f705ab9d2560ddf996e46f6aa3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ro/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ro/firefox-86.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "c68f195f10bcd7d19aa76084450419008068ee5d30c34acc02d7621ea250211a";
+      sha256 = "9c63bcf8b603b65f355460d0de6827e363ec0797bddb9d446e116b641a5f430e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ru/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ru/firefox-86.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "e6e7dcc74dac1c331d3202a141df71dbe2e5a398e2b97c9da1358707823d76b4";
+      sha256 = "f4cb8e70dd3c0b2bb97b28c6f85654786f65daf6705559a3dba87a5aa4f0ae18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/si/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/si/firefox-86.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "1bf321805bd46e0214568921b89eaf5ea4d394e43fb1d475ee61c7de8439d997";
+      sha256 = "b305cfa2be37591ae0bf49de8da37ffa3a5c69b242196073d84124dd02dd094e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/sk/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sk/firefox-86.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "221667dd6eead982d13e911e0ee9d6fb0e6288d689c59c7adc403e8eeab6fd4f";
+      sha256 = "23772e40241f955d20a1579f283c6d648e180ae7da21ef0a914156733f89e6a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/sl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sl/firefox-86.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "5df6f40394d0c2561c5103cb0600d3566b2bf42dca4d6a3194bee725577f1dad";
+      sha256 = "7213f902b853bbce4594db2f5555e437a82adaeb506a9d1421ff9015d29a9659";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/son/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/son/firefox-86.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "8ce2f3d67ea7e1889fce2f534e90320403350b27bd63e97263a9c14544d7f212";
+      sha256 = "7b45520bd7305b28803bd4e2f22d41216707754ef46cf6981f0c299b03efeedc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/sq/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sq/firefox-86.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "a4f403eefa8da37d7308bda7a10cf62dbe9ff74f848e9e3603d9b787c1629b05";
+      sha256 = "11b0b971a705d483f3dd7fab066d034f0a30dd95e16bb7d7aece44d8ccabf450";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/sr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sr/firefox-86.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "7f3d5fb8cb77c2405403f9899257d41f4e9fcdb45a1af945e337228d7648f79d";
+      sha256 = "07369958e98d1959be2e52b33145ed1075dd85220de38fcaf617d207217a0066";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/sv-SE/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sv-SE/firefox-86.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "261886fc3f3c9c40123a6b6ae0040fffb281d90cbc34506f85bcd73cb94276f2";
+      sha256 = "7671a24d1b81b26c34a21cedea05b6c132963045d3cbc28ee264f9c56302cefd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ta/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ta/firefox-86.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "3df7b4c5eb395b123d8c9a67d58e2eda268bd931394e38941545cded144b97e7";
+      sha256 = "bf605ceac99dfc2ed058ada9bb9fbd7ae56fdea3453d7dea23ca13dc284391bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/te/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/te/firefox-86.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "b27fe9f6d6e4920e5714a74f439900238900e164cce584f1a1548a02105caa10";
+      sha256 = "8aea95f2069a59cbb575f386a7e90d04ecd0f4c4139aefc6dcba54b9b56e7aac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/th/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/th/firefox-86.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "e4eadb2885d09a082c40e27eb41e5a8f721ddd45ef79ed0ccba02f18d7fc3d6a";
+      sha256 = "4985ee399155bd0854c9b9068fa747f396855b1251610c3261fc5c7da5e5894c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/tl/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/tl/firefox-86.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "392368f316cf89668e2ff9a42e0b170b55bfc610c84b0a605866914a39273fce";
+      sha256 = "d328338029e0282ca5e3c7e0bcff73faddfbb4bdcb47a2978622c80e2dd8d0b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/tr/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/tr/firefox-86.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "e9c7f55b656860dc6d2b28fcca66dbc6e7290d2f418da238ca06ccfe68fdd579";
+      sha256 = "a438f5504b0fb62173a8a739645e7f269647e33316a35a96c5dce71d9d87bb0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/trs/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/trs/firefox-86.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "9cd24da9a1dbc0665b589ea8d1f5e5a3546a8b7babbd0f9f2f27641d5c81eeaf";
+      sha256 = "41c90f6a5de249fc5b0dcec21d5d2684b5d3be2767d6073529101f31bec569a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/uk/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/uk/firefox-86.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "0bbd4c03dd422901bf2ff1a6e000ec4c6ed798bfa66ade8db03551f5509efc40";
+      sha256 = "06419fe5e671a6476500a8ecfe736237adbafdb39148d56d514fc7f07ff09e87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/ur/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ur/firefox-86.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "c0f807c2c7365f281d921fd347a173ce2538fce79b1e74beedf928f392422236";
+      sha256 = "f5c1729584fc7843da5febf2411196d4615d4d5b490dc9a0f7b0709496b61ad0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/uz/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/uz/firefox-86.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "f561501fdf1a0edf9f58289fe608b9d47c00ef666c7f980972f0f3112470ad27";
+      sha256 = "a1a898dae70288fac86c0ff36b92731e7b3400652b5bef485db73cd8ed933e8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/vi/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/vi/firefox-86.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "12ce7eae83ef3100039871e82784ba7a63742ef8f132c48ceccac22641074c1e";
+      sha256 = "7c12e8fe3b30ae8b8bb106a3ce866b23dcdcdb7924ca41e8c9b3d541e0300963";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/xh/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/xh/firefox-86.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "9def9420b6e6e252839268167e978cc357add46e54e77a0f5bf8e03a2183a855";
+      sha256 = "97f40f99c9d0204db12d1da1e58088dac2fcd02be6f4fd5c477d20f0149d1f56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/zh-CN/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/zh-CN/firefox-86.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "03cea12f34a9eb22e730d6b28f294bc2a1578e9c357a15bcf189ab1fb925e337";
+      sha256 = "309e7670632171133fef52c1426a1f42fb4e14c4d99a8f9543439b21105425f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0/linux-i686/zh-TW/firefox-86.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/zh-TW/firefox-86.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "cf5e5cdf7230bf231f63750b3747b625d64026194c29b36c3d00ff9851960745";
+      sha256 = "5993ffa86327a42ea91aa884e90bdb8626d4108a8299acb2f80623e8aaf3ed3e";
     }
     ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Fixed a frequent Linux crash on browser launch
- Other fixes

https://www.mozilla.org/en-US/firefox/86.0.1/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
