### PR TITLE
7zz: init at 21.01

### DIFF
--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchurl, autoPatchelfHook }:
+
+let platform =       if stdenv.isi686    then "x86"
+                else if stdenv.isx86_64  then "x64"
+                else if stdenv.isAarch32 then "arm"
+                else if stdenv.isAarch64 then "arm64"
+                else throw "Unsupported architecture";
+
+    url = "https://7-zip.org/a/7z2101-linux-${platform}.tar.xz";
+
+    hashes = {
+      x86 = "0k6vg85ld8i2pcv5sv3xbvf3swqh9qj8hf2jcpadssys3yyidqyj";
+      x64 = "1yfanx98fizj8d2s87yxgsy30zydx7h5w9wf4wy3blgsp0vkbjb3";
+      arm = "04iah9vijm86r8rbkhxig86fx3lpag4xi7i3vq7gfrlwkymclhm1";
+      arm64 = "0a26ginpb22aydcyvffxpbi7lxh4sgs9gb6cj96qqx7cnf7bk2ri";
+    };
+    sha256 = hashes."${platform}";
+
+in stdenv.mkDerivation {
+  pname = "7zz";
+  version = "21.01";
+
+  src = fetchurl { inherit url sha256; };
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D -t $out/bin 7zz
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Command line archiver utility";
+    homepage = "https://www.7-zip.org";
+
+    # source not released yet. will be under LGPL 2.1+ with RAR exception
+    license = licenses.unfree;
+
+    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
+    maintainers = with maintainers; [ anna328p ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -630,6 +630,8 @@ in
 
   _6tunnel = callPackage ../tools/networking/6tunnel { };
 
+  _7zz = callPackage ../tools/archivers/7zz { };
+
   _9pfs = callPackage ../tools/filesystems/9pfs { };
 
   a2ps = callPackage ../tools/text/a2ps { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add 7zz, the new Linux version of 7-zip, meant to replace p7zip, built on the updated Windows codebase by Igor Pavlov.

The source hasn't been released yet, so I'm fetching and patching binaries for now. When the source _is_ released, I will be building it natively.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
