### PR TITLE
pythonPackages.packaging: Fix cross compilation

### DIFF
--- a/pkgs/development/python-modules/packaging/default.nix
+++ b/pkgs/development/python-modules/packaging/default.nix
@@ -6,6 +6,7 @@
 , pytestCheckHook
 , pretend
 , flit-core
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -22,19 +23,17 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  propagatedBuildInputs = [ pyparsing six ];
+  propagatedBuildInputs = [ pyparsing setuptools six ];
 
   checkInputs = [
     pytestCheckHook
     pretend
   ];
 
-  checkPhase = ''
-    py.test tests
-  '';
-
   # Prevent circular dependency
   doCheck = false;
+
+  pythonImportsCheck = [ "packaging" ];
 
   meta = with lib; {
     description = "Core utilities for Python packages";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
```
nix-build -A pkgsCross.aarch64-multiplatform.python3Packages.packaging
```


```
error: build of '/nix/store/0xbsw9pqm6sblz1nq92gmw0nxz3dcs1d-python3.8-packaging-20.8-aarch64-unknown-linux-gnu.drv' on 'ssh://martha.r' failed: error: --- Error --- nix-daemon                                                                                                                                                                            builder for '/nix/store/0xbsw9pqm6sblz1nq92gmw0nxz3dcs1d-python3.8-packaging-20.8-aarch64-unknown-linux-gnu.drv' failed with exit code 2; last 10 log lines:                      File "<frozen importlib._bootstrap>", line 1014, in _gcd_import                                                                                                               File "<frozen importlib._bootstrap>", line 991, in _find_and_load                                                                                                             File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked                                                                                                    File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed                                                                                                  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import                                                                                                               File "<frozen importlib._bootstrap>", line 991, in _find_and_load                                                                                                             File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked                                                                                                  ModuleNotFoundError: No module named 'setuptools'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       builder for '/nix/store/0xbsw9pqm6sblz1nq92gmw0nxz3dcs1d-python3.8-packaging-20.8-aarch64-unknown-linux-gnu.drv' failed with exit code 1
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
