### PR TITLE
ocamlformat: 0.16.0 -> 0.17.0

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -48,5 +48,9 @@ rec {
     version = "0.16.0";
   };
 
-  ocamlformat = ocamlformat_0_16_0;
+  ocamlformat_0_17_0 = mkOCamlformat {
+    version = "0.17.0";
+  };
+
+  ocamlformat = ocamlformat_0_17_0;
 }

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -20,6 +20,7 @@ let src =
       "0.15.0" = "0190vz59n6ma9ca1m3syl3mc8i1smj1m3d8x1jp21f710y4llfr6";
       "0.15.1" = "1x6fha495sgk4z05g0p0q3zfqm5l6xzmf6vjm9g9g7c820ym2q9a";
       "0.16.0" = "1vwjvvwha0ljc014v8jp8snki5zsqxlwd7x0dl0rg2i9kcmwc4mr";
+      "0.17.0" = "0f1lxp697yq61z8gqxjjaqd2ns8fd1vjfggn55x0gh9dx098p138";
     }."${version}";
   }
 ; in
@@ -36,12 +37,33 @@ buildDunePackage rec {
   pname = "ocamlformat";
   inherit src version;
 
-  minimumOCamlVersion = "4.06";
+  minimumOCamlVersion =
+    if lib.versionAtLeast version "0.17.0"
+    then "4.08"
+    else "4.06";
 
   useDune2 = true;
 
   buildInputs =
-    if lib.versionAtLeast version "0.15.1"
+    if lib.versionAtLeast version "0.17.0"
+    then [
+      base
+      cmdliner
+      fpath
+      odoc
+      re
+      stdio
+      uuseg
+      uutf
+      fix
+      menhir
+      dune-build-info
+      ocaml-version
+      # Changed since 0.16.0:
+      (ppxlib.override { version = "0.22.0"; })
+      ocaml-migrate-parsetree-2-1
+    ]
+    else if lib.versionAtLeast version "0.15.1"
     then [
       base
       cmdliner

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10810,7 +10810,7 @@ in
     ocamlformat # latest version
     ocamlformat_0_11_0 ocamlformat_0_12 ocamlformat_0_13_0 ocamlformat_0_14_0
     ocamlformat_0_14_1 ocamlformat_0_14_2 ocamlformat_0_14_3 ocamlformat_0_15_0
-    ocamlformat_0_15_1 ocamlformat_0_16_0;
+    ocamlformat_0_15_1 ocamlformat_0_16_0 ocamlformat_0_17_0;
 
   orc = callPackage ../development/compilers/orc { };
 


### PR DESCRIPTION
Adds `ocamlformat_0_17_0` and update `ocamlformat`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
