### PR TITLE
empty: init at 0.6.21b

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2375,6 +2375,12 @@
     githubId = 10913120;
     name = "Dje4321";
   };
+  djwf = {
+    email = "dave@weller-fahy.com";
+    github = "djwf";
+    githubId = 73162;
+    name = "David J. Weller-Fahy";
+  };
   dkabot = {
     email = "dkabot@dkabot.com";
     github = "dkabot";

--- a/pkgs/tools/misc/empty/0.6-Makefile.patch
+++ b/pkgs/tools/misc/empty/0.6-Makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 1fe4c41..2c69558 100644
+--- a/Makefile
++++ b/Makefile
+@@ -16,7 +16,7 @@ LIBS =	-lutil
+ PREFIX = /usr/local
+ 
+ all:
+-	${CC} ${CFLAGS} -Wall ${LIBS} -o empty empty.c
++	${CC} ${CFLAGS} -Wall -o empty empty.c ${LIBS}
+ 
+ FreeBSD:	all
+ NetBSD:		all

--- a/pkgs/tools/misc/empty/default.nix
+++ b/pkgs/tools/misc/empty/default.nix
@@ -1,0 +1,46 @@
+{ fetchzip, lib, stdenv, which }:
+
+stdenv.mkDerivation rec {
+  pname = "empty";
+  version = "0.6.21b";
+
+  src = fetchzip {
+    url = "mirror://sourceforge/${pname}/${pname}/${pname}-${version}.tgz";
+    sha256 = "1rkixh2byr70pdxrwr4lj1ckh191rjny1m5xbjsa7nqw1fw6c2xs";
+    stripRoot = false;
+  };
+
+  patches = [
+    ./0.6-Makefile.patch
+  ];
+
+  nativeBuildInputs = [ which ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postPatch = ''
+    rm empty
+  '';
+
+  meta = with lib; {
+    homepage = "http://empty.sourceforge.net";
+    description = "A simple tool to automate interactive terminal applications";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    longDescription = ''
+      The empty utility provides an interface to execute and/or interact with
+      processes under pseudo-terminal sessions (PTYs). This tool is definitely
+      useful in programming of shell scripts designed to communicate with
+      interactive programs like telnet, ssh, ftp, etc. In some cases empty can
+      be the simplest replacement for TCL/expect or other similar programming
+      tools because empty:
+
+      - can be easily invoked directly from shell prompt or script
+      - does not use TCL, Perl, PHP, Python or anything else as an underlying language
+      - is written entirely in C
+      - has small and simple source code
+      - can easily be ported to almost all UNIX-like systems
+    '';
+    maintainers = [ maintainers.djwf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4099,6 +4099,8 @@ in
 
   emem = callPackage ../applications/misc/emem { };
 
+  empty = callPackage ../tools/misc/empty { };
+
   emulsion = callPackage ../applications/graphics/emulsion {
     inherit (darwin.apple_sdk.frameworks) AppKit CoreGraphics CoreServices Foundation OpenGL;
   };


### PR DESCRIPTION
The program `empty` is not in nixpkgs.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
