### PR TITLE
ocamlPackages.ppx_import: 1.7.1 → 1.8.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -1,27 +1,28 @@
-{ lib, fetchurl, buildDunePackage, ocaml
-, ounit, ppx_deriving, ppx_tools_versioned
-, ppxlib, ocaml-migrate-parsetree
+{ lib, fetchurl, buildDunePackage
+, ppx_tools_versioned
+, ocaml-migrate-parsetree
+, ounit, ppx_deriving, ppxlib
 }:
 
 buildDunePackage rec {
   pname = "ppx_import";
-  version = "1.7.1";
+  version = "1.8.0";
 
   useDune2 = true;
 
   minimumOCamlVersion = "4.04";
 
   src = fetchurl {
-    url = "https://github.com/ocaml-ppx/ppx_import/releases/download/v${version}/ppx_import-v${version}.tbz";
-    sha256 = "16dyxfb7syz659rqa7yq36ny5vzl7gkqd7f4m6qm2zkjc1gc8j4v";
+    url = "https://github.com/ocaml-ppx/ppx_import/releases/download/v${version}/ppx_import-${version}.tbz";
+    sha256 = "0zqcj70yyp4ik4jc6jz3qs2xhb94vxc6yq9ij0d5cyak28klc3gv";
   };
 
   propagatedBuildInputs = [
-    ppxlib ppx_tools_versioned ocaml-migrate-parsetree
+    ppx_tools_versioned ocaml-migrate-parsetree
   ];
 
   doCheck = true;
-  checkInputs = [ ounit ppx_deriving ];
+  checkInputs = [ ounit ppx_deriving ppxlib ];
 
   meta = {
     description = "A syntax extension that allows to pull in types or signatures from other compiled interface files";


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.12 (drop dependency on `ppxlib`).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
