### PR TITLE
factorio: 1.1.26 -> 1.1.27

### DIFF
--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -36,6 +36,7 @@ let
     only_admins_can_pause_the_game = true;
     autosave_only_on_server = true;
     admins = [];
+    non_blocking_saving = cfg.nonBlockingSaving;
   } // cfg.extraSettings;
   serverSettingsFile = pkgs.writeText "server-settings.json" (builtins.toJSON (filterAttrsRecursive (n: v: v != null) serverSettings));
   modDir = pkgs.factorio-utils.mkModDirDrv cfg.mods;
@@ -191,6 +192,15 @@ in
         example = 10;
         description = ''
           Autosave interval in minutes.
+        '';
+      };
+      nonBlockingSaving = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Highly experimental feature, enable only at your own risk of losing your saves.
+          On UNIX systems, server will fork itself to create an autosave.
+          Autosaving on connected Windows clients will be disabled regardless of autosave_only_on_server option.
         '';
       };
     };

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -10,12 +10,12 @@
         "version": "1.1.27"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.26.tar.xz",
+        "name": "factorio_alpha_x64-1.1.27.tar.xz",
         "needsAuth": true,
-        "sha256": "0wv1yv5v77h09nk2skfabqmxys40d806x09kac3jja1lhhr4hzl2",
+        "sha256": "0s8qnr2p819r4pjby71jp5in679yvsz235iy1csmjjm2d2q6igln",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.26/alpha/linux64",
-        "version": "1.1.26"
+        "url": "https://factorio.com/get-download/1.1.27/alpha/linux64",
+        "version": "1.1.27"
       }
     },
     "demo": {
@@ -28,12 +28,12 @@
         "version": "1.1.27"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.1.26.tar.xz",
+        "name": "factorio_demo_x64-1.1.27.tar.xz",
         "needsAuth": false,
-        "sha256": "1b6rjyhjvdhdb0d3drjpjc1v8398amcz8wmh3d84gl3aafflfl1x",
+        "sha256": "0cgnv6w8bxxskf0gxqcg9hq0zl4idnwh5d61b0510axah1m6i57z",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.26/demo/linux64",
-        "version": "1.1.26"
+        "url": "https://factorio.com/get-download/1.1.27/demo/linux64",
+        "version": "1.1.27"
       }
     },
     "headless": {
@@ -46,12 +46,12 @@
         "version": "1.1.27"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.26.tar.xz",
+        "name": "factorio_headless_x64-1.1.27.tar.xz",
         "needsAuth": false,
-        "sha256": "08hnyycwsj6srp2kcvnh5rixlcifk17r2814fr1g7jbdx7rp14mj",
+        "sha256": "08bny927jiph0zj101yx2wirm16194sap3ifk9rs582s506i1p2w",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.26/headless/linux64",
-        "version": "1.1.26"
+        "url": "https://factorio.com/get-download/1.1.27/headless/linux64",
+        "version": "1.1.27"
       }
     }
   }


### PR DESCRIPTION
###### Motivation for this change
Some friends wanted to play

Also added an option to enable the `nonBlockingSaving` feature

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
