### PR TITLE
pythonPackages.xmldiff: init at 2.4

### DIFF
--- a/pkgs/development/python-modules/xmldiff/default.nix
+++ b/pkgs/development/python-modules/xmldiff/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, lxml
+, setuptools
+, six
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "xmldiff";
+  version = "2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Bb6iDOHyyWeGg7zODDupmB+H2StwnRkOAYvL8Efsz2M=";
+  };
+
+  propagatedBuildInputs = [ lxml setuptools six ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Shoobx/xmldiff";
+    description = "Creates diffs of XML files";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sfrijters ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8850,6 +8850,8 @@ in {
 
   xml2rfc = callPackage ../development/python-modules/xml2rfc { };
 
+  xmldiff = callPackage ../development/python-modules/xmldiff { };
+
   xmljson = callPackage ../development/python-modules/xmljson { };
 
   xmlschema = callPackage ../development/python-modules/xmlschema { };


### PR DESCRIPTION
###### Motivation for this change

Package that I need - the latest release 2.4 is from 2019, but there is still recent activity on the GitHub repo, so it seems to be still alive.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
