### PR TITLE
python3Packages.ntc-templates: 1.6.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/ntc-templates/default.nix
+++ b/pkgs/development/python-modules/ntc-templates/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , isPy27
+, poetry-core
 , textfsm
 , pytestCheckHook
 , ruamel_yaml
@@ -10,22 +11,36 @@
 
 buildPythonPackage rec {
   pname = "ntc-templates";
-  version = "1.6.0";
+  version = "2.0.0";
+  format = "pyproject";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "networktocode";
     repo = pname;
-    rev = "dc27599b0c5f3bb6ff23049e781b5dab2849c2c3";  # not tagged
-    sha256 = "1vg5y5c51vc9dj3b8qcffh6dz85ri11zb1azxmyvgbq86pcvbx9f";
+    rev = "v${version}";
+    sha256 = "05ifbzps9jxrrkrqybsdbm67jhynfcjc298pqkhp21q5jwnlrl72";
   };
 
-  propagatedBuildInputs = [ textfsm ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
-  checkInputs = [ pytestCheckHook ruamel_yaml yamllint ];
+  propagatedBuildInputs = [
+    textfsm
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    ruamel_yaml
+    yamllint
+  ];
 
   # https://github.com/networktocode/ntc-templates/issues/743
-  disabledTests = [ "test_raw_data_against_mock" "test_verify_parsed_and_reference_data_exists" ];
+  disabledTests = [
+    "test_raw_data_against_mock"
+    "test_verify_parsed_and_reference_data_exists"
+  ];
 
   meta = with lib; {
     description = "TextFSM templates for parsing show commands of network devices";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/networktocode/ntc-templates/releases/tag/v1.7.0
https://github.com/networktocode/ntc-templates/releases/tag/v2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
