### PR TITLE
texworks: 0.6.5 -> 0.6.6

### DIFF
--- a/pkgs/applications/editors/texworks/default.nix
+++ b/pkgs/applications/editors/texworks/default.nix
@@ -1,26 +1,18 @@
-{ mkDerivation, lib, fetchFromGitHub, fetchpatch, cmake, pkg-config
+{ mkDerivation, lib, fetchFromGitHub, cmake, pkg-config
 , qtscript, poppler, hunspell
 , withLua ? true, lua
 , withPython ? true, python3 }:
 
 mkDerivation rec {
   pname = "texworks";
-  version = "0.6.5";
+  version = "0.6.6";
 
   src = fetchFromGitHub {
     owner = "TeXworks";
     repo = "texworks";
     rev = "release-${version}";
-    sha256 = "1lw1p4iyzxypvjhnav11g6rwf6gx7kyzwy2iprvv8zzpqcdkjp2z";
+    sha256 = "0l8jl1b8lpas7yz6m0qc2nikyn54lx2ljzmjjz3zgxgd6l502006";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-compilation-with-qt-5.15.patch";
-      url = "https://github.com/TeXworks/texworks/commit/a5352a3a94e3685125650b65e6197de060326cc2.patch";
-      sha256 = "0pf7h1m11x0s039bxknm7rxdp9b4g8ch86y38jlyy56c74mw97i6";
-    })
-  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ qtscript poppler hunspell ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
