### PR TITLE
aws-sdk-cpp: propagate Security framework

### DIFF
--- a/pkgs/development/libraries/aws-c-cal/default.nix
+++ b/pkgs/development/libraries/aws-c-cal/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ aws-c-common openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [ aws-c-common openssl ];
+
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"

--- a/pkgs/development/libraries/aws-c-io/default.nix
+++ b/pkgs/development/libraries/aws-c-io/default.nix
@@ -13,14 +13,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ aws-c-cal aws-c-common s2n-tls] ++ lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [ aws-c-cal aws-c-common s2n-tls];
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
     "-DCMAKE_MODULE_PATH=${aws-c-common}/lib/cmake"
   ];
-
-  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-Wno-error";
 
   meta = with lib; {
     description = "AWS SDK for C module for IO and TLS";

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -26,11 +26,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     curl openssl s2n-tls zlib
-    aws-c-cal aws-c-common aws-c-event-stream aws-c-io aws-checksums
+    aws-c-common aws-c-event-stream aws-checksums
   ] ++ lib.optionals (stdenv.isDarwin &&
                         ((builtins.elem "text-to-speech" apis) ||
                          (builtins.elem "*" apis)))
          [ CoreAudio AudioToolbox ];
+
+  # propagation is needed for Security.framework to be available when linking
+  propagatedBuildInputs = [ aws-c-cal aws-c-io ];
 
   cmakeFlags = [
     "-DBUILD_DEPS=OFF"


### PR DESCRIPTION
We need to propagate the Security framework to avoid getting

ld: file not found: /System/Library/Frameworks/Security.framework/Versions/A/Security for architecture x86_64

on linking aws-sdk-cpp libraries.
