### PR TITLE
cockatrice: 2.8.0 -> 2.8.1-beta

### DIFF
--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -4,7 +4,7 @@
 
 mkDerivation rec {
   pname = "cockatrice";
-  version = "2021-01-26-Release-2.8.0";
+  version = "2021-02-03-Development-2.8.1-beta";
 
   src = fetchFromGitHub {
     owner = "Cockatrice";

--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -22,7 +22,7 @@ mkDerivation rec {
   meta = {
     homepage = "https://github.com/Cockatrice/Cockatrice";
     description = "A cross-platform virtual tabletop for multiplayer card games";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ evanjs ];
     platforms = with lib.platforms; linux;
   };

--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -10,7 +10,7 @@ mkDerivation rec {
     owner = "Cockatrice";
     repo = "Cockatrice";
     rev = version;
-    sha256 = "0q8ffcklb2b7hcqhy3d2f9kz9aw22pp04pc9y4sslyqmf17pwnz9";
+    sha256 = "0g1d7zq4lh4jf08mvvgp6m2r2gdvy4y1mhf46c0s8607h2l8vavh";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
New version of Cockatrice

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Launched Cockatrice after local install with nix-env -f . -iA cockatrice in a clone of nixpkgs
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
