### PR TITLE
nixos/hledger-web: add stateDir, use own user, fix ExecStart

### DIFF
--- a/nixos/modules/services/web-apps/hledger-web.nix
+++ b/nixos/modules/services/web-apps/hledger-web.nix
@@ -26,12 +26,28 @@ in {
       '';
     };
 
-    capabilities = mkOption {
-      type = types.commas;
-      default = "view";
-      description = ''
-        Enable the view, add, and/or manage capabilities. E.g. view,add
-      '';
+    capabilities = {
+      view = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Enable the view capability.
+        '';
+      };
+      add = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the add capability.
+        '';
+      };
+      manage = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the manage capability.
+        '';
+      };
     };
 
     stateDir = mkOption {
@@ -86,6 +102,11 @@ in {
     users.groups.hledger = {};
 
     systemd.services.hledger-web = let
+      capabilityString = with cfg.capabilities; concatStringsSep "," (
+        (optional view "view")
+        ++ (optional add "add")
+        ++ (optional manage "manage")
+      );
       serverArgs = with cfg; escapeShellArgs ([
         "--serve"
         "--host=${host}"

--- a/nixos/modules/services/web-apps/hledger-web.nix
+++ b/nixos/modules/services/web-apps/hledger-web.nix
@@ -34,11 +34,22 @@ in {
       '';
     };
 
-    journalFile = mkOption {
+    stateDir = mkOption {
       type = types.path;
-      example = "/home/hledger/.hledger.journal";
+      default = "/var/lib/hledger-web";
       description = ''
-        Input journal file.
+        Path the service has access to. If left as the default value this
+        directory will automatically be created before the hledger-web server
+        starts, otherwise the sysadmin is responsible for ensuring the
+        directory exists with appropriate ownership and permissions.
+      '';
+    };
+
+    journalFiles = mkOption {
+      type = types.listOf types.str;
+      default = [ ".hledger.journal" ];
+      description = ''
+        Paths to journal files relative to <option>services.hledger-web.stateDir</option>.
       '';
     };
 
@@ -50,28 +61,61 @@ in {
         Base URL, when sharing over a network.
       '';
     };
+
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "--forecast" ];
+      description = ''
+        Extra command line arguments to pass to hledger-web.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
-    systemd.services.hledger-web = {
+
+    users.users.hledger = {
+      name = "hledger";
+      group = "hledger";
+      isSystemUser = true;
+      home = cfg.stateDir;
+      useDefaultShell = true;
+    };
+
+    users.groups.hledger = {};
+
+    systemd.services.hledger-web = let
+      serverArgs = with cfg; escapeShellArgs ([
+        "--serve"
+        "--host=${host}"
+        "--port=${toString port}"
+        "--capabilities=${capabilityString}"
+        (optionalString (cfg.baseUrl != null) "--base-url=${cfg.baseUrl}")
+        (optionalString (cfg.serveApi) "--serve-api")
+      ] ++ (map (f: "--file=${stateDir}/${f}") cfg.journalFiles)
+        ++ extraOptions);
+    in {
       description = "hledger-web - web-app for the hledger accounting tool.";
       documentation = [ https://hledger.org/hledger-web.html ];
       wantedBy = [ "multi-user.target" ];
       after = [ "networking.target" ];
-      serviceConfig = {
-        ExecStart = ''
-          ${pkgs.hledger-web}/bin/hledger-web \
-          --host=${cfg.host} \
-          --port=${toString cfg.port} \
-          --file=${cfg.journalFile}  \
-          "--capabilities=${cfg.capabilities}" \
-          ${optionalString (cfg.baseUrl != null) "--base-url=${cfg.baseUrl}"} \
-          ${optionalString (cfg.serveApi) "--serve-api"}
-        '';
-        Restart = "always";
-      };
+      serviceConfig = mkMerge [
+        {
+          ExecStart = "${pkgs.hledger-web}/bin/hledger-web ${serverArgs}";
+          Restart = "always";
+          WorkingDirectory = cfg.stateDir;
+          User = "hledger";
+          Group = "hledger";
+          PrivateTmp = true;
+        }
+        (mkIf (cfg.stateDir == "/var/lib/hledger-web") {
+          StateDirectory = "hledger-web";
+        })
+      ];
     };
+
   };
 
-  meta.maintainers = with lib.maintainers; [ marijanp ];
+  meta.maintainers = with lib.maintainers; [ marijanp erictapen ];
 }

--- a/nixos/tests/hledger-web.nix
+++ b/nixos/tests/hledger-web.nix
@@ -13,25 +13,21 @@ rec {
   name = "hledger-web";
   meta.maintainers = with lib.maintainers; [ marijanp ];
 
-  nodes = {
-    server = { config, pkgs, ... }: rec {
+  nodes = rec {
+    server = { config, pkgs, ... }: {
       services.hledger-web = {
         host = "127.0.0.1";
         port = 5000;
         enable = true;
-        journalFile = journal;
       };
-      networking.firewall.allowedTCPPorts = [ services.hledger-web.port ];
+      networking.firewall.allowedTCPPorts = [ config.services.hledger-web.port ];
+      systemd.services.hledger-web.preStart = ''
+        ln -s ${journal} /var/lib/hledger-web/.hledger.journal
+      '';
     };
-    apiserver = { config, pkgs, ... }: rec {
-      services.hledger-web = {
-        host = "127.0.0.1";
-        port = 5000;
-        enable = true;
-        serveApi = true;
-        journalFile = journal;
-      };
-      networking.firewall.allowedTCPPorts = [ services.hledger-web.port ];
+    apiserver = { ... }: {
+      imports = [ server ];
+      services.hledger-web.serveApi = true;
     };
   };
 
@@ -42,7 +38,7 @@ rec {
     server.wait_for_open_port(5000)
     with subtest("Check if web UI is accessible"):
         page = server.succeed("curl -L http://127.0.0.1:5000")
-        assert "test.journal" in page
+        assert ".hledger.journal" in page
 
     apiserver.wait_for_unit("hledger-web.service")
     apiserver.wait_for_open_port(5000)

--- a/nixos/tests/hledger-web.nix
+++ b/nixos/tests/hledger-web.nix
@@ -19,6 +19,7 @@ rec {
         host = "127.0.0.1";
         port = 5000;
         enable = true;
+        capabilities.manage = true;
       };
       networking.firewall.allowedTCPPorts = [ config.services.hledger-web.port ];
       systemd.services.hledger-web.preStart = ''


### PR DESCRIPTION
###### Motivation for this change

This allows for shared hledger installations, where the web interface is available via network and multiple user share a SSH access to the hledger user.
    
Also added `--serve` to the CLI options, as hledger-web tries to open a webbrowser otherwise:
    
`hledger-web: xdg-open: rawSystem: runInteractiveProcess: exec: does not exist (No such file or directory)`

###### Things done

- Added dedicated user. I chose `hledger` over `hledger-web`, is this should be useful for users of Hledger in general, not only hledger-web.
- Added `cfg.stateDir`
- Added myself as maintainer.
- Set `cfg.capabilities` as booleans, as I messed with shell escaping for too long and this seems more adequate to me.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
