### PR TITLE
system76-firmware: remove aarch64-linux support

### DIFF
--- a/pkgs/os-specific/linux/firmware/system76-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/system76-firmware/default.nix
@@ -29,11 +29,11 @@ rustPlatform.buildRustPackage rec {
     done
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Tools for managing firmware updates for system76 devices";
     homepage = "https://github.com/pop-os/system76-firmware";
-    license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.shlevy ];
-    platforms = lib.platforms.linux;
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ shlevy ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Package "system76-firmware" build in aarch64 is failing:
https://hydra.nixos.org/build/138891792#tabs-summary
https://hydra.nixos.org/build/138891792/nixlog/2

But it doesn't make sense on ARM because it's for installing firmware updates on System76 machines which are x86/amd64.
As it is broken now in aarch64 and cluttering build pipeline seems desirable to limit it to i386/amd64. 
A PR with a fix for aarch64 can reverse this.
Tried to reach upstream on IRC but I could only talk to community member buzel that agreed on this approach.

Took the opportunity for a minor clean-up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
