### PR TITLE
pythonPackages.pytest*: Move pytest to buildInputs to allow easy over…

### DIFF
--- a/pkgs/development/python-modules/pytest-aiohttp/default.nix
+++ b/pkgs/development/python-modules/pytest-aiohttp/default.nix
@@ -9,7 +9,9 @@ buildPythonPackage rec {
     sha256 = "0kx4mbs9bflycd8x9af0idcjhdgnzri3nw1qb0vpfyb3751qaaf9";
   };
 
-  propagatedBuildInputs = [ pytest aiohttp ];
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ aiohttp ];
 
   # There are no tests
   doCheck = false;

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -21,10 +21,12 @@ buildPythonPackage rec {
     sed -i "s/'setuptools-markdown'//g" setup.py
   '';
 
+  buildInputs = [ pytest ];
+
   # requires pandoc < 2.0
   # buildInputs = [ setuptools-markdown ];
   checkInputs =  [ mock ];
-  propagatedBuildInputs = [ ansible pytest ];
+  propagatedBuildInputs = [ ansible ];
 
   # tests not included with release, even on github
   doCheck = false;

--- a/pkgs/development/python-modules/pytest-arraydiff/default.nix
+++ b/pkgs/development/python-modules/pytest-arraydiff/default.nix
@@ -16,10 +16,11 @@ buildPythonPackage rec {
     sha256 = "de2d62f53ecc107ed754d70d562adfa7573677a263216a7f19aa332f20dc6c15";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     numpy
     six
-    pytest
   ];
 
   # The tests requires astropy, which itself requires

--- a/pkgs/development/python-modules/pytest-astropy-header/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy-header/default.nix
@@ -31,8 +31,7 @@ buildPythonPackage rec {
     })
   ];
 
-
-  propagatedBuildInputs = [
+  buildInputs = [
     pytest
   ];
 

--- a/pkgs/development/python-modules/pytest-astropy/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy/default.nix
@@ -25,9 +25,10 @@ buildPythonPackage rec {
     setuptools_scm
   ];
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     hypothesis
-    pytest
     pytest-astropy-header
     pytest-doctestplus
     pytest-filter-subpackage

--- a/pkgs/development/python-modules/pytest-bdd/default.nix
+++ b/pkgs/development/python-modules/pytest-bdd/default.nix
@@ -22,7 +22,9 @@ buildPythonPackage rec {
     sha256 = "1yqzz44as4pxffmg4hk9lijvnvlc2chg1maq1fbj5i4k4jpagvjz";
   };
 
-  propagatedBuildInputs = [ glob2 Mako parse parse-type py pytest six ];
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ glob2 Mako parse parse-type py six ];
 
   # Tests require extra dependencies
   checkInputs = [ execnet mock pytest ];

--- a/pkgs/development/python-modules/pytest-benchmark/default.nix
+++ b/pkgs/development/python-modules/pytest-benchmark/default.nix
@@ -19,7 +19,9 @@ buildPythonPackage rec {
     sha256 = "1hslzzinpwc1zqhbpllqh3sllmiyk69pcycl7ahr0rz3micgwczj";
   };
 
-  propagatedBuildInputs = [ pytest py-cpuinfo ] ++ lib.optionals (pythonOlder "3.4") [ pathlib statistics ];
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ py-cpuinfo ] ++ lib.optionals (pythonOlder "3.4") [ pathlib statistics ];
 
   meta = {
     description = "Py.test fixture for benchmarking code";

--- a/pkgs/development/python-modules/pytest-black/default.nix
+++ b/pkgs/development/python-modules/pytest-black/default.nix
@@ -16,7 +16,9 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools_scm ];
 
-  propagatedBuildInputs = [ black pytest toml ];
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ black toml ];
 
   # does not contain tests
   doCheck = false;

--- a/pkgs/development/python-modules/pytest-check/default.nix
+++ b/pkgs/development/python-modules/pytest-check/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "1i01i5ab06ic11na13gcacrlcs2ab6rmaii0yz0x06z5ynnljn6s";
   };
 
-  propagatedBuildInputs = [ pytest ];
+  buildInputs = [ pytest ];
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pytest-click/default.nix
+++ b/pkgs/development/python-modules/pytest-click/default.nix
@@ -19,8 +19,9 @@ buildPythonPackage rec {
     sha256 = "197nvlqlyfrqpy5lrkmfh1ywpr6j9zipxl9d7syg2a2n7jz3a8rj";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
-    pytest
     click
   ];
 

--- a/pkgs/development/python-modules/pytest-dependency/default.nix
+++ b/pkgs/development/python-modules/pytest-dependency/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "c2a892906192663f85030a6ab91304e508e546cddfe557d692d61ec57a1d946b";
   };
 
-  propagatedBuildInputs = [ pytest ];
+  buildInputs = [ pytest ];
 
   checkInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/pytest-doctestplus/default.nix
+++ b/pkgs/development/python-modules/pytest-doctestplus/default.nix
@@ -17,10 +17,11 @@ buildPythonPackage rec {
     sha256 = "fb083925a17ce636f33997c275f61123e63372c1db11fefac1e991ed25a4ca37";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     six
     numpy
-    pytest
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pytest-factoryboy/default.nix
+++ b/pkgs/development/python-modules/pytest-factoryboy/default.nix
@@ -21,10 +21,11 @@ buildPythonPackage rec {
     sha256 = "0v6b4ly0p8nknpnp3f4dbslfsifzzjx2vv27rfylx04kzdhg4m9p";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     factory_boy
     inflection
-    pytest
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pytest-filter-subpackage/default.nix
+++ b/pkgs/development/python-modules/pytest-filter-subpackage/default.nix
@@ -21,8 +21,9 @@ buildPythonPackage rec {
     setuptools_scm
   ];
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
-    pytest
     pytest-doctestplus
     pytestcov
     pytestCheckHook

--- a/pkgs/development/python-modules/pytest-flakes/default.nix
+++ b/pkgs/development/python-modules/pytest-flakes/default.nix
@@ -15,8 +15,9 @@ buildPythonPackage rec {
     sha256 = "bf070c5485dad82d5b5f5d0eb08d269737e378492d9a68f5223b0a90924c7754";
   };
 
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ pyflakes ];
   checkInputs = [ pytest ];
-  propagatedBuildInputs = [ pytest pyflakes ];
 
   # no longer passes
   doCheck = false;

--- a/pkgs/development/python-modules/pytest-flask/default.nix
+++ b/pkgs/development/python-modules/pytest-flask/default.nix
@@ -12,8 +12,9 @@ buildPythonPackage rec {
 
   doCheck = false;
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
-    pytest
     flask
     werkzeug
   ];

--- a/pkgs/development/python-modules/pytest-freezegun/default.nix
+++ b/pkgs/development/python-modules/pytest-freezegun/default.nix
@@ -18,9 +18,10 @@ buildPythonPackage rec {
     sha256 = "10c4pbh03b4s1q8cjd75lr0fvyf9id0zmdk29566qqsmaz28npas";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     freezegun
-    pytest
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pytest-html/default.nix
+++ b/pkgs/development/python-modules/pytest-html/default.nix
@@ -12,7 +12,8 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools_scm ];
-  propagatedBuildInputs = [ pytest pytest-metadata ];
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ pytest-metadata ];
 
   meta = with lib; {
     description = "Plugin for generating HTML reports";

--- a/pkgs/development/python-modules/pytest-httpx/default.nix
+++ b/pkgs/development/python-modules/pytest-httpx/default.nix
@@ -18,9 +18,10 @@ buildPythonPackage rec {
     sha256 = "08idd3y6khxjqkn46diqvkjvsl4w4pxhl6z1hspbkrj0pqwf9isi";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     httpx
-    pytest
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pytest-metadata/default.nix
+++ b/pkgs/development/python-modules/pytest-metadata/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools_scm ];
-  propagatedBuildInputs = [ pytest ];
+  buildInputs = [ pytest ];
 
   meta = with lib; {
     description = "Plugin for accessing test session metadata";

--- a/pkgs/development/python-modules/pytest-mypy/default.nix
+++ b/pkgs/development/python-modules/pytest-mypy/default.nix
@@ -18,7 +18,9 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools_scm ];
 
-  propagatedBuildInputs = [ pytest mypy filelock ];
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ mypy filelock ];
 
   # does not contain tests
   doCheck = false;

--- a/pkgs/development/python-modules/pytest-openfiles/default.nix
+++ b/pkgs/development/python-modules/pytest-openfiles/default.nix
@@ -20,8 +20,9 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools_scm ];
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
-    pytest
     psutil
   ];
 

--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "9c9e4f1b060414c642e88ad98ca60f1fd37937debd704bd8f4a2ef8e08b9cb6d";
   };
 
-  propagatedBuildInputs = [ pytest ];
+  buildInputs = [ pytest ];
 
   checkInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/pytest-pylint/default.nix
+++ b/pkgs/development/python-modules/pytest-pylint/default.nix
@@ -21,8 +21,9 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pytestrunner ];
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
-    pytest
     pylint
     six
     toml

--- a/pkgs/development/python-modules/pytest-pythonpath/default.nix
+++ b/pkgs/development/python-modules/pytest-pythonpath/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "0qhxh0z2b3p52v3i0za9mrmjnb1nlvvyi2g23rf88b3xrrm59z33";
   };
 
-  propagatedBuildInputs = [ pytest ];
+  buildInputs = [ pytest ];
   checkInputs = [ pytest ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/pytest-qt/default.nix
+++ b/pkgs/development/python-modules/pytest-qt/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     setuptools_scm
   ];
 
-  propagatedBuildInputs = [
+  buildInputs = [
     pytest
   ];
 

--- a/pkgs/development/python-modules/pytest-random-order/default.nix
+++ b/pkgs/development/python-modules/pytest-random-order/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.5";
 
-  propagatedBuildInputs = [ pytest ];
+  buildInputs = [ pytest ];
 
   meta = with lib; {
     homepage = "https://github.com/jbasko/pytest-random-order";

--- a/pkgs/development/python-modules/pytest-remotedata/default.nix
+++ b/pkgs/development/python-modules/pytest-remotedata/default.nix
@@ -14,9 +14,10 @@ buildPythonPackage rec {
     sha256 = "e20c58d4b7c359c4975dc3c3d3d67be0905180d2368be0be3ae09b15a136cfc0";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     six
-    pytest
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pytest-rerunfailures/default.nix
+++ b/pkgs/development/python-modules/pytest-rerunfailures/default.nix
@@ -11,9 +11,9 @@ buildPythonPackage rec {
     sha256 = "1cb11a17fc121b3918414eb5eaf314ee325f2e693ac7cb3f6abf7560790827f2";
   };
 
-  checkInputs = [ mock pytest ];
+  buildInputs = [ pytest ];
 
-  propagatedBuildInputs = [ pytest ];
+  checkInputs = [ mock pytest ];
 
   checkPhase = ''
     py.test test_pytest_rerunfailures.py

--- a/pkgs/development/python-modules/pytest-sanic/default.nix
+++ b/pkgs/development/python-modules/pytest-sanic/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pytest
+, pytestCheckHook
 , aiohttp
 , async_generator
 }:
@@ -15,10 +16,15 @@ buildPythonPackage rec {
     sha256 = "6428ed8cc2e6cfa05b92689a8589149aacdc1f0640fcf9673211aa733e6a5209";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
-    pytest
     aiohttp
     async_generator
+  ];
+
+  checkInputs = [
+    pytestCheckHook
   ];
 
   # circular dependency on sanic

--- a/pkgs/development/python-modules/pytest-services/default.nix
+++ b/pkgs/development/python-modules/pytest-services/default.nix
@@ -25,10 +25,11 @@ buildPythonPackage rec {
     toml
   ];
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     requests
     psutil
-    pytest
     zc_lockfile
   ] ++ lib.optional (!isPy3k) subprocess32;
 

--- a/pkgs/development/python-modules/pytest-shutil/default.nix
+++ b/pkgs/development/python-modules/pytest-shutil/default.nix
@@ -11,9 +11,9 @@ buildPythonPackage rec {
     sha256 = "0q8j0ayzmnvlraml6i977ybdq4xi096djhf30n2m1rvnvrhm45nq";
   };
 
+  buildInputs = [ pytest ];
   checkInputs = [ cmdline pytest ];
   propagatedBuildInputs = [ pytestcov coverage setuptools-git mock pathpy execnet contextlib2 termcolor ];
-  nativeBuildInputs = [ pytest ];
 
   checkPhase = ''
     py.test ${lib.optionalString isPyPy "-k'not (test_run or test_run_integration)'"}

--- a/pkgs/development/python-modules/pytest-snapshot/default.nix
+++ b/pkgs/development/python-modules/pytest-snapshot/default.nix
@@ -11,7 +11,9 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  propagatedBuildInputs = [ packaging pytest ];
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ packaging ];
 
   # pypi does not contain tests and GitHub archive is not supported because setuptools-scm can't detect the version
   doCheck = false;

--- a/pkgs/development/python-modules/pytest-socket/default.nix
+++ b/pkgs/development/python-modules/pytest-socket/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "1jbzkyp4xki81h01yl4vg3nrg9b6shsk1ryrmkaslffyhrqnj8zh";
   };
 
-  propagatedBuildInputs = [
+  buildInputs = [
     pytest
   ];
 

--- a/pkgs/development/python-modules/pytest-sugar/default.nix
+++ b/pkgs/development/python-modules/pytest-sugar/default.nix
@@ -16,9 +16,10 @@ buildPythonPackage rec {
     sha256 = "b1b2186b0a72aada6859bea2a5764145e3aaa2c1cfbb23c3a19b5f7b697563d3";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     termcolor
-    pytest
     packaging
   ];
 

--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "0xnsigs0kmpq1za0d4i522sp3f71x5bgpdh3ski0rs74yqy13cr0";
   };
 
-  propagatedBuildInputs = [ pytest ];
+  buildInputs = [ pytest ];
 
   checkInputs = [ pytestCheckHook pexpect pytestcov ];
 

--- a/pkgs/development/python-modules/pytest-tornado/default.nix
+++ b/pkgs/development/python-modules/pytest-tornado/default.nix
@@ -17,7 +17,9 @@ buildPythonPackage rec {
   # package has no tests
   doCheck = false;
 
-  propagatedBuildInputs = [ pytest tornado ];
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ tornado ];
 
   meta = with lib; {
     description = "A py.test plugin providing fixtures and markers to simplify testing of asynchronous tornado applications.";

--- a/pkgs/development/python-modules/pytest-tornasync/default.nix
+++ b/pkgs/development/python-modules/pytest-tornasync/default.nix
@@ -15,8 +15,9 @@ buildPythonPackage rec {
     sha256 = "04cg1cfrr55dbi8nljkpcsc103i5c6p0nr46vjr0bnxgkxx03x36";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
-    pytest
     tornado
   ];
 

--- a/pkgs/development/python-modules/pytest-trio/default.nix
+++ b/pkgs/development/python-modules/pytest-trio/default.nix
@@ -13,11 +13,12 @@ buildPythonPackage rec {
     sha256 = "0bhh2nknhp14jzsx4zzpqm4qnfaihyi65cjf6kf6qgdhc0ax6nf4";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     trio
     async_generator
     outcome
-    pytest
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pytest-twisted/default.nix
+++ b/pkgs/development/python-modules/pytest-twisted/default.nix
@@ -16,7 +16,9 @@ buildPythonPackage rec {
     sha256 = "cee2320becc5625050ab221b8f38533e636651a24644612f4726891fdf1f1847";
   };
 
-  propagatedBuildInputs = [ greenlet pytest decorator ];
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ greenlet decorator ];
 
   meta = with lib; {
     description = "A twisted plugin for py.test";

--- a/pkgs/development/python-modules/pytest-vcr/default.nix
+++ b/pkgs/development/python-modules/pytest-vcr/default.nix
@@ -16,8 +16,9 @@ buildPythonPackage rec {
     sha256 = "1i6fin91mklvbi8jzfiswvwf1m91f43smpj36a17xrzk4gisfs6i";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
-    pytest
     vcrpy
    ];
 

--- a/pkgs/development/python-modules/pytest-warnings/default.nix
+++ b/pkgs/development/python-modules/pytest-warnings/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "5939f76fe04ad18297e53af0c9fb38aca1ec74db807bd40ad72733603adbbc7d";
   };
 
-  propagatedBuildInputs = [ pytest ];
+  buildInputs = [ pytest ];
 
   meta = {
     description = "Plugin to list Python warnings in pytest report";

--- a/pkgs/development/python-modules/pytest-watch/default.nix
+++ b/pkgs/development/python-modules/pytest-watch/default.nix
@@ -16,7 +16,9 @@ buildPythonPackage rec {
     sha256 = "06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9";
   };
 
-  propagatedBuildInputs = [ pytest colorama docopt watchdog ];
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ colorama docopt watchdog ];
 
   # No Tests
   doCheck = false;

--- a/pkgs/development/python-modules/pytest-xprocess/default.nix
+++ b/pkgs/development/python-modules/pytest-xprocess/default.nix
@@ -14,7 +14,10 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools_scm ];
-  propagatedBuildInputs = [ psutil pytest ];
+
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ psutil ];
 
   # Remove test QoL package from install_requires
   postPatch = ''

--- a/pkgs/development/python-modules/pytest-xvfb/default.nix
+++ b/pkgs/development/python-modules/pytest-xvfb/default.nix
@@ -16,8 +16,9 @@ buildPythonPackage rec {
     sha256 = "1kyq5rg27dsnj7dc6x9y7r8vwf8rc88y2ppnnw6r96alw0nn9fn4";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
-    pytest
     virtual-display
   ];
 


### PR DESCRIPTION
…riding pytest

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
