### PR TITLE
zxing-cpp: init at 1.1.1

### DIFF
--- a/pkgs/development/libraries/zxing-cpp/default.nix
+++ b/pkgs/development/libraries/zxing-cpp/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zxing-cpp";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "nu-book";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-N2FTzsjxm3EE5Wqz7xt+FS4zQ60Ow4WbdX6Eo08ktek=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_EXAMPLES=OFF"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nu-book/zxing-cpp";
+    description = "C++ port of zxing (a Java barcode image processing library)";
+    longDescription = ''
+      ZXing-C++ ("zebra crossing") is an open-source, multi-format 1D/2D barcode
+      image processing library implemented in C++.
+
+      It was originally ported from the Java ZXing Library but has been
+      developed further and now includes many improvements in terms of quality
+      and performance. It can both read and write barcodes in a number of
+      formats.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30024,6 +30024,8 @@ in
 
   zxcvbn-c = callPackage ../development/libraries/zxcvbn-c { };
 
+  zxing-cpp = callPackage ../development/libraries/zxing-cpp { };
+
   snes9x-gtk = callPackage ../misc/emulators/snes9x-gtk { };
 
   openmsx = callPackage ../misc/emulators/openmsx {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
