### PR TITLE
gupnp-igd: 0.2.5 -> 1.2.0

### DIFF
--- a/pkgs/development/libraries/gupnp-igd/default.nix
+++ b/pkgs/development/libraries/gupnp-igd/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv
 , fetchurl
-, fetchpatch
-, autoreconfHook
 , pkg-config
+, meson
+, ninja
 , gettext
 , gobject-introspection
 , gtk-doc
@@ -15,26 +15,19 @@
 
 stdenv.mkDerivation rec {
   pname = "gupnp-igd";
-  version = "0.2.5";
+  version = "1.2.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "081v1vhkbz3wayv49xfiskvrmvnpx93k25am2wnarg5cifiiljlb";
+    sha256 = "sha256-S1EgCYqhPt0ngYup7k1/6WG/VAv1DQVv9wPGFUXgK+E=";
   };
-
-  patches = [
-    # Add gupnp-1.2 compatibility
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gupnp-igd/commit/63531558a16ac2334a59f627b2fca5576dcfbb2e.patch";
-      sha256 = "0s8lkyy9fnnnnkkqwbk6gxb7795bb1kl1swk5ldjnlrzhfcy1ab2";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config
-    autoreconfHook
+    meson
+    ninja
     gettext
     gobject-introspection
     gtk-doc
@@ -47,8 +40,8 @@ stdenv.mkDerivation rec {
     gupnp
   ];
 
-  configureFlags = [
-    "--enable-gtk-doc"
+  mesonFlags = [
+    "-Dgtk_doc=true"
   ];
 
   doCheck = true;
@@ -62,7 +55,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Library to handle UPnP IGD port mapping";
     homepage = "http://www.gupnp.org/";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump. Removes the need for a compatibility patch. Upstream switched to meson.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
