### PR TITLE
dockerTools.streamLayeredImage: expose conf / streamScript in passthru

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -860,6 +860,7 @@ rec {
         inherit (conf) imageName;
         passthru = {
           inherit (conf) imageTag;
+          inherit conf streamScript;
 
           # Distinguish tarballs and exes at the Nix level so functions that
           # take images can know in advance how the image is supposed to be used.


### PR DESCRIPTION
###### Motivation for this change

This is useful to create wrappers around `streamLayeredImage` and tweak
`conf` after it has been generated.

Specifically, we want to update the image tag (`repo_tag` in `conf`)
with a unique suffix based on the short hash of the
`streamLayeredImage` derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
