### PR TITLE
mysql80: downgrade icu to icu67

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18481,6 +18481,7 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     boost = boost173; # Configure checks for specific version.
     protobuf = protobuf3_7;
+    icu =  icu67;
   };
 
   mysql_jdbc = callPackage ../servers/sql/mysql/jdbc { };


### PR DESCRIPTION
###### Motivation for this change

MySQL 8.0 was failing to build with the following error
```
[ 72%] Building CXX object sql/CMakeFiles/sql_main.dir/locking_service.cc.o
/build/mysql-8.0.22/sql/mysqld.cc: In function 'int mysqld_main(int, char**)':
/build/mysql-8.0.22/sql/mysqld.cc:6991:30: error: 'TRUE' was not declared in this scope
 6991 |     my_getopt_skip_unknown = TRUE;
      |                              ^~~~
[ 72%] Building CXX object sql/CMakeFiles/sql_main.dir/opt_costconstantcache.cc.o
[ 72%] Building CXX object sql/CMakeFiles/sql_main.dir/opt_costconstants.cc.o
```

This is something with the `icu` package changing and not fully clear on why.

To get it passing again I've downgraded the `icu` package to `icu67`.
fixes #116121

```bash
nix-build -A mysql80
...
stripping (with command strip and flags -S) in /nix/store/qydw78c0zqbfxc7sgjcgi7vxqfplbj9i-mysql-8.0.22-static/lib 
patching script interpreter paths in /nix/store/qydw78c0zqbfxc7sgjcgi7vxqfplbj9i-mysql-8.0.22-static
checking for references to /build/ in /nix/store/qydw78c0zqbfxc7sgjcgi7vxqfplbj9i-mysql-8.0.22-static...
/nix/store/27c6dpwan462v8iwrdh7v5ldkybyxcjk-mysql-8.0.22
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@orivej @7c6f434c @SuperSandro2000 