### PR TITLE
tmuxPlugins: re-add mkTmuxPlugin

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -49,6 +49,8 @@ let
     }));
 
 in rec {
+  inherit mkTmuxPlugin;
+
   battery = mkTmuxPlugin {
     pluginName = "battery";
     version = "unstable-2019-07-04";

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -51,6 +51,8 @@ let
 in rec {
   inherit mkTmuxPlugin;
 
+  mkDerivation = throw "tmuxPlugins.mkDerivation is deprecated, use tmuxPlugins.mkTmuxPlugin instead"; # added 2021-03-14
+
   battery = mkTmuxPlugin {
     pluginName = "battery";
     version = "unstable-2019-07-04";


### PR DESCRIPTION
###### Motivation for this change

`mkTmuxPlugin` was removed from `tmuxPlugins` in #115718 (cc @timstott) while changing the name from `mkDerivation`. This just reintroduces it under the new name for anyone using it to build tmux plugins outside of nixpkgs.

No changes to derivation inputs/outputs, no rebuilds required.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
