### PR TITLE
python3Packages.Rtree: fix build

### DIFF
--- a/pkgs/development/python-modules/Rtree/default.nix
+++ b/pkgs/development/python-modules/Rtree/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, libspatialindex, numpy }:
+{ lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  libspatialindex,
+  numpy,
+  pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "Rtree";
@@ -9,21 +16,23 @@ buildPythonPackage rec {
     sha256 = "be8772ca34699a9ad3fb4cfe2cfb6629854e453c10b3328039301bbfc128ca3e";
   };
 
-  propagatedBuildInputs = [ libspatialindex ];
+  buildInputs = [ libspatialindex ];
 
   patchPhase = ''
-    substituteInPlace rtree/core.py --replace \
+    substituteInPlace rtree/finder.py --replace \
       "find_library('spatialindex_c')" "'${libspatialindex}/lib/libspatialindex_c${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 
-  # Tests appear to be broken due to mysterious memory unsafe issues. See #36760
-  doCheck = false;
-  checkInputs = [ numpy ];
+  checkInputs = [
+    numpy
+    pytestCheckHook
+  ];
+  pythonImportsCheck = [ "rtree" ];
 
   meta = with lib; {
     description = "R-Tree spatial index for Python GIS";
     homepage = "https://toblerity.org/rtree/";
-    license = licenses.lgpl21;
+    license = licenses.mit;
     maintainers = with maintainers; [ bgamari ];
   };
 }


### PR DESCRIPTION
Patching broke on recent version bump, this fixes and re-enables tests. Note that I have only checked that the tests pass on NixOS.

###### Motivation for this change
#116124
Also there is discussion on why the tests were originally disabled at #36760

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>python38Packages.geopandas</li>
    <li>python38Packages.osmnx</li>
    <li>python39Packages.geopandas</li>
    <li>python39Packages.osmnx</li>
  </ul>
</details>
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>flatcam</li>
    <li>python38Packages.Rtree</li>
    <li>python39Packages.Rtree</li>
  </ul>
</details>
