### PR TITLE
iniparser: add pkgconfig file

### DIFF
--- a/pkgs/development/libraries/iniparser/default.nix
+++ b/pkgs/development/libraries/iniparser/default.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation rec {
     cp libiniparser.a $out/lib
     cp libiniparser.so.1 $out/lib
     ln -s libiniparser.so.1 $out/lib/libiniparser.so
+
+    mkdir -p $out/lib/pkgconfig
+    substituteAll ${./iniparser.pc.in} $out/lib/pkgconfig/iniparser.pc
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/iniparser/iniparser.pc.in
+++ b/pkgs/development/libraries/iniparser/iniparser.pc.in
@@ -1,0 +1,12 @@
+prefix=@out@
+exec_prefix=@out@
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+datarootdir=${prefix}/share
+datadir=${datarootdir}
+
+Name: libiniparser
+Description: Iniparser library
+Version: @version@
+Libs: -L${libdir} -liniparser
+Cflags: -I${includedir}


### PR DESCRIPTION
###### Motivation for this change

The upstream pkgconfig file is not contained in any release, add our own
based on it.

Ref: https://github.com/colemickens/nixpkgs-wayland/issues/283

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
