### PR TITLE
openorienteering-mapper: 0.9.4 → 0.9.5

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , substituteAll
 , gdal
 , cmake
@@ -19,7 +20,7 @@
 
 mkDerivation rec {
   pname = "OpenOrienteering-Mapper";
-  version = "0.9.4";
+  version = "0.9.5";
 
   buildInputs = [
     gdal
@@ -38,14 +39,21 @@ mkDerivation rec {
     owner = "OpenOrienteering";
     repo = "mapper";
     rev = "v${version}";
-    sha256 = "13k9dirqm74lknhr8w121zr1hjd9gm1y73cj4rrj98rx44dzmk7b";
+    sha256 = "1w8ikqpgi0ksrzjal5ihfaik4grc5v3gdnnv79j20xkr2p4yn1h5";
   };
 
-  patches = (substituteAll {
-    # See https://github.com/NixOS/nixpkgs/issues/86054
-    src = ./fix-qttranslations-path.diff;
-    inherit qttranslations;
-  });
+  patches = [
+    # https://github.com/NixOS/nixpkgs/issues/86054
+    (substituteAll {
+      src = ./fix-qttranslations-path.diff;
+      inherit qttranslations;
+    })
+    # https://github.com/OpenOrienteering/mapper/pull/1907
+    (fetchpatch {
+      url = "https://github.com/OpenOrienteering/mapper/commit/bc52aa567e90a58d6963b44d5ae1909f3f841508.patch";
+      sha256 = "1bkckapzccn6k0ri6bgrr0nhis9498fnwj7b32s2ysym8zcg0355";
+    })
+  ];
 
   cmakeFlags = [
     # Building the manual and bundling licenses fails
@@ -81,7 +89,8 @@ mkDerivation rec {
       and provides a free alternative to the existing proprietary solution.
     '';
     homepage = "https://www.openorienteering.org/apps/mapper/";
-    license = licenses.gpl3;
+    changelog = "https://github.com/OpenOrienteering/mapper/releases/tag/v${version}";
+    license = licenses.gpl3Plus;
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ mpickering sikmir ];
   };


### PR DESCRIPTION
###### Motivation for this change
[0.9.5 changelog](https://github.com/OpenOrienteering/mapper/releases/tag/v0.9.5)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
