### PR TITLE
aerc, asuka, scdoc, wev, wlsunset, wshowkeys: use fetchFromSourceHut

### DIFF
--- a/pkgs/applications/networking/browsers/asuka/default.nix
+++ b/pkgs/applications/networking/browsers/asuka/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, rustPlatform, fetchurl, pkg-config, ncurses, openssl, Security }:
+{ lib, stdenv, rustPlatform, fetchFromSourcehut, pkg-config, ncurses, openssl, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "asuka";
   version = "0.8.1";
 
-  src = fetchurl {
-    url = "https://git.sr.ht/~julienxx/${pname}/archive/${version}.tar.gz";
-    sha256 = "07i80qmdpwfdgwrk1gzs10wln91v23qjrsk0x134xf5mjnakxc06";
+  src = fetchFromSourcehut {
+    owner = "~julienxx";
+    repo = pname;
+    rev = version;
+    sha256 = "1y8v4qc5dng3v9k0bky1xlf3qi9pk2vdsi29lff4ha5310467f0k";
   };
 
   cargoSha256 = "0p0x4ch04kydg76bfal5zqzr9hvn5268wf3k2v9h7g8r4y8xqlhw";

--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchurl
+{ lib, buildGoModule, fetchFromSourcehut
 , ncurses, notmuch, scdoc
 , python3, w3m, dante
 }:
@@ -7,9 +7,11 @@ buildGoModule rec {
   pname = "aerc";
   version = "0.5.2";
 
-  src = fetchurl {
-    url = "https://git.sr.ht/~sircmpwn/aerc/archive/${version}.tar.gz";
-    sha256 = "h7kiRA5TuZ8mDSMymWU33stFLIOMd06TQLYzKW+faO4=";
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = pname;
+    rev = version;
+    sha256 = "1ja639qry8h2d6y7qshf62ypkzs2rzady59p81scqh8nx0g9bils";
   };
 
   runVend = true;

--- a/pkgs/tools/typesetting/scdoc/default.nix
+++ b/pkgs/tools/typesetting/scdoc/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromSourcehut }:
 
 stdenv.mkDerivation rec {
   pname = "scdoc";
   version = "1.11.1";
 
-  src = fetchurl {
-    url = "https://git.sr.ht/~sircmpwn/scdoc/archive/${version}.tar.gz";
-    sha256 = "007pm3gspvya58cwb12wpnrm9dq5p28max2s0b2y9rq80nqgqag5";
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = pname;
+    rev = version;
+    sha256 = "1g37j847j3h4a4qbbfbr6vvsxpifj9v25jgv25nd71d1n0dxlhvk";
   };
 
   postPatch = ''

--- a/pkgs/tools/wayland/wev/default.nix
+++ b/pkgs/tools/wayland/wev/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromSourcehut
 , pkg-config
 , scdoc
 , wayland
@@ -12,9 +12,11 @@ stdenv.mkDerivation rec {
   pname = "wev";
   version = "1.0.0";
 
-  src = fetchurl {
-    url = "https://git.sr.ht/~sircmpwn/wev/archive/${version}.tar.gz";
-    sha256 = "0vlxdkb59v6nb10j28gh1a56sx8jk7ak7liwzv911kpmygnls03g";
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = pname;
+    rev = version;
+    sha256 = "0l71v3fzgiiv6xkk365q1l08qvaymxd4kpaya6r2g8yzkr7i2hms";
   };
 
   nativeBuildInputs = [ pkg-config scdoc wayland ];

--- a/pkgs/tools/wayland/wlsunset/default.nix
+++ b/pkgs/tools/wayland/wlsunset/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, meson, pkg-config, ninja, wayland
+{ lib, stdenv, fetchFromSourcehut, meson, pkg-config, ninja, wayland
 , wayland-protocols
 }:
 
@@ -6,9 +6,11 @@ stdenv.mkDerivation rec {
   pname = "wlsunset";
   version = "0.1.0";
 
-  src = fetchurl {
-    url = "https://git.sr.ht/~kennylevinsen/wlsunset/archive/${version}.tar.gz";
-    sha256 = "0g7mk14hlbwbhq6nqr84452sbgcja3hdxsqf0vws4njhfjgqiv3q";
+  src = fetchFromSourcehut {
+    owner = "~kennylevinsen";
+    repo = pname;
+    rev = version;
+    sha256 = "12snizvf49y40cirhr2brgyldhsykv4k2gnln2sdrajqzhrc98v6";
   };
 
   nativeBuildInputs = [ meson pkg-config ninja wayland ];

--- a/pkgs/tools/wayland/wshowkeys/default.nix
+++ b/pkgs/tools/wayland/wshowkeys/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl
+{ lib, stdenv, fetchFromSourcehut
 , meson, pkg-config, wayland, ninja
 , cairo, libinput, pango, wayland-protocols, libxkbcommon
 }:
@@ -10,9 +10,11 @@ in stdenv.mkDerivation rec {
   pname = "wshowkeys-unstable";
   inherit version;
 
-  src = fetchurl {
-    url = "https://git.sr.ht/~sircmpwn/wshowkeys/archive/${commit}.tar.gz";
-    sha256 = "0iplmw13jmc8d3m307kc047zq8yqwm42kw9fpm270562i3p0qk4d";
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "wshowkeys";
+    rev = commit;
+    sha256 = "10kafdja5cwbypspwhvaxjz3hvf51vqjzbgdasl977193cvxgmbs";
   };
 
   nativeBuildInputs = [ meson pkg-config wayland ninja ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
These packages previously used `fetchurl` and were broken due to changes to Sourcehut's gzip compression. The fancy new `fetchFromSourceHut` uses `fetchzip` internally, so won't be affected by future compression changes.

Closes #115397 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
