### PR TITLE
mastodon-archive: init at 1.3.1

### DIFF
--- a/pkgs/tools/backup/mastodon-archive/default.nix
+++ b/pkgs/tools/backup/mastodon-archive/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "mastodon-archive";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "kensanata";
+    repo = "mastodon-backup";
+    rev = "v${version}";
+    sha256 = "1dlrkygywxwm6xbn0pnfwd3f7641wnvxdyb5qihbsf62w1w08x8r";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    html2text
+    mastodon-py
+    progress
+  ];
+
+  # There is no test
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Utility for backing up your Mastodon content";
+    homepage = "https://alexschroeder.ch/software/Mastodon_Archive";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ julm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13669,6 +13669,8 @@ in
 
   massif-visualizer = libsForQt5.callPackage ../development/tools/analysis/massif-visualizer { };
 
+  mastodon-archive = callPackage ../tools/backup/mastodon-archive { };
+
   maven = maven3;
   maven3 = callPackage ../development/tools/build-managers/apache-maven { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Using `mastodon-archive` to backup accounts from Mastodon servers.

###### Things done

- ~[X] Add `pythonModules.blurhash`~.
- ~[X] Add `pythonModules.mastodonpy`~.
- [X] Add `mastodon-archive`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
