### PR TITLE
pure-maps: fix wrapper to include python dependencies

### DIFF
--- a/pkgs/applications/misc/pure-maps/default.nix
+++ b/pkgs/applications/misc/pure-maps/default.nix
@@ -1,7 +1,7 @@
 { lib, mkDerivation, fetchFromGitHub, wrapQtAppsHook
 , qmake, qttools, kirigami2, qtquickcontrols2, qtlocation, qtsensors
 , nemo-qml-plugin-dbus, mapbox-gl-qml, s2geometry
-, python3, pyotherside, python3Packages
+, python3, pyotherside
 }:
 
 mkDerivation rec {
@@ -16,12 +16,15 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ qmake python3 qttools wrapQtAppsHook ];
+  nativeBuildInputs = [
+    qmake python3 qttools wrapQtAppsHook python3.pkgs.wrapPython
+  ];
   buildInputs = [
     kirigami2 qtquickcontrols2 qtlocation qtsensors
     nemo-qml-plugin-dbus pyotherside mapbox-gl-qml s2geometry
   ];
-  propagatedBuildInputs = with python3Packages; [ gpxpy pyxdg ];
+
+  pythonPath = with python3.pkgs; [ gpxpy pyxdg ];
 
   postPatch = ''
     substituteInPlace pure-maps.pro \
@@ -32,8 +35,9 @@ mkDerivation rec {
 
   dontWrapQtApps = true;
   postInstall = ''
+    buildPythonPath "$out/share $pythonPath"
     wrapQtApp $out/bin/pure-maps \
-      --prefix PYTHONPATH : "$out/share"
+      --prefix PYTHONPATH : "$out/share:$program_PYTHONPATH"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
pure-maps currently only works in nix-shell, because it relies on propagatedBuildInputs to find its python dependencies. This PR builds the pythonPath and adds it to the wrapper produced by wrapQt.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
