### PR TITLE
dhcpcd: 8.1.4 -> 9.4.0

### DIFF
--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -1,15 +1,20 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, udev, runtimeShellPackage,
-runtimeShell }:
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, udev
+, runtimeShellPackage
+, runtimeShell
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
-  # when updating this to >=7, check, see previous reverts:
-  # nix-build -A nixos.tests.networking.scripted.macvlan.x86_64-linux nixos/release-combined.nix
   pname = "dhcpcd";
-  version = "8.1.4";
+  version = "9.4.0";
 
   src = fetchurl {
     url = "mirror://roy/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0gf1qif25wy5lffzw39pi4sshmpxz1f4a1m9sglj7am1gaix3817";
+    sha256 = "sha256-QaaSl/OAvxXuj5T3MVT4wrynFXoIfA1ayo3gALodRRM=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -21,14 +26,6 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace hooks/dhcpcd-run-hooks.in --replace /bin/sh ${runtimeShell}
   '';
-
-  patches = [
-    (fetchpatch {
-      name = "?id=114870290a8d3d696bc4049c32eef3eed03d6070";
-      url = "https://roy.marples.name/git/dhcpcd/commitdiff_plain/114870290a8d3d696bc4049c32eef3eed03d6070";
-      sha256 = "0kzpwjh2gzvl5lvlnw6lis610p67nassk3apns68ga2pyxlky8qb";
-    })
-  ];
 
   preConfigure = "patchShebangs ./configure";
 
@@ -46,11 +43,13 @@ stdenv.mkDerivation rec {
   # Check that the udev plugin got built.
   postInstall = lib.optionalString (udev != null) "[ -e ${placeholder "out"}/lib/dhcpcd/dev/udev.so ]";
 
+  passthru.tests = { inherit (nixosTests.networking.scripted) macvlan dhcpSimple dhcpOneIf; };
+
   meta = with lib; {
     description = "A client for the Dynamic Host Configuration Protocol (DHCP)";
     homepage = "https://roy.marples.name/projects/dhcpcd";
     platforms = platforms.linux;
     license = licenses.bsd2;
-    maintainers = with maintainers; [ eelco fpletz ];
+    maintainers = with maintainers; [ eelco fpletz erictapen ];
   };
 }


### PR DESCRIPTION
###### Things done

- Removed note about mandatory testing and moved it to `passthru.tests`
- Removed patch, as it is probably the same as 56b2bb17d2ec67e1f93950944211f6cf8c40e0fb, wich landed in upstream.
- Added myself as maintainer


Traditionally, `dhcpcd` upgrades can break a lot of things in a bad way, but I guess not upgrading it for 15 months isn't a solution either. So this would require thorough testing. Unfortunately I'm mostly using systemd-networkd on my machines, so I can't really provide much real world testing experience any more.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
