### PR TITLE
flatpak: attempt to fix flatpak-spawn --clear-env

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchurl
+, fetchpatch
 , autoreconfHook
 , docbook_xml_dtd_45
 , docbook-xsl-nons
@@ -92,6 +93,15 @@ stdenv.mkDerivation rec {
     # Don’t hardcode flatpak binary path in launchers stored under user’s profile otherwise they will break after Flatpak update.
     # https://github.com/NixOS/nixpkgs/issues/43581
     ./use-flatpak-from-path.patch
+
+    # Hardcode flatpak binary path for flatpak-spawn.
+    # When calling the portal’s Spawn command with FLATPAK_SPAWN_FLAGS_CLEAR_ENV flag,
+    # it will clear environment, including PATH, making the flatpak run fail.
+    # https://github.com/flatpak/flatpak/pull/4174
+    (fetchpatch {
+      url = "https://github.com/flatpak/flatpak/commit/495449daf6d3c072519a36c9e4bc6cc1da4d31db.patch";
+      sha256 = "gOX/sGupAE7Yg3MVrMhFXzWHpFn+izVyjtkuPzIckuY=";
+    })
 
     # Nix environment hacks should not leak into the apps.
     # https://github.com/NixOS/nixpkgs/issues/53441


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

﻿Chromium Flatpak package uses flatpak-spawn command for sandboxing the child processes. The command comes from flatpak-xdg-utils, which is presumably included in Flatpak runtimes. The command then calls Spawn method of the portal.

The portal supports running commands in a clear environment when passed `FLATPAK_SPAWN_FLAGS_CLEAR_ENV` flag. Unfortunately, that also clears PATH, which is probably what prevents `flatpak` command itself from being found.

There is a relevant TODO note in the code: https://github.com/flatpak/flatpak/blob/1.10.2/portal/flatpak-portal.c#L995-L999

For now, let’s hardcode the path to the binary.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
