### PR TITLE
tea: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4147,6 +4147,12 @@
     github = "j0hax";
     githubId = 3802620;
   };
+  j4m3s = {
+    name = "James Landrein";
+    email = "github@j4m3s.eu";
+    github = "j4m3s-s";
+    githubId = 9413812;
+  };
   jacg = {
     name = "Jacek Generowicz";
     email = "jacg@my-post-office.net";

--- a/pkgs/tools/misc/tea/default.nix
+++ b/pkgs/tools/misc/tea/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildGoModule, fetchgit }:
+
+buildGoModule rec {
+  pname = "tea";
+  version = "0.7.0";
+
+  src = fetchgit {
+    url = "https://gitea.com/gitea/tea";
+    rev = "v${version}";
+    sha256 = "sha256-Kq+A6YELfBJ04t7pPnX8Ulh4NSMFn3AHggplLD9J8MY=";
+  };
+
+  vendorSha256 = null;
+
+  meta = with lib; {
+    description = "Gitea official CLI client";
+    homepage    = "https://gitea.com/gitea/tea";
+    license     = licenses.mit;
+    maintainers = [ maintainers.j4m3s ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8387,6 +8387,8 @@ in
 
   tdns-cli = callPackage ../tools/networking/tdns-cli { };
 
+  tea = callPackage ../tools/misc/tea { };
+
   ted = callPackage ../tools/typesetting/ted { };
 
   teamviewer = libsForQt514.callPackage ../applications/networking/remote/teamviewer { };


### PR DESCRIPTION
###### Motivation for this change
Add gitea cli tool

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
