### PR TITLE
coreutils: disable tests which fail in sandbox

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -65,6 +65,12 @@ stdenv.mkDerivation (rec {
     for f in gnulib-tests/{test-chown.c,test-fchownat.c,test-lchown.c}; do
       echo "int main() { return 77; }" > "$f"
     done
+
+    # tests try to access user 1000 which is forbidden in sandbox
+    sed '2i print "Skipping id uid test"; exit 77' -i ./tests/id/uid.sh
+    sed '2i print "Skipping id zero test"; exit 77' -i ./tests/id/zero.sh
+    sed '2i print "Skipping misc help-versiob test"; exit 77' -i ./tests/misc/help-version.sh
+    sed '2i print "Skipping chown separator test"; exit 77' -i ./tests/chown/separator.sh
   '' + optionalString (stdenv.hostPlatform.libc == "musl") (lib.concatStringsSep "\n" [
     ''
       echo "int main() { return 77; }" > gnulib-tests/test-parse-datetime.c
@@ -134,20 +140,15 @@ stdenv.mkDerivation (rec {
   meta = {
     homepage = "https://www.gnu.org/software/coreutils/";
     description = "The basic file, shell and text manipulation utilities of the GNU operating system";
-
     longDescription = ''
       The GNU Core Utilities are the basic file, shell and text
       manipulation utilities of the GNU operating system.  These are
       the core utilities which are expected to exist on every
       operating system.
     '';
-
     license = licenses.gpl3Plus;
-
     platforms = platforms.unix ++ platforms.windows;
-
     priority = 10;
-
     maintainers = [ maintainers.eelco ];
   };
 } // optionalAttrs stdenv.hostPlatform.isMusl {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
