### PR TITLE
buildFishPlugin: do not pass irrelevant arguments down

### DIFF
--- a/pkgs/shells/fish/plugins/build-fish-plugin.nix
+++ b/pkgs/shells/fish/plugins/build-fish-plugin.nix
@@ -11,8 +11,6 @@ attrs@{
   buildPhase ? ":",
   preInstall ? "",
   postInstall ? "",
-  # name of the subdirectory in which to store the plugin
-  installPath ? lib.getName pname,
 
   checkInputs ? [],
   # plugin packages to add to the vendor paths of the test fish shell
@@ -26,7 +24,15 @@ attrs@{
   ...
 }:
 
-stdenv.mkDerivation (attrs // {
+let
+  # Do not pass attributes that are only relevant to buildFishPlugin to mkDerivation.
+  drvAttrs = builtins.removeAttrs attrs [
+    "checkPlugins"
+    "checkFunctionDirs"
+  ];
+in
+
+stdenv.mkDerivation (drvAttrs // {
   inherit name;
   inherit unpackPhase configurePhase buildPhase;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
﻿mkDerivation does not care about checkPlugins and checkFunctionDirs so let’s avoid polluting the scope. Also remove installPath argument altogether for the same reason since it is not used at all.

cc @pacien @SuperSandro2000

Fixes: https://github.com/jtojnar/nixpkgs-hammering/pull/93

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
