### PR TITLE
kgx: init at unstable-2021-03-13

### DIFF
--- a/pkgs/applications/terminal-emulators/kgx/default.nix
+++ b/pkgs/applications/terminal-emulators/kgx/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, genericBranding ? false
+, fetchFromGitLab
+, gettext
+, gnome3
+, gtk3
+, libhandy
+, pcre2
+, vte
+, appstream-glib
+, desktop-file-utils
+, git
+, meson
+, ninja
+, pkg-config
+, python3
+, sassc
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation {
+  pname = "kgx";
+  version = "unstable-2021-03-13";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "ZanderBrown";
+    repo = "kgx";
+    rev = "105adb6a8d09418a3ce622442aef6ae623dee787";
+    sha256 = "0m34y0nbcfkyicb40iv0iqaq6f9r3f66w43lr803j3351nxqvcz2";
+  };
+
+  buildInputs = [
+    gettext
+    gnome3.libgtop
+    gnome3.nautilus
+    gtk3
+    libhandy
+    pcre2
+    vte
+  ];
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    git
+    meson
+    ninja
+    pkg-config
+    python3
+    sassc
+    wrapGAppsHook
+  ];
+
+  mesonFlags = lib.optional genericBranding "-Dgeneric=true";
+
+  postPatch = ''
+    chmod +x build-aux/meson/postinstall.py
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  preFixup = ''
+    substituteInPlace $out/share/applications/org.gnome.zbrown.KingsCross.desktop \
+      --replace "Exec=kgx" "Exec=$out/bin/kgx"
+  '';
+
+  meta = with lib; {
+    description = "Simple user-friendly terminal emulator for the GNOME desktop";
+    homepage = "https://gitlab.gnome.org/ZanderBrown/kgx";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zhaofengli ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29098,6 +29098,8 @@ in
 
   keynav = callPackage ../tools/X11/keynav { };
 
+  kgx = callPackage ../applications/terminal-emulators/kgx { };
+
   kmon = callPackage ../tools/system/kmon { };
 
   kompose = callPackage ../applications/networking/cluster/kompose { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[King's Cross](https://gitlab.gnome.org/ZanderBrown/kgx) is a simple terminal emulator for GNOME. It's a popular terminal for use on mobile devices with Phosh.

The last release (0.2.1) was tagged a year ago and a lot of changes have taken place since then, thus the unstable version is being submitted here.

~~Upstream report for the missing `gio-unix-2.0` dependency (#36468): https://gitlab.gnome.org/ZanderBrown/kgx/-/issues/53~~ [Fixed](https://gitlab.gnome.org/ZanderBrown/kgx/-/commit/105adb6a8d09418a3ce622442aef6ae623dee787) by upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
