### PR TITLE
squeekboard: init at unstable-2021-03-09

### DIFF
--- a/pkgs/applications/accessibility/squeekboard/default.nix
+++ b/pkgs/applications/accessibility/squeekboard/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, gnome3
+, glib
+, gtk3
+, wayland
+, wayland-protocols
+, libxml2
+, libxkbcommon
+, rustPlatform
+, feedbackd
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "squeekboard";
+  version = "unstable-2021-03-09";
+
+  src = fetchFromGitLab {
+    domain = "source.puri.sm";
+    owner = "Librem5";
+    repo = pname;
+    rev = "bffd212e102bf71a94c599aac0359a8d30d19008";
+    sha256 = "1j10zhyb8wyrcbryfj6f3drn9b0l9x0l7hnhy2imnjbfbnwwm4w7";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    cargoUpdateHook = ''
+      cat Cargo.toml.in Cargo.deps > Cargo.toml
+    '';
+    name = "${pname}-${version}";
+    sha256 = "1qaqiaxqc4x2x5bd31na4c49vbjwrmz5clmgli7733dv55rxxias";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    glib
+    wayland
+    wrapGAppsHook
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  buildInputs = [
+    gtk3
+    gnome3.gnome-desktop
+    wayland
+    wayland-protocols
+    libxml2
+    libxkbcommon
+    feedbackd
+  ];
+
+  meta = with lib; {
+    description = "A virtual keyboard supporting Wayland";
+    homepage = "https://source.puri.sm/Librem5/squeekboard";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ artturin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8329,6 +8329,8 @@ in
 
   swiften = callPackage ../development/libraries/swiften { };
 
+  squeekboard = callPackage ../applications/accessibility/squeekboard { };
+
   t = callPackage ../tools/misc/t { };
 
   tabnine = callPackage ../development/tools/tabnine { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
squeekboard is a virtual keyboard that works on wayland

the stable release v1.12.0 is not used because of this useful commit https://source.puri.sm/Librem5/squeekboard/-/commit/a265427e8ec0bf00ce7fdb7caaff0396d0456599

i tested on x86_64 and aarch64

tagging #88767
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
