### PR TITLE
vscode-extensions.hashicorp.terraform: 2.8.1 -> 2.8.2

### DIFF
--- a/pkgs/misc/vscode-extensions/terraform/default.nix
+++ b/pkgs/misc/vscode-extensions/terraform/default.nix
@@ -3,13 +3,13 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "terraform";
     publisher = "hashicorp";
-    version = "2.8.1";
+    version = "2.8.2";
   };
 
   vsix = fetchurl {
     name = "${mktplcRef.publisher}-${mktplcRef.name}.zip";
     url = "https://github.com/hashicorp/vscode-terraform/releases/download/v${mktplcRef.version}/terraform-${mktplcRef.version}.vsix";
-    sha256 = "1pdpl8diqybqf68jvfk4kq9wg4k6c38811mh8iq12j4ba31cig9s";
+    sha256 = "0f1ck3h8ckvr75j27w2lxjbwnr24nc6fjki0gnn715ynkqg7w9bi";
   };
 
   patches = [ ./fix-terraform-ls.patch ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
