### PR TITLE
python3Packages.pywemo: init at 0.6.4

### DIFF
--- a/pkgs/development/python-modules/pywemo/default.nix
+++ b/pkgs/development/python-modules/pywemo/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, ifaddr
+, lxml
+, poetry-core
+, pytest-vcr
+, pytestCheckHook
+, pythonOlder
+, requests
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "pywemo";
+  version = "0.6.4";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "1hm1vs6m65vqar0lcjnynz0d9y9ri5s75fzhvp0yfjkcnp06gnfa";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    ifaddr
+    requests
+    urllib3
+    lxml
+  ];
+
+  checkInputs = [
+    pytest-vcr
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pywemo" ];
+
+  meta = with lib; {
+    description = "Python module to discover and control WeMo devices";
+    homepage = "https://github.com/pywemo/pywemo";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -937,7 +937,7 @@
     "webhook" = ps: with ps; [ aiohttp-cors ];
     "webostv" = ps: with ps; [ aiopylgtv ];
     "websocket_api" = ps: with ps; [ aiohttp-cors ];
-    "wemo" = ps: with ps; [ ]; # missing inputs: pywemo
+    "wemo" = ps: with ps; [ pywemo ];
     "whois" = ps: with ps; [ python-whois ];
     "wiffi" = ps: with ps; [ wiffi ];
     "wilight" = ps: with ps; [ pywilight ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -367,6 +367,7 @@ in with py.pkgs; buildPythonApplication rec {
     "weather"
     "webhook"
     "websocket_api"
+    "wemo"
     "wled"
     "workday"
     "worldclock"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7093,6 +7093,8 @@ in {
 
   pywebview = callPackage ../development/python-modules/pywebview { };
 
+  pywemo = callPackage ../development/python-modules/pywemo { };
+
   pywick = callPackage ../development/python-modules/pywick { };
 
   pywilight = callPackage ../development/python-modules/pywilight { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to discover and control WeMo devices

https://github.com/pywemo/pywemo

This is a Home Assistant dependency.

Depends on https://github.com/NixOS/nixpkgs/pull/113382

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
