### PR TITLE
python3Packages.hass-nabucasa: 0.41.0 -> 0.42.0, python3Packages.convertdate: 2.3.1 -> 2.3.2

### DIFF
--- a/pkgs/development/python-modules/convertdate/default.nix
+++ b/pkgs/development/python-modules/convertdate/default.nix
@@ -9,16 +9,15 @@
 
 buildPythonPackage rec {
   pname = "convertdate";
-  version = "2.3.1";
-
+  version = "2.3.2";
   disabled = isPy27;
 
   # Tests are not available in the PyPI tarball so use GitHub instead.
   src = fetchFromGitHub {
     owner = "fitnr";
     repo = pname;
-    rev = version;
-    sha256 = "1g8sgd3xc9viy0kb1i4xp6bdn1hzwhrnk8kmismla88scivrhq32";
+    rev = "v${version}";
+    sha256 = "0k7j59sbqwyi72vcjx5vsh3qb6hxfnkfjkd2i6f6lckdr1bkh7fz";
   };
 
   propagatedBuildInputs = [
@@ -29,6 +28,8 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
   ];
+
+  pythonImportsCheck = [ "convertdate" ];
 
   meta = with lib; {
     homepage = "https://github.com/fitnr/convertdate";

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.41.0";
+  version = "0.42.0";
 
   src = fetchFromGitHub {
     owner = "nabucasa";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ewWw3PyJGRHP23J6WBBWs9YGl4vTb9/j/soZ6n5wbLM=";
+    sha256 = "sha256-vDgjuNgwNp9cDgiCNxhACOcuaxcrR+0DW/U5OaSW0n4=";
   };
 
   postPatch = ''
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/NabuCasa/hass-nabucasa";
     description = "Home Assistant cloud integration by Nabu Casa, inc.";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ Scriptkiddi ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.42.0 and 2.3.2

Change log: 

- https://github.com/NabuCasa/hass-nabucasa/releases/tag/0.42.0
- https://github.com/fitnr/convertdate/releases/tag/v2.3.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
