### PR TITLE
portfolio-filemanager: init at 0.9.10

### DIFF
--- a/pkgs/applications/misc/portfolio-filemanager/default.nix
+++ b/pkgs/applications/misc/portfolio-filemanager/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, python3
+, fetchFromGitHub
+, appstream-glib
+, desktop-file-utils
+, gettext
+, glib
+, gobject-introspection
+, gtk3
+, libhandy
+, librsvg
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "portfolio";
+  version = "0.9.10";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "tchx84";
+    repo = "Portfolio";
+    rev = "v${version}";
+    sha256 = "06hk0kx6h8w263qa71bik68rg4r8qs94b6s60pyhzicfc822k0j4";
+  };
+
+  postPatch = ''
+    patchShebangs build-aux/meson
+  '';
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    gettext
+    glib
+    gobject-introspection
+    gtk3
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gobject-introspection
+    libhandy
+    librsvg
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+  ];
+
+  postInstall = ''
+    ln -s dev.tchx84.Portfolio "$out/bin/portfolio"
+  '';
+
+  meta = with lib; {
+    description = "A minimalist file manager for those who want to use Linux mobile devices";
+    homepage = "https://github.com/tchx84/Portfolio";
+    changelog = "https://github.com/tchx84/Portfolio/blob/v${version}/CHANGELOG.md";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24711,6 +24711,8 @@ in
 
   ponymix = callPackage ../applications/audio/ponymix { };
 
+  portfolio-filemanager = callPackage ../applications/misc/portfolio-filemanager { };
+
   pothos = libsForQt5.callPackage ../applications/radio/pothos { };
 
   potrace = callPackage ../applications/graphics/potrace {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
