### PR TITLE
python3Packages.adguardhome: 0.4.2 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/adguardhome/default.nix
+++ b/pkgs/development/python-modules/adguardhome/default.nix
@@ -1,24 +1,49 @@
-{ aiohttp, aresponses, buildPythonPackage, fetchFromGitHub, isPy3k, lib
-, pytest-asyncio, pytestCheckHook, yarl }:
+{ lib
+, aiohttp
+, aresponses
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, yarl
+}:
 
 buildPythonPackage rec {
   pname = "adguardhome";
-  version = "0.4.2";
-
-  disabled = !isPy3k;
+  version = "0.5.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "frenck";
     repo = "python-${pname}";
     rev = "v${version}";
-    sha256 = "0lcf3yg27amrnqvgn5nw4jn2j0vj4yfmyl5p5yncmn7dh6bdbsp8";
+    sha256 = "sha256-f8uZF4DXbfiL1nL82shjGNpo6lXSUomRgO1YnNT/GDw=";
   };
 
-  propagatedBuildInputs = [ aiohttp yarl ];
-  checkInputs = [ aresponses pytest-asyncio pytestCheckHook ];
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    yarl
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace "--cov" ""
+  '';
+
+  pythonImportsCheck = [ "adguardhome" ];
 
   meta = with lib; {
-    description = "Asynchronous Python client for the AdGuard Home API.";
+    description = "Python client for the AdGuard Home API";
     homepage = "https://github.com/frenck/python-adguardhome";
     license = licenses.mit;
     maintainers = with maintainers; [ jamiemagee ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.5.0

Change log: https://github.com/frenck/python-adguardhome/releases/tag/v0.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
