### PR TITLE
python3Packages.websocket_client: 0.57.0 -> 0.58.0, python3Packages.devolo-home-control-api: 0.16.0 -> 0.17.0

### DIFF
--- a/pkgs/development/python-modules/devolo-home-control-api/default.nix
+++ b/pkgs/development/python-modules/devolo-home-control-api/default.nix
@@ -2,27 +2,25 @@
 , aiohttp
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
-, pytest-cov
 , pytest-mock
+, pytestCheckHook
+, pythonOlder
 , requests
-, zeroconf
 , websocket_client
-, pytest-runner
+, zeroconf
 }:
 
 buildPythonPackage rec {
   pname = "devolo-home-control-api";
-  version = "0.16.0";
+  version = "0.17.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "2Fake";
     repo = "devolo_home_control_api";
     rev = "v${version}";
-    sha256 = "19zzdbx0dxlm8pq0yk00nn9gqqblgpp16fgl7z6a98hsa6459zzb";
+    sha256 = "sha256-g82YmlxlBdyNn7KPU+k+J3/P7ABWMMdLXUpXWnCkdpM=";
   };
-
-  nativeBuildInputs = [ pytest-runner ];
 
   propagatedBuildInputs = [
     requests
@@ -32,12 +30,22 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-    pytest-cov
     pytest-mock
   ];
 
+  postPatch = ''
+    # setup.py is not able to detect the version with setuptools_scm
+    substituteInPlace setup.py \
+      --replace "setuptools_scm" "" \
+      --replace 'use_scm_version=True' 'use_scm_version="${version}"'
+  '';
+
   # Disable test that requires network access
-  disabledTests = [ "test__on_pong" ];
+  disabledTests = [
+    "test__on_pong"
+    "TestMprm"
+  ];
+
   pythonImportsCheck = [ "devolo_home_control_api" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/websocket_client/default.nix
+++ b/pkgs/development/python-modules/websocket_client/default.nix
@@ -1,25 +1,33 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27
-, six
+{ lib
 , backports_ssl_match_hostname
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, pytestCheckHook
+, six
 }:
 
 buildPythonPackage rec {
-  version = "0.57.0";
   pname = "websocket_client";
+  version = "0.58.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010";
+    sha256 = "sha256-Y1CbQdFYrlt/Z+tK0g/su07umUNOc+FANU3D/44JcW8=";
   };
 
   propagatedBuildInputs = [
     six
   ] ++ lib.optional isPy27 backports_ssl_match_hostname;
 
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "websocket" ];
+
   meta = with lib; {
-    description = "Websocket client for python";
+    description = "Websocket client for Python";
     homepage = "https://github.com/websocket-client/websocket-client";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/servers/home-assistant/appdaemon.nix
+++ b/pkgs/servers/home-assistant/appdaemon.nix
@@ -1,4 +1,7 @@
-{ lib, python3, fetchFromGitHub }:
+{ lib
+, python3
+, fetchFromGitHub
+}:
 
 let
   python = python3.override {
@@ -24,10 +27,11 @@ let
 in python.pkgs.buildPythonApplication rec {
   pname = "appdaemon";
   version = "4.0.5";
+  disabled = python.pythonOlder "3.6";
 
   src = fetchFromGitHub {
-    owner = "home-assistant";
-    repo = "appdaemon";
+    owner = "AppDaemon";
+    repo = pname;
     rev = version;
     sha256 = "7o6DrTufAC+qK3dDfpkuQMQWuduCZ6Say/knI4Y07QM=";
   };
@@ -63,12 +67,13 @@ in python.pkgs.buildPythonApplication rec {
       --replace "feedparser==5.2.1" "feedparser>=5.2.1" \
       --replace "aiohttp_jinja2==1.2.0" "aiohttp_jinja2>=1.2.0" \
       --replace "pygments==2.6.1" "pygments>=2.6.1" \
-      --replace "paho-mqtt==1.5.0" "paho-mqtt>=1.5.0"
+      --replace "paho-mqtt==1.5.0" "paho-mqtt>=1.5.0" \
+      --replace "websocket-client==0.57.0" "websocket-client>=0.57.0"
   '';
 
   meta = with lib; {
     description = "Sandboxed Python execution environment for writing automation apps for Home Assistant";
-    homepage = "https://github.com/home-assistant/appdaemon";
+    homepage = "https://github.com/AppDaemon/appdaemon";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg dotlambda ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream releases

Change log:

- https://github.com/websocket-client/websocket-client/blob/master/ChangeLog
- https://github.com/2Fake/devolo_home_control_api/releases/tag/v0.17.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
