### PR TITLE
python3Packages.pyatv: 0.7.6 -> 0.7.7

### DIFF
--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -18,12 +18,12 @@
 
 buildPythonPackage rec {
   pname = "pyatv";
-  version = "0.7.6";
+  version = "0.7.7";
   src = fetchFromGitHub {
     owner = "postlund";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1lahv6f97fizgh5b2w5yz9455l8ygn99rslhiygkgjywi2flx3p3";
+    sha256 = "sha256-dPnh8XZN7ZVR2rYNnj7GSYXW5I2GNQwD/KRDTgs2AtI=";
   };
 
   nativeBuildInputs = [ pytestrunner];

--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -1,24 +1,25 @@
-{ lib, buildPythonPackage
+{ lib
+, buildPythonPackage
 , aiohttp
 , aiozeroconf
-, asynctest
 , cryptography
 , deepdiff
+, fetchFromGitHub
 , netifaces
 , protobuf
-, pytest
 , pytest-aiohttp
 , pytest-asyncio
-, pytestrunner
+, pytest-runner
+, pytest-timeout
+, pytestCheckHook
 , srptools
 , zeroconf
-, fetchFromGitHub
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pyatv";
   version = "0.7.7";
+
   src = fetchFromGitHub {
     owner = "postlund";
     repo = pname;
@@ -26,30 +27,32 @@ buildPythonPackage rec {
     sha256 = "sha256-dPnh8XZN7ZVR2rYNnj7GSYXW5I2GNQwD/KRDTgs2AtI=";
   };
 
-  nativeBuildInputs = [ pytestrunner];
+  nativeBuildInputs = [ pytest-runner];
 
   propagatedBuildInputs = [
-    aiozeroconf
-    srptools
     aiohttp
-    protobuf
+    aiozeroconf
     cryptography
     netifaces
+    protobuf
+    srptools
     zeroconf
   ];
 
   checkInputs = [
     deepdiff
-    pytest
     pytest-aiohttp
     pytest-asyncio
+    pytest-timeout
     pytestCheckHook
   ];
 
   __darwinAllowLocalNetworking = true;
 
+  pythonImportsCheck = [ "pyatv" ];
+
   meta = with lib; {
-    description = "A python client library for the Apple TV";
+    description = "Python client library for the Apple TV";
     homepage = "https://github.com/postlund/pyatv";
     license = licenses.mit;
     maintainers = with maintainers; [ elseym ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.7.7

Change log: https://github.com/postlund/pyatv/blob/master/CHANGES.md#077-2021-03-12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
