### PR TITLE
expliot: init at 0.9.6

### DIFF
--- a/pkgs/tools/security/expliot/default.nix
+++ b/pkgs/tools/security/expliot/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, aiocoap
+, awsiotpythonsdk
+, bluepy
+, buildPythonApplication
+, can
+, cmd2
+, cryptography
+, fetchFromGitLab
+, paho-mqtt
+, pyi2cflash
+, pymodbus
+, pynetdicom
+, pyparsing
+, pyserial
+, pyspiflash
+, pythonOlder
+, upnpy
+, xmltodict
+, zeroconf
+}:
+
+buildPythonApplication rec {
+  pname = "expliot";
+  version = "0.9.6";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitLab {
+    owner = "expliot_framework";
+    repo = pname;
+    rev = version;
+    sha256 = "1wn8fyrvis0gw80zzmpivinw6mz5n33inhv39iallsl3is8xpgpa";
+  };
+
+  propagatedBuildInputs = [
+    aiocoap
+    awsiotpythonsdk
+    bluepy
+    can
+    cmd2
+    cryptography
+    paho-mqtt
+    pyi2cflash
+    pymodbus
+    pynetdicom
+    pyparsing
+    pyserial
+    pyspiflash
+    upnpy
+    xmltodict
+    zeroconf
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "expliot" ];
+
+  meta = with lib; {
+    description = "IoT security testing and exploitation framework";
+    longDescription = ''
+      EXPLIoT is a Framework for security testing and exploiting IoT
+      products and IoT infrastructure. It provides a set of plugins
+      (test cases) which are used to perform the assessment and can
+      be extended easily with new ones. The name EXPLIoT (pronounced
+      expl-aa-yo-tee) is a pun on the word exploit and explains the
+      purpose of the framework i.e. IoT exploitation.
+    '';
+    homepage = "https://expliot.readthedocs.io/";
+    license = with licenses; [ agpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4140,6 +4140,8 @@ in
 
   expect = callPackage ../tools/misc/expect { };
 
+  expliot = python3Packages.callPackage ../tools/security/expliot { };
+
   f2fs-tools = callPackage ../tools/filesystems/f2fs-tools { };
 
   Fabric = with python3Packages; toPythonApplication Fabric;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
EXPLIoT is a Framework for security testing and exploiting IoT
products and IoT infrastructure. It provides a set of plugins
(test cases) which are used to perform the assessment and can
be extended easily with new ones. The name EXPLIoT (pronounced
expl-aa-yo-tee) is a pun on the word exploit and explains the
purpose of the framework i.e. IoT exploitation.

https://expliot.readthedocs.io/

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
