### PR TITLE
_3mux: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/tools/misc/3mux/default.nix
+++ b/pkgs/tools/misc/3mux/default.nix
@@ -1,24 +1,38 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper }:
 
 buildGoModule rec {
   pname = "3mux";
-  version = "1.0.1";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "aaronjanse";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-auEMG3txO2JS/2dMFBtEujv9s5I0A80Vwts5kXjH600=";
+    sha256 = "sha256-QT4QXTlJf2NfTqXE4GF759EoW6Ri12lxDyodyEFc+ag=";
   };
 
-  vendorSha256 = "sha256-rcbnyScD2GU1DLY6dTEPgFNXZfgkxXPn5lt6HRqa0d8=";
+  nativeBuildInputs = [ makeWrapper ];
+
+  vendorSha256 = "sha256-tbziQZIA1+b+ZtvA/865c8YQxn+r8HQy6Pqaac2kwcU=";
+
+  # This is a package used for internally testing 3mux. It's meant for
+  # use by 3mux maintainers/contributors only.
+  excludedPackages = [ "fuzz" ];
+
+  # 3mux needs to have itself in the path so users can run `3mux detach`.
+  # This ensures that, while inside 3mux, the binary in the path is the
+  # same version as the 3mux hosting the session. This also allows users
+  # to use 3mux via `nix run nixpkgs#_3mux` (otherwise they'd get "command
+  # not found").
+  postInstall = ''
+    wrapProgram $out/bin/3mux --prefix PATH : $out/bin
+  '';
 
   meta = with lib; {
     description = "Terminal multiplexer inspired by i3";
     longDescription = ''
-      3mux is a terminal multiplexer with out-of-the-box support for search,
-      mouse-controlled scrollback, and i3-like keybindings. Imagine tmux with a
-      smaller learning curve and more sane defaults.
+      Terminal multiplexer with out-of-the-box support for search,
+      mouse-controlled scrollback, and i3-like keybindings
     '';
     homepage = "https://github.com/aaronjanse/3mux";
     license = licenses.mit;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`3mux` recently released [v1.1.0](https://github.com/aaronjanse/3mux/releases/tag/v1.1.0), which has many bugfixes.

I also shortened the description to match nixpkgs best practices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
