### PR TITLE
[20.09] libtiff: fix two security issues

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, fetchpatch
 
 , pkgconfig
 
@@ -18,6 +19,32 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "bin" "dev" "out" "man" "doc" ];
+
+  patches = [
+    # https://gitlab.com/libtiff/libtiff/-/merge_requests/160
+    (fetchpatch {
+      name = "CVE-2020-35523.1.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/712fe9f5b9795c5a3e80f38db90dad11e6a8bb6a.patch";
+      sha256 = "1h4jrilnhc50qzjxljcm0471i4inwr790b1dzdf6qvwf7fqi6wky";
+    })
+    (fetchpatch {
+      name = "CVE-2020-35523.2.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/c8d613ef497058fe653c467fc84c70a62a4a71b2.patch";
+      sha256 = "01rzwf5xk5mf3j362g74h9qc45cnmqr0c14w5xj3p8mk160cd74q";
+    })
+    # https://gitlab.com/libtiff/libtiff/-/merge_requests/159
+    (fetchpatch {
+      name = "CVE-2020-35524.1.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/c6a12721b46f1a72974f91177890301730d7b330.patch";
+      sha256 = "1lac51lsvap6wzdg1rssnq2adrpxd3bqrsdm40qd88mpa0g3rsfb";
+    })
+    (fetchpatch {
+      name = "CVE-2020-35524.2.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/d74f56e3b7ea55c8a18a03bc247cd5fd0ca288b2.patch";
+      sha256 = "0v559fpsgnmhzgjhsp7fkm3hwrfjv2042lrczd32c0yb9jbrqxvi";
+    })
+
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

CVE-2020-35523:
An integer overflow flaw was found in libtiff that exists in the
tif_getimage.c file. This flaw allows an attacker to inject and execute
arbitrary code when a user opens a crafted TIFF file. The highest
threat from this vulnerability is to confidentiality, integrity, as
well as system availability.

CVE-2020-35524:
A heap-based buffer overflow flaw was found in libtiff in the handling
of TIFF images in libtiff's TIFF2PDF tool. A specially crafted TIFF
file can lead to arbitrary code execution. The highest threat from this
vulnerability is to confidentiality, integrity, as well as system
availability.

Fixes: CVE-2020-35523, CVE-2020-35524

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
