### PR TITLE
nix-prefetch-git: fix checkout_ref() for "dumb http" repositories

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -182,8 +182,10 @@ checkout_ref(){
     fi
 
     if test -n "$ref"; then
-        # --depth option is ignored on http repository.
-        clean_git fetch ${builder:+--progress} --depth 1 origin +"$ref" || return 1
+        # --depth option fails on dumb http repositories.
+        clean_git fetch ${builder:+--progress} --depth 1 origin +"$ref" ||
+          clean_git fetch ${builder:+--progress} origin +"$ref" ||
+          return 1
         clean_git checkout -b "$branchName" FETCH_HEAD || return 1
     else
         return 1


### PR DESCRIPTION
The `checkout_ref()` function was written against Git 1.6.5, just before "smart http" repositories were implemented in Git 1.6.6. In 1.6.5, the `--depth` parameter is ignored when fetching from a dumb http repository. From 1.6.6, this scenario causes a failure. This change updates the comment and falls back to fetching without `--depth`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This change causes `checkout_ref` to succeed in cases where I believe it is intended. I think that previously fetches from a dumb http repository would usually succeed through the `checkout_hash` fallback. As of #104714 `checkout_hash` doesn't seem to support tags (perhaps this should be changed as well?), so now `nix-prefetch-git` noticeably fails for tag revs on dumb http repositories.

I'm not 100% convinced about the chained `||`, but I can't find a way to instruct Git to "attempt" `--depth=1` or find a way to robustly fall back only if the first fetch fails due to a "dumb http" repository.

This seems to resolve #115145.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
