### PR TITLE
nixos/hidpi: add xserver dpi

### DIFF
--- a/nixos/modules/hardware/video/hidpi.nix
+++ b/nixos/modules/hardware/video/hidpi.nix
@@ -12,5 +12,6 @@ with lib;
     boot.loader.systemd-boot.consoleMode = mkDefault "1";
 
     # TODO Find reasonable defaults X11 & wayland
+    services.xserver.dpi = lib.mkDefault 192;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Addresses a TODO comment. More importantly, this should improve NixOS's out-of-the-box experience.

Some additions we may want to consider:

```nix
{
  services.xserver.displayManager.sessionCommands = ''
    ${pkgs.xorg.xrdb}/bin/xrdb -merge <<EOF
      Xcursor.theme: Vanilla-DMZ
      Xcursor.size: 32
    EOF
  '';
  environment.variables = {
    GDK_SCALE = "1.5";
    GDK_DPI_SCALE = "0.75";
    QT_AUTO_SCREEN_SCALE_FACTOR = "1";
  };
}
  ```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
