### PR TITLE
macvim: fix configuration

### DIFF
--- a/pkgs/applications/editors/vim/macvim-configurable.nix
+++ b/pkgs/applications/editors/vim/macvim-configurable.nix
@@ -29,7 +29,7 @@ let
           "/Applications/MacVim.app/Contents/MacOS"
           "/Applications/MacVim.app/Contents/bin"
         ];
-        nativeBuildInputs = [ makeWrapper ];
+        buildInputs = [ makeWrapper ];
         # We need to do surgery on the resulting app. We can't just make a wrapper for vim because this
         # is a GUI app. We need to copy the actual GUI executable image as AppKit uses the loaded image's
         # path to locate the bundle. We can use symlinks for other executables and resources though.


### PR DESCRIPTION
###### Motivation for this change
`macvim.configure` was broken in e03c068af5c because `buildEnv` doesn't take `nativeBuildInputs`. Revert the change for `macvim`.

Without this change:

```
> nix run '(with import <nixpkgs> { overlays = []; }; macvim.configure {})'
error: anonymous function at /nix/store/n8m7dg1nl6p9i35xwq3c8yw0azz8nhqp-nixpkgs-21.05pre275813.c5147860e23/nixpkgs/pkgs/build-support/buildenv/default.nix:8:2 called with unexpected argument 'nativeBuildInputs', at /nix/store/n8m7dg1nl6p9i35xwq3c8yw0azz8nhqp-nixpkgs-21.05pre275813.c5147860e23/nixpkgs/lib/customisation.nix:69:16
```

With this change:

```
> nix run '(with import ./. { overlays = []; }; macvim.configure {})'
[0/7 built, 1/0/3 copied (23.9/62.2 MiB), 5.6/11.5 MiB DL] fetching python3-3.7.10 from https://cache.nixos.org
…
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
