### PR TITLE
mupdf: fixing x11 and gl disabling

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -1,11 +1,27 @@
-{ stdenv, lib, fetchurl, fetchpatch, pkg-config, freetype, harfbuzz, openjpeg
-, jbig2dec, libjpeg , darwin
+{ stdenv
+, lib
+, fetchurl
+, fetchpatch
+, pkg-config
+, freetype
+, harfbuzz
+, openjpeg
+, jbig2dec
+, libjpeg
+, darwin
 , gumbo
-, enableX11 ? true, libX11, libXext, libXi, libXrandr
-, enableCurl ? true, curl, openssl
-, enableGL ? true, freeglut, libGLU
+, enableX11 ? true
+, libX11
+, libXext
+, libXi
+, libXrandr
+, enableCurl ? true
+, curl
+, openssl
+, enableGL ? true
+, freeglut
+, libGLU
 }:
-
 let
 
   # OpenJPEG version is hardcoded in package source
@@ -13,7 +29,8 @@ let
     lib.versions.majorMinor (lib.getVersion openjpeg);
 
 
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   version = "1.18.0";
   pname = "mupdf";
 
@@ -53,19 +70,20 @@ in stdenv.mkDerivation rec {
   buildFlags = [ "shared" ];
 
   makeFlags = [ "prefix=$(out)" "USE_SYSTEM_LIBS=yes" ]
-              ++ lib.optionals (!enableX11) [ "HAVE_X11=no" ]
-              ++ lib.optionals (!enableGL) [ "HAVE_GLUT=no" ];
+    ++ lib.optionals (!enableX11) [ "HAVE_X11=no" ]
+    ++ lib.optionals (!enableGL) [ "HAVE_GLUT=no" ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg gumbo ]
-                ++ lib.optionals enableX11 [ libX11 libXext libXi libXrandr ]
-                ++ lib.optionals enableCurl [ curl openssl ]
-                ++ lib.optionals enableGL (
-                  if stdenv.isDarwin then
-                    with darwin.apple_sdk.frameworks; [ GLUT OpenGL ]
-                  else
-                    [ freeglut libGLU ])
-                ;
+    ++ lib.optionals enableX11 [ libX11 libXext libXi libXrandr ]
+    ++ lib.optionals enableCurl [ curl openssl ]
+    ++ lib.optionals enableGL (
+    if stdenv.isDarwin then
+      with darwin.apple_sdk.frameworks; [ GLUT OpenGL ]
+    else
+      [ freeglut libGLU ]
+  )
+  ;
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   preConfigure = ''
@@ -88,7 +106,7 @@ in stdenv.mkDerivation rec {
     EOF
 
     moveToOutput "bin" "$bin"
-    '' + lib.optionalString enableX11 ''
+  '' + lib.optionalString enableX11 ''
     ln -s "$bin/bin/mupdf-x11" "$bin/bin/mupdf"
     mkdir -p $bin/share/applications
     cat > $bin/share/applications/mupdf.desktop <<EOF

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
 
   makeFlags = [ "prefix=$(out) USE_SYSTEM_LIBS=yes" ];
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg freeglut libGLU gumbo ]
+  buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg gumbo ]
                 ++ lib.optionals enableX11 [ libX11 libXext libXi libXrandr ]
                 ++ lib.optionals enableCurl [ curl openssl ]
                 ++ lib.optionals enableGL (

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation rec {
   # Use shared libraries to decrease size
   buildFlags = [ "shared" ];
 
-  makeFlags = [ "prefix=$(out) USE_SYSTEM_LIBS=yes" ]
+  makeFlags = [ "prefix=$(out)" "USE_SYSTEM_LIBS=yes" ]
               ++ lib.optionals (!enableX11) [ "HAVE_X11=no" ]
               ++ lib.optionals (!enableGL) [ "HAVE_GLUT=no" ];
 

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -52,7 +52,10 @@ in stdenv.mkDerivation rec {
   # Use shared libraries to decrease size
   buildFlags = [ "shared" ];
 
-  makeFlags = [ "prefix=$(out) USE_SYSTEM_LIBS=yes" ];
+  makeFlags = [ "prefix=$(out) USE_SYSTEM_LIBS=yes" ]
+              ++ lib.optionals (!enableX11) [ "HAVE_X11=no" ]
+              ++ lib.optionals (!enableGL) [ "HAVE_GLUT=no" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg gumbo ]
                 ++ lib.optionals enableX11 [ libX11 libXext libXi libXrandr ]

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -88,6 +88,7 @@ in stdenv.mkDerivation rec {
     EOF
 
     moveToOutput "bin" "$bin"
+    '' + lib.optionalString enableX11 ''
     ln -s "$bin/bin/mupdf-x11" "$bin/bin/mupdf"
     mkdir -p $bin/share/applications
     cat > $bin/share/applications/mupdf.desktop <<EOF


### PR DESCRIPTION
###### Motivation for this change

Disabling X11 and GL doesn't really work now for mupdf. This is fixed by this PR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (docker image nixpkgs/nix)
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - it can only go down by removing x11 and GL
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
