### PR TITLE
mkvtoolnix: 53.0.0 -> 55.0.0

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -13,13 +13,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "mkvtoolnix";
-  version = "53.0.0";
+  version = "55.0.0";
 
   src = fetchFromGitLab {
     owner  = "mbunkus";
     repo   = "mkvtoolnix";
     rev    = "release-${version}";
-    sha256 = "04wjs3sgb3gn85gl8y1svx177d1213hswx37zdsj80giw1k5df79";
+    sha256 = "129azp4cpdd05f6072gkxdjj811aqs29nbw6v6qm8vv47gfvjcf7";
   };
 
   nativeBuildInputs = [
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
   ];
 
   CXXFLAGS = optional stdenv.cc.isClang "-std=c++17";
+  LDFLAGS = optional stdenv.cc.isClang "-lc++fs";
 
   dontWrapQtApps = true;
   postFixup = optionalString withGUI ''
@@ -60,7 +61,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Cross-platform tools for Matroska";
     homepage    = "http://www.bunkus.org/videotools/mkvtoolnix/";
-    license     = licenses.gpl2;
+    license     = licenses.gpl2Only;
     maintainers = with maintainers; [ codyopel rnhmjoj ];
     platforms   = platforms.linux
       ++ optionals (!withGUI) platforms.darwin;

--- a/pkgs/development/libraries/libebml/default.nix
+++ b/pkgs/development/libraries/libebml/default.nix
@@ -2,19 +2,20 @@
 
 stdenv.mkDerivation rec {
   pname = "libebml";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner  = "Matroska-Org";
     repo   = "libebml";
     rev    = "release-${version}";
-    sha256 = "04bn1i7g4vwmkv3hv26rmcb59zkl2rh37qnfjm52j560bjlyd7im";
+    sha256 = "1hiilnabar826lfxsaflqjhgsdli6hzzhjv8q2nmw36fvvlyks25";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=YES"
+    "-DCMAKE_INSTALL_PREFIX="
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/libmatroska/default.nix
+++ b/pkgs/development/libraries/libmatroska/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libmatroska";
-  version = "1.6.2";
+  version = "1.6.3";
 
   src = fetchFromGitHub {
     owner  = "Matroska-Org";
     repo   = "libmatroska";
     rev    = "release-${version}";
-    sha256 = "0yhr9hhgljva1fx3b0r4s3wkkypdfgsysbl35a4g3krkbhaa9rsd";
+    sha256 = "01dg12ndxfdqgjx5v2qy4mff6xjdxglywyg82sr3if5aw6rp3dji";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=YES"
+    "-DCMAKE_INSTALL_PREFIX="
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update `mkvtoolnix` to the latest version. This may lead to a possible merge conflict with the automatic pull request https://github.com/NixOS/nixpkgs/pull/114742

###### Change details

- The new `-lc++fs` is needed for `clang7` because `mkvtoolnix` now uses the `c++17 std::filesystem` instead of the `boost/filesystem`.
- The `"-DCMAKE_INSTALL_PREFIX="` cmake flag removes the prefix to fix the
```bash
ld: warning: directory not found for option
'-L/nix/store/3wzvdvkj8aajgnn6l240vq5fbgvjw91w-libmatroska-1.6.2//nix/store/3wzvdvkj8aajgnn6l240vq5fbgvjw91w-libmatroska-1.6.2/lib'
```
(See the [latest hydra logs](https://hydra.nixos.org/build/138004974/nixlog/1))


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
