### PR TITLE
hidrd: init at unstable-2019-06-03

### DIFF
--- a/pkgs/tools/misc/hidrd/default.nix
+++ b/pkgs/tools/misc/hidrd/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation {
+  pname = "hidrd";
+  version = "unstable-2019-06-03";
+
+  src = fetchFromGitHub {
+    owner = "DIGImend";
+    repo = "hidrd";
+    rev = "6c0ed39708a5777ac620f902f39c8a0e03eefe4e";
+    sha256 = "1rnhq6b0nrmphdig1qrpzpbpqlg3943gzpw0v7p5rwcdynb6bb94";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "HID report descriptor I/O library and conversion tool";
+    homepage = "https://github.com/DIGImend/hidrd";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ pacien ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2514,6 +2514,8 @@ in
 
   hid-listen = callPackage ../tools/misc/hid-listen { };
 
+  hidrd = callPackage ../tools/misc/hidrd { };
+
   hocr-tools = with python3Packages; toPythonApplication hocr-tools;
 
   home-manager = callPackage ../tools/package-management/home-manager {};


### PR DESCRIPTION
###### Motivation for this change

This creates a package for [hidrd], an HID report descriptor I/O library and conversion tool.

[hidrd]: https://github.com/DIGImend/hidrd

###### Things done
 
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
