### PR TITLE
grpc: fix build input propagation

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -6,7 +6,7 @@
 , speechdSupport ? false, speechd
 , pulseSupport ? false, libpulseaudio
 , iceSupport ? false, zeroc-ice
-, grpcSupport ? false, grpc, c-ares, abseil-cpp, which
+, grpcSupport ? false, grpc, which
 , nixosTests
 }:
 
@@ -115,7 +115,7 @@ let
 
     buildInputs = [ libcap ]
       ++ lib.optional iceSupport zeroc-ice
-      ++ lib.optionals grpcSupport [ grpc c-ares abseil-cpp which ];
+      ++ lib.optionals grpcSupport [ grpc which ];
 
     installPhase = ''
       # bin stuff

--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ zlib c-ares c-ares.cmake-config re2 openssl protobuf gflags ]
+  propagatedBuildInputs = [ c-ares re2 zlib ];
+  buildInputs = [ c-ares.cmake-config openssl protobuf gflags ]
     ++ lib.optionals stdenv.isLinux [ libnsl ];
 
   cmakeFlags =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
See https://github.com/NixOS/nixpkgs/issues/115745

I would like to know from somebody more knowledgeable if this is actually the right fix. If it is I think it can be merged. I don't know how many rebuilds this will create but we'll see.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
