### PR TITLE
[20.09] git-big-picture: 0.10.1 -> 1.0.0 (fixes CVE-2021-3028)

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
@@ -1,30 +1,34 @@
-{ fetchFromGitHub, python2Packages, stdenv, git, graphviz }:
+{ fetchFromGitHub, python3Packages, lib, git, graphviz }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "git-big-picture";
-  version = "0.10.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "esc";
+    owner = "git-big-picture";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0b0zdq7d7k7f6p3wwc799347fraphbr20rxd1ysnc4xi1cj4wpmi";
+    sha256 = "14yf71iwgk78nw8w0bpijsnnl4vg3bvxsw3vvypxmbrc1nh0bdha";
   };
 
   buildInputs = [ git graphviz ];
 
-  checkInputs = [ git ];
+  # NOTE: Tests are disabled due to unpackaged test dependency "Scruf".
+  #       When bumping to 1.1.0, please re-enable and use:
+  #checkInputs = [ cram git pytest ];
+  #checkPhase = "pytest test.py";
+  doCheck = false;
 
   postFixup = ''
     wrapProgram $out/bin/git-big-picture \
-      --prefix PATH ":" ${ stdenv.lib.makeBinPath buildInputs  }
+      --prefix PATH ":" ${ lib.makeBinPath buildInputs  }
     '';
 
   meta = {
     description = "Tool for visualization of Git repositories";
-    homepage = "https://github.com/esc/git-big-picture";
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.nthorne ];
+    homepage = "https://github.com/git-big-picture/git-big-picture";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.nthorne ];
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
@@ -1,27 +1,20 @@
-{ fetchFromGitHub, python3Packages, lib, git, graphviz }:
+{ python3Packages, lib, git, graphviz }:
 
 python3Packages.buildPythonApplication rec {
   pname = "git-big-picture";
-  version = "1.0.0";
+  version = "1.1.1";
+  format = "wheel";
 
-  src = fetchFromGitHub {
-    owner = "git-big-picture";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "14yf71iwgk78nw8w0bpijsnnl4vg3bvxsw3vvypxmbrc1nh0bdha";
+  src = python3Packages.fetchPypi {
+    inherit format version;
+    pname = "git_big_picture";  # underscores needed for working download URL
+    python = "py3";  # i.e. no Python 2.7
+    sha256 = "a20a480057ced1585c4c38497d27a5012f12dd29697313f0bb8fa6ddbb5c17d8";
   };
-
-  buildInputs = [ git graphviz ];
-
-  # NOTE: Tests are disabled due to unpackaged test dependency "Scruf".
-  #       When bumping to 1.1.0, please re-enable and use:
-  #checkInputs = [ cram git pytest ];
-  #checkPhase = "pytest test.py";
-  doCheck = false;
 
   postFixup = ''
     wrapProgram $out/bin/git-big-picture \
-      --prefix PATH ":" ${ lib.makeBinPath buildInputs  }
+      --prefix PATH ":" ${ lib.makeBinPath [ git graphviz ]  }
     '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Solves #113440 .
Updated `stdenv.lib` -> `lib`, and removed unecessary `stdenv` in the cherry-picked commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).