### PR TITLE
imagemagick6: 6.9.12-1 -> 6.9.12-3

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/6.x.nix
+++ b/pkgs/applications/graphics/ImageMagick/6.x.nix
@@ -16,13 +16,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "imagemagick";
-  version = "6.9.12-1";
+  version = "6.9.12-3";
 
   src = fetchFromGitHub {
     owner = "ImageMagick";
     repo = "ImageMagick6";
     rev = version;
-    sha256 = "1s1zr0fqnm9jl1ni07if2klvf2lfg26dgxdbspksq5xdhsxxn841";
+    sha256 = "sha256-h9c0N9AcFVpNYpKl+95q1RVJWuacN4N4kbAJIKJp8Jc=";
   };
 
   outputs = [ "out" "dev" "doc" ]; # bin/ isn't really big

--- a/pkgs/applications/graphics/ImageMagick/6.x.nix
+++ b/pkgs/applications/graphics/ImageMagick/6.x.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation rec {
     changelog = "https://legacy.imagemagick.org/script/changelog.php";
     description = "A software suite to create, edit, compose, or convert bitmap images";
     platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ erictapen ];
     license = licenses.asl20;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

Added myself as maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
