### PR TITLE
Configure gnome2.gtksourceview to build with autoconf 2.69

### DIFF
--- a/pkgs/desktops/gnome-2/default.nix
+++ b/pkgs/desktops/gnome-2/default.nix
@@ -58,7 +58,9 @@ lib.makeScope pkgs.newScope (self: with self; {
   # Removed from recent GNOME releases, but still required
   scrollkeeper = callPackage ./desktop/scrollkeeper { };
 
-  gtksourceview = callPackage ./desktop/gtksourceview { };
+  gtksourceview = callPackage ./desktop/gtksourceview {
+    autoreconfHook = pkgs.autoreconfHook269;
+  };
 
   vte = callPackage ./desktop/vte { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`nix-build -A gnome2.gtksourceview` fails to build with autoconf 2.70 on macOS 11.2 with the following error:
```
...
autoreconf: running: intltoolize --copy --force
You should update your 'aclocal.m4' by running aclocal.
autoreconf: running: gtkdocize --copy
Can't exec "gtkdocize": No such file or directory at /nix/store/hm8xfxprfk4l1msb9hpjwgydilbqlvl5-autoconf-2.70/share/autoconf/Autom4te/FileUtils.pm line 293.
autoreconf: error: gtkdocize failed with exit status: 2
```
gnome2.gtksourceview builds successfully with autoconf 2.69.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
