### PR TITLE
bambootracker: fix executable on Darwin

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -1,4 +1,5 @@
 { mkDerivation
+, stdenv
 , lib
 , fetchFromGitHub
 , fetchpatch
@@ -38,6 +39,14 @@ mkDerivation rec {
   qmakeFlags = [ "CONFIG+=system_rtaudio" "CONFIG+=system_rtmidi" ];
 
   postConfigure = "make qmake_all";
+
+  # installs app bundle on darwin, re-extract the binary
+  # wrapQtAppsHook fails to wrap mach-o binaries, manually call wrapper (https://github.com/NixOS/nixpkgs/issues/102044)
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mv $out/bin/BambooTracker{.app/Contents/MacOS/BambooTracker,}
+    rm -r $out/bin/BambooTracker.app
+    wrapQtApp $out/bin/BambooTracker
+  '';
 
   meta = with lib; {
     description = "A tracker for YM2608 (OPNA) which was used in NEC PC-8801/9801 series computers";


### PR DESCRIPTION
###### Motivation for this change
Package builds on Darwin but installs an application bundle, and the binary within it lacks any of Qt's wrapping. I guess nobody wanted to test the binary yet? :pensive:

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
