### PR TITLE
ytfzf: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/tools/misc/ytfzf/default.nix
+++ b/pkgs/tools/misc/ytfzf/default.nix
@@ -2,24 +2,33 @@
 , stdenv
 , fetchFromGitHub
 , makeWrapper
+, coreutils
 , curl
 , dmenu
 , fzf
+, gnused
 , jq
 , mpv
+, ncurses
+, ueberzug
 , youtube-dl
 }:
 
 stdenv.mkDerivation rec {
   pname = "ytfzf";
-  version = "1.0.1";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "pystardust";
     repo = "ytfzf";
     rev = "v${version}";
-    sha256 = "1i9ya38zcaj1vkfgy1n4gp5vqb59zlrd609pdmz4jqinrb0c5fgv";
+    sha256 = "sha256-ATQRXYaIp1MKCO/EAPsopzFEZeNJzdk73/OcgjsMdkg=";
   };
+
+  patches = [
+    # Updates have to be installed through Nix.
+    ./no-update.patch
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -29,7 +38,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram "$out/bin/ytfzf" --prefix PATH : ${lib.makeBinPath [
-      curl dmenu fzf jq mpv youtube-dl
+      coreutils curl dmenu fzf gnused jq mpv ncurses ueberzug youtube-dl
     ]}
   '';
 

--- a/pkgs/tools/misc/ytfzf/no-update.patch
+++ b/pkgs/tools/misc/ytfzf/no-update.patch
@@ -1,0 +1,30 @@
+diff --git a/ytfzf b/ytfzf
+index 5238682..c5c3a1a 100755
+--- a/ytfzf
++++ b/ytfzf
+@@ -757,23 +757,8 @@ clear_history () {
+ }
+ 
+ update_ytfzf () {
+-	branch="$1"
+-	updatefile="/tmp/ytfzf-update"
+-	curl -L "https://raw.githubusercontent.com/pystardust/ytfzf/$branch/ytfzf" -o "$updatefile"
+-
+-	if sed -n '1p' < "$updatefile" | grep -q '#!/bin/sh' ; then
+-		chmod 755 "$updatefile"
+-		if [ "$(uname)" = "Darwin" ]; then
+-			sudo cp "$updatefile" "/usr/local/bin/ytfzf"
+-		else
+-			sudo cp "$updatefile" "/usr/bin/ytfzf"
+-		fi
+-	else
+-		printf "%bFailed to update ytfzf. Try again later.%b" "$c_red" "$c_reset"
+-	fi
+-
+-	rm "$updatefile"
+-	exit
++	printf "%bUpdates have to be installed through Nix.%b\n" "$c_red" "$c_reset"
++	exit 1
+ }
+ 
+ 


### PR DESCRIPTION
Prevent ytfzf from installing its own updates.
Add all programs that are possibly used in the script to $PATH.
A 10M increase in closure size seems very acceptable.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
