### PR TITLE
onlyoffice-bin: init at 6.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3615,6 +3615,12 @@
     githubId = 343415;
     name = "Greg Roodt";
   };
+  gtrunsec = {
+    email = "gtrunsec@hardenedlinux.org";
+    github = "GTrunSec";
+    githubId = 21156405;
+    name = "GuangTao Zhang";
+  };
   guibou = {
     email = "guillaum.bouchard@gmail.com";
     github = "guibou";

--- a/pkgs/applications/office/onlyoffice-bin/default.nix
+++ b/pkgs/applications/office/onlyoffice-bin/default.nix
@@ -1,0 +1,168 @@
+{ stdenv
+, lib
+, fetchurl
+# Alphabetic ordering below
+, alsaLib
+, at-spi2-atk
+, atk
+, autoPatchelfHook
+, cairo
+, curl
+, dbus
+, dconf
+, dpkg
+, fontconfig
+, gdk-pixbuf
+, glib
+, glibc
+, gnome3
+, gst_all_1
+, gtk2
+, gtk3
+, libpulseaudio
+, libudev0-shim
+, makeWrapper
+, nspr
+, nss
+, pulseaudio
+, qt5
+, wrapGAppsHook
+, xkeyboard_config
+, xorg
+}:
+let
+
+  # Note on fonts:
+  #
+  # OnlyOffice does not distribute unfree fonts, but makes it easy to pick up
+  # any fonts you install. See:
+  #
+  # * https://helpcenter.onlyoffice.com/en/installation/docs-community-install-fonts-linux.aspx
+  # * https://www.onlyoffice.com/blog/2020/04/how-to-add-new-fonts-to-onlyoffice-desktop-editors/
+  #
+  # As recommended there, you should download
+  #
+  #     arial.ttf, calibri.ttf, cour.ttf, symbol.ttf, times.ttf, wingding.ttf
+  #
+  # into `~/.local/share/fonts/`, otherwise the default template fonts, and
+  # things like bullet points, will not look as expected.
+
+  # TODO: Find out which of these fonts we'd be allowed to distribute along
+  #       with this package, or how to make this easier for users otherwise.
+
+  # Not using the `noto-fonts-cjk` package from nixpkgs, because it was
+  # reported that its `.ttc` file is not picked up by OnlyOffice, see:
+  # https://github.com/NixOS/nixpkgs/pull/116343#discussion_r593979816
+  noto-fonts-cjk = fetchurl {
+    url =
+      let
+        version = "v20201206-cjk";
+      in
+        "https://github.com/googlefonts/noto-cjk/raw/${version}/NotoSansCJKsc-Regular.otf";
+    sha256 = "sha256-aJXSVNJ+p6wMAislXUn4JQilLhimNSedbc9nAuPVxo4=";
+  };
+
+  runtimeLibs = lib.makeLibraryPath [
+    curl
+    glibc
+    libudev0-shim
+    pulseaudio
+  ];
+
+in stdenv.mkDerivation rec {
+  pname = "onlyoffice-desktopeditors";
+  version = "6.1.0";
+  minor = "90";
+  src = fetchurl {
+    url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_${version}-${minor}_amd64.deb";
+    sha256 = "sha256-TUaECChM3GxtB54/zNIKjRIocnAxpBVK7XsX3z7aq8o=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    alsaLib
+    at-spi2-atk
+    atk
+    cairo
+    dbus
+    dconf
+    fontconfig
+    gdk-pixbuf
+    glib
+    gnome3.gsettings_desktop_schemas
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    gtk2
+    gtk3
+    libpulseaudio
+    nspr
+    nss
+    qt5.qtbase
+    qt5.qtdeclarative
+    qt5.qtsvg
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libXtst
+  ];
+
+  dontWrapQtApps = true;
+
+  unpackPhase = ''
+    dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
+  '';
+
+  preConfigure = ''
+    cp --no-preserve=mode,ownership ${noto-fonts-cjk} opt/onlyoffice/desktopeditors/fonts/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib,share}
+
+    mv usr/bin/* $out/bin
+    mv usr/share/* $out/share/
+    mv opt/onlyoffice/desktopeditors $out/share
+
+    substituteInPlace $out/bin/onlyoffice-desktopeditors \
+      --replace "/opt/onlyoffice/" "$out/share/"
+
+    ln -s $out/share/desktopeditors/DesktopEditors $out/bin/DesktopEditors
+
+    wrapProgram $out/bin/DesktopEditors \
+        --set QT_XKB_CONFIG_ROOT ${xkeyboard_config}/share/X11/xkb \
+        --set QTCOMPOSE ${xorg.libX11.out}/share/X11/locale
+
+    substituteInPlace $out/share/applications/onlyoffice-desktopeditors.desktop \
+      --replace "/usr/bin/onlyoffice-desktopeditor" "$out/bin/DesktopEditor"
+
+    runHook preInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${runtimeLibs}" )
+  '';
+
+  meta = with lib; {
+    description = "Office suite that combines text, spreadsheet and presentation editors allowing to create, view and edit local documents";
+    homepage = "https://www.onlyoffice.com/";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ nh2 gtrunsec ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24148,6 +24148,8 @@ in
 
   ocenaudio = callPackage ../applications/audio/ocenaudio { };
 
+  onlyoffice-bin = callPackage ../applications/office/onlyoffice-bin { };
+
   open-policy-agent = callPackage ../development/tools/open-policy-agent { };
 
   openshift = callPackage ../applications/networking/cluster/openshift { };


### PR DESCRIPTION
###### Motivation for this change

AGPL based office suite with good compatibility for Microsoft Office documents.

Imported from:

https://github.com/icebox-nix/iceberg/blob/a49fa345b53cdf51a480cb53623a8194fb2d4b56/pkgs/office/onlyoffice-bin/default.nix


### Comaintainers wanted :heart: 

I need others that want to be co-maintainer on this package, please ping me here and I'll add you.


##### Note on fonts:

OnlyOffice does not distribute unfree fonts, but makes it easy to pick up
any fonts you install. See:

* https://helpcenter.onlyoffice.com/en/installation/docs-community-install-fonts-linux.aspx
* https://www.onlyoffice.com/blog/2020/04/how-to-add-new-fonts-to-onlyoffice-desktop-editors/

As recommended there, you should download

    arial.ttf, calibri.ttf, cour.ttf, symbol.ttf, times.ttf, wingding.ttf

into `~/.local/share/fonts/`, otherwise the default template fonts, and
things like bullet points, will not look as expected.

```
TODO: Find out which of these fonts we'd be allowed to distribute along
      with this package, or how to make this easier for users otherwise.
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I've also checked that it runs on Nix on Ubuntu, works well.

---

CC @LEXUGE @onny @emmanuelrosa @mweinelt @aszlig from https://discourse.nixos.org/t/onlyoffice-desktopeditors-packaged/7226/14

CC @tomberek from https://discourse.nixos.org/t/onlyoffice-on-nixos/4351