### PR TITLE
ocamlPackages.bitstring: 4.0.1 → 4.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/bitstring/default.nix
+++ b/pkgs/development/ocaml-modules/bitstring/default.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "bitstring";
-  version = "4.0.1";
+  version = "4.1.0";
 
   useDune2 = true;
 
@@ -10,7 +10,7 @@ buildDunePackage rec {
     owner = "xguerin";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1z7jmgljvp52lvn3ml2cp6gssxqp4sikwyjf6ym97cycbcw0fjjm";
+    sha256 = "0mghsl8b2zd2676mh1r9142hymhvzy9cw8kgkjmirxkn56wbf56b";
   };
 
   propagatedBuildInputs = [ stdlib-shims ];

--- a/pkgs/development/ocaml-modules/bitstring/ppx.nix
+++ b/pkgs/development/ocaml-modules/bitstring/ppx.nix
@@ -3,6 +3,10 @@
 , ounit
 }:
 
+if !lib.versionAtLeast ppxlib.version "0.18.0"
+then throw "ppx_bitstring is not available with ppxlib-${ppxlib.version}"
+else
+
 buildDunePackage rec {
   pname = "ppx_bitstring";
   inherit (bitstring) version useDune2 src;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -929,7 +929,9 @@ let
 
     ppx_bap = callPackage ../development/ocaml-modules/ppx_bap { };
 
-    ppx_bitstring = callPackage ../development/ocaml-modules/bitstring/ppx.nix { };
+    ppx_bitstring = callPackage ../development/ocaml-modules/bitstring/ppx.nix {
+      ppxlib = ppxlib.override { version = "0.22.0"; };
+    };
 
     ppxfind = callPackage ../development/ocaml-modules/ppxfind { };
 


### PR DESCRIPTION
###### Motivation for this change

Support for recent `ppxlib`.

cc maintainer @maurer

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
