### PR TITLE
pango: 1.47.0 → 1.48.3

### DIFF
--- a/pkgs/development/tools/documentation/gi-docgen/default.nix
+++ b/pkgs/development/tools/documentation/gi-docgen/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, fetchFromGitLab
+, fetchpatch
+, meson
+, ninja
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "gi-docgen";
+  version = "2021.2";
+
+  format = "other";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "ebassi";
+    repo = pname;
+    rev = version;
+    sha256 = "17swx4s60anfyyb6dcsl8fq3s0j9cy54qcw0ciq4qj59d4039w5h";
+  };
+
+  patches = [
+    # Add pkg-config file so that Meson projects can find this.
+    # https://gitlab.gnome.org/ebassi/gi-docgen/merge_requests/26
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/ebassi/gi-docgen/commit/d65ed2e4827c4129d26e3c1df9a48054b4e72c50.patch";
+      sha256 = "BEefcHiAd/HTW5zo39J2WtfQjGXUkNFB6MDJj8/Ge80=";
+    })
+
+    # Name generated devhelp files correctly.
+    # https://gitlab.gnome.org/ebassi/gi-docgen/merge_requests/27
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/ebassi/gi-docgen/commit/7c4de72f55cbce5670c3a6a1451548e97e5f07f7.patch";
+      sha256 = "ov/PvrZzKmCzw7nHJkbeLCnhtUVw1UbZQjFrWT3AtVg=";
+    })
+
+    # Fix broken link in Devhelp TOC.
+    # https://gitlab.gnome.org/ebassi/gi-docgen/merge_requests/28
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/ebassi/gi-docgen/commit/56f0e6f8b4bb9c92d635df60aa5d68f55b036711.patch";
+      sha256 = "5gFGiO9jPpkyZBL4qtWEotE5jY3sCGFGUGN/Fb6jZ+0=";
+    })
+
+    # Devhelp does not like subsections without links.
+    # https://gitlab.gnome.org/GNOME/devhelp/-/issues/28
+    (fetchpatch {
+      # Only visual but needed for the other two to apply.
+      # https://gitlab.gnome.org/ebassi/gi-docgen/merge_requests/28
+      url = "https://gitlab.gnome.org/ebassi/gi-docgen/commit/7f67fad5107b73489cb7bffca49177d9ad78e422.patch";
+      sha256 = "OKbC690nJsl1ckm/y9eeKDYX6AEClsNvIFy7DK+JYEc=";
+    })
+    # Add links to index.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/ebassi/gi-docgen/commit/f891cc5fd481bc4180eec144d14f32c15c91833b.patch";
+      sha256 = "Fcnvdgxei+2ulGoWoCZ8WFrNy01tlNXMkHru3ArGHVQ=";
+    })
+    # Use different link for each symbol type name.
+    # https://gitlab.gnome.org/ebassi/gi-docgen/merge_requests/29
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/jtojnar/gi-docgen/commit/08dcc31f62be1a5af9bd9f8f702f321f4b5cffde.patch";
+      sha256 = "vAT8s7zQ9zCoZWK+6PsxcD5/48ZAfIOl4RSNljRCGWQ=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  pythonPath = with python3.pkgs; [
+    jinja2
+    markdown
+    markupsafe
+    pygments
+    toml
+    typogrify
+  ];
+
+  doCheck = false; # no tests
+
+  postFixup = ''
+    # Do not propagate Python
+    substituteInPlace $out/nix-support/propagated-build-inputs \
+      --replace "${python3}" ""
+  '';
+
+  meta = with lib; {
+    description = "Documentation generator for GObject-based libraries";
+    homepage = "https://gitlab.gnome.org/ebassi/gi-docgen";
+    license = licenses.asl20; # OR GPL-3.0-or-later
+    maintainers = teams.gnome.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12452,6 +12452,8 @@ in
     inherit (xorg) libX11 libXext libXi libXtst;
   };
 
+  gi-docgen = callPackage ../development/tools/documentation/gi-docgen { };
+
   github-release = callPackage ../development/tools/github/github-release { };
 
   global = callPackage ../development/tools/misc/global { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Switches from gtk-doc to gi-doc for docs.

https://gitlab.gnome.org/GNOME/pango/-/blob/1.48.3/NEWS#L1-34

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
