### PR TITLE
dnsmasq: fix cross-compilation

### DIFF
--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, dbus, nettle, fetchpatch
-, libidn, libnetfilter_conntrack }:
+, libidn, libnetfilter_conntrack, buildPackages }:
 
 with lib;
 let
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     "BINDIR=$(out)/bin"
     "MANDIR=$(out)/man"
     "LOCALEDIR=$(out)/share/locale"
+    "PKG_CONFIG=${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config"
   ];
 
   hardeningEnable = [ "pie" ];


### PR DESCRIPTION
This is done by specifying pkg-config in the makeFlags, ensuring that the correct pkg-config is injected.

Depends on changes that are currently only in staging:

- 07ecf87693fec1032c19ba1f5b41dc9cf260abb2
- 4f6ec19dbc322d7ce8df9108b76e0db79682353e

See https://github.com/NixOS/nixpkgs/pull/114902 for those changes.

Note that in order to properly cross-compile this, you'll need to cherry-pick those two commits (since otherwise systemdMinimal doesn't compile, which is somewhere in the dependency chain). Since they're in staging, I expect them to come to master sometime soon. And if they don't, this is still valid.

This pull request supersedes https://github.com/NixOS/nixpkgs/pull/91422 and fixes #91418.

###### Motivation for this change

Improve cross-compilation support. This is somewhere in the dependency chain for phoc (which is not yet in nixpkgs, but I pulled it in my repo), so I want this to build. The previous PR was stale, so I picked this up and this seems to be all that needs to be done.

Please let me know if this is the correct way to do this, I'm not sure (and I see different patterns in nixpkgs, so not really sure...). It does build though, so there's that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - [x] Tested using `dnscrypt-proxy2.nix` (Which proves that the native dnsmasq at least starts)
    - [x] Tested using `kubernetes/dns.nix` (Which seems to hit dnsmasq somewhat more than just checking if it starts)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) -> They at least print help info, not tested further.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
