### PR TITLE
prime-server: 0.6.7 -> 0.7.0

### DIFF
--- a/pkgs/development/libraries/prime-server/default.nix
+++ b/pkgs/development/libraries/prime-server/default.nix
@@ -3,18 +3,21 @@
 
 stdenv.mkDerivation rec {
   pname = "prime-server";
-  version = "0.6.7";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "kevinkreiser";
     repo = "prime_server";
     rev = version;
-    sha256 = "027w3cqfnciyy2x78hfclpb77askn773fab37mzwf6r3mcc7vyl5";
+    sha256 = "0izmmvi3pvidhlrgfpg4ccblrw6fil3ddxg5cfxsz4qbh399x83w";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ curl zeromq czmq libsodium ];
+
+  # https://github.com/kevinkreiser/prime_server/issues/95
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=unused-variable" ];
 
   meta = with lib; {
     description = "Non-blocking (web)server API for distributed computing and SOA based on zeromq";


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
