### PR TITLE
zoom-us: unset Qt env variables to fix dialog boxes

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -23,7 +23,6 @@
 , pciutils
 , procps
 , util-linux
-, qttools
 , pulseaudioSupport ? true, libpulseaudio ? null
 }:
 
@@ -107,7 +106,7 @@ in stdenv.mkDerivation rec {
       --run "cd $out/opt/zoom" \
       --unset QML2_IMPORT_PATH \
       --unset QT_PLUGIN_PATH \
-      --prefix PATH : ${lib.makeBinPath [ coreutils glib.dev pciutils procps qttools.dev util-linux ]} \
+      --prefix PATH : ${lib.makeBinPath [ coreutils glib.dev pciutils procps util-linux ]} \
       --prefix LD_LIBRARY_PATH ":" ${libs}
 
     # Backwards compatiblity: we used to call it zoom-us

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -101,8 +101,12 @@ in stdenv.mkDerivation rec {
     rm $out/bin/zoom
     # Zoom expects "zopen" executable (needed for web login) to be present in CWD. Or does it expect
     # everybody runs Zoom only after cd to Zoom package directory? Anyway, :facepalm:
+    # Also clear Qt environment variables to prevent
+    # zoom from tripping over "foreign" Qt ressources.
     makeWrapper $out/opt/zoom/ZoomLauncher $out/bin/zoom \
       --run "cd $out/opt/zoom" \
+      --unset QML2_IMPORT_PATH \
+      --unset QT_PLUGIN_PATH \
       --prefix PATH : ${lib.makeBinPath [ coreutils glib.dev pciutils procps qttools.dev util-linux ]} \
       --prefix LD_LIBRARY_PATH ":" ${libs}
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26564,7 +26564,7 @@ in
 
   zombietrackergps = libsForQt5.callPackage ../applications/gis/zombietrackergps { };
 
-  zoom-us = libsForQt5.callPackage ../applications/networking/instant-messengers/zoom-us { };
+  zoom-us = callPackage ../applications/networking/instant-messengers/zoom-us { };
 
   zotero = callPackage ../applications/office/zotero { };
 


### PR DESCRIPTION
###### Motivation for this change

Zoom wouldn't show the "Participants" dialog box when used in a plasma environment; precisely, the dialog box failed to show its content.  The problem doesn't exist in other environments like Gnome or Xfce.  Experiments have shown that clearing the environment variable `QML2_IMPORT_PATH` before calling Zoom fixes the issue.

I suspect the reason to be as follows: While the zoom build recipe is called with `libsForQt5xx.callPackage`, putting `qttools.dev` in zoom's `PATH` is the only connection to nixpkgs' Qt ecosystem.  Zoom brings its own Qt libraries.  Hence it seems to be a good idea to shield zoom from access to nixpkgs' Qt files to avoid problems from version mismatch or similar troubles.  So the commit at hand expands zoom's wrapper script to clear the Qt-related enviornemt variables `QML2_IMPORT_PATH` and `QT_PLUGIN_PATH`.

Original issue report, with some discussion: https://github.com/NixOS/nixpkgs/issues/107495#issuecomment-764538071

Notify maintainers: @danbst @tadfisher @doronbehar
Notify reporter: @miniBill

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

More:

- [x] Tested meeting with video on current nixos-unstable channel, in Xfce and in Plasma (inside VirtualBox): participants lists shows up correctly
- [x] Tested meeting with video and audio on NixOS 20.09, in Xfce and in Plasma (Zoom package build with all dependencies from nixos-unstable, surrounding system NixOS 20.09): participants lists shows up correctly