### PR TITLE
pythonPackages: Add aliases 🎉

### DIFF
--- a/pkgs/applications/science/misc/snakemake/default.nix
+++ b/pkgs/applications/science/misc/snakemake/default.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
     pyyaml
     ratelimiter
     requests
-    smart_open
+    smart-open
     toposort
     wrapt
   ];

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -73,13 +73,14 @@ with pkgs;
           optionalExtensions = cond: as: if cond then as else [];
           python2Extension = import ../../../top-level/python2-packages.nix;
           extensions = lib.composeManyExtensions ((optionalExtensions (!self.isPy3k) [python2Extension]) ++ [ overrides ]);
+          aliases = self: super: lib.optionalAttrs (config.allowAliases or true) (import ../../../top-level/python-aliases.nix lib self super);
         in lib.makeScopeWithSplicing
           pkgs.splicePackages
           pkgs.newScope
           otherSplices
           keep
           extra
-          (lib.extends extensions pythonPackagesFun))
+          (lib.extends (lib.composeExtensions aliases extensions) pythonPackagesFun))
         {
           overrides = packageOverrides;
         };

--- a/pkgs/development/python-modules/gensim/default.nix
+++ b/pkgs/development/python-modules/gensim/default.nix
@@ -4,7 +4,7 @@
 , numpy
 , six
 , scipy
-, smart_open
+, smart-open
 , scikit-learn, testfixtures, unittest2
 , isPy3k
 }:
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     sha256 = "0rx37vnjspjl45v7bj123xwsjfgbwv91v8zpqpli8lgpf42xnskq";
   };
 
-  propagatedBuildInputs = [ smart_open numpy six scipy ];
+  propagatedBuildInputs = [ smart-open numpy six scipy ];
 
   checkInputs = [ scikit-learn testfixtures unittest2 ];
 

--- a/pkgs/development/python-modules/pathy/default.nix
+++ b/pkgs/development/python-modules/pathy/default.nix
@@ -4,7 +4,7 @@
 , pytestCheckHook
 , typer
 , dataclasses
-, smart_open
+, smart-open
 , pytest
 , mock
 , google-cloud-storage
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     sha256 = "sha256-nb8my/5rkc7thuHnXZHe1Hg8j+sLBlYyJcLHWrrKZ5M=";
   };
 
-  propagatedBuildInputs = [ smart_open typer google-cloud-storage ];
+  propagatedBuildInputs = [ smart-open typer google-cloud-storage ];
 
   postPatch = ''
     substituteInPlace requirements.txt \

--- a/pkgs/development/python-modules/smart-open/default.nix
+++ b/pkgs/development/python-modules/smart-open/default.nix
@@ -12,12 +12,13 @@
 }:
 
 buildPythonPackage rec {
-  pname = "smart_open";
+  pname = "smart-open";
   version = "4.2.0";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "smart_open";
+    inherit version;
     sha256 = "d9f5a0f173ccb9bbae528db5a3804f57145815774f77ef755b9b0f3b4b2a9dcb";
   };
 
@@ -29,9 +30,10 @@ buildPythonPackage rec {
 
   # upstream code requires both boto and boto3
   propagatedBuildInputs = [ boto boto3 bz2file requests ];
+
   meta = {
     license = lib.licenses.mit;
-    description = "smart_open is a Python 2 & Python 3 library for efficient streaming of very large file";
+    description = "Library for efficient streaming of very large file";
     maintainers = with lib.maintainers; [ jyp ];
   };
 }

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -1,0 +1,37 @@
+lib: self: super:
+
+with self;
+
+let
+  # Removing recurseForDerivation prevents derivations of aliased attribute
+  # set to appear while listing all the packages available.
+  removeRecurseForDerivations = alias: with lib;
+      if alias.recurseForDerivations or false then
+            removeAttrs alias ["recurseForDerivations"]
+                else alias;
+
+  # Disabling distribution prevents top-level aliases for non-recursed package
+  # sets from building on Hydra.
+  removeDistribute = alias: with lib;
+    if isDerivation alias then
+      dontDistribute alias
+    else alias;
+
+  # Make sure that we are not shadowing something from
+  # python-packages.nix.
+  checkInPkgs = n: alias: if builtins.hasAttr n super
+                          then throw "Alias ${n} is still in python-packages.nix"
+                          else alias;
+
+  mapAliases = aliases:
+    lib.mapAttrs (n: alias: removeDistribute
+                             (removeRecurseForDerivations
+                              (checkInPkgs n alias)))
+                     aliases;
+in
+
+  ### Deprecated aliases - for backward compatibility
+
+mapAliases ({
+  smart_open = smart-open; # added 2021-03-14
+})

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -34,4 +34,6 @@ in
 
 mapAliases ({
   smart_open = smart-open; # added 2021-03-14
+  google_api_python_client = google-api-python-client; # added 2021-03-19
+  googleapis_common_protos = googleapis-common-protos; # added 2021-03-19
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7662,7 +7662,7 @@ in {
 
   sly = callPackage ../development/python-modules/sly { };
 
-  smart_open = callPackage ../development/python-modules/smart_open { };
+  smart-open = callPackage ../development/python-modules/smart-open { };
 
   smartypants = callPackage ../development/python-modules/smartypants { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Just removing or renaming packages is not nice so I thought we want aliases for python packages. With this PR I included one package I used for testing. Most of the python-aliases.nix is copied from aliases.nix. If this PR is merged I am going to move some aliases which are currently in python-packages. I am probably not renaming all the packages though. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
