### PR TITLE
nixos/acme: Fix webroot issues

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -24,7 +24,7 @@ let
       Type = "oneshot";
       User = "acme";
       Group = mkDefault "acme";
-      UMask = 0023;
+      UMask = 0022;
       StateDirectoryMode = 750;
       ProtectSystem = "full";
       PrivateTmp = true;
@@ -275,9 +275,15 @@ let
         set -euxo pipefail
 
         ${optionalString (data.webroot != null) ''
-          # Ensure the webroot exists
-          mkdir -p '${data.webroot}/.well-known/acme-challenge'
-          chown 'acme:${data.group}' ${data.webroot}/{.well-known,.well-known/acme-challenge}
+          # Ensure the webroot exists. Fixing group is required in case configuration was changed between runs.
+          # Lego will fail if the webroot does not exist at all.
+          (
+            mkdir -p '${data.webroot}/.well-known/acme-challenge' \
+            && chgrp '${data.group}' ${data.webroot}/.well-known/acme-challenge
+          ) || (
+            echo 'Please ensure ${data.webroot}/.well-known/acme-challenge exists and is writable by acme:${data.group}' \
+            && exit 1
+          )
         ''}
 
         echo '${domainHash}' > domainhash.txt


### PR DESCRIPTION
###### Motivation for this change

Closes #114751
Closes #115976 
Closes #101726

Ping @NixOS/acme 

With the UMask set to 0023, the mkdir -p command which creates the webroot could end up unreadable if the web server changes, as surfaced by the test suite in #114751 On top of this, the following commands to chown the webroot + subdirectories was mostly unnecessary. I stripped it back to only fix the deepest part of the directory, resolving #115976, and reintroduced a human readable error message.

I also increased timeouts + added descriptions to the test suite's assertions. In particular, curling pebble on port 15000 was frequently failing on my test system as the service wasn't ready by the time the curl command ran. There were a few other places similar "not ready" issues were arising so I retry delays from 1 to 3 seconds.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
