### PR TITLE
gdal: 3.1.2 -> 3.2.2

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -7,14 +7,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "gdal";
-  # broken with poppler 20.08, however, can't fetch patches cleanly
-  version = "3.1.2.post2020-08-26";
+  version = "3.2.2";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "gdal";
-    rev = "9a8df672204a8b3b33c36e09a32f747e21166fe9";
-    sha256 = "1n25jma4x1l7slwxk702q77r84vxr90fyn4c3zpkr07q1b8wqql9";
+    rev = "a33784291d19015217ea2604988e53d448e14a07";
+    sha256 = "sha256-ynCju3chDfYtyrGmUE0n3kkaH2Mpm+/DDHHxCahjhSQ=";
   };
 
   sourceRoot = "source/gdal";


### PR DESCRIPTION
###### Motivation for this change
bump gdal

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
