### PR TITLE
touchegg: 1.1.1 -> 2.0.8

### DIFF
--- a/pkgs/tools/inputmethods/touchegg/default.nix
+++ b/pkgs/tools/inputmethods/touchegg/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "JoseExposito";
     repo = pname;
-    rev = "f6c64bbd6d00564a980bf4379dcc1178de294c85";
+    rev = "v${version}";
     sha256 = "1v1sskyxmvbc6j4l31zbabiklfmy2pm77bn0z0baj1dl3wy7xcj2";
   };
 

--- a/pkgs/tools/inputmethods/touchegg/default.nix
+++ b/pkgs/tools/inputmethods/touchegg/default.nix
@@ -1,26 +1,40 @@
-{ lib, stdenv, fetchurl, xorg, xorgserver, qt4, libGLU, libGL, geis, qmake4Hook }:
+{ stdenv, lib, fetchFromGitHub, systemd, libinput, pugixml, cairo, xorg, gtk3-x11, pcre, pkg-config, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "touchegg";
-  version = "1.1.1";
-  src = fetchurl {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/touchegg/${pname}-${version}.tar.gz";
-    sha256 = "95734815c7219d9a71282f3144b3526f2542b4fa270a8e69d644722d024b4038";
+  version = "2.0.8";
+  src = fetchFromGitHub {
+    owner = "JoseExposito";
+    repo = pname;
+    rev = "f6c64bbd6d00564a980bf4379dcc1178de294c85";
+    sha256 = "1v1sskyxmvbc6j4l31zbabiklfmy2pm77bn0z0baj1dl3wy7xcj2";
   };
 
-  buildInputs = [ xorgserver libGLU libGL xorg.libX11 xorg.libXtst xorg.libXext qt4 geis ];
+  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
 
-  nativeBuildInputs = [ qmake4Hook ];
+  buildInputs = [
+    systemd
+    libinput
+    pugixml
+    cairo
+    gtk3-x11
+    pcre
+  ] ++ (with xorg; [
+    libX11
+    libXtst
+    libXrandr
+    libXi
+    libXdmcp
+    libpthreadstubs
+    libxcb
+  ]);
 
-  preConfigure = ''
-    sed -e "s@/usr/@$out/@g" -i $(find . -name touchegg.pro)
-    sed -e "s@/usr/@$out/@g" -i $(find ./src/touchegg/config/ -name Config.cpp)
-  '';
+  nativeBuildInputs = [ pkg-config cmake ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/JoseExposito/touchegg";
-    description = "Macro binding for touch surfaces";
-    license = lib.licenses.gpl2;
-    platforms = lib.platforms.linux;
+    description = "Linux multi-touch gesture recognizer";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/inputmethods/touchegg/default.nix
+++ b/pkgs/tools/inputmethods/touchegg/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     owner = "JoseExposito";
     repo = pname;
     rev = version;
-    sha256 = "1v1sskyxmvbc6j4l31zbabiklfmy2pm77bn0z0baj1dl3wy7xcj2";
+    sha256 = "1adnqlb88yljwjybz0gsb948f7svyv01k2v5x2hhwgr0k85q8ic9";
   };
 
   PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";

--- a/pkgs/tools/inputmethods/touchegg/default.nix
+++ b/pkgs/tools/inputmethods/touchegg/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "JoseExposito";
     repo = pname;
-    rev = "v${version}";
+    rev = version;
     sha256 = "1v1sskyxmvbc6j4l31zbabiklfmy2pm77bn0z0baj1dl3wy7xcj2";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Side note
This is my first PR to nixpkgs, so sorry if I am doing anything wrong! Also, if possible, I would like to maintain this package, but I do not know if there are any specific requirements to becoming a maintainer? Thanks.

###### Motivation for this change
Since touchegg started receiving updates again, the current touchegg in nixpkgs is quite outdated. 

###### Things done

There has been done some work upstream to make it possible to build on NixOS. See

* [Discussion at discourse](https://discourse.nixos.org/t/creating-a-simple-derivation-for-touchegg-but-the-binary-returns-an-error/11801)
* [PR on the touchegg project](https://github.com/JoseExposito/touchegg/pull/467)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] (Found no tests) Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] (Found no packages that depended on touchegg with `grep -rnw '/path/to/nixpkgs/' -e 'touch.gg'`) Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
