### PR TITLE
leocad: 19.07.1 -> 21.03

### DIFF
--- a/pkgs/applications/graphics/leocad/default.nix
+++ b/pkgs/applications/graphics/leocad/default.nix
@@ -1,31 +1,53 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, fetchurl
+, qmake
+, qttools
+, zlib
+}:
+
 /*
 To use aditional parts libraries
 set the variable LEOCAD_LIB=/path/to/libs/ or use option -l /path/to/libs/
 */
 
-{ lib, stdenv, fetchFromGitHub, qt4, qmake4Hook, zlib }:
+let
+  parts = fetchurl {
+    url = "https://web.archive.org/web/20190715142541/https://www.ldraw.org/library/updates/complete.zip";
+    sha256 = "sha256-PW3XCbFwRaNkx4EgCnl2rXH7QgmpNgjTi17kZ5bladA=";
+  };
 
-stdenv.mkDerivation rec {
+in
+mkDerivation rec {
   pname = "leocad";
-  version = "19.07.1";
+  version = "21.03";
 
   src = fetchFromGitHub {
     owner = "leozide";
     repo = "leocad";
     rev = "v${version}";
-    sha256 = "02kv1m18g6s4dady9jv4sjivfkrp192bmdw2a3d9lzlp60zks0p2";
+    sha256 = "sha256-69Ocfk5dBXwcRqAZWEP9Xg41o/tAQo76dIOk9oYhCUE=";
   };
 
-  nativeBuildInputs = [ qmake4Hook ];
-  buildInputs = [ qt4 zlib ];
-  postPatch = ''
-    export qmakeFlags="$qmakeFlags INSTALL_PREFIX=$out"
-  '';
+  nativeBuildInputs = [ qmake qttools ];
+
+  buildInputs = [ zlib ];
+
+  qmakeFlags = [
+    "INSTALL_PREFIX=${placeholder "out"}"
+    "DISABLE_UPDATE_CHECK=1"
+  ];
+
+  qtWrapperArgs = [
+    "--set-default LEOCAD_LIB ${parts}"
+  ];
 
   meta = with lib; {
     description = "CAD program for creating virtual LEGO models";
     homepage = "https://www.leocad.org/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5695,7 +5695,7 @@ in
 
   lego = callPackage ../tools/admin/lego { };
 
-  leocad = callPackage ../applications/graphics/leocad { };
+  leocad = libsForQt5.callPackage ../applications/graphics/leocad { };
 
   less = callPackage ../tools/misc/less { };
 


### PR DESCRIPTION
###### Motivation for this change

Upstream update that allows us to drop qt4 in favour of qt5.

This is significantly bigger than the older version as we now include the parts library, but the application doesn't do much without.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
