### PR TITLE
alttab: `doCheck`+`gpl3Plus`

### DIFF
--- a/pkgs/tools/X11/alttab/default.nix
+++ b/pkgs/tools/X11/alttab/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, pkg-config, ronn, libpng, uthash
-, xorg }:
+{ lib, stdenv, coreutils, fetchFromGitHub, autoconf, automake, pkg-config, procps, ronn,
+libpng, uthash , which, xnee, xorg, python3Packages }:
 
 stdenv.mkDerivation rec {
   version = "1.6.0";
@@ -34,6 +34,18 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
+
+  doCheck = true;
+
+  checkInputs = [
+    coreutils
+    procps
+    python3Packages.xvfbwrapper
+    which
+    xnee
+    xorg.xeyes
+    xorg.xprop
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/sagb/alttab";

--- a/pkgs/tools/X11/alttab/default.nix
+++ b/pkgs/tools/X11/alttab/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/sagb/alttab";
     description = "X11 window switcher designed for minimalistic window managers or standalone X11 session";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.sgraf ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`alttab` has a `make check` target since 1.6.0. This PR enables running the target as part of CI, via `doCheck = true;`.

I also clarified the license to `gpl3Plus`, as the license header in e.g. https://github.com/sagb/alttab/blob/1c0754e6d2da346a08b06725ba716350553edf48/src/alttab.c clearly says "any later".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
