### PR TITLE
fwupd: 1.5.5 → 1.5.7

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -91,13 +91,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
-    # A regression is present in https://github.com/fwupd/fwupd/commit/fde4b1676a2c64e70bebd88f7720307c62635654
-    # released with 1.5.6.
-    # Fix for the regression: https://github.com/fwupd/fwupd/pull/2902
-    # Maintainer says a new release is to be expected in a few days:
-    #   https://twitter.com/hughsient/status/1362476792297185289
-    # In the mean time, please do not release 1.5.6 and go strait to 1.5.7
-    version = "1.5.5";
+    version = "1.5.7";
 
     # libfwupd goes to lib
     # daemon, plug-ins and libfwupdplugin go to out
@@ -106,7 +100,7 @@ let
 
     src = fetchurl {
       url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      sha256 = "0c2m9qz1g7zxqc6w90w9hksf8y9hvlh0vyvx06q01x893j5hzxh6";
+      sha256 = "16isrrv6zhdgccbfnz7km5g1cnvfnip7aiidkfhf5dlnrnyb2sxh";
     };
 
     patches = [
@@ -189,6 +183,11 @@ let
       "-Defi-libdir=${gnu-efi}/lib"
       "-Defi-ldsdir=${gnu-efi}/lib"
       "-Defi-includedir=${gnu-efi}/include/efi"
+      "-Defi_sbat_distro_id=nixos"
+      "-Defi_sbat_distro_summary=NixOS"
+      "-Defi_sbat_distro_pkgname=fwupd"
+      "-Defi_sbat_distro_version=${version}"
+      "-Defi_sbat_distro_url=https://search.nixos.org/packages?channel=unstable&show=fwupd&from=0&size=50&sort=relevance&query=fwupd"
       "--localstatedir=/var"
       "--sysconfdir=/etc"
       "-Dsysconfdir_install=${placeholder "out"}/etc"
@@ -236,6 +235,8 @@ let
         contrib/get-version.py \
         contrib/generate-version-script.py \
         meson_post_install.sh \
+        plugins/uefi-capsule/efi/generate_sbat.py \
+        plugins/uefi-capsule/efi/generate_binary.py \
         po/make-images \
         po/make-images.sh \
         po/test-deps
@@ -250,8 +251,8 @@ let
         testFw = fetchFromGitHub {
           owner = "fwupd";
           repo = "fwupd-test-firmware";
-          rev = "42b62c62dc85ecfb8e38099fe5de0625af87a722";
-          sha256 = "XUpxE003DZSeLJMtyV5UN5CNHH89/nEVKpCbMStm91Q=";
+          rev = "c13bfb26cae5f4f115dd4e08f9f00b3cb9acc25e";
+          sha256 = "US81i7mtLEe85KdWz5r+fQTk61IhqjVkzykBaBPuKL4=";
         };
       in ''
         # These files have weird licenses so they are shipped separately.
@@ -311,6 +312,7 @@ let
       # DisabledPlugins key in fwupd/daemon.conf
       defaultDisabledPlugins = [
         "test"
+        "test_ble"
         "invalid"
       ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
﻿Announcement:
- https://blogs.gnome.org/hughsie/2021/02/16/fwupd-1-5-6/

Changelogs:
- https://github.com/fwupd/fwupd/releases/tag/1.5.6
- https://github.com/fwupd/fwupd/releases/tag/1.5.7

Main changes:
- Adds UEFI  SBAT support:
  https://github.com/fwupd/fwupd/blob/1.5.7/plugins/uefi-capsule/README.md#uefi-sbat-support
  https://github.com/rhboot/shim/blob/39b96c01bfd4547f38c9e573ff5d551057ea272c/SBAT.md


cc @baloo
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
