### PR TITLE
vimPlugins.fzfWrapper: place the fzf binary in the plugin's bin dir

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -47,9 +47,11 @@ self: super: {
   # plugin, since part of the fzf vim plugin is included in the main fzf
   # program.
   fzfWrapper = buildVimPluginFrom2Nix {
+    inherit (fzf) src version;
     pname = "fzf";
-    version = fzf.version;
-    src = fzf.src;
+    postInstall = ''
+      ln -s ${fzf}/bin/fzf $target/bin/fzf
+    '';
   };
 
   skim = buildVimPluginFrom2Nix {


### PR DESCRIPTION
###### Motivation for this change

Backporting #115818 to fix the purity of the fzf-vim plugin.

```
$ nix-shell -I nixpkgs=. --pure -p 'with import <nixpkgs> {}; neovim.override { configure.packages.fzf.start = with vimPlugins; [fzf-vim]; }' --run 'nvim +Files'
fzf executable not found. Download binary? (y/n)
```

cherry picked from commit 34cf38fca446c67002bcdb72444ebfc4afee5526

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @teto @jonringer 