### PR TITLE
pkgs.dockertools.buildLayeredImage: support custom layer packing strategies

### DIFF
--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -283,13 +283,34 @@ rec {
   bulk-layer = pkgs.dockerTools.buildLayeredImage {
     name = "bulk-layer";
     tag = "latest";
-    contents = with pkgs; [
-      coreutils hello
-    ];
+    contents = with pkgs; [ coreutils hello ];
     maxLayers = 2;
   };
 
-  # 18. Create a "layered" image without nix store layers. This is not
+  # 19. Create a layered image with more packages in its transitive closure than
+  # max layers, using the "bottom weighted" (default) layer packing strategy.
+  # This will put 'hello' with other runtime deps that do not fit into final
+  # layer, leaving lower layers for infra pkgs like glibc.
+  bulk-layer-bottom-weighted = pkgs.dockerTools.buildLayeredImage {
+    name = "bulk-layer-bottom-weighted";
+    tag = "latest";
+    contents = with pkgs; [ hello ];
+    layerStrategy = pkgs.dockerTools.layerStrategies.popularityWeightedBottom;
+    maxLayers = 3;
+  };
+
+  # 20. Create a layered image with more packages in its transitive closure than
+  # max layers, using the "top weighted" layer packing strategy. This will put
+  # 'hello' by itself as the final layer.
+  bulk-layer-top-weighted = pkgs.dockerTools.buildLayeredImage {
+    name = "bulk-layer-top-weighted";
+    tag = "latest";
+    contents = with pkgs; [ hello ];
+    layerStrategy = pkgs.dockerTools.layerStrategies.popularityWeightedTop;
+    maxLayers = 3;
+  };
+
+  # 21. Create a "layered" image without nix store layers. This is not
   # recommended, but can be useful for base images in rare cases.
   no-store-paths = pkgs.dockerTools.buildLayeredImage {
     name = "no-store-paths";

--- a/pkgs/build-support/docker/layer-strategies/default.nix
+++ b/pkgs/build-support/docker/layer-strategies/default.nix
@@ -1,0 +1,16 @@
+{ writePython3, writeShellScript }:
+let
+
+  # See manual for documentation on these layer strategy algorithms:
+  # ../../../../doc/builders/images/dockertools.section.md
+
+  popularityWeightedBottom =
+    let text = builtins.readFile ./popularity_weighted_bottom.sh;
+    in writeShellScript "popularity-weighted-bottom" text;
+
+  popularityWeightedTop = writePython3 "popularity-weighted-top" {
+  } ./popularity_weighted_top.py;
+
+in {
+  inherit popularityWeightedBottom popularityWeightedTop;
+}

--- a/pkgs/build-support/docker/layer-strategies/popularity_weighted_bottom.sh
+++ b/pkgs/build-support/docker/layer-strategies/popularity_weighted_bottom.sh
@@ -1,0 +1,12 @@
+availableLayers=$1
+
+# The following code is fiddly w.r.t. ensuring every layer is created, and
+# that no paths are missed. If you change the following lines, double-check
+# that your code behaves properly when the number of layers equals:
+#      maxLayers-1, maxLayers, and maxLayers+1, 0
+jq -sR '
+    rtrimstr("\n") | split("\n")
+    | (.[:$availableLayers-1] | map([.])) + [ .[$availableLayers-1:] ]
+    | map(select(length > 0))
+' \
+    --argjson availableLayers "$availableLayers"

--- a/pkgs/build-support/docker/layer-strategies/popularity_weighted_top.py
+++ b/pkgs/build-support/docker/layer-strategies/popularity_weighted_top.py
@@ -1,0 +1,15 @@
+import json
+import sys
+
+available_layers = int(sys.argv[1])
+pkgs = [x.strip() for x in sys.stdin.readlines()]
+
+# Layers [2, limit] have 1 pkg each, of the user's top-most pkgs,
+# and layer 1 has the remainder.
+user_pkgs = pkgs[-(available_layers - 1):]
+layers = [pkgs[:-(available_layers - 1)]]
+
+for pkg in user_pkgs:
+    layers.append([pkg])
+
+print(json.dumps(layers))


### PR DESCRIPTION
###### Motivation for this change

The default algorithm does not work particularly well for some use cases, such
as applications with very large dependency closures when we want to optimize
iterative releases of the same application container rather than optimize across
different application containers.

Currently there's limited sharing, since almost all of the packages are in the
final layer along with the app itself. This commit adds a new layering strategy
which will emphasize cache hits for the application itself and the dependencies
closest to the application, which are the most likely to change, while leaving
the more-likely-to-be-constant low level dependencies smooshed into the first layer.

Since the current algorithm likely works well for many use cases, this leaves
the default unchanged, but enhances `buildLayeredImage` to be able to take a
per-nix-expression custom layering algorithm as a parameter.

Resolves #48462

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
