### PR TITLE
element: 1.7.22 -> 1.7.23

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "src/electron-main.js",
-  "version": "1.7.22",
+  "version": "1.7.23",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -8,12 +8,12 @@
 
 let
   executableName = "element-desktop";
-  version = "1.7.22";
+  version = "1.7.23";
   src = fetchFromGitHub {
     owner = "vector-im";
     repo = "element-desktop";
     rev = "v${version}";
-    sha256 = "152ggkkk997pg3xdcdzn3samv3vsb6qifgkyl82bnwchy8y3611d";
+    sha256 = "0vvjbh81h6sg6dbm9d6ffav0dim9sadvs67jcm702677qgigkc53";
   };
 in mkYarnPackage rec {
   name = "element-desktop-${version}";

--- a/pkgs/applications/networking/instant-messengers/element/element-web.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-web.nix
@@ -12,11 +12,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "element-web";
-  version = "1.7.22";
+  version = "1.7.23";
 
   src = fetchurl {
     url = "https://github.com/vector-im/element-web/releases/download/v${version}/element-v${version}.tar.gz";
-    sha256 = "1aaa986h38kkrnyhb1y65d73idsxmkmi201511az9zlz9210ih59";
+    sha256 = "10n899gc3qcjy2cskk0whwz60pnvh500x1b57kn22l9bhkg9xkvp";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
https://github.com/vector-im/element-web/releases/tag/v1.7.23

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).