### PR TITLE
maestral-gui: 1.4.2 -> 1.4.3

### DIFF
--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maestral-qt";
-  version = "1.4.2";
+  version = "1.4.3";
   disabled = python3.pkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-qt";
     rev = "v${version}";
-    sha256 = "sha256-cPH0wD7RL3OifDTD48x58I4qeaLALOMFnfWXjE2/lUQ=";
+    sha256 = "sha256-+eBwBZx+kp2ACbFjtYK6ux9lcPmEQsunvxAAZ2HgAYw=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -3,25 +3,23 @@
 , fetchFromGitHub
 , pythonOlder
 , python
-, alembic, click, desktop-notifier, dropbox, fasteners, keyring, keyrings-alt, packaging, pathspec, Pyro5, requests, setuptools, sdnotify, sqlalchemy, survey, watchdog
+, click, desktop-notifier, dropbox, fasteners, keyring, keyrings-alt, packaging, pathspec, Pyro5, requests, setuptools, sdnotify, survey, watchdog
 , importlib-metadata
-, importlib-resources
 }:
 
 buildPythonPackage rec {
   pname = "maestral";
-  version = "1.4.2";
+  version = "1.4.3";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral";
     rev = "v${version}";
-    sha256 = "sha256-ibAYuaPSty275/aQ0DibyWe2LjPoEpdWgElTnR+MEs8=";
+    sha256 = "sha256-3GleQNkJrGIkFqOL2Dq0jTpgw7ts9ecpovKbyh3OrEI=";
   };
 
   propagatedBuildInputs = [
-    alembic
     click
     desktop-notifier
     dropbox
@@ -34,13 +32,10 @@ buildPythonPackage rec {
     requests
     setuptools
     sdnotify
-    sqlalchemy
     survey
     watchdog
   ] ++ lib.optionals (pythonOlder "3.8") [
     importlib-metadata
-  ] ++ lib.optionals (pythonOlder "3.9") [
-    importlib-resources
   ];
 
   makeWrapperArgs = [


### PR DESCRIPTION
###### Motivation for this change

Upstream update. Some dependencies removed.

###### Things done

```
3 packages updated:
maestral (1.4.2 → 1.4.3) maestral-gui (1.4.2 → 1.4.3) python38Packages.maestral (1.4.2 → 1.4.3)

2 packages built:
maestral maestral-gui
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
