### PR TITLE
nnn: 3.5 → 3.6

### DIFF
--- a/pkgs/applications/misc/nnn/default.nix
+++ b/pkgs/applications/misc/nnn/default.nix
@@ -7,13 +7,13 @@ assert withNerdIcons -> withIcons == false;
 
 stdenv.mkDerivation rec {
   pname = "nnn";
-  version = "3.5";
+  version = "3.6";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1fa7cmwrzn6kx87kms8i98p9azdlwyh2gnif29l340syl9hkr5qy";
+    sha256 = "1hwv7ncp8pmzdir30877ni4qlmczmb3yjdkbfd1pssr08y1srsc7";
   };
 
   configFile = lib.optionalString (conf != null) (builtins.toFile "nnn.h" conf);
@@ -22,10 +22,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ readline ncurses ];
 
-  makeFlags = [
-    "DESTDIR=${placeholder "out"}"
-    "PREFIX="
-  ] ++ lib.optional withIcons [ "O_ICONS=1" ]
+  makeFlags = [ "PREFIX=$(out)" ]
+    ++ lib.optional withIcons [ "O_ICONS=1" ]
     ++ lib.optional withNerdIcons [ "O_NERD=1" ];
 
   # shell completions
@@ -38,6 +36,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Small ncurses-based file browser forked from noice";
     homepage = "https://github.com/jarun/nnn";
+    changelog = "https://github.com/jarun/nnn/blob/v${version}/CHANGELOG";
     license = licenses.bsd2;
     platforms = platforms.all;
     maintainers = with maintainers; [ jfrankenau Br1ght0ne ];


### PR DESCRIPTION
###### Motivation for this change
[CHANGELOG](https://github.com/jarun/nnn/blob/master/CHANGELOG)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
