### PR TITLE
julia: add update script, and 1.5.3 -> 1.5.4

### DIFF
--- a/pkgs/development/compilers/julia/1.5.nix
+++ b/pkgs/development/compilers/julia/1.5.nix
@@ -19,8 +19,8 @@ with lib;
 let
   majorVersion = "1";
   minorVersion = "5";
-  maintenanceVersion = "3";
-  src_sha256 = "sha256:0jds8lrhk4hfdv7dg5p2ibzin9ivga7wrx7zwcmz6dqp3x792n1i";
+  maintenanceVersion = "4";
+  src_sha256 = "1ba1v7hakgj95xvhyff0zcp0574qv6vailjl48wl1f8w5k54lsw2";
   version = "${majorVersion}.${minorVersion}.${maintenanceVersion}";
 in
 

--- a/pkgs/development/compilers/julia/1.5.nix
+++ b/pkgs/development/compilers/julia/1.5.nix
@@ -1,7 +1,6 @@
-{ lib, stdenv, fetchurl, fetchzip, fetchFromGitHub
+{ lib, stdenv, fetchzip
 # build tools
-, gfortran, m4, makeWrapper, patchelf, perl, which, python2
-, cmake
+, gfortran, m4, makeWrapper, patchelf, perl, which, python2, cmake
 # libjulia dependencies
 , libunwind, readline, utf8proc, zlib
 # standard library dependencies
@@ -28,10 +27,10 @@ stdenv.mkDerivation rec {
   pname = "julia";
   inherit version;
 
-   src = fetchzip {
-     url = "https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz";
-     sha256 = src_sha256;
-   };
+  src = fetchzip {
+    url = "https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz";
+    sha256 = src_sha256;
+  };
 
   patches = [
     ./use-system-utf8proc-julia-1.3.patch

--- a/pkgs/development/compilers/julia/update-1.5.py
+++ b/pkgs/development/compilers/julia/update-1.5.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i python3 -p python3 python3Packages.requests
 
-import hashlib
 import os
 import re
 import requests

--- a/pkgs/development/compilers/julia/update-1.5.py
+++ b/pkgs/development/compilers/julia/update-1.5.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3 python3Packages.requests
+
+import hashlib
+import os
+import re
+import requests
+import subprocess
+
+latest = requests.get("https://api.github.com/repos/JuliaLang/julia/releases/latest").json()["tag_name"]
+assert latest[0] == "v"
+major, minor, patch = latest[1:].split(".")
+assert major == "1"
+# When a new minor version comes out we'll have to refactor/copy this update script.
+assert minor == "5"
+
+sha256 = subprocess.check_output(["nix-prefetch-url", "--unpack", f"https://github.com/JuliaLang/julia/releases/download/v{major}.{minor}.{patch}/julia-{major}.{minor}.{patch}-full.tar.gz"], text=True).strip()
+
+nix_path = os.path.join(os.path.dirname(__file__), "1.5.nix")
+nix0 = open(nix_path, "r").read()
+nix1 = re.sub("maintenanceVersion = \".*\";", f"maintenanceVersion = \"{patch}\";", nix0)
+nix2 = re.sub("src_sha256 = \".*\";", f"src_sha256 = \"{sha256}\";", nix1)
+open(nix_path, "w").write(nix2)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add an auto-update script for julia 1.5.x, and easily extendible to future 1.x versions. Also demonstrate the behavior of the script by upgrading from 1.5.3 to 1.5.4 automatically.

Behavior is designed to follow https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vscode/update-vscode.sh, but written in python instead of sh for clarity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
