### PR TITLE
rpm2targz: init at 2021.03.16

### DIFF
--- a/pkgs/tools/archivers/rpm2targz/default.nix
+++ b/pkgs/tools/archivers/rpm2targz/default.nix
@@ -1,0 +1,55 @@
+{ bzip2
+, coreutils
+, cpio
+, fetchurl
+, gnutar
+, gzip
+, lib
+, stdenv
+, xz
+, zstd
+}:
+
+let
+  shdeps = [
+    bzip2
+    coreutils
+    cpio
+    gnutar
+    gzip
+    xz
+    zstd
+  ];
+
+in stdenv.mkDerivation rec {
+  pname = "rpm2targz";
+  version = "2021.03.16";
+
+  # git repo: https://gitweb.gentoo.org/proj/rpm2targz.git/
+  src = fetchurl {
+    url = "https://dev.gentoo.org/~vapier/dist/${pname}-${version}.tar.xz";
+    hash = "sha256-rcV+o9V2wWKznqSW2rA8xgnpQ02kpK4te6mYvLRC5vQ=";
+  };
+
+  buildInputs = shdeps;
+
+  postPatch = ''
+    substituteInPlace rpm2targz --replace "=\"rpmoffset\"" "=\"$out/bin/rpmoffset\""
+    # rpm2targz relies on the executable name
+    # to guess what compressor it should use
+    # this is more reliable than wrapProgram
+    sed -i -e '2iexport PATH="${lib.makeBinPath shdeps}"' rpm2targz
+  '';
+
+  preBuild = ''
+    makeFlagsArray+=(prefix=$out)
+  '';
+
+  meta = with lib; {
+    description = "Convert a .rpm file to a .tar.gz archive";
+    homepage = "http://slackware.com/config/packages.php";
+    license = licenses.bsd1;
+    maintainers = with maintainers; [ zseri ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7727,6 +7727,8 @@ in
     gperf = gperf_3_0;
   };
 
+  rpm2targz = callPackage ../tools/archivers/rpm2targz { };
+
   rpmextract = callPackage ../tools/archivers/rpmextract { };
 
   rrdtool = callPackage ../tools/misc/rrdtool { };


### PR DESCRIPTION
###### Motivation for this change

This PR packages rpm2targz (with patches from [Gentoo](https://github.com/gentoo/gentoo/blob/master/app-arch/rpm2targz/rpm2targz-9.0.0.5g-r2.ebuild), which are afaik the most recent ones).

Description from Slackware:
>  Converts an RPM (RedHat Package Manager) to a Slackware-compatible [.tar.gz] package. In case you ever run across the need to obtain something that is only in RPM format, this program may come in handy.

The package consists of a shell script `rpm2targz` and a C program `rpmoffset`, plus a bunch of symlinks to the shell script.
It has a Makefile, but it is probably easier to just copy the necessary instructions from the Makefile into `buildPhase`.
The shell scripts requires `coreutils, cpio, tar, zstd`

Repology entry: https://repology.org/project/rpm2targz/packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - new package, no dependees, ~41,5 MiB.
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
