### PR TITLE
OctoPrint-plugins: M84MotorsOff, CostEstimation, DisplayProgress, Telegram

### DIFF
--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -52,6 +52,25 @@ in {
     };
   };
 
+  costestimation = buildPlugin rec {
+    pname = "CostEstimation";
+    version = "3.2.0";
+
+    src = fetchFromGitHub {
+      owner = "OllisGit";
+      repo = "OctoPrint-${pname}";
+      rev = version;
+      sha256 = "1j476jcw7gh8zqqdc5vddwv5wpjns7cd1hhpn7m9fxq3d5bi077w";
+    };
+
+    meta = with lib; {
+      description = "Plugin to display the estimated print cost for the loaded model.";
+      homepage = "https://github.com/malnvenshorn/OctoPrint-CostEstimation";
+      license = licenses.agpl3Only;
+      maintainers = with maintainers; [ stunkymonkey ];
+    };
+  };
+
   curaenginelegacy = buildPlugin rec {
     pname = "CuraEngineLegacy";
     version = "1.1.1";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -90,6 +90,25 @@ in {
     };
   };
 
+  displayprogress = buildPlugin rec {
+    pname = "DisplayProgress";
+    version = "0.1.3";
+
+    src = fetchFromGitHub {
+      owner = "OctoPrint";
+      repo = "OctoPrint-${pname}";
+      rev = version;
+      sha256 = "080prvfwggl4vkzyi369vxh1n8231hrl8a44f399laqah3dn5qw4";
+    };
+
+    meta = with lib; {
+      description = "Displays the job progress on the printer's display";
+      homepage = "https://github.com/OctoPrint/OctoPrint-DisplayProgress";
+      license = licenses.agpl3Only;
+      maintainers = with maintainers; [ stunkymonkey ];
+    };
+  };
+
   displaylayerprogress = buildPlugin rec {
     pname = "OctoPrint-DisplayLayerProgress";
     version = "1.24.0";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -278,6 +278,27 @@ in {
     };
   };
 
+  telegram = buildPlugin rec {
+    pname = "Telegram";
+    version = "1.6.4";
+
+    src = fetchFromGitHub {
+      owner = "fabianonline";
+      repo = "OctoPrint-${pname}";
+      rev = version;
+      sha256 = "14d9f9a5m1prcikd7y26qks6c2ls6qq4b97amn24q5a8k5hbgl94";
+    };
+
+    propagatedBuildInputs = with super; [ pillow ];
+
+    meta = with lib; {
+      description = "Plugin to send status messages and receive commands via Telegram messenger.";
+      homepage = "https://github.com/fabianonline/OctoPrint-Telegram";
+      license = licenses.agpl3Only;
+      maintainers = with maintainers; [ stunkymonkey ];
+    };
+  };
+
   themeify = buildPlugin rec {
     pname = "Themeify";
     version = "1.2.2";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -13,6 +13,25 @@ self: super: let
 in {
   inherit buildPlugin;
 
+  m86motorsoff = buildPlugin rec {
+    pname = "M84MotorsOff";
+    version = "0.1.0";
+
+    src = fetchFromGitHub {
+      owner = "ntoff";
+      repo = "Octoprint-M84MotOff";
+      rev = "v${version}";
+      sha256 = "1w6h4hia286lbz2gy33rslq02iypx067yqn413xcipb07ivhvdq7";
+    };
+
+    meta = with lib; {
+      description = "Changes the \"Motors off\" button in octoprint's control tab to issue an M84 command to allow compatibility with Repetier firmware Resources";
+      homepage = "https://github.com/ntoff/OctoPrint-M84MotOff";
+      license = licenses.agpl3Only;
+      maintainers = with maintainers; [ stunkymonkey ];
+    };
+  };
+
   abl-expert = buildPlugin rec {
     pname = "ABL_Expert";
     version = "0.6";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
i am missing these four plugins on NixOs

###### Things done
so i added them one-by-one
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
