### PR TITLE
gegl_0_4: 0.4.26 → 0.4.28

### DIFF
--- a/pkgs/development/libraries/gegl/4.0.nix
+++ b/pkgs/development/libraries/gegl/4.0.nix
@@ -1,11 +1,10 @@
 { lib, stdenv
 , fetchurl
-, fetchpatch
 , pkg-config
 , vala
 , gobject-introspection
 , gtk-doc
-, docbook_xsl
+, docbook-xsl-nons
 , docbook_xml_dtd_43
 , glib
 , babl
@@ -15,6 +14,7 @@
 , librsvg
 , lensfun
 , libspiro
+, maxflow
 , netsurf
 , pango
 , poly2tri-c
@@ -35,24 +35,15 @@
 
 stdenv.mkDerivation rec {
   pname = "gegl";
-  version = "0.4.26";
+  version = "0.4.28";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
   src = fetchurl {
     url = "https://download.gimp.org/pub/gegl/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-DzceLtK5IWL+/T3edD5kjKCKahsrBQBIZ/vdx+IR5CQ=";
+    sha256 = "sha256-HRENhXfVTMo7NCOTFb03xXzLJ91DVWVQdKLSs/2JeQA=";
   };
-
-  patches = [
-    # fix build with darwin: https://github.com/NixOS/nixpkgs/issues/99108
-    # https://gitlab.gnome.org/GNOME/gegl/-/merge_requests/83
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gegl/-/merge_requests/83.patch";
-      sha256 = "sha256-CSBYbJ2xnEN23xrla1qqr244jxOR5vNK8ljBSXdg4yE=";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -62,7 +53,7 @@ stdenv.mkDerivation rec {
     vala
     gobject-introspection
     gtk-doc
-    docbook_xsl
+    docbook-xsl-nons
     docbook_xml_dtd_43
   ];
 
@@ -73,6 +64,7 @@ stdenv.mkDerivation rec {
     librsvg
     lensfun
     libspiro
+    maxflow
     netsurf.libnsgif
     pango
     poly2tri-c


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
﻿NEWS: https://gitlab.gnome.org/GNOME/gegl/-/commit/91ace253930a83874f30a1d13e0ea5bbc2e5174c
Changes: https://gitlab.gnome.org/GNOME/gegl/-/compare/GEGL_0_4_26...GEGL_0_4_28

- New dependency maxflow.
- dot path has been briefly hardcoded added (https://gitlab.gnome.org/GNOME/gegl/-/commit/5ac40e3c3f9ab25b1208a96a8fdcae6fd72958ef) but then it was switched back to finding it on PATH (https://gitlab.gnome.org/GNOME/gegl/-/commit/1f50456de59c686941a861d299a63bfcd4126ee5). Given that it is optional dependency only needed for debugging and graphviz is big, I have decided not to hardcode it in a patch.

cc @tadfisher

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
