### PR TITLE
 ocamlPackages.git: 3.3.0 -> 3.3.2; decompress: 1.2.0 -> 1.3.0; duff: 0.3 -> 0.4; and related updates

### DIFF
--- a/pkgs/development/ocaml-modules/carton/default.nix
+++ b/pkgs/development/ocaml-modules/carton/default.nix
@@ -2,19 +2,19 @@
 , ke, duff, decompress, cstruct, optint, bigstringaf, stdlib-shims
 , bigarray-compat, checkseum, logs, psq, fmt
 , result, rresult, fpath, base64, bos, digestif, mmap, alcotest
-, crowbar, alcotest-lwt, lwt, findlib, mirage-flow, cmdliner
+, crowbar, alcotest-lwt, lwt, findlib, mirage-flow, cmdliner, hxd
 }:
 
 buildDunePackage rec {
   pname = "carton";
-  version = "0.2.0";
+  version = "0.4.0";
 
   useDune2 = true;
   minimumOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${pname}-v${version}/${pname}-${pname}-v${version}.tbz";
-    sha256 = "0gfns4a9p9540kijccsg52yzyn3jfvi737mb0g71yazyc89dqwhn";
+    sha256 = "777f9692b83cd63570c17527a32c5045818ab9242d923cbbde72fc23d0da0140";
   };
 
   # remove changelogs for mimic and the git* packages
@@ -30,6 +30,7 @@ buildDunePackage rec {
     rresult
     fpath
     bos
+    hxd
   ];
   propagatedBuildInputs = [
     ke

--- a/pkgs/development/ocaml-modules/decompress/1.2.nix
+++ b/pkgs/development/ocaml-modules/decompress/1.2.nix
@@ -1,10 +1,9 @@
 { lib, fetchurl, buildDunePackage
-, checkseum, bigarray-compat, optint, cmdliner
-, bigstringaf, alcotest, camlzip, base64, ctypes, fmt
+, checkseum, bigarray-compat, optint
 }:
 
 buildDunePackage rec {
-  version = "1.3.0";
+  version = "1.2.0";
   pname = "decompress";
 
   minimumOCamlVersion = "4.07";
@@ -13,13 +12,12 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/mirage/decompress/releases/download/v${version}/decompress-v${version}.tbz";
-    sha256 = "de149896939be13fedec46a4581121d5ab74850a2241d08e6aa8ae4bb18c52c4";
+    sha256 = "1c3sq9a6kpzl0pj3gmg7w18ssjjl70yv0r3l7qjprcncjx23v62i";
   };
 
-  buildInputs = [ cmdliner ];
   propagatedBuildInputs = [ optint bigarray-compat checkseum ];
-  checkInputs = [ alcotest bigstringaf ctypes fmt camlzip base64 ];
-  doCheck = true;
+  # required hxd version is not available in nixpkgs
+  doCheck = false;
 
   meta = {
     description = "Pure OCaml implementation of Zlib";

--- a/pkgs/development/ocaml-modules/duff/default.nix
+++ b/pkgs/development/ocaml-modules/duff/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchurl, buildDunePackage, fetchpatch
 , stdlib-shims, bigarray-compat, fmt
 , alcotest, hxd, crowbar, bigstringaf
 }:

--- a/pkgs/development/ocaml-modules/duff/default.nix
+++ b/pkgs/development/ocaml-modules/duff/default.nix
@@ -5,13 +5,13 @@
 
 buildDunePackage rec {
   pname = "duff";
-  version = "0.3";
+  version = "0.4";
 
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/duff/releases/download/v${version}/duff-v${version}.tbz";
-    sha256 = "1lb67yxk93ifj94p1i3swjbnj5xy8j6xzs72bwvq6cffx5xykznm";
+    sha256 = "4795e8344a2c2562e0ef6c44ab742334b5cd807637354715889741b20a461da4";
   };
 
   propagatedBuildInputs = [ stdlib-shims bigarray-compat fmt ];

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -8,14 +8,14 @@
 
 buildDunePackage rec {
   pname = "git";
-  version = "3.3.0";
+  version = "3.3.2";
 
   minimumOCamlVersion = "4.08";
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${version}/git-${version}.tbz";
-    sha256 = "090b67e8f8a02fb52b4d0c7aa445b5ff7353fdb2da00fb37b908f089c6776cd0";
+    sha256 = "01xcjggsb13n6018lp6ic0f6pglfl39qcg126h1k3da19hvpzhrv";
   };
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/git/unix.nix
+++ b/pkgs/development/ocaml-modules/git/unix.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, fetchpatch, git
+{ buildDunePackage, git
 , mmap, rresult, result, bigstringaf
 , fmt, bos, fpath, uri, digestif, logs, lwt, git-cohttp-unix
 , mirage-clock, mirage-clock-unix, astring, awa, cmdliner
@@ -14,14 +14,6 @@ buildDunePackage {
   inherit (git) version src minimumOCamlVersion;
 
   useDune2 = true;
-
-  patches = [
-    # https://github.com/mirage/ocaml-git/pull/472
-    (fetchpatch {
-      url = "https://github.com/sternenseemann/ocaml-git/commit/54998331eb9d5c61afe8901fabe0c74c2877f096.patch";
-      sha256 = "12kd45mlfaj4hxh33k9920a22mq1q2sdrin2j41w1angvg00d3my";
-    })
-  ];
 
   buildInputs = [
     awa awa-mirage cmdliner git-cohttp-unix

--- a/pkgs/development/ocaml-modules/hxd/default.nix
+++ b/pkgs/development/ocaml-modules/hxd/default.nix
@@ -1,11 +1,11 @@
 { lib, buildDunePackage, fetchurl
-, dune-configurator, cmdliner, angstrom
-, rresult, stdlib-shims, fmt, fpath
+, ocaml, dune-configurator, cmdliner
+, lwt, withLwt ? lib.versionAtLeast ocaml.version "4.07"
 }:
 
 buildDunePackage rec {
   pname = "hxd";
-  version = "0.2.0";
+  version = "0.3.1";
 
   useDune2 = true;
 
@@ -13,24 +13,25 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/dinosaure/hxd/releases/download/v${version}/hxd-v${version}.tbz";
-    sha256 = "1lyfrq058cc9x0c0hzsf3hv3ys0h8mxkwin9lldidlnj10izqf1l";
+    sha256 = "1c226c91e17cd329dec0c287bfd20f36302aa533069ff9c6ced32721f96b29bc";
   };
+
+  # ignore yes stderr output due to trapped SIGPIPE
+  postPatch = ''
+    sed -i 's|yes ".\+"|& 2> /dev/null|' test/*.t
+  '';
 
   nativeBuildInputs = [
     dune-configurator
   ];
 
+  propagatedBuildInputs = lib.optional withLwt lwt;
+
   buildInputs = [
     cmdliner
-    angstrom
-    rresult
-    fmt
-    fpath
   ];
 
-  propagatedBuildInputs = [
-    stdlib-shims
-  ];
+  doCheck = true;
 
   meta = with lib; {
     description = "Hexdump in OCaml";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -238,6 +238,8 @@ let
 
     decompress =  callPackage ../development/ocaml-modules/decompress { };
 
+    decompress-1-2 = callPackage ../development/ocaml-modules/decompress/1.2.nix { };
+
     diet =  callPackage ../development/ocaml-modules/diet { };
 
     digestif =  callPackage ../development/ocaml-modules/digestif { };
@@ -399,7 +401,9 @@ let
 
     hxd = callPackage ../development/ocaml-modules/hxd { };
 
-    imagelib = callPackage ../development/ocaml-modules/imagelib { };
+    imagelib = callPackage ../development/ocaml-modules/imagelib {
+      decompress = decompress-1-2;
+    };
 
     inotify = callPackage ../development/ocaml-modules/inotify { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* <https://github.com/mirage/ocaml-git/releases/tag/3.3.1>
* <https://github.com/mirage/ocaml-git/releases/tag/3.3.2>
* <https://github.com/mirage/ocaml-git/releases/tag/carton-v0.2.0>
* <https://github.com/mirage/ocaml-git/releases/tag/carton-v0.4.0>
* <https://github.com/mirage/duff/releases/tag/v0.4>
* <https://github.com/dinosaure/hxd/releases/tag/v0.3.0>
* <https://github.com/dinosaure/hxd/releases/tag/v0.3.1>
* <https://github.com/mirage/decompress/releases/tag/v1.3.0>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
