### PR TITLE
ocamlPackages.owl{,-base}: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/owl-base/default.nix
+++ b/pkgs/development/ocaml-modules/owl-base/default.nix
@@ -2,13 +2,13 @@
 
 buildDunePackage rec {
   pname = "owl-base";
-  version = "1.0.0";
+  version = "1.0.1";
 
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/owlbarn/owl/releases/download/${version}/owl-${version}.tbz";
-    sha256 = "1gny4351ws2r7dp53nampfyh39l0z6qqvxj5v3d05mpdi2aa06yr";
+    sha256 = "72ca9f6edd302fdfa16c7559cedac7ac2c885466a367e17ea1ea8807b2dd13ef";
   };
 
   minimumOCamlVersion = "4.10";


### PR DESCRIPTION
<https://github.com/owlbarn/owl/releases/tag/1.0.1>

Fixes test failure on nixpkgs master.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
