### PR TITLE
 ocamlPackages.luv: init at 0.5.7 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5524,6 +5524,12 @@
     githubId = 7622248;
     name = "Sebastian Zivota";
   };
+  locallycompact = {
+    email = "dan.firth@homotopic.tech";
+    github = "locallycompact";
+    githubId = 1267527;
+    name = "Daniel Firth";
+  };
   lopsided98 = {
     email = "benwolsieffer@gmail.com";
     github = "lopsided98";

--- a/pkgs/development/ocaml-modules/luv/default.nix
+++ b/pkgs/development/ocaml-modules/luv/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildDunePackage, fetchurl
+, ctypes, result
+, alcotest
+, file
+}:
+
+buildDunePackage rec {
+  pname = "luv";
+  version = "0.5.7";
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/aantron/luv/releases/download/${version}/luv-${version}.tar.gz";
+    sha256 = "0wjnw5riydnzsk1xdzljlpzdnjwpa0j597y6x6ma4990mqj54260";
+  };
+
+  postConfigure = ''
+    for f in src/c/vendor/configure/{ltmain.sh,configure}; do
+      substituteInPlace "$f" --replace /usr/bin/file file
+    done
+  '';
+
+  nativeBuildInputs = [ file ];
+  propagatedBuildInputs = [ ctypes result ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/aantron/luv";
+    description = "Binding to libuv: cross-platform asynchronous I/O";
+    # MIT-licensed, extra licenses apply partially to libuv vendor
+    license = with licenses; [ mit bsd2 bsd3 cc-by-sa-40 ];
+    maintainers = with maintainers; [ locallycompact sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -572,6 +572,10 @@ let
 
     lua-ml = callPackage ../development/ocaml-modules/lua-ml { };
 
+    luv = callPackage ../development/ocaml-modules/luv {
+      inherit (pkgs) file;
+    };
+
     lwt = callPackage ../development/ocaml-modules/lwt {
       ocaml-migrate-parsetree = ocaml-migrate-parsetree-2-1;
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixed up version of the luv introduction in #116302.

cc @locallycompact


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
