### PR TITLE
appimagekit: 2018-07-27 -> 2020-12-31

### DIFF
--- a/pkgs/tools/package-management/appimagekit/default.nix
+++ b/pkgs/tools/package-management/appimagekit/default.nix
@@ -19,7 +19,7 @@ let
   # squashfuse adapted to nix from cmake experession in "${appimagekit_src}/lib/libappimage/cmake/dependencies.cmake"
   appimagekit_squashfuse = squashfuse.overrideAttrs (attrs: rec {
     pname = "squashfuse";
-    version = "2016-10-09";
+    version = "unstable-2016-10-09";
 
     src = fetchFromGitHub {
       owner = "vasi";
@@ -60,7 +60,7 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "appimagekit";
-  version = "2020-12-31";
+  version = "unstable-2020-12-31";
 
   src = appimagekit_src;
 

--- a/pkgs/tools/package-management/appimagekit/default.nix
+++ b/pkgs/tools/package-management/appimagekit/default.nix
@@ -11,29 +11,30 @@ let
   appimagekit_src = fetchFromGitHub {
     owner = "AppImage";
     repo = "AppImageKit";
-    rev = "b0859501df61cde198b54a317c03b41dbafc98b1";
-    sha256 = "0qqg79jw9w9rs8c2w3lla4kz62ihafrf7jm370pp1dl8y2i81jzg";
+    rev = "8bbf694455d00f48d835f56afaa1dabcd9178ba6";
+    sha256 = "sha256-pqg+joomC5CI9WdKP/h/XKPsruMgZEaIOjPLOqnNPZw=";
+    fetchSubmodules = true;
   };
 
-  # squashfuse adapted to nix from cmake experession in "${appimagekit_src}/cmake/dependencies.cmake"
+  # squashfuse adapted to nix from cmake experession in "${appimagekit_src}/lib/libappimage/cmake/dependencies.cmake"
   appimagekit_squashfuse = squashfuse.overrideAttrs (attrs: rec {
-    name = "squashfuse-${version}";
-    version = "20161009";
+    pname = "squashfuse";
+    version = "2016-10-09";
 
     src = fetchFromGitHub {
       owner = "vasi";
-      repo  = "squashfuse";
-      rev   = "1f980303b89c779eabfd0a0fdd36d6a7a311bf92";
-      sha256 = "0lrw9ff8k15l34wjwyllw3i35hl0cms97jj2hpnr2q8ipgxpb5q5";
+      repo  = pname;
+      rev = "1f980303b89c779eabfd0a0fdd36d6a7a311bf92";
+      sha256 = "sha256-BZd1+7sRYZHthULKk3RlgMIy4uCUei45GbSEiZxLPFM=";
     };
 
     patches = [
-      "${appimagekit_src}/squashfuse.patch"
-      "${appimagekit_src}/squashfuse_dlopen.patch"
+      "${appimagekit_src}/lib/libappimage/src/patches/squashfuse.patch"
+      "${appimagekit_src}/lib/libappimage/src/patches/squashfuse_dlopen.patch"
     ];
 
     postPatch = ''
-      cp -v ${appimagekit_src}/squashfuse_dlopen.[hc] .
+      cp -v ${appimagekit_src}/lib/libappimage/src/patches/squashfuse_dlopen.[hc] .
     '';
 
     preConfigure = ''
@@ -58,26 +59,26 @@ let
   });
 
 in stdenv.mkDerivation rec {
-  name = "appimagekit-20180727";
+  pname = "appimagekit";
+  version = "2020-12-31";
 
   src = appimagekit_src;
 
   patches = [ ./nix.patch ];
 
+  postPatch = ''
+    patchShebangs src/embed-magic-bytes-in-file.sh
+  '';
+
   nativeBuildInputs = [
     pkg-config cmake autoconf automake libtool wget xxd
-    desktop-file-utils
+    desktop-file-utils makeWrapper
   ];
 
   buildInputs = [
-    glib zlib cairo openssl fuse
-    xz inotify-tools libarchive
-    squashfsTools makeWrapper
+    glib zlib cairo openssl fuse xz inotify-tools
+    libarchive squashfsTools appimagekit_squashfuse
   ];
-
-  postPatch = ''
-    substituteInPlace src/appimagetool.c --replace "/usr/bin/file" "${file}/bin/file"
-  '';
 
   preConfigure = ''
     export HOME=$(pwd)
@@ -87,22 +88,22 @@ in stdenv.mkDerivation rec {
     "-DUSE_SYSTEM_XZ=ON"
     "-DUSE_SYSTEM_SQUASHFUSE=ON"
     "-DSQUASHFUSE=${appimagekit_squashfuse}"
-    "-DUSE_SYSTEM_INOTIFY_TOOLS=ON"
     "-DUSE_SYSTEM_LIBARCHIVE=ON"
     "-DUSE_SYSTEM_GTEST=ON"
     "-DUSE_SYSTEM_MKSQUASHFS=ON"
   ];
 
   postInstall = ''
+    mkdir -p $out/lib/appimagekit
     cp "${squashfsTools}/bin/mksquashfs" "$out/lib/appimagekit/"
     cp "${desktop-file-utils}/bin/desktop-file-validate" "$out/bin"
 
     wrapProgram "$out/bin/appimagetool" \
-      --prefix PATH : "${lib.makeBinPath [ file gnupg ]}"
+      --prefix PATH : "${lib.makeBinPath [ file gnupg ]}" \
+      --unset SOURCE_DATE_EPOCH
   '';
 
   checkInputs = [ gtest ];
-  doCheck = false; # fails 1 out of 4 tests, I'm too lazy to debug why
 
   # for debugging
   passthru = {
@@ -117,6 +118,7 @@ in stdenv.mkDerivation rec {
       AppImages.
     '';
     license = licenses.mit;
+    maintainers = with maintainers; [ taeer ];
     homepage = src.meta.homepage;
     platforms = platforms.linux;
   };

--- a/pkgs/tools/package-management/appimagekit/nix.patch
+++ b/pkgs/tools/package-management/appimagekit/nix.patch
@@ -1,174 +1,82 @@
-diff --git a/cmake/dependencies.cmake b/cmake/dependencies.cmake
-index ea133a3..916606c 100644
---- a/cmake/dependencies.cmake
-+++ b/cmake/dependencies.cmake
-@@ -224,21 +224,23 @@ if(NOT USE_SYSTEM_XZ)
-         LIBRARY_DIRS <INSTALL_DIR>/lib/
-         LIBRARIES "<INSTALL_DIR>/lib/liblzma.a"
-         INCLUDE_DIRS "<SOURCE_DIR>/src/liblzma/api/"
+Submodule lib/libappimage contains modified content
+diff --git a/lib/libappimage/cmake/dependencies.cmake b/lib/libappimage/cmake/dependencies.cmake
+index 8d96484..c7b17a1 100644
+--- a/lib/libappimage/cmake/dependencies.cmake
++++ b/lib/libappimage/cmake/dependencies.cmake
+@@ -91,9 +91,18 @@ if(NOT USE_SYSTEM_SQUASHFUSE)
+         INCLUDE_DIRS "<SOURCE_DIR>"
      )
  else()
-     message(STATUS "Using system xz")
- 
-     import_pkgconfig_target(TARGET_NAME xz PKGCONFIG_TARGET liblzma STATIC)
- endif()
- 
-+set(USE_SYSTEM_SQUASHFUSE OFF CACHE BOOL "Use system squashfuse instead of building our own")
- 
-+if(NOT USE_SYSTEM_SQUASHFUSE)
- # as distros don't provide suitable squashfuse and squashfs-tools, those dependencies are bundled in, can, and should
- # be used from this repository
- # TODO: implement out-of-source builds for squashfuse, as for the other dependencies
- configure_file(
-     ${CMAKE_CURRENT_SOURCE_DIR}/src/patch-squashfuse.sh.in
-     ${CMAKE_CURRENT_BINARY_DIR}/patch-squashfuse.sh
-     @ONLY
- )
- 
- ExternalProject_Add(squashfuse-EXTERNAL
-@@ -259,20 +261,34 @@ ExternalProject_Add(squashfuse-EXTERNAL
-     BUILD_IN_SOURCE ON
-     INSTALL_COMMAND ${MAKE} install
- )
- 
- import_external_project(
-     TARGET_NAME squashfuse
-     EXT_PROJECT_NAME squashfuse-EXTERNAL
-     LIBRARIES "<SOURCE_DIR>/.libs/libsquashfuse.a;<SOURCE_DIR>/.libs/libsquashfuse_ll.a;<SOURCE_DIR>/.libs/libfuseprivate.a"
-     INCLUDE_DIRS "<SOURCE_DIR>"
- )
-+else()
+-    message(STATUS "Using system squashfuse")
 +    message(STATUS "Using system squashfsfuse from ${SQUASHFUSE}")
-+
-+    add_library(squashfuse INTERFACE IMPORTED GLOBAL)
+
+-    import_pkgconfig_target(TARGET_NAME libsquashfuse PKGCONFIG_TARGET squashfuse)
++    add_library(libsquashfuse INTERFACE IMPORTED GLOBAL)
 +
 +    set(squashfuse_INCLUDE_DIRS "${SQUASHFUSE}/include")
 +    set(squashfuse_LIBRARIES "${SQUASHFUSE}/lib/libsquashfuse.a;${SQUASHFUSE}/lib/libsquashfuse_ll.a;${SQUASHFUSE}/lib/libfuseprivate.a")
 +
 +    set_property(
-+      TARGET squashfuse
++      TARGET libsquashfuse
 +      PROPERTY INTERFACE_LINK_LIBRARIES ${squashfuse_LIBRARIES}
 +    )
 +    include_directories(${squashfuse_INCLUDE_DIRS})
-+endif()
- 
- 
- set(USE_SYSTEM_INOTIFY_TOOLS OFF CACHE BOOL "Use system libinotifytools instead of building our own")
- 
- if(NOT USE_SYSTEM_INOTIFY_TOOLS)
-     message(STATUS "Downloading and building inotify-tools")
- 
-     # TODO: build out of source
-     ExternalProject_Add(inotify-tools-EXTERNAL
-         URL https://github.com/downloads/rvoicilas/inotify-tools/inotify-tools-3.14.tar.gz
-@@ -345,20 +361,23 @@ if(NOT USE_SYSTEM_GTEST)
-             INCLUDE_DIRS "<INSTALL_DIR>/include/"
-         )
-     else()
-         message(STATUS "Using system GTest")
- 
-         import_find_pkg_target(gtest GTest GTEST)
-     endif()
  endif()
- 
- 
-+set(USE_SYSTEM_MKSQUASHFS OFF CACHE BOOL "Use system mksquashfs instead of downloading and building our own")
-+
-+if(NOT USE_SYSTEM_MKSQUASHFS)
- # TODO: allow using system wide mksquashfs
- set(mksquashfs_cflags "-DXZ_SUPPORT ${CFLAGS}")
- 
- if(xz_LIBRARIES MATCHES "\\.a$")
-     set(mksquashfs_ldflags "${xz_LIBRARIES}")
- else()
-     set(mksquashfs_ldflags "-l${xz_LIBRARIES}")
- endif()
- 
- if(xz_INCLUDE_DIRS)
-@@ -385,20 +404,25 @@ ExternalProject_Add(mksquashfs
-     INSTALL_COMMAND ${MAKE} -C squashfs-tools/ install INSTALL_DIR=<INSTALL_DIR>
- )
- 
- ExternalProject_Get_Property(mksquashfs INSTALL_DIR)
- set(mksquashfs_INSTALL_DIR "${INSTALL_DIR}")
- mark_as_advanced(mksquashfs_INSTALL_DIR)
- 
- # for later use when packaging as an AppImage
- set(mksquashfs_BINARY "${mksquashfs_INSTALL_DIR}/mksquashfs")
- mark_as_advanced(mksquashfs_BINARY)
-+else()
-+    message(STATUS "Using system mksquashfs")
-+
-+    set(mksquashfs_BINARY "mksquashfs")
-+endif()
- 
- 
- #### build dependency configuration ####
- 
- # only have to build custom xz when not using system libxz
- if(TARGET xz-EXTERNAL)
-     if(TARGET squashfuse-EXTERNAL)
-         ExternalProject_Add_StepDependencies(squashfuse-EXTERNAL configure xz-EXTERNAL)
-     endif()
-     if(TARGET mksquashfs)
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 3f25442..974ed0e 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -197,27 +197,27 @@ target_include_directories(digest_md5
- 
- target_link_libraries(digest_md5
-     PRIVATE
-     libglib
- )
- 
- 
- # install binaries
- if(AUXILIARY_FILES_DESTINATION)
-     install(
--        PROGRAMS ${mksquashfs_INSTALL_DIR}/mksquashfs ${CMAKE_CURRENT_BINARY_DIR}/runtime
-+        PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/runtime
-         DESTINATION ${AUXILIARY_FILES_DESTINATION}
-         COMPONENT applications
-     )
- else()
-     install(
--        PROGRAMS ${mksquashfs_INSTALL_DIR}/mksquashfs ${CMAKE_CURRENT_BINARY_DIR}/runtime
-+        PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/runtime
-         DESTINATION bin
-         COMPONENT applications
-     )
- endif()
- 
- install(
-     TARGETS AppRun appimagetool digest validate
-     RUNTIME DESTINATION bin COMPONENT applications
-     LIBRARY DESTINATION lib COMPONENT applications
-     ARCHIVE DESTINATION lib/static COMPONENT applications
-diff --git a/src/shared.c b/src/shared.c
-index cf5fd5c..4f48dbc 100644
---- a/src/shared.c
-+++ b/src/shared.c
-@@ -34,21 +34,21 @@
- #include <sys/stat.h>
+
+
+diff --git a/src/appimagetool.c b/src/appimagetool.c
+index 6b37419..23425e7 100644
+--- a/src/appimagetool.c
++++ b/src/appimagetool.c
+@@ -38,7 +38,7 @@
+ #include <argp.h>
+
+ #include <fcntl.h>
+-#include "squashfuse.h"
++#include <squashfuse.h>
+
  #include <sys/types.h>
- #include <dirent.h>
- #include <errno.h>
- 
- #include <glib.h>
- #include <glib/gprintf.h>
- #include <glib/gstdio.h>
- #include <gio/gio.h>
- 
+ #include <sys/stat.h>
+@@ -96,7 +96,7 @@ static void die(const char *msg) {
+ }
+
+ /* Function that prints the contents of a squashfs file
+-* using libsquashfuse (#include "squashfuse.h") */
++* using libsquashfuse (#include <squashfuse.h>) */
+ int sfs_ls(char* image) {
+     sqfs_err err = SQFS_OK;
+     sqfs_traverse trv;
+diff --git a/src/appimagetoolnoglib.c b/src/appimagetoolnoglib.c
+index f900e76..ffa87f8 100644
+--- a/src/appimagetoolnoglib.c
++++ b/src/appimagetoolnoglib.c
+@@ -3,7 +3,7 @@
+
+ #include <stdlib.h>
+ #include <fcntl.h>
+-#include "squashfuse.h"
++#include <squashfuse.h>
+
+ #include <sys/types.h>
+ #include <sys/stat.h>
+@@ -118,7 +118,7 @@ int is_regular_file(const char *path)
+ }
+
+ /* Function that prints the contents of a squashfs file
+- * using libsquashfuse (#include "squashfuse.h") */
++ * using libsquashfuse (#include <squashfuse.h>) */
+ int sfs_ls(char* image) {
+ 	sqfs_err err = SQFS_OK;
+ 	sqfs_traverse trv;
+diff --git a/src/runtime.c b/src/runtime.c
+index bada3af..70a642b 100644
+--- a/src/runtime.c
++++ b/src/runtime.c
+@@ -29,7 +29,7 @@
+
+ #define _GNU_SOURCE
+
 -#include "squashfuse.h"
 +#include <squashfuse.h>
  #include <squashfs_fs.h>
- #include "getsection.h"
- #include "elf.h"
- 
- #include "xdg-basedir.h"
- 
- // own header
- #include "shared.h"
- 
- #if HAVE_LIBARCHIVE3 == 1 // CentOS
+ #include <nonstd.h>


### PR DESCRIPTION
###### Motivation for this change
appimagekit package is 2 years old, and broken as far as I can tell (see https://github.com/NixOS/nixpkgs/issues/116331). After this update, I'm no longer getting that error.

###### Comments

- I'm not sure I did the right thing adding `unset SOURCE_DATE_EPOCH` to the wrapper script. I don't really understand what that does, but `mkquashfs` was complaining about it being set, and this got it to shut up.
- I'm not sure if the version string cannot have hyphens in it or something, but "20180727" was difficult for me to parse, so I took the liberty of changing the version strings to "2020-12-31" and the like. Let me know if this isn't standard / allowed in nixpkgs and I'll change it back.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
