### PR TITLE
python3Packages.brother: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/development/python-modules/brother/default.nix
+++ b/pkgs/development/python-modules/brother/default.nix
@@ -1,25 +1,33 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
 , pysnmp
-, asynctest, pytestcov, pytestrunner, pytest-asyncio, pytest-trio, pytest-tornasync }:
+, pytest-asyncio
+, pytest-error-for-skips
+, pytest-runner
+, pytest-tornasync
+, pytest-trio
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "brother";
-  version = "0.2.1";
+  version = "0.2.2";
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-yOloGkOVhXcTt0PAjf3yWUItN1okO94DndRFsImiuz4=";
+    sha256 = "sha256-vIefcL3K3ZbAUxMFM7gbbTFdrnmufWZHcq4OA19SYXE=";
   };
 
-  # pytest-error-for-skips is not packaged
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace " --error-for-skips" ""
-    substituteInPlace setup.py \
-      --replace "\"pytest-error-for-skips\"" ""
+      --replace "--cov --cov-report term-missing " ""
+    substituteInPlace requirements-test.txt \
+      --replace "pytest-cov" ""
   '';
 
   propagatedBuildInputs = [
@@ -27,16 +35,18 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    asynctest
-    pytestcov
-    pytestrunner
     pytest-asyncio
-    pytest-trio
+    pytest-error-for-skips
+    pytest-runner
     pytest-tornasync
+    pytest-trio
+    pytestCheckHook
   ];
 
+  pythonImportsCheck = [ "brother" ];
+
   meta = with lib; {
-    description = "Python wrapper for getting data from Brother laser and inkjet printers via SNMP.";
+    description = "Python wrapper for getting data from Brother laser and inkjet printers via SNMP";
     homepage = "https://github.com/bieniu/brother";
     license = licenses.asl20;
     maintainers = with maintainers; [ hexa ];

--- a/pkgs/development/python-modules/pytest-error-for-skips/default.nix
+++ b/pkgs/development/python-modules/pytest-error-for-skips/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-error-for-skips";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "jankatins";
+    repo = pname;
+    rev = version;
+    sha256 = "04i4jd3bg4lgn2jfh0a0dzg3ml9b2bjv2ndia6b64w96r3r4p3qr";
+  };
+
+  buildInputs = [ pytest ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pytest_error_for_skips" ];
+
+  meta = with lib; {
+    description = "Pytest plugin to treat skipped tests a test failures";
+    homepage = "https://github.com/jankatins/pytest-error-for-skips";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6406,6 +6406,8 @@ in {
 
   pytest-env = callPackage ../development/python-modules/pytest-env { };
 
+  pytest-error-for-skips = callPackage ../development/python-modules/pytest-error-for-skips { };
+
   pytest-expect = callPackage ../development/python-modules/pytest-expect { };
 
   pytest-factoryboy = callPackage ../development/python-modules/pytest-factoryboy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.2.2

Change log: https://github.com/bieniu/brother/releases/tag/0.2.2

Add `pytest-error-for-skips`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
