### PR TITLE
kubectl-doctor: init at 0.3.0

### DIFF
--- a/pkgs/applications/networking/cluster/kubectl-doctor/default.nix
+++ b/pkgs/applications/networking/cluster/kubectl-doctor/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubectl-doctor";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "emirozer";
+    repo = pname;
+    rev = version;
+    sha256 = "0x784jbcwd34vzdnhg2yldh5ivkxvs2qlbsvaammbxkn04ch1ijz";
+  };
+
+  vendorSha256 = "04xq5kp1m7c98gb4fd0dni258vpfnhv535gl2qllfcp2mvk3mn55";
+
+  postInstall = ''
+    mv $out/bin/{cmd,kubectl-doctor}
+  '';
+
+  meta = with lib; {
+    description = "kubectl cluster triage plugin for k8s";
+    homepage = "https://github.com/emirozer/kubectl-doctor";
+    changelog = "https://github.com/emirozer/kubectl-doctor/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = [ maintainers.zimbatm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23508,6 +23508,8 @@ in
 
   kubectl = callPackage ../applications/networking/cluster/kubectl { };
 
+  kubectl-doctor = callPackage ../applications/networking/cluster/kubectl-doctor { };
+
   kubectl-example = callPackage ../applications/networking/cluster/kubectl-example { };
 
   kubeless = callPackage ../applications/networking/cluster/kubeless { };


### PR DESCRIPTION
###### Motivation for this change

New tool!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).