### PR TITLE
bats: 1.2.1 -> 1.3.0

### DIFF
--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bats";
-  version = "1.2.1";
+  version = "1.3.0";
 
   src = fetchzip {
     url = "https://github.com/bats-core/bats-core/archive/v${version}.tar.gz";
-    hash = "sha256-grB/rJaDU0fuw4Hm3/9nI2px8KZnSWqRjTJPd7Mmb7s=";
+    hash = "sha256-+dboExOx2YELxV8Cwk9SVwk9G3p8EoP0LdaJ3o7GT6c=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
 
   inherit doCheck;
   checkPhase = ''
+    # TODO: cut if https://github.com/bats-core/bats-core/issues/418 allows
+    sed -i '/test works even if PATH is reset/a skip' test/bats.bats
+
     # test generates file with absolute shebang dynamically
     substituteInPlace test/install.bats --replace \
       "/usr/bin/env bash" "${bash}/bin/bash"


### PR DESCRIPTION
###### Motivation for this change
Update bats to the latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @abathur