### PR TITLE
plexamp: 3.4.3 -> 3.4.4

### DIFF
--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -32,7 +32,7 @@ in appimageTools.wrapType2 {
   meta = with lib; {
     description = "A beautiful Plex music player for audiophiles, curators, and hipsters";
     homepage = "https://plexamp.com/";
-    changelog = "https://forums.plex.tv/t/plexamp-release-notes/221280/25";
+    changelog = "https://forums.plex.tv/t/plexamp-release-notes/221280/26";
     license = licenses.unfree;
     maintainers = with maintainers; [ killercup synthetica ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -2,13 +2,13 @@
 
 let
   pname = "plexamp";
-  version = "3.4.3";
+  version = "3.4.4";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}.AppImage";
     name="${pname}-${version}.AppImage";
-    sha256 = "1rzhrc5yr5f6bxydgmcjwrg85vkbkn6lqj72512lyhq5gg7zmm1w";
+    sha256 = "1iz6qi12ljafb49l73rba5rwi5sdbd8ck5h2r6jiy260lgr2iiyk";
   };
 
   appimageContents = appimageTools.extractType2 {


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog: 

Added

    iOS: Siri shortcuts for the other radios (time travel, album, discovery).
    Desktop: Escape key navigates back.
    “Colorize Seekbar” setting.
    Car View mode works in landscape.

Fixed

    Android: Crash when blurred action bar was enabled.
    Don’t do “fast skipping” when tapping tracks in artist carousel.
    Casting to Chromecast in some cases was broken.
    Memory leak in player.
    Stutter moving to library grid screens.
    Player crash and memory leak.
    Crash loading invalid URLs.
    Buttons in Car View were ironically harder to tap.
    Don’t show “undefined” as a source in the downloads list.
    Make settings w/o explanation text easier to click/tap on.
    Casting to Chromecast was broken on networks with DNS rebind protection.
    Cast: Improved checking when playback fails.
    Cast: Transferring cloud play queue to Sonos or Plex player failed.
    Cast: Playing TIDAL items to Sonos devices didn’t work.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
