### PR TITLE
pkgs.self -> pkgs.self-lang

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11702,7 +11702,7 @@ in
 
   scheme48 = callPackage ../development/interpreters/scheme48 { };
 
-  self = pkgsi686Linux.callPackage ../development/interpreters/self { };
+  self-lang = pkgsi686Linux.callPackage ../development/interpreters/self { };
 
   spark = callPackage ../applications/networking/cluster/spark { };
 


### PR DESCRIPTION
`self` is so common local variable name in Nix, so I bet somewhere it refers to `pkgs.self` instead.
Let's see for the breakages ofborg will find. 