### PR TITLE
ocamlPackages.cohttp*: 2.5.4 -> 2.5.5

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -1,11 +1,12 @@
 { lib, fetchurl, buildDunePackage
 , ppx_fields_conv, ppx_sexp_conv, stdlib-shims
 , base64, fieldslib, jsonm, re, stringext, uri-sexp
+, ocaml, fmt, alcotest
 }:
 
 buildDunePackage rec {
   pname = "cohttp";
-  version = "2.5.4";
+  version = "2.5.5";
 
   useDune2 = true;
 
@@ -13,12 +14,15 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${version}/cohttp-v${version}.tbz";
-    sha256 = "1q04spmki5zis5p5m1vs77i3k7ijm134j62g61071vblwx25z17a";
+    sha256 = "0ywmql4lp6ps2gd064ixbjzsdnnn5vk3pipm005sswl553qqwaim";
   };
 
   buildInputs = [ jsonm ppx_fields_conv ppx_sexp_conv ];
 
   propagatedBuildInputs = [ base64 fieldslib re stringext uri-sexp stdlib-shims ];
+
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  checkInputs = [ fmt alcotest ];
 
   meta = {
     description = "HTTP(S) library for Lwt, Async and Mirage";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirage/ocaml-cohttp/releases/tag/v2.5.5>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
