### PR TITLE
qtwebengine: use pure sandbox lib

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -90,11 +90,7 @@ qtModule {
     '' else ''
     substituteInPlace src/3rdparty/chromium/base/mac/mach_port_broker.mm \
       --replace "audit_token_to_pid(msg.trailer.msgh_audit)" "msg.trailer.msgh_audit.val[5]"
-    '')
-    + ''
-    substituteInPlace src/3rdparty/chromium/sandbox/mac/BUILD.gn \
-      --replace 'libs = [ "sandbox" ]' 'libs = [ "/usr/lib/libsandbox.1.dylib" ]'
-    '');
+    ''));
 
   NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [
     # with gcc8, -Wclass-memaccess became part of -Wall and this exceeds the logging limit
@@ -190,6 +186,7 @@ qtModule {
 
   buildInputs = optionals stdenv.isDarwin (with darwin; [
     cups
+    apple_sdk.libs.sandbox
 
     # `sw_vers` is used by `src/3rdparty/chromium/build/config/mac/sdk_info.py`
     # to get some information about the host platform.
@@ -205,14 +202,7 @@ qtModule {
         shift
       done
     '')
-
-    # For sandbox.h include
-    (runCommand "MacOS_SDK_sandbox.h" {} ''
-      install -Dm444 "${lib.getDev darwin.apple_sdk.sdk}"/include/sandbox.h "$out"/include/sandbox.h
-    '')
   ]);
-
-  __impureHostDeps = optional stdenv.isDarwin "/usr/lib/libsandbox.1.dylib";
 
   dontUseNinjaBuild = true;
   dontUseNinjaInstall = true;

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -241,6 +241,18 @@ in rec {
         popd >/dev/null
       '';
     };
+
+    sandbox = stdenv.mkDerivation {
+      name = "apple-lib-sandbox";
+      dontUnpack = true;
+
+      installPhase = ''
+        mkdir -p $out/include $out/lib
+        ln -s "${lib.getDev sdk}/include/sandbox.h" $out/include/sandbox.h
+        cp "${darwin-stubs}/usr/lib/libsandbox.1.tbd" $out/lib
+        ln -s libsandbox.1.tbd $out/lib/libsandbox.tbd
+      '';
+    };
   };
 
   overrides = super: {


### PR DESCRIPTION
###### Motivation for this change

Improve purity and fix the build on Big Sur, see https://github.com/NixOS/nixpkgs/issues/116358 and https://github.com/NixOS/nixpkgs/pull/98541#issuecomment-730144202

I don't know if this package should be called `sandbox` or `libsandbox`, but the other libraries didn't have the `lib` prefix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
