### PR TITLE
ocamlPackages.ocaml_extlib: add support for OCaml 4.12

### DIFF
--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, cppo, minimal ? true }:
+{ stdenv, lib, fetchurl, fetchpatch, ocaml, findlib, cppo, minimal ? true }:
 
 assert lib.versionAtLeast (lib.getVersion ocaml) "3.11";
 
@@ -9,6 +9,13 @@ stdenv.mkDerivation {
     url = "http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.7.tar.gz";
     sha256 = "1sxmzc1mx3kg62j8kbk0dxkx8mkf1rn70h542cjzrziflznap0s1";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/ygrek/ocaml-extlib/pull/55.patch";
+      sha256 = "0mj3xii56rh8j8brdyv5d06rbs6jjjcy4ib9chafkq3f3sbq795p";
+    })
+  ];
 
   buildInputs = [ ocaml findlib cppo ];
 


### PR DESCRIPTION
Pull in patches from https://github.com/ygrek/ocaml-extlib/pull/55
which add support for OCaml 4.12. These patches are also included in
extlib 1.7.8, however extlib 1.7.8 includes some API changes which break
for example google-drive-ocamlfuse.

Therefore we follow the opam repository and patch our default extlib
version: https://github.com/ocaml/opam-repository/pull/18041

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
