### PR TITLE
sogo: python2 -> python3

### DIFF
--- a/pkgs/servers/web-apps/sogo/default.nix
+++ b/pkgs/servers/web-apps/sogo/default.nix
@@ -1,4 +1,4 @@
-{ gnustep, lib, fetchFromGitHub, fetchpatch, makeWrapper, python2, lndir
+{ gnustep, lib, fetchFromGitHub, fetchpatch, makeWrapper, python3, lndir
 , openssl_1_1, openldap, sope, libmemcached, curl, libsodium, libzip, pkg-config }:
 with lib; gnustep.stdenv.mkDerivation rec {
   pname = "SOGo";
@@ -11,7 +11,7 @@ with lib; gnustep.stdenv.mkDerivation rec {
     sha256 = "145hdlwnqds5zmpxbh4yainsbv5vy99ji93d6pl7xkbqwncfi80i";
   };
 
-  nativeBuildInputs = [ gnustep.make makeWrapper python2 ];
+  nativeBuildInputs = [ gnustep.make makeWrapper python3 ];
   buildInputs = [ gnustep.base sope openssl_1_1 libmemcached (curl.override { openssl = openssl_1_1; }) libsodium libzip pkg-config ]
     ++ optional (openldap != null) openldap;
 


### PR DESCRIPTION
###### Motivation for this change
Python 2 is deprecated. Debian does the same https://sources.debian.org/patches/sogo/5.0.1-4/python3.patch/

None of the python code in `Tests/` seems compatible with python3, but apparently we don't run the test suite.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).