### PR TITLE
libayatana-appindicator: drop unneeded python dependency

### DIFF
--- a/pkgs/development/libraries/libayatana-appindicator/default.nix
+++ b/pkgs/development/libraries/libayatana-appindicator/default.nix
@@ -4,7 +4,7 @@
 , gtkVersion ? "3"
 , gtk2, libayatana-indicator-gtk2, libdbusmenu-gtk2
 , gtk3, libayatana-indicator-gtk3, libdbusmenu-gtk3
-, dbus-glib, python2, python2Packages
+, dbus-glib,
 }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = "1sba0w455rdkadkhxrx4fr63m0d9blsbb1q1hcshxw1k1z2nh1gk";
   };
 
-  nativeBuildInputs = [ pkg-config autoreconfHook gtk-doc gobject-introspection python2 python2Packages.pygtk dbus-glib ];
+  nativeBuildInputs = [ pkg-config autoreconfHook gtk-doc gobject-introspection dbus-glib ];
 
   buildInputs =
     lib.lists.optional (gtkVersion == "2") libayatana-indicator-gtk2


### PR DESCRIPTION
###### Motivation for this change
All of that was dropped in 0.5.5 https://github.com/AyatanaIndicators/libayatana-appindicator/blob/0.5.5/ChangeLog

If anything actually relied on the pygtk bindings, it's been broken since f0cd4058273c8b29d384a9f2fc63f7257e3aeca0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
