### PR TITLE
rdkafka: python2 -> python3

### DIFF
--- a/pkgs/development/libraries/rdkafka/default.nix
+++ b/pkgs/development/libraries/rdkafka/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, zlib, perl, pkg-config, python, openssl }:
+{ lib, stdenv, fetchFromGitHub, zlib, pkg-config, python3, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "rdkafka";
@@ -11,9 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-EoNzxwuLiYi6sMhyqD/x+ku6BKA+i5og4XsUy2JBN0U=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config python3 ];
 
-  buildInputs = [ zlib perl python openssl ];
+  buildInputs = [ zlib openssl ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=strict-overflow";
 


### PR DESCRIPTION
###### Motivation for this change
https://www.python.org/doc/sunset-python-2/

Also drop unused perl dependency. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
