### PR TITLE
heimdal: python2 -> python3

### DIFF
--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, python2, perl, yacc, flex
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, python3, perl, yacc, flex
 , texinfo, perlPackages
 , openldap, libcap_ng, sqlite, openssl, db, libedit, pam
 , CoreFoundation, Security, SystemConfiguration
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./heimdal-make-missing-headers.patch ];
 
-  nativeBuildInputs = [ autoreconfHook pkg-config python2 perl yacc flex texinfo ]
+  nativeBuildInputs = [ autoreconfHook pkg-config python3 perl yacc flex texinfo ]
     ++ (with perlPackages; [ JSON ]);
   buildInputs = optionals (stdenv.isLinux) [ libcap_ng ]
     ++ [ db sqlite openssl libedit openldap pam]


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
