### PR TITLE
sway: 1.5 -> 1.6; wlroots: 1.12 -> 1.13

### DIFF
--- a/pkgs/applications/window-managers/dwl/default.nix
+++ b/pkgs/applications/window-managers/dwl/default.nix
@@ -12,7 +12,26 @@
 , patches ? [ ]
 , conf ? null
 , writeText
+, fetchpatch
 }:
+
+let
+  # Add two patches to fix compile errors with wlroots 0.13:
+  totalPatches = patches ++ [
+    # Fix the renamed constant WLR_KEY_PRESSED => WL_KEYBOARD_KEY_STATE_PRESSED
+    # https://github.com/djpohly/dwl/pull/66
+    (fetchpatch {
+      url = "https://github.com/djpohly/dwl/commit/a42613db9d9f6debfa4fb2363d75af9457d238ed.patch";
+      sha256 = "0h76hx1fhazi07gqg7sljh13f91v6bvjy7m9qqmimhvqgfwdcc0j";
+    })
+    # Use the new signature for wlr_backend_autocreate, which removes an argument:
+    # https://github.com/djpohly/dwl/pull/76
+    (fetchpatch {
+      url = "https://github.com/djpohly/dwl/commit/0ff13cf216056a36a261f4eed53c6a864989a9fb.patch";
+      sha256 = "18clpdb4il1vxf1b0cx0qrwild68s9dism8ab66zpmvxs5qag2dm";
+    })
+  ];
+in
 
 stdenv.mkDerivation rec {
   pname = "dwl";
@@ -39,7 +58,7 @@ stdenv.mkDerivation rec {
   ];
 
   # Allow users to set their own list of patches
-  inherit patches;
+  patches = totalPatches;
 
   # Last line of config.mk enables XWayland
   prePatch = lib.optionalString enable-xwayland ''

--- a/pkgs/applications/window-managers/labwc/default.nix
+++ b/pkgs/applications/window-managers/labwc/default.nix
@@ -8,7 +8,6 @@
 , glib
 , libinput
 , libxml2
-, pandoc
 , pango
 , wayland
 , wayland-protocols
@@ -16,20 +15,22 @@
 , libxcb
 , libxkbcommon
 , xwayland
+, libdrm
+, scdoc
 }:
 
 stdenv.mkDerivation rec {
   pname = "labwc";
-  version = "unstable-2021-02-06";
+  version = "unstable-2021-03-15";
 
   src = fetchFromGitHub {
     owner = "johanmalm";
     repo = pname;
-    rev = "4a8fcf5c6d0b730b1e2e17e544ce7d7d3c72cd13";
-    sha256 = "g1ba8dchUN393eis0VAu1bIjQfthDGLaSijSavz4lfU=";
+    rev = "fddeb74527e5b860d9c1a91a237d390041c758b6";
+    sha256 = "0rhniv5j4bypqxxj0nbpa3hclmn8znal9rldv0mrgbizn3wsbs54";
   };
 
-  nativeBuildInputs = [ pkg-config meson ninja pandoc ];
+  nativeBuildInputs = [ pkg-config meson ninja scdoc ];
   buildInputs = [
     cairo
     glib
@@ -42,6 +43,7 @@ stdenv.mkDerivation rec {
     libxcb
     libxkbcommon
     xwayland
+    libdrm
   ];
 
   mesonFlags = [ "-Dxwayland=enabled" ];

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -2,18 +2,18 @@
 , meson, ninja, pkg-config, wayland, scdoc
 , libxkbcommon, pcre, json_c, dbus, libevdev
 , pango, cairo, libinput, libcap, pam, gdk-pixbuf, librsvg
-, wlroots, wayland-protocols
+, wlroots, wayland-protocols, libdrm
 }:
 
 stdenv.mkDerivation rec {
   pname = "sway-unwrapped";
-  version = "1.5.1";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "sway";
     rev = version;
-    sha256 = "1xsa3h8zhf29p0mi90baxpr76jkd9pd1gr97ky8cnjbcs4isj9j0";
+    sha256 = "0vnplva11yafhbijrk68wy7pw0psn9jm0caaymswq1s951xsn1c8";
   };
 
   patches = [
@@ -33,11 +33,12 @@ stdenv.mkDerivation rec {
   buildInputs = [
     wayland libxkbcommon pcre json_c dbus libevdev
     pango cairo libinput libcap pam gdk-pixbuf librsvg
-    wlroots wayland-protocols
+    wlroots wayland-protocols libdrm
   ];
 
   mesonFlags = [
     "-Ddefault-wallpaper=false"
+    "-Dsd-bus-provider=libsystemd"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/window-managers/sway/load-configuration-from-etc.patch
+++ b/pkgs/applications/window-managers/sway/load-configuration-from-etc.patch
@@ -1,22 +1,26 @@
-From 26f9c65ef037892977a824f0d7d7111066856b53 Mon Sep 17 00:00:00 2001
-From: Michael Weiss <dev.primeos@gmail.com>
-Date: Sat, 27 Apr 2019 14:26:16 +0200
+From 92283df3acbffa5c1bb21f23cdd686113d905114 Mon Sep 17 00:00:00 2001
+From: Patrick Hilhorst <git@hilhorst.be>
+Date: Wed, 31 Mar 2021 21:14:13 +0200
 Subject: [PATCH] Load configs from /etc but fallback to /nix/store
 
 This change will load all configuration files from /etc, to make it easy
 to override them, but fallback to /nix/store/.../etc/sway/config to make
 Sway work out-of-the-box with the default configuration on non NixOS
 systems.
+
+Original patch by Michael Weiss, updated for Sway 1.6 by Patrick Hilhorst
+
+Co-authored-by: Michael Weiss <dev.primeos@gmail.com>
 ---
  meson.build   | 3 ++-
- sway/config.c | 1 +
- 2 files changed, 3 insertions(+), 1 deletion(-)
+ sway/config.c | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 02b5d606..c03a9c0f 100644
+index b7a29660..8ae8ceb3 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -129,7 +129,8 @@ if scdoc.found()
+@@ -164,7 +164,8 @@ if scdoc.found()
  	endforeach
  endif
  
@@ -25,18 +29,20 @@ index 02b5d606..c03a9c0f 100644
 +add_project_arguments('-DNIX_SYSCONFDIR="/@0@"'.format(join_paths(prefix, sysconfdir)), language : 'c')
  
  version = '"@0@"'.format(meson.project_version())
- if git.found()
+ git = find_program('git', native: true, required: false)
 diff --git a/sway/config.c b/sway/config.c
-index 4cd21bbc..dd855753 100644
+index 76b9ec08..fb5b51aa 100644
 --- a/sway/config.c
 +++ b/sway/config.c
-@@ -317,6 +317,7 @@ static char *get_config_path(void) {
- 		"$XDG_CONFIG_HOME/i3/config",
- 		SYSCONFDIR "/sway/config",
- 		SYSCONFDIR "/i3/config",
-+		NIX_SYSCONFDIR "/sway/config",
+@@ -374,7 +374,8 @@ static char *get_config_path(void) {
+ 		{ .prefix = home, .config_folder = ".i3"},
+ 		{ .prefix = config_home, .config_folder = "i3"},
+ 		{ .prefix = SYSCONFDIR, .config_folder = "sway"},
+-		{ .prefix = SYSCONFDIR, .config_folder = "i3"}
++		{ .prefix = SYSCONFDIR, .config_folder = "i3"},
++		{ .prefix = NIX_SYSCONFDIR, .config_folder = "sway"},
  	};
  
- 	char *config_home = getenv("XDG_CONFIG_HOME");
+ 	size_t num_config_paths = sizeof(config_paths)/sizeof(config_paths[0]);
 -- 
-2.19.2
+2.30.1

--- a/pkgs/applications/window-managers/wayfire/applications.nix
+++ b/pkgs/applications/window-managers/wayfire/applications.nix
@@ -1,23 +1,20 @@
-{ newScope, wayfirePlugins }:
+{ lib, newScope, wayfirePlugins }:
 
-let
-  self = with self; {
-    inherit wayfirePlugins;
+lib.makeExtensible (self: with self; {
+  inherit wayfirePlugins;
 
-    callPackage = newScope self;
+  callPackage = newScope self;
 
-    wayfire = callPackage ./. { };
+  wayfire = callPackage ./. { };
 
-    wcm = callPackage ./wcm.nix {
-      inherit (wayfirePlugins) wf-shell;
-    };
-
-    wrapWayfireApplication = callPackage ./wrapper.nix { };
-
-    withPlugins = selector: self // {
-      wayfire = wrapWayfireApplication wayfire selector;
-      wcm = wrapWayfireApplication wcm selector;
-    };
+  wcm = callPackage ./wcm.nix {
+    inherit (wayfirePlugins) wf-shell;
   };
-in
-self
+
+  wrapWayfireApplication = callPackage ./wrapper.nix { };
+
+  withPlugins = selector: self // {
+    wayfire = wrapWayfireApplication wayfire selector;
+    wcm = wrapWayfireApplication wcm selector;
+  };
+})

--- a/pkgs/development/libraries/wlroots/0.12.nix
+++ b/pkgs/development/libraries/wlroots/0.12.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/swaywm/wlroots/releases/tag/${version}";
     license     = licenses.mit;
     platforms   = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ primeos synthetica ];
   };
 }

--- a/pkgs/development/libraries/wlroots/0.12.nix
+++ b/pkgs/development/libraries/wlroots/0.12.nix
@@ -1,0 +1,57 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland
+, libGL, wayland-protocols, libinput, libxkbcommon, pixman
+, xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
+, libpng, ffmpeg
+}:
+
+# Fixed version derivation.
+# nixpkgs-update: no auto update
+stdenv.mkDerivation rec {
+  pname = "wlroots";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "swaywm";
+    repo = "wlroots";
+    rev = version;
+    sha256 = "01j38lmgs2c6fq68v8b75pkilia2wsgzgp46ivfbi9hhx47kgcfn";
+  };
+
+  # $out for the library and $examples for the example programs (in examples):
+  outputs = [ "out" "examples" ];
+
+  nativeBuildInputs = [ meson ninja pkg-config wayland ];
+
+  buildInputs = [
+    libGL wayland wayland-protocols libinput libxkbcommon pixman
+    xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
+    libpng ffmpeg
+  ];
+
+  mesonFlags = [ "-Dlogind-provider=systemd" "-Dlibseat=disabled" ];
+
+  postFixup = ''
+    # Install ALL example programs to $examples:
+    # screencopy dmabuf-capture input-inhibitor layer-shell idle-inhibit idle
+    # screenshot output-layout multi-pointer rotation tablet touch pointer
+    # simple
+    mkdir -p $examples/bin
+    cd ./examples
+    for binary in $(find . -executable -type f -printf '%P\n' | grep -vE '\.so'); do
+      cp "$binary" "$examples/bin/wlroots-$binary"
+    done
+  '';
+
+  meta = with lib; {
+    description = "A modular Wayland compositor library";
+    longDescription = ''
+      Pluggable, composable, unopinionated modules for building a Wayland
+      compositor; or about 50,000 lines of code you were going to write anyway.
+    '';
+    inherit (src.meta) homepage;
+    changelog = "https://github.com/swaywm/wlroots/releases/tag/${version}";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -1,18 +1,18 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland
 , libGL, wayland-protocols, libinput, libxkbcommon, pixman
 , xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
-, libpng, ffmpeg
+, libpng, ffmpeg, libuuid, xcbutilrenderutil, xwayland
 }:
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "01j38lmgs2c6fq68v8b75pkilia2wsgzgp46ivfbi9hhx47kgcfn";
+    sha256 = "01plhbnsp5yg18arz0v8fr0pr9l4w4pdzwkg9px486qdvb3s1vgy";
   };
 
   # $out for the library and $examples for the example programs (in examples):
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libGL wayland wayland-protocols libinput libxkbcommon pixman
     xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
-    libpng ffmpeg
+    libpng ffmpeg libuuid xcbutilrenderutil xwayland
   ];
 
   mesonFlags = [ "-Dlogind-provider=systemd" "-Dlibseat=disabled" ];

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/swaywm/wlroots/releases/tag/${version}";
     license     = licenses.mit;
     platforms   = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ primeos synthetica ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23479,7 +23479,9 @@ in
 
   super-productivity = callPackage ../applications/networking/super-productivity { };
 
-  wlroots = callPackage ../development/libraries/wlroots { };
+  wlroots = callPackage ../development/libraries/wlroots {
+    inherit (xorg) xcbutilrenderutil;
+  };
 
   wlroots_0_12 = callPackage ../development/libraries/wlroots/0.12.nix {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22038,7 +22038,9 @@ in
 
   caerbannog = callPackage ../applications/misc/caerbannog { };
 
-  cage = callPackage ../applications/window-managers/cage { };
+  cage = callPackage ../applications/window-managers/cage {
+    wlroots = wlroots_0_12;
+  };
 
   calf = callPackage ../applications/audio/calf {
       inherit (gnome2) libglade;
@@ -23479,6 +23481,8 @@ in
 
   wlroots = callPackage ../development/libraries/wlroots { };
 
+  wlroots_0_12 = callPackage ../development/libraries/wlroots/0.12.nix {};
+
   sway-unwrapped = callPackage ../applications/window-managers/sway { };
   sway = callPackage ../applications/window-managers/sway/wrapper.nix { };
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
@@ -23499,7 +23503,9 @@ in
 
   wbg = callPackage ../applications/misc/wbg { };
 
-  hikari = callPackage ../applications/window-managers/hikari { };
+  hikari = callPackage ../applications/window-managers/hikari {
+    wlroots = wlroots_0_12;
+  };
 
   i3 = callPackage ../applications/window-managers/i3 {
     xcb-util-cursor = if stdenv.isDarwin then xcb-util-cursor-HEAD else xcb-util-cursor;
@@ -23561,7 +23567,9 @@ in
 
   i3-wk-switch = callPackage ../applications/window-managers/i3/wk-switch.nix { };
 
-  waybox = callPackage ../applications/window-managers/waybox { };
+  waybox = callPackage ../applications/window-managers/waybox {
+    wlroots = wlroots_0_12;
+  };
 
   windowchef = callPackage ../applications/window-managers/windowchef/default.nix { };
 
@@ -26432,10 +26440,15 @@ in
 
   wayfireApplications = wayfireApplications-unwrapped.withPlugins (plugins: [ plugins.wf-shell ]);
   inherit (wayfireApplications) wayfire wcm;
-  wayfireApplications-unwrapped = recurseIntoAttrs (callPackage ../applications/window-managers/wayfire/applications.nix { });
-  wayfirePlugins = recurseIntoAttrs (callPackage ../applications/window-managers/wayfire/plugins.nix {
-    inherit (wayfireApplications-unwrapped) wayfire;
-  });
+  wayfireApplications-unwrapped = recurseIntoAttrs (
+    (callPackage ../applications/window-managers/wayfire/applications.nix { }).
+    extend (_: _: { wlroots = wlroots_0_12; })
+  );
+  wayfirePlugins = recurseIntoAttrs (
+    callPackage ../applications/window-managers/wayfire/plugins.nix {
+      inherit (wayfireApplications-unwrapped) wayfire;
+    }
+  );
   wf-config = callPackage ../applications/window-managers/wayfire/wf-config.nix { };
 
   waypipe = callPackage ../applications/networking/remote/waypipe { };
@@ -26477,7 +26490,9 @@ in
 
   weston = callPackage ../applications/window-managers/weston { pipewire = pipewire_0_2; };
 
-  wio = callPackage ../applications/window-managers/wio { };
+  wio = callPackage ../applications/window-managers/wio {
+    wlroots = wlroots_0_12;
+  };
 
   whitebox-tools = callPackage ../applications/gis/whitebox-tools {
     inherit (darwin.apple_sdk.frameworks) Security;
@@ -30806,7 +30821,9 @@ in
 
   bottom = callPackage ../tools/system/bottom {};
 
-  cagebreak = callPackage ../applications/window-managers/cagebreak/default.nix {};
+  cagebreak = callPackage ../applications/window-managers/cagebreak/default.nix {
+    wlroots = wlroots_0_12;
+  };
 
   psftools = callPackage ../os-specific/linux/psftools {};
 


### PR DESCRIPTION
###### Motivation for this change

Tracking PR for Sway 1.6, first RC just landed: https://github.com/swaywm/sway/releases/tag/1.6-rc1

EDIT 2021-03-24: Next RC landed https://github.com/swaywm/sway/releases/tag/1.6-rc2

EDIT: 2021-04-07: Final version of wlroots 0.13 landed. https://github.com/swaywm/wlroots/releases/tag/0.13.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
