### PR TITLE
libseat: init at 0.5.0

### DIFF
--- a/pkgs/development/libraries/libseat/default.nix
+++ b/pkgs/development/libraries/libseat/default.nix
@@ -1,0 +1,37 @@
+{ fetchFromSourcehut
+, lib
+, meson
+, ninja
+, pkg-config
+, stdenv
+, systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libseat";
+  version = "0.5.0";
+
+  src = fetchFromSourcehut {
+    owner = "~kennylevinsen";
+    repo = "seatd";
+    rev = version;
+    sha256 = "sha256-JwlJLHkRgSRqfQEhXbzuFTmhxfbwKVdLICPbTDbC9M0=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+
+  buildInputs = [
+    systemd
+  ];
+
+  mesonFlags = [ "-Dserver=disabled" "-Dseatd=disabled" "-Dlogind=enabled"];
+
+  meta = with lib; {
+    description = "A universal seat management library";
+    changelog   = "https://git.sr.ht/~kennylevinsen/seatd/refs/${version}";
+    homepage    = "https://sr.ht/~kennylevinsen/seatd/";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ emantor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15680,6 +15680,8 @@ in
 
   libsearpc = callPackage ../development/libraries/libsearpc { };
 
+  libseat = callPackage ../development/libraries/libseat { };
+
   libsigcxx = callPackage ../development/libraries/libsigcxx { };
 
   libsigcxx12 = callPackage ../development/libraries/libsigcxx/1.2.nix { };


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Wlroots will require libseat in the future, add the library to nixpkgs
in preparation.

Ref: https://github.com/swaywm/wlroots/issues/2755 & https://github.com/swaywm/wlroots/pull/2786

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
