### PR TITLE
kwin: Unwrap executable name for desktop file search

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/0001-NixOS-Unwrap-executable-name-for-.desktop-search.patch
+++ b/pkgs/desktops/plasma-5/kwin/0001-NixOS-Unwrap-executable-name-for-.desktop-search.patch
@@ -1,0 +1,57 @@
+From 29ec6fada935ef966e5859082435ed57daa9522d Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Tue, 16 Mar 2021 15:03:59 -0400
+Subject: [PATCH] [NixOS] Unwrap executable name for .desktop search
+
+Why is this necessary even though -a "$0" is used in the wrapper?
+Because it's completely bypassing argv0! This looks at the executable
+file in-use according to the kernel!
+
+Wrappers cannot affect the `/proc/.../exe` symlink!
+---
+ service_utils.h | 28 +++++++++++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
+
+diff --git a/service_utils.h b/service_utils.h
+index 8a70c1fad..6674f553b 100644
+--- a/service_utils.h
++++ b/service_utils.h
+@@ -26,8 +26,34 @@ namespace KWin
+ const static QString s_waylandInterfaceName = QStringLiteral("X-KDE-Wayland-Interfaces");
+ const static QString s_dbusRestrictedInterfaceName = QStringLiteral("X-KDE-DBUS-Restricted-Interfaces");
+ 
+-static QStringList fetchProcessServiceField(const QString &executablePath, const QString &fieldName)
++static QStringList fetchProcessServiceField(const QString &in_executablePath, const QString &fieldName)
+ {
++    // !! Start NixOS fix
++    // NixOS fixes many packaging issues through "wrapper" scripts that manipulates the environment or does
++    // miscellaneous trickeries and mischievous things to make the programs work.
++    // In turn, programs often employs different mischievous schemes and trickeries to do *other things.
++    // It often happens that they conflict.
++    // Here, `kwin` tries to detect the .desktop file for a given process.
++    // `kwin` followed the process `/proc/.../exe` up to the actual binary running.
++    // It normally would be fine, e.g. /usr/bin/foobar is what's in the desktop file.
++    // But it's not the truth here! It's extremely likely the resolved path is /nix/store/.../bin/.foobar-wrapped
++    // rather than what the desktop file points to, something like /nix/store/.../bin/foobar !!
++    // Since the wrappers for Nixpkgs *always* prepend a dot and append -wrapped, we assume here that we can keep
++    // `/^(.*)\/\.([^/]*)-wrapped/` until the (equivalent) regex does not match.
++    // This should canonicalize the wrapper name to the expected name to look for in the desktop file.
++
++    // Use a copy of the const string
++    QString executablePath(in_executablePath);
++
++    // While the parts needed are present, "unwrap" one layer of wrapper names.
++    while (executablePath.endsWith("-wrapped") && executablePath[executablePath.lastIndexOf("/")+1] == QChar('.')) {
++        // Approximately equivalent to s/-wrapped$//
++        executablePath.remove(executablePath.length() - 8, 8);
++        // Approximately equivalent to s;/\.;/;
++        executablePath.remove(executablePath.lastIndexOf("/")+1, 1);
++    }
++    // !! End NixOS fix
++
+     // needed to be able to use the logging category in a header static function
+     static QLoggingCategory KWIN_UTILS ("KWIN_UTILS", QtWarningMsg);
+     const auto servicesFound = KApplicationTrader::query([&executablePath] (const KService::Ptr &service) {
+-- 
+2.28.0
+

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -38,6 +38,7 @@ mkDerivation {
     ./0001-follow-symlinks.patch
     ./0002-xwayland.patch
     ./0003-plugins-qpa-allow-using-nixos-wrapper.patch
+    ./0001-NixOS-Unwrap-executable-name-for-.desktop-search.patch
   ];
   CXXFLAGS = [
     ''-DNIXPKGS_XWAYLAND=\"${lib.getBin xwayland}/bin/Xwayland\"''


### PR DESCRIPTION
KWin for wayland uses the `.desktop` file to determine whether a process
is allowed to access some wayland services.

This would be fine if there was a stable interface to map a process to a
`.desktop` file.

Since there is no such interface, they are scanning `.desktop` files for
one where the executable path matches the resolved file "exe" from
`/proc/$PID/exe`.

This would be fine, if we didn't wrap many (most?) KDE/Plasma binaries.

Since we are wrapping binaries, the `exe` symlink points to a wrapped
binary. No `.desktop` file will match for the wrapped binary.

The solution here is to peel away at the `.${name}-wrapped` layers until
we have the intended name for the executable.

It is expected that no `.desktop` file will ever point to a wrapped
binary.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixing plasma mobile (PR will be coming later), and fixing plasma wayland session in general.

Should fix some of the issues in this linked comment:

 - https://github.com/NixOS/nixpkgs/pull/100057#issuecomment-800425470

As for plasma mobile shell, it fixes all of its "tasks" management. Without this, it cannot get the appropriate services from the compositor, meaning it cannot spy at the tasks running, so it cannot switch between tasks, or ask to go back to the desktop, among other things.

The patch was written in a way where it would be the least instrusive possible.

It is **highly likely** other KDE or Plasma components or apps use similar trickeries to get information from the desktop files. Coordination with upstream to produce a common interface those apps should use instead of readin `exe` themselves is likely the better solution.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Ran this with a VM with a fresh plasma mobile shell setup. Worked quite well.

cc @oxalica if you want to test for the issues you were having
cc @worldofpeace @ttuegel as plasma5 peeps