### PR TITLE
nuclei: 2.2.0 -> 2.3.1

### DIFF
--- a/pkgs/tools/security/nuclei/default.nix
+++ b/pkgs/tools/security/nuclei/default.nix
@@ -1,24 +1,27 @@
-{ buildGoModule
+{ lib
+, buildGoModule
 , fetchFromGitHub
-, lib
 }:
 
 buildGoModule rec {
   pname = "nuclei";
-  version = "2.2.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
-    repo = "nuclei";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0xrvza86aczlnb11x58fiqch5g0q6gvpxwsi5dq3akfi95gk3a3x";
+    sha256 = "sha256-NM/Ggd5MKctQKE0MNawyE+Xciuj9++6DXXkMrrpfkhA=";
   };
 
-  vendorSha256 = "1v3ax8l1lgp2vs50gsa2fhdd6bvyfdlkd118akrqmwxahyyyqycv";
+  vendorSha256 = "sha256-h+MuMfIKXgXzLU6hNMxfPXawic9UZrwzVlzjjRF7X3o=";
 
   preBuild = ''
     mv v2/* .
   '';
+
+  # Test files are not part of the release tarball
+  doCheck = false;
 
   meta = with lib; {
     description = "Tool for configurable targeted scanning";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.3.1

Change log: https://github.com/projectdiscovery/nuclei/releases/tag/v2.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
