### PR TITLE
libplctag: init at v2.3.5

### DIFF
--- a/pkgs/development/libraries/libplctag/default.nix
+++ b/pkgs/development/libraries/libplctag/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, stdenv
+, cmake
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libplctag";
+  version = "2.3.5";
+
+  nativeBuildInputs = [ cmake ];
+
+  src = fetchurl {
+    url = "https://github.com/libplctag/libplctag/archive/v${version}.tar.gz";
+    sha256 = "16azdxyl82js17xcav7v23zvi64w72181wylj489zim9x5h5sxsr";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/libplctag/libplctag";
+    description = "Library that uses EtherNet/IP or Modbus TCP to read and write tags in PLCs";
+    license = [ licenses.lgpl2Plus licenses.mpl20 ];
+    maintainers = [ maintainers.petterstorvik ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libplctag/default.nix
+++ b/pkgs/development/libraries/libplctag/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "libplctag";
-    repo = "libpcltag";
+    repo = "libplctag";
     rev = "v${version}";
     sha256 = "0brmzr863chybm5y0q5hld5mhf6kx0bl4dddr7j69adlraak7x6s";
   };

--- a/pkgs/development/libraries/libplctag/default.nix
+++ b/pkgs/development/libraries/libplctag/default.nix
@@ -1,25 +1,27 @@
 { lib
 , stdenv
 , cmake
-, fetchurl
+, fetchFromGitHub
 }:
 
 stdenv.mkDerivation rec {
   pname = "libplctag";
   version = "2.3.5";
 
-  nativeBuildInputs = [ cmake ];
-
-  src = fetchurl {
-    url = "https://github.com/libplctag/libplctag/archive/v${version}.tar.gz";
-    sha256 = "16azdxyl82js17xcav7v23zvi64w72181wylj489zim9x5h5sxsr";
+  src = fetchFromGitHub {
+    owner = "libplctag";
+    repo = "libpcltag";
+    rev = "v${version}";
+    sha256 = "0brmzr863chybm5y0q5hld5mhf6kx0bl4dddr7j69adlraak7x6s";
   };
+
+  nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
     homepage = "https://github.com/libplctag/libplctag";
     description = "Library that uses EtherNet/IP or Modbus TCP to read and write tags in PLCs";
-    license = [ licenses.lgpl2Plus licenses.mpl20 ];
-    maintainers = [ maintainers.petterstorvik ];
+    license = with licenses; [ lgpl2Plus mpl20 ];
+    maintainers = with maintainers; [ petterstorvik ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6090,6 +6090,8 @@ in
 
   libnixxml = callPackage ../development/libraries/libnixxml { };
 
+  libplctag = callPackage ../development/libraries/libplctag { };
+
   libpointmatcher = callPackage ../development/libraries/libpointmatcher { };
 
   libportal = callPackage ../development/libraries/libportal { };


### PR DESCRIPTION

###### Motivation for this change

Add library libplctag. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
