### PR TITLE
python3Packages.openwrt-luci-rpc: 1.1.7 -> 1.1.8

### DIFF
--- a/pkgs/development/python-modules/openwrt-luci-rpc/default.nix
+++ b/pkgs/development/python-modules/openwrt-luci-rpc/default.nix
@@ -1,12 +1,11 @@
-{ buildPythonPackage
-, fetchPypi
-, lib
+{ lib
+, buildPythonPackage
 , click
-, requests
+, fetchPypi
 , packaging
+, pytestCheckHook
+, requests
 }:
-
-with lib;
 
 buildPythonPackage rec {
   pname = "openwrt-luci-rpc";
@@ -17,17 +16,24 @@ buildPythonPackage rec {
     sha256 = "sha256-bo9HLT0q0yiLJI7i5v/36G82FHbGCtnAI50iGniyKSU=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "requests==2.21.0" "requests"
-    substituteInPlace setup.py --replace "packaging==19.1" "packaging"
-  '';
+  propagatedBuildInputs = [
+    click
+    requests
+    packaging
+  ];
 
-  propagatedBuildInputs = [ click requests packaging ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  meta = {
-    description = ''
-      Python3 module for interacting with the OpenWrt Luci RPC interface.
-      Supports 15.X & 17.X & 18.X or newer releases of OpenWrt.
+  pythonImportsCheck = [ "openwrt_luci_rpc" ];
+
+  meta = with lib; {
+    description = "Python module for interacting with the OpenWrt Luci RPC interface";
+    longDescription = ''
+      This module allows you to use the Luci RPC interface to fetch connected devices
+      on your OpenWrt based router. Supports 15.X & 17.X & 18.X or newer releases of
+      OpenWrt.
     '';
     homepage = "https://github.com/fbradyirl/openwrt-luci-rpc";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/openwrt-luci-rpc/default.nix
+++ b/pkgs/development/python-modules/openwrt-luci-rpc/default.nix
@@ -10,11 +10,11 @@ with lib;
 
 buildPythonPackage rec {
   pname = "openwrt-luci-rpc";
-  version = "1.1.7";
+  version = "1.1.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8074c1ed24cdd1fadc5a99bd63d9313a0a44703714473ed781ed11e7fb45c96f";
+    sha256 = "sha256-bo9HLT0q0yiLJI7i5v/36G82FHbGCtnAI50iGniyKSU=";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.1.8

Change log: https://github.com/fbradyirl/openwrt-luci-rpc/blob/master/HISTORY.rst#118-2021-03-12

- Re-work test part
- Remove obsolete patching
- Update meta

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
