### PR TITLE
python3Packages.googlemaps: 4.4.2 -> 4.4.5

### DIFF
--- a/pkgs/development/python-modules/googlemaps/default.nix
+++ b/pkgs/development/python-modules/googlemaps/default.nix
@@ -1,34 +1,40 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pytest-cov
+, pytestCheckHook
+, pythonOlder
 , requests
 , responses
-, pytestCheckHook
-, pytestcov
-, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "googlemaps";
-  version = "4.4.2";
-  disabled = isPy27;
+  version = "4.4.5";
+  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "googlemaps";
     repo = "google-maps-services-python";
     rev = "v${version}";
-    sha256 = "DYhW1OGce/0gY7Jmwq6iM45PxLyXIYo4Cfg2u6Xuyg4=";
+    sha256 = "sha256-Rdfp98UqTMbqcOpkzh0Dz8fNSSbuvCnCztCkxiBgaAA=";
   };
 
   propagatedBuildInputs = [ requests ];
 
-  checkInputs = [ pytestCheckHook responses pytestcov ];
+  checkInputs = [
+    pytest-cov
+    pytestCheckHook
+    responses
+  ];
 
   disabledTests = [
     # touches network
     "test_elevation_along_path_single"
     "test_transit_without_time"
   ];
+
+  pythonImportsCheck = [ "googlemaps" ];
 
   meta = with lib; {
     homepage = "https://github.com/googlemaps/google-maps-services-python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 4.4.5

Change log: https://github.com/googlemaps/google-maps-services-python/releases/tag/v4.4.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
