### PR TITLE
treewide: don't reference aliases in packages

### DIFF
--- a/pkgs/applications/editors/jetbrains/update.pl
+++ b/pkgs/applications/editors/jetbrains/update.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i perl -p perl perlPackages.LWPProtocolhttps perlPackages.FileSlurp
+#!nix-shell -i perl -p perl perlPackages.LWPProtocolHttps perlPackages.FileSlurp
 
 use strict;
 use List::Util qw(reduce);

--- a/pkgs/applications/misc/bemenu/default.nix
+++ b/pkgs/applications/misc/bemenu/default.nix
@@ -2,12 +2,12 @@
 , pango, fribidi, harfbuzz, pcre, pkg-config
 , ncursesSupport ? true, ncurses ? null
 , waylandSupport ? true, wayland ? null, wayland-protocols ? null
-, x11Support ? true, xlibs ? null, xorg ? null
+, x11Support ? true, xorg ? null
 }:
 
 assert ncursesSupport -> ncurses != null;
 assert waylandSupport -> ! lib.elem null [wayland wayland-protocols];
-assert x11Support -> xlibs != null && xorg != null;
+assert x11Support -> xorg != null;
 
 stdenv.mkDerivation rec {
   pname = "bemenu";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   ] ++ optional ncursesSupport ncurses
     ++ optionals waylandSupport [ wayland wayland-protocols ]
     ++ optionals x11Support [
-      xlibs.libX11 xlibs.libXinerama xlibs.libXft
+      xorg.libX11 xorg.libXinerama xorg.libXft
       xorg.libXdmcp xorg.libpthreadstubs xorg.libxcb
     ];
 

--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -5,7 +5,7 @@
 
 let
   perlDeps =
-    [ perlPackages.MIMEtools perlPackages.HTMLParser ]
+    [ perlPackages.MIMETools perlPackages.HTMLParser ]
     ++ lib.optional cursesSupport perlPackages.CursesUI
     ++ lib.optional uriFindSupport perlPackages.URIFind;
 

--- a/pkgs/applications/misc/gcstar/default.nix
+++ b/pkgs/applications/misc/gcstar/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     JSON
     ImageExifTool
     librelative
-    LWPUserAgent
+    LWP
     LWPProtocolHttps
     MP3Info
     MP3Tag

--- a/pkgs/applications/misc/marktext/default.nix
+++ b/pkgs/applications/misc/marktext/default.nix
@@ -25,7 +25,7 @@ appimageTools.wrapType2 rec {
   multiPkgs = null; # no 32bit needed
   extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [
     p.libsecret
-    p.xlibs.libxkbfile
+    p.xorg.libxkbfile
   ];
 
   # Strip version from binary name.

--- a/pkgs/applications/misc/regextester/default.nix
+++ b/pkgs/applications/misc/regextester/default.nix
@@ -6,7 +6,7 @@
 , pkg-config
 , glib
 , gtk3
-, gnome3
+, libgee
 , meson
 , ninja
 , gobject-introspection
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     pantheon.elementary-icon-theme
     pantheon.granite
     glib
-    gnome3.libgee
+    libgee
     gsettings-desktop-schemas
     gtk3
   ];

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -6,7 +6,7 @@
 , jbig2dec
 , libjpeg
 , mupdf
-, openjpeg_2
+, openjpeg
 , pkg-config
 , zathura_core
 }:
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     jbig2dec
     libjpeg
     mupdf
-    openjpeg_2
+    openjpeg
     zathura_core
   ] ++ lib.optional stdenv.isDarwin gtk-mac-integration;
 

--- a/pkgs/applications/networking/cluster/nixops/shell.nix
+++ b/pkgs/applications/networking/cluster/nixops/shell.nix
@@ -3,7 +3,7 @@
 pkgs.mkShell {
   buildInputs = [
     pkgs.poetry2nix.cli
-    pkgs.pkgconfig
+    pkgs.pkg-config
     pkgs.libvirt
     pkgs.poetry
   ];

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -4,7 +4,7 @@
 
 , autoAwaySupport ? true,       libXScrnSaver ? null, libX11 ? null
 , notifySupport ? true,         libnotify ? null, gdk-pixbuf ? null
-, traySupport ? true,           gnome2 ? null
+, traySupport ? true,           gtk2 ? null
 , pgpSupport ? true,            gpgme ? null
 , pythonPluginSupport ? true,   python ? null
 , omemoSupport ? true,          libsignal-protocol-c ? null, libgcrypt ? null
@@ -12,7 +12,7 @@
 
 assert autoAwaySupport     -> libXScrnSaver != null && libX11 != null;
 assert notifySupport       -> libnotify != null && gdk-pixbuf != null;
-assert traySupport         -> gnome2 != null;
+assert traySupport         -> gtk2 != null;
 assert pgpSupport          -> gpgme != null;
 assert pythonPluginSupport -> python != null;
 assert omemoSupport        -> libsignal-protocol-c != null && libgcrypt != null;
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     curl libmesode cmocka libmicrohttpd sqlite
   ] ++ optionals autoAwaySupport     [ libXScrnSaver libX11 ]
     ++ optionals notifySupport       [ libnotify gdk-pixbuf ]
-    ++ optionals traySupport         [ gnome2.gtk ]
+    ++ optionals traySupport         [ gtk2 ]
     ++ optionals pgpSupport          [ gpgme ]
     ++ optionals pythonPluginSupport [ python ]
     ++ optionals omemoSupport        [ libsignal-protocol-c libgcrypt ];

--- a/pkgs/applications/networking/instant-messengers/stride/default.nix
+++ b/pkgs/applications/networking/instant-messengers/stride/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, dpkg, alsaLib, atk, cairo, cups, dbus, expat, fontconfig
-, freetype, gdk-pixbuf, glib, gnome2, nspr, nss, pango, udev, xorg }:
+, freetype, gdk-pixbuf, glib, gnome2, gtk2, nspr, nss, pango, udev, xorg }:
 let
   fullPath = lib.makeLibraryPath [
     alsaLib
@@ -13,7 +13,7 @@ let
     gdk-pixbuf
     glib
     gnome2.GConf
-    gnome2.gtk
+    gtk2
     nspr
     nss
     pango

--- a/pkgs/applications/networking/irc/convos/default.nix
+++ b/pkgs/applications/networking/irc/convos/default.nix
@@ -28,7 +28,7 @@ perlPackages.buildPerlPackage rec {
 
   propagatedBuildInputs = [ openssl ];
 
-  checkInputs = with perlPackages; [ TestDeep TestMore ];
+  checkInputs = with perlPackages; [ TestDeep ];
 
   postPatch = ''
     patchShebangs script/convos

--- a/pkgs/applications/networking/p2p/gnunet/gtk.nix
+++ b/pkgs/applications/networking/p2p/gnunet/gtk.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, gnome3
+, glade
 , gnunet
 , gnutls
 , gtk3
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gnome3.glade
+    glade
     gnunet
     gnutls
     gtk3

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -12,7 +12,7 @@
 , pcre
   # Build options
 , enableGTK3 ? false
-, gnome3
+, gtk3
 , xorg
 , wrapGAppsHook
 , enableQt ? false
@@ -65,7 +65,7 @@ in stdenv.mkDerivation {
     pcre
   ]
   ++ lib.optionals enableQt [ qt5.qttools qt5.qtbase ]
-  ++ lib.optionals enableGTK3 [ gnome3.gtk xorg.libpthreadstubs ]
+  ++ lib.optionals enableGTK3 [ gtk3 xorg.libpthreadstubs ]
   ++ lib.optionals enableSystemd [ systemd ]
   ++ lib.optionals stdenv.isLinux [ inotify-tools ]
   ;

--- a/pkgs/applications/networking/pcloud/default.nix
+++ b/pkgs/applications/networking/pcloud/default.nix
@@ -21,7 +21,7 @@
   # Runtime dependencies;
   # A few additional ones (e.g. Node) are already shipped together with the
   # AppImage, so we don't have to duplicate them here.
-  alsaLib, dbus-glib, fuse, gnome3, libdbusmenu-gtk2, udev, nss
+  alsaLib, dbus-glib, fuse, gnome3, gtk3, libdbusmenu-gtk2, udev, nss
 }:
 
 let
@@ -56,7 +56,7 @@ in stdenv.mkDerivation {
     alsaLib
     dbus-glib
     fuse
-    gnome3.gtk
+    gtk3
     libdbusmenu-gtk2
     nss
     udev
@@ -92,7 +92,7 @@ in stdenv.mkDerivation {
 
     # This is required for the file picker dialog - otherwise pcloud just
     # crashes
-    export XDG_DATA_DIRS="${gnome3.gsettings-desktop-schemas}/share/gsettings-schemas/${gnome3.gsettings-desktop-schemas.name}:${gnome3.gtk}/share/gsettings-schemas/${gnome3.gtk.name}:$XDG_DATA_DIRS"
+    export XDG_DATA_DIRS="${gnome3.gsettings-desktop-schemas}/share/gsettings-schemas/${gnome3.gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS"
 
     exec "$out/app/pcloud"
     EOF

--- a/pkgs/applications/office/onlyoffice-bin/default.nix
+++ b/pkgs/applications/office/onlyoffice-bin/default.nix
@@ -15,7 +15,7 @@
 , gdk-pixbuf
 , glib
 , glibc
-, gnome3
+, gsettings-desktop-schemas
 , gst_all_1
 , gtk2
 , gtk3
@@ -95,7 +95,7 @@ in stdenv.mkDerivation rec {
     fontconfig
     gdk-pixbuf
     glib
-    gnome3.gsettings_desktop_schemas
+    gsettings-desktop-schemas
     gst_all_1.gst-plugins-base
     gst_all_1.gstreamer
     gtk2

--- a/pkgs/applications/radio/dablin/default.nix
+++ b/pkgs/applications/radio/dablin/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config
-, mpg123, SDL2, gnome3, faad2, pcre
+, mpg123, SDL2, gtkmm3, faad2, pcre
 } :
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ faad2 mpg123 SDL2 gnome3.gtkmm pcre ];
+  buildInputs = [ faad2 mpg123 SDL2 gtkmm3 pcre ];
 
   meta = with lib; {
     description = "Play DAB/DAB+ from ETI-NI aligned stream";

--- a/pkgs/applications/science/electronics/horizon-eda/default.nix
+++ b/pkgs/applications/science/electronics/horizon-eda/default.nix
@@ -6,7 +6,7 @@
 , epoxy
 , fetchFromGitHub
 , glm
-, gnome3
+, gtkmm3
 , lib
 , libgit2
 , librsvg
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     curl
     epoxy
     glm
-    gnome3.gtkmm
+    gtkmm3
     libgit2
     librsvg
     libuuid

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -186,7 +186,7 @@ stdenv.mkDerivation rec {
   makeWrapperArgs = with passthru.libraries; [
     "--prefix XDG_DATA_DIRS : ${base}/share"
     "--prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share"
-    "--prefix XDG_DATA_DIRS : ${gnome3.defaultIconTheme}/share"
+    "--prefix XDG_DATA_DIRS : ${gnome3.adwaita-icon-theme}/share"
     "--prefix XDG_DATA_DIRS : ${wxGTK.gtk}/share/gsettings-schemas/${wxGTK.gtk.name}"
     "--prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}"
     # wrapGAppsHook did these two as well, no idea if it matters...

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchFromGitLab
 , gnome3
+, dconf
 , wxGTK30
 , wxGTK31
 , makeWrapper
@@ -191,7 +192,7 @@ stdenv.mkDerivation rec {
     "--prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}"
     # wrapGAppsHook did these two as well, no idea if it matters...
     "--prefix XDG_DATA_DIRS : ${cups}/share"
-    "--prefix GIO_EXTRA_MODULES : ${gnome3.dconf}/lib/gio/modules"
+    "--prefix GIO_EXTRA_MODULES : ${dconf}/lib/gio/modules"
 
     "--set-default KISYSMOD ${footprints}/share/kicad/modules"
     "--set-default KICAD_SYMBOL_DIR ${symbols}/share/kicad/library"

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -127,7 +127,7 @@ self = stdenv.mkDerivation {
   buildInputs = [ ncurses ] ++ ocamlBuildInputs
     ++ optionals buildIde
       (if versionAtLeast "8.10"
-       then [ ocamlPackages.lablgtk3-sourceview3 glib gnome3.defaultIconTheme wrapGAppsHook ]
+       then [ ocamlPackages.lablgtk3-sourceview3 glib gnome3.adwaita-icon-theme wrapGAppsHook ]
        else [ ocamlPackages.lablgtk ]);
 
   postPatch = ''

--- a/pkgs/applications/science/math/gfm/default.nix
+++ b/pkgs/applications/science/math/gfm/default.nix
@@ -5,6 +5,7 @@
 , pkg-config
 , autoreconfHook
 , gnome2
+, gtk2
 , glib
 , libtifiles2
 , libticables2
@@ -32,7 +33,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gnome2.gtk
+    gtk2
     gnome2.libglade
     glib
     libtifiles2

--- a/pkgs/applications/science/math/tilp2/default.nix
+++ b/pkgs/applications/science/math/tilp2/default.nix
@@ -7,6 +7,7 @@
 , intltool
 , glib
 , gnome2
+, gtk2
 , gfm
 , libticables2
 , libticalcs2
@@ -36,7 +37,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
-    gnome2.gtk
+    gtk2
     gnome2.libglade
     gfm
     libticables2

--- a/pkgs/applications/terminal-emulators/evilvte/default.nix
+++ b/pkgs/applications/terminal-emulators/evilvte/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchgit, makeWrapper, pkg-config,
-  gnome2, glib, pango, cairo, gdk-pixbuf, atk, freetype, xorg,
+  gnome2, gtk2, glib, pango, cairo, gdk-pixbuf, atk, freetype, xorg,
   configH ? ""
 }:
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    gnome2.vte glib pango gnome2.gtk cairo gdk-pixbuf atk freetype xorg.libX11
+    gnome2.vte glib pango gtk2 cairo gdk-pixbuf atk freetype xorg.libX11
     xorg.xorgproto xorg.libXext makeWrapper pkg-config
   ];
 

--- a/pkgs/applications/terminal-emulators/kgx/default.nix
+++ b/pkgs/applications/terminal-emulators/kgx/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitLab
 , gettext
 , gnome3
+, libgtop
 , gtk3
 , libhandy
 , pcre2
@@ -33,7 +34,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     gettext
-    gnome3.libgtop
+    libgtop
     gnome3.nautilus
     gtk3
     libhandy

--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -1,6 +1,6 @@
 {
   alsaLib, atk, cairo, cups, dbus, dpkg, expat, fetchurl, fetchzip, fontconfig, freetype,
-  gdk-pixbuf, glib, gnome3, libX11, libXScrnSaver, libXcomposite, libXcursor,
+  gdk-pixbuf, glib, gtk3, libX11, libXScrnSaver, libXcomposite, libXcursor,
   libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst,
   libxcb, nspr, nss, lib, stdenv, udev, libuuid, pango, at-spi2-atk, at-spi2-core
 }:
@@ -19,7 +19,7 @@
     freetype
     gdk-pixbuf
     glib
-    gnome3.gtk
+    gtk3
     pango
     libuuid
     libX11

--- a/pkgs/applications/window-managers/wayfire/wcm.nix
+++ b/pkgs/applications/window-managers/wayfire/wcm.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, meson, ninja, pkg-config, wayland, wrapGAppsHook
-, gnome3, libevdev, libxml2, wayfire, wayland-protocols, wf-config, wf-shell
+, gtk3, libevdev, libxml2, wayfire, wayland-protocols, wf-config, wf-shell
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkg-config wayland wrapGAppsHook ];
   buildInputs = [
-    gnome3.gtk libevdev libxml2 wayfire wayland
+    gtk3 libevdev libxml2 wayfire wayland
     wayland-protocols wf-config wf-shell
   ];
 

--- a/pkgs/applications/window-managers/wayfire/wf-shell.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-shell.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, meson, ninja, pkg-config, wayland, git
-, alsaLib, gnome3, gtk-layer-shell, pulseaudio, wayfire, wf-config
+, alsaLib, gtkmm3, gtk-layer-shell, pulseaudio, wayfire, wf-config
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkg-config wayland ];
   buildInputs = [
-    alsaLib gnome3.gtkmm gtk-layer-shell pulseaudio wayfire wf-config
+    alsaLib gtkmm3 gtk-layer-shell pulseaudio wayfire wf-config
   ];
 
   mesonFlags = [ "--sysconfdir" "/etc" ];

--- a/pkgs/development/compilers/gnu-smalltalk/default.nix
+++ b/pkgs/development/compilers/gnu-smalltalk/default.nix
@@ -1,6 +1,6 @@
 { config, lib, stdenv, fetchurl, pkg-config, libtool
 , zip, libffi, libsigsegv, readline, gmp
-, gnutls, gnome2, cairo, SDL, sqlite
+, gnutls, gtk2, cairo, SDL, sqlite
 , emacsSupport ? config.emacsSupport or false, emacs ? null }:
 
 assert emacsSupport -> (emacs != null);
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
   # http://smalltalk.gnu.org/download
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    libtool zip libffi libsigsegv-shared readline gmp gnutls gnome2.gtk
+    libtool zip libffi libsigsegv-shared readline gmp gnutls gtk2
     cairo SDL sqlite
   ]
   ++ lib.optional emacsSupport emacs;

--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, meson, ninja, makeFontsConf, vala, fetchpatch
-, gnome3, glib, json-glib, libarchive, libsoup, gobject-introspection }:
+, gnome3, libgee, glib, json-glib, libarchive, libsoup, gobject-introspection }:
 
 let
   pname = "libhttpseverywhere";
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ vala gobject-introspection meson ninja pkg-config ];
-  buildInputs = [ glib gnome3.libgee json-glib libsoup libarchive ];
+  buildInputs = [ glib libgee json-glib libsoup libarchive ];
 
   # Fixes build with vala >=0.42
   patches = [

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -225,7 +225,7 @@ $out/lib/common-lisp/query-fs"
       x.deps;
   };
   cl-cffi-gtk-glib = addNativeLibs [pkgs.glib];
-  cl-cffi-gtk-gdk-pixbuf = addNativeLibs [pkgs.gdk_pixbuf];
+  cl-cffi-gtk-gdk-pixbuf = addNativeLibs [pkgs.gdk-pixbuf];
   cl-cffi-gtk-cairo = addNativeLibs [pkgs.cairo];
   cl-cffi-gtk-pango = addNativeLibs [pkgs.pango];
   cl-cffi-gtk-gdk = addNativeLibs [pkgs.gtk3];

--- a/pkgs/development/lisp-modules/shell.nix
+++ b/pkgs/development/lisp-modules/shell.nix
@@ -11,6 +11,6 @@ self = rec {
     lispPackages.quicklisp-to-nix lispPackages.quicklisp-to-nix-system-info
   ];
   CPATH = "${libfixposix}/include";
-  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${libmysqlclient}/lib:${libmysqlclient}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib:${glib.out}/lib:${gdk_pixbuf}/lib:${cairo}/lib:${pango.out}/lib:${gtk3}/lib:${webkitgtk}/lib";
+  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${libmysqlclient}/lib:${libmysqlclient}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib:${glib.out}/lib:${gdk-pixbuf}/lib:${cairo}/lib:${pango.out}/lib:${gtk3}/lib:${webkitgtk}/lib";
 };
 in stdenv.mkDerivation self

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -5,16 +5,16 @@ deployAndroidPackage {
   buildInputs = [ autoPatchelfHook makeWrapper ]
   ++ lib.optional (os == "linux") [
     pkgs.glibc
-    pkgs.xlibs.libX11
-    pkgs.xlibs.libXext
-    pkgs.xlibs.libXdamage
-    pkgs.xlibs.libXfixes
-    pkgs.xlibs.libxcb
-    pkgs.xlibs.libXcomposite
-    pkgs.xlibs.libXcursor
-    pkgs.xlibs.libXi
-    pkgs.xlibs.libXrender
-    pkgs.xlibs.libXtst
+    pkgs.xorg.libX11
+    pkgs.xorg.libXext
+    pkgs.xorg.libXdamage
+    pkgs.xorg.libXfixes
+    pkgs.xorg.libxcb
+    pkgs.xorg.libXcomposite
+    pkgs.xorg.libXcursor
+    pkgs.xorg.libXi
+    pkgs.xorg.libXrender
+    pkgs.xorg.libXtst
     pkgs.libcxx
     pkgs.libGL
     pkgs.libpulseaudio

--- a/pkgs/development/mobile/androidenv/tools/26.nix
+++ b/pkgs/development/mobile/androidenv/tools/26.nix
@@ -4,7 +4,7 @@ deployAndroidPackage {
   name = "androidsdk";
   inherit os package;
   buildInputs = [ autoPatchelfHook makeWrapper ]
-    ++ lib.optional (os == "linux") [ pkgs.glibc pkgs.xlibs.libX11 pkgs.xlibs.libXrender pkgs.xlibs.libXext pkgs.fontconfig pkgs.freetype pkgs_i686.glibc pkgs_i686.xlibs.libX11 pkgs_i686.xlibs.libXrender pkgs_i686.xlibs.libXext pkgs_i686.fontconfig.lib pkgs_i686.freetype pkgs_i686.zlib pkgs.fontconfig.lib ];
+    ++ lib.optional (os == "linux") [ pkgs.glibc pkgs.xorg.libX11 pkgs.xorg.libXrender pkgs.xorg.libXext pkgs.fontconfig pkgs.freetype pkgs_i686.glibc pkgs_i686.xorg.libX11 pkgs_i686.xorg.libXrender pkgs_i686.xorg.libXext pkgs_i686.fontconfig.lib pkgs_i686.freetype pkgs_i686.zlib pkgs.fontconfig.lib ];
 
   patchInstructions = ''
     ${lib.optionalString (os == "linux") ''
@@ -27,7 +27,7 @@ deployAndroidPackage {
     # Wrap monitor script
     wrapProgram $PWD/monitor \
       --prefix PATH : ${pkgs.jdk8}/bin \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ pkgs.xlibs.libX11 pkgs.xlibs.libXtst ]}
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ pkgs.xorg.libX11 pkgs.xorg.libXtst ]}
 
     # Patch all script shebangs
     patchShebangs .

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -107,7 +107,7 @@ let
     mirakurun = super.mirakurun.override rec {
       nativeBuildInputs = with pkgs; [ makeWrapper ];
       postInstall = let
-        runtimeDeps = [ nodejs ] ++ (with pkgs; [ bash which v4l_utils ]);
+        runtimeDeps = [ nodejs ] ++ (with pkgs; [ bash which v4l-utils ]);
       in
       ''
         substituteInPlace $out/lib/node_modules/mirakurun/processes.json \

--- a/pkgs/development/python-modules/notify/default.nix
+++ b/pkgs/development/python-modules/notify/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
       configure
   '';
 
-  nativeBuildInputs = [ pkgs.pkgconfig ];
+  nativeBuildInputs = [ pkgs.pkg-config ];
   buildInputs = [ python pygobject2 pygtk pkgs.libnotify pkgs.glib pkgs.gtk2 pkgs.dbus-glib ];
 
   postInstall = "cd $out/lib/python*/site-packages && ln -s gtk-*/pynotify .";

--- a/pkgs/development/python-modules/pycdio/default.nix
+++ b/pkgs/development/python-modules/pycdio/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     patchShebangs .
   '';
 
-  nativeBuildInputs = [ nose pkgs.pkgconfig pkgs.swig ];
+  nativeBuildInputs = [ nose pkgs.pkg-config pkgs.swig ];
   buildInputs = [ setuptools pkgs.libcdio ]
     ++ lib.optional stdenv.isDarwin pkgs.libiconv;
 

--- a/pkgs/development/python-modules/pyparted/default.nix
+++ b/pkgs/development/python-modules/pyparted/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     PATH="${pkgs.parted}/sbin:$PATH"
   '';
 
-  nativeBuildInputs = [ pkgs.pkgconfig ];
+  nativeBuildInputs = [ pkgs.pkg-config ];
   checkInputs = [ six ];
   propagatedBuildInputs = [ pkgs.parted ];
 

--- a/pkgs/development/python-modules/pypoppler/default.nix
+++ b/pkgs/development/python-modules/pypoppler/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   };
 
   NIX_CFLAGS_COMPILE="-I${pkgs.poppler.dev}/include/poppler/";
-  nativeBuildInputs = [ pkgs.pkgconfig ];
+  nativeBuildInputs = [ pkgs.pkg-config ];
   buildInputs = [ pkgs.poppler.dev ];
   propagatedBuildInputs = [ pycairo pygobject2 ];
 

--- a/pkgs/development/python-modules/sane/default.nix
+++ b/pkgs/development/python-modules/sane/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, saneBackends
+, sane-backends
 }:
 
 buildPythonPackage rec {
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [
-    saneBackends
+    sane-backends
   ];
 
   meta = with lib; {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -231,7 +231,7 @@ let
   };
 
   packagesWithNativeBuildInputs = {
-    arrow = [ pkgs.pkgconfig pkgs.arrow-cpp ];
+    arrow = [ pkgs.pkg-config pkgs.arrow-cpp ];
     adimpro = [ pkgs.imagemagick ];
     animation = [ pkgs.which ];
     audio = [ pkgs.portaudio ];

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
@@ -313,7 +313,7 @@ self: super:
           nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.pkg-config ];
           buildInputs =
             (old.buildInputs or [ ])
-            ++ [ pkgs.hdf5 self.pkgconfig self.cython ]
+            ++ [ pkgs.hdf5 self.pkg-config self.cython ]
             ++ lib.optional mpiSupport mpi
           ;
           propagatedBuildInputs =
@@ -453,7 +453,7 @@ self: super:
   );
 
   jsonslicer = super.jsonslicer.overridePythonAttrs (old: {
-    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.pkgconfig ];
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.pkg-config ];
     buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.yajl ];
   });
 

--- a/pkgs/misc/emulators/tilem/default.nix
+++ b/pkgs/misc/emulators/tilem/default.nix
@@ -3,7 +3,7 @@
 , lib
 , pkg-config
 , glib
-, gnome2
+, gtk2
 , libticonv
 , libtifiles2
 , libticables2
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ba38xzhp3yf21ip3cgql6jzy49jc34sfnjsl4syxyrd81d269zw";
   };
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ glib gnome2.gtk libticonv libtifiles2 libticables2 libticalcs2 ];
+  buildInputs = [ glib gtk2 libticonv libtifiles2 libticables2 libticalcs2 ];
   NIX_CFLAGS_COMPILE = [ "-lm" ];
   meta = with lib; {
     homepage = "http://lpg.ticalc.org/prj_tilem/";

--- a/pkgs/servers/mail/sympa/default.nix
+++ b/pkgs/servers/mail/sympa/default.nix
@@ -56,7 +56,7 @@ let
     IOSocketSSL
     MailDKIM
     NetDNS
-    NetLDAP
+    perlldap
     NetSMTP
     SOAPLite
   ]);

--- a/pkgs/servers/mail/sympa/default.nix
+++ b/pkgs/servers/mail/sympa/default.nix
@@ -12,7 +12,6 @@ let
     DBI
     DateTimeFormatMail
     DateTimeTimeZone
-    DigestMD5
     Encode
     FCGI
     FileCopyRecursive
@@ -28,7 +27,6 @@ let
     libintl_perl
 
     MHonArc
-    MIMEBase64
     MIMECharset
     MIMETools
     MIMEEncWords
@@ -57,7 +55,7 @@ let
     MailDKIM
     NetDNS
     perlldap
-    NetSMTP
+    libnet
     SOAPLite
   ]);
 in

--- a/pkgs/tools/graphics/nip2/default.nix
+++ b/pkgs/tools/graphics/nip2/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, pkg-config, glib, libxml2, flex, bison, vips, gnome2,
-fftw, gsl, goffice, libgsf }:
+{ lib, stdenv, fetchurl, pkg-config, glib, libxml2, flex, bison, vips, gtk2
+, fftw, gsl, goffice, libgsf }:
 
 stdenv.mkDerivation rec {
   pname = "nip2";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
   [ pkg-config glib libxml2 flex bison vips
-    gnome2.gtk fftw gsl goffice libgsf
+    gtk2 fftw gsl goffice libgsf
   ];
 
   meta = with lib; {

--- a/pkgs/tools/misc/shelldap/default.nix
+++ b/pkgs/tools/misc/shelldap/default.nix
@@ -6,7 +6,7 @@ perlPackages.buildPerlPackage rec {
     url = "https://bitbucket.org/mahlon/shelldap/downloads/shelldap-${version}.tar.gz";
     sha256 = "07gkvvxcgw3pgkfy8p9mmidakciaq1rsq5zhmdqd8zcwgqkrr24i";
   };
-  buildInputs = with perlPackages; [ perl YAMLSyck NetLDAP AlgorithmDiff IOSocketSSL AuthenSASL TermReadLineGnu TermShell ];
+  buildInputs = with perlPackages; [ perl YAMLSyck perlldap AlgorithmDiff IOSocketSSL AuthenSASL TermReadLineGnu TermShell ];
   prePatch = ''
     touch Makefile.PL
   '';

--- a/pkgs/tools/security/gencfsm/default.nix
+++ b/pkgs/tools/security/gencfsm/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, autoconf, automake, intltool, libtool, pkg-config, encfs
-, glib , gnome3, gtk3, libgnome-keyring, vala, wrapGAppsHook, xorg, gobject-introspection
+, glib , libgee, gtk3, libgnome-keyring, vala, wrapGAppsHook, xorg, gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ autoconf automake intltool libtool vala glib encfs
-    gtk3 libgnome-keyring gnome3.libgee xorg.libSM xorg.libICE
+    gtk3 libgnome-keyring libgee xorg.libSM xorg.libICE
     wrapGAppsHook gobject-introspection  ];
 
   patches = [ ./makefile-mkdir.patch ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14866,7 +14866,7 @@ let
       url = "mirror://cpan/authors/id/E/ES/ESTRABD/MySQL-Diff-0.60.tar.gz";
       sha256 = "5d7080a4bd5714ff9ef536aa774a7adb3c6f0e760215ca6c39d8a3545344f956";
     };
-    propagatedBuildInputs = [ pkgs.mysql-client FileSlurp StringShellQuote ];
+    propagatedBuildInputs = [ pkgs.mariadb.client FileSlurp StringShellQuote ];
     meta = {
       homepage = "https://github.com/estrabd/mysqldiff";
       description = "Generates a database upgrade instruction set";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23070,7 +23070,7 @@ let
       sha256 = "582db53a091f8da3670c037733314f2510af5e8ee0ba42a0e391e2f2e3ca7734";
     };
     prePatch = "rm examples.pl";
-    propagatedBuildInputs = [ LWPProtocolhttps ];
+    propagatedBuildInputs = [ LWPProtocolHttps ];
     meta = {
       description = "Accessing Twilio's REST API with Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1843,7 +1843,7 @@ let
       url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Authentication-Store-LDAP-1.016.tar.gz";
       sha256 = "0cm399vxqqf05cjgs1j5v3sk4qc6nmws5nfhf52qvpbwc4m82mq8";
     };
-    propagatedBuildInputs = [ perlldap CatalystPluginAuthentication ClassAccessorFast ];
+    propagatedBuildInputs = [ perlldap CatalystPluginAuthentication ClassAccessor ];
     buildInputs = [ TestMockObject TestException NetLDAPServerTest ];
     meta = {
       description= "Authentication from an LDAP Directory";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1843,7 +1843,7 @@ let
       url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Authentication-Store-LDAP-1.016.tar.gz";
       sha256 = "0cm399vxqqf05cjgs1j5v3sk4qc6nmws5nfhf52qvpbwc4m82mq8";
     };
-    propagatedBuildInputs = [ NetLDAP CatalystPluginAuthentication ClassAccessorFast ];
+    propagatedBuildInputs = [ perlldap CatalystPluginAuthentication ClassAccessorFast ];
     buildInputs = [ TestMockObject TestException NetLDAPServerTest ];
     meta = {
       description= "Authentication from an LDAP Directory";
@@ -15365,7 +15365,7 @@ let
       url = "mirror://cpan/authors/id/A/AA/AAR/Net-LDAP-Server-0.43.tar.gz";
       sha256 = "0qmh3cri3fpccmwz6bhwp78yskrb3qmalzvqn0a23hqbsfs4qv6x";
     };
-    propagatedBuildInputs = [ NetLDAP ConvertASN1 ];
+    propagatedBuildInputs = [ perlldap ConvertASN1 ];
     meta = {
       description = "LDAP server side protocol handling";
       license = with lib.licenses; [ artistic1 ];
@@ -15392,7 +15392,7 @@ let
       url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-Server-Test-0.22.tar.gz";
       sha256 = "13idip7jky92v4adw60jn2gcc3zf339gsdqlnc9nnvqzbxxp285i";
     };
-    propagatedBuildInputs = [ NetLDAP NetLDAPServer DataDump NetLDAPSID ];
+    propagatedBuildInputs = [ perlldap NetLDAPServer DataDump NetLDAPSID ];
     meta = {
       description= "test Net::LDAP code";
       license = with lib.licenses; [ artistic1 ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1844,7 +1844,7 @@ let
       sha256 = "0cm399vxqqf05cjgs1j5v3sk4qc6nmws5nfhf52qvpbwc4m82mq8";
     };
     propagatedBuildInputs = [ NetLDAP CatalystPluginAuthentication ClassAccessorFast ];
-    buildInputs = [ TestMore TestMockObject TestException NetLDAPServerTest ];
+    buildInputs = [ TestMockObject TestException NetLDAPServerTest ];
     meta = {
       description= "Authentication from an LDAP Directory";
       license = with lib.licenses; [ artistic1 ];
@@ -15392,7 +15392,7 @@ let
       url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-Server-Test-0.22.tar.gz";
       sha256 = "13idip7jky92v4adw60jn2gcc3zf339gsdqlnc9nnvqzbxxp285i";
     };
-    propagatedBuildInputs = [ NetLDAP NetLDAPServer TestMore DataDump NetLDAPSID ];
+    propagatedBuildInputs = [ NetLDAP NetLDAPServer DataDump NetLDAPSID ];
     meta = {
       description= "test Net::LDAP code";
       license = with lib.licenses; [ artistic1 ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7326,7 +7326,7 @@ in {
   salmon-mail = callPackage ../development/python-modules/salmon-mail { };
 
   sane = callPackage ../development/python-modules/sane {
-    inherit (pkgs) saneBackends;
+    inherit (pkgs) sane-backends;
   };
 
   sampledata = callPackage ../development/python-modules/sampledata { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix building with `config.allowAliases = false;`.

The only package rebuilds this causes are because of removing references to `perlPackages.TestMore` in https://github.com/NixOS/nixpkgs/commit/e5deebdf53c25cc38a58fb0bf8d51f0548503a04. This does not affect the packages in any way because TestMore has been merged into Perl and the alias already defines it as `null`:

https://github.com/NixOS/nixpkgs/blob/496963f42819f4e20f5eea08da4c04b054aa4ce0/pkgs/top-level/perl-packages.nix#L23851
https://github.com/NixOS/nixpkgs/blob/496963f42819f4e20f5eea08da4c04b054aa4ce0/pkgs/top-level/perl-packages.nix#L23783

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
