### PR TITLE
gphotos-sync: init at 2.14.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2405,6 +2405,12 @@
     githubId = 1708810;
     name = "Daniel Vianna";
   };
+  dnr = {
+    email = "dnr@dnr.im";
+    github = "dnr";
+    githubId = 466723;
+    name = "David Reiss";
+  };
   dochang = {
     email = "dochang@gmail.com";
     github = "dochang";

--- a/pkgs/development/python-modules/baseline/default.nix
+++ b/pkgs/development/python-modules/baseline/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "baseline";
+  version = "1.2.1";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "dmgass";
+    repo = "baseline";
+    rev = "95a0b71806ed16310eb0f27bc48aa5e21f731423";
+    sha256 = "0qjg46ipyfjflvjqzqr5p7iylwwqn2mhhrq952d01vi8wvfds10d";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Easy String Baseline";
+    longDescription = ''
+      This tool streamlines creation and maintenance of tests which compare
+      string output against a baseline.
+    '';
+    homepage = "https://github.com/dmgass/baseline";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dnr ];
+  };
+}

--- a/pkgs/development/python-modules/exif/default.nix
+++ b/pkgs/development/python-modules/exif/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitLab, isPy3k, plum-py, pytestCheckHook, baseline }:
+
+buildPythonPackage rec {
+  pname = "exif";
+  version = "1.2.0";
+  disabled = !isPy3k;
+
+  src = fetchFromGitLab {
+    owner = "TNThieding";
+    repo = "exif";
+    rev = "686857c677f489759db90b1ad61fa1cc1cac5f9a";
+    sha256 = "0z2if23kmi0iyxviz32mlqs997i3dqpqfz6nznlwkhkkb6rkwwnh";
+  };
+
+  propagatedBuildInputs = [ plum-py ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "plum-py==0.3.1" "plum-py>=0.3.1"
+  '';
+
+  checkInputs = [ pytestCheckHook baseline ];
+
+  meta = with lib; {
+    description = "Read and modify image EXIF metadata using Python";
+    homepage    = "https://gitlab.com/TNThieding/exif";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ dnr ];
+  };
+}

--- a/pkgs/development/python-modules/plum-py/default.nix
+++ b/pkgs/development/python-modules/plum-py/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchFromGitLab, isPy3k, pytest, baseline }:
+
+buildPythonPackage rec {
+  pname = "plum-py";
+  version = "0.4.0";
+  disabled = !isPy3k;
+
+  src = fetchFromGitLab {
+    owner = "dangass";
+    repo = "plum";
+    rev = "6a9ff863c0e9fa21f7b2230d25402155a5522e4b";
+    sha256 = "1iv62yb704c61b0dvsmyp3j6xpbmay532g9ny4pw4zbg3l69vd5j";
+  };
+
+  postPatch = ''
+    substituteInPlace src/plum/int/flag/_flag.py \
+      --replace 'if sys.version_info < (3, 7):' 'if True:'
+  '';
+
+  checkInputs = [ pytest baseline ];
+  checkPhase = "pytest tests";
+
+  meta = with lib; {
+    description = "Classes and utilities for packing/unpacking bytes";
+    homepage = "https://plum-py.readthedocs.io/en/latest/index.html";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dnr ];
+  };
+}

--- a/pkgs/tools/backup/gphotos-sync/default.nix
+++ b/pkgs/tools/backup/gphotos-sync/default.nix
@@ -1,0 +1,44 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "gphotos-sync";
+  version = "2.14.2";
+
+  src = fetchFromGitHub {
+    owner = "gilesknap";
+    repo = "gphotos-sync";
+    rev = version;
+    sha256 = "0cfmbrdy6w18hb623rjn0a4hnn3n63jw2jlmgn4a2k1sjqhpx3bf";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    appdirs
+    attrs
+    exif
+    psutil
+    pyyaml
+    requests_oauthlib
+  ];
+  checkInputs = with python3Packages; [
+    pytestCheckHook
+    mock
+  ];
+  checkPhase = ''
+    export HOME=$(mktemp -d)
+
+    # patch to skip all tests that do network access
+    cat >>test/test_setup.py <<EOF
+    import pytest, requests
+    requests.Session.__init__ = lambda *args, **kwargs: pytest.skip("no network access")
+    EOF
+
+    pytestCheckPhase
+  '';
+
+  meta = with lib; {
+    description = "Google Photos and Albums backup with Google Photos Library API";
+    homepage    = "https://github.com/gilesknap/gphotos-sync";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ dnr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4918,6 +4918,8 @@ in
 
   ldmtool = callPackage ../tools/misc/ldmtool { };
 
+  gphotos-sync = callPackage ../tools/backup/gphotos-sync { };
+
   gpodder = callPackage ../applications/audio/gpodder { };
 
   gpp = callPackage ../development/tools/gpp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2202,6 +2202,8 @@ in {
 
   executor = callPackage ../development/python-modules/executor { };
 
+  exif = callPackage ../development/python-modules/exif { };
+
   exifread = callPackage ../development/python-modules/exifread { };
 
   exrex = callPackage ../development/python-modules/exrex { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5152,6 +5152,8 @@ in {
 
   plugwise = callPackage ../development/python-modules/plugwise { };
 
+  plum-py = callPackage ../development/python-modules/plum-py { };
+
   plumbum = callPackage ../development/python-modules/plumbum { };
 
   ply = callPackage ../development/python-modules/ply { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -906,6 +906,8 @@ in {
 
   base58 = callPackage ../development/python-modules/base58 { };
 
+  baseline = callPackage ../development/python-modules/baseline { };
+
   baselines = callPackage ../development/python-modules/baselines { };
 
   basemap = callPackage ../development/python-modules/basemap { };


### PR DESCRIPTION
###### Motivation for this change

gphotos-sync is a backup photos and videos from Google Photos. This packages it, along with two dependent libraries.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
