### PR TITLE
juniper: init at 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10300,6 +10300,12 @@
     githubId = 13378502;
     name = "Wulfsta";
   };
+  wunderbrick = {
+    name = "Andrew Phipps";
+    email = "lambdafuzz@tutanota.com";
+    github = "wunderbrick";
+    githubId = 52174714;
+  };
   wyvie = {
     email = "elijahrum@gmail.com";
     github = "wyvie";

--- a/pkgs/development/compilers/juniper/default.nix
+++ b/pkgs/development/compilers/juniper/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchzip, makeWrapper, mono }:
+
+stdenv.mkDerivation rec {
+  pname = "juniper";
+  version = "2.3.0";
+
+  src = fetchzip {
+    url = "http://www.juniper-lang.org/installers/Juniper-${version}.zip";
+    sha256 = "10am6fribyl7742yk6ag0da4rld924jphxja30gynzqysly8j0vg";
+    stripRoot = false;
+  };
+
+  doCheck = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ mono ];
+
+  installPhase = ''
+    runHook preInstall
+    rm juniper # original script with regular Linux assumptions
+    mkdir -p $out/bin
+    cp -r ./* $out
+    makeWrapper ${mono}/bin/mono $out/bin/juniper \
+      --add-flags "$out/Juniper.exe \$@"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Functional reactive programming language for programming Arduino";
+    longDescription = ''
+      Juniper targets Arduino and supports many features typical of functional programming languages, including algebraic data types, tuples, records,
+      pattern matching, immutable data structures, parametric polymorphic functions, and anonymous functions (lambdas).
+      Some imperative programming concepts are also present in Juniper, such as for, while and do while loops, the ability to mark variables as mutable, and mutable references.
+    '';
+    homepage = "https://www.juniper-lang.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wunderbrick ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10560,6 +10560,8 @@ in
 
   javacard-devkit = pkgsi686Linux.callPackage ../development/compilers/javacard-devkit { };
 
+  juniper = callPackage ../development/compilers/juniper/default.nix { };
+
   julia_10 = callPackage ../development/compilers/julia/1.0.nix {
     gmp = gmp6;
     inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Juniper is a functional reactive programming language for programming Arduino.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
