### PR TITLE
pahole: 1.17 -> 1.20

### DIFF
--- a/pkgs/development/tools/misc/pahole/default.nix
+++ b/pkgs/development/tools/misc/pahole/default.nix
@@ -2,11 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "pahole";
-  version = "1.17";
+  version = "1.20";
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/devel/pahole/pahole.git";
     rev = "v${version}";
-    sha256 = "13dxsmhpf9n2wqggf4gd6f12rm0vhv0q96jd50gkvaxzzvgpzzbc";
+    sha256 = "11q9dpfi4qj2v8z0nlf8c0079mlv10ljhh0d1yr0j4ds3saacd15";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake ];
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://git.kernel.org/cgit/devel/pahole/pahole.git/";
     description = "Pahole and other DWARF utils";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
 
     platforms = platforms.linux;
     maintainers = [ maintainers.bosu ];


### PR DESCRIPTION
Also make fetchSubodules explicit, it is strictly required by pahole
build system until debian efforts to use system libbpf finish:
see https://www.spinics.net/lists/dwarves/msg00732.html

###### Motivation for this change
Simple update before trying to build linux with CONFIG_DEBUG_INFO_BTF

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - tested pahole
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
