### PR TITLE
python3Packages.hwi: 1.2.1 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/hwi/default.nix
+++ b/pkgs/development/python-modules/hwi/default.nix
@@ -7,27 +7,19 @@
 , libusb1
 , mnemonic
 , pyaes
-, pythonAtLeast
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "hwi";
-  version = "1.2.1";
-  disabled = pythonAtLeast "3.9";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "bitcoin-core";
     repo = "HWI";
     rev = version;
-    sha256 = "0fs3152lw7y5l9ssr5as8gd739m9lb7wxpv1vc5m77k5nw7l8ax5";
+    sha256 = "0m8maxhjpfxnkry2l0x8143m1gmds8mbwyd9flnkfipxz0r0xwbr";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'ecdsa>=0.13.0,<0.14.0'" "'ecdsa'" \
-      --replace "'hidapi>=0.7.99,<0.8.0'" "'hidapi'" \
-      --replace "'mnemonic>=0.18.0,<0.19.0'" "'mnemonic'"
-  '';
 
   propagatedBuildInputs = [
     bitbox02
@@ -36,6 +28,7 @@ buildPythonPackage rec {
     libusb1
     mnemonic
     pyaes
+    typing-extensions
   ];
 
   # tests require to clone quite a few firmwares


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

new major release

supersedes https://github.com/NixOS/nixpkgs/pull/116592

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
