### PR TITLE
renoise: fix installation

### DIFF
--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -54,7 +54,9 @@ stdenv.mkDerivation rec {
 
     # Desktop item icons
     mkdir -p $out/share/icons/hicolor/{48x48,64x64,128x128}/apps
-    cp Installer/renoise-{48,64,128}.png $out/share/icons/hicolor/{48x48,64x64,128x128}/apps/renoise.png
+    cp Installer/renoise-48.png $out/share/icons/hicolor/48x48/apps/renoise.png
+    cp Installer/renoise-64.png $out/share/icons/hicolor/64x64/apps/renoise.png
+    cp Installer/renoise-128.png $out/share/icons/hicolor/128x128/apps/renoise.png
   '';
 
   postFixup = ''


### PR DESCRIPTION
This fixes an error during installation of Renoise, introduced in 3d703d6307647339ed936ca04bdd4aec17f0ef61:

```
cp: target '/nix/store/g74p2csvj4vfv3rjdkvh8s8sjbi4qrid-renoise-3.3.1/share/icons/hicolor/128x128/apps/renoise.png' is not a directory
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
