### PR TITLE
irssi: fix GLib > 2.62 breaking input on nul byte

### DIFF
--- a/pkgs/applications/networking/irc/irssi/default.nix
+++ b/pkgs/applications/networking/irc/irssi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, ncurses, glib, openssl, perl, libintl, libgcrypt, libotr }:
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, ncurses, glib, openssl, perl, libintl, libgcrypt, libotr }:
 
 stdenv.mkDerivation rec {
   pname = "irssi";
@@ -7,6 +7,13 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://github.com/irssi/irssi/releases/download/${version}/${pname}-${version}.tar.gz";
     sha256 = "0g2nxazn4lszmd6mf1s36x5ablk4999g1qx7byrnvgnjsihjh62k";
+  };
+
+  # Fix irssi on GLib >2.62 input being stuck after entering a NUL byte
+  # See https://github.com/irssi/irssi/issues/1180 - remove after next update.
+  patches = fetchpatch {
+    url = "https://github.com/irssi/irssi/releases/download/1.2.2/glib-2-63.patch";
+    sha256 = "1ad1p7395n8dfmv97wrf751wwzgncqfh9fp27kq5kfdvh661da1i";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
See https://github.com/irssi/irssi/issues/1180 for rationale

###### Motivation for this change

It's not fun loosing all input all of a sudden for no apparent reason? (I just found out ctrl+space inputs a nul byte...)
Also debian bug report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=977335

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
