### PR TITLE
distrho-ports: 2020-07-14 -> 2021-03-15

### DIFF
--- a/pkgs/applications/audio/distrho/default.nix
+++ b/pkgs/applications/audio/distrho/default.nix
@@ -1,6 +1,8 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , alsaLib
 , fetchFromGitHub
+, fftwFloat
 , freetype
 , libGL
 , libX11
@@ -12,20 +14,24 @@
 , pkg-config
 }:
 
+let rpathLibs = [
+  fftwFloat
+];
+in
 stdenv.mkDerivation rec {
   pname = "distrho-ports";
-  version = "2020-07-14";
+  version = "2021-03-15";
 
   src = fetchFromGitHub {
     owner = "DISTRHO";
     repo = "DISTRHO-Ports";
     rev = version;
-    sha256 = "03ji41i6dpknws1vjwfxnl8c8bgisv2ng8xa4vqy2473k7wgdw4v";
+    sha256 = "00fgqwayd20akww3n2imyqscmyrjyc9jj0ar13k9dhpaxqk2jxbf";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja ];
 
-  buildInputs = [
+  buildInputs = rpathLibs ++ [
     alsaLib
     freetype
     libGL
@@ -35,6 +41,16 @@ stdenv.mkDerivation rec {
     libXrender
   ];
 
+  postFixup = ''
+    for file in \
+      "$out/lib/lv2/vitalium.lv2/vitalium.so" \
+      "$out/lib/vst/vitalium.so" \
+      "$out/lib/vst3/vitalium.vst3/Contents/x86_64-linux/vitalium.so"
+    do
+      patchelf --set-rpath "${lib.makeLibraryPath rpathLibs}:$(patchelf --print-rpath $file)" $file
+    done
+  '';
+
   meta = with lib; {
     homepage = "http://distrho.sourceforge.net/ports";
     description = "Linux audio plugins and LV2 ports";
@@ -42,6 +58,7 @@ stdenv.mkDerivation rec {
       Includes:
         arctican-function
         arctican-pilgrim
+        CHOW
         dexed
         drowaudio-distortion
         drowaudio-distortionshaper
@@ -61,6 +78,7 @@ stdenv.mkDerivation rec {
         pitchedDelay
         refine
         stereosourceseparation
+        Swanky Amp
         tal-dub-3
         tal-filter
         tal-filter-2
@@ -71,9 +89,10 @@ stdenv.mkDerivation rec {
         tal-vocoder-2
         temper
         vex
+        vitalium
         wolpertinger
     '';
-    license = with licenses; [ gpl2 gpl3 gpl2Plus lgpl3 mit ];
+    license = with licenses; [ gpl2Only gpl2Plus gpl3Only gpl3Plus lgpl2Only lgpl3Only mit ];
     maintainers = [ maintainers.goibhniu ];
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Distrho-ports now contains Vitalium, a port of Vital, which is a neat new wavetable synth.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
