### PR TITLE
teams: reorder arguments produced by wrapper

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -82,6 +82,11 @@ stdenv.mkDerivation rec {
       echo "Adding runtime dependencies to RPATH of Node module $mod"
       patchelf --set-rpath "$runtime_rpath:$mod_rpath" "$mod"
     done;
+
+    # fix for https://docs.microsoft.com/en-us/answers/questions/298724/open-teams-meeting-link-on-linux-doens39t-work.html?childToView=309406#comment-309406
+    # while we create the wrapper ourselves, gappsWrapperArgs leads to the same issue
+    # another option would be to introduce gappsWrapperAppendedArgs, to allow control of positioning
+    substituteInPlace "$out/bin/teams" --replace '.teams-wrapped"  --disable-namespace-sandbox --disable-setuid-sandbox "$@"' '.teams-wrapped" "$@" --disable-namespace-sandbox --disable-setuid-sandbox'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
this fixes launching meetings from links

substituteInPlace was chosen over amending the gAppsWrap function to avoid a possible mass rebuild

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

When Meeting links were clicked (e.g. in OWA) Teams would open, but not launch the meeting. This is a [known regression introduced by Teams upstream](https://docs.microsoft.com/en-us/answers/questions/298724/open-teams-meeting-link-on-linux-doens39t-work.html?childToView=309406#comment-309406).
This change add the workaround mention in the link above.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 116609"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
