### PR TITLE
xa: fix typo in derivation

### DIFF
--- a/pkgs/development/compilers/xa/xa.nix
+++ b/pkgs/development/compilers/xa/xa.nix
@@ -15,13 +15,12 @@ stdenv.mkDerivation rec {
   dontConfigure = true;
 
   postPatch = ''
-    substitueInPlace \
+    substituteInPlace Makefile \
       --replace "DESTDIR" "PREFIX" \
       --replace "CC = gcc" "CC = cc" \
       --replace "LDD = gcc" "LDD = ld" \
       --replace "CFLAGS = -O2" "CFLAGS ?=" \
       --replace "LDFLAGS = -lc" "LDFLAGS ?= -lc" \
-      Makefile
   '';
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This derivation would not build due to a typo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 116611"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
