### PR TITLE
pdfslicer: unvendor dependencies

### DIFF
--- a/pkgs/applications/misc/pdfslicer/default.nix
+++ b/pkgs/applications/misc/pdfslicer/default.nix
@@ -6,10 +6,14 @@
 , intltool
 , pkg-config
 , wrapGAppsHook
+, fmt
 , gtkmm3
 , libuuid
+, microsoft_gsl
 , poppler
 , qpdf
+, range-v3
+, spdlog
 }:
 
 stdenv.mkDerivation rec {
@@ -20,9 +24,12 @@ stdenv.mkDerivation rec {
     owner = "junrrein";
     repo = "pdfslicer";
     rev = "v${version}";
-    fetchSubmodules = true;
     sha256 = "0sja0ddd9c8wjjpzk2ag8q1lxpj09adgmhd7wnsylincqnj2jyls";
   };
+
+  patches = [
+    ./unvendor.patch
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -33,10 +40,14 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    fmt.dev
     gtkmm3
     libuuid
+    microsoft_gsl
     poppler
     qpdf
+    range-v3
+    spdlog.dev
   ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/pdfslicer/unvendor.patch
+++ b/pkgs/applications/misc/pdfslicer/unvendor.patch
@@ -1,0 +1,34 @@
+diff --git a/third-party/CMakeLists.txt b/third-party/CMakeLists.txt
+index 31fc934..16c2f42 100644
+--- a/third-party/CMakeLists.txt
++++ b/third-party/CMakeLists.txt
+@@ -1,13 +1,13 @@
+ add_subdirectory (adda25-threadpool)
+ add_subdirectory (catch2)
+-add_subdirectory (fmtlib)
+-add_subdirectory (GSL)
++find_package (fmt REQUIRED)
++find_package (Microsoft.GSL REQUIRED)
+ add_subdirectory (LouisCharlesC-safe)
+-add_subdirectory (spdlog)
++find_package (spdlog REQUIRED)
+ add_subdirectory (stduuid)
+ 
+ set (RANGE_V3_TESTS OFF)
+ set (RANGE_V3_EXAMPLES OFF)
+ set (RANGE_V3_PERF OFF)
+ set (RANGE_V3_HEADER_CHECKS OFF)
+-add_subdirectory (range-v3)
++find_package (range-v3 REQUIRED)
+diff --git a/third-party/stduuid/CMakeLists.txt b/third-party/stduuid/CMakeLists.txt
+index b785a64..db1eeb4 100644
+--- a/third-party/stduuid/CMakeLists.txt
++++ b/third-party/stduuid/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ add_library (stduuid INTERFACE)
+ target_include_directories (stduuid INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+-target_link_libraries (stduuid INTERFACE GSL)
++target_link_libraries (stduuid INTERFACE Microsoft.GSL)
+ 
+ # FIXME: In Apple platforms, we need to link against CoreFoundation
+ if (NOT WIN32)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
I get
```
CMake Error at cmake-modules/Utils.cmake:4 (get_target_property):
  get_target_property() called with non-existent target "range-v3".
Call Stack (most recent call first):
  src/backend/CMakeLists.txt:17 (target_link_libraries_system)


CMake Error at cmake-modules/Utils.cmake:4 (get_target_property):
  get_target_property() called with non-existent target
  "fmt::fmt-header-only".
Call Stack (most recent call first):
  src/CMakeLists.txt:16 (target_link_libraries_system)


CMake Error at cmake-modules/Utils.cmake:4 (get_target_property):
  get_target_property() called with non-existent target "spdlog".
Call Stack (most recent call first):
  src/CMakeLists.txt:16 (target_link_libraries_system)
```
Does someone know how to fix that?

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/115627#discussion_r590828838

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @strager @junrrein