### PR TITLE
wire-desktop: linux 3.22.2937 -> 3.23.2938, mac 3.21.3959 -> 3.23.4046

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -22,12 +22,12 @@ let
   pname = "wire-desktop";
 
   version = {
-    x86_64-darwin = "3.21.3959";
+    x86_64-darwin = "3.23.4046";
     x86_64-linux = "3.23.2938";
   }.${system} or throwSystem;
 
   sha256 = {
-    x86_64-darwin = "0fgzzqf1wnkjbcr0j0vjn6sggkz0z1kx6w4gi7gk4c4markdicm1";
+    x86_64-darwin = "19k8102chh4yphk89kiz83yarawnzdnsq0hbsqpjdhbmarqjcd9s";
     x86_64-linux = "1cx5azl5dvya1hf0gayafm4rg6ccmmq978xsgm6lf0rlb4kirj65";
   }.${system} or throwSystem;
 

--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -23,12 +23,12 @@ let
 
   version = {
     x86_64-darwin = "3.21.3959";
-    x86_64-linux = "3.22.2937";
+    x86_64-linux = "3.23.2938";
   }.${system} or throwSystem;
 
   sha256 = {
     x86_64-darwin = "0fgzzqf1wnkjbcr0j0vjn6sggkz0z1kx6w4gi7gk4c4markdicm1";
-    x86_64-linux = "1pl2dsrgckkd8mm0cpxrz8i8rn4jfx7b9lvdyc8392sbq4chjcb7";
+    x86_64-linux = "1cx5azl5dvya1hf0gayafm4rg6ccmmq978xsgm6lf0rlb4kirj65";
   }.${system} or throwSystem;
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump of both the linux and mac release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
