### PR TITLE
sphinx-autobuild: Use correct package

### DIFF
--- a/pkgs/development/python-modules/sphinx-autobuild/default.nix
+++ b/pkgs/development/python-modules/sphinx-autobuild/default.nix
@@ -24,6 +24,6 @@ buildPythonPackage rec {
     description = "Rebuild Sphinx documentation on changes, with live-reload in the browser";
     homepage = "https://github.com/executablebooks/sphinx-autobuild";
     license = with licenses; [ mit ];
-    maintainer = with maintainers; [holgerpeters];
+    maintainers = with maintainers; [holgerpeters];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7807,7 +7807,7 @@ in {
 
   sphinx-argparse = callPackage ../development/python-modules/sphinx-argparse { };
 
-  sphinx-autobuild = callPackage ../development/python-modules/sphinx-argparse { };
+  sphinx-autobuild = callPackage ../development/python-modules/sphinx-autobuild { };
 
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 


### PR DESCRIPTION
###### Motivation for this change

The `sphinx-autobuild` attribute wrongly points to `sphinx-argparse`. This causes sphinx-autobuild to not be installable. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
