### PR TITLE
[20.09] libetpan: Fix CVE-2020-15953

### DIFF
--- a/pkgs/development/libraries/libetpan/default.nix
+++ b/pkgs/development/libraries/libetpan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, fetchpatch
 , autoconf
 , automake
 , libtool
@@ -17,6 +17,28 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ libtool autoconf automake ];
+
+  patches = [
+    # The following two patches are fixing CVE-2020-15953, as reported in the
+    # issue tracker: https://github.com/dinhvh/libetpan/issues/386
+    # They might be removed for the next version bump.
+
+    # CVE-2020-15953: Detect extra data after STARTTLS response and exit
+    # https://github.com/dinhvh/libetpan/pull/387
+    (fetchpatch {
+      name = "cve-2020-15953-imap.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/1002a0121a8f5a9aee25357769807f2c519fa50b.patch";
+      sha256 = "1h9ds2z4jii40a0i3z6hsnzx1ldmd2jqidsxp2y2ksyp1ijcgabn";
+    })
+
+    # CVE-2020-15953: Detect extra data after STARTTLS responses in SMTP and POP3 and exit
+    # https://github.com/dinhvh/libetpan/pull/388
+    (fetchpatch {
+      name = "cve-2020-15953-pop3-smtp.patch";
+      url = "https://github.com/dinhvh/libetpan/commit/298460a2adaabd2f28f417a0f106cb3b68d27df9.patch";
+      sha256 = "0lq829djar7nb3fai3vdzirmks3w2lfagzqc809lx2lln6y213a0";
+    })
+  ];
 
   buildInputs = [ openssl ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #94733 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
