### PR TITLE
[20.09] ndpi: 2.8 -> 3.4

### DIFF
--- a/pkgs/development/libraries/ndpi/default.nix
+++ b/pkgs/development/libraries/ndpi/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, fetchFromGitHub, which, autoconf, automake, libtool, libpcap }:
+{ stdenv, fetchFromGitHub, which, autoconf, automake, libtool, libpcap
+, pkg-config }:
 
-let version = "2.8"; in
+let version = "3.4"; in
 
 stdenv.mkDerivation {
   pname = "ndpi";
@@ -10,13 +11,16 @@ stdenv.mkDerivation {
     owner = "ntop";
     repo = "nDPI";
     rev = version;
-    sha256 = "0lc4vga89pm954vf92g9fa6xwsjkb13jd6wrcc35zy5j04nf9rzf";
+    sha256 = "0xjh9gv0mq0213bjfs5ahrh6m7l7g99jjg8104c0pw54hz0p5pq1";
   };
 
   configureScript = "./autogen.sh";
 
   nativeBuildInputs = [which autoconf automake libtool];
-  buildInputs = [libpcap];
+  buildInputs = [
+    libpcap
+    pkg-config
+  ];
 
   meta = with stdenv.lib; {
     description = "A library for deep-packet inspection";


### PR DESCRIPTION
###### Motivation for this change

Fixes #92860 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
