### PR TITLE
vowpal-wabbit: init at 8.9.2 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4177,6 +4177,12 @@
     githubId = 175537;
     name = "Johannes Lötzsch";
   };
+  jackgerrits = {
+    email = "jack@jackgerrits.com";
+    github = "jackgerrits";
+    githubId = 7558482;
+    name = "Jack Gerrits";
+  };
   jagajaga = {
     email = "ars.seroka@gmail.com";
     github = "jagajaga";

--- a/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
+++ b/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv, fetchFromGitHub, cmake, boost169, rapidjson, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "vowpal-wabbit";
+  version = "8.9.2";
+
+  src = fetchFromGitHub {
+    owner = "VowpalWabbit";
+    repo = "vowpal_wabbit";
+    rev = version;
+    sha256 = "0ng1kip7sh3br85691xvszxd6lhv8nhfkgqkpwxd89wy85znzhmd";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    boost169
+    rapidjson
+    zlib
+  ];
+
+  # -DBUILD_TESTS=OFF is set as both it saves time in the build and the default
+  # cmake flags appended by the builder include -DBUILD_TESTING=OFF for which
+  # this is the equivalent flag.
+  cmakeFlags = [
+    "-DVW_INSTALL=ON"
+    "-DBUILD_TESTS=OFF"
+    "-DBUILD_JAVA=OFF"
+    "-DBUILD_PYTHON=OFF"
+    "-DUSE_LATEST_STD=ON"
+    "-DRAPIDJSON_SYS_DEP=ON"
+  ];
+
+  meta = with lib; {
+    broken = stdenv.isAarch32 || stdenv.isAarch64;
+    description = "Machine learning system focused on online reinforcement learning";
+    homepage = "https://github.com/VowpalWabbit/vowpal_wabbit/";
+    license = licenses.bsd3;
+    longDescription = ''
+      Machine learning system which pushes the frontier of machine learning with techniques such as online,
+      hashing, allreduce, reductions, learning2search, active, and interactive and reinforcement learning
+    '';
+    maintainers = with maintainers; [ jackgerrits ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3965,6 +3965,8 @@ in
 
   vorta = libsForQt5.callPackage ../applications/backup/vorta { };
 
+  vowpal-wabbit = callPackage ../applications/science/machine-learning/vowpal-wabbit { };
+
   utahfs = callPackage ../applications/networking/utahfs { };
 
   wakeonlan = callPackage ../tools/networking/wakeonlan { };


### PR DESCRIPTION
###### Motivation for this change

VowpalWabbit is an open source library and command line tool for reinforcement learning. See the [project repo](https://github.com/VowpalWabbit/vowpal_wabbit). I am one of the maintainers and would like to enable consuming the project through nix.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu 20.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
    - Note: there are none
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
