### PR TITLE
blucontrol-wrapper: init

### DIFF
--- a/pkgs/applications/misc/blucontrol/wrapper.nix
+++ b/pkgs/applications/misc/blucontrol/wrapper.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, makeWrapper, ghcWithPackages, packages ? (_:[]) }:
+let
+  blucontrolEnv = ghcWithPackages (self: [ self.blucontrol ] ++ packages self);
+in
+  stdenv.mkDerivation {
+    pname = "blucontrol-with-packages";
+    version = blucontrolEnv.version;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    buildCommand = ''
+      makeWrapper ${blucontrolEnv}/bin/blucontrol $out/bin/blucontrol \
+        --prefix PATH : ${lib.makeBinPath [ blucontrolEnv ]}
+    '';
+
+    # trivial derivation
+    preferLocalBuild = true;
+    allowSubstitues = false;
+
+    meta = with lib; {
+      description = "Configurable blue light filter";
+      longDescription = ''
+        This application is a blue light filter, with the main focus on configurability.
+        Configuration is done in Haskell in the style of xmonad.
+        Blucontrol makes use of monad transformers and allows monadic calculation of gamma values and recoloring. The user chooses, what will be captured in the monadic state.
+      '';
+      license = licenses.bsd3;
+      homepage = "https://github.com/jumper149/blucontrol";
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ jumper149 ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21653,6 +21653,10 @@ in
 
   blogc = callPackage ../applications/misc/blogc { };
 
+  blucontrol = callPackage ../applications/misc/blucontrol/wrapper.nix {
+    inherit (haskellPackages) ghcWithPackages;
+  };
+
   bluefish = callPackage ../applications/editors/bluefish {
     gtk = gtk3;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This wrapper is necessary for xmonad-like compiling.
`haskellPackages.blucontrol` can't access ghc.

###### Things done

I mainly used [xmonad-wrapper](https://github.com/NixOS/nixpkgs/blob/nixos-20.09/pkgs/applications/window-managers/xmonad/wrapper.nix) for inspiration.
In addition I put in meta information.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
