### PR TITLE
[staging] pythonPackages.python-dateutil: modernize expression

### DIFF
--- a/pkgs/development/python-modules/dateutil/default.nix
+++ b/pkgs/development/python-modules/dateutil/default.nix
@@ -1,4 +1,10 @@
-{ lib, buildPythonPackage, fetchPypi, six, setuptools_scm, pytest }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, six
+}:
+
 buildPythonPackage rec {
   pname = "python-dateutil";
   version = "2.8.1";
@@ -8,19 +14,27 @@ buildPythonPackage rec {
     sha256 = "73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c";
   };
 
-  checkInputs = [ pytest ];
-  propagatedBuildInputs = [ six setuptools_scm ];
+  nativeBuildInputs = [ setuptools-scm ];
 
-  checkPhase = ''
-    py.test dateutil/test
-  '';
+  propagatedBuildInputs = [ six ];
 
-  # Requires fixing
+  # cyclic dependency: tests need freezegun, which depends on python-dateutil
   doCheck = false;
+
+  pythonImportsCheck = [
+    "dateutil.easter"
+    "dateutil.parser"
+    "dateutil.relativedelta"
+    "dateutil.rrule"
+    "dateutil.tz"
+    "dateutil.utils"
+    "dateutil.zoneinfo"
+  ];
 
   meta = with lib; {
     description = "Powerful extensions to the standard datetime module";
-    homepage = "https://pypi.python.org/pypi/python-dateutil";
-    license = "BSD-style";
+    homepage = "https://github.com/dateutil/dateutil/";
+    license = with licenses; [ asl20 bsd3 ];
+    maintainers = with maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
