### PR TITLE
[20.09] go_1_16: backport to release-20.09

### DIFF
--- a/pkgs/development/compilers/go/1.16.nix
+++ b/pkgs/development/compilers/go/1.16.nix
@@ -1,0 +1,267 @@
+{ lib, stdenv, fetchurl, tzdata, iana-etc, runCommand
+, perl, which, pkg-config, patch, procps, pcre, cacert, Security, Foundation, xcbuild
+, mailcap, runtimeShell
+, buildPackages
+, pkgsBuildTarget
+, fetchpatch
+, callPackage
+}:
+
+let
+
+  inherit (lib) optionals optionalString;
+
+  version = "1.16.2";
+
+  go_bootstrap = buildPackages.callPackage ./bootstrap.nix { };
+
+  goBootstrap = runCommand "go-bootstrap" {} ''
+    mkdir $out
+    cp -rf ${go_bootstrap}/* $out/
+    chmod -R u+w $out
+    find $out -name "*.c" -delete
+    cp -rf $out/bin/* $out/share/go/bin/
+  '';
+
+  goarch = platform: {
+    "i686" = "386";
+    "x86_64" = "amd64";
+    "aarch64" = "arm64";
+    "arm" = "arm";
+    "armv5tel" = "arm";
+    "armv6l" = "arm";
+    "armv7l" = "arm";
+    "powerpc64le" = "ppc64le";
+  }.${platform.parsed.cpu.name} or (throw "Unsupported system");
+
+  # We need a target compiler which is still runnable at build time,
+  # to handle the cross-building case where build != host == target
+  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
+in
+
+stdenv.mkDerivation rec {
+  pname = "go";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://dl.google.com/go/go${version}.src.tar.gz";
+    sha256 = "1sl33wkhp6pi9f15f6khp5a7l7xwmpc3sp1zmji8pjr3g8l19jip";
+  };
+
+  # perl is used for testing go vet
+  nativeBuildInputs = [ perl which pkg-config patch procps ];
+  buildInputs = [ cacert pcre ]
+    ++ optionals stdenv.isLinux [ stdenv.cc.libc.out ]
+    ++ optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+  propagatedBuildInputs = optionals stdenv.isDarwin [ xcbuild ];
+
+  depsTargetTargetPropagated = optionals stdenv.isDarwin [ Security Foundation ];
+
+  hardeningDisable = [ "all" ];
+
+  prePatch = ''
+    patchShebangs ./ # replace /bin/bash
+
+    # This source produces shell script at run time,
+    # and thus it is not corrected by patchShebangs.
+    substituteInPlace misc/cgo/testcarchive/carchive_test.go \
+      --replace '#!/usr/bin/env bash' '#!${runtimeShell}'
+
+    # Patch the mimetype database location which is missing on NixOS.
+    # but also allow static binaries built with NixOS to run outside nix
+    sed -i 's,\"/etc/mime.types,"${mailcap}/etc/mime.types\"\,\n\t&,' src/mime/type_unix.go
+
+    # Disabling the 'os/http/net' tests (they want files not available in
+    # chroot builds)
+    rm src/net/{listen,parse}_test.go
+    rm src/syscall/exec_linux_test.go
+
+    # !!! substituteInPlace does not seems to be effective.
+    # The os test wants to read files in an existing path. Just don't let it be /usr/bin.
+    sed -i 's,/usr/bin,'"`pwd`", src/os/os_test.go
+    sed -i 's,/bin/pwd,'"`type -P pwd`", src/os/os_test.go
+    # Fails on aarch64
+    sed -i '/TestFallocate/aif true \{ return\; \}' src/cmd/link/internal/ld/fallocate_test.go
+    # Skip this test since ssl patches mess it up.
+    sed -i '/TestLoadSystemCertsLoadColonSeparatedDirs/aif true \{ return\; \}' src/crypto/x509/root_unix_test.go
+    # Disable another PIE test which breaks.
+    sed -i '/TestTrivialPIE/aif true \{ return\; \}' misc/cgo/testshared/shared_test.go
+    # Disable the BuildModePie test
+    sed -i '/TestBuildmodePIE/aif true \{ return\; \}' src/cmd/go/go_test.go
+    # Disable the unix socket test
+    sed -i '/TestShutdownUnix/aif true \{ return\; \}' src/net/net_test.go
+    # Disable the hostname test
+    sed -i '/TestHostname/aif true \{ return\; \}' src/os/os_test.go
+    # ParseInLocation fails the test
+    sed -i '/TestParseInSydney/aif true \{ return\; \}' src/time/format_test.go
+    # Remove the api check as it never worked
+    sed -i '/src\/cmd\/api\/run.go/ireturn nil' src/cmd/dist/test.go
+    # Remove the coverage test as we have removed this utility
+    sed -i '/TestCoverageWithCgo/aif true \{ return\; \}' src/cmd/go/go_test.go
+    # Remove the timezone naming test
+    sed -i '/TestLoadFixed/aif true \{ return\; \}' src/time/time_test.go
+    # Remove disable setgid test
+    sed -i '/TestRespectSetgidDir/aif true \{ return\; \}' src/cmd/go/internal/work/build_test.go
+    # Remove cert tests that conflict with NixOS's cert resolution
+    sed -i '/TestEnvVars/aif true \{ return\; \}' src/crypto/x509/root_unix_test.go
+    # TestWritevError hangs sometimes
+    sed -i '/TestWritevError/aif true \{ return\; \}' src/net/writev_test.go
+    # TestVariousDeadlines fails sometimes
+    sed -i '/TestVariousDeadlines/aif true \{ return\; \}' src/net/timeout_test.go
+
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
+
+    # Disable cgo lookup tests not works, they depend on resolver
+    rm src/net/cgo_unix_test.go
+
+  '' + optionalString stdenv.isLinux ''
+    # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
+    # that run outside a nix server
+    sed -i 's,\"/usr/share/zoneinfo/,"${tzdata}/share/zoneinfo/\"\,\n\t&,' src/time/zoneinfo_unix.go
+
+  '' + optionalString stdenv.isAarch32 ''
+    echo '#!${runtimeShell}' > misc/cgo/testplugin/test.bash
+  '' + optionalString stdenv.isDarwin ''
+    substituteInPlace src/race.bash --replace \
+      "sysctl machdep.cpu.extfeatures | grep -qv EM64T" true
+    sed -i 's,strings.Contains(.*sysctl.*,true {,' src/cmd/dist/util.go
+    sed -i 's,"/etc","'"$TMPDIR"'",' src/os/os_test.go
+    sed -i 's,/_go_os_test,'"$TMPDIR"'/_go_os_test,' src/os/path_test.go
+
+    sed -i '/TestChdirAndGetwd/aif true \{ return\; \}' src/os/os_test.go
+    sed -i '/TestCredentialNoSetGroups/aif true \{ return\; \}' src/os/exec/exec_posix_test.go
+    sed -i '/TestRead0/aif true \{ return\; \}' src/os/os_test.go
+    sed -i '/TestSystemRoots/aif true \{ return\; \}' src/crypto/x509/root_darwin_test.go
+
+    sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/aif true \{ return\; \}' src/cmd/go/go_test.go
+    sed -i '/TestBuildDashIInstallsDependencies/aif true \{ return\; \}' src/cmd/go/go_test.go
+
+    sed -i '/TestDisasmExtld/aif true \{ return\; \}' src/cmd/objdump/objdump_test.go
+
+    sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
+
+    # TestCurrent fails because Current is not implemented on Darwin
+    sed -i 's/TestCurrent/testCurrent/g' src/os/user/user_test.go
+    sed -i 's/TestLookup/testLookup/g' src/os/user/user_test.go
+
+    touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
+  '';
+
+  patches = [
+    ./remove-tools-1.11.patch
+    ./ssl-cert-file-1.16.patch
+    ./remove-test-pie-1.15.patch
+    ./creds-test.patch
+    ./go-1.9-skip-flaky-19608.patch
+    ./go-1.9-skip-flaky-20072.patch
+    ./skip-external-network-tests-1.16.patch
+    ./skip-nohup-tests.patch
+    ./skip-cgo-tests-1.15.patch
+    ./go_no_vendor_checks-1.16.patch
+  ] ++ [
+    # breaks under load: https://github.com/golang/go/issues/25628
+    (if stdenv.isAarch32
+    then ./skip-test-extra-files-on-aarch32-1.14.patch
+    else ./skip-test-extra-files-on-386-1.14.patch)
+  ];
+
+  postPatch = ''
+    find . -name '*.orig' -exec rm {} ';'
+  '';
+
+  GOOS = stdenv.targetPlatform.parsed.kernel.name;
+  GOARCH = goarch stdenv.targetPlatform;
+  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+  # Go will nevertheless build a for host system that we will copy over in
+  # the install phase.
+  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
+  GOHOSTARCH = goarch stdenv.buildPlatform;
+
+  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+  # to be different from CC/CXX
+  CC_FOR_TARGET = if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${targetCC}/bin/${targetCC.targetPrefix}cc"
+    else
+      null;
+  CXX_FOR_TARGET = if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${targetCC}/bin/${targetCC.targetPrefix}c++"
+    else
+      null;
+
+  GOARM = toString (lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
+  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
+  CGO_ENABLED = 1;
+  # Hopefully avoids test timeouts on Hydra
+  GO_TEST_TIMEOUT_SCALE = 3;
+
+  # Indicate that we are running on build infrastructure
+  # Some tests assume things like home directories and users exists
+  GO_BUILDER_NAME = "nix";
+
+  GOROOT_BOOTSTRAP="${goBootstrap}/share/go";
+
+  postConfigure = ''
+    export GOCACHE=$TMPDIR/go-cache
+    # this is compiled into the binary
+    export GOROOT_FINAL=$out/share/go
+
+    export PATH=$(pwd)/bin:$PATH
+
+    ${optionalString (stdenv.buildPlatform != stdenv.targetPlatform) ''
+    # Independent from host/target, CC should produce code for the building system.
+    # We only set it when cross-compiling.
+    export CC=${buildPackages.stdenv.cc}/bin/cc
+    ''}
+    ulimit -a
+  '';
+
+  postBuild = ''
+    (cd src && ./make.bash)
+  '';
+
+  doCheck = stdenv.hostPlatform == stdenv.targetPlatform && !stdenv.isDarwin;
+
+  checkPhase = ''
+    runHook preCheck
+    (cd src && HOME=$TMPDIR GOCACHE=$TMPDIR/go-cache ./run.bash --no-rebuild)
+    runHook postCheck
+  '';
+
+  preInstall = ''
+    rm -r pkg/obj
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  '' + (if (stdenv.buildPlatform != stdenv.hostPlatform) then ''
+    mv bin/*_*/* bin
+    rmdir bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOHOSTOS}_${GOHOSTARCH} pkg/tool/${GOHOSTOS}_${GOHOSTARCH}
+    ''}
+  '' else if (stdenv.hostPlatform != stdenv.targetPlatform) then ''
+    rm -rf bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOOS}_${GOARCH} pkg/tool/${GOOS}_${GOARCH}
+    ''}
+  '' else "");
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $GOROOT_FINAL
+    cp -a bin pkg src lib misc api doc $GOROOT_FINAL
+    ln -s $GOROOT_FINAL/bin $out/bin
+    runHook postInstall
+  '';
+
+  disallowedReferences = [ goBootstrap ];
+
+  meta = with lib; {
+    homepage = "http://golang.org/";
+    description = "The Go Programming language";
+    license = licenses.bsd3;
+    maintainers = teams.golang.members;
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/compilers/go/binary.nix
+++ b/pkgs/development/compilers/go/binary.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchurl, version, hashes }:
+let
+  toGoKernel = platform:
+    if platform.isDarwin then "darwin"
+    else platform.parsed.kernel.name;
+
+  toGoCPU = platform: {
+    "i686" = "386";
+    "x86_64" = "amd64";
+    "aarch64" = "arm64";
+    "armv6l" = "arm";
+    "armv7l" = "arm";
+    "powerpc64le" = "ppc64le";
+  }.${platform.parsed.cpu.name} or (throw "Unsupported CPU ${platform.parsed.cpu.name}");
+
+  toGoPlatform = platform: "${toGoKernel platform}-${toGoCPU platform}";
+
+  platform = toGoPlatform stdenv.hostPlatform;
+in
+stdenv.mkDerivation rec {
+  name = "go-${version}-${platform}-bootstrap";
+
+  src = fetchurl {
+    url = "https://golang.org/dl/go${version}.${platform}.tar.gz";
+    sha256 = hashes.${platform} or (throw "Missing Go bootstrap hash for platform ${platform}");
+  };
+
+  # We must preserve the signature on Darwin
+  dontStrip = stdenv.hostPlatform.isDarwin;
+
+  installPhase = ''
+    mkdir -p $out/share/go $out/bin
+    mv bin/* $out/bin
+    cp -r . $out/share/go
+    ${lib.optionalString stdenv.isLinux (''
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/bin/go
+    '')}
+  '' ;
+}

--- a/pkgs/development/compilers/go/bootstrap.nix
+++ b/pkgs/development/compilers/go/bootstrap.nix
@@ -1,0 +1,15 @@
+{ callPackage }:
+callPackage ./binary.nix {
+  version = "1.16";
+  hashes = {
+    # Use `print-hashes.sh ${version}` to generate the list below
+    darwin-amd64 = "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8";
+    darwin-arm64 = "4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810";
+    linux-386 = "ea435a1ac6d497b03e367fdfb74b33e961d813883468080f6e239b3b03bea6aa";
+    linux-amd64 = "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2";
+    linux-arm64 = "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098";
+    linux-armv6l = "d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd";
+    linux-ppc64le = "27a1aaa988e930b7932ce459c8a63ad5b3333b3a06b016d87ff289f2a11aacd6";
+    linux-s390x = "be4c9e4e2cf058efc4e3eb013a760cb989ddc4362f111950c990d1c63b27ccbe";
+  };
+}

--- a/pkgs/development/compilers/go/go_no_vendor_checks-1.16.patch
+++ b/pkgs/development/compilers/go/go_no_vendor_checks-1.16.patch
@@ -1,0 +1,23 @@
+Starting from go1.14, go verifes that vendor/modules.txt matches the requirements
+and replacements listed in the main module go.mod file, and it is a hard failure if
+vendor/modules.txt is missing.
+
+Relax module consistency checks and switch back to pre go1.14 behaviour if
+vendor/modules.txt is missing regardless of go version requirement in go.mod.
+
+This has been ported from FreeBSD: https://reviews.freebsd.org/D24122
+See https://github.com/golang/go/issues/37948 for discussion.
+
+diff --git a/src/cmd/go/internal/modload/vendor.go b/src/cmd/go/internal/modload/vendor.go
+index d8fd91f1fe..8bc08e6fed 100644
+--- a/src/cmd/go/internal/modload/vendor.go
++++ b/src/cmd/go/internal/modload/vendor.go
+@@ -133,7 +133,7 @@ func checkVendorConsistency() {
+ 	readVendorList()
+
+ 	pre114 := false
+-	if semver.Compare(index.goVersionV, "v1.14") < 0 {
++	if semver.Compare(index.goVersionV, "v1.14") < 0 || (os.Getenv("GO_NO_VENDOR_CHECKS") == "1" && len(vendorMeta) == 0) {
+ 		// Go versions before 1.14 did not include enough information in
+ 		// vendor/modules.txt to check for consistency.
+ 		// If we know that we're on an earlier version, relax the consistency check.

--- a/pkgs/development/compilers/go/skip-external-network-tests-1.16.patch
+++ b/pkgs/development/compilers/go/skip-external-network-tests-1.16.patch
@@ -1,0 +1,33 @@
+diff --git a/src/internal/testenv/testenv.go b/src/internal/testenv/testenv.go
+index c902b1404f..66016088a2 100644
+--- a/src/internal/testenv/testenv.go
++++ b/src/internal/testenv/testenv.go
+@@ -163,13 +163,15 @@ func MustHaveExecPath(t testing.TB, path string) {
+ // HasExternalNetwork reports whether the current system can use
+ // external (non-localhost) networks.
+ func HasExternalNetwork() bool {
+-	return !testing.Short() && runtime.GOOS != "js"
++	// Nix sandbox does not external network in sandbox
++	return false
+ }
+ 
+ // MustHaveExternalNetwork checks that the current system can use
+ // external (non-localhost) networks.
+ // If not, MustHaveExternalNetwork calls t.Skip with an explanation.
+ func MustHaveExternalNetwork(t testing.TB) {
++	t.Skipf("Nix sandbox does not have networking")
+ 	if runtime.GOOS == "js" {
+ 		t.Skipf("skipping test: no external network on %s", runtime.GOOS)
+ 	}
+diff --git a/src/net/dial_test.go b/src/net/dial_test.go
+index 57cf5554ad..d00be53b2c 100644
+--- a/src/net/dial_test.go
++++ b/src/net/dial_test.go
+@@ -990,6 +990,7 @@ func TestDialerControl(t *testing.T) {
+ // except that it won't skip testing on non-mobile builders.
+ func mustHaveExternalNetwork(t *testing.T) {
+ 	t.Helper()
++	t.Skipf("Nix sandbox does not have networking")
+ 	mobile := runtime.GOOS == "android" || runtime.GOOS == "ios"
+ 	if testenv.Builder() == "" || mobile {
+ 		testenv.MustHaveExternalNetwork(t)

--- a/pkgs/development/compilers/go/ssl-cert-file-1.16.patch
+++ b/pkgs/development/compilers/go/ssl-cert-file-1.16.patch
@@ -1,0 +1,34 @@
+diff --git a/src/crypto/x509/root.go b/src/crypto/x509/root.go
+index ac92915128..fb1d70c735 100644
+--- a/src/crypto/x509/root.go
++++ b/src/crypto/x509/root.go
+@@ -6,7 +6,11 @@ package x509
+ 
+ //go:generate go run root_ios_gen.go -version 55161.140.3
+ 
+-import "sync"
++import (
++	"io/ioutil"
++	"os"
++	"sync"
++)
+ 
+ var (
+ 	once           sync.Once
+@@ -20,6 +24,16 @@ func systemRootsPool() *CertPool {
+ }
+ 
+ func initSystemRoots() {
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots := NewCertPool()
++			roots.AppendCertsFromPEM(data)
++			systemRoots = roots
++			return
++		}
++	}
++
+ 	systemRoots, systemRootsErr = loadSystemRoots()
+ 	if systemRootsErr != nil {
+ 		systemRoots = nil

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9082,6 +9082,13 @@ in
     buildPackages = buildPackages // { stdenv = gcc8Stdenv; };
   });
 
+  go_1_16 = callPackage ../development/compilers/go/1.16.nix ({
+    inherit (darwin.apple_sdk.frameworks) Security Foundation;
+  } // lib.optionalAttrs (stdenv.cc.isGNU && stdenv.isAarch64) {
+    stdenv = gcc8Stdenv;
+    buildPackages = buildPackages // { stdenv = gcc8Stdenv; };
+  });
+
   go = go_1_15;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };
@@ -16099,6 +16106,9 @@ in
   buildGo115Package = callPackage ../development/go-packages/generic {
     go = buildPackages.go_1_15;
   };
+  buildGo116Package = callPackage ../development/go-packages/generic {
+    go = buildPackages.go_1_16;
+  };
 
   buildGoPackage = buildGo115Package;
 
@@ -16107,6 +16117,9 @@ in
   };
   buildGo115Module = callPackage ../development/go-modules/generic {
     go = buildPackages.go_1_15;
+  };
+  buildGo116Module = callPackage ../development/go-modules/generic {
+    go = buildPackages.go_1_16;
   };
 
   buildGoModule = buildGo115Module;


### PR DESCRIPTION
###### Motivation for this change
I can't be the only one that's had need for golang 1.16 on a stable base. Perhaps this isn't appropriate for merge for a branch that only has a couple of months to go, perhaps it is.

This is simply the state of `go_1_16` in `master` as of commit eecacdf3d8d58ccc689b7194d33a5ba53a7bdd79 squashed to a single commit. I initially started off cherry-picking and editing the various commits that had got it to that state, but the result was an ugly and confusing mess of nonsensical partial commits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
