### PR TITLE
sjasmplus: init at 1.18.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2725,6 +2725,12 @@
     githubId = 1753498;
     name = "Dejan Lukan";
   };
+  electrified = {
+    email = "ed@maidavale.org";
+    github = "electrified";
+    githubId = 103082;
+    name = "Ed Brindley";
+  };
   elliottvillars = {
     email = "elliottvillars@gmail.com";
     github = "elliottvillars";

--- a/pkgs/development/compilers/sjasmplus/default.nix
+++ b/pkgs/development/compilers/sjasmplus/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "sjasmplus";
+  version = "1.18.2";
+
+  src = fetchFromGitHub {
+    owner = "z00m128";
+    repo = "sjasmplus";
+    rev = "v${version}";
+    sha256 = "04348zcmc0b3crzwhvj1shx6f1n3x05vs8d5qdm7qhgdfki8r74v";
+  };
+
+  buildFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "CXX=${stdenv.cc.targetPrefix}c++"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D sjasmplus $out/bin/sjasmplus
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://z00m128.github.io/sjasmplus/";
+    description = "A Z80 assembly language cross compiler. It is based on the SjASM source code by Sjoerd Mastijn";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ electrified ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21103,6 +21103,8 @@ in
 
   shades-of-gray-theme = callPackage ../data/themes/shades-of-gray { };
 
+  sjasmplus = callPackage ../development/compilers/sjasmplus { };
+
   skeu = callPackage ../data/themes/skeu { };
 
   sweet = callPackage ../data/themes/sweet { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
sjasmplus is a popular Z80 assembler, used by people coding for "retro" platforms (e.g. Gameboy, Sega Master System, ZX Spectrum etc). It is maintained and under current development, with relatively frequent releases. I think it would be a good addition to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
