### PR TITLE
agda nixos test: fix hello world program

### DIFF
--- a/nixos/tests/agda.nix
+++ b/nixos/tests/agda.nix
@@ -3,8 +3,9 @@ import ./make-test-python.nix ({ pkgs, ... }:
 let
   hello-world = pkgs.writeText "hello-world" ''
     open import IO
+    open import Level
 
-    main = run(putStrLn "Hello World!")
+    main = run {0ℓ} (putStrLn "Hello World!")
   '';
 in
 {

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -1,6 +1,6 @@
 # Builder for Agda packages.
 
-{ stdenv, lib, self, Agda, runCommandNoCC, makeWrapper, writeText, mkShell, ghcWithPackages }:
+{ stdenv, lib, self, Agda, runCommandNoCC, makeWrapper, writeText, mkShell, ghcWithPackages, nixosTests }:
 
 with lib.strings;
 
@@ -18,7 +18,10 @@ let
   in runCommandNoCC "${pname}-${version}" {
     inherit pname version;
     nativeBuildInputs = [ makeWrapper ];
-    passthru.unwrapped = Agda;
+    passthru = {
+      unwrapped = Agda;
+      tests = { inherit (nixosTests) agda; };
+    };
   } ''
     mkdir -p $out/bin
     makeWrapper ${Agda}/bin/agda $out/bin/agda \

--- a/pkgs/development/libraries/agda/standard-library/default.nix
+++ b/pkgs/development/libraries/agda/standard-library/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitHub, ghcWithPackages }:
+{ lib, mkDerivation, fetchFromGitHub, ghcWithPackages, nixosTests }:
 
 mkDerivation rec {
   pname = "standard-library";
@@ -19,6 +19,7 @@ mkDerivation rec {
     rm EverythingSafe.agda EverythingSafeGuardedness.agda EverythingSafeSizedTypes.agda
   '';
 
+  passthru.tests = { inherit (nixosTests) agda; };
   meta = with lib; {
     homepage = "https://wiki.portal.chalmers.se/agda/pmwiki.php?n=Libraries.StandardLibrary";
     description = "A standard library for use with the Agda compiler";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Agda standard library recently changed some of it's IO library, meaning the old hello world program in the agda test no longer works. See https://github.com/NixOS/nixpkgs/issues/114787

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @turion 

P.S. are unicode characters allowed in nixpkgs?
