### PR TITLE
ocamlPackages.tcpip: 6.0.0 -> 6.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/tcpip/default.nix
+++ b/pkgs/development/ocaml-modules/tcpip/default.nix
@@ -1,5 +1,5 @@
 { lib, buildDunePackage, fetchurl
-, bisect_ppx, ppx_cstruct
+, bisect_ppx, ppx_cstruct, pkg-config
 , rresult, cstruct, cstruct-lwt, mirage-net, mirage-clock
 , mirage-random, mirage-stack, mirage-protocols, mirage-time
 , ipaddr, macaddr, macaddr-cstruct, mirage-profile, fmt
@@ -11,18 +11,23 @@
 
 buildDunePackage rec {
   pname = "tcpip";
-  version = "6.0.0";
+  version = "6.1.0";
 
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "0wbrs8jz1vw3zdrqmqcwawxh4yhc2gy30rw7gz4w116cblkvnb8s";
+    sha256 = "e81c98a6e80e05f9fa4e5fbee50e6c247f6011254c7b1d9a0e58bae318c1f0c8";
   };
+
+  patches = [
+    ./no-opam-pkg-config-path.patch
+  ];
 
   nativeBuildInputs = [
     bisect_ppx
     ppx_cstruct
+    pkg-config
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/tcpip/no-opam-pkg-config-path.patch
+++ b/pkgs/development/ocaml-modules/tcpip/no-opam-pkg-config-path.patch
@@ -1,0 +1,21 @@
+diff --git a/freestanding/Makefile b/freestanding/Makefile
+index f22d220d..4bb3ac57 100644
+--- a/freestanding/Makefile
++++ b/freestanding/Makefile
+@@ -1,6 +1,4 @@
+-PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
+-
+-EXISTS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists ocaml-freestanding; echo $$?)
++EXISTS := $(shell pkg-config --exists ocaml-freestanding; echo $$?)
+ 
+ .PHONY: all clean
+ all: libtcpip_freestanding_stubs.a
+@@ -10,7 +8,7 @@ libtcpip_freestanding_stubs.a:
+ 	touch $@
+ else
+ CC ?= cc
+-FREESTANDING_CFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags ocaml-freestanding)
++FREESTANDING_CFLAGS := $(shell pkg-config --cflags ocaml-freestanding)
+ CFLAGS := $(FREESTANDING_CFLAGS)
+ 
+ OBJS=checksum_stubs.o


### PR DESCRIPTION
<https://github.com/mirage/mirage-tcpip/releases/tag/v6.1.0>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
