### PR TITLE
solo5: install ocaml bindings for all targets that are enabled 

### DIFF
--- a/pkgs/os-specific/solo5/default.nix
+++ b/pkgs/os-specific/solo5/default.nix
@@ -1,6 +1,16 @@
 { lib, stdenv, fetchurl, pkg-config, libseccomp, util-linux, qemu }:
 
-let version = "0.6.8";
+let
+  version = "0.6.8";
+  # list of all theoretically available targets
+  targets = [
+    "genode"
+    "hvt"
+    "muen"
+    "spt"
+    "virtio"
+    "xen"
+  ];
 in stdenv.mkDerivation {
   pname = "solo5";
   inherit version;
@@ -29,9 +39,15 @@ in stdenv.mkDerivation {
     export DESTDIR=$out
     export PREFIX=$out
     make install-tools
-    ${lib.optionalString stdenv.hostPlatform.isLinux "make ${
-      (lib.concatMapStringsSep " " (x: "install-opam-${x}") [ "hvt" "spt" ])
-    }"}
+
+    # get CONFIG_* vars from Makeconf which also parse in sh
+    grep '^CONFIG_' Makeconf > nix_tmp_targetconf
+    source nix_tmp_targetconf
+    # install opam / pkg-config files for all enabled targets
+    ${lib.concatMapStrings (bind: ''
+      [ -n "$CONFIG_${lib.toUpper bind}" ] && make install-opam-${bind}
+    '') targets}
+
     runHook postInstall
   '';
 

--- a/pkgs/os-specific/solo5/default.nix
+++ b/pkgs/os-specific/solo5/default.nix
@@ -51,15 +51,14 @@ in stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  doCheck = true;
+  doCheck = stdenv.hostPlatform.isLinux;
   checkInputs = [ util-linux qemu ];
-  checkPhase = if stdenv.hostPlatform.isLinux then
-    ''
+  checkPhase = ''
+    runHook preCheck
     patchShebangs tests
     ./tests/bats-core/bats ./tests/tests.bats
-    ''
-  else
-    null;
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "Sandboxed execution environment";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change



Reuse the configuration generated by configure.sh to dynamically install
the bindings for all enabled targets. A bit of a hack grepping for the
respective lines in the Makeconf which incidentally also parse as shell.

Alternative would be to check for the target libs.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
