### PR TITLE
coqPackages: etc

### DIFF
--- a/doc/languages-frameworks/coq.section.md
+++ b/doc/languages-frameworks/coq.section.md
@@ -24,7 +24,7 @@ The recommended way of defining a derivation for a Coq library, is to use the `c
   * if `origin` is not `null`, it is used to set the final derivation `version`,
   * if `origin` is `null`, it is used exactly in the same way as `origin`, for backward compatibility reasons. This is discouraged and you will get a warning, unless the provided `version` matches exactly the computed one, which happens only when using a specific release,
   * if both `origin` and `version` are null, then `defaultVersion` is used.
-* `defaultVersion` (optional): Coq libraries may be compatible with some specific versions of Coq only. The `defaultVersion` attribute is used when no `version` or `origin` is provided (or if `version = origin = null`) to select the version of the library to use by default, depending on the context. This selection will mainly depend on a `coq` version number but also possibly on other packages versions (e.g. `mathcomp`). If its value ends up to be `null`, the package is marked for removal in end-user `coqPackages` attribute set.
+* `defaultVersion` (optional): Coq libraries may be compatible with some specific versions of Coq only. The `defaultVersion` attribute is used when `version` or `origin` are not provided (or set to `null`) to select the version of the library to use by default, depending on the context. This selection will mainly depend on a `coq` version number but also possibly on other packages versions (e.g. `mathcomp`). If its value ends up to be `null`, the package is marked for removal in end-user `coqPackages` attribute set.
 * `release` (optional, defaults to `{}`), lists all the known releases of the library and for each of them provides an attribute set with at least a `sha256` attribute (you may put the empty string `""` in order to automatically insert a fake sha256, this will trigger an error which will allow you to find the correct sha256), each attribute set of the list of releases also takes optional overloading arguments for the fetcher as below (i.e.`domain`, `owner`, `repo`, `rev` assuming the default fetcher is used) and optional overrides for the result of the fetcher (i.e. `version` and `src`).
 * `fetcher` (optional, defaults to a generic fetching mechanism supporting github or gitlab based infrastructures), is a function that takes at least an `owner`, a `repo`, a `rev`, and a `sha256` and returns an attribute set with a `version` and `src`.
 * `repo` (optional, defaults to the value of `pname`),
@@ -45,7 +45,7 @@ The recommended way of defining a derivation for a Coq library, is to use the `c
 
 It also takes other standard `mkDerivation` attributes, they are added as such, except for `meta` which extends an automatically computed `meta` (where the `platform` is the same as `coq` and the homepage is automatically computed).
 
-The builder `mkCoqDerivation` can also by applied to a function taking an attribute set and returning one. The main reason for using this feature is to get the version number as computed by `mkCoqDerivation`, as in:
+The builder `mkCoqDerivation` can also be applied to a function taking an attribute set and returning one. The main reason for using this feature is to get the version number as computed by `mkCoqDerivation`, as in:
 ```
 cat $(nix-build -E 'with import ./. {}; coqPackages.mkCoqDerivation (computed: {
   pname = "test"; src = mktemp; defaultVersion = "1.0";

--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -4,106 +4,112 @@ with builtins; with lib;
 let
   isGitHubDomain = d: match "^github.*" d != null;
   isGitLabDomain = d: match "^gitlab.*" d != null;
+  mk =
+  { pname,
+    version ? null,
+    origin ? null,
+    fetcher ? null,
+    owner ? "coq-community",
+    domain ? "github.com",
+    repo ? pname,
+    defaultVersion ? null,
+    releaseRev ? (v: v),
+    displayVersion ? {},
+    release ? {},
+    extraBuildInputs ? [],
+    namePrefix ? [],
+    enableParallelBuilding ? true,
+    extraInstallFlags ? [],
+    setCOQBIN ? true,
+    mlPlugin ? false,
+    useMelquiondRemake ? null,
+    dropAttrs ? [],
+    keepAttrs ? [],
+    dropDerivationAttrs ? [],
+    useDune2ifVersion ? (x: false),
+    useDune2 ? false,
+    ...
+  }@args:
+  let
+    args-to-remove = foldl (flip remove) ([
+      "version" "origin" "fetcher" "repo" "owner" "domain" "releaseRev"
+      "displayVersion" "defaultVersion" "useMelquiondRemake"
+      "release" "extraBuildInputs" "extraPropagatedBuildInputs" "namePrefix"
+      "meta" "useDune2ifVersion" "useDune2"
+      "extraInstallFlags" "setCOQBIN" "mlPlugin"
+      "dropAttrs" "dropDerivationAttrs" "keepAttrs" ] ++ dropAttrs) keepAttrs;
+    fetched = import ../coq/meta-fetch/default.nix
+      { inherit lib stdenv fetchzip; }
+      ({ inherit release releaseRev; combined = true;
+         location = { inherit domain owner repo; };
+      } // optionalAttrs (args?fetcher) {inherit fetcher;})
+      { inherit pname origin version defaultVersion; };
+    namePrefix = args.namePrefix or [ "coq" ];
+    display-pkg = n: sep: v:
+      let d = displayVersion.${n} or (if sep == "" then ".." else true); in
+      n + optionalString (v != "" && v != null) (switch d [
+        { case = true;       out = sep + v; }
+        { case = ".";        out = sep + versions.major v; }
+        { case = "..";       out = sep + versions.majorMinor v; }
+        { case = "...";      out = sep + versions.majorMinorPatch v; }
+        { case = isFunction; out = optionalString (d v != "") (sep + d v); }
+        { case = isString;   out = optionalString (d != "") (sep + d); }
+      ] "") + optionalString (v == null) "-broken";
+    append-version = p: n: p + display-pkg n "" coqPackages.${n}.version + "-";
+    prefix-name = foldl append-version "" namePrefix;
+    var-coqlib-install = (optionalString (versions.isGe "8.7" coq.coq-version) "COQMF_") + "COQLIB";
+    useDune2 = args.useDune2 or useDune2ifVersion fetched.version;
+  in
+
+  flip removeAttrs dropDerivationAttrs ({
+
+    name = prefix-name + (display-pkg pname "-" fetched.version);
+
+    inherit (fetched) version src;
+
+    buildInputs = [ coq ]
+      ++ optionals mlPlugin coq.ocamlBuildInputs
+      ++ optionals useDune2 [coq.ocaml coq.ocamlPackages.dune_2]
+      ++ extraBuildInputs;
+    inherit enableParallelBuilding;
+
+    meta = ({ platforms = coq.meta.platforms; } //
+      (switch domain [{
+          case = pred.union isGitHubDomain isGitLabDomain;
+          out = { homepage = "https://${domain}/${owner}/${repo}"; };
+        }] {}) //
+      optionalAttrs (fetched.broken or false) { coqFilter = true; broken = true; }) //
+      (args.meta or {}) ;
+
+  }
+  // (optionalAttrs setCOQBIN { COQBIN = "${coq}/bin/"; })
+  // (optionalAttrs (!args?installPhase && !args?useMelquiondRemake) {
+    installFlags =
+      [ "${var-coqlib-install}=$(out)/lib/coq/${coq.coq-version}/" ] ++
+      optional (match ".*doc$" (args.installTargets or "") != null)
+        "DOCDIR=$(out)/share/coq/${coq.coq-version}/" ++
+      extraInstallFlags;
+  })
+  // (optionalAttrs useDune2 {
+    installPhase = ''
+      runHook preInstall
+      dune install --prefix=$out
+      mv $out/lib/coq $out/lib/TEMPORARY
+      mkdir $out/lib/coq/
+      mv $out/lib/TEMPORARY $out/lib/coq/${coq.coq-version}
+      runHook postInstall
+    '';
+  })
+  // (optionalAttrs (args?useMelquiondRemake) rec {
+    COQUSERCONTRIB = "$out/lib/coq/${coq.coq-version}/user-contrib";
+    preConfigurePhases = "autoconf";
+    configureFlags = [ "--libdir=${COQUSERCONTRIB}/${useMelquiondRemake.logpath or ""}" ];
+    buildPhase = "./remake -j$NIX_BUILD_CORES";
+    installPhase = "./remake install";
+  })
+  // (removeAttrs args args-to-remove));
 in
-{ pname,
-  version ? null,
-  fetcher ? null,
-  owner ? "coq-community",
-  domain ? "github.com",
-  repo ? pname,
-  defaultVersion ? null,
-  releaseRev ? (v: v),
-  displayVersion ? {},
-  release ? {},
-  extraBuildInputs ? [],
-  namePrefix ? [],
-  enableParallelBuilding ? true,
-  extraInstallFlags ? [],
-  setCOQBIN ? true,
-  mlPlugin ? false,
-  useMelquiondRemake ? null,
-  dropAttrs ? [],
-  keepAttrs ? [],
-  dropDerivationAttrs ? [],
-  useDune2ifVersion ? (x: false),
-  useDune2 ? false,
-  ...
-}@args:
-let
-  args-to-remove = foldl (flip remove) ([
-    "version" "fetcher" "repo" "owner" "domain" "releaseRev"
-    "displayVersion" "defaultVersion" "useMelquiondRemake"
-    "release" "extraBuildInputs" "extraPropagatedBuildInputs" "namePrefix"
-    "meta" "useDune2ifVersion" "useDune2"
-    "extraInstallFlags" "setCOQBIN" "mlPlugin"
-    "dropAttrs" "dropDerivationAttrs" "keepAttrs" ] ++ dropAttrs) keepAttrs;
-  fetch = import ../coq/meta-fetch/default.nix
-    { inherit lib stdenv fetchzip; } ({
-      inherit release releaseRev;
-      location = { inherit domain owner repo; };
-    } // optionalAttrs (args?fetcher) {inherit fetcher;});
-  fetched = fetch (if !isNull version then version else defaultVersion);
-  namePrefix = args.namePrefix or [ "coq" ];
-  display-pkg = n: sep: v:
-    let d = displayVersion.${n} or (if sep == "" then ".." else true); in
-    n + optionalString (v != "" && v != null) (switch d [
-      { case = true;       out = sep + v; }
-      { case = ".";        out = sep + versions.major v; }
-      { case = "..";       out = sep + versions.majorMinor v; }
-      { case = "...";      out = sep + versions.majorMinorPatch v; }
-      { case = isFunction; out = optionalString (d v != "") (sep + d v); }
-      { case = isString;   out = optionalString (d != "") (sep + d); }
-    ] "") + optionalString (v == null) "-broken";
-  append-version = p: n: p + display-pkg n "" coqPackages.${n}.version + "-";
-  prefix-name = foldl append-version "" namePrefix;
-  var-coqlib-install = (optionalString (versions.isGe "8.7" coq.coq-version) "COQMF_") + "COQLIB";
-  useDune2 = args.useDune2 or useDune2ifVersion fetched.version;
-in
-
-stdenv.mkDerivation (removeAttrs ({
-
-  name = prefix-name + (display-pkg pname "-" fetched.version);
-
-  inherit (fetched) version src;
-
-  buildInputs = [ coq ]
-    ++ optionals mlPlugin coq.ocamlBuildInputs
-    ++ optionals useDune2 [coq.ocaml coq.ocamlPackages.dune_2]
-    ++ extraBuildInputs;
-  inherit enableParallelBuilding;
-
-  meta = ({ platforms = coq.meta.platforms; } //
-    (switch domain [{
-        case = pred.union isGitHubDomain isGitLabDomain;
-        out = { homepage = "https://${domain}/${owner}/${repo}"; };
-      }] {}) //
-    optionalAttrs (fetched.broken or false) { coqFilter = true; broken = true; }) //
-    (args.meta or {}) ;
-
-}
-// (optionalAttrs setCOQBIN { COQBIN = "${coq}/bin/"; })
-// (optionalAttrs (!args?installPhase && !args?useMelquiondRemake) {
-  installFlags =
-    [ "${var-coqlib-install}=$(out)/lib/coq/${coq.coq-version}/" ] ++
-    optional (match ".*doc$" (args.installTargets or "") != null)
-      "DOCDIR=$(out)/share/coq/${coq.coq-version}/" ++
-    extraInstallFlags;
-})
-// (optionalAttrs useDune2 {
-  installPhase = ''
-    runHook preInstall
-    dune install --prefix=$out
-    mv $out/lib/coq $out/lib/TEMPORARY
-    mkdir $out/lib/coq/
-    mv $out/lib/TEMPORARY $out/lib/coq/${coq.coq-version}
-    runHook postInstall
-  '';
-})
-// (optionalAttrs (args?useMelquiondRemake) rec {
-  COQUSERCONTRIB = "$out/lib/coq/${coq.coq-version}/user-contrib";
-  preConfigurePhases = "autoconf";
-  configureFlags = [ "--libdir=${COQUSERCONTRIB}/${useMelquiondRemake.logpath or ""}" ];
-  buildPhase = "./remake -j$NIX_BUILD_CORES";
-  installPhase = "./remake install";
-})
-// (removeAttrs args args-to-remove)) dropDerivationAttrs)
+args: stdenv.mkDerivation (switch args [
+  { case = isFunction; out = fix (x: mk (args x)); }
+  { case = isAttrs;    out = mk args; }
+] (throw "mkCoqDerivation: unsupported argments (must be set or set -> set)"))

--- a/pkgs/build-support/coq/meta-fetch/default.nix
+++ b/pkgs/build-support/coq/meta-fetch/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchzip }@args:
-let lib' = lib; in
-let lib = import ../extra-lib.nix {lib = lib';}; in
-with builtins; with lib;
+let lib' = import ../extra-lib.nix {inherit lib;}; in
+with builtins; with lib';
 let
   default-fetcher = {domain ? "github.com", owner ? "", repo, rev, name ? "source", sha256 ? null, ...}@args:
     let ext = if args?sha256 then "zip" else "tar.gz";
@@ -25,46 +24,73 @@ in
   location,
   release ? {},
   releaseRev ? (v: v),
+  combined ? false, # set combined to true return a meta-fetcher which
+                    # uses one of origin, version and defaultVersion
+                    # origin is used first, else version and otherwise defaultVersion
 }:
-let isVersion      = x: isString x && match "^/.*" x == null && release?${x};
-    shortVersion   = x: if (isString x && match "^/.*" x == null)
-      then findFirst (v: versions.majorMinor v == x) null
-        (sort versionAtLeast (attrNames release))
-      else null;
-    isShortVersion = x: shortVersion x != null;
-    isPathString   = x: isString x && match "^/.*" x != null && pathExists x; in
-arg:
-switch arg [
-  { case = isNull;       out = { version = "broken"; src = ""; broken = true; }; }
-  { case = isPathString; out = { version = "dev"; src = arg; }; }
-  { case = pred.union isVersion isShortVersion;
-    out = let v = if isVersion arg then arg else shortVersion arg; in
-      let
-        given-sha256 = release.${v}.sha256 or "";
-        sha256 = if given-sha256 == "" then lib.fakeSha256 else given-sha256;
-        rv = release.${v} // { inherit sha256; }; in
-      {
-        version = rv.version or v;
-        src = rv.src or fetcher (location // { rev = releaseRev v; } // rv);
-      };
-    }
-  { case = isString;
-    out = let
-        splitted  = filter isString (split ":" arg);
-        rev       = last splitted;
-        has-owner = length splitted > 1;
-        version   = "dev"; in {
-      inherit version;
-      src = fetcher (location // { inherit rev; } //
-        (optionalAttrs has-owner { owner = head splitted; }));
-    }; }
-  { case = isAttrs;
-    out = let
-    { version = arg.version or "dev";
-      src = (arg.fetcher or fetcher) (location // (arg.location or {}));
-    }; }
-  { case = isPath;
-    out = {
-      version = "dev" ;
-      src = builtins.path {path = arg; name = location.name or "source";}; }; }
-] (throw "not a valid source description")
+let
+  isVersion      = x: isString x && match "^/.*" x == null && release?${x};
+  shortVersion   = x: if (isString x && match "^/.*" x == null)
+                      then findFirst (v: versions.majorMinor v == x) null
+                             (sort versionAtLeast (attrNames release))
+                      else null;
+  isShortVersion = x: shortVersion x != null;
+  isPathString   = x: isString x && match "^/.*" x != null && pathExists x;
+  unNull = value: default: if !isNull value then value else default;
+
+  # it can be convenient to provide a combination of
+  # origin, version and defaultVersion
+  combine = {origin ? null, version ? null, defaultVersion ? null, pname ? ""}:
+    let fetched = fetch (unNull origin (unNull version defaultVersion)); in {
+      inherit (fetched) src;
+      version = switch-if [
+        { cond = !isNull origin && !isNull version; out = version; }
+        { cond =  isNull origin && !isNull version;
+          out = (if version == fetched.version || isNull version then (x: x) else
+            warn (optionalString (pname != "") "while building ${pname}" + ''
+              using `version` without `origin` is deprecated except for releases,
+              please use `origin` instead of `version`.
+            '')) fetched.version; }
+        ] fetched.version;
+    } // optionalAttrs (fetched.broken or false) { inherit (fetched) broken; };
+
+  # main function, with only one argument
+  fetch = origin: switch origin [
+    { case = isNull;       out = { version = "broken"; src = ""; broken = true; }; }
+    { case = isPathString; out = { version = "999"; src = origin; }; }
+    { case = pred.union isVersion isShortVersion;
+      out = let v = if isVersion origin then origin else shortVersion origin; in
+        let
+          given-sha256 = release.${v}.sha256 or "";
+          sha256 = if given-sha256 == "" then lib.fakeSha256 else given-sha256;
+          rv = release.${v} // { inherit sha256; }; in
+        {
+          version = rv.version or v;
+          src = rv.src or fetcher (location // { rev = releaseRev v; } // rv);
+        };
+      }
+    { case = isString;
+      out = let
+          # syntax: "[owner[/repo]:]rev" where brackets denote optionals
+          ownerRepo-rev = filter isString (split ":" origin);
+          owner-repo    = filter isString (split "/" (head ownerRepo-rev));
+          rev           = last ownerRepo-rev;
+          has-ownerRepo = length ownerRepo-rev > 1;
+          has-repo      = has-ownerRepo && length owner-repo > 1;
+          version       = "999"; in {
+        inherit version;
+        src = fetcher (location // { inherit rev; }
+          // (optionalAttrs has-ownerRepo { owner = head owner-repo; })
+          // (optionalAttrs has-repo      { repo  = last owner-repo; }));
+      }; }
+    { case = isAttrs;
+      out = let
+      { version = origin.version or "999";
+        src = (origin.fetcher or fetcher) (location // (origin.location or {}));
+      }; }
+    { case = isPath;
+      out = {
+        version = "999" ;
+        src = builtins.path {path = origin; name = location.name or "source";}; }; }
+  ] (throw "not a valid source description");
+in if combined then combine else fetch

--- a/pkgs/development/coq-modules/Cheerios/default.nix
+++ b/pkgs/development/coq-modules/Cheerios/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, StructTact, version ? null }:
+{ lib, mkCoqDerivation, coq, StructTact, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname   = "cheerios";
   owner   = "uwplse";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.isGe "8.6" coq.coq-version then "20200201" else null;
   release."20200201".rev    = "9c7f66e57b91f706d70afa8ed99d64ed98ab367d";
   release."20200201".sha256 = "1h55s6lk47bk0lv5ralh81z55h799jbl9mhizmqwqzy57y8wqgs1";

--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, bignums, version ? null }:
+{ lib, mkCoqDerivation, coq, bignums, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "color";
   owner = "fblanqui";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     {case = range "8.12" "8.13"; out = "1.8.1"; }
     {case = range "8.10" "8.11"; out = "1.7.0"; }

--- a/pkgs/development/coq-modules/HoTT/default.nix
+++ b/pkgs/development/coq-modules/HoTT/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, autoconf, automake, coq, version ? null }:
+{ lib, mkCoqDerivation, autoconf, automake, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "HoTT";
   owner = "HoTT";
-  inherit version;
+  inherit version origin;
   defaultVersion = if coq.coq-version == "8.6" then "20170921" else null;
   release."20170921".rev    = "e3557740a699167e6adb1a65855509d55a392fa1";
   release."20170921".sha256 = "0zwfp8g62b50vmmbb2kmskj3v6w7qx1pbf43yw0hr7asdz2zbx5v";

--- a/pkgs/development/coq-modules/ITree/default.nix
+++ b/pkgs/development/coq-modules/ITree/default.nix
@@ -1,9 +1,10 @@
-{ lib, mkCoqDerivation, coq, version ? null , paco, coq-ext-lib }:
+{ lib, mkCoqDerivation, coq, paco, coq-ext-lib
+  , version ? null, origin ? null}:
 
 with lib; mkCoqDerivation rec {
   pname = "InteractionTrees";
   owner = "DeepSpec";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = range "8.10" "8.13";  out = "4.0.0"; }
   ] null;

--- a/pkgs/development/coq-modules/InfSeqExt/default.nix
+++ b/pkgs/development/coq-modules/InfSeqExt/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 mkCoqDerivation {
   pname = "InfSeqExt";
   owner = "DistributedComponents";
-  inherit version;
+  inherit version origin;
   defaultVersion = if lib.versions.isGe "8.5" coq.coq-version then "20200131" else null;
   release."20200131".rev    = "203d4c20211d6b17741f1fdca46dbc091f5e961a";
   release."20200131".sha256 = "0xylkdmb2dqnnqinf3pigz4mf4zmczcbpjnn59g5g76m7f2cqxl0";

--- a/pkgs/development/coq-modules/StructTact/default.nix
+++ b/pkgs/development/coq-modules/StructTact/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "StructTact";
   owner = "uwplse";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.isGe "8.5" coq.coq-version then "20181102" else null;
   release."20181102".rev =    "82a85b7ec07e71fa6b30cfc05f6a7bfb09ef2510";
   release."20181102".sha256 = "08zry20flgj7qq37xk32kzmg4fg6d4wi9m7pf9aph8fd3j2a0b5v";

--- a/pkgs/development/coq-modules/VST/default.nix
+++ b/pkgs/development/coq-modules/VST/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, coq, compcert, version ? null }:
+{ lib, mkCoqDerivation, coq, compcert, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "coq${coq.coq-version}-VST";
@@ -6,7 +6,7 @@ with lib; mkCoqDerivation {
   displayVersion = { coq = false; };
   owner = "PrincetonUniversity";
   repo = "VST";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = range "8.12" "8.13"; out = "2.7.1"; }
     { case = "8.11"; out = "2.6"; }

--- a/pkgs/development/coq-modules/Velisarios/default.nix
+++ b/pkgs/development/coq-modules/Velisarios/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "Velisarios";
   owner = "vrahli";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.range "8.6" "8.8" coq.coq-version then "20180221" else null;
 
   release."20180221".rev    = "e1eee1f10d5d46331a560bd8565ac101229d0d6b";

--- a/pkgs/development/coq-modules/Verdi/default.nix
+++ b/pkgs/development/coq-modules/Verdi/default.nix
@@ -1,10 +1,10 @@
-{ lib, mkCoqDerivation, coq, Cheerios, InfSeqExt, ssreflect, version ? null }:
+{ lib, mkCoqDerivation, coq, Cheerios, InfSeqExt, ssreflect, version ? null, origin ? null }:
 
 
 with lib; mkCoqDerivation {
   pname = "verdi";
   owner = "uwplse";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.7"; out = "20200131"; }
     { case = isEq "8.6"; out = "20181102"; }

--- a/pkgs/development/coq-modules/autosubst/default.nix
+++ b/pkgs/development/coq-modules/autosubst/default.nix
@@ -1,15 +1,18 @@
-{ lib, mkCoqDerivation, coq, mathcomp-ssreflect, version ? null }:
+{ lib, mkCoqDerivation, coq, mathcomp-ssreflect,
+  version ? null, origin ? null }:
 with lib;
 
 mkCoqDerivation {
-  pname = "autosubst";
+  pname   = "autosubst";
+  owner   = "uds-psl";
+  inherit version origin;
 
   release."1.7".rev    = "v1.7";
   release."1.7".sha256 = "sha256-qoyteQ5W2Noxf12uACOVeHhPLvgmTzrvEo6Ts+FKTGI=";
 
-  inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = isGe "8.10"; out = "1.7"; }
+    { case = isGe "8.10";       out = "1.7"; }
+    { case = range "8.5" "8.7"; out = "5b40a32e"; }
   ] null;
 
   propagatedBuildInputs = [ mathcomp-ssreflect ];

--- a/pkgs/development/coq-modules/autosubst/default.nix
+++ b/pkgs/development/coq-modules/autosubst/default.nix
@@ -4,7 +4,6 @@ with lib;
 
 mkCoqDerivation {
   pname   = "autosubst";
-  owner   = "uds-psl";
   inherit version origin;
 
   release."1.7".rev    = "v1.7";

--- a/pkgs/development/coq-modules/bignums/default.nix
+++ b/pkgs/development/coq-modules/bignums/default.nix
@@ -1,10 +1,10 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "bignums";
   owner = "coq";
   displayVersion = { bignums = ""; };
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.isGe "8.5" coq.coq-version
     then "${coq.coq-version}.0" else null;
 

--- a/pkgs/development/coq-modules/category-theory/default.nix
+++ b/pkgs/development/coq-modules/category-theory/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, coq, ssreflect, equations, version ? null }:
+{ lib, mkCoqDerivation, coq, ssreflect, equations, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
 
@@ -10,7 +10,7 @@ with lib; mkCoqDerivation {
   release."20180709".rev    = "3b9ba7b26a64d49a55e8b6ccea570a7f32c11ead";
   release."20180709".sha256 = "0f2nr8dgn1ab7hr7jrdmr1zla9g9h8216q4yf4wnff9qkln8sbbs";
 
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = range "8.8" "8.9"; out = "20190414"; }
     { case = range "8.6" "8.7"; out = "20180709"; }

--- a/pkgs/development/coq-modules/contribs/default.nix
+++ b/pkgs/development/coq-modules/contribs/default.nix
@@ -1,8 +1,8 @@
 { lib, mkCoqDerivation, coq, callPackage }:
 
 with lib; let mkContrib = pname: coqs: param:
-  let contribVersion = {version ? null}: mkCoqDerivation ({
-      inherit pname version;
+  let contribVersion = {version ? null, origin ? null}: mkCoqDerivation ({
+      inherit pname version origin;
       owner = "coq-contribs";
       mlPlugin = true;
     } // optionalAttrs (builtins.elem coq.coq-version coqs) ({

--- a/pkgs/development/coq-modules/coq-bits/default.nix
+++ b/pkgs/development/coq-modules/coq-bits/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, mathcomp, version ? null }:
+{ lib, mkCoqDerivation, coq, mathcomp, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "coq-bits";
   repo = "bits";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.isGe "8.7" coq.version then "20190812" else null;
 
   release."20190812".rev    = "1.0.0";

--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, which, coq, version ? null }:
+{ lib, mkCoqDerivation, which, coq, version ? null, origin ? null }:
 
 with builtins; with lib; let
   elpi = coq.ocamlPackages.elpi.override (lib.switch coq.coq-version [
@@ -10,7 +10,7 @@ in mkCoqDerivation {
   pname = "elpi";
   repo  = "coq-elpi";
   owner = "LPCIC";
-  inherit version;
+  inherit version origin;
   defaultVersion = lib.switch coq.coq-version [
     { case = "8.13"; out = "1.10.1"; }
     { case = "8.12"; out = "1.8.3_8.12"; }

--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation rec {
   pname = "coq-ext-lib";
   owner = "coq-ext-lib";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = range "8.8" "8.13"; out = "0.11.3"; }
     { case = "8.7";              out = "0.9.7"; }

--- a/pkgs/development/coq-modules/coq-haskell/default.nix
+++ b/pkgs/development/coq-modules/coq-haskell/default.nix
@@ -1,10 +1,10 @@
-{ lib, mkCoqDerivation, coq, ssreflect, version ? null }:
+{ lib, mkCoqDerivation, coq, ssreflect, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
 
   pname = "coq-haskell";
   owner = "jwiegley";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.range "8.5" "8.8" coq.coq-version then "20171215" else null;
   release."20171215".rev    = "e2cf8b270c2efa3b56fab1ef6acc376c2c3de968";
   release."20171215".sha256 = "09dq1vvshhlhgjccrhqgbhnq2hrys15xryfszqq11rzpgvl2zgdv";

--- a/pkgs/development/coq-modules/coqeal/default.nix
+++ b/pkgs/development/coq-modules/coqeal/default.nix
@@ -1,11 +1,11 @@
 { coq, mkCoqDerivation, mathcomp, bignums, paramcoq, multinomials,
-  lib, which, version ? null }:
+  lib, which, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
 
   pname = "CoqEAL";
   owner = "CoqEAL";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch [ coq.version mathcomp.version ]  [
       { cases = [ (isGe "8.10") (range "1.11.0" "1.12.0") ]; out = "1.0.5"; }
       { cases = [ (isGe "8.7") "1.11.0" ]; out = "1.0.4"; }

--- a/pkgs/development/coq-modules/coqhammer/default.nix
+++ b/pkgs/development/coq-modules/coqhammer/default.nix
@@ -1,7 +1,7 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
-  inherit version;
+  inherit version origin;
   pname = "coqhammer";
   owner = "lukaszcz";
   defaultVersion = with versions; switch coq.coq-version [

--- a/pkgs/development/coq-modules/coqprime/default.nix
+++ b/pkgs/development/coq-modules/coqprime/default.nix
@@ -1,10 +1,10 @@
-{ which, lib, mkCoqDerivation, coq, bignums, version ? null }:
+{ which, lib, mkCoqDerivation, coq, bignums, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
 
   pname = "coqprime";
   owner = "thery";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = range "8.12" "8.13"; out = "8.12"; }
     { case = range "8.10" "8.11"; out = "8.10"; }

--- a/pkgs/development/coq-modules/coqtail-math/default.nix
+++ b/pkgs/development/coq-modules/coqtail-math/default.nix
@@ -1,11 +1,11 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib;
 
 mkCoqDerivation {
   pname = "coqtail-math";
   owner = "coq-community";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.range "8.11" "8.13" coq.coq-version then "20201124" else null;
   release."20201124".rev    = "5c22c3d7dcd8cf4c47cf84a281780f5915488e9e";
   release."20201124".sha256 = "sha256-wd+Lh7dpAD4zfpyKuztDmSFEZo5ZiFrR8ti2jUCVvoQ=";

--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -1,11 +1,11 @@
 { lib, mkCoqDerivation, which, autoconf,
-  coq, ssreflect, version ? null }:
+  coq, ssreflect, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "coquelicot";
   owner = "coquelicot";
   domain = "gitlab.inria.fr";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.8" ;        out = "3.2.0"; }
     { case = range "8.8" "8.13"; out = "3.1.0"; }

--- a/pkgs/development/coq-modules/corn/default.nix
+++ b/pkgs/development/coq-modules/corn/default.nix
@@ -1,8 +1,8 @@
-{ lib, mkCoqDerivation, coq, bignums, math-classes, version ? null }:
+{ lib, mkCoqDerivation, coq, bignums, math-classes, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation rec {
   pname = "corn";
-  inherit version;
+  inherit version origin;
   defaultVersion = switch coq.coq-version [
     { case = "8.6"; out = "8.8.1"; }
     { case = (versions.range "8.7" "8.12"); out = "8.12.0"; }

--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, autoreconfHook, coq, version ? null }:
+{ lib, mkCoqDerivation, autoreconfHook, coq, version ? null, origin ? null }:
 
 with lib;
 let hasWarning = versionAtLeast coq.ocamlPackages.ocaml.version "4.08"; in
@@ -7,7 +7,7 @@ mkCoqDerivation {
   pname = "dpdgraph";
   owner = "Karmaki";
   repo = "coq-dpdgraph";
-  inherit version;
+  inherit version origin;
   defaultVersion = switch coq.coq-version [
     { case = "8.13"; out = "0.6.9"; }
     { case = "8.12"; out = "0.6.8"; }

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -1,10 +1,10 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "equations";
   owner = "mattam82";
   repo = "Coq-Equations";
-  inherit version;
+  inherit version origin;
   defaultVersion = switch coq.coq-version [
     { case = "8.13"; out = "1.2.4+coq8.13"; }
     { case = "8.12"; out = "1.2.4+coq8.12"; }

--- a/pkgs/development/coq-modules/fiat/HEAD.nix
+++ b/pkgs/development/coq-modules/fiat/HEAD.nix
@@ -1,11 +1,11 @@
-{lib, mkCoqDerivation, coq, python27, version ? null }:
+{lib, mkCoqDerivation, coq, python27, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation rec {
   pname = "fiat";
   owner = "mit-plv";
   repo = "fiat";
   displayVersion = { fiat = v: "unstable-${v}"; };
-  inherit version;
+  inherit version origin;
   defaultVersion = if coq.coq-version == "8.5" then "2016-10-24" else null;
   release."2016-10-24".rev    = "7feb6c64be9ebcc05924ec58fe1463e73ec8206a";
   release."2016-10-24".sha256 = "0griqc675yylf9rvadlfsabz41qy5f5idya30p5rv6ysiakxya64";

--- a/pkgs/development/coq-modules/flocq/default.nix
+++ b/pkgs/development/coq-modules/flocq/default.nix
@@ -1,11 +1,11 @@
 { lib, bash, which, autoconf, automake,
-  mkCoqDerivation, coq, version ? null }:
+  mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "flocq";
   owner = "flocq";
   domain = "gitlab.inria.fr";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.7";        out = "3.3.1"; }
     { case = range "8.5" "8.8"; out = "2.6.1"; }

--- a/pkgs/development/coq-modules/fourcolor/default.nix
+++ b/pkgs/development/coq-modules/fourcolor/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, coq, mathcomp, version ? null }:
+{ lib, mkCoqDerivation, coq, mathcomp, version ? null, origin ? null }:
 with lib;
 
 mkCoqDerivation {
@@ -8,7 +8,7 @@ mkCoqDerivation {
   release."1.2.3".rev    = "v1.2.3";
   release."1.2.3".sha256 = "sha256-gwKfUa74fIP7j+2eQgnLD7AswjCtOFGHGaIWb4qI0n4=";
 
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch mathcomp.version [
     { case = pred.inter (isGe "1.11.0") (isLt "1.13"); out = "1.2.3"; }
   ] null;

--- a/pkgs/development/coq-modules/gappalib/default.nix
+++ b/pkgs/development/coq-modules/gappalib/default.nix
@@ -1,11 +1,11 @@
-{ which, lib, mkCoqDerivation, autoconf, coq, flocq, version ? null }:
+{ which, lib, mkCoqDerivation, autoconf, coq, flocq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "gappalib";
   repo = "coq";
   owner = "gappa";
   domain = "gitlab.inria.fr";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.isGe "8.8" coq.coq-version then "1.4.5" else null;
   release."1.4.5".sha256 = "081hib1d9wfm29kis390qsqch8v6fs3q71g2rgbbzx5y5cf48n9k";
   release."1.4.4".sha256 = "114q2hgw64j6kqa9mg3qcp1nlf0ia46z2xadq81fnkxqm856ml7l";

--- a/pkgs/development/coq-modules/goedel/default.nix
+++ b/pkgs/development/coq-modules/goedel/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, coq, hydra-battles, pocklington, version ? null }:
+{ lib, mkCoqDerivation, coq, hydra-battles, pocklington, version ? null, origin ? null }:
 with lib;
 
 mkCoqDerivation {
@@ -8,7 +8,7 @@ mkCoqDerivation {
   release."8.12.0".rev    = "v8.12.0";
   release."8.12.0".sha256 = "sha256-4lAwWFHGUzPcfHI9u5b+N+7mQ0sLJ8bH8beqQubfFEQ=";
 
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.11"; out = "8.12.0"; }
   ] null;

--- a/pkgs/development/coq-modules/heq/default.nix
+++ b/pkgs/development/coq-modules/heq/default.nix
@@ -1,11 +1,11 @@
-{lib, fetchzip, mkCoqDerivation, coq, version ? null }:
+{lib, fetchzip, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "heq";
   repo = "Heq";
   owner = "gil";
   domain = "mpi-sws.org";
-  inherit version fetcher;
+  inherit version origin fetcher;
   defaultVersion = if versions.isLt "8.8" coq.coq-version then "0.92" else null;
   release."0.92".sha256 = "0cf8y6728n81wwlbpq3vi7l2dbzi7759klypld4gpsjjp1y1fj74";
 

--- a/pkgs/development/coq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/coq-modules/hierarchy-builder/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, which, coq, coq-elpi, version ? null }:
+{ lib, mkCoqDerivation, which, coq, coq-elpi, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "hierarchy-builder";
   owner = "math-comp";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.12";         out = "1.0.0"; }
     { case = range "8.11" "8.12"; out = "0.10.0"; }

--- a/pkgs/development/coq-modules/hydra-battles/default.nix
+++ b/pkgs/development/coq-modules/hydra-battles/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, coq, mathcomp, equations, paramcoq, version ? null }:
+{ lib, mkCoqDerivation, coq, mathcomp, equations, paramcoq, version ? null, origin ? null }:
 with lib;
 
 mkCoqDerivation {
@@ -8,7 +8,7 @@ mkCoqDerivation {
   release."0.3".rev    = "v0.3";
   release."0.3".sha256 = "sha256-rXP/vJqVEg2tN/I9LWV13YQ1+C7M6lzGu3oI+7pSZzg=";
 
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.11"; out = "0.3"; }
   ] null;

--- a/pkgs/development/coq-modules/interval/default.nix
+++ b/pkgs/development/coq-modules/interval/default.nix
@@ -1,10 +1,11 @@
-{ lib, mkCoqDerivation, which, autoconf, coq, coquelicot, flocq, bignums ? null, version ? null }:
+{ lib, mkCoqDerivation, which, autoconf, coq, coquelicot, flocq
+, bignums ? null, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "interval";
   owner = "coqinterval";
   domain = "gitlab.inria.fr";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.8" ;        out = "4.1.1"; }
     { case = range "8.8" "8.12"; out = "4.0.0"; }

--- a/pkgs/development/coq-modules/iris/default.nix
+++ b/pkgs/development/coq-modules/iris/default.nix
@@ -1,16 +1,16 @@
-{ lib, mkCoqDerivation, coq, stdpp, version ? null }:
+{ lib, mkCoqDerivation, coq, stdpp, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation rec {
   pname = "iris";
   domain = "gitlab.mpi-sws.org";
   owner = "iris";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.11";        out = "3.4.0"; }
     { case = range "8.9" "8.11"; out = "3.3.0"; }
   ] null;
   release."3.4.0".sha256 = "0vdc2mdqn5jjd6yz028c0c6blzrvpl0c7apx6xas7ll60136slrb";
-  release."3.3.0".sha256 = "0az4gkp5m8sq0p73dlh0r7ckkzhk7zkg5bndw01bdsy5ywj0vilp";
+
   releaseRev = v: "iris-${v}";
 
   propagatedBuildInputs = [ stdpp ];

--- a/pkgs/development/coq-modules/ltac2/default.nix
+++ b/pkgs/development/coq-modules/ltac2/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, which, coq, version ? null }:
+{ lib, mkCoqDerivation, which, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "ltac2";
   owner = "coq";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = "8.10"; out = "0.3"; }
     { case = "8.9";  out = "0.2"; }

--- a/pkgs/development/coq-modules/math-classes/default.nix
+++ b/pkgs/development/coq-modules/math-classes/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, bignums, version ? null }:
+{ lib, mkCoqDerivation, coq, bignums, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
 
   pname = "math-classes";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.range "8.6" "8.12" coq.coq-version then "8.12.0" else null;
   release."8.12.0".sha256 = "14nd6a08zncrl5yg2gzk0xf4iinwq4hxnsgm4fyv07ydbkxfb425";
 

--- a/pkgs/development/coq-modules/mathcomp-abel/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-abel/default.nix
@@ -1,4 +1,4 @@
-{ coq, mkCoqDerivation, mathcomp, mathcomp-real-closed, lib, version ? null }:
+{ coq, mkCoqDerivation, mathcomp, mathcomp-real-closed, lib, version ? null, origin ? null }:
 
 mkCoqDerivation {
 
@@ -8,7 +8,7 @@ mkCoqDerivation {
 
   release."1.0.0".sha256 = "190jd8hb8anqsvr9ysr514pm5sh8qhw4030ddykvwxx9d9q6rbp3";
 
-  inherit version;
+  inherit version origin;
   defaultVersion = with lib; with versions; switch [ coq.version mathcomp.version ]  [
       { cases = [ (range "8.10" "8.13") (range "1.11.0" "1.12.0") ]; out = "1.0.0"; }
     ] null;

--- a/pkgs/development/coq-modules/mathcomp-analysis/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-analysis/default.nix
@@ -1,8 +1,8 @@
 { coq, mkCoqDerivation, mathcomp, mathcomp-finmap, mathcomp-bigenough, mathcomp-real-closed,
-  hierarchy-builder, lib, version ? null }:
+  hierarchy-builder, lib, version ? null, origin ? null }:
 
 with lib;
-let mca = mkCoqDerivation {
+mkCoqDerivation (mca: {
 
   namePrefix = [ "coq" "mathcomp" ];
   pname = "analysis";
@@ -14,7 +14,7 @@ let mca = mkCoqDerivation {
   release."0.3.1".sha256 = "1iad288yvrjv8ahl9v18vfblgqb1l5z6ax644w49w9hwxs93f2k8";
   release."0.2.3".sha256 = "0p9mr8g1qma6h10qf7014dv98ln90dfkwn76ynagpww7qap8s966";
 
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch [ coq.version mathcomp.version ]  [
       { cases = [ (range "8.11" "8.13") "1.12.0" ];             out = "0.3.6"; }
       { cases = [ (range "8.11" "8.13") "1.11.0" ];             out = "0.3.4"; }
@@ -25,19 +25,12 @@ let mca = mkCoqDerivation {
 
   propagatedBuildInputs =
     [ mathcomp.ssreflect mathcomp.field
-      mathcomp-finmap mathcomp-bigenough mathcomp-real-closed ];
+      mathcomp-finmap mathcomp-bigenough mathcomp-real-closed ]
+    ++ optional (versions.isGe "0.3.4" mca.version) hierarchy-builder;
 
   meta = {
     description = "Analysis library compatible with Mathematical Components";
     maintainers = [ maintainers.cohencyril ];
     license = licenses.cecill-c;
   };
-}; in
-mca.overrideAttrs (o:
-  let ext = { propagatedBuildInputs = o.propagatedBuildInputs
-                                      ++ [ hierarchy-builder ]; };
-  in with versions; switch o.version [
-    {case = "dev";        out = ext;}
-    {case = isGe "0.3.4"; out = ext;}
-  ] {}
-)
+})

--- a/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
@@ -1,4 +1,4 @@
-{ coq, mkCoqDerivation, mathcomp, lib, version ? null }:
+{ coq, mkCoqDerivation, mathcomp, lib, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
 
@@ -7,7 +7,7 @@ with lib; mkCoqDerivation {
   owner = "math-comp";
 
   release = { "1.0.0".sha256 = "10g0gp3hk7wri7lijkrqna263346wwf6a3hbd4qr9gn8hmsx70wg"; };
-  inherit version;
+  inherit version origin;
   defaultVersion = "1.0.0";
 
   propagatedBuildInputs = [ mathcomp.ssreflect ];

--- a/pkgs/development/coq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-finmap/default.nix
@@ -1,11 +1,11 @@
-{ coq, mkCoqDerivation, mathcomp, lib, version ? null }:
+{ coq, mkCoqDerivation, mathcomp, lib, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
 
   namePrefix = [ "coq" "mathcomp" ];
   pname = "finmap";
   owner = "math-comp";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch [ coq.version mathcomp.version ]  [
       { cases = [ (isGe "8.10")          (range "1.11" "1.12") ]; out = "1.5.1"; }
       { cases = [ (range "8.7" "8.11")   "1.11.0" ];              out = "1.5.0"; }

--- a/pkgs/development/coq-modules/mathcomp-real-closed/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-real-closed/default.nix
@@ -1,12 +1,12 @@
 { coq, mkCoqDerivation, mathcomp, mathcomp-bigenough,
-  lib, version ? null }:
+  lib, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
 
   namePrefix = [ "coq" "mathcomp" ];
   pname = "real-closed";
   owner = "math-comp";
-  inherit version;
+  inherit version origin;
   release = {
     "1.1.2".sha256 = "0907x4nf7nnvn764q3x9lx41g74rilvq5cki5ziwgpsdgb98pppn";
     "1.1.1".sha256 = "0ksjscrgq1i79vys4zrmgvzy2y4ylxa8wdsf4kih63apw6v5ws6b";

--- a/pkgs/development/coq-modules/mathcomp-zify/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-zify/default.nix
@@ -1,10 +1,10 @@
-{ lib, mkCoqDerivation, coq, mathcomp-algebra, version ? null }:
+{ lib, mkCoqDerivation, coq, mathcomp-algebra, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation rec {
   pname = "mathcomp-zify";
   repo = "mczify";
   owner = "math-comp";
-  inherit version;
+  inherit version origin;
 
   defaultVersion = with versions;
      switch [ coq.coq-version mathcomp-algebra.version ] [

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -12,7 +12,7 @@
 
 { lib, ncurses, which, graphviz, lua, fetchzip,
   mkCoqDerivation, recurseIntoAttrs, withDoc ? false, single ? false,
-  coqPackages, coq, ocamlPackages, version ? null }@args:
+  coqPackages, coq, ocamlPackages, version ? null, origin ? null }@args:
 with builtins // lib;
 let
   repo  = "math-comp";
@@ -53,7 +53,7 @@ let
         echo "-R . mathcomp.all" >> Make
       '';
       derivation = mkCoqDerivation ({
-        inherit version pname defaultVersion release releaseRev repo owner;
+        inherit version origin pname defaultVersion release releaseRev repo owner;
 
         nativeBuildInputs = optionals withDoc [ graphviz lua ];
         mlPlugin = versions.isLe "8.6" coq.coq-version;

--- a/pkgs/development/coq-modules/metalib/default.nix
+++ b/pkgs/development/coq-modules/metalib/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "metalib";
   owner = "plclub";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.range "8.10" "8.13" coq.coq-version then "20200527" else null;
   release."20200527".rev    = "597fd7d0c93eb159274e84a39d554f10f1efccf8";
   release."20200527".sha256 = "0wbypc05d2lqfm9qaw98ynr5yc1p0ipsvyc3bh1rk9nz7zwirmjs";

--- a/pkgs/development/coq-modules/multinomials/default.nix
+++ b/pkgs/development/coq-modules/multinomials/default.nix
@@ -1,11 +1,11 @@
 { coq, mkCoqDerivation, mathcomp, mathcomp-finmap, mathcomp-bigenough,
-  lib, version ? null, useDune2 ? false }@args:
+  lib, version ? null, origin ? null, useDune2 ? false }@args:
 with lib; mkCoqDerivation {
 
   namePrefix = [ "coq" "mathcomp" ];
   pname = "multinomials";
   owner = "math-comp";
-  inherit version;
+  inherit version origin;
   defaultVersion =  with versions; switch [ coq.version mathcomp.version ] [
       { cases = [ (range "8.10" "8.13") "1.12.0" ];             out = "1.5.4"; }
       { cases = [ (range "8.10" "8.12") "1.12.0" ];             out = "1.5.3"; }

--- a/pkgs/development/coq-modules/odd-order/default.nix
+++ b/pkgs/development/coq-modules/odd-order/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, mathcomp, version ? null }:
+{ lib, mkCoqDerivation, mathcomp, version ? null, origin ? null }:
 with lib;
 
 mkCoqDerivation {
@@ -8,7 +8,7 @@ mkCoqDerivation {
   release."1.12.0".rev    = "mathcomp-odd-order.1.12.0";
   release."1.12.0".sha256 = "sha256-omsfdc294CxKAHNMMeqJCcVimvyRCHgxcQ4NJOWSfNM=";
 
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch mathcomp.character.version [
     { case = pred.union (isGe "1.10.0") (isEq "dev"); out = "1.12.0"; }
   ] null;

--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "paco";
   owner = "snu-sf";
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.6";         out = "4.0.2"; }
     { case = range "8.5" "8.8";  out = "1.2.8"; }

--- a/pkgs/development/coq-modules/paramcoq/default.nix
+++ b/pkgs/development/coq-modules/paramcoq/default.nix
@@ -1,8 +1,8 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "paramcoq";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.range "8.7" "8.13" coq.coq-version
     then "1.1.2+coq${coq.coq-version}" else null;
   displayVersion = { paramcoq = "1.1.2"; };

--- a/pkgs/development/coq-modules/pocklington/default.nix
+++ b/pkgs/development/coq-modules/pocklington/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 with lib;
 
 mkCoqDerivation {
@@ -8,7 +8,7 @@ mkCoqDerivation {
   release."8.12.0".rev    = "v8.12.0";
   release."8.12.0".sha256 = "sha256-0xBrw9+4g14niYdNqp0nx00fPJoSSnaDSDEaIVpPfjs=";
 
-  inherit version;
+  inherit version origin;
   defaultVersion = with versions; switch coq.coq-version [
     { case = isGe "8.7"; out = "8.12.0"; }
   ] null;

--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -1,10 +1,10 @@
-{ lib, mkCoqDerivation, coq, coq-ext-lib, version ? null }:
+{ lib, mkCoqDerivation, coq, coq-ext-lib, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation {
   pname = "simple-io";
   owner = "Lysxia";
   repo = "coq-simple-io";
-  inherit version;
+  inherit version origin;
   defaultVersion = if versions.range "8.7" "8.13" coq.coq-version then "1.3.0" else null;
   release."1.3.0".sha256 = "1yp7ca36jyl9kz35ghxig45x6cd0bny2bpmy058359p94wc617ax";
   extraBuildInputs = (with coq.ocamlPackages; [ ocaml ocamlbuild ]);

--- a/pkgs/development/coq-modules/stdpp/default.nix
+++ b/pkgs/development/coq-modules/stdpp/default.nix
@@ -1,8 +1,8 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; mkCoqDerivation rec {
   pname = "stdpp";
-  inherit version;
+  inherit version origin;
   domain = "gitlab.mpi-sws.org";
   owner = "iris";
   defaultVersion = with versions; switch coq.coq-version [

--- a/pkgs/development/coq-modules/tlc/default.nix
+++ b/pkgs/development/coq-modules/tlc/default.nix
@@ -1,9 +1,9 @@
-{ lib, mkCoqDerivation, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null, origin ? null }:
 
 with lib; (mkCoqDerivation {
   pname = "tlc";
   owner = "charguer";
-  inherit version;
+  inherit version origin;
   displayVersion = { tlc = false; };
   defaultVersion = with versions; switch coq.coq-version [
     { case = range "8.12" "8.13"; out = "20210316"; }

--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -1,8 +1,9 @@
 { stdenv, lib, fetchzip, buildDunePackage, camlp5
 , ppxlib, ppx_deriving, re, perl, ncurses
-, version ? "1.13.5"
+, version ? "1.13.5", origin ? null,
 }:
-with lib;
+let lib' = import ../../../build-support/coq/extra-lib.nix {inherit lib;}; in
+with lib';
 let fetched = import ../../../build-support/coq/meta-fetch/default.nix
   {inherit lib stdenv fetchzip; } ({
     release."1.13.5".sha256 = "02a6r23mximrdvs6kgv6rp0r2dgk7zynbs99nn7lphw2c4189kka";
@@ -11,8 +12,9 @@ let fetched = import ../../../build-support/coq/meta-fetch/default.nix
     release."1.12.0".sha256 = "1agisdnaq9wrw3r73xz14yrq3wx742i6j8i5icjagqk0ypmly2is";
     release."1.11.4".sha256 = "1m0jk9swcs3jcrw5yyw5343v8mgax238cjb03s8gc4wipw1fn9f5";
     releaseRev = v: "v${v}";
+    combined = true;
     location = { domain = "github.com"; owner = "LPCIC"; repo = "elpi"; };
-  }) version;
+  }) { inherit origin version; pname = "elpi"; };
 in
 buildDunePackage rec {
   pname = "elpi";

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -97,8 +97,8 @@ let
               else v))
       ) (lib.attrNames set)
     );
-  mkCoq = version: callPackage ../applications/science/logic/coq {
-    inherit version ocamlPackages_4_05 ocamlPackages_4_09 ocamlPackages_4_10;
+  mkCoq = origin: callPackage ../applications/science/logic/coq {
+    inherit origin ocamlPackages_4_05 ocamlPackages_4_09 ocamlPackages_4_10;
   };
 in rec {
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Many backward compatible changes
- additional format `owner/repo:branch` to fetch sources in meta-fetcher
- new argument `origin` to `coq` and `mkCoqDerivation` in order to
  replace the current input `version` attribute, so that ultimately
  the input and output `version` coincide. To preserve backward compatibility
  we still allow to use `version` instead of `origin` but we send a warning
  if the input and output versions differ. (This might be turned into an
  error in the future).
  + Refactored `coqPackages` to pass it to every derivation,
- `mkCoqDerivation` can now take a function instead of an attribute set,
  the argument is a previous iteration of the arguments that `mkCoqDerivation`
  pass to `mkDerivation`, mostly to get the computed version.
  + simplified derivation of `mathcomp-analysis` thanks to this.

All changes are duely documented


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).