### PR TITLE
 ocamlPackages.ocaml-freestanding: init at 0.6.4 

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-freestanding/configurable-binding.patch
+++ b/pkgs/development/ocaml-modules/ocaml-freestanding/configurable-binding.patch
@@ -1,0 +1,49 @@
+commit b273c9f7ab10475787db4d6e09bd4b71b374d0ec
+Author: sternenseemann <0rpkxez4ksa01gb3typccl0i@systemli.org>
+Date:   Thu Mar 18 01:28:46 2021 +0100
+
+    Let user specify solo5-binding to use
+    
+    This is a little feature for the configure script I wanted to have for
+    the NixOS package: It allows the user to set PKG_CONFIG_DEPS before
+    running configure.sh to disable the autodetection mechanism. This is
+    useful for NixOS as we have all bindings bundled in the solo5 package,
+    so the result would also be solo5-bindings-xen. Additionally, it allows
+    us to do the binding selection declaratively and minimize the risk of
+    accidentally switching backend.
+    
+    PKG_CONFIG_DEPS seems like a bit of an unappropriate variable name for a
+    user “interface”, let me know if you want a dedicated environment
+    variable for this in case there will be more PKG_CONFIG_DEPS.
+
+diff --git a/configure.sh b/configure.sh
+index c254f7b..c675a02 100755
+--- a/configure.sh
++++ b/configure.sh
+@@ -11,13 +11,19 @@ if pkg_exists solo5-bindings-hvt solo5-bindings-spt solo5-bindings-virtio solo5-
+     echo "ERROR: Only one of solo5-bindings-hvt, solo5-bindings-spt, solo5-bindings-virtio, solo5-bindings-muen, solo5-bindings-genode, solo5-bindings-xen can be installed." 1>&2
+     exit 1
+ fi
+-PKG_CONFIG_DEPS=
+-pkg_exists solo5-bindings-hvt && PKG_CONFIG_DEPS=solo5-bindings-hvt
+-pkg_exists solo5-bindings-spt && PKG_CONFIG_DEPS=solo5-bindings-spt
+-pkg_exists solo5-bindings-muen && PKG_CONFIG_DEPS=solo5-bindings-muen
+-pkg_exists solo5-bindings-virtio && PKG_CONFIG_DEPS=solo5-bindings-virtio
+-pkg_exists solo5-bindings-genode && PKG_CONFIG_DEPS=solo5-bindings-genode
+-pkg_exists solo5-bindings-xen && PKG_CONFIG_DEPS=solo5-bindings-xen
++if [ -z "${PKG_CONFIG_DEPS}" ]; then
++    PKG_CONFIG_DEPS=
++    pkg_exists solo5-bindings-hvt && PKG_CONFIG_DEPS=solo5-bindings-hvt
++    pkg_exists solo5-bindings-spt && PKG_CONFIG_DEPS=solo5-bindings-spt
++    pkg_exists solo5-bindings-muen && PKG_CONFIG_DEPS=solo5-bindings-muen
++    pkg_exists solo5-bindings-virtio && PKG_CONFIG_DEPS=solo5-bindings-virtio
++    pkg_exists solo5-bindings-genode && PKG_CONFIG_DEPS=solo5-bindings-genode
++    pkg_exists solo5-bindings-xen && PKG_CONFIG_DEPS=solo5-bindings-xen
++else
++    pkg_exists "${PKG_CONFIG_DEPS}" \
++        || (echo "ERROR: ${PKG_CONFIG_DEPS} is not installed" 1>&2; exit 1) \
++        || exit 1
++fi
+ if [ -z "${PKG_CONFIG_DEPS}" ]; then
+     echo "ERROR: No supported Solo5 bindings package found." 1>&2
+     echo "ERROR: solo5-bindings-hvt, solo5-bindings-spt, solo5-bindings-virtio, solo5-bindings-muen, solo5-bindings-genode or solo5-bindings-xen must be installed." 1>&2

--- a/pkgs/development/ocaml-modules/ocaml-freestanding/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-freestanding/default.nix
@@ -1,0 +1,87 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, ocaml
+, pkg-config
+, solo5
+, target ? "xen"
+}:
+
+# note: this is not technically an ocaml-module,
+# but can be built with different compilers, so
+# the ocamlPackages set is very useful.
+
+let
+  pname = "ocaml-freestanding";
+in
+
+if lib.versionOlder ocaml.version "4.08"
+then builtins.throw "${pname} is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+  inherit pname;
+  version = "0.6.4";
+
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0w3x2wfd04qr6mci4cp1gfqw33yysp8gamgkpgbgwslr0skryiq5";
+  };
+
+  postUnpack = ''
+    # get ocaml-src from the ocaml drv instead of via ocamlfind
+    mkdir -p "${src.name}/ocaml"
+    tar --strip-components=1 -xf ${ocaml.src} -C "${src.name}/ocaml"
+  '';
+
+  patches = [
+    ./no-opam.patch
+    ./configurable-binding.patch
+  ];
+
+  nativeBuildInputs = [
+    ocaml
+    pkg-config
+  ];
+
+  buildInputs = [ solo5 ];
+
+  configurePhase = ''
+    runHook preConfigure
+    env PKG_CONFIG_DEPS=solo5-bindings-${target} sh configure.sh
+    runHook postConfigure
+  '';
+
+  preBuild = ''
+    # perform substitutions, so opam isn't needed
+    for flags in flags/cflags.tmp flags/libs.tmp; do
+      substitute "$flags.in" "$flags" \
+        --replace "%{prefix}%" "$out" \
+        --replace "%{ocaml-freestanding:lib}%" "$out/lib"
+    done
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    ./install.sh "$out"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Freestanding OCaml runtime";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://github.com/mirage/ocaml-freestanding";
+    platforms = builtins.map ({ arch, os }: "${arch}-${os}")
+      (cartesianProductOfSets {
+          arch = [ "aarch64" "x86_64" ];
+          os = [ "linux" ];
+      } ++ [
+        { arch = "x86_64"; os = "freebsd"; }
+        { arch = "x86_64"; os = "openbsd"; }
+      ]);
+  };
+}

--- a/pkgs/development/ocaml-modules/ocaml-freestanding/no-opam.patch
+++ b/pkgs/development/ocaml-modules/ocaml-freestanding/no-opam.patch
@@ -1,0 +1,84 @@
+commit 637b7ce639d54e617170433aa9596176b167d085
+Author: sternenseemann <0rpkxez4ksa01gb3typccl0i@systemli.org>
+Date:   Thu Mar 18 01:07:49 2021 +0100
+
+    Allow building without ocamlfind and opam
+    
+    This change is the result of my first go at packaging ocaml-freestanding
+    for NixOS. Our build infrastructure for ocaml there is completely
+    independent of opam at the moment, so depending on opam for the build
+    time is not an option, especially in this case where the information it
+    would give us would be garbage.
+    
+    Fortunately the build environment plays nicely with pkg-config which is
+    already heavily used by ocaml-freestanding. This patch leaves pkg-config
+    to its own devices if opam is not present (it can be assisted by a
+    manually set PKG_CONFIG_PATH environment variable).
+    
+    Additionally, in configure.sh we check if the target ocaml source
+    directory already exists. This allows for building ocaml-freestanding
+    without the ocaml-src package (which would be unnecessarily cumbersome
+    to package for NixOS) and ocamlfind (one less dependency is always a
+    nice bonus). The Makefile needs no fix since the target ocaml/Makefile
+    won't be built if it's already present.
+
+diff --git a/Makefile b/Makefile
+index b07b8c6..a68b31d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,6 +2,12 @@
+ 
+ include Makeconf
+ 
++ifneq ($(shell command -v opam),)
++	# only set if opam is available and PKG_CONFIG_PATH isn't
++	# already set in the environment or on the command line
++	PKG_CONFIG_PATH ?= $(shell opam config var prefix)/lib/pkgconfig
++endif
++
+ FREESTANDING_LIBS=openlibm/libopenlibm.a \
+ 		  ocaml/runtime/libasmrun.a \
+ 		  nolibc/libnolibc.a
+@@ -73,8 +79,7 @@ flags/libs.tmp: flags/libs.tmp.in
+ 	opam config subst $@
+ 
+ flags/libs: flags/libs.tmp Makeconf
+-	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
+-	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
++	pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
+ 	awk -v RS= -- '{ \
+ 	    sub("@@PKG_CONFIG_EXTRA_LIBS@@", "$(PKG_CONFIG_EXTRA_LIBS)", $$0); \
+ 	    print "(", $$0, ")" \
+@@ -84,8 +89,7 @@ flags/cflags.tmp: flags/cflags.tmp.in
+ 	opam config subst $@
+ 
+ flags/cflags: flags/cflags.tmp Makeconf
+-	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
+-	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
++	pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
+ 	awk -v RS= -- '{ \
+ 	    print "(", $$0, ")" \
+ 	    }' $< >$@
+diff --git a/configure.sh b/configure.sh
+index 4d154ed..c254f7b 100755
+--- a/configure.sh
++++ b/configure.sh
+@@ -1,6 +1,8 @@
+ #!/bin/sh
+ 
+-export PKG_CONFIG_PATH=$(opam config var prefix)/lib/pkgconfig
++if command -v opam &> /dev/null; then
++    export PKG_CONFIG_PATH=$(opam config var prefix)/lib/pkgconfig
++fi
+ pkg_exists() {
+     pkg-config --exists "$@"
+ }
+@@ -21,7 +23,7 @@ if [ -z "${PKG_CONFIG_DEPS}" ]; then
+     echo "ERROR: solo5-bindings-hvt, solo5-bindings-spt, solo5-bindings-virtio, solo5-bindings-muen, solo5-bindings-genode or solo5-bindings-xen must be installed." 1>&2
+     exit 1
+ fi
+-ocamlfind query ocaml-src >/dev/null || exit 1
++[ -e "$(dirname "$0")/ocaml" ] || ocamlfind query ocaml-src >/dev/null || exit 1
+ 
+ FREESTANDING_CFLAGS="$(pkg-config --cflags ${PKG_CONFIG_DEPS})"
+ BUILD_ARCH="$(uname -m)"

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -785,6 +785,8 @@ let
 
     ocamlfuse = callPackage ../development/ocaml-modules/ocamlfuse { };
 
+    ocaml-freestanding = callPackage ../development/ocaml-modules/ocaml-freestanding { };
+
     ocaml_gettext = callPackage ../development/ocaml-modules/ocaml-gettext { };
 
     gettext-stub = callPackage ../development/ocaml-modules/ocaml-gettext/stub.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


#23955


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
