### PR TITLE
xorg.xkbcomp: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2471,11 +2471,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xkbcomp = callPackage ({ stdenv, pkg-config, fetchurl, libX11, libxkbfile, xorgproto }: stdenv.mkDerivation {
-    name = "xkbcomp-1.4.4";
+    name = "xkbcomp-1.4.5";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/app/xkbcomp-1.4.4.tar.bz2";
-      sha256 = "0zpjkbap9160pdd6jpgb5f0yg5281w0rkkx1l0i7g887lq1ydk2r";
+      url = "mirror://xorg/individual/app/xkbcomp-1.4.5.tar.bz2";
+      sha256 = "0pmhshqinwqh5rip670l3szjpywky67hv232ql6gvdj489n0hlb8";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -46,7 +46,7 @@ mirror://xorg/individual/app/xgc-1.0.5.tar.bz2
 mirror://xorg/individual/app/xhost-1.0.8.tar.bz2
 mirror://xorg/individual/app/xinit-1.4.1.tar.bz2
 mirror://xorg/individual/app/xinput-1.6.3.tar.bz2
-mirror://xorg/individual/app/xkbcomp-1.4.4.tar.bz2
+mirror://xorg/individual/app/xkbcomp-1.4.5.tar.bz2
 mirror://xorg/individual/app/xkbevd-1.1.4.tar.bz2
 mirror://xorg/individual/app/xkbprint-1.0.4.tar.bz2
 mirror://xorg/individual/app/xkbutils-1.0.4.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-March/003075.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).