### PR TITLE
rustc: update llvm on darwin to current

### DIFF
--- a/pkgs/development/compilers/rust/1_50.nix
+++ b/pkgs/development/compilers/rust/1_50.nix
@@ -15,7 +15,7 @@
 , CoreFoundation, Security
 , pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
 , makeRustPlatform
-, llvmPackages_5, llvm_11
+, llvmPackages_11, llvm_11
 } @ args:
 
 import ./default.nix {
@@ -26,7 +26,7 @@ import ./default.nix {
   llvmSharedForHost = pkgsBuildHost.llvm_11.override { enableSharedLibraries = true; };
   llvmSharedForTarget = pkgsBuildTarget.llvm_11.override { enableSharedLibraries = true; };
 
-  llvmBootstrapForDarwin = llvmPackages_5;
+  llvmBootstrapForDarwin = llvmPackages_11;
 
   # For use at runtime
   llvmShared = llvm_11.override { enableSharedLibraries = true; };
@@ -54,4 +54,4 @@ import ./default.nix {
   ];
 }
 
-(builtins.removeAttrs args [ "fetchpatch" "pkgsBuildHost" "llvmPackages_5" "llvm_11"])
+(builtins.removeAttrs args [ "fetchpatch" "pkgsBuildHost" "llvmPackages_11" "llvm_11"])


### PR DESCRIPTION
###### Motivation for this change

We downgraded when LLVM 10 wasn't working well on Darwin: #101136. Now that we're using LLVM 11, the issue is no longer present. This also removes the need for any special conditions on `aarch64-darwin` (#105026), which doesn't work with LLVM 5.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64 + x86_64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).