### PR TITLE
ocamlPackages.npy: unstable-2019-04-02 → 0.0.9

### DIFF
--- a/pkgs/development/ocaml-modules/npy/default.nix
+++ b/pkgs/development/ocaml-modules/npy/default.nix
@@ -2,15 +2,17 @@
 
 buildDunePackage rec {
   pname = "npy";
-  version = "unstable-2019-04-02";
+  version = "0.0.9";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.06";
 
   src = fetchFromGitHub {
     owner = "LaurentMazare";
     repo   = "${pname}-ocaml";
-    rev    = "c051086bfea6bee58208098bcf1c2f725a80a1fb";
-    sha256 = "06mgrnm7xiw2lhqvbdv2zmd65sqfdnjd7j4qmcswanmplm17yhvb";
+    rev    = version;
+    sha256 = "1fryglkm20h6kdqjl55b7065b34bdg3g3p6j0jv33zvd1m5888m1";
   };
 
   propagatedBuildInputs = [ camlzip ];


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.12.

cc maintainer @bcdarwin

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
