### PR TITLE
pythonPackages.ajsonrpc: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/ajsonrpc/default.nix
+++ b/pkgs/development/python-modules/ajsonrpc/default.nix
@@ -1,0 +1,24 @@
+{ lib, pythonOlder, buildPythonPackage, fetchPypi, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "ajsonrpc";
+  version = "1.1.0";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b5r8975wdnk3qnc1qjnn4lkxmqcir3brbwnxml9ii90dnsw408a";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "ajsonrpc" ];
+
+  meta = with lib; {
+    description = "Async JSON-RPC 2.0 protocol + asyncio server";
+    homepage = "https://github.com/pavlov99/ajsonrpc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -328,6 +328,8 @@ in {
 
   ajpy = callPackage ../development/python-modules/ajpy { };
 
+  ajsonrpc = callPackage ../development/python-modules/ajsonrpc { };
+
   alabaster = callPackage ../development/python-modules/alabaster { };
 
   alarmdecoder = callPackage ../development/python-modules/alarmdecoder { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds the [ajsonrpc](https://github.com/pavlov99/ajsonrpc) python package, required by the latest PlatformIO version (#114014).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
