### PR TITLE
ocaml-ng.ocamlPackages_4_12: use ppxlib 0.22.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -1,5 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml
-, version ? if lib.versionAtLeast ocaml.version "4.07" then "0.15.0" else "0.13.0"
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, version
 , ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
 , stdlib-shims, ocaml-migrate-parsetree-2-1
 }:

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -929,7 +929,14 @@ let
 
     ppxfind = callPackage ../development/ocaml-modules/ppxfind { };
 
-    ppxlib = callPackage ../development/ocaml-modules/ppxlib { };
+    ppxlib = callPackage ../development/ocaml-modules/ppxlib {
+      version =
+        if lib.versionAtLeast ocaml.version "4.12"
+        then "0.22.0"
+        else if lib.versionAtLeast ocaml.version "4.07"
+        then "0.15.0"
+        else "0.13.0";
+    };
 
     psmt2-frontend = callPackage ../development/ocaml-modules/psmt2-frontend { };
 


### PR DESCRIPTION
0.15.0 still uses ocaml-migrate-parsetree 1.8.0 which has no support for
OCaml 4.12, so it makes no sense defaulting to that version. This change
should fix the build of some packages in the 4.12 set, but also break packages
already broken in a new way. I haven't tested it extensively yet though.

Version branching was moved into top-level since the if branching got a bit
clunky in the function inputs.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
