### PR TITLE
python3Packages.ytmusicapi: init at 0.14.3

### DIFF
--- a/pkgs/development/python-modules/ytmusicapi/default.nix
+++ b/pkgs/development/python-modules/ytmusicapi/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchPypi
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "ytmusicapi";
+  version = "0.14.3";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "83251a95d5bd74116353d29dfda2d0c5055b88276a0876a313a66f8b9c691344";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  doCheck = false; # requires network access
+
+  pythonImportsCheck = [ "ytmusicapi" ];
+
+  meta = with lib; {
+    description = "Unofficial API for YouTube Music";
+    homepage = "https://github.com/sigma67/ytmusicapi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8949,6 +8949,8 @@ in {
 
   yt = callPackage ../development/python-modules/yt { };
 
+  ytmusicapi = callPackage ../development/python-modules/ytmusicapi { };
+
   yubico-client = callPackage ../development/python-modules/yubico-client { };
 
   z3c-checkversions = callPackage ../development/python-modules/z3c-checkversions { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Try out https://invent.kde.org/jbbgameich/audiotube. But I'm not able to get it to show controls and actually play music yet, so I thought I can at least make a pull request for this dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
