### PR TITLE
gomobile: init at 2020-06-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4401,6 +4401,12 @@
     githubId = 5283991;
     name = "Jake Waksbaum";
   };
+  jakubgs = {
+    email = "jakub@gsokolowski.pl";
+    github = "jakubgs";
+    githubId = 2212681;
+    name = "Jakub Grzgorz Sokołowski";
+  };
   jamiemagee = {
     email = "jamie.magee@gmail.com";
     github = "JamieMagee";

--- a/pkgs/development/mobile/gomobile/default.nix
+++ b/pkgs/development/mobile/gomobile/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, lib, fetchgit, buildGoModule, zlib, makeWrapper, xcodeenv, androidenv
+, xcodeWrapperArgs ? { }
+, xcodeWrapper ? xcodeenv.composeXcodeWrapper xcodeWrapperArgs
+, androidPkgs ? androidenv.composeAndroidPackages {
+    includeNDK = true;
+    ndkVersion = "21.3.6528147"; # WARNING: 22.0.7026061 is broken.
+  } }:
+
+buildGoModule {
+  pname = "gomobile";
+  version = "unstable-2020-06-22";
+
+  vendorSha256 = "1n1338vqkc1n8cy94501n7jn3qbr28q9d9zxnq2b4rxsqjfc9l94";
+
+  src = fetchgit {
+    # WARNING: Next commit removes support for ARM 32 bit builds for iOS
+    rev = "33b80540585f2b31e503da24d6b2a02de3c53ff5";
+    name = "gomobile";
+    url = "https://go.googlesource.com/mobile";
+    sha256 = "0c9map2vrv34wmaycsv71k4day3b0z5p16yzxmlp8amvqb38zwlm";
+  };
+
+  subPackages = [ "bind" "cmd/gobind" "cmd/gomobile" ];
+
+  # Fails with: go: cannot find GOROOT directory
+  doCheck = false;
+
+  patches = [ ./resolve-nix-android-sdk.patch ];
+
+  nativeBuildInputs = [ makeWrapper ]
+    ++ lib.optionals stdenv.isDarwin [ xcodeWrapper ];
+
+  # Prevent a non-deterministic temporary directory from polluting the resulting object files
+  postPatch = ''
+    substituteInPlace cmd/gomobile/env.go --replace \
+      'tmpdir, err = ioutil.TempDir("", "gomobile-work-")' \
+      'tmpdir = filepath.Join(os.Getenv("NIX_BUILD_TOP"), "gomobile-work")' \
+      --replace '"io/ioutil"' ""
+    substituteInPlace cmd/gomobile/init.go --replace \
+      'tmpdir, err = ioutil.TempDir(gomobilepath, "work-")' \
+      'tmpdir = filepath.Join(os.Getenv("NIX_BUILD_TOP"), "work")'
+  '';
+
+  # Necessary for GOPATH when using gomobile.
+  postInstall = ''
+    mkdir -p $out/src/golang.org/x
+    ln -s $src $out/src/golang.org/x/mobile
+    wrapProgram $out/bin/gomobile \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ zlib ]}" \
+      --prefix PATH : "${androidPkgs.androidsdk}/bin" \
+      --set ANDROID_HOME "${androidPkgs.androidsdk}/libexec/android-sdk" \
+      --set GOPATH $out
+  '';
+
+  meta = with lib; {
+    description = "A tool for building and running mobile apps written in Go";
+    homepage = "https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jakubgs ];
+  };
+}

--- a/pkgs/development/mobile/gomobile/resolve-nix-android-sdk.patch
+++ b/pkgs/development/mobile/gomobile/resolve-nix-android-sdk.patch
@@ -1,0 +1,15 @@
+diff --git a/cmd/gomobile/bind_androidapp.go b/cmd/gomobile/bind_androidapp.go
+index 3b01adc..76216fa 100644
+--- a/cmd/gomobile/bind_androidapp.go
++++ b/cmd/gomobile/bind_androidapp.go
+@@ -372,6 +372,10 @@ func androidAPIPath() (string, error) {
+ 	var apiVer int
+ 	for _, fi := range fis {
+ 		name := fi.Name()
++		// Resolve symlinked directories (this is how the Nix Android SDK package is built)
++		if fi2, err := os.Stat(filepath.Join(sdkDir.Name(), name)); err == nil {
++			fi = fi2
++		}
+ 		if !fi.IsDir() || !strings.HasPrefix(name, "android-") {
+ 			continue
+ 		}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1563,6 +1563,10 @@ in
 
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
+  gomobile = callPackage ../development/mobile/gomobile {
+    buildGoModule = buildGo115Module;
+  };
+
   ssh-agents = callPackage ../tools/networking/ssh-agents { };
 
   ssh-import-id = python3Packages.callPackage ../tools/admin/ssh-import-id { };


### PR DESCRIPTION
###### Motivation for this change

The Android SDK is provided by `nixpkgs`, and in case of the [Status Project](https://status.im/) we build our app using that SDK in combination with [gomobile](https://github.com/golang/mobile) since our protocol library is written in Go.

This tool is quite powerful and allows you even to build [entire applications in Go](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile#hdr-Compile_android_APK_and_iOS_app).

There was a previous attempt in #59018 but the employee left before he managed to get it merged.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
     - https://github.com/status-im/status-react/pull/11900
   - [x] other Linux distributions
     - Ubuntu 20.04, also https://github.com/status-im/status-react/pull/1190
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
