### PR TITLE
fcitx5: bump packages to fix positioning issue on wayland

### DIFF
--- a/pkgs/development/libraries/libime/default.nix
+++ b/pkgs/development/libraries/libime/default.nix
@@ -18,21 +18,21 @@ let
     url = "https://download.fcitx-im.org/data/lm_sc.3gm.arpa-${arpaVer}.tar.bz2";
     sha256 = "0bqy3l7mif0yygjrcm65qallszgn17mvgyxhvz7a54zaamyan6vm";
   };
-  dictVer = "20200715";
+  dictVer = "20210203";
   dict = fetchurl {
     url = "https://download.fcitx-im.org/data/dict.utf8-${dictVer}.tar.xz";
-    sha256 = "1ln7r64j8mc7wz4j0q4v8wd68wy7qqz4bz1dpxk7zqbdvza6rhr3";
+    sha256 = "sha256-LWtNyoNAzoUlqHGUPvDj64Hz7ahakoVxFsrlX7ONbsQ=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "libime";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "libime";
     rev = version;
-    sha256 = "sha256-Ykj4/3yKUqK0BRqW1E2zFYNgeUOXQ1DsotmKU6c8vEg=";
+    sha256 = "sha256-WWTe/TuwpICk+AXdpV7rxrKra0LBjkDxgEy6Xg29yzY=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -41,13 +41,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5";
-  version = "5.0.4";
+  version = "5.0.5";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5";
     rev = version;
-    sha256 = "sha256-2KGdR1m70Qatidzf/DZuFK3lc1t8z7sxjyhaxuc0Tqg=";
+    sha256 = "sha256-LHmIqetxJWvSxno9lDMZU4i7/n/d/Twsad/fjW2ttUw=";
   };
 
   prePatch = ''

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -31,13 +31,13 @@ in
 
 mkDerivation rec {
   pname = "fcitx5-chinese-addons";
-  version = "5.0.3";
+  version = "5.0.4";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-chinese-addons";
     rev = version;
-    sha256 = "sha256-kCihpRUtUXrqqf7FPQp8ZRexiygOuDVOdQwVx7tSn+c=";
+    sha256 = "sha256-kaRc9pWaxnu5Yl+pc/PTCktP+imM4IGKRBRKWl0xOp4=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
@@ -19,13 +19,13 @@
 
 mkDerivation rec {
   pname = "fcitx5-configtool";
-  version = "5.0.2";
+  version = "5.0.3";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-configtool";
     rev = version;
-    sha256 = "sha256-kw0KIbS5SVMf6kR/9xsYiChHXQBM0enSVXyh0QfiiPY=";
+    sha256 = "sha256-VIQPPkn4JyR+EMpuCpFNe9OW7WzNaSSPJ0BJEvRY+Ps=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
@@ -19,18 +19,20 @@
 , dbus
 , at-spi2-core
 , libXtst
+, fmt
+, glib
 , withGTK2 ? false
 }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-gtk";
-  version = "5.0.3";
+  version = "5.0.4";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-gtk";
     rev = version;
-    sha256 = "sha256-+BzXbZyzC3fvLqysufblk0zK9fAg5jslVdm/v3jz4B4=";
+    sha256 = "sha256-rP0L7D7VdbNSmwQhnS5tvQT4FS3qpOnuBTQQp82O5fE=";
   };
 
   cmakeFlags = [
@@ -55,7 +57,11 @@ stdenv.mkDerivation rec {
     dbus
     at-spi2-core
     libXtst
+    fmt
+    glib
   ] ++ lib.optional withGTK2 gtk2;
+
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -1,6 +1,7 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , extra-cmake-modules
 , fcitx5
@@ -12,14 +13,27 @@
 
 mkDerivation rec {
   pname = "fcitx5-qt";
-  version = "5.0.2";
+  version = "5.0.3";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-qt";
     rev = version;
-    sha256 = "sha256-QylvjhjiIujYGKFtL4bKVXpobkN5t6Q2MGf16dsL24A=";
+    sha256 = "sha256-zKGx/lAZeTHkbvADodSuMi69rjNYSdlhp29b/v8XXjA=";
   };
+
+  patches = [
+    # Fix missing includes.
+    (fetchpatch {
+      url = "https://github.com/fcitx/fcitx5-qt/commit/921901a122cbecc5f34fca6b167b63e8ccb8ac39.patch";
+      sha256 = "sha256-RmS9KSTJCgd8q4NuGFBtk4xvLqoFXmcaUDVPWVjrUhs=";
+    })
+    # Fix compatibility with Qt 5.12
+    (fetchpatch {
+      url = "https://github.com/fcitx/fcitx5-qt/commit/2f6db731cc6c873a08aefe31ff81f11c64fe7ded.patch";
+      sha256 = "sha256-PXkaLcFkhOylnzKWcdLvGloqbS1BHMNSr8f46AvuAiM=";
+    })
+  ];
 
   preConfigure = ''
     substituteInPlace qt5/platforminputcontext/CMakeLists.txt \

--- a/pkgs/tools/inputmethods/fcitx5/update.py
+++ b/pkgs/tools/inputmethods/fcitx5/update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i python3 -p nix-prefetch-github python3Packages.requests
+#!nix-shell -i python3 -p nix-update nix-prefetch-github python3Packages.requests
 
 from nix_prefetch_github import *
 import json
@@ -12,8 +12,7 @@ REPOS = [ "libime", "xcb-imdkit", "fcitx5", "fcitx5-gtk", "fcitx5-qt", "fcitx5-c
 OWNER = "fcitx"
 
 def get_latest_tag(repo, owner=OWNER):
-    r = requests.get( 'https://api.github.com/repos/{}/{}/tags'.format(owner,repo)
-                    , auth=('poscat', 'db5e6fd16d0eb8c36385d3d944e058a1178b4265'))
+    r = requests.get('https://api.github.com/repos/{}/{}/tags'.format(owner,repo))
     return r.json()[0].get("name")
 
 def main():


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bump fcitx5 packages. Also fix the issue that input method window is displayed on wrong position far from input place, on wayland.
Tested to work fine with `fcitx5-rime` in Qt programs on plasma-wayland (#100057).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
