### PR TITLE
dockerTools.streamLayeredImage: add fakeRootCommands option

### DIFF
--- a/doc/builders/images/dockertools.section.md
+++ b/doc/builders/images/dockertools.section.md
@@ -141,6 +141,10 @@ Create a Docker image with many of the store paths being on their own layer to i
 
 : Shell commands to run while building the final layer, without access to most of the layer contents. Changes to this layer are "on top" of all the other layers, so can create additional directories and files.
 
+`fakeRootCommands` _optional_
+
+: Shell commands to run while creating the archive for the final layer in a fakeroot environment. Unlike `extraCommands`, you can run chown to change the owners of the files in the archive, without actually persisting the change to the filesystem. By default all files in the archive will be owned by root.
+
 ### Behavior of `contents` in the final image {#dockerTools-buildLayeredImage-arg-contents}
 
 Each path directly listed in `contents` will have a symlink in the root of the image.

--- a/doc/builders/images/dockertools.section.md
+++ b/doc/builders/images/dockertools.section.md
@@ -143,7 +143,7 @@ Create a Docker image with many of the store paths being on their own layer to i
 
 `fakeRootCommands` _optional_
 
-: Shell commands to run while creating the archive for the final layer in a fakeroot environment. Unlike `extraCommands`, you can run chown to change the owners of the files in the archive, without actually persisting the change to the filesystem. By default all files in the archive will be owned by root.
+: Shell commands to run while creating the archive for the final layer in a fakeroot environment. Unlike `extraCommands`, you can run `chown` to change the owners of the files in the archive, changing fakeroot's state instead of the real filesystem. The latter would require privileges that the build user does not have. Static binaries do not interact with the fakeroot environment. By default all files in the archive will be owned by root.
 
 ### Behavior of `contents` in the final image {#dockerTools-buildLayeredImage-arg-contents}
 

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -270,5 +270,13 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         docker.succeed(
             "docker images --format '{{.Repository}}' | grep -F '${examples.prefixedLayeredImage.imageName}'"
         )
+
+    with subtest("buildLayeredImage supports running chown with fakeRootCommands"):
+        docker.succeed(
+            "docker load --input='${examples.layeredImageWithFakeRootCommands}'"
+        )
+        docker.succeed(
+            "docker run --rm ${examples.layeredImageWithFakeRootCommands.imageName} sh -c 'stat -c '%u' /home/jane | grep -E ^1000$'"
+        )
   '';
 })

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -767,8 +767,7 @@ rec {
       customisationLayer = symlinkJoin {
         name = "${baseName}-customisation-layer";
         paths = contentsList;
-        inherit extraCommands;
-        inherit fakeRootCommands;
+        inherit extraCommands fakeRootCommands;
         nativeBuildInputs = [ fakeroot ];
         postBuild = ''
           mv $out old_out

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -7,6 +7,7 @@
   coreutils,
   docker,
   e2fsprogs,
+  fakeroot,
   findutils,
   go,
   jq,
@@ -738,6 +739,9 @@ rec {
     created ? "1970-01-01T00:00:01Z",
     # Optional bash script to run on the files prior to fixturizing the layer.
     extraCommands ? "",
+    # Optional bash script to run inside fakeroot environment.
+    # Could be used for changing ownership of files in customisation layer.
+    fakeRootCommands ? "",
     # We pick 100 to ensure there is plenty of room for extension. I
     # believe the actual maximum is 128.
     maxLayers ? 100
@@ -764,18 +768,24 @@ rec {
         name = "${baseName}-customisation-layer";
         paths = contentsList;
         inherit extraCommands;
+        inherit fakeRootCommands;
+        nativeBuildInputs = [ fakeroot ];
         postBuild = ''
           mv $out old_out
           (cd old_out; eval "$extraCommands" )
 
           mkdir $out
 
-          tar \
-            --sort name \
-            --owner 0 --group 0 --mtime "@$SOURCE_DATE_EPOCH" \
-            --hard-dereference \
-            -C old_out \
-            -cf $out/layer.tar .
+          fakeroot bash -c '
+            set -e
+            cd old_out
+            eval "$fakeRootCommands"
+            tar \
+              --sort name \
+              --numeric-owner --mtime "@$SOURCE_DATE_EPOCH" \
+              --hard-dereference \
+              -cf $out/layer.tar .
+          '
 
           sha256sum $out/layer.tar \
             | cut -f 1 -d ' ' \

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -776,7 +776,7 @@ rec {
           mkdir $out
 
           fakeroot bash -c '
-            set -e
+            source $stdenv/setup
             cd old_out
             eval "$fakeRootCommands"
             tar \

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -441,4 +441,17 @@ rec {
     tag = "latest";
     config.Cmd = [ "${pkgs.hello}/bin/hello" ];
   };
+
+  # layered image with files owned by a user other than root
+  layeredImageWithFakeRootCommands = pkgs.dockerTools.buildLayeredImage {
+    name = "layered-image-with-fake-root-commands";
+    tag = "latest";
+    contents = [
+      pkgs.pkgsStatic.busybox
+    ];
+    fakeRootCommands = ''
+      mkdir -p ./home/jane
+      chown 1000 ./home/jane
+    '';
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Allow adding files/directories owned by users other than root.
You can now optionally specify owner of files by running chown, For example:

```nix
let
  sources = import ./nix/sources.nix;
  overlay = _: pkgs: {
    dockerTools = (import sources.nixpkgs-vroad {}).dockerTools;
  };
  pkgs = import sources.nixpkgs {
    overlays = [ overlay ];
  };
in
  pkgs.dockerTools.buildLayeredImage {
    name = "my-app";
    contents = with pkgs; [
      busybox
    ];
    fakeRootCommands = ''
      mkdir -p ./home/jenkins
      chown 1000:1000 ./home/jenkins
    '';
  }
```

I removed user name to user id mapping of the archive by adding `--numeric-owner` option to tar command, since it didn't seem to be needed for creating a docker image.

https://github.com/NixOS/nixpkgs/issues/94636 talks about implementing similar fakeRoot feature, though OP was talking about adding the feature to buildImage, not buildLayeredImage or streamLayeredImage.

It's even possible to allow running programs other than fakeRoot (by adding more options to `streamLayeredImage` ), though to minimize the scope of the pull request, I didn't include it in the changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (WSL Ubuntu, nixos/nix container image)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
