### PR TITLE
 ocamlPackages_4_{11,12}: merlin: 3.4.2 -> 4.1;  dot-merlin-reader: 3.4.2 -> 4.1 

### DIFF
--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -1,0 +1,77 @@
+{ lib
+, substituteAll
+, fetchurl
+, ocaml
+, dune_2
+, buildDunePackage
+, yojson
+, csexp
+, result
+, dot-merlin-reader
+, jq
+, menhir
+}:
+
+let
+  merlinVersion = "4.1";
+
+  hashes = {
+    "4.1-411" = "9e2e6fc799c93ce1f2c7181645eafa37f64e43ace062b69218e1c29ac459937d";
+    "4.1-412" = "fb4caede73bdb8393bd60e31792af74b901ae2d319ac2f2a2252c694d2069d8d";
+  };
+
+  ocamlVersionShorthand = lib.concatStrings
+    (lib.take 2 (lib.splitVersion ocaml.version));
+
+  version = "${merlinVersion}-${ocamlVersionShorthand}";
+in
+
+if !lib.hasAttr version hashes
+then builtins.throw "merlin ${merlinVersion} is not available for OCaml ${ocaml.version}"
+else
+
+buildDunePackage {
+  pname = "merlin";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/ocaml/merlin/releases/download/v${version}/merlin-v${version}.tbz";
+    sha256 = hashes."${version}";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      dot_merlin_reader = "${dot-merlin-reader}/bin/dot-merlin-reader";
+      dune = "${dune_2}/bin/dune";
+    })
+  ];
+
+  useDune2 = true;
+
+  buildInputs = [
+    dot-merlin-reader
+    yojson
+    csexp
+    result
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    patchShebangs tests/merlin-wrapper
+    dune runtest # filtering with -p disables tests
+    runHook postCheck
+  '';
+  checkInputs = [
+    jq
+    menhir
+  ];
+
+  meta = with lib; {
+    description = "An editor-independent tool to ease the development of programs in OCaml";
+    homepage = "https://github.com/ocaml/merlin";
+    license = licenses.mit;
+    maintainers = [ maintainers.vbgl maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -3,8 +3,14 @@
 
 buildDunePackage rec {
   pname = "merlin";
+  version = "3.4.2";
 
-  inherit (dot-merlin-reader) src version useDune2;
+  src = fetchurl {
+    url = "https://github.com/ocaml/merlin/releases/download/v${version}/merlin-v${version}.tbz";
+    sha256 = "e1b7b897b11119d92995c558530149fd07bd67a4aaf140f55f3c4ffb5e882a81";
+  };
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.02.3";
 

--- a/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
+++ b/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
@@ -4,15 +4,15 @@ with ocamlPackages;
 
 buildDunePackage rec {
   pname = "dot-merlin-reader";
-  version = "3.4.2";
+  version = "4.1";
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.02.1";
+  minimumOCamlVersion = "4.06";
 
   src = fetchurl {
-    url = "https://github.com/ocaml/merlin/releases/download/v${version}/merlin-v${version}.tbz";
-    sha256 = "109ai1ggnkrwbzsl1wdalikvs1zx940m6n65jllxj68in6bvidz1";
+    url = "https://github.com/ocaml/merlin/releases/download/v${version}/dot-merlin-reader-v${version}.tbz";
+    sha256 = "14a36d6fb8646a5df4530420a7861722f1a4ee04753717947305e3676031e7cd";
   };
 
   buildInputs = [ yojson csexp result ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -620,7 +620,10 @@ let
 
     menhir = callPackage ../development/ocaml-modules/menhir { };
 
-    merlin = callPackage ../development/tools/ocaml/merlin { };
+    merlin =
+      if lib.versionAtLeast ocaml.version "4.11"
+      then callPackage ../development/tools/ocaml/merlin/4.x.nix { }
+      else callPackage ../development/tools/ocaml/merlin { };
 
     merlin-extend = callPackage ../development/ocaml-modules/merlin-extend { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

OCaml 4.12 support. Testing from actual merlin users would be appreciated!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
