### PR TITLE
libbfd: Patch CVE-2020-35448

### DIFF
--- a/pkgs/development/tools/misc/binutils/CVE-2020-35448.patch
+++ b/pkgs/development/tools/misc/binutils/CVE-2020-35448.patch
@@ -1,0 +1,77 @@
+From 8642dafaef21aa6747cec01df1977e9c52eb4679 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Fri, 4 Sep 2020 19:19:18 +0930
+Subject: [PATCH] PR26574, heap buffer overflow in
+ _bfd_elf_slurp_secondary_reloc_section
+
+A horribly fuzzed object with section headers inside the ELF header.
+Disallow that, and crazy reloc sizes.
+
+	PR 26574
+	* elfcode.h (elf_object_p): Sanity check section header offset.
+	* elf.c (_bfd_elf_slurp_secondary_reloc_section): Sanity check
+	sh_entsize.
+---
+ bfd/elf.c     | 4 +++-
+ bfd/elfcode.h | 8 ++++----
+ 3 files changed, 14 insertions(+), 5 deletions(-)
+
+diff --git a/bfd/elf.c b/bfd/elf.c
+index ac2095f787d..5a02f8dc309 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -12576,7 +12576,9 @@ _bfd_elf_slurp_secondary_reloc_section (bfd *      abfd,
+       Elf_Internal_Shdr * hdr = & elf_section_data (relsec)->this_hdr;
+ 
+       if (hdr->sh_type == SHT_SECONDARY_RELOC
+-	  && hdr->sh_info == (unsigned) elf_section_data (sec)->this_idx)
++	  && hdr->sh_info == (unsigned) elf_section_data (sec)->this_idx
++	  && (hdr->sh_entsize == ebd->s->sizeof_rel
++	      || hdr->sh_entsize == ebd->s->sizeof_rela))
+ 	{
+ 	  bfd_byte * native_relocs;
+ 	  bfd_byte * native_reloc;
+diff --git a/bfd/elfcode.h b/bfd/elfcode.h
+index 2ed2f135c34..606ff64fd4d 100644
+--- a/bfd/elfcode.h
++++ b/bfd/elfcode.h
+@@ -571,7 +571,7 @@ elf_object_p (bfd *abfd)
+ 
+   /* If this is a relocatable file and there is no section header
+      table, then we're hosed.  */
+-  if (i_ehdrp->e_shoff == 0 && i_ehdrp->e_type == ET_REL)
++  if (i_ehdrp->e_shoff < sizeof (x_ehdr) && i_ehdrp->e_type == ET_REL)
+     goto got_wrong_format_error;
+ 
+   /* As a simple sanity check, verify that what BFD thinks is the
+@@ -581,7 +581,7 @@ elf_object_p (bfd *abfd)
+     goto got_wrong_format_error;
+ 
+   /* Further sanity check.  */
+-  if (i_ehdrp->e_shoff == 0 && i_ehdrp->e_shnum != 0)
++  if (i_ehdrp->e_shoff < sizeof (x_ehdr) && i_ehdrp->e_shnum != 0)
+     goto got_wrong_format_error;
+ 
+   ebd = get_elf_backend_data (abfd);
+@@ -618,7 +618,7 @@ elf_object_p (bfd *abfd)
+       && ebd->elf_osabi != ELFOSABI_NONE)
+     goto got_wrong_format_error;
+ 
+-  if (i_ehdrp->e_shoff != 0)
++  if (i_ehdrp->e_shoff >= sizeof (x_ehdr))
+     {
+       file_ptr where = (file_ptr) i_ehdrp->e_shoff;
+ 
+@@ -819,7 +819,7 @@ elf_object_p (bfd *abfd)
+ 	}
+     }
+ 
+-  if (i_ehdrp->e_shstrndx != 0 && i_ehdrp->e_shoff != 0)
++  if (i_ehdrp->e_shstrndx != 0 && i_ehdrp->e_shoff >= sizeof (x_ehdr))
+     {
+       unsigned int num_sec;
+ 
+-- 
+2.27.0
+
+

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation {
     # cross-compiling.
     ./always-search-rpath.patch
 
+    ./CVE-2020-35448.patch
   ] ++ lib.optional stdenv.targetPlatform.isiOS ./support-ios.patch
     ++ # This patch was suggested by Nick Clifton to fix
        # https://sourceware.org/bugzilla/show_bug.cgi?id=16177


### PR DESCRIPTION
###### Motivation for this change

Relates to #113420 .
Patch amended from original to remove updates to `Changelog` (causing the patching to fail in `nixpkgs`...).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
