### PR TITLE
jruby: build it from source

### DIFF
--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -1,67 +1,115 @@
-{ lib, stdenv, callPackage, fetchurl, makeWrapper, jre }:
+{ lib, stdenv, callPackage, fetchFromGitHub, makeWrapper, jre, maven, ant, jrubyVersion ? "9.2.16.0" }:
 
 let
-# The version number here is whatever is reported by the RUBY_VERSION string
-rubyVersion = callPackage ../ruby/ruby-version.nix {} "2" "5" "7" "";
-jruby = stdenv.mkDerivation rec {
-  pname = "jruby";
-
-  version = "9.2.16.0";
-
-  src = fetchurl {
-    url = "https://s3.amazonaws.com/jruby.org/downloads/${version}/jruby-bin-${version}.tar.gz";
-    sha256 = "sha256-WuJ/FJ9z8/6k80NZy7dzwl2dmH5yte3snouTlXmX6zA=";
+  # The version number here is whatever is reported by the RUBY_VERSION string
+  rubyVersion = callPackage ../ruby/ruby-version.nix { } "2" "5" "7" "";
+  jruby-src = fetchFromGitHub {
+    owner = "jruby";
+    repo = "jruby";
+    rev = jrubyVersion;
+    sha256 = "14zs1xr9rb7ydna7kfr2xvsvgwpm8lr5ngmb8dqgdv1hq687h6wz";
   };
+  # Nixpkgs works by disallowing Internet access in order to enforce
+  # reproducibility. One way around that however is if your build is already
+  # binary reproducible, which you can toggle by specifying outputHash.
+  # We create a maven repository (~/.m2) for use in the build further down.
+  maven-repository = stdenv.mkDerivation {
+    name = "jruby-maven-repository";
+    buildInputs = [ jre maven ];
 
-  nativeBuildInputs = [ makeWrapper ];
+    src = jruby-src;
+    buildPhase = ''
+      mkdir $out
+      mvn -Pdist -Dmaven.repo.local=$out -Dmaven.wagon.rto=5000
+    '';
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+    installPhase = ''
+      find $out -type f -name '*.lastUpdated' -delete
+      find $out -type f -name resolver-status.properties -delete
+      find $out -type f -name _remote.repositories -delete
 
-  installPhase = ''
-     mkdir -pv $out/docs
-     mv * $out
-     rm $out/bin/*.{bat,dll,exe,sh}
-     mv $out/COPYING $out/LICENSE* $out/docs
+      # This check here is placed because I had trouble with find actually deleting the
+      # desired files. Originally, I had used finds `-or` command to chain the above
+      # but it was failing to perform the desired action. This is a little sanity check.
+      lines=$(find $out -type f \
+        -name '*.lastUpdated' -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories | wc -l)
+      if [ $lines -ne 0 ]; then
+        echo "Failed to delete files that cause output hash to change"
+        exit 1
+      fi
+    '';
+    # don't do any fixup
+    dontFixup = true;
 
-     for i in $out/bin/jruby{,.bash}; do
-       wrapProgram $i \
-         --set JAVA_HOME ${jre.home}
-     done
-
-     ln -s $out/bin/jruby $out/bin/ruby
-
-     # Bundler tries to create this directory
-     mkdir -pv $out/${passthru.gemPath}
-     mkdir -p $out/nix-support
-     cat > $out/nix-support/setup-hook <<EOF
-       addGemPath() {
-         addToSearchPath GEM_PATH \$1/${passthru.gemPath}
-       }
-
-       addEnvHooks "$hostOffset" addGemPath
-     EOF
-  '';
-
-  postFixup = ''
-    PATH=$out/bin:$PATH patchShebangs $out/bin
-  '';
-
-  passthru = rec {
-    rubyEngine = "jruby";
-    gemPath = "lib/${rubyEngine}/gems/${rubyVersion.libDir}";
-    libPath = "lib/${rubyEngine}/${rubyVersion.libDir}";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0fl18x9ax0aqgzzgx06frgwclpx7di5apmy7mzdv6x2x1wmlw90y";
   };
+  jruby = stdenv.mkDerivation rec {
+    pname = "jruby";
 
-  meta = with lib; {
-    description = "Ruby interpreter written in Java";
-    homepage = "http://jruby.org/";
-    license = with licenses; [ cpl10 gpl2 lgpl21 ];
-    platforms = platforms.unix;
-    maintainers = [ maintainers.fzakaria ];
+    version = jrubyVersion;
+
+    src = jruby-src;
+
+    buildInputs = [ makeWrapper maven ant jre ];
+
+    buildPhase = ''
+      echo "Using repository ${maven-repository}"
+      # We make sure to avoid installation since the maven repository is read-only now
+      mvn -Dmaven.install.skip=true -Pdist --offline -Dmaven.repo.local=${maven-repository}
+      mkdir ./dist
+      tar -xzvf ./maven/jruby-dist/target/jruby-dist-*-bin.tar.gz --strip-components=1 -C ./dist
+      cd ./dist
+    '';
+
+    installPhase = ''
+      mkdir -pv $out/docs
+      mv * $out
+      rm $out/bin/*.{bat,dll,exe,sh}
+      mv $out/COPYING $out/LICENSE* $out/docs
+
+      for i in $out/bin/jruby{,.bash}; do
+        wrapProgram $i \
+          --set JAVA_HOME ${jre.home}
+      done
+
+      ln -s $out/bin/jruby $out/bin/ruby
+
+      # Bundler tries to create this directory
+      mkdir -pv $out/${passthru.gemPath}
+      mkdir -p $out/nix-support
+      cat > $out/nix-support/setup-hook <<EOF
+        addGemPath() {
+          addToSearchPath GEM_PATH \$1/${passthru.gemPath}
+        }
+
+        addEnvHooks "$hostOffset" addGemPath
+      EOF
+    '';
+
+    postFixup = ''
+      PATH=$out/bin:$PATH patchShebangs $out/bin
+    '';
+
+    passthru = rec {
+      rubyEngine = "jruby";
+      gemPath = "lib/${rubyEngine}/gems/${rubyVersion.libDir}";
+      libPath = "lib/${rubyEngine}/${rubyVersion.libDir}";
+    };
+
+    meta = with lib; {
+      description = "Ruby interpreter written in Java";
+      homepage = "http://jruby.org/";
+      license = with licenses; [ cpl10 gpl2 lgpl21 ];
+      platforms = platforms.unix;
+      maintainers = [ maintainers.fzakaria ];
+    };
   };
-};
 in jruby.overrideAttrs (oldAttrs: {
   passthru = oldAttrs.passthru // {
-    devEnv = callPackage ../ruby/dev.nix {
-      ruby = jruby;
-    };
+    devEnv = callPackage ../ruby/dev.nix { ruby = jruby; };
   };
 })


### PR DESCRIPTION
###### Motivation for this change

I was inspired for this pull-request following @davidak [post on discourse](https://discourse.nixos.org/t/vision-for-nixpkgs/11950). 
Many VM built software, choose not to build from source since there's no "machine dependent" code.

However part of the power of building from source is ability to change to any commit, or easily apply patch files to the source if needed.

###### Things done

This pull-request changes the JRuby derivation such that it builds from source rather than downloading the release binaries.

```bash
❯ nix-build -A jruby
/nix/store/z9z5dwz76h6f5ccqhakxqd3m8xjhr9lg-jruby-9.2.16.0
❯ ./result/bin/jruby -v
jruby 9.2.16.0 (2.5.7) 2021-03-18 ffffffffff OpenJDK 64-Bit Server VM 15.0.1+0-adhoc..jdk15u-jdk-15.0.1-ga on 15.0.1+0-adhoc..jdk15u-jdk-15.0.1-ga +jit [linux-x86_64]
```

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
