### PR TITLE
sunwait: init at 20201026

### DIFF
--- a/pkgs/applications/misc/sunwait/default.nix
+++ b/pkgs/applications/misc/sunwait/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "sunwait";
+  version = "2020-10-26";
+
+  src = fetchFromGitHub {
+    owner = "risacher";
+    repo = "sunwait";
+    rev = "102cb417ecbb7a3757ba9ee4b94d6db3225124c4";
+    sha256 = "0cs8rdcnzsl10zia2k49a6c2z6gvp5rnf31sgn3hn5c7kgy7l3ax";
+  };
+
+  installPhase = ''
+    install -Dm755 sunwait -t $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Calculates sunrise or sunset times with civil, nautical, astronomical and custom twilights";
+    homepage = "https://github.com/risacher/sunwait";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8155,6 +8155,8 @@ in
 
   stubby = callPackage ../tools/networking/stubby { };
 
+  sunwait = callPackage ../applications/misc/sunwait { };
+
   surface-control = callPackage ../applications/misc/surface-control { };
 
   syntex = callPackage ../tools/graphics/syntex {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
