### PR TITLE
nss: 3.62 -> 3.63

### DIFF
--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -10,7 +10,8 @@
 with lib;
 
 let
-  version = "3.60";
+  version = "3.63";
+
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 in
 
@@ -19,7 +20,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/nss-${version}.tar.gz";
-    sha256 = "hKvVV1q4dMU65RG9Rh5dCGjRobOE7kB1MVTN0dWQ/j0=";
+    sha256 = "0892xbjcaw6g4rd2rs4qa37nbda248cjrgxa4faaw0licbpjyb8q";
   };
 
   certdata2pem = fetchurl {

--- a/pkgs/development/libraries/nspr/default.nix
+++ b/pkgs/development/libraries/nspr/default.nix
@@ -2,7 +2,7 @@
 , CoreServices ? null
 , buildPackages }:
 
-let version = "4.29"; in
+let version = "4.30"; in
 
 stdenv.mkDerivation {
   pname = "nspr";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://mozilla/nspr/releases/v${version}/src/nspr-${version}.tar.gz";
-    sha256 = "22286bdb8059d74632cc7c2865c139e63953ecfb33bf4362ab58827e86e92582";
+    sha256 = "0fwivizfz88625lwv1ngxirnal7w9csq1q9i7m6dr14l83wdhk4d";
   };
 
   patches = [

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -18,7 +18,7 @@ let
   #       It will rebuild itself using the version of this package (NSS) and if
   #       an update is required do the required changes to the expression.
   #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
-  version = "3.62";
+  version = "3.63";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${pname}-${version}.tar.gz";
-    sha256 = "0y2ld90bncjjggrn64c7g7mq9i03z6dc3r2kz978snz2xiydzml6";
+    sha256 = "0892xbjcaw6g4rd2rs4qa37nbda248cjrgxa4faaw0licbpjyb8q";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];


### PR DESCRIPTION
###### Motivation for this change
Upstream release.

There aren't any release notes yet and this is **NOT NEEDED FOR THE UPCOMING FIREFOX RELEASE** in five days, but for the one after that, next month.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s): firefox
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
