### PR TITLE
fdtools: set platforms to linux only

### DIFF
--- a/pkgs/tools/misc/fdtools/default.nix
+++ b/pkgs/tools/misc/fdtools/default.nix
@@ -76,7 +76,7 @@ in stdenv.mkDerivation {
     homepage = "https://code.dogmap.org./fdtools/";
     description = "A set of utilities for working with file descriptors";
     license = lib.licenses.gpl2;
-    platforms = lib.platforms.all;
+    platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.Profpatsch ];
   };
 }


### PR DESCRIPTION
Seems like there is portability trouble preventing it from working on
darwin and likely also BSDs. The website says:

>  On some systems (currently only Linux, as far as I know) they can
> also allocate, lock, and switch virtual consoles.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
