### PR TITLE
appdaemon: fix astral dependency

### DIFF
--- a/pkgs/servers/home-assistant/appdaemon.nix
+++ b/pkgs/servers/home-assistant/appdaemon.nix
@@ -6,6 +6,14 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
+      astral = super.astral.overridePythonAttrs (oldAttrs: rec {
+        version = "1.10.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "1wbvnqffbgh8grxm07cabdpahlnyfq91pyyaav432cahqi1p59nj";
+        };
+      });
+
       bcrypt = super.bcrypt.overridePythonAttrs (oldAttrs: rec {
         version = "3.1.7";
         src = oldAttrs.src.override {
@@ -62,7 +70,6 @@ in python.pkgs.buildPythonApplication rec {
       --replace "sockjs==0.10.0" "sockjs" \
       --replace "deepdiff==4.3.1" "deepdiff" \
       --replace "voluptuous==0.11.7" "voluptuous" \
-      --replace "astral==1.10.1" "astral" \
       --replace "python-socketio==4.4.0" "python-socketio" \
       --replace "feedparser==5.2.1" "feedparser>=5.2.1" \
       --replace "aiohttp_jinja2==1.2.0" "aiohttp_jinja2>=1.2.0" \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

appdaemon v4.0.5 pins astral to v1.10.1. The appdaemon package
definition removes this pinning. However, the current nixpkgs version of
astral (v2.x) is incompatible with the v1.x API. I added an override for
the astral package to bring back v1.10.1 into this derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
