### PR TITLE
xedit: init at 1.2.2

### DIFF
--- a/pkgs/applications/editors/xedit/default.nix
+++ b/pkgs/applications/editors/xedit/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, autoreconfHook
+, pkg-config
+, utilmacros
+, libX11
+, libXaw
+, libXmu
+, libXt
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xedit";
+  version = "1.2.2";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "xorg/app";
+    repo = "xedit";
+    rev = "${pname}-${version}";
+    sha256 = "0b5ic13aasv6zh20v2k7zyxsqbnsxfq5rs3w8nwzl1gklmgrjxa3";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config utilmacros ];
+  buildInputs = [
+    libX11
+    libXaw
+    libXmu
+    libXt
+  ];
+
+  configureFlags = [
+    "--with-lispdir=$out/share/X11/xedit/lisp"
+    "--with-appdefaultdir=$out/share/X11/app-defaults"
+  ];
+
+  meta = with lib; {
+    description = "Simple graphical text editor using Athena Widgets (Xaw)";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xedit";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20168,6 +20168,8 @@ with pkgs;
 
   xed = callPackage ../development/libraries/xed { };
 
+  xedit = callPackage ../applications/editors/xedit { };
+
   xine-lib = callPackage ../development/libraries/xine-lib { };
 
   xautolock = callPackage ../misc/screensavers/xautolock { };


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/116684

###### Things done
Packaged Xedit.

Couldn't make it working, I got : stderr 

```
Error: Shell widget fileMenu has zero width and/or height
``` 
Return value : 1


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
