### PR TITLE
liblapack: disable select tests on all darwin platforms

### DIFF
--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   #
   # Upstream issue to track:
   # * https://github.com/Reference-LAPACK/lapack/issues/440
-  ctestArgs = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) "-E '^(CBLAS-(x[sdcz]cblat[23]))$'";
+  ctestArgs = lib.optionalString stdenv.isDarwin "-E '^(CBLAS-(x[sdcz]cblat[23]))$'";
 
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
###### Motivation for this change

I missed broken x86-64-darwin in #116579.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
