### PR TITLE
sqlint: 0.1.10 -> 0.2.0

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -211,7 +211,16 @@ in
     '';
   };
 
-  pg_query = attrs: lib.optionalAttrs (attrs.version == "1.3.0") {
+  pg_query = attrs: lib.optionalAttrs (attrs.version == "2.0.1") {
+    dontBuild = false;
+    postPatch = ''
+      sed -i "s;'https://codeload.github.com.*';'${fetchurl {
+        url = "https://codeload.github.com/lfittl/libpg_query/tar.gz/13-2.0.0";
+        sha256 = "0ghk0dlmrn634p3zjr41fy4ipgw8i44f67a4l8cspqg0395m3rp5";
+      }}';" ext/pg_query/extconf.rb
+    '';
+  } // lib.optionalAttrs (attrs.version == "1.3.0") {
+    # Needed for gitlab
     dontBuild = false;
     postPatch = ''
       sed -i "s;'https://codeload.github.com.*';'${fetchurl {

--- a/pkgs/development/tools/sqlint/Gemfile.lock
+++ b/pkgs/development/tools/sqlint/Gemfile.lock
@@ -1,9 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    pg_query (1.2.0)
-    sqlint (0.1.10)
-      pg_query (~> 1)
+    google-protobuf (3.15.6)
+    pg_query (2.0.1)
+      google-protobuf (~> 3.15.5)
+    sqlint (0.2.0)
+      pg_query (~> 2)
 
 PLATFORMS
   ruby

--- a/pkgs/development/tools/sqlint/default.nix
+++ b/pkgs/development/tools/sqlint/default.nix
@@ -1,27 +1,10 @@
-{ lib, bundlerApp, fetchurl, bundlerUpdateScript }:
+{ lib, bundlerApp, bundlerUpdateScript }:
 
-let
-  LIB_PG_QUERY_TAG = "10-1.0.1";
-  libpgQuerySrc = fetchurl {
-    name = "libpg_query.tar.gz";
-    url = "https://codeload.github.com/lfittl/libpg_query/tar.gz/${LIB_PG_QUERY_TAG}";
-    sha256 = "0m5jv134hgw2vcfkqlnw80fr3wmrdvgrvk1ndcx9s44bzi5nsp47";
-  };
-in bundlerApp {
+bundlerApp {
   pname = "sqlint";
   gemdir = ./.;
 
   exes = [ "sqlint" ];
-
-  gemConfig = {
-    pg_query = attrs: {
-      dontBuild = false;
-      postPatch = ''
-        substituteInPlace ext/pg_query/extconf.rb \
-          --replace "#{workdir}/libpg_query.tar.gz" "${libpgQuerySrc}"
-      '';
-    };
-  };
 
   passthru.updateScript = bundlerUpdateScript "sqlint";
 
@@ -29,7 +12,7 @@ in bundlerApp {
     description = "Simple SQL linter";
     homepage    = "https://github.com/purcell/sqlint";
     license     = licenses.mit;
-    maintainers = with maintainers; [ ariutta nicknovitski ];
+    maintainers = with maintainers; [ ariutta nicknovitski purcell ];
     platforms   = with platforms; [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/tools/sqlint/gemset.nix
+++ b/pkgs/development/tools/sqlint/gemset.nix
@@ -1,13 +1,24 @@
 {
-  pg_query = {
+  google-protobuf = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0p9s6znavm6v5dwk1hxg9a8h2lrrwh9l0rlk0sy8cx4sq2mq82m1";
+      sha256 = "1ak5yqqhr04b4x0axzvpw1xzwmxmfcw0gf4r1ijixv15kidhsj3z";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "3.15.6";
+  };
+  pg_query = {
+    dependencies = ["google-protobuf"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01a8asbgkr7f1gp50ikzr1zzmvwv50da389943hrrqzxwd202268";
+      type = "gem";
+    };
+    version = "2.0.1";
   };
   sqlint = {
     dependencies = ["pg_query"];
@@ -15,9 +26,9 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0ds7qsaqi745fda8nliy15is36l1bkfbfkr43q6smpy103xbk44c";
+      sha256 = "1ylicsc9x4vpj6ff3hmrm6iz1xswrwwgn1m7ri8nx86ij30w9hkk";
       type = "gem";
     };
-    version = "0.1.10";
+    version = "0.2.0";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New release with support for PostgreSQL 12 and 13 syntax.

- Updates libpg_query to 2.0.0 in gem config, used by pg_query gem 2.0.1
- Remove redundant gem config override in sqlint expression
- Add myself as a maintainer


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
