### PR TITLE
texlive.combine: export `packages` attribute to help find-tarballs.nix

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -52,6 +52,9 @@ in (buildEnv {
 
   buildInputs = [ makeWrapper ] ++ pkgList.extraInputs;
 
+  # This is set primarily to help find-tarballs.nix to do its job
+  passthru.packages = pkgList.all;
+
   postBuild = ''
     cd "$out"
     mkdir -p ./bin


### PR DESCRIPTION
Can be verified using:

```
nix-instantiate --eval --json --strict ./maintainers/scripts/find-tarballs.nix --arg expr '(import ./. {}).texlive.combined.scheme-small' 2>/dev/null | jq '.[].name' | grep -E "r[0-9]+\.tar\.xz"
```
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Improve long term reproducibility of texlive build by allowing its tarballs to be mirrored at tarballs.nixos.org.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
