### PR TITLE
handlr: init at 0.5.0

### DIFF
--- a/pkgs/tools/misc/handlr/default.nix
+++ b/pkgs/tools/misc/handlr/default.nix
@@ -1,0 +1,25 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "handlr";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "chmln";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1f4gmlqzgw1r8n0w9dr9lpsn94f2hlnak9bbq5xgf6jwgc9mwqzg";
+  };
+
+  cargoSha256 = "16d4dywwkgvvxw6ninrx87rqhx0whdq3yy01m27qjy4gz6z6ad8p";
+
+  # Most tests fail (at least some due to directory permissions)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Alternative to xdg-open to manage default applications with ease";
+    homepage = "https://github.com/chmln/handlr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23759,6 +23759,8 @@ in
     inherit (darwin) libobjc;
   };
 
+  handlr = callPackage ../tools/misc/handlr { };
+
   jftui = callPackage ../applications/video/jftui { };
 
   lime = callPackage ../development/libraries/lime { };


### PR DESCRIPTION
###### Motivation for this change

New interesting package

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
