### PR TITLE
python3Packages.urllib3: remove obsolete SSL dependencies

### DIFF
--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -21,7 +21,6 @@
 buildPythonPackage rec {
   pname = "urllib3";
   version = "1.26.3";
-  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -2,11 +2,11 @@
 , stdenv
 , brotli
 , buildPythonPackage
-, certifi
 , cryptography
 , dateutil
 , fetchPypi
 , idna
+, isPy27
 , mock
 , pyopenssl
 , pysocks
@@ -29,11 +29,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     brotli
-    certifi
+    pysocks
+  ] ++ lib.optionals isPy27 [
     cryptography
     idna
     pyopenssl
-    pysocks
   ];
 
   checkInputs = [


### PR DESCRIPTION
Same as
https://github.com/gentoo/gentoo/pull/19383

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Drop build time dependency on Rust

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
