### PR TITLE
perlPackages.GitAutoFixup: fix too long shebang under darwin

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8682,6 +8682,10 @@ let
       url = "mirror://cpan/authors/id/T/TO/TORBIAK/App-Git-Autofixup-0.003001.tar.gz";
       sha256 = "1q7im0zj238k5agwi7d1mz26a8r0wrxwfwp1l8n5k777gx3b5xhp";
     };
+    nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
+    postInstall = lib.optionalString stdenv.isDarwin ''
+      shortenPerlShebang $out/bin/git-autofixup
+    '';
     meta = {
       maintainers = [ maintainers.DamienCassou ];
       description = "Create fixup commits for topic branches";


### PR DESCRIPTION
###### Motivation for this change
Similarly to https://github.com/NixOS/nixpkgs/issues/91419 and other, this package had a shebang line longer than 512 characters, making the invocation fail on OS X with an `exec format error`:
```sh
zsh: /Users/aisamu/.nix-profile/bin/git-autofixup: bad interpreter: /nix/store/f18m26x5d7xywdx12ni631j79d5k1kjw-perl-5.32.0/bin/perl -I/nix/store/f18m26x5d7xywdx12ni631j79d5k1kjw-perl-5.32.0/lib: exec format error
```

###### Things done

- Built on platform(s)
   - [x] macOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
