### PR TITLE
funkin: init at unstable-2021-04-02

### DIFF
--- a/pkgs/games/funkin/default.nix
+++ b/pkgs/games/funkin/default.nix
@@ -1,0 +1,125 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch
+, haxe, haxePackages, neko, makeWrapper
+, alsaLib, libpulseaudio, libGL, libX11, libXdmcp, libXext, libXi, libXinerama, libXrandr
+, xdg-utils
+}:
+
+let
+  runtimeDeps = [ alsaLib libpulseaudio libGL libX11 libXdmcp libXext libXi libXinerama libXrandr ];
+in
+stdenv.mkDerivation rec {
+  pname = "funkin";
+  version = "unstable-2021-04-02";
+
+  src = fetchFromGitHub {
+    owner = "ninjamuffin99";
+    repo = "Funkin";
+    rev = "faaf064e37d5a150d8aba451d740eeb81bd2e974";
+    sha256 = "053qbmib9nsgx63d0rcykky6284cixibrwq9rv1sqx2ghsdn78ff";
+  };
+
+  patches = [
+    # TODO remove when fix pushed
+    # Fixes Freeplay crash on master
+    (fetchpatch {
+      name = "check-if-response-result-is-actually-there.patch";
+      url = "https://github.com/ninjamuffin99/Funkin/pull/412/commits/af62bdca4d70e06ea8b383ab5c9c6b3f5d8f087b.patch";
+      sha256 = "1p9vzm7hkay8fzrd82hgrnafd0g5qi34brzv0hyjirryhni840fy";
+    })
+    # Fixes bugged version outdated version
+    (fetchpatch {
+      name = "fix-the-update-check.patch";
+      url = "https://github.com/ninjamuffin99/Funkin/pull/941/commits/996c9b6d89bf4447b1f39390bb6e8fb7d6a8c37c.patch";
+      sha256 = "1m5b47y2pbdwdk5dsvgivq8705cz95n8imdckyg3r9jazhkrvh6k";
+    })
+    # Fix link opening
+    (fetchpatch {
+      name = "Makes-the-donation-button-actually-work-on-Linux.patch";
+      url = "https://github.com/ninjamuffin99/Funkin/pull/172.patch";
+      sha256 = "1491fw52j5am5bg02v05y82njbdj1aqqdidxz36i4g6kcdy2x2iz";
+    })
+  ];
+
+  postPatch = ''
+    # Real API keys are stripped from repo for scoreboard integrity
+    cat >source/APIStuff.hx <<EOF
+    package;
+
+    class APIStuff
+    {
+      public static var API:String = "";
+      public static var EncKey:String = "";
+    }
+    EOF
+  '';
+
+  nativeBuildInputs = [ haxe neko makeWrapper ]
+  ++ (with haxePackages; [
+    hxcpp
+    hscript
+    openfl
+    lime
+    flixel
+    flixel-addons
+    flixel-ui
+    newgrounds
+    polymod
+    discord_rpc
+  ]);
+
+  buildInputs = runtimeDeps ++ [ xdg-utils ];
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$PWD
+    export HXCPP_COMPILE_THREADS=${if enableParallelBuilding then "$NIX_BUILD_CORES" else "1"}
+    haxelib run lime build linux -final
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/funkin}
+    cp -R export/release/linux/bin/* $out/lib/funkin/
+    for so in $out/lib/funkin/{Funkin,lime.ndll}; do
+      $STRIP -s $so
+    done
+    wrapProgram $out/lib/funkin/Funkin \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeDeps} \
+      --prefix PATH : ${lib.makeBinPath [ xdg-utils ]} \
+      --run "cd $out/lib/funkin"
+    ln -s $out/{lib/funkin,bin}/Funkin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Friday Night Funkin'";
+    longDescription = ''
+      Uh oh! Your tryin to kiss ur hot girlfriend, but her MEAN and EVIL dad is
+      trying to KILL you! He's an ex-rockstar, the only way to get to his
+      heart? The power of music...
+
+      WASD/ARROW KEYS IS CONTROLS
+
+      - and + are volume control
+
+      0 to Mute
+
+      It's basically like DDR, press arrow when arrow over other arrow.
+      And uhhh don't die.
+    '';
+    homepage = "https://ninja-muffin24.itch.io/funkin";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ OPNA2608 ];
+    # Some Haxe packages with pre-compiled binaries only work properly on x86_64 Linux.
+    # TODO Mark the affected packages as broken & rebuild their binary contents instead
+    broken = stdenv.system != "x86_64-linux";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27640,6 +27640,10 @@ in
 
   fslint = callPackage ../applications/misc/fslint {};
 
+  funkin = callPackage ../games/funkin {
+    haxe = haxe_4_1;
+  };
+
   galaxis = callPackage ../games/galaxis { };
 
   gambatte = callPackage ../games/gambatte { };

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -148,5 +148,15 @@ let
       };
     };
 
+    flixel = buildHaxeLib {
+      libname = "flixel";
+      version = "4.8.1";
+      sha256 = "1m7l92xg6nndy7m98yfmcrsqvd2rhafckx1xbv0im69y823c27a3";
+      meta = with lib; {
+        license = licenses.mit;
+        description = "2D game engine based on OpenFL that delivers cross-platform games";
+      };
+    };
+
   };
 in self

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -203,5 +203,21 @@ let
       };
     };
 
+    discord_rpc = buildHaxeLib {
+      libname = "discord_rpc";
+      version = "unstable-2021-03-26";
+      src = fetchFromGitHub {
+        owner = "Aidan63";
+        repo = "linc_discord-rpc";
+        rev = "2d83fa863ef0c1eace5f1cf67c3ac315d1a3a8a5";
+        fetchSubmodules = true;
+        sha256 = "0w3f9772ypqil348dq8xvhh5g1z5dii5rrwlmmvcdr2gs2c28c7k";
+      };
+      meta = with lib; {
+        license = licenses.mit;
+        description = "Native bindings for discord-rpc";
+      };
+    };
+
   };
 in self

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -178,5 +178,15 @@ let
       };
     };
 
+    newgrounds = buildHaxeLib {
+      libname = "newgrounds";
+      version = "1.1.4";
+      sha256 = "0lk4wiqj3k209qfxc1c6qs038m6a3hd1mhjk0z40y90r13n3hfzj";
+      meta = with lib; {
+        license = licenses.mit;
+        description = "Newgrounds API for haxe";
+      };
+    };
+
   };
 in self

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -128,13 +128,23 @@ let
       };
     };
 
-    lime = buildHaxeLib rec {
+    lime = buildHaxeLib {
       libname = "lime";
       version = "7.9.0";
       sha256 = "0n2qkvfbwgk35py26vlnmgga711x37rik32dca63jhh46j1m4h7d";
       meta = with lib; {
         license = licenses.mit;
         description = "Flexible, lightweight layer for Haxe cross-platform developers";
+      };
+    };
+
+    openfl = buildHaxeLib {
+      libname = "openfl";
+      version = "9.1.0";
+      sha256 = "0ri9s8d7973d2jz6alhl5i4fx4ijh0kb27mvapq28kf02sp8kgim";
+      meta = with lib; {
+        license = licenses.mit;
+        description = "Open Flash Library for fast 2D development";
       };
     };
 

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -63,8 +63,8 @@ let
 
     hxcpp = buildHaxeLib rec {
       libname = "hxcpp";
-      version = "4.1.15";
-      sha256 = "1ybxcvwi4655563fjjgy6xv5c78grjxzadmi3l1ghds48k1rh50p";
+      version = "4.2.1";
+      sha256 = "10ijb8wiflh46bg30gihg7fyxpcf26gibifmq5ylx0fam4r51lhp";
       postFixup = ''
         for f in $out/lib/haxe/${withCommas libname}/${withCommas version}/{,project/libs/nekoapi/}bin/Linux{,64}/*; do
           chmod +w "$f"

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -23,20 +23,22 @@ let
     buildHaxeLib = {
       libname,
       version,
-      sha256,
+      sha256 ? null,
+      src ? null,
       meta,
       ...
     } @ attrs:
+      assert sha256 != null || src != null;
       stdenv.mkDerivation (attrs // {
         name = "${libname}-${version}";
 
         buildInputs = (attrs.buildInputs or []) ++ [ haxe neko ]; # for setup-hook.sh to work
-        src = fetchzip rec {
+        src = attrs.src or (fetchzip rec {
           name = "${libname}-${version}";
           url = "http://lib.haxe.org/files/3.0/${withCommas name}.zip";
           inherit sha256;
           stripRoot = false;
-        };
+        });
 
         installPhase = attrs.installPhase or ''
           runHook preInstall

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -128,5 +128,15 @@ let
       };
     };
 
+    lime = buildHaxeLib rec {
+      libname = "lime";
+      version = "7.9.0";
+      sha256 = "0n2qkvfbwgk35py26vlnmgga711x37rik32dca63jhh46j1m4h7d";
+      meta = with lib; {
+        license = licenses.mit;
+        description = "Flexible, lightweight layer for Haxe cross-platform developers";
+      };
+    };
+
   };
 in self

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -168,5 +168,15 @@ let
       };
     };
 
+    flixel-ui = buildHaxeLib {
+      libname = "flixel-ui";
+      version = "2.3.3";
+      sha256 = "1xrsjzcg1wv7j9fbifcg5v9zvfr1vhs0spar8nmi86liiqv1iwka";
+      meta = with lib; {
+        license = licenses.mit;
+        description = "UI library for Flixel";
+      };
+    };
+
   };
 in self

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -158,5 +158,15 @@ let
       };
     };
 
+    flixel-addons = buildHaxeLib {
+      libname = "flixel-addons";
+      version = "2.9.0";
+      sha256 = "1zz1pcp20j3r87m0laq32dg0708kir3188dpgpx7c3c3mmxlw6sp";
+      meta = with lib; {
+        license = licenses.mit;
+        description = "Set of useful, but optional classes for HaxeFlixel created by the community";
+      };
+    };
+
   };
 in self

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -117,5 +117,16 @@ let
         description = "Extern definitions for node.js 6.9";
       };
     };
+
+    hscript = buildHaxeLib {
+      libname = "hscript";
+      version = "2.4.0";
+      sha256 = "0qdxgqb75j1v125l9xavs1d32wwzi60rhfymngdhjqhdvq72bhxx";
+      meta = with lib; {
+        license = licenses.mit;
+        description = "Scripting engine for a subset of the Haxe language";
+      };
+    };
+
   };
 in self

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -188,5 +188,20 @@ let
       };
     };
 
+    polymod = buildHaxeLib {
+      libname = "polymod";
+      version = "unstable-2021-04-06";
+      src = fetchFromGitHub {
+        owner = "larsiusprime";
+        repo = "polymod";
+        rev = "bb5f0a120419ac3a7132d96aff1e6f7a36b97d67";
+        sha256 = "1afrajf4mcw0kqz64gsa8h71r54c4i6hhb2pn6kw6z4rg3ilixlf";
+      };
+      meta = with lib; {
+        license = licenses.mit;
+        description = "Atomic modding framework for Haxe games/apps";
+      };
+    };
+
   };
 in self


### PR DESCRIPTION
*getting freaky on a friday night yeah*

![Bildschirmfoto von 2021-03-19 00-04-18](https://user-images.githubusercontent.com/23431373/111708732-b0c94200-8846-11eb-8283-484c72b3d2cb.png)

###### Motivation for this change
Packaging the game [Friday Night Funkin'](https://ninja-muffin24.itch.io/funkin). May require some tuning of your PulseAudio device's latency settings to feel comfortable, certainly did for me.

~~As noted in the file the source code is available at https://github.com/ninjamuffin99/Funkin but requires new haxePackages entries & a newer version of Haxe itself (#116953 perhaps, although it needs 4.1.x specifically) to compile. For that reason I've only packaged the prebuilt 64-bit Linux build from the itch.io page for now. I'll give a source build a shot if that PR gets merged, though I've never done anything with Haxe before.~~

We are now building the game from source. Only `x86_64-linux` (any maybe `i686-linux`, untested) compile with our current way of packaging Haxe packages.

The game complains on launch about an updated version being available, ~~but that elusive v0.2.7.1 version lacks a Linux build on itch.io so *¯\\\_(ツ)\_/¯*.~~ that's a currently-broken version check in the game. Pressing space will also fail to bring up the itch.io page because of a hardcoded `/usr/bin/xdg-open`, I've mentioned that problem on a relevant issue of the github repo. Adding a FSH env just to get that to work feels overkill so I didn't bother with it. (Not that I'd know how to make a FSH env for a package either)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
