### PR TITLE
texlive.bin.dvipng: refactor gs hardcoding, add a test for it

### DIFF
--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -1,4 +1,4 @@
-{ runCommandNoCC, fetchurl, file, texlive }:
+{ runCommandNoCC, fetchurl, file, texlive, writeShellScript }:
 
 {
   chktex = runCommandNoCC "texlive-test-chktex" {
@@ -17,7 +17,7 @@
   '';
 
   # https://github.com/NixOS/nixpkgs/issues/75605
-  dvipng = runCommandNoCC "texlive-test-dvipng" {
+  dvipng.basic = runCommandNoCC "texlive-test-dvipng-basic" {
     nativeBuildInputs = [ file texlive.combined.scheme-medium ];
     input = fetchurl {
       name = "test_dvipng.tex";
@@ -37,6 +37,47 @@
     mkdir "$out"
     mv document*.png "$out"/
   '';
+
+  # test dvipng's limited capability to render postscript specials via GS
+  dvipng.ghostscript = runCommandNoCC "texlive-test-ghostscript" {
+    nativeBuildInputs = [ file (with texlive; combine { inherit scheme-small dvipng; }) ];
+    input = builtins.toFile "postscript-sample.tex" ''
+      \documentclass{minimal}
+      \begin{document}
+        Ni
+        \special{ps:
+          newpath
+          0 0 moveto
+          7 7 rlineto
+          0 7 moveto
+          7 -7 rlineto
+          stroke
+          showpage
+        }
+      \end{document}
+    '';
+    gs_trap = writeShellScript "gs_trap.sh" ''
+      exit 1
+    '';
+  } ''
+    cp "$gs_trap" ./gs
+    export PATH=$PWD:$PATH
+    # check that the trap works
+    gs && exit 1
+
+    cp "$input" ./document.tex
+
+    latex document.tex
+    dvipng -T 1in,1in -strict -picky document.dvi
+    for f in document*.png; do
+      file "$f" | tee output
+      grep PNG output
+    done
+
+    mkdir "$out"
+    mv document*.png "$out"/
+  '';
+
 
   # https://github.com/NixOS/nixpkgs/issues/75070
   dvisvgm = runCommandNoCC "texlive-test-dvisvgm" {

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -281,12 +281,9 @@ dvipng = stdenv.mkDerivation {
   configureFlags = common.configureFlags
     ++ [ "--with-system-kpathsea" "--with-gs=yes" "--disable-debug" ];
 
-  enableParallelBuilding = true;
+  GS="${ghostscript}/bin/gs";
 
-  # I didn't manage to hardcode gs location by configureFlags
-  postInstall = ''
-    wrapProgram "$out/bin/dvipng" --prefix PATH : '${ghostscript}/bin'
-  '';
+  enableParallelBuilding = true;
 };
 
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
