### PR TITLE
ocamlPackages.ocaml-lsp: 1.4.1 -> 1.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -14,10 +14,10 @@
 , lib
 }:
 let
-  version = "1.4.1";
+  version = "1.5.0";
   src = fetchzip {
     url = "https://github.com/ocaml/ocaml-lsp/releases/download/${version}/jsonrpc-${version}.tbz";
-    sha256 = "0hzpw17qfhb0cxgwah1fv4k300r363dy1kv0977anl44dlanx1v5";
+    sha256 = "0njjn0b2nmmdn243bddp5fxvrv3c9555dviha3ynd55jap8z8dr7";
   };
 
   # unvendor some (not all) dependencies.


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/ocaml/ocaml-lsp/releases/tag/1.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
