### PR TITLE
epkowa: add epson perfection v600 photo

### DIFF
--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -13,7 +13,6 @@
 , rpm
 , cpio
 , getopt
-, patchelf
 , autoPatchelfHook
 , gcc
 }:
@@ -324,17 +323,16 @@ stdenv.mkDerivation rec {
     sha256 = "1ma76jj0k3bz0fy06fiyl4di4y77rcryb0mwjmzs5ms2vq9rjysr";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config libtool makeWrapper ];
   buildInputs = [
     gtk2
     libxml2
-    libtool
     libusb-compat-0_1
     sane-backends
-    makeWrapper
   ];
 
   patches = [
+    # Patch for compatibility with libpng versions greater than 10499
     (fetchpatch {
       urls = [
         "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-2.28.1.3+libpng-1.5.patch?h=b6e4c805d53b49da79a0f64ef16bb82d6d800fcf"
@@ -342,7 +340,9 @@ stdenv.mkDerivation rec {
       ];
       sha256 = "04y70qjd220dpyh771fiq50lha16pms98mfigwjczdfmx6kpj1jd";
     })
+    # Patch iscan to search appropriate folders for firmware files
     ./firmware_location.patch
+    # Patch deprecated use of sscanf code to use a more modern C99 compatible version
     ./sscanf.patch
   ];
   patchFlags = [ "-p0" ];

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -99,6 +99,35 @@ let plugins = {
     };
     meta = common_meta // { description = "Plugin to support " + passthru.hw + " scanner in sane"; };
   };
+  v600 = stdenv.mkDerivation rec {
+    pname = "iscan-gt-x820-bundle";
+    version = "2.30.4";
+
+    nativeBuildInputs = [ autoPatchelfHook rpm ];
+    src = fetchurl {
+      urls = [
+        "https://download2.ebz.epson.net/iscan/plugin/gt-x820/rpm/x64/iscan-gt-x820-bundle-${version}.x64.rpm.tar.gz"
+        "https://web.archive.org/web/https://download2.ebz.epson.net/iscan/plugin/gt-x820/rpm/x64/iscan-gt-x820-bundle-${version}.x64.rpm.tar.gz"
+      ];
+      sha256 = "1vlba7dsgpk35nn3n7is8nwds3yzlk38q43mppjzwsz2d2n7sr33";
+    };
+    installPhase = ''
+      cd plugins
+      ${rpm}/bin/rpm2cpio iscan-plugin-gt-x820-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      mkdir $out
+      cp -r usr/share $out
+      cp -r usr/lib64 $out/lib
+      mv $out/share/iscan $out/share/esci
+      mv $out/lib/iscan $out/lib/esci
+    '';
+    passthru = {
+      registrationCommand = ''
+        $registry --add interpreter usb 0x04b8 0x013a "$plugin/lib/esci/libesintA1 $plugin/share/esci/esfwA1.bin"
+      '';
+      hw = "Perfection V600 Photo";
+    };
+    meta = common_meta // { description = "iscan esci x820 plugin for " + passthru.hw; };
+  };
   x770 = stdenv.mkDerivation rec {
     pname = "iscan-gt-x770-bundle";
     version = "2.30.4";


### PR DESCRIPTION
###### Motivation for this change

Add Epson Perfection V600 Photo scanner driver to epkowa package.

###### Things done

Tested by scanning with epkowa on a 20.09 system with:
```
nixpkgs.overlays = [
    (self: super: {
        epkowa = super.callPackage /path/to/my/nixpkgs/pkgs/misc/drivers/epkowa/default.nix {};
    })
  ];
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
