### PR TITLE
pythonPackages.pylint: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -63,8 +63,6 @@ buildPythonPackage rec {
     "test_py3k_jobs_option"
   ];
 
-  disabledTestPaths = lib.optional stdenv.isDarwin "pylint/test/test_functional.py";
-
   meta = with lib; {
     homepage = "https://pylint.pycqa.org/";
     description = "A bug and style checker for Python";


### PR DESCRIPTION
###### Motivation for this change

The test no longer exists after #112908:

```
Disabled tests path "pylint/test/test_functional.py" does not exist. Aborting
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).