### PR TITLE
nvidia-x11: 460.56 -> 460.67

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -28,10 +28,10 @@ rec {
   # Policy: use the highest stable version as the default (on our master).
   stable = if stdenv.hostPlatform.system == "x86_64-linux"
     then generic {
-      version = "460.56";
-      sha256_64bit = "003kwlsghlix2kilrqad7mn7ygkb755rzjlxd0b52vqz1nx1qmsf";
-      settingsSha256 = "1xwhbd78q0bc3v8fnlss9amkl03vnvf91ffpfnz0v7clvn3xymkf";
-      persistencedSha256 = "0sh2csv04fkimf1msbmdc608gxb3j95g8i3rqf32b1pl9jv0p5ly";
+      version = "460.67";
+      sha256_64bit = "L2cRySVw7mgYSN25mJV+b4uOeHTdjLGvFPEkwyFgtec=";
+      settingsSha256 = "DB+ZeKm6cYQuVkJWjVd71qOTOmwIcRqx1CxfkgMbDpg=";
+      persistencedSha256 = "HCmZZRlNhOHi5yN2lNHhBILZkdng73q0vCbv7CIX/8s=";
     }
     else legacy_390;
 


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Reference:
```
Fixed a bug where using ray tracing extensions on multi-GPU setups could result in application instability if the GPUs did not match.
Fixed an issue that prevented G-SYNC from working properly after a mode switch on Kepler-based GPUs.
Fixed a driver installation failure on Linux kernel 5.11 release candidates, where the NVIDIA kernel module failed to build with error
"error: implicit declaration of function 'sys_close'".
Fixed a bug where vkCreateSwapchain could cause the X Server to crash when an invalid imageFormat was provided.
Fixed a driver installation failure on Linux kernel 5.11 release candidates, where the NVIDIA kernel module failed to build with error
"fatal error: asm/kmap_types.h: No such file or directory".
```

Tested on linux 5.11.7.