### PR TITLE
polar-bookshelf: init at 1.100.14

### DIFF
--- a/pkgs/applications/misc/polar-bookshelf/1.100.14.nix
+++ b/pkgs/applications/misc/polar-bookshelf/1.100.14.nix
@@ -1,0 +1,90 @@
+{ stdenv, lib, makeWrapper, fetchurl
+, dpkg, wrapGAppsHook, autoPatchelfHook
+, gtk3, cairo, pango, atk, gdk-pixbuf, glib
+, at-spi2-atk, dbus, libX11, libxcb, libXi
+, libXcursor, libXdamage, libXrandr, libXcomposite
+, libXext, libXfixes, libXrender, libXtst, libXScrnSaver
+, nss, nspr, alsaLib, cups, fontconfig, expat
+, libudev0-shim, glibc, curl, openssl, libnghttp2, gsettings-desktop-schemas
+}:
+
+stdenv.mkDerivation rec {
+  pname = "polar-bookshelf";
+  version = "1.100.14";
+
+  # fetching a .deb because there's no easy way to package this Electron app
+  src = fetchurl {
+    url = "https://github.com/burtonator/polar-bookshelf/releases/download/v${version}/polar-bookshelf-${version}-amd64.deb";
+    hash = "sha256-5xa+Nwu0p1x5DLn1GNI0HDt7GtBGoFQ/9qGTeq9uBgU=";
+  };
+
+  buildInputs = [
+    gsettings-desktop-schemas
+    glib
+    gtk3
+    cairo
+    pango
+    atk
+    gdk-pixbuf
+    at-spi2-atk
+    dbus
+    libX11
+    libxcb
+    libXi
+    libXcursor
+    libXdamage
+    libXrandr
+    libXcomposite
+    libXext
+    libXfixes
+    libXrender
+    libXtst
+    libXScrnSaver
+    nss
+    nspr
+    alsaLib
+    cups
+    fontconfig
+    expat
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    autoPatchelfHook
+    makeWrapper
+    dpkg
+  ];
+
+  runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl libnghttp2 ];
+
+  unpackPhase = ''
+    dpkg-deb -x $src .
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/polar-bookshelf $out/bin $out/lib
+
+    mv opt/Polar\ Bookshelf/* $out/share/polar-bookshelf
+    mv $out/share/polar-bookshelf/*.so $out/lib
+
+    mv usr/share/* $out/share/
+
+    ln -s $out/share/polar-bookshelf/polar-bookshelf $out/bin/polar-bookshelf
+
+    # Correct desktop file `Exec`
+    substituteInPlace $out/share/applications/polar-bookshelf.desktop \
+      --replace "/opt/Polar Bookshelf/polar-bookshelf" "$out/bin/polar-bookshelf"
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${runtimeLibs}" )
+  '';
+
+  meta = with lib; {
+    homepage = "https://getpolarized.io/";
+    description = "Personal knowledge repository for PDF and web content supporting incremental reading and document annotation";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.noneucat ];
+  };
+}

--- a/pkgs/applications/misc/polar-bookshelf/1.100.14.nix
+++ b/pkgs/applications/misc/polar-bookshelf/1.100.14.nix
@@ -85,6 +85,6 @@ stdenv.mkDerivation rec {
     description = "Personal knowledge repository for PDF and web content supporting incremental reading and document annotation";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = [ maintainers.noneucat ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
The polar-bookshelf package is outdated. Unstable has 2.0.42 but version 2 is a cloud only application and incompatible with version 1.100.14 which is the final version 1 according to the developer. https://www.reddit.com/r/PolarBookshelf/comments/j9yfbx/polar_110014_last_1x_version_with_autoupdates/

Adapted the paths from https://github.com/NixOS/nixpkgs/blob/nixos-20.09/pkgs/applications/misc/polar-bookshelf/default.nix

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).