### PR TITLE
Bump (lib)sidplayfp

### DIFF
--- a/pkgs/applications/audio/sidplayfp/default.nix
+++ b/pkgs/applications/audio/sidplayfp/default.nix
@@ -1,40 +1,47 @@
 { stdenv
 , lib
-, fetchurl
+, fetchFromGitHub
+, autoreconfHook
+, perl
 , pkg-config
 , libsidplayfp
 , alsaSupport ? stdenv.hostPlatform.isLinux
 , alsaLib
 , pulseSupport ? stdenv.hostPlatform.isLinux
 , libpulseaudio
+, out123Support ? stdenv.hostPlatform.isDarwin
+, mpg123
 }:
 
-assert alsaSupport -> alsaLib != null;
-assert pulseSupport -> libpulseaudio != null;
-let
-  inherit (lib) optional;
-  inherit (lib.versions) majorMinor;
-in
 stdenv.mkDerivation rec {
   pname = "sidplayfp";
-  version = "2.0.2";
+  version = "2.1.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/sidplay-residfp/sidplayfp/${majorMinor version}/${pname}-${version}.tar.gz";
-    sha256 = "1s2dfs9z1hwarpfzawg11wax9nh0zcqx4cafwq7iysckyg4scz4k";
+  src = fetchFromGitHub {
+    owner = "libsidplayfp";
+    repo = "sidplayfp";
+    rev = "v${version}";
+    sha256 = "0s3xmg3yzfqbsnlh2y46w7b5jim5zq7mshs6hx03q8wdr75cvwh4";
   };
 
-  nativeBuildInputs = [ pkg-config ]
-    ++ optional alsaSupport alsaLib
-    ++ optional pulseSupport libpulseaudio;
+  nativeBuildInputs = [ autoreconfHook perl pkg-config ];
 
-  buildInputs = [ libsidplayfp ];
+  buildInputs = [ libsidplayfp ]
+    ++ lib.optional alsaSupport alsaLib
+    ++ lib.optional pulseSupport libpulseaudio
+    ++ lib.optional out123Support mpg123;
+
+  configureFlags = lib.optionals out123Support [
+    "--with-out123"
+  ];
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "A SID player using libsidplayfp";
-    homepage = "https://sourceforge.net/projects/sidplay-residfp/";
+    homepage = "https://github.com/libsidplayfp/sidplayfp";
     license = with licenses; [ gpl2Plus ];
-    maintainers = with maintainers; [ dezgeg ];
-    platforms = with platforms; linux;
+    maintainers = with maintainers; [ dezgeg OPNA2608 ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/compilers/xa/dxa.nix
+++ b/pkgs/development/compilers/xa/dxa.nix
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
   version = "0.1.4";
 
   src = fetchurl {
-    url = "https://www.floodgap.com/retrotech/xa/dists/${pname}-${version}.tar.gz";
+    urls = [
+      "https://www.floodgap.com/retrotech/xa/dists/${pname}-${version}.tar.gz"
+      "https://www.floodgap.com/retrotech/xa/dists/unsupported/${pname}-${version}.tar.gz"
+    ];
     hash = "sha256-C0rgwK51Ij9EZCm9GeiVnWIkEkse0d60ok8G9hm2a5U=";
   };
 

--- a/pkgs/development/compilers/xa/xa.nix
+++ b/pkgs/development/compilers/xa/xa.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, perl
 }:
 
 stdenv.mkDerivation rec {
@@ -8,22 +9,39 @@ stdenv.mkDerivation rec {
   version = "2.3.11";
 
   src = fetchurl {
-    url = "https://www.floodgap.com/retrotech/xa/dists/${pname}-${version}.tar.gz";
+    urls = [
+      "https://www.floodgap.com/retrotech/xa/dists/${pname}-${version}.tar.gz"
+      "https://www.floodgap.com/retrotech/xa/dists/unsupported/${pname}-${version}.tar.gz"
+    ];
     hash = "sha256-MvIWTJnjBSGOmSlwhW3Y4jCbXLasR1jXsq/jv+vJAS0=";
   };
+
+  checkInputs = [ perl ];
 
   dontConfigure = true;
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace "DESTDIR" "PREFIX" \
       --replace "CC = gcc" "CC = ${stdenv.cc.targetPrefix}cc" \
-      --replace "LDD = gcc" "LDD = ${stdenv.cc.targetPrefix}cc" \
+      --replace "LD = gcc" "LD = ${stdenv.cc.targetPrefix}cc" \
       --replace "CFLAGS = -O2" "CFLAGS ?=" \
       --replace "LDFLAGS = -lc" "LDFLAGS ?= -lc"
   '';
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  makeFlags = [
+    "DESTDIR:=${placeholder "out"}"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  # Running tests in parallel does not work
+  enableParallelChecking = false;
+
+  preCheck = ''
+    patchShebangs tests
+  '';
 
   meta = with lib; {
     homepage = "https://www.floodgap.com/retrotech/xa/";

--- a/pkgs/development/libraries/libexsid/default.nix
+++ b/pkgs/development/libraries/libexsid/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, docSupport ? true
+, doxygen
+, libftdi1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libexsid";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "libsidplayfp";
+    repo = "exsid-driver";
+    rev = version;
+    sha256 = "1qbiri549fma8c72nmj3cpz3sn1vc256kfafnygkmkzg7wdmgi7r";
+  };
+
+  outputs = [ "out" ]
+    ++ lib.optional docSupport "doc";
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ]
+    ++ lib.optional docSupport doxygen;
+
+  buildInputs = [ libftdi1 ];
+
+  enableParallelBuilding = true;
+
+  installTargets = [ "install" ]
+    ++ lib.optional docSupport "doc";
+
+  postInstall = lib.optionalString docSupport ''
+    mkdir -p $doc/share/libexsid/doc
+    cp -r docs/html $doc/share/libexsid/doc/
+  '';
+
+  meta = with lib; {
+    description = "Driver for exSID USB";
+    homepage = "http://hacks.slashdirt.org/hw/exsid/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libsidplayfp/default.nix
+++ b/pkgs/development/libraries/libsidplayfp/default.nix
@@ -1,45 +1,88 @@
 { stdenv
 , lib
-, fetchurl
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
 , pkg-config
+, perl
+, unittest-cpp
+, xa
+, libgcrypt
+, libexsid
 , docSupport ? true
-, doxygen ? null
-, graphviz ? null
+, doxygen
+, graphviz
 }:
 
-assert docSupport -> doxygen != null && graphviz != null;
-let
-  inherit (lib) optionals optionalString;
-  inherit (lib.versions) majorMinor;
-in
 stdenv.mkDerivation rec {
   pname = "libsidplayfp";
-  version = "2.0.5";
+  version = "2.1.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/sidplay-residfp/${pname}/${majorMinor version}/${pname}-${version}.tar.gz";
-    sha256 = "04vdrrkh5y9x9rrmj6gdp242ah70b4sslwqfby8wp2riis4hr9z0";
+  src = fetchFromGitHub {
+    owner = "libsidplayfp";
+    repo = "libsidplayfp";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "0487gap2b0ypikyra74lk1qwqwr0vncldamk5xb1db2x97v504fd";
   };
 
-  nativeBuildInputs = [ pkg-config ]
-    ++ optionals docSupport [ doxygen graphviz ];
+  # https://github.com/libsidplayfp/libsidplayfp/issues/13
+  # Remove on next version bump
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/libsidplayfp/libsidplayfp/commit/84f5498f5653261ed84328e1b5676c31e3ba9e6e.patch";
+      sha256 = "1vysbl4fkdzm11k40msng2ag6i6mb6z9jsw32vyj9calcfha5957";
+    })
+    (fetchpatch {
+      url = "https://github.com/libsidplayfp/libsidplayfp/commit/c1a1b732cc2e791d910522d58f47c6d094493c6d.patch";
+      sha256 = "1d3sgdly0q9dysgkx5afxbwfas6p0m8n3lw1hmj4n6wm3j9sdz4g";
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config perl xa ]
+    ++ lib.optionals docSupport [ doxygen graphviz ];
+
+  buildInputs = [ libgcrypt libexsid ];
+
+  doCheck = true;
+
+  checkInputs = [ unittest-cpp ];
+
+  enableParallelBuilding = true;
 
   installTargets = [ "install" ]
-    ++ optionals docSupport [ "doc" ];
+    ++ lib.optionals docSupport [ "doc" ];
 
   outputs = [ "out" ]
-    ++ optionals docSupport [ "doc" ];
+    ++ lib.optionals docSupport [ "doc" ];
 
-  postInstall = optionalString docSupport ''
+  configureFlags = [
+    "--enable-hardsid"
+    "--with-gcrypt"
+    "--with-exsid"
+  ]
+  ++ lib.optional doCheck "--enable-tests";
+
+  postInstall = lib.optionalString docSupport ''
     mkdir -p $doc/share/doc/libsidplayfp
     mv docs/html $doc/share/doc/libsidplayfp/
   '';
 
   meta = with lib; {
     description = "A library to play Commodore 64 music derived from libsidplay2";
-    homepage = "https://sourceforge.net/projects/sidplay-residfp/";
+    longDescription = ''
+      libsidplayfp is a C64 music player library which integrates
+      the reSID SID chip emulation into a cycle-based emulator
+      environment, constantly aiming to improve emulation of the
+      C64 system and the SID chips.
+    '';
+    homepage = "https://github.com/libsidplayfp/libsidplayfp";
     license = with licenses; [ gpl2Plus ];
-    maintainers = with maintainers; [ ramkromberg ];
-    platforms = with platforms; unix;
+    maintainers = with maintainers; [ ramkromberg OPNA2608 ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15505,6 +15505,8 @@ in
 
   libexosip = callPackage ../development/libraries/exosip {};
 
+  libexsid = callPackage ../development/libraries/libexsid { };
+
   libextractor = callPackage ../development/libraries/libextractor {
     libmpeg2 = mpeg2dec;
   };


### PR DESCRIPTION
Closes #113169
Closes #115619
Closes #117590

###### Motivation for this change
Upstream moved from SourceForge to GitHub & changed their build system abit. Added some new dependencies & myself as a maintainer for (lib)sidplayfp.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
