### PR TITLE
[20.09] grafana: 7.4.3 -> 7.4.5

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "grafana";
-  version = "7.4.3";
+  version = "7.4.5";
 
   excludedPackages = [ "release_publisher" ];
 
@@ -10,15 +10,15 @@ buildGoModule rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "sha256-FPQa6q1ks9Lpod5sI29YBnGZvVRU12hTiw6GR85/mEs=";
+    sha256 = "10pnwd4d19ry7w2x46acc3j8gjn73b45fzc579gz1hc8hx2b3s0s";
   };
 
   srcStatic = fetchurl {
     url = "https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "sha256-idbG+K9NVnNhEB0f7DfP7iaEnHMf59ieQtYnmT6CvVM=";
+    sha256 = "1x9jx3ww37cn6r6cn6gqlavmllxydks23vm8w4934bv8zppj1zwz";
   };
 
-  vendorSha256 = "sha256-LL+EkDZbbaNo/fPMGlPsB8jgBYHoe6SdkBbQoW5y4EU=";
+  vendorSha256 = "0ig0f9pa3l0nj2fs8yz8h42y1j07xi9imk7kzmla6vav6s889grc";
 
   postPatch = ''
     substituteInPlace pkg/cmd/grafana-server/main.go \


### PR DESCRIPTION
###### Motivation for this change


This fixes a few CVEs around authentication bypass with Grafana. Details
are available in the [annoucement].

CVE-2021-27962, CVE-2021-28146, CVE-2021-28147, CVE-2021-28148

[annoucement]: https://grafana.com/blog/2021/03/18/grafana-6.7.6-7.3.10-and-7.4.5-released-with-important-security-fixes-for-grafana-enterprise/

(cherry picked from commit 9a3f2457f128cbbcbddb9053822988fdd247e416)

Backport of #116829 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))