### PR TITLE
watson: 1.10.0 -> 2.0.0

### DIFF
--- a/pkgs/applications/office/watson/default.nix
+++ b/pkgs/applications/office/watson/default.nix
@@ -4,26 +4,22 @@ with pythonPackages;
 
 buildPythonApplication rec {
   pname = "watson";
-  version = "1.10.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "TailorDev";
     repo = "Watson";
     rev = version;
-    sha256 = "1s0k86ldqky6avwjaxkw1y02wyf59qwqldcahy3lhjn1b5dgsb3s";
+    sha256 = "1yxqjirv7cpg4hqj4l3a53p3p3kl82bcx6drgvl9v849vcc3l7s0";
   };
-
-  checkPhase = ''
-    pytest -vs tests
-  '';
 
   postInstall = ''
     installShellCompletion --bash --name watson watson.completion
     installShellCompletion --zsh --name _watson watson.zsh-completion
   '';
 
-  checkInputs = [ py pytest pytest-datafiles pytest-mock pytestrunner ];
-  propagatedBuildInputs = [ arrow click click-didyoumean requests ];
+  checkInputs = [ pytestCheckHook pytest-mock mock pytest-datafiles ];
+  propagatedBuildInputs = [ arrow_1 click click-didyoumean requests ];
   nativeBuildInputs = [ installShellFiles ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/arrow/1.nix
+++ b/pkgs/development/python-modules/arrow/1.nix
@@ -1,0 +1,41 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, simplejson, typing-extensions, python-dateutil, pytz, pytest-mock, sphinx
+, dateparser, pytestcov, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "arrow";
+  version = "1.0.3";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0793badh4hgbk2c5g70hmbl7n3d4g5d87bcflld0w9rjwy59r71r";
+  };
+
+  propagatedBuildInputs = [ python-dateutil ]
+    ++ lib.optionals (!pythonOlder "3.8") [ typing-extensions ];
+
+  checkInputs = [
+    dateparser
+    pytestCheckHook
+    pytestcov
+    pytest-mock
+    pytz
+    simplejson
+    sphinx
+  ];
+
+  # ParserError: Could not parse timezone expression "America/Nuuk"
+  disabledTests = [
+    "test_parse_tz_name_zzz"
+  ];
+
+  meta = with lib; {
+    description = "Python library for date manipulation";
+    homepage = "https://github.com/crsmithdev/arrow";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ thoughtpolice oxzi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -482,6 +482,8 @@ in {
 
   arrow = callPackage ../development/python-modules/arrow { };
 
+  arrow_1 = callPackage ../development/python-modules/arrow/1.nix { };
+
   arviz = callPackage ../development/python-modules/arviz { };
 
   arxiv2bib = callPackage ../development/python-modules/arxiv2bib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This pull request updates watson to its latest release. Therefore, the arrow dependency needs to be bumped first. Thus, this two changes are within this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
