### PR TITLE
llvmPackages_{10,11}.compiler-rt: restrict build to current arch

### DIFF
--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     # The compiler-rt build infrastructure sniffs supported platforms on Darwin
     # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
     # when it tries to use libc++ and libc++api for i386.
-    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.parsed.cpu.name}"
+    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
     # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
     # when it tries to use libc++ and libc++api for i386.
     "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
+    "-DDARWIN_osx_BUILTIN_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/compilers/llvm/11/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/11/compiler-rt.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (stdenv.isDarwin) [
     "-DDARWIN_macosx_OVERRIDE_SDK_VERSION=ON"
-    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.parsed.cpu.name}"
+    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"

--- a/pkgs/development/compilers/llvm/11/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/11/compiler-rt.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.isDarwin) [
     "-DDARWIN_macosx_OVERRIDE_SDK_VERSION=ON"
     "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
+    "-DDARWIN_osx_BUILTIN_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"

--- a/pkgs/development/compilers/llvm/5/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     # The compiler-rt build infrastructure sniffs supported platforms on Darwin
     # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
     # when it tries to use libc++ and libc++api for i386.
-    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.parsed.cpu.name}"
+    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/compilers/llvm/6/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/6/compiler-rt.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     # The compiler-rt build infrastructure sniffs supported platforms on Darwin
     # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
     # when it tries to use libc++ and libc++api for i386.
-    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.parsed.cpu.name}"
+    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/compilers/llvm/7/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     # The compiler-rt build infrastructure sniffs supported platforms on Darwin
     # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
     # when it tries to use libc++ and libc++api for i386.
-    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.parsed.cpu.name}"
+    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/compilers/llvm/8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     # The compiler-rt build infrastructure sniffs supported platforms on Darwin
     # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
     # when it tries to use libc++ and libc++api for i386.
-    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.parsed.cpu.name}"
+    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/compilers/llvm/9/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/9/compiler-rt.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     # The compiler-rt build infrastructure sniffs supported platforms on Darwin
     # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
     # when it tries to use libc++ and libc++api for i386.
-    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.parsed.cpu.name}"
+    "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ];
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

Fix `llvmPackages_10.compiler-rt` and `llvmPackages_11.compiler-rt` on `staging-next`.

These packages were broken by #114817 (see https://github.com/NixOS/nixpkgs/pull/114817#issuecomment-802709527).

While I'm here, use `darwinArch` for all compiler-rts, which is a no-op on `x86_64-darwin`.

I assert this change is correct in that nixpkgs only targets a single architecture at once, so building for extra platforms is unnecessary work. The alternative is to remove the `-arch` argument from the cc/bintools wrappers (revert fc0456bed1372ccff51fc6fd578e5d2a09d64534, b26e0bac8dab068e54b0c8ee1bf8fd5fe5683b39 and 8feb949ab540130063d1c57db7244024887c4ed9).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
