### PR TITLE
sumo: init at 1.8.0

### DIFF
--- a/pkgs/applications/science/networking/sumo/default.nix
+++ b/pkgs/applications/science/networking/sumo/default.nix
@@ -1,0 +1,68 @@
+{ lib, bzip2, cmake, eigen, fetchFromGitHub, ffmpeg, fox_1_6, gdal,
+  git, gl2ps, gpp , gtest, jdk, libGL, libGLU, libX11, libjpeg,
+  libpng, libtiff, openscenegraph , proj, python3, python37Packages,
+  stdenv, swig, xercesc, xorg, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "sumo";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "eclipse";
+    repo = "sumo";
+    rev = "v${lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "1w9im1zz8xnkdwmv4v11kn1xcqm889268g1fw4y2s9f6shi41mxx";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    git
+    swig
+  ];
+
+  buildInputs = [
+    bzip2
+    eigen
+    ffmpeg
+    fox_1_6
+    gdal
+    gl2ps
+    gpp
+    gtest
+    jdk
+    libGL
+    libGLU
+    libX11
+    libjpeg
+    libpng
+    libtiff
+    openscenegraph
+    proj
+    python37Packages.setuptools
+    xercesc
+    zlib
+    python3
+  ] ++ (with xorg; [
+    libXcursor
+    libXext
+    libXfixes
+    libXft
+    libXrandr
+    libXrender
+  ]);
+
+  meta = with lib; {
+    description = "The SUMO traffic simulator";
+    longDescription = ''
+      Eclipse SUMO is an open source, highly
+      portable, microscopic and continuous traffic simulation package
+      designed to handle large networks. It allows for intermodal
+      simulation including pedestrians and comes with a large set of
+      tools for scenario creation.
+    '';
+    homepage = "https://github.com/eclipse/sumo";
+    license = licenses.epl20;
+    maintainers = with maintainers; [ mtreca ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28811,6 +28811,8 @@ in
 
   simgrid = callPackage ../applications/science/misc/simgrid { };
 
+  sumo = callPackage ../applications/science/networking/sumo { };
+
   spyder = with python3.pkgs; toPythonApplication spyder;
 
   openspace = callPackage ../applications/science/astronomy/openspace { };


### PR DESCRIPTION
###### Motivation for this change

Adding the SUMO traffic simulator to the nixpkgs repository. I have been using this derivation locally for more than a year without issues. In order to use the provided python libraries (they are optional), I use the following nix-shell:

```nix

{ pkgs ? import <nixpkgs> {}}:

let
  sumo = pkgs.callPackage ./sumo.nix {};
in
pkgs.mkShell rec {

  name = "sumo-dev";
  venvDir = "./.venv";
  buildInputs = with pkgs; [
    python38Full
    python38Packages.python
    python38Packages.venvShellHook
    sumo
  ];

  propagatedBuildInputs = with pkgs; [
    python38Full
    sumo
  ];

  postShellHook = ''
    export SUMO_HOME="${sumo}/share/sumo";
    export PYTHONPATH="${sumo}/share/sumo/tools:$PYTHONPATH"
    export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [pkgs.stdenv.cc.cc]}
  '';
}

```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
