### PR TITLE
jdk14: init (restore)

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/14.nix
+++ b/pkgs/development/compilers/openjdk/darwin/14.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
+let
+  jce-policies = fetchurl {
+    # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
+    url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
+  };
+
+  jdk = stdenv.mkDerivation rec {
+    name = "zulu14.28.21-ca-jdk14.0.1";
+
+    src = fetchurl {
+      url = "https://cdn.azul.com/zulu/bin/${name}-macosx_x64.tar.gz";
+      sha256 = "1pc0y3fxhlf42a51qbdha1fabci61yzq70kk5c1rzk0ai78d92q8";
+      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
+    };
+
+    buildInputs = [ unzip freetype ];
+
+    installPhase = ''
+      mkdir -p $out
+      mv * $out
+      unzip ${jce-policies}
+      mv -f ZuluJCEPolicies/*.jar $out/lib/security/
+      # jni.h expects jni_md.h to be in the header search path.
+      ln -s $out/include/darwin/*_md.h $out/include/
+      if [ -f $out/LICENSE ]; then
+        install -D $out/LICENSE $out/share/zulu/LICENSE
+        rm $out/LICENSE
+      fi
+    '';
+
+    preFixup = ''
+      # Propagate the setJavaClassPath setup hook from the JDK so that
+      # any package that depends on the JDK has $CLASSPATH set up
+      # properly.
+      mkdir -p $out/nix-support
+      printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/lib/libfontmanager.dylib
+      # Set JAVA_HOME automatically.
+      cat <<EOF >> $out/nix-support/setup-hook
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+      EOF
+    '';
+
+    passthru = {
+      home = jdk;
+    };
+
+    meta = with lib; {
+      license = licenses.gpl2;
+      platforms = platforms.darwin;
+    };
+
+  };
+in jdk

--- a/pkgs/development/compilers/openjdk/openjfx/14.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/14.nix
@@ -1,0 +1,113 @@
+{ stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradleGen
+, pkgconfig, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib
+, ffmpeg_3, python, ruby }:
+
+let
+  major = "14";
+  update = "";
+  build = "-ga";
+  repover = "${major}${update}${build}";
+  gradle_ = (gradleGen.override {
+    java = openjdk11_headless;
+  }).gradle_5_6;
+
+  makePackage = args: stdenv.mkDerivation ({
+    version = "${major}${update}${build}";
+
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jfx";
+      rev = repover;
+      sha256 = "16aj15xksc266gv3y42m0g277pfvp71901lrngndcnpr7i2zshnr";
+    };
+
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsaLib ffmpeg_3 ];
+    nativeBuildInputs = [ gradle_ perl pkgconfig cmake gperf python ruby ];
+
+    dontUseCmakeConfigure = true;
+
+    config = writeText "gradle.properties" (''
+      CONF = Release
+      JDK_HOME = ${openjdk11_headless.home}
+    '' + args.gradleProperties or "");
+
+    #avoids errors about deprecation of GTypeDebugFlags, GTimeVal, etc.
+    NIX_CFLAGS_COMPILE = [ "-DGLIB_DISABLE_DEPRECATION_WARNINGS" ];
+
+    buildPhase = ''
+      runHook preBuild
+      export GRADLE_USER_HOME=$(mktemp -d)
+      ln -s $config gradle.properties
+      export NIX_CFLAGS_COMPILE="$(pkg-config --cflags glib-2.0) $NIX_CFLAGS_COMPILE"
+      gradle --no-daemon $gradleFlags sdk
+      runHook postBuild
+    '';
+  } // args);
+
+  # Fake build to pre-download deps into fixed-output derivation.
+  # We run nearly full build because I see no other way to download everything that's needed.
+  # Anyone who knows a better way?
+  deps = makePackage {
+    pname = "openjfx-deps";
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME -type f -regex '.*/modules.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+      rm -rf $out/tmp
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    # Downloaded AWT jars differ by platform.
+    outputHash = {
+      x86_64-linux = "077zss95iq6iskx7ghz1c57ymydpzj0wm7r1pkznw99l9xwvdmqi";
+      i686-linux = "03gglr2sh77cyg16qw9g45ji33dg7i93s5s30hz3mh420g112qa0";
+    }.${stdenv.system} or (throw "Unsupported platform");
+  };
+
+in makePackage {
+  pname = "openjfx-modular-sdk";
+
+  gradleProperties = ''
+    COMPILE_MEDIA = true
+    COMPILE_WEBKIT = true
+  '';
+
+  preBuild = ''
+    swtJar="$(find ${deps} -name org.eclipse.swt\*.jar)"
+    substituteInPlace build.gradle \
+      --replace 'mavenCentral()' 'mavenLocal(); maven { url uri("${deps}") }' \
+      --replace 'name: SWT_FILE_NAME' "files('$swtJar')"
+  '';
+
+  installPhase = ''
+    cp -r build/modular-sdk $out
+  '';
+
+  # glib-2.62 deprecations
+  NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
+
+  stripDebugList = [ "." ];
+
+  postFixup = ''
+    # Remove references to bootstrap.
+    find "$out" -name \*.so | while read lib; do
+      new_refs="$(patchelf --print-rpath "$lib" | sed -E 's,:?${lib.escape ["+"] openjdk11_headless.outPath}[^:]*,,')"
+      patchelf --set-rpath "$new_refs" "$lib"
+    done
+  '';
+
+  disallowedReferences = [ openjdk11_headless ];
+
+  passthru.deps = deps;
+
+  meta = with lib; {
+    homepage = "http://openjdk.java.net/projects/openjfx/";
+    license = licenses.gpl2;
+    description = "The next-generation Java client toolkit";
+    maintainers = with maintainers; [ abbradar ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10432,6 +10432,8 @@ in
 
   openjfx11 = callPackage ../development/compilers/openjdk/openjfx/11.nix { };
 
+  openjfx14 = callPackage ../development/compilers/openjdk/openjfx/14.nix { };
+
   openjfx15 = callPackage ../development/compilers/openjdk/openjfx/15.nix { };
 
   openjdk8-bootstrap =
@@ -10509,6 +10511,41 @@ in
 
   jdk11 = openjdk11;
   jdk11_headless = openjdk11_headless;
+
+  openjdk14 =
+    if stdenv.isDarwin then
+      callPackage ../development/compilers/openjdk/darwin/14.nix { }
+    else
+      callPackage ../development/compilers/openjdk/14.nix {
+        openjfx = openjfx14;
+        inherit (gnome2) GConf gnome_vfs;
+      };
+  openjdk14_headless =
+    if stdenv.isDarwin then
+      openjdk14
+    else
+      openjdk14.override { headless = true; };
+
+  jdk14 = openjdk14;
+  jdk14_headless = openjdk14_headless;
+
+  openjdk14-bootstrap =
+    if adoptopenjdk-hotspot-bin-13.meta.available then
+      adoptopenjdk-hotspot-bin-13
+    else
+      /* adoptopenjdk not available for i686, so fall back to our old builds of 12 & 13 for bootstrapping */
+      callPackage ../development/compilers/openjdk/13.nix {
+        openjfx = openjfx11; /* need this despite next line :-( */
+        enableJavaFX = false;
+        headless = true;
+        inherit (gnome2) GConf gnome_vfs;
+        openjdk13-bootstrap = callPackage ../development/compilers/openjdk/12.nix {
+          openjfx = openjfx11; /* need this despite next line :-( */
+          enableJavaFX = false;
+          headless = true;
+          inherit (gnome2) GConf gnome_vfs;
+        };
+      };
 
   /* Latest JDK */
   openjdk15 =


### PR DESCRIPTION
###### Motivation for this change

It was removed incompletely, while some packages do not support
jdk15 yet, one of them being logstash.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
