### PR TITLE
scimark: init at 4c

### DIFF
--- a/pkgs/misc/scimark/default.nix
+++ b/pkgs/misc/scimark/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchurl
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "scimark";
+  version = "4c";
+
+  src = fetchurl {
+    url = "https://math.nist.gov/scimark2/${pname}${version}.zip";
+    hash = "sha256-kcg5vKYp0B7+bC/CmFMO/tMwxf9q6nvuFv0vRSy3MbE=";
+  };
+
+  nativeBuildInputs = [
+    unzip
+  ];
+
+  dontConfigure = true;
+
+  installPhase = ''
+    install -d $out/bin/
+    install scimark4 $out/bin/
+  '';
+
+  meta = with lib; {
+    homepage = "https://math.nist.gov/scimark2/index.html";
+    description = "Scientific and numerical computing benchmark (ANSI C version)";
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.all;
+  };
+}
+# TODO [ AndersonTorres ]: Java version

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7877,6 +7877,8 @@ in
     pulseSupport = config.pulseaudio or false;
   };
 
+  scimark = callPackage ../misc/scimark { };
+
   screen = callPackage ../tools/misc/screen {
     inherit (darwin.apple_sdk.libs) utmp;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
