### PR TITLE
adoptopenjdk-{13,14}: mark insecure

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -1,4 +1,4 @@
-sourcePerArch:
+{ sourcePerArch, knownVulnerabilities ? [] }:
 
 { swingSupport ? true # not used for now
 , lib, stdenv
@@ -48,6 +48,7 @@ let cpuName = stdenv.hostPlatform.parsed.cpu.name;
     description = "AdoptOpenJDK, prebuilt OpenJDK binary";
     platforms = [ "x86_64-darwin" ]; # some inherit jre.meta.platforms
     maintainers = with lib.maintainers; [ taku0 ];
+    inherit knownVulnerabilities;
   };
 
 }; in result

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -1,4 +1,4 @@
-sourcePerArch:
+{ sourcePerArch, knownVulnerabilities ? [] }:
 
 { stdenv
 , lib
@@ -107,6 +107,7 @@ let result = stdenv.mkDerivation rec {
     description = "AdoptOpenJDK, prebuilt OpenJDK binary";
     platforms = lib.mapAttrsToList (arch: _: arch + "-linux") sourcePerArch; # some inherit jre.meta.platforms
     maintainers = with lib.maintainers; [ taku0 ];
+    inherit knownVulnerabilities;
   };
 
 }; in result

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-darwin-base.nix sources.openjdk11.mac.jdk.hotspot;
-  jre-hotspot = import ./jdk-darwin-base.nix sources.openjdk11.mac.jre.hotspot;
-  jdk-openj9 = import ./jdk-darwin-base.nix sources.openjdk11.mac.jdk.openj9;
-  jre-openj9 = import ./jdk-darwin-base.nix sources.openjdk11.mac.jre.openj9;
+  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk11.mac.jdk.hotspot; };
+  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk11.mac.jre.hotspot; };
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk11.mac.jdk.openj9; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk11.mac.jre.openj9; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-linux-base.nix sources.openjdk11.linux.jdk.hotspot;
-  jre-hotspot = import ./jdk-linux-base.nix sources.openjdk11.linux.jre.hotspot;
-  jdk-openj9 = import ./jdk-linux-base.nix sources.openjdk11.linux.jdk.openj9;
-  jre-openj9 = import ./jdk-linux-base.nix sources.openjdk11.linux.jre.openj9;
+  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk11.linux.jdk.hotspot; };
+  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk11.linux.jre.hotspot; };
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk11.linux.jdk.openj9; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk11.linux.jre.openj9; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk13-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk13-darwin.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-darwin-base.nix sources.openjdk13.mac.jdk.hotspot;
-  jre-hotspot = import ./jdk-darwin-base.nix sources.openjdk13.mac.jre.hotspot;
-  jdk-openj9 = import ./jdk-darwin-base.nix sources.openjdk13.mac.jdk.openj9;
-  jre-openj9 = import ./jdk-darwin-base.nix sources.openjdk13.mac.jre.openj9;
+  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk13.mac.jdk.hotspot; knownVulnerabilities = ["Support ended"]; };
+  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk13.mac.jre.hotspot; knownVulnerabilities = ["Support ended"]; };
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk13.mac.jdk.openj9; knownVulnerabilities = ["Support ended"]; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk13.mac.jre.openj9; knownVulnerabilities = ["Support ended"]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk13-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk13-linux.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-linux-base.nix sources.openjdk13.linux.jdk.hotspot;
-  jre-hotspot = import ./jdk-linux-base.nix sources.openjdk13.linux.jre.hotspot;
-  jdk-openj9 = import ./jdk-linux-base.nix sources.openjdk13.linux.jdk.openj9;
-  jre-openj9 = import ./jdk-linux-base.nix sources.openjdk13.linux.jre.openj9;
+  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk13.linux.jdk.hotspot; knownVulnerabilities = ["Support ended"]; };
+  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk13.linux.jre.hotspot; knownVulnerabilities = ["Support ended"]; };
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk13.linux.jdk.openj9; knownVulnerabilities = ["Support ended"]; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk13.linux.jre.openj9; knownVulnerabilities = ["Support ended"]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk14-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk14-darwin.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-darwin-base.nix sources.openjdk14.mac.jdk.hotspot;
-  jre-hotspot = import ./jdk-darwin-base.nix sources.openjdk14.mac.jre.hotspot;
-  jdk-openj9 = import ./jdk-darwin-base.nix sources.openjdk14.mac.jdk.openj9;
-  jre-openj9 = import ./jdk-darwin-base.nix sources.openjdk14.mac.jre.openj9;
+  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk14.mac.jdk.hotspot; knownVulnerabilities = ["Support ended"]; };
+  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk14.mac.jre.hotspot; knownVulnerabilities = ["Support ended"]; };
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk14.mac.jdk.openj9; knownVulnerabilities = ["Support ended"]; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk14.mac.jre.openj9; knownVulnerabilities = ["Support ended"]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk14-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk14-linux.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-linux-base.nix sources.openjdk14.linux.jdk.hotspot;
-  jre-hotspot = import ./jdk-linux-base.nix sources.openjdk14.linux.jre.hotspot;
-  jdk-openj9 = import ./jdk-linux-base.nix sources.openjdk14.linux.jdk.openj9;
-  jre-openj9 = import ./jdk-linux-base.nix sources.openjdk14.linux.jre.openj9;
+  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk14.linux.jdk.hotspot; knownVulnerabilities = ["Support ended"]; };
+  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk14.linux.jre.hotspot; knownVulnerabilities = ["Support ended"]; };
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk14.linux.jdk.openj9; knownVulnerabilities = ["Support ended"]; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk14.linux.jre.openj9; knownVulnerabilities = ["Support ended"]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk15-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk15-darwin.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-darwin-base.nix sources.openjdk15.mac.jdk.hotspot;
-  jre-hotspot = import ./jdk-darwin-base.nix sources.openjdk15.mac.jre.hotspot;
-  jdk-openj9 = import ./jdk-darwin-base.nix sources.openjdk15.mac.jdk.openj9;
-  jre-openj9 = import ./jdk-darwin-base.nix sources.openjdk15.mac.jre.openj9;
+  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.hotspot; };
+  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.hotspot; };
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.openj9; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.openj9; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk15-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk15-linux.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-linux-base.nix sources.openjdk15.linux.jdk.hotspot;
-  jre-hotspot = import ./jdk-linux-base.nix sources.openjdk15.linux.jre.hotspot;
-  jdk-openj9 = import ./jdk-linux-base.nix sources.openjdk15.linux.jdk.openj9;
-  jre-openj9 = import ./jdk-linux-base.nix sources.openjdk15.linux.jre.openj9;
+  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.linux.jdk.hotspot; };
+  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.linux.jre.hotspot; };
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.linux.jdk.openj9; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.linux.jre.openj9; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk8-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk8-darwin.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-darwin-base.nix sources.openjdk8.mac.jdk.hotspot;
-  jre-hotspot = import ./jdk-darwin-base.nix sources.openjdk8.mac.jre.hotspot;
-  jdk-openj9 = import ./jdk-darwin-base.nix sources.openjdk8.mac.jdk.openj9;
-  jre-openj9 = import ./jdk-darwin-base.nix sources.openjdk8.mac.jre.openj9;
+  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk8.mac.jdk.hotspot; };
+  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk8.mac.jre.hotspot; };
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk8.mac.jdk.openj9; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk8.mac.jre.openj9; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk8-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk8-linux.nix
@@ -2,8 +2,8 @@ let
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = import ./jdk-linux-base.nix sources.openjdk8.linux.jdk.hotspot;
-  jre-hotspot = import ./jdk-linux-base.nix sources.openjdk8.linux.jre.hotspot;
-  jdk-openj9 = import ./jdk-linux-base.nix sources.openjdk8.linux.jdk.openj9;
-  jre-openj9 = import ./jdk-linux-base.nix sources.openjdk8.linux.jre.openj9;
+  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk8.linux.jdk.hotspot; };
+  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk8.linux.jre.hotspot; };
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk8.linux.jdk.openj9; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk8.linux.jre.openj9; };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

These JDKs are end-of-life, so shouldn't be used.
15 is also at or close to eol, but I haven't marked that one. It'd be nice if we could provide 16 first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
