### PR TITLE
pythonPackages.nbconvert: include templates in search paths

### DIFF
--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -30,6 +30,16 @@ buildPythonPackage rec {
     sha256 = "cbbc13a86dfbd4d1b5dee106539de0795b4db156c894c2c5dc382062bbc29002";
   };
 
+  # Add $out/share/jupyter to the list of paths that are used to search for
+  # various exporter templates
+  patches = [
+    ./templates.patch
+  ];
+
+  postPatch = ''
+    substituteAllInPlace ./nbconvert/exporters/templateexporter.py
+  '';
+
   checkInputs = [ pytestCheckHook glibcLocales ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/nbconvert/templates.patch
+++ b/pkgs/development/python-modules/nbconvert/templates.patch
@@ -1,0 +1,12 @@
+diff --git a/nbconvert/exporters/templateexporter.py b/nbconvert/exporters/templateexporter.py
+index 0d540eb1..440f6382 100644
+--- a/nbconvert/exporters/templateexporter.py
++++ b/nbconvert/exporters/templateexporter.py
+@@ -616,6 +616,7 @@ class TemplateExporter(Exporter):
+         if DEV_MODE:
+             root_dirs.append(os.path.abspath(os.path.join(ROOT, '..', '..', 'share', 'jupyter')))
+         root_dirs.extend(jupyter_path())
++        root_dirs.append(os.path.join("@out@", "share", "jupyter"))
+         return root_dirs
+ 
+     def _init_resources(self, resources):


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

By default, nbconvert searches for templates from a few hard-coded locations. As these don't include the store path under which nbconvert is installed, nbconvert doesn't find the templates and it raises an error like this:

```
nbconvert: ValueError: No template sub-directory with name 'rst' found in the following paths
```

This PR patches nbconvert so that the nix store path is included in the default set of paths. Without this, one cannot export Jupyter notebooks to various formats.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
