### PR TITLE
lib3mf: 2.0.0 -> 2.1.1

### DIFF
--- a/pkgs/development/tools/misc/automaticcomponenttoolkit/default.nix
+++ b/pkgs/development/tools/misc/automaticcomponenttoolkit/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchFromGitHub, go }:
+
+stdenv.mkDerivation rec {
+  pname = "AutomaticComponentToolkit";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "Autodesk";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1r0sbw82cf9dbcj3vgnbd4sc1lklzvijic2z5wgkvs21azcm0yzh";
+  };
+
+  nativeBuildInputs = [ go ];
+
+  buildPhase = ''
+    cd Source
+    export HOME=/tmp
+    go build -o act *.go
+  '';
+
+  installPhase = ''
+    install -Dm0755 act $out/bin/act
+  '';
+
+  meta = with lib; {
+    description = "Toolkit to automatically generate software components: abstract API, implementation stubs and language bindings";
+    homepage = "https://github.com/Autodesk/AutomaticComponentToolkit";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ gebner ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11982,6 +11982,8 @@ in
 
   astyle = callPackage ../development/tools/misc/astyle { };
 
+  automaticcomponenttoolkit = callPackage ../development/tools/misc/automaticcomponenttoolkit { };
+
   awf = callPackage ../development/tools/misc/awf { };
 
   aws-adfs = with python3Packages; toPythonApplication aws-adfs;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #116888 

openscad's 3MF support has been broken since #101105, since lib3mf 2.0 has a different API.  I believe the easiest way to fix this is to wait for the next openscad release (with the new cmake build system).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
