### PR TITLE
python3Packages.setuptools-rust: 0.11.6 -> 0.12.1

### DIFF
--- a/pkgs/development/python-modules/setuptools-rust/default.nix
+++ b/pkgs/development/python-modules/setuptools-rust/default.nix
@@ -2,7 +2,7 @@
 , lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
+, pythonOlder
 , semantic-version
 , setuptools
 , setuptools-scm
@@ -11,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "setuptools-rust";
-  version = "0.11.6";
-  disabled = isPy27;
+  version = "0.12.1";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a5b5954909cbc5d66b914ee6763f81fa2610916041c7266105a469f504a7c4ca";
+    sha256 = "647009e924f0ae439c7f3e0141a184a69ad247ecb9044c511dabde232d3d570e";
   };
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/python-modules/setuptools-rust/pyo3-test/default.nix
+++ b/pkgs/development/python-modules/setuptools-rust/pyo3-test/default.nix
@@ -17,5 +17,9 @@ callPackage ../../../tools/rust/maturin/pyo3-test/generic.nix {
     rust.rustc
   ]);
 
-  sourceRoot = "source/examples/word-count";
+  preConfigure = ''
+    # sourceRoot puts Cargo.lock in the wrong place due to the
+    # example setup.
+    cd examples/word-count
+  '';
 }

--- a/pkgs/development/tools/rust/maturin/pyo3-test/default.nix
+++ b/pkgs/development/tools/rust/maturin/pyo3-test/default.nix
@@ -1,8 +1,8 @@
-{ callPackage
+{ python3
 , rustPlatform
 }:
 
-callPackage ./generic.nix {
+python3.pkgs.callPackage ./generic.nix {
   buildAndTestSubdir = "examples/word-count";
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/tools/rust/maturin/pyo3-test/generic.nix
+++ b/pkgs/development/tools/rust/maturin/pyo3-test/generic.nix
@@ -3,7 +3,7 @@
 
 { lib
 , fetchFromGitHub
-, python3Packages
+, python
 , rustPlatform
 
 , nativeBuildInputs
@@ -13,7 +13,7 @@
 , preConfigure ? ""
 }:
 
-python3Packages.buildPythonPackage rec {
+python.pkgs.buildPythonPackage rec {
   pname = "word-count";
   version = "0.13.2";
 

--- a/pkgs/development/tools/rust/maturin/pyo3-test/generic.nix
+++ b/pkgs/development/tools/rust/maturin/pyo3-test/generic.nix
@@ -10,7 +10,7 @@
 
 , buildAndTestSubdir ? null
 , format ? "pyproject"
-, sourceRoot ? "source"
+, preConfigure ? ""
 }:
 
 python3Packages.buildPythonPackage rec {
@@ -25,14 +25,14 @@ python3Packages.buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src sourceRoot patches;
+    inherit src patches;
     name = "${pname}-${version}";
     hash = "sha256-//TmozgWy9zrSpMKX92XdHj4fw/T1Elfgn4YhhR7ot0=";
   };
 
   patches = [ ./Cargo.lock.patch ];
 
-  inherit buildAndTestSubdir format nativeBuildInputs sourceRoot;
+  inherit buildAndTestSubdir format nativeBuildInputs preConfigure;
 
   pythonImportsCheck = [ "word_count" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog:

https://github.com/PyO3/setuptools-rust/releases/tag/v0.12.1
https://github.com/PyO3/setuptools-rust/releases/tag/v0.12.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
