### PR TITLE
python3Packages.imbalanced-learn: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/imbalanced-learn/default.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/default.nix
@@ -1,5 +1,7 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27
-, fetchpatch
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
 , pandas
 , pytestCheckHook
 , scikitlearn
@@ -7,23 +9,13 @@
 
 buildPythonPackage rec {
   pname = "imbalanced-learn";
-  version = "0.7.0";
+  version = "0.8.0";
   disabled = isPy27; # scikit-learn>=0.21 doesn't work on python2
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "da59de0d1c0fa66f62054dd9a0a295a182563aa1abbb3bf9224a3678fcfe8fa4";
+    sha256 = "0a9xrw4qsh95g85pg2611hvj6xcfncw646si2icaz22haw1x410w";
   };
-
-  patches = [
-    # Fix compatibility with scikit-learn 0.24. This patch will be included in releases of
-    # imbalanced-learn after 0.7.0
-    (fetchpatch {
-      url = "https://github.com/scikit-learn-contrib/imbalanced-learn/commit/dc4051fe0011c68d900be05971b71016d4ad9e90.patch";
-      sha256 = "1rv61k9wv4q37a0v943clr8fflcg9ly530smgndgkjlxkyzw6swh";
-      excludes = ["doc/conf.py" "build_tools/*" "azure-pipelines.yml"];
-    })
-  ];
 
   propagatedBuildInputs = [ scikitlearn ];
   checkInputs = [ pytestCheckHook pandas ];
@@ -37,6 +29,9 @@ buildPythonPackage rec {
     "show_versions"
     "test_make_imbalanced_iris"
     "test_rusboost[SAMME.R]"
+
+    # https://github.com/scikit-learn-contrib/imbalanced-learn/issues/824
+    "ValueDifferenceMetric"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/scikit-learn-contrib/imbalanced-learn/releases/tag/0.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
