### PR TITLE
python3Packages.gremlinpython: 3.4.8 -> 3.4.10

### DIFF
--- a/pkgs/development/python-modules/gremlinpython/default.nix
+++ b/pkgs/development/python-modules/gremlinpython/default.nix
@@ -1,22 +1,23 @@
-{ stdenv, lib, buildPythonPackage, fetchFromGitHub, python, pythonOlder
-, pytestCheckHook, pyhamcrest, pytestrunner, pytest
+{ lib, buildPythonPackage, fetchFromGitHub
+, pytestCheckHook, pyhamcrest, pytestrunner
 , six, isodate, tornado, aenum, radish-bdd, mock
 }:
 
 buildPythonPackage rec {
   pname = "gremlinpython";
-  version = "3.4.8";
+  version = "3.4.10";
 
   # pypi tarball doesn't include tests
   src = fetchFromGitHub {
     owner = "apache";
     repo = "tinkerpop";
     rev = version;
-    sha256 = "0kcyhfxz7z4f8i64gig8q1q9dhy24cprbh63vwsdiwryg74q4chl";
+    sha256 = "0i9lkrwbsmpx1h9480vf97pibm2v37sgw2qm2r1c0i8gg5bcmhj3";
   };
   sourceRoot = "source/gremlin-python/src/main/jython";
   postPatch = ''
     substituteInPlace setup.py \
+      --replace 'aenum>=1.4.5,<3.0.0' 'aenum' \
       --replace 'tornado>=4.4.1,<6.0' 'tornado' \
       --replace 'PyHamcrest>=1.9.0,<2.0.0' 'PyHamcrest' \
       --replace 'radish-bdd==0.8.6' 'radish-bdd' \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Failing to build on master: https://github.com/NixOS/nixpkgs/pull/116957#issuecomment-803098766

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
