### PR TITLE
pythonPackages.APScheduler: drop Py2K support

### DIFF
--- a/pkgs/development/python-modules/APScheduler/default.nix
+++ b/pkgs/development/python-modules/APScheduler/default.nix
@@ -11,20 +11,19 @@
 , tornado
 , twisted
 , mock
-, trollius
 , gevent
 , six
 , pytz
 , tzlocal
 , funcsigs
-, futures
 , setuptools
-, isPy3k
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "APScheduler";
   version = "3.7.0";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -45,7 +44,7 @@ buildPythonPackage rec {
     twisted
     mock
     gevent
-  ] ++ lib.optionals (!isPy3k) [ trollius ];
+  ];
 
   propagatedBuildInputs = [
     six
@@ -53,7 +52,7 @@ buildPythonPackage rec {
     tzlocal
     funcsigs
     setuptools
-  ] ++ lib.optional (!isPy3k) futures;
+  ];
 
   disabledTests = lib.optionals stdenv.isDarwin [
     "test_submit_job"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/116950
This is a first step to remove the orphaned trollius package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
