### PR TITLE
privacyIDEA: 3.3 -> 3.5.1

### DIFF
--- a/pkgs/development/python-modules/privacyidea/default.nix
+++ b/pkgs/development/python-modules/privacyidea/default.nix
@@ -1,22 +1,24 @@
-{ lib, buildPythonPackage, fetchFromGitHub, cacert, openssl, python
+{ lib, buildPythonPackage, fetchFromGitHub, cacert, openssl, python, nixosTests
 
 , cryptography, pyrad, pymysql, python-dateutil, flask-versioned, flask_script
 , defusedxml, croniter, flask_migrate, pyjwt, configobj, sqlsoup, pillow
 , python-gnupg, passlib, pyopenssl, beautifulsoup4, smpplib, flask-babel
 , ldap3, huey, pyyaml, qrcode, oauth2client, requests, lxml, cbor2, psycopg2
+, pydash
 
-, mock, pytest, responses, testfixtures
+, mock, pytestCheckHook, responses, testfixtures
 }:
 
 buildPythonPackage rec {
   pname = "privacyIDEA";
-  version = "3.3";
+  version = "3.5.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "188ki924dig899wlih45xfsm0s7mjkya56vii26bg02h91izrb4b";
+    sha256 = "sha256-XJnrrpU0x2Axu7W4G3oDTjSJuqEyh3C/0Aga5D0gw9k=";
+    fetchSubmodules = true;
   };
 
   propagatedBuildInputs = [
@@ -24,11 +26,24 @@ buildPythonPackage rec {
     defusedxml croniter flask_migrate pyjwt configobj sqlsoup pillow
     python-gnupg passlib pyopenssl beautifulsoup4 smpplib flask-babel
     ldap3 huey pyyaml qrcode oauth2client requests lxml cbor2 psycopg2
+    pydash
   ];
 
-  checkInputs = [ openssl mock pytest responses testfixtures ];
-  # issues with hardware token tests
-  doCheck = false;
+  passthru.tests = { inherit (nixosTests) privacyidea; };
+
+  checkInputs = [ openssl mock pytestCheckHook responses testfixtures ];
+  disabledTests = [
+    "AESHardwareSecurityModuleTestCase"
+    "test_01_cert_request"
+    "test_01_loading_scripts"
+    "test_02_cert_enrolled"
+    "test_02_enroll_rights"
+    "test_02_get_resolvers"
+    "test_02_success"
+    "test_03_get_identifiers"
+    "test_04_remote_user_auth"
+    "test_14_convert_timestamp_to_utc"
+  ];
 
   pythonImportsCheck = [ "privacyidea" ];
 
@@ -46,6 +61,6 @@ buildPythonPackage rec {
     description = "Multi factor authentication system (2FA, MFA, OTP Server)";
     license = licenses.agpl3Plus;
     homepage = "http://www.privacyidea.org";
-    maintainers = [ maintainers.globin ];
+    maintainers = with maintainers; [ globin ma27 ];
   };
 }

--- a/pkgs/development/python-modules/pydash/0001-Only-build-unit-tests.patch
+++ b/pkgs/development/python-modules/pydash/0001-Only-build-unit-tests.patch
@@ -1,0 +1,30 @@
+From 2fe7a445bafedee2c43050e40697d8b0fd7f7b30 Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Fri, 19 Mar 2021 19:37:34 +0100
+Subject: [PATCH] Only build unit-tests
+
+---
+ setup.cfg | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/setup.cfg b/setup.cfg
+index 2c2f49f..a5ec152 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -83,13 +83,6 @@ force_sort_within_sections = true
+ junit_family = xunit2
+ addopts =
+     --verbose
+-    --doctest-modules
+-    --no-cov-on-fail
+-    --cov-fail-under=100
+-    --cov-report=term-missing
+-    --cov-report=xml:build/coverage/coverage.xml
+-    --cov-report=html:build/coverage
+-    --junitxml=build/testresults/junit.xml
+ 
+ [coverage:run]
+ omit =
+-- 
+2.29.3
+

--- a/pkgs/development/python-modules/pydash/default.nix
+++ b/pkgs/development/python-modules/pydash/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub, mock, pytestCheckHook, invoke }:
+
+buildPythonPackage rec {
+  pname = "pydash";
+  version = "4.9.3";
+
+  src = fetchFromGitHub {
+    owner = "dgilland";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-BAyiSnILvujUOFOAkiXSgyozs2Q809pYihHwa+6BHcQ=";
+  };
+
+  patches = [ ./0001-Only-build-unit-tests.patch ];
+
+  checkInputs = [ mock pytestCheckHook invoke ];
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/pydash/";
+    description = "The kitchen sink of Python utility libraries for doing \"stuff\" in a functional way. Based on the Lo-Dash Javascript library.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/development/python-modules/pydash/default.nix
+++ b/pkgs/development/python-modules/pydash/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   checkInputs = [ mock pytestCheckHook invoke ];
 
   meta = with lib; {
-    homepage = "https://pypi.org/project/pydash/";
+    homepage = "https://github.com/dgilland/pydash";
     description = "The kitchen sink of Python utility libraries for doing \"stuff\" in a functional way. Based on the Lo-Dash Javascript library.";
     license = licenses.mit;
     maintainers = with maintainers; [ ma27 ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5583,6 +5583,8 @@ in {
 
   pydantic = callPackage ../development/python-modules/pydantic { };
 
+  pydash = callPackage ../development/python-modules/pydash { };
+
   pydbus = callPackage ../development/python-modules/pydbus { };
 
   pydenticon = callPackage ../development/python-modules/pydenticon { };


### PR DESCRIPTION


###### Motivation for this change

ChangeLog: https://github.com/privacyidea/privacyidea/blob/v3.5.1/Changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
