### PR TITLE
python3Packages.autobahn: 20.12.3 -> 21.3.1

### DIFF
--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -1,18 +1,18 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k,
-  six, txaio, twisted, zope_interface, cffi, trollius, futures,
+{ lib, buildPythonPackage, fetchPypi, iyPy27,
+  txaio, twisted, zope_interface, cffi,
   mock, pytest, cryptography, pynacl
 }:
 buildPythonPackage rec {
   pname = "autobahn";
-  version = "20.12.3";
+  version = "21.3.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "15b8zm7jalwisfwc08szxy3bh2bnn0hd41dbsnswi0lqwbh962j1";
+    sha256 = "00wf9dkfgakg80gy62prg650lb8zz9y9fdlxwxcznwp8hgsw29p1";
   };
 
-  propagatedBuildInputs = [ six txaio twisted zope_interface cffi cryptography pynacl ] ++
-    (lib.optionals (!isPy3k) [ trollius futures ]);
+  propagatedBuildInputs = [ txaio twisted zope_interface cffi cryptography pynacl ];
 
   checkInputs = [ mock pytest ];
   checkPhase = ''

--- a/pkgs/development/python-modules/hyperlink/default.nix
+++ b/pkgs/development/python-modules/hyperlink/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "hyperlink";
-  version = "20.0.1";
+  version = "21.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "47fcc7cd339c6cb2444463ec3277bdcfe142c8b1daf2160bdd52248deec815af";
+    sha256 = "0sx50lkivsfjxx9zr4yh7l9gll2l9kvl0v0w8w4wk2x5v9bzjyj2";
   };
 
   propagatedBuildInputs = [ idna ]
@@ -14,6 +14,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A featureful, correct URL for Python";
+    homepage    = "https://github.com/python-hyper/hyperlink";
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ apeschar ];

--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "txaio";
-  version = "20.4.1";
+  version = "21.2.1";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "17938f2bca4a9cabce61346758e482ca4e600160cbc28e861493eac74a19539d";
+    sha256 = "1j0xpa6lrl0g9hbvwqkrlfkx522yvx4bgpdr9lf3y8w0ars8jvvx";
   };
 
   checkInputs = [ pytest mock ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump and dropping of Py27 support of dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
