### PR TITLE
boltbrowser: init at 2.0

### DIFF
--- a/pkgs/tools/misc/boltbrowser/default.nix
+++ b/pkgs/tools/misc/boltbrowser/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "boltbrowser";
+  version = "2.0";
+
+  src = fetchFromGitHub {
+    owner = "br0xen";
+    repo = pname;
+    rev = version;
+    sha256 = "17v3pv80dxs285d0b6x772h5cb4f0xg9n5p9jwlir5hjbfn1635i";
+  };
+
+  vendorSha256 = "1x28m72626cchnsasyxips8jaqs0l2p9jhjrdcgws144zm6fz3hv";
+
+  meta = with lib; {
+    description = "CLI Browser for BoltDB files";
+    homepage = "https://github.com/br0xen/boltbrowser";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3136,6 +3136,8 @@ in
 
   bash_unit = callPackage ../tools/misc/bash_unit { };
 
+  boltbrowser = callPackage ../tools/misc/boltbrowser { };
+
   bsc = callPackage ../tools/compression/bsc {
     inherit (llvmPackages) openmp;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A CLI Browser for BoltDB Files

https://github.com/br0xen/boltbrowser

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
