### PR TITLE
librespeed-cli: init at 1.0.7

### DIFF
--- a/pkgs/tools/misc/librespeed-cli/default.nix
+++ b/pkgs/tools/misc/librespeed-cli/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "librespeed-cli";
+  version = "1.0.7";
+
+  src = fetchFromGitHub {
+    owner = "librespeed";
+    repo = "speedtest-cli";
+    rev = "v${version}";
+    sha256 = "03bhxx33fy1cgp83anm51fm8v079v0az0d0p785dz98jg14vzibl";
+  };
+
+  vendorSha256 = "1kccxmmzbkzbrxypcrz0j1zz51c0q1d5hh25lcpfbkm3498mj02c";
+
+  # Tests have additonal requirements
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Command line client for LibreSpeed";
+    homepage = "https://github.com/librespeed/speedtest-cli";
+    license = with licenses; [ lgpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6142,6 +6142,8 @@ in
 
   libzmf = callPackage ../development/libraries/libzmf {};
 
+  librespeed-cli = callPackage ../tools/misc/librespeed-cli { };
+
   libreswan = callPackage ../tools/networking/libreswan { };
 
   librest = callPackage ../development/libraries/librest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is a command line interface for LibreSpeed speed test backends, written in Go.

https://github.com/librespeed/speedtest-cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
