### PR TITLE
passage: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10942,4 +10942,10 @@
     github = "zupo";
     githubId = 311580;
   };
+  rassmike = {
+    name = "Mihalis Rasoulis";
+    email = "rassmike@gmail.com";
+    github = "rassmike";
+    githubId = 23300548;
+  };
 }

--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -1,0 +1,35 @@
+{ lib, fetchFromSourcehut, rustPlatform, installShellFiles, asciidoctor, python3, xorg, passAlias ? false }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "passage";
+  version = "0.1.0";
+
+  src = fetchFromSourcehut {
+    owner = "~gpanders";
+    repo = "passage";
+    rev = "9bddfe8e03b39ceccfa736e88924d3b4cb59748f";
+    sha256 = "1vdl02aqxb66nniwgsafq45b1xb53jqsprs7n0liry4gh639rc81";
+  };
+
+  cargoSha256 = "06clfavpxc7a11jxml0vkw8x7lya5kipv8xyi59f8fqsksj79k8m";
+
+  nativeBuildInputs = [ asciidoctor python3 installShellFiles ];
+  buildInputs = [ xorg.libxcb ];
+
+  postBuild = ''
+    asciidoctor doc/passage.1.txt --backend manpage --doctype manpage -o passage.1
+  '';
+
+  postInstall = ''
+    installManPage passage.1
+  '' + lib.optionalString passAlias ''
+    ln -s $out/bin/passage $out/bin/pass
+  '';
+
+  meta = with lib; {
+    description = "passage is a password store utilizing the age encryption library";
+    homepage = "https://sr.ht/~gpanders/passage";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ rassmike ];
+  };
+}

--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -1,0 +1,34 @@
+{ lib, rustPlatform, installShellFiles, asciidoctor, xorg, python3, passAlias ? false }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "passage";
+  version = "0.1.0";
+
+  src = builtins.fetchGit {
+    url = "https://git.sr.ht/~gpanders/passage";
+    ref = "master";
+    rev = "9bddfe8e03b39ceccfa736e88924d3b4cb59748f";
+  };
+
+  cargoSha256 = "06clfavpxc7a11jxml0vkw8x7lya5kipv8xyi59f8fqsksj79k8m";
+
+  nativeBuildInputs = [ asciidoctor python3 installShellFiles ];
+  buildInputs = [ xorg.libxcb.dev ];
+
+  postBuild = ''
+    asciidoctor doc/passage.1.txt --backend manpage --doctype manpage -o passage.1
+  '';
+
+  postInstall = ''
+    installManPage passage.1
+  '' + lib.optionalString passAlias ''
+    ln -s $out/bin/passage $out/bin/pass
+  '';
+
+  meta = with lib; {
+    description = "passage is a password store utilizing the age encryption library";
+    homepage = "https://sr.ht/~gpanders/passage";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ rassmike ];
+  };
+}

--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -1,4 +1,12 @@
-{ lib, fetchFromSourcehut, rustPlatform, installShellFiles, asciidoctor, python3, xorg, passAlias ? false }:
+{ lib
+, rustPlatform
+, fetchFromSourcehut
+, installShellFiles
+, asciidoctor
+, python3
+, xorg
+, passAlias ? false
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "passage";

--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -6,7 +6,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromSourcehut {
     owner = "~gpanders";
-    repo = "passage";
+    repo = pname;
     rev = "9bddfe8e03b39ceccfa736e88924d3b4cb59748f";
     sha256 = "1vdl02aqxb66nniwgsafq45b1xb53jqsprs7n0liry4gh639rc81";
   };

--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "passage is a password store utilizing the age encryption library";
     homepage = "https://sr.ht/~gpanders/passage";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl2;
     maintainers = with maintainers; [ rassmike ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1417,6 +1417,8 @@ in
 
   pass = callPackage ../tools/security/pass { };
 
+  passage = callPackage ../tools/security/passage { };
+
   passphrase2pgp = callPackage ../tools/security/passphrase2pgp { };
 
   pass-git-helper = python3Packages.callPackage ../applications/version-management/git-and-tools/pass-git-helper { };


### PR DESCRIPTION
###### Motivation for this change
Add passage a password store utilizing the age encryption library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
