### PR TITLE
treewide (darwin): fix or enable darwin build for many packages (7)

### DIFF
--- a/pkgs/tools/networking/philter/default.nix
+++ b/pkgs/tools/networking/philter/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "Mail sorter for Maildirs";
     homepage = "http://philter.sourceforge.net";
     maintainers = with maintainers; [ raskin ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
     license = licenses.gpl2;
   };
 

--- a/pkgs/tools/networking/pixiecore/default.nix
+++ b/pkgs/tools/networking/pixiecore/default.nix
@@ -23,6 +23,6 @@ buildGoModule rec {
     homepage = "https://github.com/danderson/netboot/tree/master/pixiecore";
     license =  lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bbigras danderson ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/networking/pixiewps/default.nix
+++ b/pkgs/tools/networking/pixiewps/default.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/wiire/pixiewps";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.nico202 ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/networking/redir/default.nix
+++ b/pkgs/tools/networking/redir/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/troglobit/redir";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/networking/rshijack/default.nix
+++ b/pkgs/tools/networking/rshijack/default.nix
@@ -18,6 +18,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/kpcyrd/rshijack";
     license = licenses.gpl3;
     maintainers = with maintainers; [ xrelkd ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/networking/surfraw/default.nix
+++ b/pkgs/tools/networking/surfraw/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     description = "Provides a fast unix command line interface to a variety of popular WWW search engines and other artifacts of power";
     homepage = "https://gitlab.com/surfraw/Surfraw";
     maintainers = [];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
     license = lib.licenses.publicDomain;
   };
 }

--- a/pkgs/tools/security/asc-key-to-qr-code-gif/default.nix
+++ b/pkgs/tools/security/asc-key-to-qr-code-gif/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://github.com/yishilin14/asc-key-to-qr-code-gif";
     description = "Convert ASCII-armored PGP keys to animated QR code";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ asymmetric ];
   };
 }

--- a/pkgs/tools/security/bash-supergenpass/default.nix
+++ b/pkgs/tools/security/bash-supergenpass/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
       supergenpass will ask for your master password interactively, and it will not be displayed on your terminal.
     '';
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = with maintainers; [ fgaz ];
     homepage = "https://github.com/lanzz/bash-supergenpass";
   };

--- a/pkgs/tools/security/pdfcrack/default.nix
+++ b/pkgs/tools/security/pdfcrack/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     homepage = "http://pdfcrack.sourceforge.net/";
     description = "Small command line driven tool for recovering passwords and content from PDF files";
     license = with licenses; [ gpl2 ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = with maintainers; [ qoelet ];
   };
 }

--- a/pkgs/tools/security/shc/default.nix
+++ b/pkgs/tools/security/shc/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://neurobin.org/projects/softwares/unix/shc/";
     description = "Shell Script Compiler";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
     license = licenses.gpl3;
   };
 }

--- a/pkgs/tools/system/gt5/default.nix
+++ b/pkgs/tools/system/gt5/default.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "http://gt5.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [viric];
-    platforms = with lib.platforms; linux;
+    platforms = with lib.platforms; all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
See #114976 for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
