### PR TITLE
python3Packages.iaqualink: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/iaqualink/default.nix
+++ b/pkgs/development/python-modules/iaqualink/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-runner
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "iaqualink";
+  version = "0.4.0";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "flz";
+    repo = "iaqualink-py";
+    rev = "v${version}";
+    sha256 = "13iwngjjqzr1pkmskbc2wakccvcjkf4bk65f4jp4ywpciilr4zjw";
+  };
+
+  nativeBuildInputs = [ pytest-runner ];
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "iaqualink" ];
+
+  meta = with lib; {
+    description = "Python library for Jandy iAqualink";
+    homepage = "https://github.com/flz/iaqualink-py";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -374,7 +374,7 @@
     "hydrawise" = ps: with ps; [ hydrawiser ];
     "hyperion" = ps: with ps; [ ]; # missing inputs: hyperion-py
     "iammeter" = ps: with ps; [ ]; # missing inputs: iammeter
-    "iaqualink" = ps: with ps; [ ]; # missing inputs: iaqualink
+    "iaqualink" = ps: with ps; [ iaqualink ];
     "icloud" = ps: with ps; [ pyicloud ];
     "idteck_prox" = ps: with ps; [ ]; # missing inputs: rfk101py
     "ifttt" = ps: with ps; [ aiohttp-cors pyfttt ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -28,6 +28,21 @@ let
     (mkOverride "astral" "1.10.1"
       "d2a67243c4503131c856cafb1b1276de52a86e5b8a1d507b7e08bee51cb67bf1")
 
+    # Pinned due to API changes in iaqualink>=2.0, remove after
+    # https://github.com/home-assistant/core/pull/48137 was merged
+    (self: super: {
+      iaqualink = super.iaqualink.overridePythonAttrs (oldAttrs: rec {
+        version = "0.3.4";
+        src = fetchFromGitHub {
+          owner = "flz";
+          repo = "iaqualink-py";
+          rev = version;
+          sha256 = "16mn6nd9x3hm6j6da99qhwbqs95hh8wx21r1h1m9csl76z77n9lh";
+        };
+        checkInputs = oldAttrs.checkInputs ++ [ python3.pkgs.asynctest ];
+      });
+    })
+
     # Pinned due to bug in ring-doorbell 0.7.0
     # https://github.com/tchellomello/python-ring-doorbell/issues/240
     (mkOverride "ring-doorbell" "0.6.2"

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -213,6 +213,7 @@ in with py.pkgs; buildPythonApplication rec {
     "html5"
     "http"
     "hue"
+    "iaqualink"
     "ifttt"
     "image"
     "image_processing"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3184,6 +3184,8 @@ in {
 
   iapws = callPackage ../development/python-modules/iapws { };
 
+  iaqualink = callPackage ../development/python-modules/iaqualink { };
+
   ibis = callPackage ../development/python-modules/ibis { };
 
   ibis-framework = callPackage ../development/python-modules/ibis-framework { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for Jandy iAqualink

https://github.com/flz/iaqualink-py

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
