### PR TITLE
snes9x-gtk: set license to unfreeRedistributable

### DIFF
--- a/pkgs/misc/emulators/snes9x-gtk/default.nix
+++ b/pkgs/misc/emulators/snes9x-gtk/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation rec {
       includes some real gems that were only ever released in Japan.
     '';
 
-    license = licenses.lgpl2;
+    # see https://github.com/snes9xgit/snes9x/blob/master/LICENSE for exact details
+    license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ qknight ];
     platforms = platforms.linux;
   };

--- a/pkgs/misc/emulators/snes9x-gtk/default.nix
+++ b/pkgs/misc/emulators/snes9x-gtk/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   preConfigure = "cd gtk";
 
   meta = with lib; {
-    homepage = "http://www.snes9x.com";
+    homepage = "https://www.snes9x.com";
     description = "Super Nintendo Entertainment System (SNES) emulator";
 
     longDescription = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Snes9x was never free software, and the current license seems to be incorrect. It may make sense to backport this, I don't know what are policies about doing so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
