### PR TITLE
vim_configurable: Make disabling guiSupport easier

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -75,7 +75,6 @@ in stdenv.mkDerivation rec {
   patches = [ ./cflags-prune.diff ] ++ lib.optional ftNixSupport ./ft-nix-support.patch;
 
   configureFlags = [
-    "--enable-gui=${guiSupport}"
     "--with-features=${features}"
     "--disable-xsmp"              # XSMP session management
     "--disable-xsmp_interact"     # XSMP interaction
@@ -95,6 +94,7 @@ in stdenv.mkDerivation rec {
     "--disable-carbon_check"
     "--disable-gtktest"
   ]
+    ++ lib.optional (guiSupport == "gtk2" || guiSupport == "gtk3") "--enable-gui=${guiSupport}"
   ++ lib.optional stdenv.isDarwin
      (if darwinSupport then "--enable-darwin" else "--disable-darwin")
   ++ lib.optionals luaSupport [
@@ -127,8 +127,22 @@ in stdenv.mkDerivation rec {
   ++ lib.optional (guiSupport == "gtk3") wrapGAppsHook
   ;
 
-  buildInputs = [ ncurses libX11 libXext libSM libXpm libXt libXaw libXau
-    libXmu glib libICE ]
+  buildInputs = [
+    ncurses
+    glib
+  ]
+    # All X related dependencies
+    ++ lib.optionals (guiSupport == "gtk2" || guiSupport == "gtk3") [
+      libSM
+      libICE
+      libX11
+      libXext
+      libXpm
+      libXt
+      libXaw
+      libXau
+      libXmu
+    ]
     ++ lib.optional (guiSupport == "gtk2") gtk2-x11
     ++ lib.optional (guiSupport == "gtk3") gtk3-x11
     ++ lib.optionals darwinSupport [ CoreServices CoreData Cocoa Foundation libobjc ]


### PR DESCRIPTION
Now it's possible to use in an overlay `guiSupport` set to `false`
(boolean) and doing so will disable many X related dependencies from
being used and the closure would be reduced automatically - Close #116716.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
