### PR TITLE
ell: 0.36 -> 0.38, iwd: 1.11 -> 1.12

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ell";
-  version = "0.36";
+  version = "0.38";
 
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/libs/${pname}/${pname}.git";
     rev = version;
-    sha256 = "0w7v2hihwwmnqd56bsmbjsiw8yyadr7zbdssjamqxx0pyl3dnrda";
+    sha256 = "sha256-UR6NHIO/L/QbuVerXe32RNT33wwrDvIZpV6nlYaImI8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchgit
-, fetchpatch
 , autoreconfHook
 , pkg-config
 , ell
@@ -13,12 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "iwd";
-  version = "1.11";
+  version = "1.12";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git";
     rev = version;
-    sha256 = "0wnyg0f1swi7gvvgf5kzbiz44g2wscf5d5bp320iwyfwnlbqb1bn";
+    sha256 = "sha256-o3Vc5p/AFZwbkEWJZzO6wWAJ/BmSh0eKxdnjm5B9BFU=";
   };
 
   outputs = [ "out" "man" ]
@@ -88,7 +87,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://git.kernel.org/pub/scm/network/wireless/iwd.git";
     description = "Wireless daemon for Linux";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ dtzWill fpletz ];
   };


### PR DESCRIPTION
###### Motivation for this change
ell, https://git.kernel.org/pub/scm/libs/ell/ell.git/tree/ChangeLog?h=0.38
> ver 0.38:
> 	Fix issue with DHCP v6 Rapid Commit option check.
> 	Fix issue with handling RFC8018/RFC1423 padding.
> 
> ver 0.37:
> 	Fix issue with D-Bus filter messages with no interfaces set.
> 	Add support for PKCS#12 certification loading. 

iwd, https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/ChangeLog?h=1.12

> ver 1.12:
> 	Fix issue with handling retry roaming without higher RSSI.
> 	Fix issue with WPA3, OWE and FILS authentication handling.
> 	Fix issue with handling locally generated deauth frames.
> 	Fix issue with quick scanning and connect interaction.
> 	Add support for diagnostic D-Bus interfaces.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
