### PR TITLE
networkmanager: 1.30.0 -> 1.30.2

### DIFF
--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -10,11 +10,11 @@ let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   pname = "networkmanager";
-  version = "1.30.0";
+  version = "1.30.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "1yf3k3pcszn904lk6rdya1qhp3yxbzsbhcd9l6yfrhlbc8r15w1r";
+    sha256 = "sha256-DI6A53h3hg5KTmq0oPfNwRhuNWtlsEKnUYlxiLiJRNI=";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/1.30.2/NEWS

```
===============================================
NetworkManager-1.30.2
Overview of changes since NetworkManager-1.30.0
===============================================

* Increase the limit of open file descriptors in NetworkManager.service
* Fix hostname lookup via DNS when resolv.conf is managed by
  systemd-resolved
* Enable WPA3 for Wi-Fi connections with key_mgmt=WPA-PSK
* Fix crash with the IWD Wi-Fi backend
* Avoid logging warning when setting bond option
  "ad_actor_system=00:00:00:00:00:00"
* Update SpecificObject D-Bus property of ActiveConnection after WiFi
  roaming
* Multiple bugfixes in the initrd generator
* Various minor bugfixes
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
