### PR TITLE
sks: 1.1.6 -> unstable-2021-02-04; use ocaml 4.10

### DIFF
--- a/pkgs/servers/sks/default.nix
+++ b/pkgs/servers/sks/default.nix
@@ -1,22 +1,36 @@
-{ lib, stdenv, fetchFromBitbucket, ocaml, zlib, db, perl, camlp4 }:
+{ lib, stdenv, fetchFromGitHub, ocamlPackages, perl
+, zlib, db
+}:
+
+let
+  inherit (ocamlPackages)
+    ocaml
+    findlib
+    cryptokit
+    num
+    ;
+in
 
 stdenv.mkDerivation rec {
   pname = "sks";
-  version = "1.1.6";
+  version = "unstable-2021-02-04";
 
-  src = fetchFromBitbucket {
-    owner = "skskeyserver";
+  src = fetchFromGitHub {
+    owner = "SKS-Keyserver";
     repo = "sks-keyserver";
-    rev = version;
-    sha256 = "00q5ma5rvl10rkc6cdw8d69bddgrmvy0ckqj3hbisy65l4idj2zm";
+    rev = "c3ba6d5abb525dcb84745245631c410c11c07ec1";
+    sha256 = "0fql07sc69hv6jy7x5svb19977cdsz0p1j8wv53k045a6v7rw1jw";
   };
 
   # pkgs.db provides db_stat, not db$major.$minor_stat
-  patches = [ ./adapt-to-nixos.patch ];
+  patches = [
+    ./adapt-to-nixos.patch
+  ];
 
   outputs = [ "out" "webSamples" ];
 
-  buildInputs = [ ocaml zlib db perl camlp4 ];
+  nativeBuildInputs = [ ocaml findlib perl ];
+  buildInputs = [ zlib db cryptokit num ];
 
   makeFlags = [ "PREFIX=$(out)" "MANDIR=$(out)/share/man" ];
   preConfigure = ''
@@ -44,7 +58,7 @@ stdenv.mkDerivation rec {
       spotty connectivity, can fully synchronize with rest of the system.
     '';
     inherit (src.meta) homepage;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ primeos fpletz globin ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8087,7 +8087,7 @@ in
 
   skippy-xd = callPackage ../tools/X11/skippy-xd {};
 
-  sks = callPackage ../servers/sks { inherit (ocaml-ng.ocamlPackages_4_02) ocaml camlp4; };
+  sks = callPackage ../servers/sks { };
 
   skydns = callPackage ../servers/skydns { };
 


### PR DESCRIPTION
OCaml 4.02 is pretty old by now and sks builds with a trivial change
also with OCaml 4.04 which isn't affected by any CVEs at least.

We can still go further probably by picking patches from master, but
that's for another PR.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
