### PR TITLE
unoconv: improve expression

### DIFF
--- a/pkgs/tools/text/unoconv/program-name.patch
+++ b/pkgs/tools/text/unoconv/program-name.patch
@@ -1,0 +1,15 @@
+diff --git a/unoconv b/unoconv
+index 6aa1bfa..6a81987 100755
+--- a/unoconv
++++ b/unoconv
+@@ -739,8 +739,9 @@ class Options:
+ 
+         ### If no format was specified, probe it or provide it
+         if not self.format:
++            command = os.environ.get('NIX_PROGRAM_NAME', sys.argv[0])
+             ### Check if the command is in the form odt2pdf
+-            l = sys.argv[0].split('2')
++            l = command.split('2')
+             if len(l) == 2:
+                 self.format = l[1]
+             ### Use the extension of the output file


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Since Python does not support `exec -a`, we need a different way to tell
unoconv which command was executed.
This does not work yet since I'm not able to work around `makeWrapper` replacing `$0` with the its own path respectively variables expansion not working within single quotes.
We need something like https://github.com/NixOS/nixpkgs/pull/25985.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @akirak @sjau 