### PR TITLE
kodi.packages.jellyfin: init at 0.7.1, a few fixups

### DIFF
--- a/pkgs/applications/video/kodi-packages/dateutil/default.nix
+++ b/pkgs/applications/video/kodi-packages/dateutil/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, six }:
+
+buildKodiAddon rec {
+  pname = "dateutil";
+  namespace = "script.module.dateutil";
+  version = "2.8.1+matrix.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "1jr77017ihs7j3455i72af71wyvs792kbizq4539ccd98far8lm7";
+  };
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  passthru.updateScript = addonUpdateScript {
+    attrPath = "kodi.packages.dateutil";
+  };
+
+  meta = with lib; {
+    homepage = "https://dateutil.readthedocs.io/en/stable/";
+    description = "Extensions to the standard Python datetime module";
+    license = with licenses; [ asl20 bsd3 ];
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi-packages/jellyfin/default.nix
+++ b/pkgs/applications/video/kodi-packages/jellyfin/default.nix
@@ -1,0 +1,49 @@
+{ lib, addonDir, buildKodiAddon, fetchFromGitHub, kodi, requests, dateutil, six, kodi-six, signals }:
+let
+  python = kodi.pythonPackages.python.withPackages (p: with p; [ pyyaml ]);
+in
+buildKodiAddon rec {
+  pname = "jellyfin";
+  namespace = "plugin.video.jellyfin";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-kodi";
+    rev = "v${version}";
+    sha256 = "0fx20gmd5xlg59ks4433qh2b3jhbs5qrnc49zi4rkqqr4jr4nhnn";
+  };
+
+  nativeBuildInputs = [
+    python
+  ];
+
+  prePatch = ''
+    substituteInPlace .config/generate_xml.py \
+      --replace "'jellyfin-kodi/release.yaml'" "'release.yaml'" \
+      --replace "'jellyfin-kodi/addon.xml'" "'addon.xml'"
+  '';
+
+  buildPhase = ''
+    ${python}/bin/python3 .config/generate_xml.py py3
+  '';
+
+  postInstall = ''
+    mv /build/source/addon.xml $out${addonDir}/${namespace}/
+  '';
+
+  propagatedBuildInputs = [
+    requests
+    dateutil
+    six
+    kodi-six
+    signals
+  ];
+
+  meta = with lib; {
+    homepage = "https://jellyfin.org/";
+    description = "A whole new way to manage and view your media library";
+    license = licenses.gpl3Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi-packages/kodi-six/default.nix
+++ b/pkgs/applications/video/kodi-packages/kodi-six/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript }:
+
+buildKodiAddon rec {
+  pname = "kodi-six";
+  namespace = "script.module.kodi-six";
+  version = "0.1.3.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "14m232p9hx925pbk8knsg994m1nbpa5278zmcrnfblh4z84gjv4x";
+  };
+
+  passthru.updateScript = addonUpdateScript {
+    attrPath = "kodi.packages.kodi-six";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/romanvm/kodi.six";
+    description = "Wrappers around Kodi Python API for seamless Python 2/3 compatibility";
+    license = licenses.gpl3Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi-packages/netflix/default.nix
+++ b/pkgs/applications/video/kodi-packages/netflix/default.nix
@@ -1,4 +1,5 @@
-{ lib, buildKodiAddon, fetchFromGitHub, signals, inputstreamhelper, requests, myconnpy }:
+{ lib, buildKodiAddon, fetchFromGitHub, signals, inputstream-adaptive, inputstreamhelper, requests, myconnpy }:
+
 buildKodiAddon rec {
   pname = "netflix";
   namespace = "plugin.video.netflix";
@@ -13,6 +14,7 @@ buildKodiAddon rec {
 
   propagatedBuildInputs = [
     signals
+    inputstream-adaptive
     inputstreamhelper
     requests
     myconnpy

--- a/pkgs/applications/video/kodi-packages/six/default.nix
+++ b/pkgs/applications/video/kodi-packages/six/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript }:
+
+buildKodiAddon rec {
+  pname = "six";
+  namespace = "script.module.six";
+  version = "1.14.0+matrix.2";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "1f9g43j4y5x7b1bgbwqqfj0p2bkqjpycj17dj7a9j271mcr5zhwb";
+  };
+
+  passthru.updateScript = addonUpdateScript {
+    attrPath = "kodi.packages.six";
+  };
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/six/";
+    description = "Python 2 and 3 compatibility utilities";
+    license = licenses.mit;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi/build-kodi-addon.nix
+++ b/pkgs/applications/video/kodi/build-kodi-addon.nix
@@ -11,11 +11,15 @@ toKodiAddon (stdenv.mkDerivation ({
   extraRuntimeDependencies = [ ];
 
   installPhase = ''
+    runHook preInstall
+
     cd $src/$sourceDir
     d=$out${addonDir}/${namespace}
     mkdir -p $d
     sauce="."
     [ -d ${namespace} ] && sauce=${namespace}
     cp -R "$sauce/"* $d
+
+    runHook postInstall
   '';
 } // attrs))

--- a/pkgs/applications/video/kodi/build-kodi-binary-addon.nix
+++ b/pkgs/applications/video/kodi/build-kodi-binary-addon.nix
@@ -24,8 +24,12 @@ toKodiAddon (stdenv.mkDerivation ({
   # and the non-wrapped kodi lib/... folder before even trying to dlopen
   # them. Symlinking .so, as setting LD_LIBRARY_PATH is of no use
   installPhase = let n = namespace; in ''
+    runHook preInstall
+
     make install
     ln -s $out/lib/addons/${n}/${n}.so.${version} $out${addonDir}/${n}/${n}.so.${version}
     ${extraInstallPhase}
+
+    runHook postInstall
   '';
 } // attrs))

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -66,6 +66,8 @@ let self = rec {
     snes = callPackage ../applications/video/kodi-packages/controllers { controller = "snes"; };
   };
 
+  jellyfin = callPackage ../applications/video/kodi-packages/jellyfin { };
+
   joystick = callPackage ../applications/video/kodi-packages/joystick { };
 
   netflix = callPackage ../applications/video/kodi-packages/netflix { };
@@ -96,17 +98,23 @@ let self = rec {
 
   chardet = callPackage ../applications/video/kodi-packages/chardet { };
 
+  dateutil = callPackage ../applications/video/kodi-packages/dateutil { };
+
   idna = callPackage ../applications/video/kodi-packages/idna { };
 
   inputstream-adaptive = callPackage ../applications/video/kodi-packages/inputstream-adaptive { };
 
   inputstreamhelper = callPackage ../applications/video/kodi-packages/inputstreamhelper { };
 
+  kodi-six = callPackage ../applications/video/kodi-packages/kodi-six { };
+
   myconnpy = callPackage ../applications/video/kodi-packages/myconnpy { };
 
   requests = callPackage ../applications/video/kodi-packages/requests { };
 
   signals = callPackage ../applications/video/kodi-packages/signals { };
+
+  six = callPackage ../applications/video/kodi-packages/six { };
 
   urllib3 = callPackage ../applications/video/kodi-packages/urllib3 { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- add the `jellyfin` package to `kodi.packages.*`, as well as dependencies
- fixup `kodi.packages.netflix`

This PR is based on top of #116806

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
