### PR TITLE
gnucap: init at 20210107

### DIFF
--- a/pkgs/applications/science/electronics/gnucap/default.nix
+++ b/pkgs/applications/science/electronics/gnucap/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "gnucap";
+  version = "20210107";
+
+  src = fetchurl {
+    url = "https://git.savannah.gnu.org/cgit/gnucap.git/snapshot/${pname}-${version}.tar.gz";
+    sha256 = "12rlwd4mfc54qq1wrx5k8qk578xls5z4isf94ybkf2z6qxk4mhnj";
+  };
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Gnu Circuit Analysis Package";
+    longDescription = ''
+Gnucap is a modern general purpose circuit simulator with several advantages over Spice derivatives.
+It performs nonlinear dc and transient analyses, fourier analysis, and ac analysis.
+    '';
+    homepage = "http://www.gnucap.org/";
+    changelog = "https://git.savannah.gnu.org/cgit/gnucap.git/plain/NEWS?h=v${version}";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = [ maintainers.raboof ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4819,6 +4819,8 @@ in
 
   gnuapl = callPackage ../development/interpreters/gnu-apl { };
 
+  gnucap = callPackage ../applications/science/electronics/gnucap { };
+
   gnu-cobol = callPackage ../development/compilers/gnu-cobol { };
 
   gnuclad = callPackage ../applications/graphics/gnuclad { };


### PR DESCRIPTION
###### Motivation for this change

Submitting on behalf of kvtb,
https://discourse.nixos.org/t/casual-nixpkgs-contributions/9607/13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).