### PR TITLE
gwenhywfar: 5.4.1 -> 5.6.0, aqbanking: 6.2.5 -> 6.2.10

### DIFF
--- a/pkgs/development/libraries/aqbanking/sources.nix
+++ b/pkgs/development/libraries/aqbanking/sources.nix
@@ -1,7 +1,7 @@
 {
-  gwenhywfar.version = "5.4.1";
-  gwenhywfar.sha256 = "16waq39mbhhjcma2ykdbqvpcw0ba3ksqqwsp55zczhg320s41zgv";
-  gwenhywfar.releaseId = "344";
+  gwenhywfar.version = "5.6.0";
+  gwenhywfar.sha256 = "1isbj4a7vdgagp3kkvx2pjcjy8lba6kzjr11fmr06aci1694dbsp";
+  gwenhywfar.releaseId = "364";
   libchipcard.version = "5.0.4";
   libchipcard.sha256 = "0fj2h39ll4kiv28ch8qgzdbdbnzs8gl812qnm660bw89rynpjnnj";
   libchipcard.releaseId = "158";

--- a/pkgs/development/libraries/aqbanking/sources.nix
+++ b/pkgs/development/libraries/aqbanking/sources.nix
@@ -5,7 +5,7 @@
   libchipcard.version = "5.0.4";
   libchipcard.sha256 = "0fj2h39ll4kiv28ch8qgzdbdbnzs8gl812qnm660bw89rynpjnnj";
   libchipcard.releaseId = "158";
-  aqbanking.version = "6.2.5";
-  aqbanking.sha256 = "1pyny15g8y5dzzl4yg7jjnavygfzsi2g1jl7as9grqy77q70cnyg";
-  aqbanking.releaseId = "342";
+  aqbanking.version = "6.2.10";
+  aqbanking.sha256 = "13dbpi58mw09gnsza11pxy5c8j99r11nkyg2j53y4lqk47rmyhvq";
+  aqbanking.releaseId = "368";
 }


### PR DESCRIPTION
###### Motivation for this change
It might also be worth converting these into a more normal form (by building from git directly) so they can be updated automatically.

cc @cillianderoiste 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
