### PR TITLE
gtksourceview4: fix intermittent "resource not found" build errors

### DIFF
--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, atk, cairo, glib, gtk3, pango, fribidi, vala
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, atk, cairo, glib, gtk3, pango, fribidi, vala
 , libxml2, perl, gettext, gnome3, gobject-introspection, dbus, xvfb_run, shared-mime-info
 , meson, ninja }:
 
@@ -26,7 +26,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ atk cairo glib pango fribidi libxml2 ];
 
-  patches = [ ./4.x-nix_share_path.patch ];
+  patches = [
+    ./4.x-nix_share_path.patch
+
+    # fixes intermittent "gtksourceview-gresources.h: no such file" errors
+    (fetchpatch {
+      name = "ensure-access-to-resources-in-corelib-build.patch";
+      url = "https://gitlab.gnome.org/GNOME/gtksourceview/-/commit/9bea9d1c4a56310701717bb106c52a5324ee392a.patch";
+      sha256 = "sha256-rSB6lOFEyz58HfOSj7ZM48/tHxhqbtWWbh60JuySAZ0=";
+    })
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes intermittent build errors. See https://github.com/NixOS/nixpkgs/pull/114981#issuecomment-799042784 for the build logs and https://gitlab.gnome.org/GNOME/gtksourceview/-/commit/290d2a7258540ca53b37bb4b932e86f1de43e0f2 for discussion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
