### PR TITLE
mksh: fix license

### DIFF
--- a/pkgs/shells/mksh/default.nix
+++ b/pkgs/shells/mksh/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchurl }:
+{ lib
+, stdenv
+, fetchurl
+, installShellFiles
+}:
 
 stdenv.mkDerivation rec {
   pname = "mksh";
@@ -6,20 +10,30 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     urls = [
-      "https://www.mirbsd.org/MirOS/dist/mir/mksh/mksh-R${version}.tgz"
-      "http://pub.allbsd.org/MirOS/dist/mir/mksh/mksh-R${version}.tgz"
+      "https://www.mirbsd.org/MirOS/dist/mir/mksh/${pname}-R${version}.tgz"
+      "http://pub.allbsd.org/MirOS/dist/mir/mksh/${pname}-R${version}.tgz"
     ];
-    sha256 = "01n5ggw33bw4jv4d3148wlw9n4aj7vdn3ffnc66c9w9pldjidbkp";
+    hash = "sha256-d64WZaM38cSMYda5Yds+UhGbOOWIhNHIloSvMfh7xQY=";
   };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
   dontConfigure = true;
 
-  buildPhase = "sh ./Build.sh -r";
+  buildPhase = ''
+    runHook preBuild
+    sh ./Build.sh -r
+    runHook postBuild
+  '';
 
   installPhase = ''
-    install -D -m 755 mksh $out/bin/mksh
-    install -D -m 644 mksh.1 $out/share/man/man1/mksh.1
-    install -D -m 644 dot.mkshrc $out/share/mksh/mkshrc
+    runHook preInstall
+    install -D mksh $out/bin/mksh
+    install -D dot.mkshrc $out/share/mksh/mkshrc
+    installManPage mksh.1
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -32,7 +46,7 @@ stdenv.mkDerivation rec {
       systems.
     '';
     homepage = "https://www.mirbsd.org/mksh.htm";
-    license = licenses.bsd3;
+    license = with licenses; [ miros isc unicode-dfs-2016 ];
     maintainers = with maintainers; [ AndersonTorres joachifm ];
     platforms = platforms.unix;
   };
@@ -41,3 +55,5 @@ stdenv.mkDerivation rec {
     shellPath = "/bin/mksh";
   };
 }
+# TODO [ AndersonTorres ]: lksh
+# TODO [ AndersonTorres ]: a more accurate licensing info


### PR DESCRIPTION
According to official documentation (http://www.mirbsd.org/TaC-mksh.txt), mksh
licensing changes according to build-time configuration. According to it, the
license was changed.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
