### PR TITLE
moonlight-qt: init at 3.1.0

### DIFF
--- a/pkgs/applications/misc/moonlight-qt/default.nix
+++ b/pkgs/applications/misc/moonlight-qt/default.nix
@@ -1,0 +1,59 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, wrapQtAppsHook
+, pkg-config
+, qmake
+, qtquickcontrols2
+, SDL2
+, SDL2_ttf
+, libva
+, libvdpau
+, libxkbcommon
+, alsaLib
+, libpulseaudio
+, openssl
+, libopus
+, ffmpeg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "moonlight-qt";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "moonlight-stream";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "e7fwb76zzidtF1COqrQ6gSF7bCX20j/CGjPu1Cb4HGc=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    pkg-config
+    qmake
+  ];
+
+  buildInputs = [
+    qtquickcontrols2
+    SDL2
+    SDL2_ttf
+    libva
+    libvdpau
+    libxkbcommon
+    alsaLib
+    libpulseaudio
+    openssl
+    libopus
+    ffmpeg
+  ];
+
+  meta = with lib; {
+    description = "Play your PC games on almost any device";
+    homepage = "https://moonlight-stream.org";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ luc65r ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24010,6 +24010,8 @@ in
 
   moonlight-embedded = callPackage ../applications/misc/moonlight-embedded { };
 
+  moonlight-qt = libsForQt5.callPackage ../applications/misc/moonlight-qt { };
+
   mooSpace = callPackage ../applications/audio/mooSpace { };
 
   mop = callPackage ../applications/misc/mop { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
