### PR TITLE
openssh: Fix cross-compile regression from c99c499

### DIFF
--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -8,6 +8,9 @@
 }:
 
 { lib, stdenv
+# This *is* correct, though unusual. as a way of getting krb5-config from the
+# pacakge without splicing See: https://github.com/NixOS/nixpkgs/pull/107606
+, pkgs
 , fetchurl
 , fetchpatch
 , zlib
@@ -42,7 +45,10 @@ stdenv.mkDerivation rec {
     '';
 
   nativeBuildInputs = [ pkg-config ]
-    ++ optional withKerberos kerberos
+    # This is not the same as the kerberos from the inputs! pkgs.kerberos is
+    # needed here to access krb5-config in order to cross compile. See:
+    # https://github.com/NixOS/nixpkgs/pull/107606
+    ++ optional withKerberos pkgs.kerberos
     ++ extraNativeBuildInputs;
   buildInputs = [ zlib openssl libedit ]
     ++ optional withFIDO libfido2

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -9,7 +9,7 @@
 
 { lib, stdenv
 # This *is* correct, though unusual. as a way of getting krb5-config from the
-# pacakge without splicing See: https://github.com/NixOS/nixpkgs/pull/107606
+# package without splicing See: https://github.com/NixOS/nixpkgs/pull/107606
 , pkgs
 , fetchurl
 , fetchpatch


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Recent refactoring from c99c499 into a "common.nix" dropped some unusual details that allowed cross-compilation. See https://github.com/NixOS/nixpkgs/pull/107606 for more details on the original patch.

###### Things done

This patch reinstates those, and adds comments for posterity linking to cross compilation discussion.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
