### PR TITLE
[staging-next] pythonPackages.drf-yasg: does not depend on packaging

### DIFF
--- a/pkgs/development/python-modules/drf-yasg/default.nix
+++ b/pkgs/development/python-modules/drf-yasg/default.nix
@@ -19,6 +19,11 @@ buildPythonPackage rec {
     sha256 = "d50f197c7f02545d0b736df88c6d5cf874f8fea2507ad85ad7de6ae5bf2d9e5a";
   };
 
+  postPatch = ''
+    # https://github.com/axnsan12/drf-yasg/pull/710
+    substituteInPlace requirements/base.txt --replace packaging ""
+  '';
+
   nativeBuildInputs = [
     setuptools_scm
   ];

--- a/pkgs/development/python-modules/drf-yasg/default.nix
+++ b/pkgs/development/python-modules/drf-yasg/default.nix
@@ -1,13 +1,15 @@
-{
-  lib,
-  buildPythonPackage,
-  fetchPypi,
-  inflection,
-  ruamel_yaml,
-  setuptools_scm,
-  six,
-  coreapi,
-  djangorestframework,
+{ lib
+, buildPythonPackage
+, fetchPypi
+, inflection
+, ruamel_yaml
+, setuptools_scm
+, six
+, coreapi
+, djangorestframework
+, pytestCheckHook
+, pytest-django
+, datadiff
 }:
 
 buildPythonPackage rec {
@@ -35,6 +37,17 @@ buildPythonPackage rec {
     coreapi
     djangorestframework
   ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-django
+    datadiff
+  ];
+
+  # ImportError: No module named 'testproj.settings'
+  doCheck = false;
+
+  pythonImportsCheck = [ "drf_yasg" ];
 
   meta = with lib; {
     description = "Generation of Swagger/OpenAPI schemas for Django REST Framework";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
build is broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
