### PR TITLE
rsbep: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/tools/backup/rsbep/default.nix
+++ b/pkgs/tools/backup/rsbep/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, lib, coreutils, gnused, gawk, fetchurl }:
+{ lib, stdenv, coreutils, gawk, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "rsbep";
-  version = "0.1.0";
+  version = "0.2.0";
 
-  src = fetchurl {
-    url = "https://www.thanassis.space/rsbep-0.1.0-ttsiodras.tar.bz2";
-    sha256 = "1zji34kc9srxp0h1s1m7k60mvgsir1wrx1n3wc990jszfplr32zc";
+  src = fetchFromGitHub {
+    owner = "ttsiodras";
+    repo = "rsbep-backup";
+    rev = "v${version}";
+    sha256 = "0is4jgil3wdqbvx9h66xcyzbqy84ndyydnnay2g9k81a4mcz4dns";
   };
 
   postFixup = ''
@@ -18,20 +20,27 @@ stdenv.mkDerivation {
     mv rsbep_chopper $libexecDir
 
     # Fix store dependencies in scripts
-    path="export PATH=$out/bin:$libexecDir:${lib.makeBinPath [ coreutils gnused gawk ]}"
+    path="export PATH=$out/bin:$libexecDir:${lib.makeBinPath [ coreutils gawk ]}"
     sed -i "2i$path" freeze.sh
     sed -i "2i$path" melt.sh
-
-    substituteInPlace freeze.sh --replace /bin/ls ls
 
     # Remove unneded binary
     rm poorZFS.py
   '';
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    cd $TMP
+    echo hello > input
+    $out/bin/freeze.sh input > packed
+    $out/bin/melt.sh packed > output
+    diff -u input output
+  '';
+
   meta = with lib; {
     description = "Create resilient backups with Reed-Solomon error correction and byte-spreading";
     homepage = "https://www.thanassis.space/rsbep.html";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.earvstedt ];
   };
 }


### PR DESCRIPTION
This release is currently available only through GitHub, hence the change to `fetchFromGithub`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).