### PR TITLE
python3Packages.pytest-dependency: Fix build with pytest ≥ 6.2.0

### DIFF
--- a/pkgs/development/python-modules/pytest-dependency/default.nix
+++ b/pkgs/development/python-modules/pytest-dependency/default.nix
@@ -9,6 +9,14 @@ buildPythonPackage rec {
     sha256 = "c2a892906192663f85030a6ab91304e508e546cddfe557d692d61ec57a1d946b";
   };
 
+  patches = [
+    # Fix build with pytest ≥ 6.2.0, https://github.com/RKrahl/pytest-dependency/pull/51
+    (fetchpatch {
+      url = "https://github.com/RKrahl/pytest-dependency/commit/0930889a13e2b9baa7617f05dc9b55abede5209d.patch";
+      sha256 = "0ka892j0rrlnfvk900fcph0f6lsnr9dy06q5k2s2byzwijhdw6n5";
+    })
+  ];
+
   propagatedBuildInputs = [ pytest ];
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change

Commit 84d6dfc4aa22be61455c515975978ad9ae5ed195 (#113382) bumped pytest from 6.1.2 to 6.2.2 with insufficient testing, breaking pytest-dependency.  Fix it by pulling in the upstream patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
