### PR TITLE
less.nix: fix escape

### DIFF
--- a/nixos/modules/programs/less.nix
+++ b/nixos/modules/programs/less.nix
@@ -40,7 +40,7 @@ in
       configFile = mkOption {
         type = types.nullOr types.path;
         default = null;
-        example = literalExample "$${pkgs.my-configs}/lesskey";
+        example = literalExample "\${pkgs.my-configs}/lesskey";
         description = ''
           Path to lesskey configuration file.
 


### PR DESCRIPTION
`$$` does not escape `$`
`\$` does
