### PR TITLE
assh: set version

### DIFF
--- a/pkgs/tools/networking/assh/default.nix
+++ b/pkgs/tools/networking/assh/default.nix
@@ -1,4 +1,9 @@
-{ lib, buildGoModule, fetchFromGitHub, openssh, makeWrapper }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, openssh
+, makeWrapper
+}:
 
 buildGoModule rec {
   pname = "assh";
@@ -14,6 +19,10 @@ buildGoModule rec {
   vendorSha256 = "sha256-6OAsO7zWAgPfQWD9k+nYH7hnDDUlKIjTB61ivvoubn0=";
 
   doCheck = false;
+
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-s -w -X moul.io/assh/v2/pkg/version.Version=${version}")
+  '';
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Set version for `-v` output.
 
```bash
...:~/nixpkgs]$ ./result/bin/assh -v
assh version 2.11.3 (n/a)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
