### PR TITLE
inspircd: init at 3.9.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -682,6 +682,7 @@
   ./services/networking/i2p.nix
   ./services/networking/icecream/scheduler.nix
   ./services/networking/icecream/daemon.nix
+  ./services/networking/inspircd.nix
   ./services/networking/iodine.nix
   ./services/networking/iperf3.nix
   ./services/networking/ircd-hybrid/default.nix

--- a/nixos/modules/services/networking/inspircd.nix
+++ b/nixos/modules/services/networking/inspircd.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.inspircd;
+
+  configFile = pkgs.writeText "inspircd.conf" cfg.config;
+
+in {
+  options = {
+    services.inspircd = {
+      enable = lib.mkEnableOption "InspIRCd";
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.inspircd;
+        defaultText = lib.literalExample "pkgs.inspircd";
+        example = lib.literalExample "pkgs.inspircdMinimal";
+        description = ''
+          The InspIRCd package to use. This is mainly useful
+          to specify an overridden version of the
+          <literal>pkgs.inspircd</literal> dervivation, for
+          example if you want to use a more minimal InspIRCd
+          distribution with less modules enabled or with
+          modules enabled which can't be distributed in binary
+          form due to licensing issues.
+        '';
+      };
+
+      config = lib.mkOption {
+        type = lib.types.lines;
+        description = ''
+          Verbatim <literal>inspircd.conf</literal> file.
+          For a list of options, consult the
+          <link xlink:href="https://docs.inspircd.org/3/configuration/">InspIRCd documentation</link>, the
+          <link xlink:href="https://docs.inspircd.org/3/modules/">Module documentation</link>
+          and the example configuration files distributed
+          with <literal>pkgs.inspircd.doc</literal>
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.inspircd = {
+      description = "InspIRCd - the stable, high-performance and modular Internet Relay Chat Daemon";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = ''
+          ${lib.getBin cfg.package}/bin/inspircd start --config ${configFile} --nofork --nopid
+        '';
+        DynamicUser = true;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/inspircd.nix
+++ b/nixos/modules/services/networking/inspircd.nix
@@ -6,6 +6,10 @@ let
   configFile = pkgs.writeText "inspircd.conf" cfg.config;
 
 in {
+  meta = {
+    maintainers = [ lib.maintainers.sternenseemann ];
+  };
+
   options = {
     services.inspircd = {
       enable = lib.mkEnableOption "InspIRCd";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -176,6 +176,7 @@ in
   initrd-network-ssh = handleTest ./initrd-network-ssh {};
   initrdNetwork = handleTest ./initrd-network.nix {};
   initrd-secrets = handleTest ./initrd-secrets.nix {};
+  inspircd = handleTest ./inspircd.nix {};
   installer = handleTest ./installer.nix {};
   iodine = handleTest ./iodine.nix {};
   ipfs = handleTest ./ipfs.nix {};

--- a/nixos/tests/inspircd.nix
+++ b/nixos/tests/inspircd.nix
@@ -88,6 +88,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       # to the next one.
     '' + lib.concatStrings
       (reduce
-        (a: b: lib.zipListsWith (cs: c: cs + "\n" + c) a b)
+        (lib.zipListsWith (cs: c: cs + c))
         (builtins.map clientScript clients));
 })

--- a/nixos/tests/inspircd.nix
+++ b/nixos/tests/inspircd.nix
@@ -74,9 +74,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
         ${client}.succeed(
             "grep '${msg other}$' ${iiDir}/${server}/#${channel}/out"
         )
-      '') clients ++ [
-        "# trailing comment to please reformatter :)"
-      ];
+      '') clients;
 
       # foldl', but requires a non-empty list instead of a start value
       reduce = f: list:
@@ -88,9 +86,8 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       # run clientScript for all clients so that every list
       # entry is executed by every client before advancing
       # to the next one.
-      ${lib.concatStringsSep "\n"
-        (reduce
-          (a: b: lib.zipListsWith (cs: c: cs + "\n" + c) a b)
-          (builtins.map clientScript clients))}
-    '';
+    '' + lib.concatStrings
+      (reduce
+        (a: b: lib.zipListsWith (cs: c: cs + "\n" + c) a b)
+        (builtins.map clientScript clients));
 })

--- a/nixos/tests/inspircd.nix
+++ b/nixos/tests/inspircd.nix
@@ -1,0 +1,96 @@
+let
+  clients = [
+    "ircclient1"
+    "ircclient2"
+  ];
+  server = "inspircd";
+  ircPort = 6667;
+  channel = "nixos-cat";
+  iiDir = "/tmp/irc";
+in
+
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "inspircd";
+  nodes = {
+    "${server}" = {
+      networking.firewall.allowedTCPPorts = [ ircPort ];
+      services.inspircd = {
+        enable = true;
+        package = pkgs.inspircdMinimal;
+        config = ''
+          <bind address="" port="${toString ircPort}" type="clients">
+          <connect name="main" allow="*" pingfreq="15">
+        '';
+      };
+    };
+  } // lib.listToAttrs (builtins.map (client: lib.nameValuePair client {
+    imports = [
+      ./common/user-account.nix
+    ];
+
+    systemd.services.ii = {
+      requires = [ "network.target" ];
+      wantedBy = [ "default.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecPreStartPre = "mkdir -p ${iiDir}";
+        ExecStart = ''
+          ${lib.getBin pkgs.ii}/bin/ii -n ${client} -s ${server} -i ${iiDir}
+        '';
+        User = "alice";
+      };
+    };
+  }) clients);
+
+  testScript =
+    let
+      msg = client: "Hello, my name is ${client}";
+      clientScript = client: [
+        ''
+          ${client}.wait_for_unit("network.target")
+          ${client}.systemctl("start ii")
+          ${client}.wait_for_unit("ii")
+          ${client}.wait_for_file("${iiDir}/${server}/out")
+        ''
+        # wait until first PING from server arrives before joining,
+        # so we don't try it too early
+        ''
+          ${client}.wait_until_succeeds("grep 'PING' ${iiDir}/${server}/out")
+        ''
+        # join ${channel}
+        ''
+          ${client}.succeed("echo '/j #${channel}' > ${iiDir}/${server}/in")
+          ${client}.wait_for_file("${iiDir}/${server}/#${channel}/in")
+        ''
+        # send a greeting
+        ''
+          ${client}.succeed(
+              "echo '${msg client}' > ${iiDir}/${server}/#${channel}/in"
+          )
+        ''
+        # check that all greetings arrived on all clients
+      ] ++ builtins.map (other: ''
+        ${client}.succeed(
+            "grep '${msg other}$' ${iiDir}/${server}/#${channel}/out"
+        )
+      '') clients ++ [
+        "# trailing comment to please reformatter :)"
+      ];
+
+      # foldl', but requires a non-empty list instead of a start value
+      reduce = f: list:
+        builtins.foldl' f (builtins.head list) (builtins.tail list);
+    in ''
+      start_all()
+      ${server}.wait_for_open_port(${toString ircPort})
+
+      # run clientScript for all clients so that every list
+      # entry is executed by every client before advancing
+      # to the next one.
+      ${lib.concatStringsSep "\n"
+        (reduce
+          (a: b: lib.zipListsWith (cs: c: cs + "\n" + c) a b)
+          (builtins.map clientScript clients))}
+    '';
+})

--- a/pkgs/servers/irc/inspircd/default.nix
+++ b/pkgs/servers/irc/inspircd/default.nix
@@ -61,7 +61,7 @@ in
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
+, nixosTests
 , perl
 , pkg-config
 , libargon2
@@ -191,6 +191,10 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  passthru.tests = {
+    nixos-test = nixosTests.inspircd;
+  };
 
   meta = {
     description = "A modular C++ IRC server";

--- a/pkgs/servers/irc/inspircd/default.nix
+++ b/pkgs/servers/irc/inspircd/default.nix
@@ -1,0 +1,218 @@
+let
+  # inspircd ships a few extra modules that users can load
+  # via configuration. Upstream thus recommends to ship as
+  # many of them as possible. There is however a problem:
+  # inspircd is licensed under the GPL version 2 only and
+  # some modules link libraries that are incompatible with
+  # the GPL 2. Therefore we can't provide them as binaries
+  # via our binary-caches, but users should still be able
+  # to override this package and build the incompatible
+  # modules themselves.
+  #
+  # This means for us we need to a) prevent hydra from
+  # building a module set with a GPL incompatibility
+  # and b) dynamically figure out the largest possible
+  # set of modules to use depending on stdenv, because
+  # the used libc needs to be compatible as well.
+  #
+  # For an overview of all modules and their licensing
+  # situation, see https://docs.inspircd.org/packaging/
+
+  # Predicate for checking license compatibility with
+  # GPLv2. Since this is _only_ used for libc compatibility
+  # checking, only whitelist licenses used by notable
+  # libcs in nixpkgs (musl and glibc).
+  compatible = lib: drv:
+    lib.any (lic: lic == drv.meta.license) [
+      lib.licenses.mit        # musl
+      lib.licenses.lgpl2Plus  # glibc
+    ];
+
+  # compatible if libc is compatible
+  libcModules = [
+    "regex_posix"
+    "sslrehashsignal"
+  ];
+
+  # compatible if libc++ is compatible
+  # TODO(sternenseemann):
+  # we could enable "regex_stdlib" automatically, but only if
+  # we are using libcxxStdenv which is compatible with GPLv2,
+  # since the gcc libstdc++ license is GPLv2-incompatible
+  libcxxModules = [
+    "regex_stdlib"
+  ];
+
+  compatibleModules = lib: stdenv: [
+    # GPLv2 compatible dependencies
+    "argon2"
+    "ldap"
+    "mysql"
+    "pgsql"
+    "regex_pcre"
+    "regex_re2"
+    "regex_tre"
+    "sqlite3"
+    "ssl_gnutls"
+  ] ++ lib.optionals (compatible lib stdenv.cc.libc) libcModules;
+
+in
+
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, perl
+, pkg-config
+, libargon2
+, openldap
+, postgresql
+, libmysqlclient
+, pcre
+, tre
+, re2
+, sqlite
+, gnutls
+, libmaxminddb
+, openssl
+, mbedtls
+# For a full list of module names, see https://docs.inspircd.org/packaging/
+, extraModules ? compatibleModules lib stdenv
+}:
+
+let
+  extras = {
+    # GPLv2 compatible
+    argon2 = [
+      (libargon2 // {
+        meta = libargon2.meta // {
+          # use libargon2 as CC0 since ASL20 is GPLv2-incompatible
+          # updating this here is important that meta.license is accurate
+          license = lib.licenses.cc0;
+        };
+      })
+    ];
+    ldap            = [ openldap ];
+    mysql           = [ libmysqlclient ];
+    pgsql           = [ postgresql ];
+    regex_pcre      = [ pcre ];
+    regex_re2       = [ re2 ];
+    regex_tre       = [ tre ];
+    sqlite3         = [ sqlite ];
+    ssl_gnutls      = [ gnutls ];
+    # depends on stdenv.cc.libc
+    regex_posix     = [];
+    sslrehashsignal = [];
+    # depends on used libc++
+    regex_stdlib    = [];
+    # GPLv2 incompatible
+    geo_maxmind     = [ libmaxminddb ];
+    ssl_mbedtls     = [ mbedtls ];
+    ssl_openssl     = [ openssl ];
+  };
+
+  # buildInputs necessary for the enabled extraModules
+  extraInputs = lib.concatMap
+    (m: extras."${m}" or (builtins.throw "Unknown extra module ${m}"))
+    extraModules;
+
+  # if true, we can't provide a binary version of this
+  # package without violating the GPL 2
+  gpl2Conflict =
+    let
+      allowed = compatibleModules lib stdenv;
+    in
+      !lib.all (lib.flip lib.elem allowed) extraModules;
+
+  # return list of the license(s) of the given derivation
+  getLicenses = drv:
+    let
+      lics = drv.meta.license or [];
+    in
+      if lib.isAttrs lics || lib.isString lics
+      then [ lics ]
+      else lics;
+
+  # Whether any member of list1 is also member of list2, i. e. set intersection.
+  anyMembers = list1: list2:
+    lib.any (m1: lib.elem m1 list2) list1;
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "inspircd";
+  version = "3.9.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0x3paasf4ynx4ddky2nq613vyirbhfnxzkjq148k7154pz3q426s";
+  };
+
+  patches = [
+    # Remove at next release, makes --prefix and --system work together
+    (fetchpatch {
+      url = "https://github.com/inspircd/inspircd/commit/b378b5087b41f72a1624ebb58990180e0b0140aa.patch";
+      sha256 = "0c0fmhjbkfh2r1cmjrm5d4whcignwsyi6kwkhmcvqy9mv99pj2ir";
+    })
+  ];
+
+  nativeBuildInputs = [
+    perl
+    pkg-config
+  ];
+  buildInputs = extraInputs;
+
+  preConfigure = ''
+    patchShebangs configure make/*.pl
+    # configure is executed twice, once to set the extras
+    # to use and once to do the Makefile setup
+    ./configure --enable-extras \
+      ${lib.escapeShellArg (lib.concatStringsSep " " extraModules)}
+  '';
+
+  configureFlags = [
+    "--disable-auto-extras"
+    "--distribution-label" "nixpkgs${version}"
+    "--system"
+    "--uid" "0"
+    "--gid" "0"
+    "--prefix" (placeholder "out")
+  ];
+
+  postInstall = ''
+    # installs to $out/usr by default unfortunately
+    mv "$out/usr/lib" "$out/lib"
+    mv "$out/usr/sbin" "$out/bin"
+    mv "$out/usr/share" "$out/share"
+    rm -r "$out/usr"
+    rm -r "$out/var" # only empty directories
+    rm -r "$out/etc" # only contains documentation
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A modular C++ IRC server";
+    license = [ lib.licenses.gpl2Only ]
+      ++ lib.concatMap getLicenses extraInputs
+      ++ lib.optionals (anyMembers extraModules libcModules) (getLicenses stdenv.cc.libc)
+      # FIXME(sternenseemann): get license of used lib(std)c++ somehow
+      ++ lib.optional (anyMembers extraModules libcxxModules) "Unknown"
+      # Hack: Definitely prevent a hydra from building this package on
+      # a GPL 2 incompatibility even if it is not in a top-level attribute,
+      # but pulled in indirectly somehow.
+      ++ lib.optional gpl2Conflict lib.licenses.unfree;
+    maintainers = [ lib.maintainers.sternenseemann ];
+    # windows is theoretically possible, but requires extra work
+    # which I am not willing to do and can't test.
+    # https://github.com/inspircd/inspircd/blob/master/win/README.txt
+    platforms = lib.platforms.unix;
+    homepage = "https://www.inspircd.org/";
+  } // lib.optionalAttrs gpl2Conflict {
+    # make sure we never distribute a GPLv2-violating module
+    # in binary form. They can be built locally of course.
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18229,6 +18229,10 @@ in
     theme-spring = callPackage ../servers/icingaweb2/theme-spring { };
   };
 
+  inspircd = callPackage ../servers/irc/inspircd { };
+
+  inspircdMinimal = inspircd.override { extraModules = []; };
+
   imgproxy = callPackage ../servers/imgproxy { };
 
   ircdog = callPackage ../applications/networking/irc/ircdog { };


### PR DESCRIPTION
Packaging inspircd is relatively straightforward, once we adapt to the
slightly strange Perl configure script and it's firm opinion that
$prefix/usr should exist.

Most complexity in this derivation stems from the following:

* inspircd has modules which users can load dynamically in the form of
  shared objects that link against other libraries for various tasks

* inspircd is licensed exclusively under the GPL version 2.

* Some of the libraries inspircd modules link against are GPL 2
  incompatible (GPL 3, ASL 2.0) and we therefore must not distribute
  these in binary form.

* Some modules combine GPL 2 code of inspircd and libc into a shared
  object and may not be redistributed in binary form depending on the
  license of the libc. Similarly for libc++.
  Open Question: Does the fact that we may build the inspircd binary, i.
  e. link against libc and libc++ imply that we can do this?
  https://docs.inspircd.org/packaging/ seems to imply this is not the
  case.

Thus we have some additional code which a) determines the set of modules
we should enable by default (the largest possible set as upstream
recommends it) and b) collects all applying licenses into meta.license.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
