### PR TITLE
libpg_query: init at 13-2.0.4

### DIFF
--- a/pkgs/development/libraries/libpg_query/default.nix
+++ b/pkgs/development/libraries/libpg_query/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, which }:
+
+stdenv.mkDerivation rec {
+  pname = "libpg_query";
+  version = "13-2.0.4";
+
+  src = fetchFromGitHub {
+    owner = "pganalyze";
+    repo = "libpg_query";
+    rev = version;
+    sha256 = "0d88fh613kh1izb6w288bfh7s3db4nz8cxyhmhq3lb7gl4axs2pv";
+  };
+
+  nativeBuildInputs = [ which ];
+
+  makeFlags = [ "build" ];
+
+  installPhase = ''
+    install -Dm644 -t $out/lib libpg_query.a
+    install -Dm644 -t $out/include pg_query.h
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/pganalyze/libpg_query";
+    description = "C library for accessing the PostgreSQL parser outside of the server environment";
+    changelog = "https://github.com/pganalyze/libpg_query/raw/${version}/CHANGELOG.md";
+    license = licenses.bsd3;
+    platforms = platforms.x86_64;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15885,6 +15885,8 @@ in
 
   libpeas = callPackage ../development/libraries/libpeas { };
 
+  libpg_query = callPackage ../development/libraries/libpg_query { };
+
   libpipeline = callPackage ../development/libraries/libpipeline { };
 
   libpgf = callPackage ../development/libraries/libpgf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add https://github.com/pganalyze/libpg_query
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
