### PR TITLE
plasma_5_21: add missing dependencies

### DIFF
--- a/pkgs/desktops/plasma-5/discover.nix
+++ b/pkgs/desktops/plasma-5/discover.nix
@@ -1,10 +1,34 @@
-{
-  mkDerivation, lib,
-  extra-cmake-modules, gettext, kdoctools, python,
-  appstream-qt, discount, flatpak, fwupd, ostree, packagekit-qt, pcre, util-linux,
-  qtbase, qtquickcontrols2,
-  karchive, kconfig, kcrash, kdbusaddons, kdeclarative, kio, kirigami2, kitemmodels,
-  knewstuff, kwindowsystem, kxmlgui, plasma-framework
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, gettext
+, kdoctools
+, python
+, appstream-qt
+, discount
+, flatpak
+, fwupd
+, ostree
+, packagekit-qt
+, pcre
+, util-linux
+, qtbase
+, qtquickcontrols2
+, qtx11extras
+, karchive
+, kcmutils
+, kconfig
+, kcrash
+, kdbusaddons
+, kdeclarative
+, kidletime
+, kio
+, kirigami2
+, kitemmodels
+, knewstuff
+, kwindowsystem
+, kxmlgui
+, plasma-framework
 }:
 
 mkDerivation {
@@ -13,9 +37,29 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python ];
   buildInputs = [
     # discount is needed for libmarkdown
-    appstream-qt discount flatpak fwupd ostree packagekit-qt pcre util-linux
+    appstream-qt
+    discount
+    flatpak
+    fwupd
+    ostree
+    packagekit-qt
+    pcre
+    util-linux
     qtquickcontrols2
-    karchive kconfig kcrash kdbusaddons kdeclarative kio kirigami2 kitemmodels knewstuff kwindowsystem kxmlgui
+    qtx11extras
+    karchive
+    kcmutils
+    kconfig
+    kcrash
+    kdbusaddons
+    kdeclarative
+    kidletime
+    kio
+    kirigami2
+    kitemmodels
+    knewstuff
+    kwindowsystem
+    kxmlgui
     plasma-framework
   ];
 }

--- a/pkgs/desktops/plasma-5/sddm-kcm.nix
+++ b/pkgs/desktops/plasma-5/sddm-kcm.nix
@@ -1,8 +1,19 @@
-{
-  mkDerivation, lib, extra-cmake-modules, shared-mime-info,
-  libpthreadstubs, libXcursor, libXdmcp,
-  qtbase, qtquickcontrols2, qtx11extras,
-  karchive, ki18n, kio, knewstuff
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, shared-mime-info
+, libpthreadstubs
+, libXcursor
+, libXdmcp
+, qtbase
+, qtquickcontrols2
+, qtx11extras
+, karchive
+, kcmutils
+, kdeclarative
+, ki18n
+, kio
+, knewstuff
 }:
 
 mkDerivation {
@@ -10,8 +21,16 @@ mkDerivation {
   meta.broken = lib.versionOlder qtbase.version "5.15.0";
   nativeBuildInputs = [ extra-cmake-modules shared-mime-info ];
   buildInputs = [
-    libpthreadstubs libXcursor libXdmcp
-    qtquickcontrols2 qtx11extras
-    karchive ki18n kio knewstuff
+    libpthreadstubs
+    libXcursor
+    libXdmcp
+    qtquickcontrols2
+    qtx11extras
+    karchive
+    kcmutils
+    kdeclarative
+    ki18n
+    kio
+    knewstuff
   ];
 }


### PR DESCRIPTION
###### Motivation for this change

Latest update to 5.21 broke a few packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
