### PR TITLE
vollkorn: init at 4.105

### DIFF
--- a/pkgs/data/fonts/vollkorn/default.nix
+++ b/pkgs/data/fonts/vollkorn/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchzip }:
+let
+  pname = "vollkorn";
+  version = "4.105";
+in
+fetchzip {
+  name = "${pname}-${version}";
+  url = "http://vollkorn-typeface.com/download/vollkorn-4-105.zip";
+  sha256 = "0srff2nqs7353mqcpmvaq156lamfh621py4h1771n0l9ix2c8mss";
+  stripRoot = false;
+
+  postFetch = ''
+    mkdir -pv $out/share/{doc/${pname}-${version},fonts/{opentype,truetype,WOFF,WOFF2}}
+    unzip $downloadedFile
+    cp -v {Fontlog,OFL-FAQ,OFL}.txt $out/share/doc/${pname}-${version}/
+    cp -v PS-OTF/*.otf $out/share/fonts/opentype
+    cp -v TTF/*.ttf $out/share/fonts/truetype
+    cp -v WOFF/*.woff $out/share/fonts/WOFF
+    cp -v WOFF2/*.woff2 $out/share/fonts/WOFF2
+  '';
+
+  meta = with lib; {
+    homepage = "http://vollkorn-typeface.com/";
+    description = "The free and healthy typeface for bread and butter use";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.schmittlauch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21405,6 +21405,8 @@ in
 
   vistafonts-chs = callPackage ../data/fonts/vista-fonts-chs { };
 
+  vollkorn = callPackage ../data/fonts/vollkorn { };
+
   weather-icons = callPackage ../data/fonts/weather-icons { };
 
   wireless-regdb = callPackage ../data/misc/wireless-regdb { };


### PR DESCRIPTION
###### Motivation for this change

adding a popular Serif font. This addition should have a low maintenance burden due to low complexity and slow release schedule.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).