### PR TITLE
xh: 0.7.0 -> 0.9.1

### DIFF
--- a/pkgs/tools/networking/xh/default.nix
+++ b/pkgs/tools/networking/xh/default.nix
@@ -1,22 +1,31 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, Security }:
+{ stdenv, lib, openssl, pkg-config, rustPlatform, fetchFromGitHub, Security
+, libiconv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "xh";
-  version = "0.7.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "ducaale";
     repo = "xh";
     rev = "v${version}";
-    sha256 = "0b7q0xbfbrhvpnxbm9bd1ncdza9k2kcmcir3qhqzb2pgsb5b5njx";
+    sha256 = "pRVlcaPfuO7IMH2p0AQfVrCIXCRyF37WIirOJQkcAJE=";
   };
 
-  cargoSha256 = "02fgqys9qf0jzs2n230pyj151v6xbm6wm2rd9qm5gsib6zaq7gfa";
+  cargoSha256 = "dXo1+QvCW3CWN2OhsqGh2Q1xet6cmi2xVy1Xk7s1YR8=";
 
-  buildInputs = lib.optional stdenv.isDarwin Security;
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = if stdenv.isDarwin then [ Security libiconv ] else [ openssl ];
+
+  # Get openssl-sys to use pkg-config
+  OPENSSL_NO_VENDOR = 1;
 
   checkFlagsArray = [ "--skip=basic_options" ];
 
+  # Nix build happens in sandbox without internet connectivity
+  # disable tests as some of them require internet due to nature of application
+  doCheck = false;
   doInstallCheck = true;
   postInstallCheck = ''
     $out/bin/xh --help > /dev/null


### PR DESCRIPTION
###### Motivation for this change
Update to upstream package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
