### PR TITLE
miniserve: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/tools/misc/miniserve/default.nix
+++ b/pkgs/tools/misc/miniserve/default.nix
@@ -4,24 +4,27 @@
 , fetchFromGitHub
 , pkg-config
 , zlib
+, libiconv
 , Security
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "miniserve";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "svenstaro";
     repo = "miniserve";
     rev = "v${version}";
-    sha256 = "sha256-/vtiHRHsbF7lfn9tfgfKhm5YwofjSJniNNnKahphHFg=";
+    sha256 = "sha256-hTNwEspM1qlQkC6lD7N947tvS7O7RCIUYACvj4KYsAY=";
   };
 
-  cargoSha256 = "sha256-gwy/LeVznZyawliXnkULyyVSXATk0sjSTUZPHO2K+9o=";
+  cargoSha256 = "sha256-7G+h+g00T/aJ1cQ1SChxy8dq3CWWdHlx5DAH77xM9Oc=";
 
   nativeBuildInputs = [ pkg-config zlib ];
-  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  checkFlags = [ "--skip=cant_navigate_up_the_root" ];
 
   meta = with lib; {
     description = "For when you really just want to serve some files over HTTP right now!";


### PR DESCRIPTION
https://github.com/svenstaro/miniserve/releases/tag/v0.12.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
