### PR TITLE
plasma-systemmonitor: init at 5.21.1

### DIFF
--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -131,6 +131,7 @@ let
       plasma-integration = callPackage ./plasma-integration {};
       plasma-nm = callPackage ./plasma-nm {};
       plasma-pa = callPackage ./plasma-pa.nix { inherit gconf; };
+      plasma-systemmonitor = callPackage ./plasma-systemmonitor.nix { };
       plasma-thunderbolt = callPackage ./plasma-thunderbolt.nix { };
       plasma-vault = callPackage ./plasma-vault {};
       plasma-workspace = callPackage ./plasma-workspace {};

--- a/pkgs/desktops/plasma-5/plasma-systemmonitor.nix
+++ b/pkgs/desktops/plasma-5/plasma-systemmonitor.nix
@@ -1,0 +1,32 @@
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, kdoctools
+, qtquickcontrols2
+, kconfig
+, kcoreaddons
+, ki18n
+, kiconthemes
+, kitemmodels
+, kitemviews
+, knewstuff
+, libksysguard
+, qtbase
+}:
+
+mkDerivation {
+  name = "plasma-systemmonitor";
+  meta.broken = lib.versionOlder qtbase.version "5.15.0";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    qtquickcontrols2
+    kconfig
+    kcoreaddons
+    ki18n
+    kitemmodels
+    kitemviews
+    knewstuff
+    kiconthemes
+    libksysguard
+  ];
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -942,13 +942,29 @@ mapAliases ({
     yakuake
   ;
   inherit (plasma5Packages)
-    bluedevil breeze-gtk breeze-qt5 breeze-grub breeze-plymouth discover
-    kactivitymanagerd kde-cli-tools kde-gtk-config kdeplasma-addons kgamma5
-    kinfocenter kmenuedit kscreen kscreenlocker ksshaskpass ksysguard
-    kwallet-pam kwayland-integration kwin kwrited milou oxygen plasma-browser-integration
-    plasma-desktop plasma-integration plasma-nm plasma-pa plasma-vault plasma-workspace
-    plasma-workspace-wallpapers polkit-kde-agent powerdevil sddm-kcm
-    systemsettings xdg-desktop-portal-kde
+    bluedevil breeze-gtk breeze-qt5 breeze-grub breeze-plymouth
+    discover
+    kactivitymanagerd
+    kde-cli-tools kde-gtk-config kdeplasma-addons
+    kgamma5
+    kinfocenter
+    kmenuedit
+    kscreen kscreenlocker ksshaskpass ksysguard
+    kwallet-pam kwayland-integration kwin kwrited
+    milou
+    oxygen
+    plasma-browser-integration
+    plasma-desktop
+    plasma-integration
+    plasma-nm
+    plasma-pa
+    plasma-systemmonitor
+    plasma-thunderbolt
+    plasma-vault
+    plasma-workspace plasma-workspace-wallpapers
+    polkit-kde-agent powerdevil
+    sddm-kcm systemsettings
+    xdg-desktop-portal-kde
   ;
   inherit (plasma5Packages.thirdParty)
     plasma-applet-caffeine-plus


### PR DESCRIPTION
###### Motivation for this change

 The new, shiny system-monitor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
