### PR TITLE
noweb: add useIcon boolean arg

### DIFF
--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, nawk, groff, icon-lang }:
+{ lib, stdenv, fetchFromGitHub, nawk, groff, icon-lang, useIcon ? true }:
 
 lib.fix (noweb: stdenv.mkDerivation rec {
   pname = "noweb";
@@ -22,14 +22,14 @@ lib.fix (noweb: stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace 'strip' '${stdenv.cc.targetPrefix}strip'
   '';
 
-  nativeBuildInputs = [ groff ] ++ lib.optionals (!isNull icon-lang) [ icon-lang ];
+  nativeBuildInputs = [ groff ] ++ lib.optionals useIcon [ icon-lang ];
   buildInputs = [ nawk ];
 
   preBuild = ''
     mkdir -p "$out/lib/noweb"
   '';
 
-  makeFlags = lib.optionals (!isNull icon-lang) [
+  makeFlags = lib.optionals useIcon [
     "LIBSRC=icon"
     "ICONC=icont"
   ] ++ [ "CC=${stdenv.cc.targetPrefix}cc" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12863,7 +12863,7 @@ in
     gconf = pkgs.gnome2.GConf;
   };
 
-  # NOTE: Override and set icon-lang = null to use Awk instead of Icon.
+  # NOTE: Override and set useIcon = false to use Awk instead of Icon.
   noweb = callPackage ../development/tools/literate-programming/noweb { };
 
   nuweb = callPackage ../development/tools/literate-programming/nuweb { tex = texlive.combined.scheme-medium; };


### PR DESCRIPTION
###### Motivation for this change

@SuperSandro2000 said to avoid override packages to `null` (ref: https://github.com/NixOS/nixpkgs/pull/114657#issuecomment-803388580) 


###### Things done

Tested `noweb.override { useIcon = false; }` as well.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
