### PR TITLE
python3Packages.aioresponses: 0.7.1 -> 0.7.2, python3Packages.asdf: 2.7.1 -> 2.7.3

### DIFF
--- a/pkgs/development/python-modules/aioresponses/default.nix
+++ b/pkgs/development/python-modules/aioresponses/default.nix
@@ -1,12 +1,12 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-, pythonOlder
-, pbr
 , aiohttp
-, ddt
 , asynctest
-, pytest
+, buildPythonPackage
+, ddt
+, fetchPypi
+, pbr
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -30,13 +30,16 @@ buildPythonPackage rec {
   checkInputs = [
     asynctest
     ddt
-    pytest
+    pytestCheckHook
   ];
 
-  # Skip a test which makes requests to httpbin.org
-  checkPhase = ''
-    pytest -k "not (test_address_as_instance_of_url_combined_with_pass_through or test_pass_through_with_origin_params)"
-  '';
+  disabledTests = [
+    # Skip a test which makes requests to httpbin.org
+    "test_address_as_instance_of_url_combined_with_pass_through"
+    "test_pass_through_with_origin_params"
+  ];
+
+  pythonImportsCheck = [ "aioresponses" ];
 
   meta = {
     description = "A helper to mock/fake web requests in python aiohttp package";

--- a/pkgs/development/python-modules/aioresponses/default.nix
+++ b/pkgs/development/python-modules/aioresponses/default.nix
@@ -11,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "aioresponses";
-  version = "0.7.1";
+  version = "0.7.2";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f65bba2be1e9a4997ee166bc0161a50be0fef7350ad09e6afdb2adccf74dfefe";
+    sha256 = "sha256-guSV0Ri3SJaqW01H4X7/teLMeD5RCuOVzq3l6Hyr6Jo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/asdf/default.nix
+++ b/pkgs/development/python-modules/asdf/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "asdf";
-  version = "2.7.1";
+  version = "2.7.2";
   disabled = isPy27;
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4ba2e31cb24b974a10dfae3edee23db2e6bea2d00608604d062366aa3af6e81a";
+    sha256 = "4ba2e31cb24b974a11dfae3edee23db2e6bea2d00608604d062366aa3af6e81a";
   };
 
   checkInputs = [

--- a/pkgs/development/python-modules/asdf/default.nix
+++ b/pkgs/development/python-modules/asdf/default.nix
@@ -1,54 +1,55 @@
 { lib
+, astropy
 , buildPythonPackage
 , fetchPypi
-, pytest-astropy
-, semantic-version
-, pyyaml
 , jsonschema
-, six
 , numpy
-, isPy27
-, astropy
-, setuptools_scm
-, setuptools
+, packaging
+, pytest-astropy
+, pytestCheckHook
+, pythonOlder
+, pyyaml
+, semantic-version
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "asdf";
-  version = "2.7.2";
-  disabled = isPy27;
+  version = "2.7.3";
+  disabled = pythonOlder "3.6";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4ba2e31cb24b974a11dfae3edee23db2e6bea2d00608604d062366aa3af6e81a";
+    sha256 = "11dyr295wn5m2pcynlwj7kgw9xr66msfvwn1m6a5vv13vzj19spp";
   };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [
+    jsonschema
+    numpy
+    packaging
+    pyyaml
+    semantic-version
+  ];
 
   checkInputs = [
     pytest-astropy
     astropy
+    pytestCheckHook
   ];
 
-  propagatedBuildInputs = [
-    semantic-version
-    pyyaml
-    jsonschema
-    six
-    numpy
-    setuptools_scm
-    setuptools
-  ];
-
-  checkPhase = ''
-    PY_IGNORE_IMPORTMISMATCH=1 pytest
+  preCheck = ''
+    export PY_IGNORE_IMPORTMISMATCH=1
   '';
+
+  pythonImportsCheck = [ "asdf" ];
 
   meta = with lib; {
     description = "Python tools to handle ASDF files";
     homepage = "https://github.com/spacetelescope/asdf";
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
-    # many ValueError in tests
-    broken = true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.7.2. This fixes the version parsing issue.

Change log: https://github.com/pnuckowski/aioresponses/releases/tag/0.7.2

Attached is also an update of `asdf` to 2.7.3 (https://github.com/asdf-format/asdf/releases/tag/2.7.3) to make `sunpy` build again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
