### PR TITLE
GNOME 40 fixups

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -40,6 +40,8 @@ let
 
         "0.50" = ./disable-graphviz-0.46.1.patch;
 
+        "0.52" = ./disable-graphviz-0.46.1.patch;
+
       }.${lib.versions.majorMinor version} or (throw "no graphviz patch for this version of vala");
 
     disableGraphviz = lib.versionAtLeast version "0.38" && !withGraphviz;
@@ -134,5 +136,10 @@ in rec {
     sha256 = "1353j852h04d1x6b4n6lbg3ay40ph0adb9yi25dh74pligx33z2q";
   };
 
-  vala = vala_0_48;
+  vala_0_52 = generic {
+    version = "0.52.0";
+    sha256 = "12y6p8wdjp01vmfhxg2cgh32xnyqq6ivblvrar9clnj6vc867qhx";
+  };
+
+  vala = vala_0_52;
 }

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -14,6 +14,7 @@
 , libX11
 , libXtst # at-spi2-core can be build without X support, but due it is a client-side library, GUI-less usage is a very rare case
 , libXi
+, libXext
 
 , gnome3 # To pass updateScript
 }:
@@ -30,7 +31,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ meson ninja pkg-config gobject-introspection makeWrapper ];
-  buildInputs = [ libX11 libXtst libXi ];
+  # libXext is a transitive dependency of libXi
+  buildInputs = [ libX11 libXtst libXi libXext ];
   # In atspi-2.pc dbus-1 glib-2.0
   propagatedBuildInputs = [ dbus glib ];
 

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -45,11 +45,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "glib";
-  version = "2.66.8";
+  version = "2.68.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-l7yH3ZE2VYmvXLv+oldIM66nobcYQP02Xs0oUsdrnIs=";
+    sha256 = "sha256-Z3NPWE86BaKHL1fpqNs487BscIf7Uxxag52RcZaBA+o=";
   };
 
   patches = optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/glibmm/default.nix
+++ b/pkgs/development/libraries/glibmm/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "glibmm";
-  version = "2.68.0";
+  version = "2.66.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-wfOFcxkdzu2FoFYAiIz0z0aVlB8zlxW9Z9UcJBb083U=";
+    sha256 = "sha256-nh231D0uLU36J3E1TiGmmmvux8RGtxFhnPjHeeE6WB4=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gobject-introspection/absolute_gir_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_gir_path.patch
@@ -1,8 +1,10 @@
+diff --git a/gir/cairo-1.0.gir.in b/gir/cairo-1.0.gir.in
+index e4c9fb3d..3351b184 100644
 --- a/gir/cairo-1.0.gir.in
 +++ b/gir/cairo-1.0.gir.in
-@@ -5,7 +5,7 @@
-             xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+@@ -6,7 +6,7 @@
    <package name="@CAIRO_GIR_PACKAGE@"/>
+   <c:include name="cairo-gobject.h"/>
    <namespace name="cairo" version="1.0"
 -	     shared-library="@CAIRO_SHARED_LIBRARY@"
 +	     shared-library="@cairoLib@/@CAIRO_SHARED_LIBRARY@"

--- a/pkgs/development/libraries/pangomm/default.nix
+++ b/pkgs/development/libraries/pangomm/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pangomm";
-  version= "2.48.0";
+  version= "2.46.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-ng7UdMM/jCACyp4rYcoNHz2OQJ4J6Z9NjBnur8z1W3g=";
+    sha256 = "sha256-03h9BNYZi2BvPvo1eztFKnFA4qfe5W+fnOUW19X87Bs=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11253,6 +11253,7 @@ in
     vala_0_46
     vala_0_48
     vala_0_50
+    vala_0_52
     vala;
 
   vyper = with python3Packages; toPythonApplication vyper;


### PR DESCRIPTION
###### Motivation for this change
Adds vala 0.52 and bumps it as default.
Fixes building at-spi2-core.
Bumps glib.
Reverts glibmm back to 2.66.0 (most recent release, indicated by gnome as the intended release for 40, https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/40.rc/elements/core-deps/glibmm-2.4.bst). Potentially the correct thing would be renaming this package to glibmm-2.4, as by next release I would assume they'll be aiming for both to be used in parallel.
Reverts pangomm back to 2.46.0 (see previous comment and https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/40.rc/elements/core-deps/pangomm-1.4.bst). Potentially the better option would be renaming this package to pangomm-1.4

@jtojnar I was unclear on how fixup commits should be marked in this case, so if there's something to reword, please let me know.

Relevant to #117081

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
