### PR TITLE
ocamlPackages.ocaml_extlib: 1.7.7 -> 1.7.8

### DIFF
--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -1,35 +1,29 @@
-{ stdenv, lib, fetchurl, fetchpatch, ocaml, findlib, cppo, minimal ? true }:
+{ stdenv, lib, fetchurl, ocaml, findlib, cppo
+# De facto, option minimal seems to be the default. See the README.
+, minimal ? true
+}:
 
-assert lib.versionAtLeast (lib.getVersion ocaml) "3.11";
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-extlib-1.7.7";
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-extlib";
+  version = "1.7.8";
 
   src = fetchurl {
-    url = "http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.7.tar.gz";
-    sha256 = "1sxmzc1mx3kg62j8kbk0dxkx8mkf1rn70h542cjzrziflznap0s1";
+    url = "https://ygrek.org/p/release/ocaml-extlib/extlib-${version}.tar.gz";
+    sha256 = "0npq4hq3zym8nmlyji7l5cqk6drx2rkcx73d60rxqh5g8dla8p4k";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/ygrek/ocaml-extlib/pull/55.patch";
-      sha256 = "0mj3xii56rh8j8brdyv5d06rbs6jjjcy4ib9chafkq3f3sbq795p";
-    })
-  ];
 
   buildInputs = [ ocaml findlib cppo ];
 
   createFindlibDestdir = true;
+  dontConfigure = true;
 
-  dontConfigure = true;      # Skip configure
-  # De facto, option minimal=1 seems to be the default.  See the README.
-  buildPhase     = "make ${if minimal then "minimal=1" else ""} build";
-  installPhase   = "make ${if minimal then "minimal=1" else ""} install";
+  makeFlags = lib.optional minimal "minimal=1";
 
   meta = {
     homepage = "https://github.com/ygrek/ocaml-extlib";
     description = "Enhancements to the OCaml Standard Library modules";
-    license = lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21Only;
     platforms = ocaml.meta.platforms or [];
+    maintainers = [ lib.maintainers.sternenseemann ];
   };
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1398,7 +1398,10 @@ let
 
     omake_rc1 = callPackage ../development/tools/ocaml/omake/0.9.8.6-rc1.nix { };
 
-    google-drive-ocamlfuse = callPackage ../applications/networking/google-drive-ocamlfuse { };
+    google-drive-ocamlfuse = callPackage ../applications/networking/google-drive-ocamlfuse {
+      # needs Base64 module
+      ocaml_extlib = ocaml_extlib.override { minimal = false; };
+    };
 
     hol_light = callPackage ../applications/science/logic/hol_light { };
 


### PR DESCRIPTION
Supersedes #110374.

1.7.8 changed the behavior of the minimal build type (which we are
keeping as the default because opam-repository does it as well): It now
excludes the Base64 module which is prone to namespacing problems.

Since google-drive-ocamlfuse still uses the Base64 module, we need to
override it to use extlib without the minimal build type. 1.7.9 (?)
should make this obsolete as it is planned to split the Base64 module
into a separate package.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
