### PR TITLE
GNOME 40 fixups

### DIFF
--- a/pkgs/development/libraries/atkmm/default.nix
+++ b/pkgs/development/libraries/atkmm/default.nix
@@ -1,19 +1,19 @@
-{ lib, stdenv, fetchurl, atk, glibmm, pkg-config, gnome3 }:
+{ lib, stdenv, fetchurl, atk, glibmm, pkg-config, meson, ninja, python3, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "atkmm";
-  version = "2.36.0";
+  version = "2.28.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0wwr0663jrqx2klsasffd9wpk3kqnwisj1y3ahdkjdk5hzrsjgy9";
+    sha256 = "sha256-EWh2YEdwZBpFDjnB9QMCiEhIzpzEjUPF3I6O/DHzG60=";
   };
 
   outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [ atk glibmm ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config meson ninja python3 ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/gtkmm/3.x.nix
+++ b/pkgs/development/libraries/gtkmm/3.x.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gtkmm";
-  version = "3.24.3";
+  version = "3.24.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-YEl8T381TDvSVXSF8CVPi3tM9L68n+4L4mp3dE6s1DU=";
+    sha256 = "sha256-m+txw+kM/Pt5A5a1Hj9ecWmWZ1Hv1PPvlpcRS+O+Z0M=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/libgudev/default.nix
+++ b/pkgs/development/libraries/libgudev/default.nix
@@ -1,10 +1,13 @@
 { lib, stdenv
 , fetchurl
 , pkg-config
+, meson
+, ninja
 , udev
 , glib
 , gobject-introspection
 , gnome3
+, vala
 }:
 
 stdenv.mkDerivation rec {
@@ -18,11 +21,13 @@ stdenv.mkDerivation rec {
     sha256 = "094mgjmwgsgqrr1i0vd20ynvlkihvs3vgbmpbrhswjsrdp86j0z5";
   };
 
-  nativeBuildInputs = [ pkg-config gobject-introspection ];
+  nativeBuildInputs = [ pkg-config gobject-introspection meson ninja vala ];
   buildInputs = [ udev glib ];
 
-  # There's a dependency cycle with umockdev and the tests fail to LD_PRELOAD anyway.
-  configureFlags = [ "--disable-umockdev" ];
+  mesonFlags = [
+    # There's a dependency cycle with umockdev and the tests fail to LD_PRELOAD anyway
+    "-Dtests=disabled"
+  ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/libsigcxx/default.nix
+++ b/pkgs/development/libraries/libsigcxx/default.nix
@@ -1,15 +1,15 @@
-{ lib, stdenv, fetchurl, pkg-config, gnum4, gnome3 }:
+{ lib, stdenv, fetchurl, pkg-config, meson, ninja, gnum4, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "libsigc++";
-  version = "2.10.1";
+  version = "2.10.6";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "00v08km4wwzbh6vjxb21388wb9dm6g2xh14rgwabnv4c2wk5z8n9";
+    sha256 = "sha256-3aF23EaBvanVoqwbxVJzvdOBZit6bUnpGCZ9E+h3Ths=";
   };
 
-  nativeBuildInputs = [ pkg-config gnum4 ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change
For #117081.

atkmm reverted and bumped to 2.28.1, fixed building
gtkmm bumped to 3.24.4
libsigcxx bumped to 2.10.6, fixed building
libgudev fixed building

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
