### PR TITLE
flutter 1.22.4 -> 2.0.3, dart 2.10.5 -> 2.12.2

### DIFF
--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -4,7 +4,7 @@ let
   getPatches = dir:
     let files = builtins.attrNames (builtins.readDir dir);
     in map (f: dir + ("/" + f)) files;
-  version = "1.22.4";
+  version = "2.0.3";
   channel = "stable";
   filename = "flutter_linux_${version}-${channel}.tar.xz";
 in
@@ -15,7 +15,7 @@ in
     pname = "flutter";
     src = fetchurl {
       url = "https://storage.googleapis.com/flutter_infra/releases/${channel}/linux/${filename}";
-      sha256 = "0qalgav9drqddcj8lfvl9ddf3325n953pvkmgha47lslg9sa88zw";
+      sha256 = "14a63cpkp78rgymmlrppds69jsrdarg33dr43nb7s61r0xfh9icm";
     };
     patches = getPatches ./patches;
   };

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -45,7 +45,6 @@ let
 
     postPatch = ''
       patchShebangs --build ./bin/
-      find ./bin/ -executable -type f -exec patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) {} \;
     '';
 
     buildPhase = ''

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -41,7 +41,7 @@ let
 
     buildInputs = [ git ];
 
-    inherit src patches;
+    inherit src patches version;
 
     postPatch = ''
       patchShebangs --build ./bin/

--- a/pkgs/development/compilers/flutter/patches/disable-auto-update.patch
+++ b/pkgs/development/compilers/flutter/patches/disable-auto-update.patch
@@ -1,8 +1,8 @@
 diff --git a/bin/internal/shared.sh b/bin/internal/shared.sh
-index 8d613de739..a673466726 100644
+index c44f867746..c9eda34e26 100644
 --- a/bin/internal/shared.sh
 +++ b/bin/internal/shared.sh
-@@ -204,8 +204,6 @@ function shared::execute() {
+@@ -218,8 +218,6 @@ function shared::execute() {
    # FLUTTER_TOOL_ARGS="--enable-asserts $FLUTTER_TOOL_ARGS"
    # FLUTTER_TOOL_ARGS="$FLUTTER_TOOL_ARGS --observe=65432"
  
@@ -12,20 +12,18 @@ index 8d613de739..a673466726 100644
    case "$BIN_NAME" in
      flutter*)
 diff --git a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
-index 8a1a1e29da..778f253358 100644
+index 3dc7929dd1..e65d70d55b 100644
 --- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
 +++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
-@@ -293,13 +293,6 @@ class FlutterCommandRunner extends CommandRunner<void> {
+@@ -246,11 +246,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
            globals.flutterUsage.suppressAnalytics = true;
          }
  
--        try {
--          await globals.flutterVersion.ensureVersionFile();
--        } on FileSystemException catch (e) {
--          globals.printError('Failed to write the version file to the artifact cache: "$e".');
--          globals.printError('Please ensure you have permissions in the artifact cache directory.');
--          throwToolExit('Failed to write the version file');
--        }
+-        globals.flutterVersion.ensureVersionFile();
          final bool machineFlag = topLevelResults['machine'] as bool;
-         if (topLevelResults.command?.name != 'upgrade' && topLevelResults['version-check'] as bool && !machineFlag) {
-           await globals.flutterVersion.checkFlutterVersionFreshness();
+-        if (topLevelResults.command?.name != 'upgrade' && topLevelResults['version-check'] as bool && !machineFlag) {
+-          await globals.flutterVersion.checkFlutterVersionFreshness();
+-        }
+ 
+         // See if the user specified a specific device.
+         globals.deviceManager.specifiedDeviceId = topLevelResults['device-id'] as String;

--- a/pkgs/development/compilers/flutter/patches/move-cache.patch
+++ b/pkgs/development/compilers/flutter/patches/move-cache.patch
@@ -1,59 +1,54 @@
-diff --git a/dev/devicelab/lib/framework/runner.dart b/dev/devicelab/lib/framework/runner.dart
-index d045c83f04..d51973020b 100644
---- a/dev/devicelab/lib/framework/runner.dart
-+++ b/dev/devicelab/lib/framework/runner.dart
-@@ -136,7 +136,7 @@ Future<void> cleanupSystem() async {
-     print('\nTelling Gradle to shut down (JAVA_HOME=$javaHome)');
-     final String gradlewBinaryName = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
-     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_shutdown_gradle.');
--    recursiveCopy(Directory(path.join(flutterDirectory.path, 'bin', 'cache', 'artifacts', 'gradle_wrapper')), tempDir);
-+    recursiveCopy(Directory(path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'artifacts', 'gradle_wrapper')), tempDir);
-     copy(File(path.join(path.join(flutterDirectory.path, 'packages', 'flutter_tools'), 'templates', 'app', 'android.tmpl', 'gradle', 'wrapper', 'gradle-wrapper.properties')), Directory(path.join(tempDir.path, 'gradle', 'wrapper')));
-     if (!Platform.isWindows) {
-       await exec(
 diff --git a/packages/flutter_tools/lib/src/asset.dart b/packages/flutter_tools/lib/src/asset.dart
-index 8da01315ae..bb8d61d7f2 100644
+index a6c59bae07..21f6c9812a 100644
 --- a/packages/flutter_tools/lib/src/asset.dart
 +++ b/packages/flutter_tools/lib/src/asset.dart
-@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
+@@ -5,6 +5,7 @@
+ import 'package:meta/meta.dart';
  import 'package:package_config/package_config.dart';
- import 'package:yaml/yaml.dart';
  
 +import 'base/common.dart';
  import 'base/context.dart';
  import 'base/file_system.dart';
- import 'base/utils.dart';
-@@ -399,7 +400,7 @@ List<_Asset> _getMaterialAssets(String fontSet) {
-     for (final Map<dynamic, dynamic> font in (family['fonts'] as List<dynamic>).cast<Map<dynamic, dynamic>>()) {
-       final Uri entryUri = globals.fs.path.toUri(font['asset'] as String);
-       result.add(_Asset(
--        baseDir: globals.fs.path.join(Cache.flutterRoot, 'bin', 'cache', 'artifacts', 'material_fonts'),
-+        baseDir: globals.fs.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'artifacts', 'material_fonts'),
-         relativeUri: Uri(path: entryUri.pathSegments.last),
-         entryUri: entryUri,
-         package: null,
+ import 'base/logger.dart';
+@@ -14,6 +15,7 @@ import 'cache.dart';
+ import 'convert.dart';
+ import 'dart/package_map.dart';
+ import 'devfs.dart';
++import 'globals.dart' as globals;
+ import 'flutter_manifest.dart';
+ import 'license_collector.dart';
+ import 'project.dart';
+@@ -377,7 +379,7 @@ class ManifestAssetBundle implements AssetBundle {
+       for (final Map<String, Object> font in family['fonts'] as List<Map<String, Object>>) {
+         final Uri entryUri = _fileSystem.path.toUri(font['asset'] as String);
+         result.add(_Asset(
+-          baseDir: _fileSystem.path.join(Cache.flutterRoot, 'bin', 'cache', 'artifacts', 'material_fonts'),
++          baseDir: _fileSystem.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'artifacts', 'material_fonts'),
+           relativeUri: Uri(path: entryUri.pathSegments.last),
+           entryUri: entryUri,
+           package: null,
 diff --git a/packages/flutter_tools/lib/src/cache.dart b/packages/flutter_tools/lib/src/cache.dart
-index a35d8f87d0..a40027dc74 100644
+index 11e3bf3e11..39d6fae0d1 100644
 --- a/packages/flutter_tools/lib/src/cache.dart
 +++ b/packages/flutter_tools/lib/src/cache.dart
-@@ -215,8 +215,15 @@ class Cache {
+@@ -321,8 +321,15 @@ class Cache {
        return;
      }
      assert(_lock == null);
 +
-+    final Directory dir = globals.fs.directory(globals.fs.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter'));
++    final Directory dir = _fileSystem.directory(_fileSystem.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter'));
 +    if (!dir.existsSync()) {
 +      dir.createSync(recursive: true);
 +      globals.os.chmod(dir, '755');
 +    }
 +
      final File lockFile =
--        globals.fs.file(globals.fs.path.join(flutterRoot, 'bin', 'cache', 'lockfile'));
-+        globals.fs.file(globals.fs.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'lockfile'));
+-      _fileSystem.file(_fileSystem.path.join(flutterRoot, 'bin', 'cache', 'lockfile'));
++      _fileSystem.file(_fileSystem.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'lockfile'));
      try {
        _lock = lockFile.openSync(mode: FileMode.write);
      } on FileSystemException catch (e) {
-@@ -319,7 +326,7 @@ class Cache {
+@@ -424,7 +431,7 @@ class Cache {
      if (_rootOverride != null) {
        return _fileSystem.directory(_fileSystem.path.join(_rootOverride.path, 'bin', 'cache'));
      } else {

--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -16,7 +16,7 @@
   {
     "${version}-x86_64-darwin" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
-      sha256 = "0000000000000000000000000000000000000000000000000000";
+      sha256 = "0h6mpy0kfc842vhg053fyxbjnd8lw1d1shdcsj800048260lxhyd";
     };
     "${version}-x86_64-linux" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
@@ -24,11 +24,11 @@
     };
     "${version}-i686-linux" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
-      sha256 = "0000000000000000000000000000000000000000000000000000";
+      sha256 = "1wngxba71j20gq9vy7n8q0m9rnqs047xm5b03bxk3hhaq6dyzkwn";
     };
     "${version}-aarch64-linux" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
-      sha256 = "0000000000000000000000000000000000000000000000000000";
+      sha256 = "0rqsmzl5g5kgk54qb03kamjm5n5g5pqfl79np37xdzwqbv0zx22b";
     };
   }
 }:

--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -2,7 +2,7 @@
 , lib
 , fetchurl
 , unzip
-, version ? "2.10.5"
+, version ? "2.12.2"
 , sources ?
   let
     base = "https://storage.googleapis.com/dart-archive/channels";
@@ -11,24 +11,24 @@
     aarch64 = "arm64";
     # Make sure that if the user overrides version parameter they're
     # also need to override sources, to avoid mistakes
-    version = "2.10.5";
+    version = "2.12.2";
   in
   {
     "${version}-x86_64-darwin" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
-      sha256 = "1vb2m25w6v901id9syan9q69fa60sxxd7qpyzq21fn5dpah0g99i";
+      sha256 = "0000000000000000000000000000000000000000000000000000";
     };
     "${version}-x86_64-linux" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
-      sha256 = "1mb6m3vxjya1dz47mdna23c2015n3bz8dvz8fwggq6k3zp0a4dsh";
+      sha256 = "1gg210gf4yif3bl9k19znkndc4c1cd529xwxpi20ykaw3zfxxz2z";
     };
     "${version}-i686-linux" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
-      sha256 = "10g4qrwvmabrdg4i8y0wq9g7whqcpkdfp05yilflg70ybplrscf7";
+      sha256 = "0000000000000000000000000000000000000000000000000000";
     };
     "${version}-aarch64-linux" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
-      sha256 = "0js83wy496swcwia144fhxk872irb5nr6i8558hxabkdrpv1bky5";
+      sha256 = "0000000000000000000000000000000000000000000000000000";
     };
   }
 }:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Flutter major upgrade to version 2.0.3.

I've upgraded all patches and made sure they apply and build. I did not check if new patches are required due to new version.

I also had to upgrade dart since we need dart in order to build flutter itself. Since the dart sdk is now included in flutter itself, I'm not quite sure if we need this at all, or if it would require changes to the flutter build declaration. To discuss? Maybe someone more knowledgable than me has a better idea :slightly_smiling_face: 

I've been able to create [a new flutter app](https://flutter.dev/docs/get-started/test-drive) with the new built nix flutter package and build it for android.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
