### PR TITLE
plasmatube: init at unstable-2021-03-18

### DIFF
--- a/pkgs/applications/video/plasmatube/default.nix
+++ b/pkgs/applications/video/plasmatube/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, kcoreaddons
+, kdeclarative
+, ki18n
+, kirigami2
+, mpv
+, qtmultimedia
+, qtquickcontrols2
+, youtube-dl
+}:
+
+mkDerivation rec {
+  pname = "plasmatube";
+  version = "unstable-2021-03-18";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "lnj";
+    repo = "plasmatube";
+    rev = "48dd9056326f512c2b67a2d7faecb7c02b1fe253";
+    sha256 = "14p623ra2m5n1r4aly5nlrd7qbb85ycnjf1mzb9mspm8r22nlv4g";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kcoreaddons
+    kdeclarative
+    ki18n
+    kirigami2
+    mpv
+    qtmultimedia
+    qtquickcontrols2
+  ];
+
+  qtWrapperArgs = [
+    "--prefix" "PATH" ":" (lib.makeBinPath [ youtube-dl ])
+  ];
+
+  meta = with lib; {
+    description = "Kirigami YouTube video player based on libmpv and youtube-dl";
+    homepage = "https://invent.kde.org/lnj/plasmatube";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24837,6 +24837,8 @@ in
 
   piston-cli = callPackage ../tools/misc/piston-cli { };
 
+  plasmatube = libsForQt5.callPackage ../applications/video/plasmatube { };
+
   plater = libsForQt5.callPackage ../applications/misc/plater { };
 
   plexamp = callPackage ../applications/audio/plexamp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Doesn't play any videos yet. Help is very welcome.
I also filed an upstream issue about some error messages: https://invent.kde.org/lnj/plasmatube/-/issues/8.