### PR TITLE
rclone: build with 'cmount' support

### DIFF
--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   buildInputs = lib.optional enableCmount (if stdenv.isDarwin then macfuse-stubs else fuse);
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
-  buildFlagsArray = lib.optional enableCmount "-tags=cmount"
+  buildFlagsArray = lib.optionals enableCmount [ "-tags=cmount" ]
     ++ [ "-ldflags=-s -w -X github.com/rclone/rclone/fs.Version=${version}" ];
 
   postInstall =

--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, buildGoModule, fetchFromGitHub, buildPackages, installShellFiles }:
+{ lib, stdenv, buildGoModule, fetchFromGitHub, buildPackages, installShellFiles
+, makeWrapper
+, enableCmount ? true, fuse, macfuse-stubs
+}:
 
 buildGoModule rec {
   pname = "rclone";
@@ -17,9 +20,11 @@ buildGoModule rec {
 
   outputs = [ "out" "man" ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  buildInputs = lib.optional enableCmount (if stdenv.isDarwin then macfuse-stubs else fuse);
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
 
-  buildFlagsArray = [ "-ldflags=-s -w -X github.com/rclone/rclone/fs.Version=${version}" ];
+  buildFlagsArray = lib.optional enableCmount "-tags=cmount"
+    ++ [ "-ldflags=-s -w -X github.com/rclone/rclone/fs.Version=${version}" ];
 
   postInstall =
     let
@@ -34,6 +39,8 @@ buildGoModule rec {
         ${rcloneBin}/bin/rclone genautocomplete $shell rclone.$shell
         installShellCompletion rclone.$shell
       done
+    '' + lib.optionalString (enableCmount && !stdenv.isDarwin) ''
+      wrapProgram $out/bin/rclone --prefix LD_LIBRARY_PATH : "${fuse}/lib"
     '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`rclone cmount` provides the same functionality as `rclone mount`. They both provide FUSE integration, but `cmount` is backed by libfuse while `mount` is backed by a pure go reimplementation of libfuse.

`cmount` support is required for continued support for FUSE on macOS because the traditional `rclone mount` is [no longer supported for macOS][1]. Although `rclone mount` would work on macOS with recent versions of rclone, it's aliased to `rclone cmount`.

This change is not strictly required for Linux, but it still has its merits. According to the upstream maintainer, the libfuse implementation is "[a bit more compatible and reliable][2]" than the go implementation. Taking this into account, I've also enabled `cmount` support on Linux by default.

[1]: https://github.com/rclone/rclone/issues/4393
[2]: https://github.com/restic/restic/issues/3096#issuecomment-727215997


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
