### PR TITLE
cypari2, cysignals: updates

### DIFF
--- a/pkgs/applications/science/math/gap/default.nix
+++ b/pkgs/applications/science/math/gap/default.nix
@@ -101,6 +101,9 @@ stdenv.mkDerivation rec {
       excludes = ["tst/testinstall/stringobj.tst"];
       sha256 = "1mz5b4mbw2jdd1ypp5s0dy6pp0jsvwsxr2dm4kbkls20r1r192sc";
     })
+
+    # fixes aarch64 gc crashes: https://github.com/gap-system/gap/pull/3965
+    ./mark-genstackfuncbags-as-noinline.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/science/math/gap/mark-genstackfuncbags-as-noinline.patch
+++ b/pkgs/applications/science/math/gap/mark-genstackfuncbags-as-noinline.patch
@@ -1,0 +1,13 @@
+diff --git a/src/gasman.c b/src/gasman.c
+index 417811401..314a74190 100644
+--- a/src/gasman.c
++++ b/src/gasman.c
+@@ -1861,7 +1861,7 @@ void SparcStackFuncBags( void )
+ #endif
+ 
+ 
+-void GenStackFuncBags ( void )
++NOINLINE void GenStackFuncBags ( void )
+ {
+     Bag *               top;            /* top of stack                    */
+     Bag *               p;              /* loop variable                   */

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -153,6 +153,14 @@ stdenv.mkDerivation rec {
       rev = "75c1516f0abb9e6f8c335e38e4031f6ef674ed30";
       sha256 = "sha256-RukkieIZcXNrju904H2oyGKdtpdE+9vNzvyjN2IBNg0=";
     })
+
+    # cypari 2.1.2 update (https://trac.sagemath.org/ticket/31029)
+    (fetchSageDiff {
+      base = "9.3.beta3";
+      name = "cypari-2.1.2-update.patch";
+      rev = "b9aadfd08e81d74ca7c229bb80eb853b592887d0";
+      sha256 = "sha256-eKaMy7kpu+YKdL8bPStgocxBCTfc2Z/10RrGy2LENFw=";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -87,6 +87,14 @@ stdenv.mkDerivation rec {
       rev = "2959ac792ebd6107fe87c9af1541083de5ba02d6";
       sha256 = "sha256-bWIpEGir9Kawak5CJegBMNcHm/CqhWmdru+emeSsvO0=";
     })
+
+    # fix intermittent errors in doctest/test.py: https://trac.sagemath.org/ticket/26912
+    (fetchSageDiff {
+      base = "9.3.beta8";
+      name = "set-cysignals-crash-ndebug.patch";
+      rev = "ca5257a5d0f32efc9f8f07e126020856270b1a18";
+      sha256 = "sha256-KViw63xE3O0eUiOYzoxNrr4NL+csql9GPJLDJCf/EZs=";
+    })
   ];
 
   # Patches needed because of package updates. We could just pin the versions of

--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , python
+, fetchpatch
 , fetchPypi
 , pari
 , gmp
@@ -11,12 +12,22 @@
 buildPythonPackage rec {
   pname = "cypari2";
   # upgrade may break sage, please test the sage build or ping @timokau on upgrade
-  version = "2.1.1";
+  version = "2.1.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "df1ef62e771ec36e5a456f5fc8b51bc6745b70f0efdd0c7a30c3f0b5f1fb93db";
+    sha256 = "03cd45edab8716ebbfdb754e65fea72e873c73dc91aec098fe4a01e35324ac7a";
   };
+
+  patches = [
+    # patch to avoid some segfaults in sage's totallyreal.pyx test.
+    # (https://trac.sagemath.org/ticket/27267). depends on Cython patch.
+    (fetchpatch {
+      name = "use-trashcan-for-gen.patch";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/cypari/patches/trashcan.patch?id=b6ea17ef8e4d652de0a85047bac8d41e90b25555";
+      sha256 = "sha256-w4kktWb9/aR9z4CjrUvAMOxEwRN2WkubaKzQttN8rU8=";
+    })
+  ];
 
   # This differs slightly from the default python installPhase in that it pip-installs
   # "." instead of "*.whl".
@@ -48,7 +59,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Cython bindings for PARI";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = teams.sage.members;
     homepage = "https://github.com/defeo/cypari2";
   };

--- a/pkgs/development/python-modules/cysignals/default.nix
+++ b/pkgs/development/python-modules/cysignals/default.nix
@@ -1,5 +1,4 @@
 { lib
-, fetchpatch
 , fetchPypi
 , buildPythonPackage
 , cython
@@ -10,22 +9,12 @@ assert pariSupport -> pari != null;
 
 buildPythonPackage rec {
   pname = "cysignals";
-  version = "1.10.2";
+  version = "1.10.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ckxzch3wk5cg80mppky5jib5z4fzslny3001r5zg4ar1ixbc1w1";
+    sha256 = "sha256-XEYGxDV3UCgxb3Jf23y4lOPK4Lb9L4YqDSlxdIRptDo=";
   };
-
-  patches = [
-    # fixes intermittent crashes in Sage tests (including in interfaces/singular.py)
-    # will be included in cysignals 1.10.3: https://github.com/sagemath/cysignals/pull/127
-    (fetchpatch {
-      name = "fix-verify_exc_value.patch";
-      url = "https://github.com/sagemath/cysignals/commit/49a7eee4bba3ab8f340cf56c371fa4f5ed702dcc.patch";
-      sha256 = "sha256-Pfc5tL9VDSP6ftDoHoIb+MDi5rjYqr0PRfIajFuuYVs=";
-    })
-  ];
 
   # explicit check:
   # build/src/cysignals/implementation.c:27:2: error: #error "cysignals must be compiled without _FORTIFY_SOURCE"


### PR DESCRIPTION
###### Motivation for this change

Some Sage-related package updates that didn't make it into #114881. For future PRs, the following still needs to be done (after Sage 9.3, probably):

- The `eclib` update requires Sage patches that change the public API (https://trac.sagemath.org/ticket/31443), so I think we should just wait until Sage 9.3 to upgrade it.
- The `pari` update is still not ready upstream (https://trac.sagemath.org/ticket/30801).
- `gap` needs to be updated to 4.11.1.

Closes #103810.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
