### PR TITLE
bash: don't rely on patch timestamps in build

### DIFF
--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     -DSSH_SOURCE_BASHRC
   '';
 
-  patchFlags = [ "-p0" "-T" ];
+  patchFlags = [ "-p0" ];
 
   patches = upstreamPatches
     ++ [ ./pgrp-pipe-4.4.patch ]

--- a/pkgs/shells/bash/5.1.nix
+++ b/pkgs/shells/bash/5.1.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     -DSSH_SOURCE_BASHRC
   '';
 
-  patchFlags = [ "-p0" "-T" ];
+  patchFlags = [ "-p0" ];
 
   patches = upstreamPatches
     ++ [ ./pgrp-pipe-5.1.patch ];

--- a/pkgs/shells/bash/pgrp-pipe-4.4.patch
+++ b/pkgs/shells/bash/pgrp-pipe-4.4.patch
@@ -13,17 +13,3 @@ diff -u ./configure ../bash-4.4-fixed/configure
  *qnx6*)		LOCAL_CFLAGS="-Dqnx -Dqnx6" LOCAL_LIBS="-lncurses" ;;
  *qnx*)		LOCAL_CFLAGS="-Dqnx -F -3s" LOCAL_LDFLAGS="-3s" LOCAL_LIBS="-lunix -lncurses" ;;
  powerux*)	LOCAL_LIBS="-lgen" ;;
-diff -u ./configure.ac ../bash-4.4-fixed/configure.ac
---- ./configure.ac	2016-09-07 22:56:28.000000000 +0200
-+++ ../bash-4.4-fixed/configure.ac	2016-09-07 22:56:28.000000000 +0200
-@@ -1092,9 +1092,7 @@
- solaris2*)	LOCAL_CFLAGS=-DSOLARIS ;;
- lynxos*)	LOCAL_CFLAGS=-DRECYCLES_PIDS ;;
- linux*)		LOCAL_LDFLAGS=-rdynamic		 # allow dynamic loading
--		case "`uname -r`" in
--		2.[[456789]]*|[[34]]*)	AC_DEFINE(PGRP_PIPE) ;;
--		esac ;;
-+		AC_DEFINE(PGRP_PIPE) ;;
- *qnx6*)		LOCAL_CFLAGS="-Dqnx -Dqnx6" LOCAL_LIBS="-lncurses" ;;
- *qnx*)		LOCAL_CFLAGS="-Dqnx -F -3s" LOCAL_LDFLAGS="-3s" LOCAL_LIBS="-lunix -lncurses" ;;
- powerux*)	LOCAL_LIBS="-lgen" ;;

--- a/pkgs/shells/bash/pgrp-pipe-5.1.patch
+++ b/pkgs/shells/bash/pgrp-pipe-5.1.patch
@@ -14,18 +14,3 @@ diff -u ./configure ../bash-5.0-fixed/configure
  netbsd*|openbsd*)	LOCAL_CFLAGS="-DDEV_FD_STAT_BROKEN" ;;
  *qnx[67]*)	LOCAL_LIBS="-lncurses" ;;
  *qnx*)		LOCAL_CFLAGS="-Dqnx -F -3s" LOCAL_LDFLAGS="-3s" LOCAL_LIBS="-lunix -lncurses" ;;
-diff -u ./configure.ac ../bash-5.0-fixed/configure.ac
---- ./configure.ac	2019-01-02 15:39:11.000000000 +0100
-+++ ../bash-5.0-fixed/configure.ac	2019-01-02 15:39:11.000000000 +0100
-@@ -1108,10 +1108,7 @@
- solaris2*)	LOCAL_CFLAGS=-DSOLARIS ;;
- lynxos*)	LOCAL_CFLAGS=-DRECYCLES_PIDS ;;
- linux*)		LOCAL_LDFLAGS=-rdynamic		 # allow dynamic loading
--		case "`uname -r`" in
--		1.*|2.[[0123]]*)	: ;;
--		*)	AC_DEFINE(PGRP_PIPE) ;;
--		esac ;;
-+		AC_DEFINE(PGRP_PIPE) ;;
- netbsd*|openbsd*)	LOCAL_CFLAGS="-DDEV_FD_STAT_BROKEN" ;;
- *qnx[[67]]*)	LOCAL_LIBS="-lncurses" ;;
- *qnx*)		LOCAL_CFLAGS="-Dqnx -F -3s" LOCAL_LDFLAGS="-3s" LOCAL_LIBS="-lunix -lncurses" ;;


### PR DESCRIPTION
###### Motivation for this change

When, after patching, `configure.ac` is newer than `configure`, the
Makefile will try to regenerate `configure` from `configure.ac`.

While that might usually be desirable, in this case we want to keep
bootstrapping simple and directly use the `configure` from the package
so we can avoid a dependency on automake.

Previously, we used the `-T` parameter to automake to make sure the
timestamps were okay. However, this is brittle when we update: when the
timestamp of the original file changes, and no longer matches the
timestamp of the original file in the patch, `patch` will show a warning
but otherwise continue without updating the timestamp.

This PR changes things so we only patch `configure`, so that will always
have a newer timestamp.

Refs https://github.com/NixOS/nixpkgs/issues/115177

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).