### PR TITLE
Openimageio, Blender: fix failing builds

### DIFF
--- a/pkgs/applications/graphics/openimageio/2.x.nix
+++ b/pkgs/applications/graphics/openimageio/2.x.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchFromGitHub
-, fetchpatch
 , boost
 , cmake
 , ilmbase
@@ -11,25 +10,19 @@
 , openexr
 , robin-map
 , unzip
+, fmt
 }:
 
 stdenv.mkDerivation rec {
   pname = "openimageio";
-  version = "2.1.9.0";
+  version = "2.2.12.0";
 
   src = fetchFromGitHub {
     owner = "OpenImageIO";
     repo = "oiio";
     rev = "Release-${version}";
-    sha256 = "1bbxx3bcc5jlb90ffxbk29gb8227097rdr8vg97vj9axw2mjd5si";
+    sha256 = "16z8lnsqhljbfaarfwx9rc95p0a9wxf4p271j6kxdfknjb88p56i";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/OpenImageIO/oiio/pull/2441/commits/e9bdd69596103edf41b659ad8ab0ca4ce002f6f5.patch";
-      sha256 = "0x1wmjf1jrm19d1izhs1cs3y1if9al1zx48lahkfswyjag3r5dn0";
-    })
-  ];
 
   outputs = [ "bin" "out" "dev" "doc" ];
 
@@ -47,6 +40,7 @@ stdenv.mkDerivation rec {
     opencolorio
     openexr
     robin-map
+    fmt
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/graphics/openimageio/2539_backport.patch
+++ b/pkgs/applications/graphics/openimageio/2539_backport.patch
@@ -1,0 +1,31 @@
+diff --git a/src/libOpenImageIO/exif.cpp b/src/libOpenImageIO/exif.cpp
+index 10b75c21..0287d9c5 100644
+--- a/src/libOpenImageIO/exif.cpp
++++ b/src/libOpenImageIO/exif.cpp
+@@ -213,6 +213,9 @@ static const EXIF_tag_info exif_tag_table[] = {
+ 
+ 
+ 
++// libtiff > 4.1.0 defines these in tiff.h. For older libtiff, let's define
++// them ourselves.
++#ifndef GPSTAG_VERSIONID
+ enum GPSTag {
+     GPSTAG_VERSIONID = 0, 
+     GPSTAG_LATITUDEREF = 1,  GPSTAG_LATITUDE = 2,
+@@ -237,6 +240,7 @@ enum GPSTag {
+     GPSTAG_DIFFERENTIAL = 30,
+     GPSTAG_HPOSITIONINGERROR = 31
+ };
++#endif
+ 
+ static const EXIF_tag_info gps_tag_table[] = {
+     { GPSTAG_VERSIONID,		"GPS:VersionID",	TIFF_BYTE, 4 }, 
+@@ -270,7 +274,7 @@ static const EXIF_tag_info gps_tag_table[] = {
+     { GPSTAG_AREAINFORMATION,	"GPS:AreaInformation",	TIFF_UNDEFINED, 1 },
+     { GPSTAG_DATESTAMP,		"GPS:DateStamp",	TIFF_ASCII, 0 },
+     { GPSTAG_DIFFERENTIAL,	"GPS:Differential",	TIFF_SHORT, 1 },
+-    { GPSTAG_HPOSITIONINGERROR,	"GPS:HPositioningError",TIFF_RATIONAL, 1 },
++    { GPSTAG_GPSHPOSITIONINGERROR,     "GPS:HPositioningError",TIFF_RATIONAL, 1 },
+     { -1, NULL }  // signal end of table
+ };
+ 

--- a/pkgs/applications/graphics/openimageio/default.nix
+++ b/pkgs/applications/graphics/openimageio/default.nix
@@ -33,6 +33,11 @@ stdenv.mkDerivation rec {
     "dist_dir="
   ];
 
+  patches = [
+    # Backported from https://github.com/OpenImageIO/oiio/pull/2539 for 1.8.17
+    ./2539_backport.patch
+  ];
+
   meta = with lib; {
     homepage = "http://www.openimageio.org";
     description = "A library and tools for reading and writing images";

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   patches = lib.optional stdenv.isDarwin ./darwin.patch;
 
-  nativeBuildInputs = [ cmake ] ++ optional cudaSupport addOpenGLRunpath;
+  nativeBuildInputs = [ cmake makeWrapper ] ++ optional cudaSupport addOpenGLRunpath;
   buildInputs =
     [ boost ffmpeg gettext glew ilmbase
       freetype libjpeg libpng libsamplerate libsndfile libtiff
@@ -41,9 +41,9 @@ stdenv.mkDerivation rec {
       alembic
       (opensubdiv.override { inherit cudaSupport; })
       tbb
-      makeWrapper
       embree
       gmp
+      pugixml
     ]
     ++ (if (!stdenv.isDarwin) then [
       libXi libX11 libXext libXrender
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       openvdb
     ]
     else [
-      pugixml llvmPackages.openmp SDL Cocoa CoreGraphics ForceFeedback OpenAL OpenGL
+      llvmPackages.openmp SDL Cocoa CoreGraphics ForceFeedback OpenAL OpenGL
     ])
     ++ optional jackaudioSupport libjack2
     ++ optional cudaSupport cudatoolkit


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
On master as of 42ad5a66366314c1f8527620a4568429c933e750 blender and its dependency openimageio fail to build.

###### Things done
- Add a patch to fix failing builds for openimageio 1.8.17 based on https://github.com/OpenImageIO/oiio/pull/2539
- Bump openimageio2 to 2.2.12.0
- Make pugixml a dependency for all targets to fix failing blender build on Linux
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
