### PR TITLE
ntfs3g: add darwin build

### DIFF
--- a/pkgs/tools/filesystems/ntfs-3g/default.nix
+++ b/pkgs/tools/filesystems/ntfs-3g/default.nix
@@ -1,5 +1,7 @@
-{lib, stdenv, fetchurl, util-linux, libuuid
-, crypto ? false, libgcrypt, gnutls, pkg-config}:
+{ lib, stdenv, fetchurl, pkg-config, mount, libuuid
+, macfuse-stubs, DiskArbitration
+, crypto ? false, libgcrypt, gnutls
+}:
 
 stdenv.mkDerivation rec {
   pname = "ntfs3g";
@@ -7,8 +9,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "man" "doc" ];
 
-  buildInputs = [ libuuid ] ++ lib.optionals crypto [ gnutls libgcrypt ];
-  nativeBuildInputs = lib.optional crypto pkg-config;
+  buildInputs = [ libuuid ] ++ lib.optionals crypto [ gnutls libgcrypt ]
+    ++ lib.optionals stdenv.isDarwin [ macfuse-stubs DiskArbitration ];
+  nativeBuildInputs = [ pkg-config ];
 
   src = fetchurl {
     url = "https://tuxera.com/opensource/ntfs-3g_ntfsprogs-${version}.tgz";
@@ -19,8 +22,8 @@ stdenv.mkDerivation rec {
     substituteInPlace src/Makefile.in --replace /sbin '@sbindir@'
     substituteInPlace ntfsprogs/Makefile.in --replace /sbin '@sbindir@'
     substituteInPlace libfuse-lite/mount_util.c \
-      --replace /bin/mount ${util-linux}/bin/mount \
-      --replace /bin/umount ${util-linux}/bin/umount
+      --replace /bin/mount ${mount}/bin/mount \
+      --replace /bin/umount ${mount}/bin/umount
   '';
 
   configureFlags = [
@@ -43,7 +46,10 @@ stdenv.mkDerivation rec {
     homepage = "https://www.tuxera.com/community/open-source-ntfs-3g/";
     description = "FUSE-based NTFS driver with full write support";
     maintainers = with maintainers; [ dezgeg ];
-    platforms = platforms.linux;
-    license = licenses.gpl2Plus; # and (lib)fuse-lite under LGPL2+
+    platforms = with platforms; darwin ++ linux;
+    license = with licenses; [
+      gpl2Plus # ntfs-3g itself
+      lgpl2Plus # fuse-lite
+    ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6804,7 +6804,9 @@ in
 
   nss_pam_ldapd = callPackage ../tools/networking/nss-pam-ldapd {};
 
-  ntfs3g = callPackage ../tools/filesystems/ntfs-3g { };
+  ntfs3g = callPackage ../tools/filesystems/ntfs-3g {
+    inherit (darwin.apple_sdk.frameworks) DiskArbitration;
+  };
 
   # ntfsprogs are merged into ntfs-3g
   ntfsprogs = pkgs.ntfs3g;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Provide darwin package for ntfs-3g.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Confirmed that filesystem creation, mounts, reads, and writes work on both macOS and NixOS.

```console
❯ touch ntfs.img
❯ nix run nixpkgs.coreutils -c truncate --size=10M ntfs.img
❯ result/bin/mkntfs --force --fast --label nixpkgs ntfs.img
ntfs.img is not a block device.
mkntfs forced anyway.
The sector size was not specified for ntfs.img and it could not be obtained automatically.  It has been set to 512 bytes.
The partition start sector was not specified for ntfs.img and it could not be obtained automatically.  It has been set to 0.
The number of sectors per track was not specified for ntfs.img and it could not be obtained automatically.  It has been set to 0.
The number of heads was not specified for ntfs.img and it could not be obtained automatically.  It has been set to 0.
Cluster size has been automatically set to 4096 bytes.
To boot from a device, Windows needs the 'partition start sector', the 'sectors per track' and the 'number of heads' to be set.
Windows will not be able to boot from this device.
Creating NTFS volume structures.
mkntfs completed successfully. Have a nice day.
❯ result/bin/ntfsfix --no-action ntfs.img
Mounting volume... OK
Processing of $MFT and $MFTMirr completed successfully.
Checking the alternate boot sector... OK
NTFS volume version is 3.1.
NTFS partition ntfs.img was processed successfully.
❯ result/bin/ntfslabel ntfs.img
nixpkgs
❯ mkdir mnt
❯ result/bin/mount.ntfs ntfs.img mnt
❯ cd mnt
❯ echo hi > hi.txt
❯ cat hi.txt
hi
❯ cd ..
❯ umount mnt
❯ file ntfs.img
ntfs.img: DOS/MBR boot sector, code offset 0x52+2, OEM-ID "NTFS    ", sectors/cluster 8, Media descriptor 0xf8, sectors/track 0, dos < 4.0 BootSector (0x80), FAT (1Y bit by descriptor); NTFS, sectors 20479, $MFT start cluster 4, $MFTMirror start cluster 1279, bytes/RecordSegment 2^(-1*246), clusters/index block 1, serial number 02f9b8743065cc656
```