### PR TITLE
ocaml-lsp, lsp, jsonrpc: allow overriding the source globally

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -1,78 +1,15 @@
-{ buildDunePackage
-, stdlib-shims
-, ppx_yojson_conv_lib
-, ocaml-syntax-shims
-, yojson
-, result
-, omd
-, octavius
-, dune-build-info
-, uutf
-, csexp
-, cmdliner
-, fetchzip
-, lib
-}:
-let
-  version = "1.4.1";
-  src = fetchzip {
-    url = "https://github.com/ocaml/ocaml-lsp/releases/download/${version}/jsonrpc-${version}.tbz";
-    sha256 = "0hzpw17qfhb0cxgwah1fv4k300r363dy1kv0977anl44dlanx1v5";
-  };
+{ buildDunePackage, jsonrpc, lsp }:
 
-  # unvendor some (not all) dependencies.
-  # They are vendored by upstream only because it is then easier to install
-  # ocaml-lsp without messing with your opam switch, but nix should prevent
-  # this type of problems without resorting to vendoring.
-  preBuild = ''
-    rm -r ocaml-lsp-server/vendor/{octavius,uutf,ocaml-syntax-shims,omd,cmdliner}
-  '';
-
-  buildInputs = [
-    stdlib-shims
-    ppx_yojson_conv_lib
-    ocaml-syntax-shims
-    octavius
-    uutf
-    csexp
-    dune-build-info
-    omd
-    cmdliner
-    jsonrpc
-  ];
-
-  lsp = buildDunePackage {
-    pname = "lsp";
-    inherit version src;
-    useDune2 = true;
-    minimumOCamlVersion = "4.06";
-
-    inherit buildInputs preBuild;
-  };
-
-  jsonrpc = buildDunePackage {
-    pname = "jsonrpc";
-    inherit version src;
-    useDune2 = true;
-    minimumOCamlVersion = "4.06";
-
-    buildInputs = [ yojson stdlib-shims ocaml-syntax-shims ppx_yojson_conv_lib result ];
-  };
-
-in
 buildDunePackage {
   pname = "ocaml-lsp-server";
-  inherit version src;
+  inherit (jsonrpc) version src;
   useDune2 = true;
 
-  inherit preBuild;
+  inherit (lsp) preBuild;
 
-  buildInputs = buildInputs ++ [ lsp ];
+  buildInputs = lsp.buildInputs ++ [ lsp ];
 
-  meta = with lib; {
+  meta = jsonrpc.meta // {
     description = "OCaml Language Server Protocol implementation";
-    license = lib.licenses.isc;
-    platforms = platforms.unix;
-    maintainers = [ maintainers.symphorien maintainers.marsam ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -1,0 +1,31 @@
+{ buildDunePackage
+, stdlib-shims
+, ppx_yojson_conv_lib
+, ocaml-syntax-shims
+, yojson
+, result
+, fetchzip
+, lib
+}:
+
+
+buildDunePackage rec {
+  pname = "jsonrpc";
+  version = "1.4.1";
+  src = fetchzip {
+    url = "https://github.com/ocaml/ocaml-lsp/releases/download/${version}/jsonrpc-${version}.tbz";
+    sha256 = "0hzpw17qfhb0cxgwah1fv4k300r363dy1kv0977anl44dlanx1v5";
+  };
+
+  useDune2 = true;
+  minimumOCamlVersion = "4.06";
+
+  buildInputs = [ yojson stdlib-shims ocaml-syntax-shims ppx_yojson_conv_lib result ];
+
+  meta = with lib; {
+    description = "Jsonrpc protocol implementation in OCaml";
+    license = licenses.isc;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ symphorien marsam ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -1,0 +1,44 @@
+{ buildDunePackage
+, stdlib-shims
+, ppx_yojson_conv_lib
+, ocaml-syntax-shims
+, jsonrpc
+, omd
+, octavius
+, dune-build-info
+, uutf
+, csexp
+, cmdliner
+}:
+
+buildDunePackage {
+  pname = "lsp";
+  inherit (jsonrpc) version src;
+  useDune2 = true;
+  minimumOCamlVersion = "4.06";
+
+  # unvendor some (not all) dependencies.
+  # They are vendored by upstream only because it is then easier to install
+  # ocaml-lsp without messing with your opam switch, but nix should prevent
+  # this type of problems without resorting to vendoring.
+  preBuild = ''
+    rm -r ocaml-lsp-server/vendor/{octavius,uutf,ocaml-syntax-shims,omd,cmdliner}
+  '';
+
+  buildInputs = [
+    stdlib-shims
+    ppx_yojson_conv_lib
+    ocaml-syntax-shims
+    octavius
+    uutf
+    csexp
+    dune-build-info
+    omd
+    cmdliner
+    jsonrpc
+  ];
+
+  meta = jsonrpc.meta // {
+    description = "LSP protocol implementation in OCaml";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -781,6 +781,8 @@ let
 
     ocamlify = callPackage ../development/tools/ocaml/ocamlify { };
 
+    jsonrpc = callPackage ../development/ocaml-modules/ocaml-lsp/jsonrpc.nix { };
+    lsp = callPackage ../development/ocaml-modules/ocaml-lsp/lsp.nix { };
     ocaml-lsp = callPackage ../development/ocaml-modules/ocaml-lsp { };
 
     ocaml-migrate-parsetree = ocaml-migrate-parsetree-1-8;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It wasn't possible to override the `src` for these packages so that they'd affect each other (they're released in tandem).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
