### PR TITLE
bearssl: init at 0.6 & s6-networking bearssl backend

### DIFF
--- a/pkgs/development/libraries/bearssl/default.nix
+++ b/pkgs/development/libraries/bearssl/default.nix
@@ -1,0 +1,61 @@
+{ lib, stdenv, fetchurl }:
+
+let
+  version = "0.6";
+  sha256 = "057zhgy9w4y8z2996r0pq5k2k39lpvmmvz4df8db8qa9f6hvn1b7";
+
+in
+stdenv.mkDerivation {
+  pname = "bearssl";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://www.bearssl.org/bearssl-${version}.tar.gz";
+    inherit sha256;
+  };
+
+  outputs = [ "bin" "lib" "dev" "out" ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D build/brssl $bin/brssl
+    install -D build/testcrypto $bin/testcrypto
+    install -Dm644 build/libbearssl.so $lib/lib/libbearssl.so
+    install -Dm644 build/libbearssl.a $lib/lib/libbearssl.a
+    install -Dm644 -t $dev/include inc/*.h
+    touch $out
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://www.bearssl.org/";
+    description = "An implementation of the SSL/TLS protocol written in C";
+    longDescription = ''
+      BearSSL is an implementation of the SSL/TLS protocol (RFC 5246)
+      written in C. It aims at offering the following features:
+
+      * Be correct and secure. In particular, insecure protocol versions and
+        choices of algorithms are not supported, by design; cryptographic
+        algorithm implementations are constant-time by default.
+
+      * Be small, both in RAM and code footprint. For instance, a minimal
+        server implementation may fit in about 20 kilobytes of compiled code
+        and 25 kilobytes of RAM.
+
+      * Be highly portable. BearSSL targets not only “big” operating systems
+        like Linux and Windows, but also small embedded systems and even
+        special contexts like bootstrap code.
+
+      * Be feature-rich and extensible. SSL/TLS has many defined cipher
+        suites and extensions; BearSSL should implement most of them, and
+        allow extra algorithm implementations to be added afterwards,
+        possibly from third parties.
+    '';
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.Profpatsch ];
+  };
+
+}

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -1,9 +1,8 @@
 { lib, stdenv, skawarePackages
 
 # Whether to build the TLS/SSL tools and what library to use
-# acceptable values: "libressl", false
-# TODO: add bearssl
-, sslSupport ? "libressl" , libressl
+# acceptable values: "bearssl", "libressl", false
+, sslSupport ? "bearssl" , libressl, bearssl
 }:
 
 with skawarePackages;
@@ -11,6 +10,7 @@ let
   sslSupportEnabled = sslSupport != false;
   sslLibs = {
     libressl = libressl;
+    bearssl = bearssl;
   };
 
 in
@@ -58,7 +58,7 @@ buildPackage {
     # remove all s6 executables from build directory
     rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable)
     rm minidentd
-    rm libs6net.* libstls.* libs6tls.*
+    rm libs6net.* libstls.* libs6tls.* libsbearssl.*
 
     mv doc $doc/share/doc/s6-networking/html
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13500,6 +13500,8 @@ in
 
   bctoolbox = callPackage ../development/libraries/bctoolbox { };
 
+  bearssl = callPackage ../development/libraries/bearssl { };
+
   beecrypt = callPackage ../development/libraries/beecrypt { };
 
   belcard = callPackage ../development/libraries/belcard { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
