### PR TITLE
GNOME 40: gtksourceview4 and yelp-tools fixups

### DIFF
--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gtksourceview";
-  version = "5.0.0";
+  version = "4.8.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1hyrmh9r1zd5kjh5ch9d7bhk2kphbqhm7ijfxfkcdln8q0rnd0k4";
+    sha256 = "0WPXG1/K+8Wx7sbdhB7b283dOnURzV/c/9hri7/mmsE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/misc/yelp-tools/default.nix
+++ b/pkgs/development/misc/yelp-tools/default.nix
@@ -6,6 +6,9 @@
 , itstool
 , gnome3
 , pkg-config
+, meson
+, ninja
+, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -19,6 +22,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
+    meson
+    ninja
+    python3
+    python3.pkgs.lxml
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Reverts gtksourceview and fixes building yelp-tools.

I'll try fixing tracker tomorrow.

For #117081

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
