### PR TITLE
ocamlPackages.ocaml-lsp: wrap with dot-merlin-reader

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, jsonrpc, lsp }:
+{ buildDunePackage, jsonrpc, lsp, makeWrapper, dot-merlin-reader }:
 
 buildDunePackage {
   pname = "ocaml-lsp-server";
@@ -8,6 +8,12 @@ buildDunePackage {
   inherit (lsp) preBuild;
 
   buildInputs = lsp.buildInputs ++ [ lsp ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/ocamllsp --prefix PATH : ${dot-merlin-reader}/bin
+  '';
 
   meta = jsonrpc.meta // {
     description = "OCaml Language Server Protocol implementation";

--- a/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
+++ b/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
@@ -1,6 +1,4 @@
-{ lib, fetchurl, ocamlPackages }:
-
-with ocamlPackages;
+{ lib, fetchurl, yojson, csexp, result, buildDunePackage }:
 
 buildDunePackage rec {
   pname = "dot-merlin-reader";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2240,7 +2240,7 @@ in
 
   dotenv-linter = callPackage ../development/tools/analysis/dotenv-linter { };
 
-  dot-merlin-reader = callPackage ../development/tools/ocaml/merlin/dot-merlin-reader.nix { };
+  inherit (ocamlPackages) dot-merlin-reader;
 
   dozenal = callPackage ../applications/misc/dozenal { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -624,6 +624,8 @@ let
 
     merlin-extend = callPackage ../development/ocaml-modules/merlin-extend { };
 
+    dot-merlin-reader = callPackage ../development/tools/ocaml/merlin/dot-merlin-reader.nix { };
+
     metrics = callPackage ../development/ocaml-modules/metrics { };
 
     metrics-influx = callPackage ../development/ocaml-modules/metrics/influx.nix { };


### PR DESCRIPTION
this requires that dot-merlin-reader be built with the same ocaml version as
ocaml-lsp

cc @anmonteiro @sternenseemann 

###### Motivation for this change

ocaml-lsp is broken without dot-merlin-reader
when using non-default ocaml, simply adding pkgs.dot-merlin-reader to the shell does not work because this brings ocaml-dependencies from distinct ocaml version into scope and breaks everything.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
