### PR TITLE
dbeaver: 21.0.0 -> 21.0.1

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, copyDesktopItems
 , fetchFromGitHub
 , makeDesktopItem
 , makeWrapper
@@ -14,26 +15,16 @@
 , zlib
 , maven
 }:
-let
-  desktopItem = makeDesktopItem {
-    name = "dbeaver";
-    exec = "dbeaver";
-    icon = "dbeaver";
-    desktopName = "dbeaver";
-    comment = "SQL Integrated Development Environment";
-    genericName = "SQL Integrated Development Environment";
-    categories = "Development;";
-  };
-in
+
 stdenv.mkDerivation rec {
   pname = "dbeaver-ce";
-  version = "21.0.0"; # When updating also update fetchedMavenDeps.sha256
+  version = "21.0.1"; # When updating also update fetchedMavenDeps.sha256
 
   src = fetchFromGitHub {
     owner = "dbeaver";
     repo = "dbeaver";
     rev = version;
-    sha256 = "sha256-it0EcPD7TXSknjVkGv22Nq1D4J32OEncQDy4w9CIPNk=";
+    sha256 = "sha256-9l8604STqmdoUjD+EJCp4aDk4juKsPCmFnD/WYpajxo=";
   };
 
   fetchedMavenDeps = stdenv.mkDerivation {
@@ -62,6 +53,12 @@ stdenv.mkDerivation rec {
     outputHash = "sha256-xKlFFQXd2U513KZKQa7ttSFNX2gxVr9hNsvyaoN/rEE=";
   };
 
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+    maven
+  ];
+
   buildInputs = [
     fontconfig
     freetype
@@ -71,12 +68,19 @@ stdenv.mkDerivation rec {
     libX11
     libXrender
     libXtst
-    makeWrapper
     zlib
   ];
 
-  nativeBuildInputs = [
-    maven
+  desktopItems = [
+    (makeDesktopItem {
+      name = "dbeaver";
+      exec = "dbeaver";
+      icon = "dbeaver";
+      desktopName = "dbeaver";
+      comment = "SQL Integrated Development Environment";
+      genericName = "SQL Integrated Development Environment";
+      categories = "Development;";
+    })
   ];
 
   buildPhase = ''
@@ -89,7 +93,7 @@ stdenv.mkDerivation rec {
 
   installPhase =
     let
-      productTargetPath = "product/standalone/target/products/org.jkiss.dbeaver.core.product";
+      productTargetPath = "product/community/target/products/org.jkiss.dbeaver.core.product";
 
       platformMap = {
         aarch64-linux = "aarch64";
@@ -128,10 +132,6 @@ stdenv.mkDerivation rec {
         --prefix PATH : ${jdk}/bin \
         --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([ glib gtk3 libXtst ])} \
         --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-
-      # Create desktop item.
-      mkdir -p $out/share/applications
-      cp ${desktopItem}/share/applications/* $out/share/applications
 
       mkdir -p $out/share/pixmaps
       ln -s $out/dbeaver/icon.xpm $out/share/pixmaps/dbeaver.xpm


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release (https://github.com/dbeaver/dbeaver/releases/tag/21.0.1). 

Also replaced the manual cp'ing of the desktop File with `copyDesktopItems` and fixed some `nixpkgs-hammering` warnings.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/mxpkpr80rzlfsbwpcjxzgp6f31ljj6pp-dbeaver-ce-21.0.0	 1355389656
/nix/store/pvf120fpv8y025qcvn0ix25c4mj4ndpv-dbeaver-ce-21.0.1	 1355492848
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
