### PR TITLE
epkowa: update iscan-data 1.39.1-2 -> 1.39.2-1

### DIFF
--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -294,14 +294,14 @@ let fwdir = symlinkJoin {
 in
 let iscan-data = stdenv.mkDerivation rec {
   pname = "iscan-data";
-  version = "1.39.1-2";
+  version = "1.39.2-1";
 
   src = fetchurl {
     urls = [
       "http://support.epson.net/linux/src/scanner/iscan/iscan-data_${version}.tar.gz"
       "https://web.archive.org/web/http://support.epson.net/linux/src/scanner/iscan/iscan-data_${version}.tar.gz"
     ];
-    sha256 = "04zrvbnxf1k6zinrd13hwnbzscc3qhmwlvx3k2jhjys2lginw7w4";
+    sha256 = "092qhlnjjgz11ifx6mng7mz20i44gc0nlccrbmw18xr5hipbqqka";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update iscan-data in epkowa package from 1.39.1-2 to 1.39.2-1

The upstream Epson server at https://support.epson.net/linux/src/scanner/iscan/ has removed the old tarball and replaced it with a new version as of 2020-07-22.

old file: iscan-data_1.39.1-2.tar.gz
new file: iscan-data_1.39.2-1.tar.gz

Fortunately the backup url at https://web.archive.org has been serving the old file in the meantime.  This pull request will update the package to use the new tarball and pull from the Epson server (the primary url).

###### Things done

Testing was conducted on a 20.09 system using an Epson V600 scanner and the following in /etc/nixos/configuration.nix:
```
nix.useSandbox = true;
nixpkgs.overlays = [
    (self: super: {
        epkowa = super.callPackage /path/to/my/nixpkgs/pkgs/misc/drivers/epkowa/default.nix {};
    })
];
```
I've also double checked that the new backup url serves the correct file at the link below:
https://web.archive.org/web/https://support.epson.net/linux/src/scanner/iscan/iscan-data_1.39.2-1.tar.gz

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
