### PR TITLE
digitemp: init at 3.7.2

### DIFF
--- a/pkgs/tools/misc/digitemp/default.nix
+++ b/pkgs/tools/misc/digitemp/default.nix
@@ -1,0 +1,53 @@
+{ fetchFromGitHub, lib, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "digitemp";
+  version = "3.7.2";
+
+  src = fetchFromGitHub {
+    owner = "bcl";
+    repo = "digitemp";
+    rev = "v${version}";
+    sha256 = "19zka5fcdxhhginaspak76l984iqq9v2j6qrwvi5mvca7bcj8f72";
+  };
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "LOCK=no"
+    "ds9097"
+    "ds9097u"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m555 -t $out/bin digitemp_*
+    install -D -m444 -t $out/share/doc/${pname} FAQ README
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Temperature logging and reporting using Maxim's iButtons and 1-Wire protocol";
+    longDescription = ''
+      DigiTemp is a command line application used for reading 1-wire sensors like
+      the DS18S20 temperature sensor, or DS2438 battery monitor. DigiTemp supports
+      the following devices:
+
+        DS18S20 (and older DS1820) Temperature Sensor
+        DS18B20 Temperature Sensor
+        DS1822 Temperature Sensor
+        DS2438 Battery monitor
+        DS2409 1-wire coupler (used in 1-wire hubs)
+        DS2422 Counter
+        DS2423 Counter
+
+      The output format can be customized and all settings are stored in a
+      configuration file (.digitemprc) in the current directory. DigiTemp can
+      repeatedly read the sensors and output to stdout and/or to a logfile.
+    '';
+    homepage = "https://www.digitemp.com";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ zseri ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2187,6 +2187,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  digitemp = callPackage ../tools/misc/digitemp { };
+
   dijo = callPackage ../tools/misc/dijo {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #116667. Seems to work on production machine (currently a single-user Nix install on top of Gentoo, but I intend to replace the Gentoo with NixOS once this is added to nixpkgs).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - initial: adds ~0.7 MiB (derivation) + ~31 MiB (result)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
