### PR TITLE
pythonPackages: fix nix-shell development environments

### DIFF
--- a/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
@@ -31,6 +31,17 @@ setuptoolsShellHook() {
         mkdir -p "$tmp_path/@pythonSitePackages@"
         eval "@pythonInterpreter@ -m pip install -e . --prefix $tmp_path \
           --no-build-isolation >&2"
+
+        # setuptools no longer installs a site.py file since version 49. Using
+        # a sitecustomize.py file is a workaround for making nix-shell
+        # environments work again.
+        # See https://github.com/pypa/setuptools/issues/2612
+        cat >"$tmp_path/@pythonSitePackages@/sitecustomize.py" <<EOF
+import site
+import pathlib
+here = pathlib.Path(__file__).parent
+site.addsitedir(str(here))
+EOF
     fi
 
     runHook postShellHook


### PR DESCRIPTION
A change in setuptools v49.0.0 broke the development mode of Python
packages inside nix-shell. This workaround fixes it.

Closes #108525.

Note that this change will require a rebuild of all Python packages. I only tested the change using the example described in the issue (using the sampleproject package). I'm not sure if this change will introduce a regression, so if possible hydra should check that all Python packages work ok before merging this.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #108525.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
