### PR TITLE
faraday-{lwt,lwt-unix,async}: add Faraday runtimes

### DIFF
--- a/pkgs/development/ocaml-modules/faraday/async.nix
+++ b/pkgs/development/ocaml-modules/faraday/async.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage, faraday, core, async }:
+
+buildDunePackage rec {
+  pname = "faraday-async";
+  inherit (faraday) version src useDune2;
+
+  minimumOCamlVersion = "4.08";
+
+  propagatedBuildInputs = [ faraday core async ];
+
+  meta = faraday.meta // {
+    description = "Async support for Faraday";
+  };
+}

--- a/pkgs/development/ocaml-modules/faraday/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/faraday/lwt-unix.nix
@@ -1,0 +1,12 @@
+{ buildDunePackage, faraday, faraday-lwt, lwt }:
+
+buildDunePackage rec {
+  pname = "faraday-lwt-unix";
+  inherit (faraday) version src useDune2 minimumOCamlVersion;
+
+  propagatedBuildInputs = [ lwt faraday-lwt ];
+
+  meta = faraday.meta // {
+    description = "Lwt + Unix support for Faraday";
+  };
+}

--- a/pkgs/development/ocaml-modules/faraday/lwt.nix
+++ b/pkgs/development/ocaml-modules/faraday/lwt.nix
@@ -1,0 +1,12 @@
+{ buildDunePackage, faraday, lwt }:
+
+buildDunePackage rec {
+  pname = "faraday-lwt";
+  inherit (faraday) version src useDune2 minimumOCamlVersion;
+
+  propagatedBuildInputs = [ faraday lwt ];
+
+  meta = faraday.meta // {
+    description = "Lwt support for Faraday";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -345,6 +345,12 @@ let
 
     faraday = callPackage ../development/ocaml-modules/faraday { };
 
+    faraday-async = callPackage ../development/ocaml-modules/faraday/async.nix { };
+
+    faraday-lwt = callPackage ../development/ocaml-modules/faraday/lwt.nix { };
+
+    faraday-lwt-unix = callPackage ../development/ocaml-modules/faraday/lwt-unix.nix { };
+
     farfadet = callPackage ../development/ocaml-modules/farfadet { };
 
     fdkaac = callPackage ../development/ocaml-modules/fdkaac { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
These libraries are missing in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
