### PR TITLE
kodi.packages.a4ksubtitles: init at 2.3.0

### DIFF
--- a/pkgs/applications/video/kodi-packages/a4ksubtitles/default.nix
+++ b/pkgs/applications/video/kodi-packages/a4ksubtitles/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildKodiAddon, fetchFromGitHub, requests, vfs-libarchive  }:
+
+buildKodiAddon rec {
+  pname = "a4ksubtitles";
+  namespace = "service.subtitles.a4ksubtitles";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "a4k-openproject";
+    repo = "a4kSubtitles";
+    rev = "${namespace}/${namespace}-${version}";
+    sha256 = "0hxvxkbihfyvixmlxf5n4ccn70w0244hhw3hr44rqvx00a0bg1lh";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    vfs-libarchive
+  ];
+
+  meta = with lib; {
+    homepage = "https://a4k-openproject.github.io/a4kSubtitles/";
+    description = "Multi-Source Subtitles Addon";
+    license = licenses.mit;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -46,6 +46,8 @@ let self = rec {
 
   # addon packages
 
+  a4ksubtitles = callPackage ../applications/video/kodi-packages/a4ksubtitles { };
+
   controllers = {
     default = callPackage ../applications/video/kodi-packages/controllers { controller = "default"; };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Subtitles for `kodi`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
