### PR TITLE
lm-sensors: Read system configuration files from /etc directory

### DIFF
--- a/pkgs/os-specific/linux/lm-sensors/default.nix
+++ b/pkgs/os-specific/linux/lm-sensors/default.nix
@@ -20,16 +20,20 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
-    "ETCDIR=${placeholder "out"}/etc"
     "CC=${stdenv.cc.targetPrefix}cc"
     "AR=${stdenv.cc.targetPrefix}ar"
   ] ++ lib.optional sensord "PROG_EXTRA=sensord";
+
+  installFlags = [
+    "ETCDIR=${placeholder "out"}/etc"
+  ];
 
   meta = with lib; {
     homepage = "https://hwmon.wiki.kernel.org/lm_sensors";
     changelog = "https://raw.githubusercontent.com/lm-sensors/lm-sensors/V${dashedVersion}/CHANGES";
     description = "Tools for reading hardware sensors";
     license = with licenses; [ lgpl21Plus gpl2Plus ];
+    maintainers = with maintainers; [ pengmeiyu ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Let `sensors` read system configuration files from /etc directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
