### PR TITLE
nerdctl: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/applications/networking/cluster/nerdctl/default.nix
+++ b/pkgs/applications/networking/cluster/nerdctl/default.nix
@@ -10,20 +10,20 @@
 
 buildGoModule rec {
   pname = "nerdctl";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
-    owner = "AkihiroSuda";
+    owner = "containerd";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-tMzob+ljGBKkfbxwMqy+8bqVp51Eqyx4kXhsj/LRfzQ=";
+    sha256 = "sha256-0q3UmlXzW0fGYPc1IptuIbCMnKW4pyDm1KxkRqU2voA=";
   };
 
-  vendorSha256 = "sha256-zUX/kneVz8uXmxly8yqmcttK3Wj4EmBaT8gmg3hDms4=";
+  vendorSha256 = "sha256-QVvID9rrOFngL94LWN75HSnyTgh3F0KaScWxMIKUqDM=";
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
-  preBuild = let t = "github.com/AkihiroSuda/nerdctl/pkg/version"; in
+  preBuild = let t = "github.com/containerd/nerdctl/pkg/version"; in
     ''
       buildFlagsArray+=("-ldflags" "-s -w -X ${t}.Version=v${version} -X ${t}.Revision=<unknown>")
     '';
@@ -35,9 +35,6 @@ buildGoModule rec {
     wrapProgram $out/bin/nerdctl \
       --prefix PATH : "${lib.makeBinPath ([ buildkit ] ++ extraPackages)}" \
       --prefix CNI_PATH : "${cni-plugins}/bin"
-
-    # nerdctl panics without XDG_RUNTIME_DIR set
-    export XDG_RUNTIME_DIR=$TMPDIR
 
     installShellCompletion --cmd nerdctl \
       --bash <($out/bin/nerdctl completion bash)
@@ -52,8 +49,8 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/AkihiroSuda/nerdctl/";
-    changelog = "https://github.com/AkihiroSuda/nerdctl/releases/tag/v${version}";
+    homepage = "https://github.com/containerd/nerdctl/";
+    changelog = "https://github.com/containerd/nerdctl/releases/tag/v${version}";
     description = "A Docker-compatible CLI for containerd";
     license = licenses.asl20;
     maintainers = with maintainers; [ jk ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- nerdctl moved to containerd org
- `XDG_RUNTIME_DIRS` no longer needed for --version or completion



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
