### PR TITLE
rtmidi: Add patch for header location

### DIFF
--- a/pkgs/development/libraries/audio/rtmidi/default.nix
+++ b/pkgs/development/libraries/audio/rtmidi/default.nix
@@ -37,14 +37,16 @@ stdenv.mkDerivation rec {
       url = "https://github.com/thestk/rtmidi/pull/230/commits/7a32e23e3f6cb43c0d2d58443ce205d438e76f44.patch";
       sha256 = "06im8mb05wah6bnkadw2gpkhmilxb8p84pxqr50b205cchpq304w";
     })
+    (fetchpatch {
+      name = "RtMidi-Adjust-public-header-installs-to-match-autotools.patch";
+      url = "https://github.com/thestk/rtmidi/pull/230/commits/892fe5492f0e787484fa4a37027b08c265ce001f.patch";
+      sha256 = "0ca9m42xa3gmycimzvzvl67wa266xq9pfp1b4v555rh2fp52kbcj";
+    })
   ];
 
   postPatch = ''
     substituteInPlace rtmidi.pc.in \
       --replace 'Requires:' 'Requires.private:'
-    substituteInPlace CMakeLists.txt \
-      --replace 'PUBLIC_HEADER RtMidi.h' 'PUBLIC_HEADER "RtMidi.h;rtmidi_c.h"' \
-      --replace 'PUBLIC_HEADER DESTINATION $''\{CMAKE_INSTALL_INCLUDEDIR}' 'PUBLIC_HEADER DESTINATION $''\{CMAKE_INSTALL_INCLUDEDIR}/rtmidi'
   '';
 
   nativeBuildInputs = [ cmake pkg-config ];


### PR DESCRIPTION
###### Motivation for this change
Replacing another bit of custom `substituteInPlace`ing with a `fetchpatch`. PR is unfortunately still unmerged :pensive:.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
