### PR TITLE
openjdk_darwin: fix eval for vscode-extensions.redhat.java

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/default.nix
+++ b/pkgs/development/compilers/openjdk/darwin/default.nix
@@ -7,10 +7,11 @@ let
   };
 
   jdk = stdenv.mkDerivation rec {
-    name = "zulu15.28.51-ca-jdk15.0.1";
+    pname = "zulu";
+    version = "15.28.51-ca-jdk15.0.1";
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/${name}-macosx_x64.tar.gz";
+      url = "https://cdn.azul.com/zulu/bin/${pname}-${version}-macosx_x64.tar.gz";
       sha256 = "0h738pbnwcn7pjp0qyryzazqj5nw5sy2f8l0ycl39crm9ia6akvh";
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };


### PR DESCRIPTION
Fix a regression introduced in be9a983b6629f9e170abbb158c84e1b2b2108b42

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
