### PR TITLE
gnomeExtensions.sound-output-device-chooser: 32 -> 35

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/sound-output-device-chooser/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/sound-output-device-chooser/default.nix
@@ -7,16 +7,17 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-sound-output-device-chooser";
-  version = "32";
+  version = "35";
 
   src = fetchFromGitHub {
     owner = "kgshank";
     repo = "gse-sound-output-device-chooser";
     rev = version;
-    sha256 = "1s83scr80qv5xmlfsy6dnsj96lwg2rr4pbsw9inld3ylblgvi35l";
+    sha256 = "sha256-Yl5ut6kJAkAAdCBiNFpwDgshXCLMmFH3/zhnFGpyKqs=";
   };
 
   patches = [
+    # Fix paths to libpulse and python
     (substituteAll {
       src = ./fix-paths.patch;
       libpulse = "${libpulseaudio}/lib/libpulse.so";
@@ -36,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "GNOME Shell extension adding audio device chooser to panel";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jtojnar ];
     homepage = "https://github.com/kgshank/gse-sound-output-device-chooser";
   };

--- a/pkgs/desktops/gnome-3/extensions/sound-output-device-chooser/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/extensions/sound-output-device-chooser/fix-paths.patch
@@ -2,20 +2,20 @@ diff --git a/sound-output-device-chooser@kgshank.net/convenience.js b/sound-outp
 index 54ad06f..0860531 100644
 --- a/sound-output-device-chooser@kgshank.net/convenience.js
 +++ b/sound-output-device-chooser@kgshank.net/convenience.js
-@@ -129,7 +129,7 @@ function refreshCards() {
-     if(_settings.get_boolean(Prefs.NEW_PROFILE_ID))    {
+@@ -142,7 +142,7 @@ function refreshCards() {
+     if (newProfLogic) {
          _log("New logic");
-         let pyLocation =  Me.dir.get_child('utils/pa_helper.py').get_path();
--        let pythonExec = 'python';
+         let pyLocation = Me.dir.get_child("utils/pa_helper.py").get_path();
+-        let pythonExec = ["python", "python3", "python2"].find(cmd => isCmdFound(cmd));
 +        let pythonExec = '@python@';
-         let pyVer = 3;
-         while(!isCmdFound(pythonExec) && pyVer >=2){
-             _log(pythonExec + " is not found. Try next");
+         if (!pythonExec) {
+             _log("ERROR: Python not found. fallback to default mode");
+             _settings.set_boolean(Prefs.NEW_PROFILE_ID, false);
 diff --git a/sound-output-device-chooser@kgshank.net/utils/libpulse_introspect.py b/sound-output-device-chooser@kgshank.net/utils/libpulse_introspect.py
 index c4d2484..262608d 100644
 --- a/sound-output-device-chooser@kgshank.net/utils/libpulse_introspect.py
 +++ b/sound-output-device-chooser@kgshank.net/utils/libpulse_introspect.py
-@@ -86,7 +86,7 @@ else:
+@@ -82,7 +82,7 @@ else:
  
  _libraries = {}
  


### PR DESCRIPTION
Refresh paths patch.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
