### PR TITLE
sshfs: add darwin build

### DIFF
--- a/pkgs/os-specific/darwin/macfuse/default.nix
+++ b/pkgs/os-specific/darwin/macfuse/default.nix
@@ -56,4 +56,10 @@ stdenv.mkDerivation rec {
       lgpl2Plus # libfuse
     ];
   };
+
+  passthru.warning = ''
+    macFUSE is required for this package to work on macOS. To install macFUSE,
+    use the installer from the <link xlink:href="https://osxfuse.github.io/">
+    project website</link>.
+  '';
 }

--- a/pkgs/tools/filesystems/sshfs-fuse/common.nix
+++ b/pkgs/tools/filesystems/sshfs-fuse/common.nix
@@ -1,0 +1,61 @@
+{ version, sha256, platforms, patches ? [ ] }:
+
+{ lib, stdenv, fetchFromGitHub
+, meson, pkg-config, ninja, docutils, makeWrapper
+, fuse3, macfuse-stubs, glib
+, which, python3Packages
+, openssh
+}:
+
+let
+  fuse = if stdenv.isDarwin then macfuse-stubs else fuse3;
+in stdenv.mkDerivation rec {
+  pname = "sshfs-fuse";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "libfuse";
+    repo = "sshfs";
+    rev = "sshfs-${version}";
+    inherit sha256;
+  };
+
+  inherit patches;
+
+  nativeBuildInputs = [ meson pkg-config ninja docutils makeWrapper ];
+  buildInputs = [ fuse glib ];
+  checkInputs = [ which python3Packages.pytest ];
+
+  NIX_CFLAGS_COMPILE = lib.optionalString
+    (stdenv.hostPlatform.system == "i686-linux")
+    "-D_FILE_OFFSET_BITS=64";
+
+  postInstall = ''
+    mkdir -p $out/sbin
+    ln -sf $out/bin/sshfs $out/sbin/mount.sshfs
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    wrapProgram $out/bin/sshfs --prefix PATH : "${openssh}/bin"
+  '';
+
+  # doCheck = true;
+  checkPhase = lib.optionalString (!stdenv.isDarwin) ''
+    # The tests need fusermount:
+    mkdir bin
+    cp ${fuse}/bin/fusermount3 bin/fusermount
+    export PATH=bin:$PATH
+    # Can't access /dev/fuse within the sandbox: "FUSE kernel module does not seem to be loaded"
+    substituteInPlace test/util.py --replace "/dev/fuse" "/dev/null"
+    # TODO: "fusermount executable not setuid, and we are not root"
+    # We should probably use a VM test instead
+    ${python3Packages.python.interpreter} -m pytest test/
+  '';
+
+  meta = with lib; {
+    inherit platforms;
+    description = "FUSE-based filesystem that allows remote filesystems to be mounted over SSH";
+    longDescription = macfuse-stubs.warning;
+    homepage = "https://github.com/libfuse/sshfs";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/tools/filesystems/sshfs-fuse/fix-fuse-darwin-h.patch
+++ b/pkgs/tools/filesystems/sshfs-fuse/fix-fuse-darwin-h.patch
@@ -1,0 +1,14 @@
+diff --git a/sshfs.c b/sshfs.c
+index 97eaf06..d442577 100644
+--- a/sshfs.c
++++ b/sshfs.c
+@@ -14,9 +14,6 @@
+ #if !defined(__CYGWIN__)
+ #include <fuse_lowlevel.h>
+ #endif
+-#ifdef __APPLE__
+-#  include <fuse_darwin.h>
+-#endif
+ #include <assert.h>
+ #include <stdio.h>
+ #include <stdlib.h>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add Darwin build for sshfs. The Darwin build is a single major version behind the Linux release because macFUSE isn't yet compatible with libfuse 3.x.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
