### PR TITLE
nixos/lib/testing-python: disable line length check

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -149,7 +149,11 @@ rec {
 
             echo -n "$testScript" > $out/test-script
             ${lib.optionalString (!skipLint) ''
-              ${python3Packages.black}/bin/black --check --diff $out/test-script
+              # set some large line length limit so we aren't
+              # hindered in string interpolation.
+              ${python3Packages.black}/bin/black \
+                --line-length 2147483647 \
+                --check --diff $out/test-script
             ''}
 
             ln -s ${testDriver}/bin/nixos-test-driver $out/bin/


### PR DESCRIPTION
skipLint only enables a very strict black formatting check which has
absurd ideas about line length and such which have no real merit on the
actual source file since the test script will be a nix string more often
than not.

Additionally we have a pretty powerful programming language to
_generate_ a test script by using string interpolation and other
capabilities we often utilize in the module system. With linting enabled
this becomes a chore since you have to e. g. worry about your lines not
getting too long without knowing in advance how long they are going to
be. Using a programming language with syntactically significant
whitespace for this is already annoying enough :)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
