### PR TITLE
python3Packages.tatsu: 5.5.0 -> 5.6.0

### DIFF
--- a/pkgs/development/python-modules/tatsu/default.nix
+++ b/pkgs/development/python-modules/tatsu/default.nix
@@ -1,31 +1,26 @@
 { lib, buildPythonPackage, fetchFromGitHub, pythonOlder
-, colorama, mypy, pyyaml, regex
-, dataclasses, typing
-, pytestrunner, pytest-mypy
+, colorama, regex
+, pytestrunner, pytestCheckHook, pytest-mypy
 }:
 
 buildPythonPackage rec {
-  pname = "TatSu";
-  version = "5.5.0";
+  pname = "tatsu";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "neogeny";
-    repo = pname;
+    repo = "TatSu";
     rev = "v${version}";
-    sha256 = "07bmdnwh99p60cgzhlb8s5vwi5v4r5zi8shymxnnarannkc66hzn";
+    sha256 = "sha256-kC2MxMebS4TQEZBgTmYRBWaWSF36rVS3bXIsQgRrF0Y=";
   };
 
   disabled = pythonOlder "3.8";
 
   nativeBuildInputs = [ pytestrunner ];
-  propagatedBuildInputs = [ colorama mypy pyyaml regex ]
-    ++ lib.optionals (pythonOlder "3.7") [ dataclasses ]
-    ++ lib.optionals (pythonOlder "3.5") [ typing ];
-  checkInputs = [ pytest-mypy ];
+  propagatedBuildInputs = [ colorama regex ];
+  checkInputs = [ pytestCheckHook pytest-mypy ];
 
-  checkPhase = ''
-    pytest test/
-  '';
+  pythonImportsCheck = [ "tatsu" ];
 
   meta = with lib; {
     description = "Generates Python parsers from grammars in a variation of EBNF";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
build is broken on staging-next

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
