### PR TITLE
gatotray: init at 3.3

### DIFF
--- a/pkgs/tools/system/gatotray/0001-Fix-issue-4-free-invalid-pointer.patch
+++ b/pkgs/tools/system/gatotray/0001-Fix-issue-4-free-invalid-pointer.patch
@@ -1,0 +1,25 @@
+From 31fac126851f1ee10ab5e45a392f840c26fb9f01 Mon Sep 17 00:00:00 2001
+From: gatopeich <gatoguan-os@yahoo.com>
+Date: Sun, 21 Mar 2021 22:14:04 +0000
+Subject: [PATCH] Fix issue #4 (free(): invalid pointer)
+
+---
+diff --git a/settings.c b/settings.c
+index 221b27c..ffedd06 100644
+--- a/settings.c
++++ b/settings.c
+@@ -144,9 +144,9 @@ void pref_init()
+     for(PrefString* s=pref_strings; s < pref_strings+G_N_ELEMENTS(pref_strings); s++)
+     {
+         GError* gerror = NULL;
+-        *s->value = s->default_value;
+         gchar* value = g_key_file_get_string(pref_file, "Options", s->description, &gerror);
+-        if(!gerror) *s->value = value;
++        if (!gerror) *s->value = value;
++        else *s->value = g_strdup(s->default_value);
+     }
+     preferences_changed();
+ }
+-- 
+2.25.4
+

--- a/pkgs/tools/system/gatotray/default.nix
+++ b/pkgs/tools/system/gatotray/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, pkg-config, gdk-pixbuf, gtk2, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "gatotray";
+  version = "3.3";
+
+  src = fetchFromGitHub {
+    owner = "gatopeich";
+    repo = "gatotray";
+    rev = "v${version}";
+    sha256 = "08hy1zyq0nkrhmp599x6k0sn93a4484yi2lfgl0xf25lwdsrsyr5";
+  };
+
+  # Fix https://github.com/gatopeich/gatotray/issues/4 for latest stable version
+  patches = [ ./0001-Fix-issue-4-free-invalid-pointer.patch ];
+
+  postPatch = ''
+    # Substitute hard-coded install destinations
+    substituteInPlace Makefile \
+      --replace /usr/local/bin $out/bin \
+      --replace /usr/share/ $out/share/
+
+    # Leave stripping to fixup phase
+    sed -i "/strip/d" Makefile
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gdk-pixbuf gtk2 ];
+
+  dontConfigure = true;
+
+  preInstall = ''
+    mkdir -p $out/bin $out/share/applications $out/share/icons
+  '';
+
+  meta = with lib; {
+    description = "A lightweight graphical system tray CPU monitor";
+    homepage = "https://github.com/gatopeich/gatotray";
+    license = licenses.cc-by-30;
+    maintainers = [ maintainers.timor ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4553,6 +4553,8 @@ in
 
   garmintools = callPackage ../development/libraries/garmintools {};
 
+  gatotray = callPackage ../tools/system/gatotray { };
+
   gau = callPackage ../tools/security/gau { };
 
   gauge = callPackage ../development/tools/gauge { };


### PR DESCRIPTION
###### Motivation for this change
Provide package for simple CPU info tray application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
