### PR TITLE
python39Packages.rope: fix tests

### DIFF
--- a/pkgs/development/python-modules/rope/default.nix
+++ b/pkgs/development/python-modules/rope/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonAtLeast, nose }:
+{ lib, buildPythonPackage, fetchPypi, fetchpatch, nose }:
 
 buildPythonPackage rec {
   pname = "rope";
@@ -8,6 +8,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "786b5c38c530d4846aa68a42604f61b4e69a493390e3ca11b88df0fbfdc3ed04";
   };
+
+  patches = [
+    # Python 3.9 ast changes
+    (fetchpatch {
+      url = "https://github.com/python-rope/rope/pull/333.patch";
+      excludes = [ ".github/workflows/main.yml" ];
+      sha256 = "1gq7n1zs18ndmv0p8jg1h5pawabi1m9m9z2w5hgidvqmpmcziky0";
+    })
+  ];
 
   checkInputs = [ nose ];
   checkPhase = ''
@@ -19,6 +28,6 @@ buildPythonPackage rec {
     description = "Python refactoring library";
     homepage = "https://github.com/python-rope/rope";
     maintainers = with maintainers; [ goibhniu ];
-    license = licenses.gpl2;
+    license = licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

One test of `python39.pkgs.python-languageserver` fails.