### PR TITLE
one-password-cli: init at 1.8.0

### DIFF
--- a/pkgs/tools/security/one-password-cli/default.nix
+++ b/pkgs/tools/security/one-password-cli/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, autoPatchelfHook
+, fetchzip
+}:
+
+let
+  archNameMapping = {
+    i686 = "386";
+    x86_64 = "amd64";
+    aarch64 = "arm";
+    armv5tel = "arm";
+    armv6l = "arm";
+    armv7a = "arm";
+    armv7l = "arm";
+  };
+  archName = archNameMapping.${stdenv.targetPlatform.uname.processor};
+  kernelName = stdenv.targetPlatform.parsed.kernel.name;
+in
+
+stdenv.mkDerivation rec {
+  pname = "one-password";
+  version = "1.8.0";
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  src = fetchzip {
+    url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_${kernelName}_${archName}_v${version}.zip";
+    sha256 = "1651ricswsdq9yi742k4403qar7cvfc2glr4wr2glga7f891spax";
+    postFetch = ''
+      mkdir $out
+      cd $out
+
+      unzip $downloadedFile
+      rm -rf op.sig
+    '';
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/op $out/bin/op
+  '';
+
+  meta = with lib; {
+    description = "1Password command line tool";
+    homepage = "https://1password.com/downloads/command-line/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cpcloud ];
+    platforms = [
+      "x86_64-darwin"
+
+      "i686-freebsd"
+      "x86_64-freebsd"
+
+      "i686-linux"
+      "x86_64-linux"
+
+      "aarch64-linux"
+      "armv5tel-linux"
+      "armv6l-linux"
+      "armv7a-linux"
+      "armv7l-linux"
+
+      "i686-openbsd"
+      "x86_64-openbsd"
+    ];
+    changelog = "https://app-updates.agilebits.com/product_history/CLI";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1456,6 +1456,8 @@ in
 
   browserpass = callPackage ../tools/security/browserpass { };
 
+  one-password-cli = callPackage ../tools/security/one-password-cli { };
+
   passff-host = callPackage ../tools/security/passff-host { };
 
   oracle-instantclient = callPackage ../development/libraries/oracle-instantclient { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds the `one-password-cli` package, containing the `op` binary for
command line usage of the 1Password secret manager product.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
