### PR TITLE
drone-runner-docker: init at 1.6.3

### DIFF
--- a/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
@@ -10,7 +10,6 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "sha256-WI3pr0t6EevIBOQwCAI+CY2O8Q7+W/CLDT/5Y0+tduQ=";
   };
-  
   vendorSha256 = "15lpdliqz129yq5zgzjvndwdxngxa96g0ska4zkny7ycb3vwq0xm";
 
   meta = with lib; {

--- a/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "drone-runner-docker";
+  version = "1.6.3";
+
+  vendorSha256 = "15lpdliqz129yq5zgzjvndwdxngxa96g0ska4zkny7ycb3vwq0xm";
+
+  src = fetchFromGitHub {
+    owner = "drone-runners";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-WI3pr0t6EevIBOQwCAI+CY2O8Q7+W/CLDT/5Y0+tduQ=";
+  };
+
+  meta = with lib; {
+    maintainers = with maintainers; [ endocrimes ];
+    license = licenses.unfreeRedistributable;
+    homepage = "https://github.com/drone-runners/drone-runner-docker";
+    description = "Drone pipeline runner that executes builds inside Docker containers";
+  };
+}

--- a/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
@@ -4,14 +4,14 @@ buildGoModule rec {
   pname = "drone-runner-docker";
   version = "1.6.3";
 
-  vendorSha256 = "15lpdliqz129yq5zgzjvndwdxngxa96g0ska4zkny7ycb3vwq0xm";
-
   src = fetchFromGitHub {
     owner = "drone-runners";
     repo = pname;
     rev = "v${version}";
     sha256 = "sha256-WI3pr0t6EevIBOQwCAI+CY2O8Q7+W/CLDT/5Y0+tduQ=";
   };
+  
+  vendorSha256 = "15lpdliqz129yq5zgzjvndwdxngxa96g0ska4zkny7ycb3vwq0xm";
 
   meta = with lib; {
     maintainers = with maintainers; [ endocrimes ];

--- a/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
@@ -10,6 +10,7 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "sha256-WI3pr0t6EevIBOQwCAI+CY2O8Q7+W/CLDT/5Y0+tduQ=";
   };
+
   vendorSha256 = "15lpdliqz129yq5zgzjvndwdxngxa96g0ska4zkny7ycb3vwq0xm";
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3852,6 +3852,8 @@ in
 
   drone-runner-exec = callPackage ../development/tools/continuous-integration/drone-runner-exec { };
 
+  drone-runner-docker = callPackage ../development/tools/continuous-integration/drone-runner-docker { };
+
   dropbear = callPackage ../tools/networking/dropbear { };
 
   dsview = libsForQt5.callPackage ../applications/science/electronics/dsview { };


### PR DESCRIPTION
###### Motivation for this change

Setting up Drone, plus saw an outstanding packaging request.

fixes #104675

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
