### PR TITLE
gambit: fix compiler paths

### DIFF
--- a/pkgs/development/compilers/gambit/build.nix
+++ b/pkgs/development/compilers/gambit/build.nix
@@ -63,11 +63,11 @@ gccStdenv.mkDerivation rec {
     lib.optional (!gccStdenv.isDarwin) "--enable-poll";
 
   configurePhase = ''
-    export CC=${gccStdenv.cc.targetPrefix}gcc \
-           CXX=${gccStdenv.cc.targetPrefix}g++ \
-           CPP=${gccStdenv.cc.targetPrefix}cpp \
-           CXXCPP=${gccStdenv.cc.targetPrefix}cpp \
-           LD=${gccStdenv.cc.targetPrefix}ld \
+    export CC=${gccStdenv.cc}/bin/${gccStdenv.cc.targetPrefix}gcc \
+           CXX=${gccStdenv.cc}/bin/${gccStdenv.cc.targetPrefix}g++ \
+           CPP=${gccStdenv.cc}/bin/${gccStdenv.cc.targetPrefix}cpp \
+           CXXCPP=${gccStdenv.cc}/bin/${gccStdenv.cc.targetPrefix}cpp \
+           LD=${gccStdenv.cc}/bin/${gccStdenv.cc.targetPrefix}ld \
            XMKMF=${coreutils}/bin/false
     unset CFLAGS LDFLAGS LIBS CPPFLAGS CXXFLAGS
 


### PR DESCRIPTION
###### Motivation for this change

Prior to the recent merge, the full paths were specified here, so gambit would get the full paths and not need to propagate the compiler inputs.  This restores that behavior while keeping the architecture prefixes.

This allows packages (transitively) depending on gambit to work again. Specifically, I have a number of local gerbil packages that stopped building, and this fixes them.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @fare @7c6f434c