### PR TITLE
libftdi1: 1.4 -> 1.5

### DIFF
--- a/pkgs/development/libraries/libftdi/1.x.nix
+++ b/pkgs/development/libraries/libftdi/1.x.nix
@@ -1,47 +1,73 @@
-{ lib, stdenv, fetchurl, cmake, pkg-config, libusb1, libconfuse
-, cppSupport ? true, boost ? null
-, pythonSupport ? true, python3 ? null, swig ? null
-, docSupport ? true, doxygen ? null
+{ lib
+, stdenv
+, fetchgit
+, cmake
+, pkg-config
+, libusb1
+, libconfuse
+, cppSupport ? true
+, boost
+, pythonSupport ? true
+, python3
+, swig
+, docSupport ? true
+, doxygen
+, graphviz
 }:
 
-assert cppSupport -> boost != null;
-assert pythonSupport -> python3 != null && swig != null;
-assert docSupport -> doxygen != null;
-
+let
+  inherit (lib) optionals optionalString;
+  onOff = a: if a then "ON" else "OFF";
+in
 stdenv.mkDerivation rec {
-  name = "libftdi1-1.4";
+  pname = "libftdi";
+  version = "1.5";
 
-  src = fetchurl {
-    url = "https://www.intra2net.com/en/developer/libftdi/download/${name}.tar.bz2";
-    sha256 = "0x0vncf6i92slgrn0h7ghkskqbglbs534220qa84d0qg114zndpc";
+  src = fetchgit {
+    url = "git://developer.intra2net.com/libftdi";
+    rev = "v${version}";
+    sha256 = "0vipg3y0kbbzjhxky6hfyxy42mpqhvwn1r010zr5givcfp8ghq26";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = with lib; [ libconfuse ]
-    ++ optionals cppSupport [ boost ]
-    ++ optionals pythonSupport [ python3 swig ]
-    ++ optionals docSupport [ doxygen ];
+  nativeBuildInputs = [ cmake pkg-config ]
+    ++ optionals docSupport [ doxygen graphviz ]
+    ++ optionals pythonSupport [ swig ];
 
-  preBuild = lib.optionalString docSupport ''
-    make doc_i
-  '';
+  buildInputs = [ libconfuse ]
+    ++ optionals cppSupport [ boost ]
+    ++ optionals pythonSupport [ python3 ];
+
+  cmakeFlags = [
+    "-DFTDIPP=${onOff cppSupport}"
+    "-DBUILD_TESTS=${onOff cppSupport}"
+    "-DLINK_PYTHON_LIBRARY=${onOff pythonSupport}"
+    "-DPYTHON_BINDINGS=${onOff pythonSupport}"
+    "-DDOCUMENTATION=${onOff docSupport}"
+  ];
 
   propagatedBuildInputs = [ libusb1 ];
 
   postInstall = ''
     mkdir -p "$out/etc/udev/rules.d/"
     cp ../packages/99-libftdi.rules "$out/etc/udev/rules.d/"
+  '' + optionalString docSupport ''
     cp -r doc/man "$out/share/"
-  '' + lib.optionalString docSupport ''
-    mkdir -p "$out/share/libftdi/doc/"
-    cp -r doc/html "$out/share/libftdi/doc/"
+    cp -r doc/html "$out/share/doc/libftdi1/"
+  '';
+
+  postFixup = optionalString cppSupport ''
+    # This gets misassigned to the C++ version's path for some reason
+    for fileToFix in $out/{bin/libftdi1-config,lib/pkgconfig/libftdi1.pc}; do
+      substituteInPlace $fileToFix \
+        --replace "$out/include/libftdipp1" "$out/include/libftdi1"
+    done
   '';
 
   meta = with lib; {
     description = "A library to talk to FTDI chips using libusb";
     homepage = "https://www.intra2net.com/en/developer/libftdi/";
-    license = with licenses; [ lgpl2 gpl2 ];
-    platforms = with platforms; linux ++ darwin;
-    maintainers = [ maintainers.bjornfor ];
+    license = with licenses; [ lgpl2Only gpl2Only ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ bjornfor ];
   };
 }

--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub
+{ stdenv, lib, fetchFromGitHub, fetchpatch
 , gcc-arm-embedded, libftdi1, libusb-compat-0_1, pkg-config
 , python, pythonPackages
 }:
@@ -18,6 +18,14 @@ stdenv.mkDerivation rec {
     sha256 = "18w8y64fs7wfdypa4vm3migk5w095z8nbd8qp795f322mf2bz281";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # Fix deprecation warning with libftdi 1.5
+    (fetchpatch {
+      url = "https://github.com/blacksphere/blackmagic/commit/dea4be2539c5ea63836ec78dca08b52fa8b26ab5.patch";
+      sha256 = "0f81simij1wdhifsxaavalc6yxzagfbgwry969dbjmxqzvrsrds5";
+    })
+  ];
 
   nativeBuildInputs = [
     gcc-arm-embedded pkg-config


### PR DESCRIPTION
###### Motivation for this change
Extracted from #116826. It was an optional dependency for the packages there and I bumped it because I noticed a newer version, but the amount of rebuilds it caused was too much for my taste. I don't really use any of the packages/functionalities this bump affects but no point in throwing this away either, so here you go.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
