### PR TITLE
kakounePlugins.kak-ansi: 0.2.1 -> 0.2.3

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/overrides.nix
+++ b/pkgs/applications/editors/kakoune/plugins/overrides.nix
@@ -34,13 +34,13 @@ self: super: {
 
   kak-ansi = stdenv.mkDerivation rec {
     pname = "kak-ansi";
-    version = "0.2.1";
+    version = "0.2.3";
 
     src = fetchFromGitHub {
       owner = "eraserhd";
       repo = "kak-ansi";
       rev = "v${version}";
-      sha256 = "0ddjih8hfyf6s4g7y46p1355kklaw1ydzzh61141i0r45wyb2d0d";
+      sha256 = "pO7M3MjKMJQew9O20KALEvsXLuCKPYGGTtuN/q/kj8Q=";
     };
 
     installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Big performance fixes in kak-ansi, and handling of `:` as an ansi-code separator.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).