### PR TITLE
[20.09] steghide-0.5.1: mark as insecure

### DIFF
--- a/pkgs/tools/security/steghide/default.nix
+++ b/pkgs/tools/security/steghide/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation rec {
     description = "Steganography program that is able to hide data in various kinds of image- and audio-files";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    knownVulnerabilities = [ "CVE-2021-27211" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This package is considered insecure (weak RNG seeding). As it has seen no upstream activity for 18 years, a bug fix is unlikely.

See also:

* CVE-2021-27211
* https://discourse.nixos.org/t/removal-of-insecure-steghide-package/12071

Re #116923

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
