### PR TITLE
aws-lambda-rie: init at 1.0

### DIFF
--- a/pkgs/tools/admin/aws-lambda-runtime-interface-emulator/default.nix
+++ b/pkgs/tools/admin/aws-lambda-runtime-interface-emulator/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "aws-lambda-runtime-interface-emulator";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "aws-lambda-runtime-interface-emulator";
+    rev = "v${version}";
+    sha256 = "sha256-vbVygZzLlJlxaRF/LIqSJP0gZGyu1wSSdeVjILl/OJE=";
+  };
+
+  vendorSha256 = "sha256-WcvYPGgkrK7Zs5IplAoUTay5ys9LrDJHpRN3ywEdWRM=";
+
+  # disabled because I lack the skill
+  doCheck = false;
+
+  meta = with lib; {
+    description = "To locally test their Lambda function packaged as a container image.";
+    homepage = "https://github.com/aws/aws-lambda-runtime-interface-emulator";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1035,6 +1035,8 @@ in
 
   awslogs = callPackage ../tools/admin/awslogs { };
 
+  aws-lambda-rie = callPackage ../tools/admin/aws-lambda-runtime-interface-emulator { };
+
   aws-env = callPackage ../tools/admin/aws-env { };
 
   aws-google-auth = python3Packages.callPackage ../tools/admin/aws-google-auth { };


### PR DESCRIPTION
The AWS Runtime Interface Emulator is used to test lambda functions embedded in containers. 

There is a testsuite but I have no go knowledge and so didn't look into fixing them.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
