### PR TITLE
e2fsprogs: fix darwin build

### DIFF
--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "e2fsprogs";
-  version = "1.45.6";
+  version = "1.46.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-X2SsUKK2C45nxbOCuxN97Dk0QBcQPK/8OmFVRCTy1pM=";
+    sha256 = "sha256-958mtPZb3AWfyhLh7GowQMPOGlA/tw65Fb7nGQOBXNU=";
   };
 
   outputs = [ "bin" "dev" "out" "man" "info" ];
@@ -68,10 +68,13 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://e2fsprogs.sourceforge.net/";
     description = "Tools for creating and checking ext2/ext3/ext4 filesystems";
-    license = licenses.gpl2;
+    license = with licenses; [
+      gpl2Plus
+      lgpl2Plus # lib/ext2fs, lib/e2p
+      bsd3      # lib/uuid
+      mit       # lib/et, lib/ss
+    ];
     platforms = platforms.unix;
     maintainers = [ maintainers.eelco ];
-    # imager.c:70:2: error: unknown type name 'loff_t'; did you mean 'off_t'?
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix darwin build for e2fsprogs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```console
❯ result-bin/bin/uuidgen
d42991fc-9978-4cf2-9089-debb685b21a5
❯ nix run nixpkgs.coreutils -c truncate --size=10M ext4.img
❯ result-bin/bin/mkfs.ext4 -L nixpkgs ext4.img
mke2fs 1.45.6 (20-Mar-2020)
Creating filesystem with 10240 1k blocks and 2560 inodes
Filesystem UUID: 30a79b4d-e2a7-483a-9b73-8f514142f846
Superblock backups stored on blocks:
	8193

Allocating group tables: done
Writing inode tables: done
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

❯ file ext4.img
ext4.img: Linux rev 1.0 ext4 filesystem data, UUID=30a79b4d-e2a7-483a-9b73-8f514142f846, volume name "nixpkgs" (extents) (64bit) (large files) (huge files)
❯ result-bin/bin/e2label ext4.img
nixpkgs
```
