### PR TITLE
lndmanage: init at 0.11.0

### DIFF
--- a/pkgs/applications/blockchains/lndmanage.nix
+++ b/pkgs/applications/blockchains/lndmanage.nix
@@ -1,0 +1,44 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "lndmanage";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "bitromortac";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19sqf7cjslwpfzcdbyq182dx7gnn9hii77sahbnh88v69qxgwzvb";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    cycler
+    decorator
+    googleapis-common-protos
+    grpcio
+    grpcio-tools
+    kiwisolver
+    networkx
+    numpy
+    protobuf
+    pyparsing
+    python-dateutil
+    six
+    pygments
+  ];
+
+  preBuild = ''
+    substituteInPlace setup.py --replace '==' '>='
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = with lib; {
+    description = "Channel management tool for lightning network daemon (LND) operators";
+    homepage = "https://github.com/bitromortac/lndmanage";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mmilata ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26797,6 +26797,8 @@ in
 
   lndconnect = callPackage ../applications/blockchains/lndconnect { };
 
+  lndmanage = callPackage ../applications/blockchains/lndmanage.nix { };
+
   monero = callPackage ../applications/blockchains/monero {
     inherit (darwin.apple_sdk.frameworks) CoreData IOKit PCSC;
     boost = boost17x;


### PR DESCRIPTION
###### Motivation for this change

Utility useful for operators of lnd which is packaged in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
