### PR TITLE
Don't format XML of the NixOS manual

### DIFF
--- a/nixos/doc/manual/Makefile
+++ b/nixos/doc/manual/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: manual-combined.xml format
+all: manual-combined.xml
 
 .PHONY: debug
 debug: generated manual-combined.xml

--- a/nixos/doc/manual/development/writing-documentation.xml
+++ b/nixos/doc/manual/development/writing-documentation.xml
@@ -25,7 +25,8 @@
 
 <screen>
 <prompt>$ </prompt>cd /path/to/nixpkgs/nixos/doc/manual
-<prompt>$ </prompt>make
+<prompt>$ </prompt>nix-shell
+<prompt>nix-shell$ </prompt>make
 </screen>
 
   <para>


### PR DESCRIPTION


###### Motivation for this change

Fix the horribly broken workflow.

Formatting has been neglected. Running `make` would format dozens
of files, which is a great way of scaring away newcomers and those
with less git experience. It would also annoy the heck out of
regular contributors.

The purpose of formatting is to avoid a small annoyance, so it
should not become a big annoyance that makes people give up on
their work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
