### PR TITLE
vimPlugins: add tests

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -402,7 +402,7 @@ self: super: {
       export HOME=$TMPDIR
       echo $HOME
       set -x
-      ${neovim}/bin/nvim -n -u NONE -i NONE -V1 -E --cmd "set rtp+=$out/share/vim-plugins/minimap-vim" --cmd "set loadplugins" -c "MinimapToggle"  +quit!
+      ${neovim}/bin/nvim -n -u NONE -i NONE -V1 --cmd "set rtp+=$out/share/vim-plugins/minimap-vim" --cmd "runtime! plugin/*.vim" -c "MinimapToggle"  +quit!
     '';
   });
 

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -33,6 +33,7 @@
 , stylish-haskell
 , tabnine
 , vim
+, neovim
 , which
 , xkb-switch
 , ycmd
@@ -391,6 +392,17 @@ self: super: {
         --replace "code-minimap" "${code-minimap}/bin/code-minimap"
       substituteInPlace $out/bin/minimap_generator.sh \
         --replace "code-minimap" "${code-minimap}/bin/code-minimap"
+    '';
+
+    # ${vim}/bin/vim -N -u NONE -i NONE -n -E -s -V1 +quit!;
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      echo "Hello world"
+      export HOME=$TMPDIR
+      echo $HOME
+      set -x
+      ${neovim}/bin/nvim -n -u NONE -i NONE -V1 -E --cmd "set rtp+=$out/share/vim-plugins/minimap-vim" --cmd "set loadplugins" -c "MinimapToggle"  +quit!
     '';
   });
 


### PR DESCRIPTION
some vim plugins need overrides to be functional. These overrides can get outdated so it makes sense to test those plugins.

We should add some code to check if those plugin commands work fine. I've tried here with minimap.vim but seems like it requires neovim 0.5 (or fails with older one).

Targeted plugins:
- [ ] unicode-vim (we patch the path towards unicode data)
- [ ] minimap.vim for example (we patch the path to  code-minimap.vim

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
