### PR TITLE
steam: Add Loop Hero dependencies

### DIFF
--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -135,6 +135,13 @@ in buildFHSUserEnv rec {
     libbsd
     alsaLib
 
+    # Loop Hero
+    libidn2
+    libpsl
+    nghttp2.lib
+    openssl_1_1
+    rtmpdump
+
     # needed by getcap for vr startup
     libcap
 
@@ -201,7 +208,6 @@ in buildFHSUserEnv rec {
     SDL
     SDL2_image
     glew110
-    openssl
     libidn
     tbb
     wayland


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds dependencies necessary for Loop Hero game on Steam to run.

`libidn2`, `libpsl`, `nghttp2.lib` and `openssl_1_1` are dependencies of curl. Loop Hero happens to vendor libcurl, but none of packages libcurl depends on. `openssl_1_1` won't conflict with OpenSSL provides by Steam runtime as those have different versions (1.0 vs 1.1). I'm not expecting issues with inclusion of OpenSSL 1.1 considering this library co-exists on Ubuntu with Steam provided OpenSSL 1.0, and nothing breaks due to that.

`rtmpdump` is necessary for game to run. Curiously, the game does vendor `librtmp.so.1`, however for whatever reason it calls it  `librtmp.so.0` which means that an attempt to vendor a dependency doesn't actually work. Oh well.

I would like to point out that `libidn2` depends on `bootstrap-tools` which bloats the closure. This is something that may be worth looking into. This change makes Steam 100MB larger, mostly because of `bootstrap-tools` being included for no real reason. That said, I don't see it as a blocker for this pull request necessarily because as it turns out, this issue affects all installations of NixOS unstable as `systemd` requires `libidn2`, it probably should be fixed, but I think it's out of scope for this pull request.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
