### PR TITLE
python3Packages.pydeconz: init at 77

### DIFF
--- a/pkgs/development/python-modules/pydeconz/default.nix
+++ b/pkgs/development/python-modules/pydeconz/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, aiohttp
+, aioresponses
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pydeconz";
+  version = "77";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "Kane610";
+    repo = "deconz";
+    rev = "v${version}";
+    sha256 = "0qpipw3si3a23c3nafagfx3zl3v481ha8yakcz1d42mbwsc6hkk4";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  checkInputs = [
+    aioresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pydeconz" ];
+
+  meta = with lib; {
+    description = "Python library wrapping the Deconz REST API";
+    homepage = "https://github.com/Kane610/deconz";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -151,7 +151,7 @@
     "datadog" = ps: with ps; [ datadog ];
     "ddwrt" = ps: with ps; [ ];
     "debugpy" = ps: with ps; [ debugpy ];
-    "deconz" = ps: with ps; [ ]; # missing inputs: pydeconz
+    "deconz" = ps: with ps; [ pydeconz ];
     "decora" = ps: with ps; [ bluepy ]; # missing inputs: decora
     "decora_wifi" = ps: with ps; [ ]; # missing inputs: decora_wifi
     "default_config" = ps: with ps; [ pynacl aiohttp-cors async-upnp-client defusedxml distro emoji hass-nabucasa netdisco pillow scapy sqlalchemy zeroconf ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -193,6 +193,7 @@ in with py.pkgs; buildPythonApplication rec {
     "conversation"
     "counter"
     "cover"
+    "deconz"
     "default_config"
     "demo"
     "derivative"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5608,6 +5608,8 @@ in {
 
   pydbus = callPackage ../development/python-modules/pydbus { };
 
+  pydeconz = callPackage ../development/python-modules/pydeconz { };
+
   pydenticon = callPackage ../development/python-modules/pydenticon { };
 
   pydexcom = callPackage ../development/python-modules/pydexcom { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library wrapping the Deconz REST API

https://github.com/Kane610/deconz

This is a Home Assistant dependency.

The tests of `pydeconz` are all skipped. I have to look into this why they are skipped.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
