### PR TITLE
python3Packages.subarulink: 0.3.12 -> 0.3.13

### DIFF
--- a/pkgs/development/python-modules/subarulink/default.nix
+++ b/pkgs/development/python-modules/subarulink/default.nix
@@ -1,37 +1,48 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
 , aiohttp
 , asynctest
-, stdiomask
+, buildPythonPackage
 , cryptography
-, pytestcov
+, fetchFromGitHub
 , pytest-asyncio
 , pytestCheckHook
+, pythonOlder
+, stdiomask
 }:
 
 buildPythonPackage rec {
   pname = "subarulink";
-  version = "0.3.12";
+  version = "0.3.13";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "G-Two";
     repo = pname;
     rev = "subaru-v${version}";
-    sha256 = "0mhy4np3g10k778062sp2q65cfjhp4y1fghn8yvs6qg6jmg047z6";
+    sha256 = "0dqbb1iiil1vn97zxnpphn63bl8z0ibgyca90ynx958cy78kys0g";
   };
 
-  propagatedBuildInputs = [ aiohttp stdiomask ];
+  propagatedBuildInputs = [
+    aiohttp
+    stdiomask
+  ];
 
   checkInputs = [
     asynctest
     cryptography
     pytest-asyncio
-    pytestcov
     pytestCheckHook
   ];
 
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "--cov=subarulink" ""
+  '';
+
   __darwinAllowLocalNetworking = true;
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   pythonImportsCheck = [ "subarulink" ];
 

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -299,6 +299,7 @@ in with py.pkgs; buildPythonApplication rec {
     "sql"
     "ssdp"
     "stream"
+    "subaru"
     "sun"
     "switch"
     "system_health"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.3.13

Change log: https://github.com/G-Two/subarulink/releases/tag/subaru-v0.3.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
