### PR TITLE
plasma-workspace: fix path to qdbus

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -53,9 +53,10 @@ mkDerivation {
     ./0002-absolute-wallpaper-install-dir.patch
   ];
 
+  # QT_INSTALL_BINS refers to qtbase, and qdbus is in qttools
   postPatch = ''
-    substituteInPlace wallpapers/image/wallpaper.knsrc.cmake \
-      --replace '@QtBinariesDir@/qdbus' ${getBin qttools}/bin/qdbus
+    substituteInPlace CMakeLists.txt \
+      --replace 'query_qmake(QtBinariesDir QT_INSTALL_BINS)' 'set(QtBinariesDir "${lib.getBin qttools}/bin")'
   '';
 
   NIX_CFLAGS_COMPILE = [


### PR DESCRIPTION
###### Motivation for this change
 This is the "proper(tm)" fix for the broken paths that https://github.com/NixOS/nixpkgs/pull/117102 handles.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
