### PR TITLE
supercollider: fix Qt wrapping

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,16 +1,15 @@
-{ lib, stdenv, fetchurl, cmake, pkg-config, alsaLib
+{ lib, stdenv, mkDerivation, fetchurl, cmake, pkg-config, alsaLib
 , libjack2, libsndfile, fftw, curl, gcc
 , libXt, qtbase, qttools, qtwebengine
 , readline, qtwebsockets, useSCEL ? false, emacs
 }:
 
-let optional = lib.optional;
+let
+  inherit (lib) optional;
 in
-
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "supercollider";
   version = "3.11.2";
-
 
   src = fetchurl {
     url = "https://github.com/supercollider/supercollider/releases/download/Version-${version}/SuperCollider-${version}-Source.tar.bz2";
@@ -31,13 +30,11 @@ stdenv.mkDerivation rec {
       ++ optional (!stdenv.isDarwin) alsaLib
       ++ optional useSCEL emacs;
 
-  dontWrapQtApps = true;
-
   meta = with lib; {
     description = "Programming language for real time audio synthesis";
     homepage = "https://supercollider.github.io";
     maintainers = with maintainers; [ mrmebelman ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = [ "x686-linux" "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
Don't know how to use this package, but it launches. I've only wrapped the binaries that depend on Qt.

![grafik](https://user-images.githubusercontent.com/23431373/112126621-ec586900-8bc4-11eb-8092-d3f5f0397c05.png)

###### Motivation for this change
#116548, cc @turion 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
