### PR TITLE
SPAdes: 3.15.1 -> 3.15.2 + fix license and platform

### DIFF
--- a/pkgs/applications/science/biology/spades/default.nix
+++ b/pkgs/applications/science/biology/spades/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "SPAdes";
-  version = "3.15.1";
+  version = "3.15.2";
 
   src = fetchurl {
     url = "http://cab.spbu.ru/files/release${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-2wZzdFRZ7zyhWwYL+c/5qhKDgj+LPtnge3UNHWJ9Ykk=";
+    sha256 = "03cxz4m1n4rc81lqb4p1pz2ammms7f31wvi4daywfkc13aal6fz9";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "St. Petersburg genome assembler: assembly toolkit containing various assembly pipelines";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     homepage = "http://cab.spbu.ru/software/spades/";
-    platforms = platforms.unix;
+    platforms = with platforms; [ "x86_64-linux" "x86_64-darwin"];
     maintainers = [ maintainers.bzizou ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade and minor fixes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
