### PR TITLE
elmPackages.elm-format: fix build

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -80,8 +80,8 @@ let
         # Needed for elm-format
         indents = self.callPackage ./packages/indents.nix {};
         bimap = self.callPackage ./packages/bimap.nix {};
-        avh4-lib = self.callPackage ./packages/avh4-lib.nix {};
-        elm-format-lib = self.callPackage ./packages/elm-format-lib.nix {};
+        avh4-lib = doJailbreak (self.callPackage ./packages/avh4-lib.nix {});
+        elm-format-lib = doJailbreak (self.callPackage ./packages/elm-format-lib.nix {});
         elm-format-test-lib = self.callPackage ./packages/elm-format-test-lib.nix {};
         elm-format-markdown = self.callPackage ./packages/elm-format-markdown.nix {};
       };


### PR DESCRIPTION
closes #117336

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
