### PR TITLE
(my packages) don't put runtime deps into buildInputs

### DIFF
--- a/pkgs/tools/archivers/rpm2targz/default.nix
+++ b/pkgs/tools/archivers/rpm2targz/default.nix
@@ -10,18 +10,7 @@
 , zstd
 }:
 
-let
-  shdeps = [
-    bzip2
-    coreutils
-    cpio
-    gnutar
-    gzip
-    xz
-    zstd
-  ];
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "rpm2targz";
   version = "2021.03.16";
 
@@ -31,9 +20,17 @@ in stdenv.mkDerivation rec {
     hash = "sha256-rcV+o9V2wWKznqSW2rA8xgnpQ02kpK4te6mYvLRC5vQ=";
   };
 
-  buildInputs = shdeps;
-
-  postPatch = ''
+  postPatch = let
+    shdeps = [
+      bzip2
+      coreutils
+      cpio
+      gnutar
+      gzip
+      xz
+      zstd
+    ];
+  in ''
     substituteInPlace rpm2targz --replace "=\"rpmoffset\"" "=\"$out/bin/rpmoffset\""
     # rpm2targz relies on the executable name
     # to guess what compressor it should use
@@ -41,9 +38,7 @@ in stdenv.mkDerivation rec {
     sed -i -e '2iexport PATH="${lib.makeBinPath shdeps}"' rpm2targz
   '';
 
-  preBuild = ''
-    makeFlagsArray+=(prefix=$out)
-  '';
+  installFlags = [ "prefix=$(out)" ];
 
   meta = with lib; {
     description = "Convert a .rpm file to a .tar.gz archive";

--- a/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
+++ b/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
@@ -20,11 +20,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ fping libowlevelzs net-snmp ];
+  buildInputs = [ libowlevelzs net-snmp ];
 
   postPatch = ''
     substituteInPlace src/confent.cxx \
-      --replace /usr/sbin/fping "${lib.makeBinPath [fping]}/fping"
+      --replace /usr/sbin/fping "${fping}/bin/fping"
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/zs-wait4host/default.nix
+++ b/pkgs/tools/networking/zs-wait4host/default.nix
@@ -1,4 +1,4 @@
-{ bash, coreutils, fetchurl, fping, lib, stdenvNoCC }:
+{ coreutils, fetchurl, fping, lib, stdenvNoCC }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "zs-wait4host";
@@ -8,8 +8,6 @@ stdenvNoCC.mkDerivation rec {
     url = "https://ytrizja.de/distfiles/${pname}-${version}.tar.gz";
     sha256 = "9F1264BDoGlRR7bWlRXhfyvxWio4ydShKmabUQEIz9I=";
   };
-
-  buildInputs = [ bash coreutils fping ];
 
   postPatch = ''
     for i in zs-wait4host zs-wait4host-inf; do

--- a/pkgs/tools/text/zstxtns-utils/default.nix
+++ b/pkgs/tools/text/zstxtns-utils/default.nix
@@ -1,5 +1,4 @@
-{ bash
-, coreutils
+{ coreutils
 , fetchurl
 , gnugrep
 , lib
@@ -18,7 +17,6 @@ stdenvNoCC.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ bash coreutils gnugrep moreutils ];
 
   installPhase = ''
     runHook preInstall
@@ -27,8 +25,8 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   postInstall = ''
-    wrapProgram $out/bin/zstxtns-merge --prefix PATH ":" "${lib.makeBinPath [coreutils gnugrep moreutils]}"
-    wrapProgram $out/bin/zstxtns-unmerge --prefix PATH ":" "${lib.makeBinPath [coreutils gnugrep]}"
+    wrapProgram $out/bin/zstxtns-merge --set PATH "${lib.makeBinPath [coreutils gnugrep moreutils]}"
+    wrapProgram $out/bin/zstxtns-unmerge --set PATH "${lib.makeBinPath [coreutils gnugrep]}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

getting rid of unnecessary dependencies. https://github.com/NixOS/nixpkgs/pull/117249#issuecomment-804827933

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [ ] `rpm2targz`
  - [X] `zs-wait4host`
  - [ ] `zstxtns-utils`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
