### PR TITLE
fuse: use macfuse-stubs instead on Darwin

### DIFF
--- a/doc/builders/packages/fuse.section.md
+++ b/doc/builders/packages/fuse.section.md
@@ -1,0 +1,19 @@
+# FUSE {#sec-fuse}
+
+Some packages rely on
+[FUSE](https://www.kernel.org/doc/html/latest/filesystems/fuse.html) to provide
+support for additional filesystems not supported by the kernel.
+
+In general, FUSE software are primarily developed for Linux but many of them can
+also run on macOS. Nixpkgs supports FUSE packages on macOS, but it requires
+[macFUSE](https://osxfuse.github.io) to be installed outside of Nix. macFUSE
+currently isn't packaged in Nixpkgs mainly because it includes a kernel
+extension, which isn't supported by Nix outside of NixOS.
+
+If a package fails to run on macOS with an error message similar to the
+following, it's a likely sign that you need to have macFUSE installed.
+
+    dyld: Library not loaded: /usr/local/lib/libfuse.2.dylib
+    Referenced from: /nix/store/w8bi72bssv0bnxhwfw3xr1mvn7myf37x-sshfs-fuse-2.10/bin/sshfs
+    Reason: image not found
+    [1]    92299 abort      /nix/store/w8bi72bssv0bnxhwfw3xr1mvn7myf37x-sshfs-fuse-2.10/bin/sshfs

--- a/doc/builders/packages/index.xml
+++ b/doc/builders/packages/index.xml
@@ -12,6 +12,7 @@
  <xi:include href="emacs.section.xml" />
  <xi:include href="firefox.section.xml" />
  <xi:include href="fish.section.xml" />
+ <xi:include href="fuse.section.xml" />
  <xi:include href="ibus.section.xml" />
  <xi:include href="kakoune.section.xml" />
  <xi:include href="linux.section.xml" />

--- a/pkgs/development/python-modules/llfuse/default.nix
+++ b/pkgs/development/python-modules/llfuse/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchPypi, fetchpatch, buildPythonPackage, pkg-config, pytest, fuse, attr, which
-, contextlib2, macfuse-stubs, DiskArbitration
+, contextlib2
 }:
 
 buildPythonPackage rec {
@@ -21,9 +21,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs =
-    lib.optionals stdenv.isLinux [ fuse ]
-    ++ lib.optionals stdenv.isDarwin [ DiskArbitration macfuse-stubs ];
+  buildInputs = [ fuse ];
 
   checkInputs = [ pytest which ] ++
     lib.optionals stdenv.isLinux [ attr ];

--- a/pkgs/os-specific/darwin/macfuse/default.nix
+++ b/pkgs/os-specific/darwin/macfuse/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cpio, xar, undmg, libtapi }:
+{ lib, stdenv, fetchurl, cpio, xar, undmg, libtapi, DiskArbitration }:
 
 stdenv.mkDerivation rec {
   pname = "macfuse-stubs";
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cpio xar undmg libtapi ];
+  propagatedBuildInputs = [ DiskArbitration ];
 
   postUnpack = ''
     xar -xf 'Install macFUSE.pkg'
@@ -40,6 +41,11 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://osxfuse.github.io";
     description = "Build time stubs for FUSE on macOS";
+    longDescription = ''
+      macFUSE is required for this package to work on macOS. To install macFUSE,
+      use the installer from the <link xlink:href="https://osxfuse.github.io/">
+      project website</link>.
+    '';
     platforms = platforms.darwin;
     maintainers = with maintainers; [ midchildan ];
 

--- a/pkgs/tools/filesystems/bindfs/default.nix
+++ b/pkgs/tools/filesystems/bindfs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fuse, pkg-config, macfuse-stubs }:
+{ lib, stdenv, fetchurl, fuse, pkg-config }:
 
 stdenv.mkDerivation rec {
   version = "1.15.1";
@@ -10,9 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = if stdenv.isDarwin
-                then [ macfuse-stubs ]
-                else [ fuse ];
+  buildInputs = [ fuse ];
   postFixup = ''
     ln -s $out/bin/bindfs $out/bin/mount.fuse.bindfs
   '';

--- a/pkgs/tools/filesystems/s3fs/default.nix
+++ b/pkgs/tools/filesystems/s3fs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, curl, openssl, libxml2, fuse, macfuse-stubs }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, curl, openssl, libxml2, fuse }:
 
 stdenv.mkDerivation rec {
   pname = "s3fs-fuse";
@@ -11,9 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Agb0tq7B98Ioe0G/XEZCYcFQKnMuYXX9x0yg4Gvu3/k=";
   };
 
-  buildInputs = [ curl openssl libxml2 ]
-    ++ lib.optionals stdenv.isLinux [ fuse ]
-    ++ lib.optionals stdenv.isDarwin [ macfuse-stubs ];
+  buildInputs = [ curl openssl libxml2 fuse ];
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   configureFlags = [

--- a/pkgs/tools/filesystems/unionfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/unionfs-fuse/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fuse, macfuse-stubs }:
+{ lib, stdenv, fetchFromGitHub, cmake, fuse }:
 
 stdenv.mkDerivation rec {
   pname = "unionfs-fuse";
@@ -21,11 +21,11 @@ stdenv.mkDerivation rec {
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace CMakeLists.txt \
-      --replace '/usr/local/include/osxfuse/fuse' '${macfuse-stubs}/include/fuse'
+      --replace '/usr/local/include/osxfuse/fuse' '${fuse}/include/fuse'
   '';
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ (if stdenv.isDarwin then macfuse-stubs else fuse) ];
+  buildInputs = [ fuse ];
 
   # Put the unionfs mount helper in place as mount.unionfs-fuse. This makes it
   # possible to do:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19273,7 +19273,7 @@ in
   fusePackages = dontRecurseIntoAttrs (callPackage ../os-specific/linux/fuse {
     util-linux = util-linuxMinimal;
   });
-  fuse = lowPrio fusePackages.fuse_2;
+  fuse = lowPrio (if stdenv.isDarwin then macfuse-stubs else fusePackages.fuse_2);
   fuse3 = fusePackages.fuse_3;
   fuse-common = hiPrio fusePackages.fuse_3.common;
 
@@ -19412,6 +19412,7 @@ in
 
   macfuse-stubs = callPackage ../os-specific/darwin/macfuse {
     inherit (darwin) libtapi;
+    inherit (darwin.apple_sdk.frameworks) DiskArbitration;
   };
 
   osxsnarf = callPackage ../os-specific/darwin/osxsnarf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3968,7 +3968,6 @@ in {
 
   llfuse = callPackage ../development/python-modules/llfuse {
     inherit (pkgs) fuse;
-    inherit (pkgs.darwin.apple_sdk.frameworks) DiskArbitration;
   };
 
   llvmlite = callPackage ../development/python-modules/llvmlite {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Replaces the Linux-only `fuse` package with `macfuse-stubs` on Darwin. This should further increase the number of FUSE packages available on Darwin, although more fixes would probably be needed on a per-package basis.

`macfuse-stubs` should mostly work as a drop-in replacement for `fuse`. However, it isn't yet compatible with libfuse 3.x, so packages that depends on `fuse3` would still be unsupported on Darwin.

It should be noted that [macFUSE](https://osxfuse.github.io/) would need to be installed outside of Nix in order to run FUSE packages. macFUSE isn't packaged in Nix because it includes a kernel extension, which isn't supported by Nix outside of NixOS. I don't know how best to warn users of this, but I added brief explanation in the `longDescription` of `macfuse-stubs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
