### PR TITLE
python3Packages.sklearn-deap: mark as broken

### DIFF
--- a/pkgs/development/python-modules/sklearn-deap/default.nix
+++ b/pkgs/development/python-modules/sklearn-deap/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    # Fix for newer versions of scikit-learn. See: https://github.com/rsteca/sklearn-deap/pull/62
+    # Fix for scikit-learn v0.21.1. See: https://github.com/rsteca/sklearn-deap/pull/62
     (fetchpatch {
       url = "https://github.com/rsteca/sklearn-deap/commit/3ae62990fc87f36b59382e7c4db3c74cf99ec3bf.patch";
       sha256 = "1na6wf4v0dcmyz3pz8aiqkmv76d1iz3hi4iyfq9kfnycgzpv1kxk";
@@ -31,6 +31,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/rsteca/sklearn-deap";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ psyanticy ];
+    # broken by scikit-learn 0.24.1
+    broken = true;
   };
 }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package was broken by sklearn API changes in 0.24, and hasn't been updated upstream since 2019.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
