### PR TITLE
python38Packages.sasmodels: 1.0.2 -> 1.0.4

### DIFF
--- a/pkgs/development/python-modules/sasmodels/default.nix
+++ b/pkgs/development/python-modules/sasmodels/default.nix
@@ -1,20 +1,30 @@
-{ lib, fetchFromGitHub, buildPythonPackage, pytest, numpy, scipy, matplotlib, docutils
-, pyopencl, opencl-headers
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pytest_5
+, numpy
+, scipy
+, matplotlib
+, docutils
+, pyopencl
+, opencl-headers
 }:
 
 buildPythonPackage rec {
   pname = "sasmodels";
-  version = "1.0.2";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "SasView";
     repo = "sasmodels";
     rev = "v${version}";
-    sha256 = "1qvh7q0fkls5r8r9mrph6igcvv8x3qsslqsc5jf1n20alcs5zjrl";
+    sha256 = "0h2k81dm92sm0z086qy3ipw6y6cfgpb7ppl7lhjmx6816s3k50sa";
   };
 
   buildInputs = [ opencl-headers ];
-  checkInputs = [ pytest ];
+  # Note: the 1.0.5 release should be compatible with pytest6, so this can
+  # be set back to 'pytest' at that point
+  checkInputs = [ pytest_5 ];
   propagatedBuildInputs = [ docutils matplotlib numpy scipy pyopencl ];
 
   checkPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes [hydra failure](https://hydra.nixos.org/build/139374311) by using older pytest.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
