### PR TITLE
python3Packages.restview: 2.9.1 -> 2.9.2

### DIFF
--- a/pkgs/development/python-modules/restview/default.nix
+++ b/pkgs/development/python-modules/restview/default.nix
@@ -7,38 +7,32 @@
 , packaging
 , pygments
 , mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "restview";
-  version = "2.9.1";
+  version = "2.9.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "de87c84f19526bd4a76505f6d40b51b7bb03ca43b6067c93f82f1c7237ac9e84";
+    sha256 = "1p1jgdvc04ws8kga3r0vrq3m0b52qw3clwyydl96a13wb3mrf03r";
   };
 
-  propagatedBuildInputs = [ docutils readme_renderer packaging pygments ];
-  checkInputs = [ mock ];
-
   patches = [
-    # fix tests after readme_renderer update
-    # TODO remove on next update
     (fetchpatch {
-      url = "https://github.com/mgedmin/restview/commit/541743ded13ae55dea4c437046984a5f13d06e8b.patch";
-      sha256 = "031b1dlqx346bz7afpc011lslnq771lnxb6iy1l2285pph534bci";
+      url = "https://github.com/mgedmin/restview/commit/a1ded30a87c65f3ce59a18497a7fc5099317c2be.patch";
+      sha256 = "1ax7pih456a3nbj8qrrq7hqigbyag4ihzpn6bm0z4y74d0r3v8a5";
     })
   ];
 
-  postPatch = ''
-    # dict order breaking tests
-    sed -i 's@<a href="http://www.example.com" rel="nofollow">@...@' src/restview/tests.py
-  '';
+  propagatedBuildInputs = [ docutils readme_renderer packaging pygments ];
+  checkInputs = [ mock pytestCheckHook ];
 
   meta = {
     description = "ReStructuredText viewer";
     homepage = "https://mg.pov.lt/restview/";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ koral ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I git-bisected [the hydra failure](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.python38Packages.restview.x86_64-linux) to  8d46e3f8197e2403bb4b83119a0b128c3cdfd8a5, and disabled two tests as remediation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
