### PR TITLE
i3wsr: init at 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8675,6 +8675,12 @@
     githubId = 19472270;
     name = "Sebastian";
   };
+  sebbadk = {
+    email = "sebastian@sebba.dk";
+    github = "SEbbaDK";
+    githubId = 1567527;
+    name = "Sebastian Hyberts";
+  };
   sellout = {
     email = "greg@technomadic.org";
     github = "sellout";

--- a/pkgs/applications/window-managers/i3/wsr.nix
+++ b/pkgs/applications/window-managers/i3/wsr.nix
@@ -1,0 +1,33 @@
+{ lib, fetchFromGitHub, rustPlatform, libxcb, python3 }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "i3wsr";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "roosta";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zpyncg29y8cv5nw0vgd69nywbj1ppxf6qfm4zc6zz0gk0vxy4pn";
+  };
+
+  cargoSha256 = "0snys419d32anf73jcvrq8h9kp1fq0maqcxz6ww04yg2jv6j47nc";
+
+  nativeBuildInputs = [ python3 ];
+  buildInputs = [ libxcb ];
+
+  # has not tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Automatically change i3 workspace names based on their contents";
+    longDescription = ''
+      Automatically sets the workspace names to match the windows on the workspace.
+      The chosen name for a workspace is a user-defined composite of the WM_CLASS X11
+      window property for each window in a workspace.
+    '';
+    homepage = "https://github.com/roosta/i3wsr";
+    license = licenses.mit;
+    maintainers = [ maintainers.sebbadk ];
+  };
+}

--- a/pkgs/applications/window-managers/sway/wsr.nix
+++ b/pkgs/applications/window-managers/sway/wsr.nix
@@ -1,0 +1,33 @@
+{ lib, fetchFromGitHub, rustPlatform, libxcb, python3 }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "swaywsr";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "pedroscaff";
+    repo = pname;
+    rev = "6c4671c702f647395d983aaf607286db1c692db6";
+    sha256 = "0bmpbhyvgnbi5baj6v0wdxpdh9cnlzvcc44vh3vihmzsp6i5q05a";
+  };
+
+  cargoSha256 = "15wa03279lflr16a6kw7zcn3nvalnjydk9g6nj7xqxmc7zkpf0rm";
+
+  nativeBuildInputs = [ python3 ];
+  buildInputs = [ libxcb ];
+
+  # has not tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Automatically change sway workspace names based on their contents";
+    longDescription = ''
+      Automatically sets the workspace names to match the windows on the workspace.
+      The chosen name for a workspace is a composite of the app_id or WM_CLASS X11
+      window property for each window in a workspace.
+    '';
+    homepage = "https://github.com/pedroscaff/swaywsr";
+    license = licenses.mit;
+    maintainers = [ maintainers.sebbadk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23508,6 +23508,8 @@ in
 
   i3status-rust = callPackage ../applications/window-managers/i3/status-rust.nix { };
 
+  i3wsr = callPackage ../applications/window-managers/i3/wsr.nix { };
+
   i3-wk-switch = callPackage ../applications/window-managers/i3/wk-switch.nix { };
 
   waybox = callPackage ../applications/window-managers/waybox { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23436,6 +23436,7 @@ in
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
   swaylock = callPackage ../applications/window-managers/sway/lock.nix { };
+  swaywsr = callPackage ../applications/window-managers/sway/wsr.nix { };
   sway-contrib = recurseIntoAttrs (callPackages ../applications/window-managers/sway/contrib.nix { });
 
   swaylock-fancy = callPackage ../applications/window-managers/sway/lock-fancy.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Packaging a simple way to rename i3 and sway workspaces via `i3wsr`and `swaywsr`.
Packaged together because they depend on the same core and are built in nearly identical ways.
The software builds fine on macOS, but it doesn't make much sense to use it as neither WM works on macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
