### PR TITLE
python38Packages.loguru: unbreak

### DIFF
--- a/pkgs/development/python-modules/loguru/default.nix
+++ b/pkgs/development/python-modules/loguru/default.nix
@@ -1,19 +1,36 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, isPy27, colorama, pytestCheckHook }:
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, isPy27
+, colorama
+, pytestCheckHook
+, pythonAtLeast
+}:
 
 buildPythonPackage rec {
   pname = "loguru";
   version = "0.5.3";
 
-  disabled = isPy27;
+  # python3.9 compatibility should be in the next release after 0.5.3
+  disabled = isPy27 || pythonAtLeast "3.9";
   src = fetchPypi {
     inherit pname version;
     sha256 = "b28e72ac7a98be3d28ad28570299a393dfcd32e5e3f6a353dec94675767b6319";
   };
 
+  patches = [
+    # Fixes tests with pytest>=6.2.2. Will be part of the next release after 0.5.3
+    (fetchpatch {
+      url = "https://github.com/Delgan/loguru/commit/31cf758ee9d22dbfa125f38153782fe20ac9dce5.patch";
+      sha256 = "1lzbs8akg1s7s6xjl3samf4c4bpssqvwg5fn3mwlm4ysr7jd5y67";
+    })
+  ];
+
   checkInputs = [ pytestCheckHook colorama ];
 
-  pytestFlagsArray = lib.optionals stdenv.isDarwin [ "--ignore=tests/test_multiprocessing.py" ];
-
+  disabledTestPaths = lib.optionals stdenv.isDarwin [ "tests/test_multiprocessing.py" ];
   disabledTests = [ "test_time_rotation_reopening" "test_file_buffering" ]
     ++ lib.optionals stdenv.isDarwin [ "test_rotation_and_retention" "test_rotation_and_retention_timed_file" "test_renaming" "test_await_complete_inheritance" ];
 
@@ -21,6 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Delgan/loguru";
     description = "Python logging made (stupidly) simple";
     license = licenses.mit;
-    maintainers = with maintainers; [ jakewaksbaum ];
+    maintainers = with maintainers; [ jakewaksbaum rmcgibbo ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Pull in a patch from upstream to fix loguru, which was [failing on hydra](https://hydra.nixos.org/job/nixpkgs/trunk/python38Packages.loguru.x86_64-linux), and add myself as a maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
