### PR TITLE
tz: init at 0.4

### DIFF
--- a/pkgs/tools/misc/tz/default.nix
+++ b/pkgs/tools/misc/tz/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "tz";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "oz";
+    repo = "tz";
+    rev = "v${version}";
+    sha256 = "sha256-36nTau7xjABdeUOioHar28cuawFWW3DBaDH0YAvdufI=";
+  };
+
+  vendorSha256 = "sha256-Soa87I7oMa34LjYKxNAz9Limi0kQ6JUtb/zI4G7yZnw=";
+
+  meta = with lib; {
+    description = "A time zone helper";
+    homepage = "https://github.com/oz/tz";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8765,6 +8765,8 @@ in
 
   tydra = callPackage ../tools/misc/tydra { };
 
+  tz = callPackage ../tools/misc/tz { };
+
   u9fs = callPackage ../servers/u9fs { };
 
   ua = callPackage ../tools/networking/ua { };


### PR DESCRIPTION
###### Motivation for this change
Add tz: a time zone helper

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
