### PR TITLE
cen64: unstable-2020-02-20 -> unstable-2021-03-12

### DIFF
--- a/pkgs/misc/emulators/cen64/default.nix
+++ b/pkgs/misc/emulators/cen64/default.nix
@@ -2,21 +2,22 @@
 
 stdenv.mkDerivation rec {
   pname = "cen64";
-  version = "unstable-2020-02-20";
+  version = "unstable-2021-03-12";
 
   src = fetchFromGitHub {
     owner = "n64dev";
     repo = "cen64";
-    rev = "6f9f5784bf0a720522c4ecb0915e20229c126aed";
-    sha256 = "08q0a3b2ilb95zlz4cw681gwz45n2wrb2gp2z414cf0bhn90vz0s";
+    rev = "1b31ca9b3c3bb783391ab9773bd26c50db2056a8";
+    sha256 = "0x1fz3z4ffl5xssiyxnmbhpjlf0k0fxsqn4f2ikrn17742dx4c0z";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libGL libiconv openal libX11 ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv cen64 $out/bin
+    runHook preInstall
+    install -D {,$out/bin/}${pname}
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Yearly version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### Note
I wanted to add `cmakeFlags=[-DCEN64_ARCH_SUPPORT=AVX]`, but running `nix repl`, `:l`, `stdenv.hostPlatform` gave me several false supports comparing to `lscpu` supports.