### PR TITLE
ocamlPackages.ppxlib: 0.15.0 → 0.22.0

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchzip, which, ocsigen_server, ocaml,
   lwt_react,
   opaline, ppx_deriving, findlib
+, ocaml-migrate-parsetree
 , ppx_tools_versioned
 , js_of_ocaml-ocamlbuild, js_of_ocaml-ppx, js_of_ocaml-ppx_deriving_json
 , js_of_ocaml-lwt
@@ -22,7 +23,9 @@ stdenv.mkDerivation rec
     sha256 = "00m6v2k4mg8705dy41934lznl6gj91i6dk7p1nkaccm51nna25kz";
   };
 
-  buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild js_of_ocaml-ppx_deriving_json opaline
+  buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild
+    ocaml-migrate-parsetree
+    js_of_ocaml-ppx_deriving_json opaline
     ppx_tools_versioned
   ];
 

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -182,7 +182,8 @@ rec {
 
   base_quickcheck = janePackage {
     pname = "base_quickcheck";
-    hash = "1lmp1h68g0gqiw8m6gqcbrp0fn76nsrlsqrwxp20d7jhh0693f3j";
+    version = "0.14.1";
+    hash = "0apq3d9xb0zdaqsl4cjk5skyig57ff1plndb2mh0nn3czvfhifxs";
     minimumOCamlVersion = "4.04.2";
     meta.description = "Randomized testing framework, designed for compatibility with Base";
     propagatedBuildInputs = [ ppx_base ppx_fields_conv ppx_let ppx_sexp_value splittable_random ];
@@ -450,7 +451,8 @@ rec {
 
   ppx_custom_printf = janePackage {
     pname = "ppx_custom_printf";
-    hash = "0p9hgx0krxqw8hlzfv2bg2m3zi5nxsnzhyp0fj5936rapad02hc5";
+    version = "0.14.1";
+    hash = "0c1m65kn27zvwmfwy7kk46ga76yw2a3ik9jygpy1b6nn6pi026w9";
     minimumOCamlVersion = "4.04.2";
     meta.description = "Printf-style format-strings for user-defined string conversion";
     propagatedBuildInputs = [ ppx_sexp_conv ];
@@ -466,7 +468,8 @@ rec {
 
   ppx_expect = janePackage {
     pname = "ppx_expect";
-    hash = "05v6jzn1nbmwk3vzxxnb3380wzg2nb28jpb3v5m5c4ikn0jrhcwn";
+    version = "0.14.1";
+    hash = "0vbbnjrzpyk5p0js21lafr6fcp2wqka89p1876rdf472cmg0l7fv";
     minimumOCamlVersion = "4.04.2";
     meta.description = "Cram like framework for OCaml";
     propagatedBuildInputs = [ ppx_here ppx_inline_test re ];
@@ -559,7 +562,8 @@ rec {
 
   ppx_optcomp = janePackage {
     pname = "ppx_optcomp";
-    hash = "1wav3zgh4244x1ll562g735cwwrzyk5jj72niq9jgz9qjlpsprlk";
+    version = "0.14.1";
+    hash = "0j5smqa0hig1yn8wfrb4mv0y59kkwsalmqkm5asbd7kcc6589ap4";
     minimumOCamlVersion = "4.04.2";
     meta.description = "Optional compilation for OCaml";
     propagatedBuildInputs = [ ppxlib ];
@@ -591,16 +595,17 @@ rec {
 
   ppx_sexp_conv = janePackage {
     pname = "ppx_sexp_conv";
-    version = "0.14.1";
+    version = "0.14.3";
     minimumOCamlVersion = "4.04.2";
-    hash = "04bx5id99clrgvkg122nx03zig1m7igg75piphhyx04w33shgkz2";
+    hash = "0dbri9d00ydi0dw1cavswnqdmhjaaz80vap29ns2lr6mhhlvyjmj";
     meta.description = "[@@deriving] plugin to generate S-expression conversion functions";
     propagatedBuildInputs = [ ppxlib sexplib0 base ];
   };
 
   ppx_sexp_message = janePackage {
     pname = "ppx_sexp_message";
-    hash = "17xnq345xwfkl9ydn05ljsg37m2glh3alnspayl3fgbhmcjmav3i";
+    version = "0.14.1";
+    hash = "1lvsr0d68kakih1ll33hy6dxbjkly6lmky4q6z0h0hrcbd6z48k4";
     minimumOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter for easy construction of s-expressions";
     propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
@@ -634,9 +639,9 @@ rec {
 
   ppx_typerep_conv = janePackage {
     pname = "ppx_typerep_conv";
-    version = "0.14.1";
+    version = "0.14.2";
     minimumOCamlVersion = "4.04.2";
-    hash = "1r0z7qlcpaicas5hkymy2q0gi207814wlay4hys7pl5asd59wcdh";
+    hash = "0yk9vkpnwr8labgfncqdi4rfkj88d8mb3cr8m4gdqpi3f2r27hf0";
     meta.description = "Generation of runtime types from type declarations";
     propagatedBuildInputs = [ ppxlib typerep ];
   };

--- a/pkgs/development/ocaml-modules/pgocaml/default.nix
+++ b/pkgs/development/ocaml-modules/pgocaml/default.nix
@@ -4,12 +4,12 @@
 
 buildDunePackage rec {
   pname = "pgocaml";
-  version = "4.2.2";
+  version = "4.2.2-dev-20210111";
   src = fetchFromGitHub {
     owner = "darioteixeira";
     repo = "pgocaml";
-    rev = version;
-    sha256 = "1rdypc83nap9j2ml9r6n1pzgf79gk1yffwyi6fmcrl7zmy01cg0n";
+    rev = "1bb0025deeb3d14029afdcc69aaa7847026e243e";
+    sha256 = "11inbjf87gclc2xmpq56ag4cm4467y9q9hjgbdn69fa1bman2zn2";
   };
 
   minimumOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/pgocaml/ppx.nix
+++ b/pkgs/development/ocaml-modules/pgocaml/ppx.nix
@@ -1,8 +1,8 @@
-{ buildDunePackage, pgocaml, ppx_optcomp, ppx_tools, ppx_tools_versioned, rresult }:
+{ buildDunePackage, pgocaml, ppx_optcomp }:
 
 buildDunePackage {
   pname = "pgocaml_ppx";
   inherit (pgocaml) src version useDune2 meta;
 
-  propagatedBuildInputs = [ pgocaml ppx_optcomp ppx_tools ppx_tools_versioned rresult ];
+  propagatedBuildInputs = [ pgocaml ppx_optcomp ];
 }

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -19,11 +19,13 @@ let param = {
   "0.15.0" = {
     sha256 = "1p037kqj5858xrhh0dps6vbf4fnijla6z9fjz5zigvnqp4i2xkrn";
     min_version = "4.07";
+    max_version = "4.12";
     useOMP2 = false;
   };
   "0.18.0" = {
     sha256 = "1ciy6va2gjrpjs02kha83pzh0x1gkmfsfsdgabbs1v14a8qgfibm";
     min_version = "4.07";
+    max_version = "4.12";
   };
   "0.22.0" = {
     sha256 = "0kf7lgcwygf6zlx7rwddqpqvasa6v7xiq0bqal8vxlib6lpg074q";

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -1,5 +1,8 @@
 { lib, fetchFromGitHub, buildDunePackage, ocaml
-, version ? if lib.versionAtLeast ocaml.version "4.07" then "0.15.0" else "0.13.0"
+, version ?
+  if lib.versionAtLeast ocaml.version "4.07"
+  then if lib.versionAtLeast ocaml.version "4.08"
+  then "0.22.0" else "0.15.0" else "0.13.0"
 , ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
 , stdlib-shims, ocaml-migrate-parsetree-2-1
 }:

--- a/pkgs/development/ocaml-modules/visitors/default.nix
+++ b/pkgs/development/ocaml-modules/visitors/default.nix
@@ -2,18 +2,18 @@
 
 buildDunePackage rec {
   pname = "visitors";
-  version = "20210127";
+  version = "20210316";
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.07";
+  minimumOCamlVersion = "4.08";
 
   src = fetchFromGitLab {
     owner = "fpottier";
     repo = pname;
     rev = version;
     domain = "gitlab.inria.fr";
-    sha256 = "0b73h7d4yv04a0b5x2i222jknbcgf9vvxzfjxzy2jwanxz9d873z";
+    sha256 = "12d45ncy3g9mpcs6n58aq6yzs5qz662msgcr7ccms9jhiq44m8f7";
   };
 
   propagatedBuildInputs = [ ppxlib ppx_deriving result ];

--- a/pkgs/development/tools/analysis/flow/default.nix
+++ b/pkgs/development/tools/analysis/flow/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     install -Dm644 resources/shell/bash-completion $out/share/bash-completion/completions/flow
   '';
 
-  buildInputs = (with ocamlPackages; [ ocaml findlib ocamlbuild dtoa core_kernel sedlex_2 ocaml_lwt lwt_log lwt_ppx ppx_deriving ppx_gen_rec ppx_tools_versioned visitors wtf8 ocaml-migrate-parsetree ])
+  buildInputs = (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml-migrate-parsetree dtoa core_kernel sedlex_2 ocaml_lwt lwt_log lwt_ppx ppx_deriving ppx_gen_rec ppx_tools_versioned visitors wtf8 ])
     ++ lib.optionals stdenv.isDarwin [ CoreServices ];
 
   meta = with lib; {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -317,7 +317,15 @@ let
 
     eliom = callPackage ../development/ocaml-modules/eliom { };
 
-    elpi = callPackage ../development/ocaml-modules/elpi { };
+    elpi = callPackage ../development/ocaml-modules/elpi (
+      let ppxlib_0_15 = if lib.versionAtLeast ppxlib.version "0.15"
+        then ppxlib.override { version = "0.15.0"; }
+        else ppxlib; in
+      {
+        ppx_deriving = ppx_deriving.override { ppxlib = ppxlib_0_15; };
+        ppxlib = ppxlib_0_15;
+      }
+    );
 
     encore = callPackage ../development/ocaml-modules/encore { };
 
@@ -1031,13 +1039,23 @@ let
 
     ppx_deriving_protobuf = callPackage ../development/ocaml-modules/ppx_deriving_protobuf {};
 
-    ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc { };
+    ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc {
+      ppxlib = ppxlib.override { version = "0.15.0"; };
+   };
 
     ppx_deriving_yojson = callPackage ../development/ocaml-modules/ppx_deriving_yojson {};
 
     ppx_gen_rec = callPackage ../development/ocaml-modules/ppx_gen_rec {};
 
-    ppx_import = callPackage ../development/ocaml-modules/ppx_import {};
+    ppx_import = callPackage ../development/ocaml-modules/ppx_import (
+      let ppxlib_0_15 = if lib.versionAtLeast ppxlib.version "0.15"
+        then ppxlib.override { version = "0.15.0"; }
+        else ppxlib; in
+      {
+        ppx_deriving = ppx_deriving.override { ppxlib = ppxlib_0_15; };
+        ppxlib = ppxlib_0_15;
+      }
+    );
 
     ppx_irmin = callPackage ../development/ocaml-modules/irmin/ppx.nix {
     };


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.12

cc @sternenseemann

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
