### PR TITLE
python3Packages.forbiddenfruit: unbreak

### DIFF
--- a/pkgs/development/python-modules/forbiddenfruit/default.nix
+++ b/pkgs/development/python-modules/forbiddenfruit/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , nose
 }:
 
@@ -8,13 +8,20 @@ buildPythonPackage rec {
   version = "0.1.4";
   pname = "forbiddenfruit";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e3f7e66561a29ae129aac139a85d610dbf3dd896128187ed5454b6421f624253";
+  src = fetchFromGitHub {
+    owner = "clarete";
+    repo = "forbiddenfruit";
+    rev = version;
+    sha256 = "16chhrxbbmg6lfbzm532fq0v00z8qihcsj0kg2b5jlgnb6qijwn8";
   };
 
   checkInputs = [ nose ];
 
+  preBuild = ''
+    export FFRUIT_EXTENSION="true";
+  '';
+
+  # https://github.com/clarete/forbiddenfruit/pull/47 required to switch to pytest
   checkPhase = ''
     find ./build -name '*.so' -exec mv {} tests/unit \;
     nosetests
@@ -22,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Patch python built-in objects";
-    homepage = "https://pypi.python.org/pypi/forbiddenfruit";
+    homepage = "https://github.com/clarete/forbiddenfruit";
     license = licenses.mit;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.python38Packages.forbiddenfruit.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
