### PR TITLE
qt5: Include the "out" derivation as well as the "dev" in qt5.full

### DIFF
--- a/pkgs/development/libraries/qt-5/qt-env.nix
+++ b/pkgs/development/libraries/qt-5/qt-env.nix
@@ -5,7 +5,7 @@ buildEnv {
   paths = [ qtbase ] ++ paths;
 
   pathsToLink = [ "/bin" "/mkspecs" "/include" "/lib" "/share" ];
-  extraOutputsToInstall = [ "dev" ];
+  extraOutputsToInstall = [ "out" "dev" ];
 
   postBuild = ''
     rm "$out/bin/qmake"


### PR DESCRIPTION
Without a number of important Qt libraries (all of those with a "dev"
derivation) are not included in the bundled package, and qmake can't
find them.

Fixes #110199

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
