### PR TITLE
gitea: 1.13.5 -> 1.13.6 + reformatting

### DIFF
--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -1,5 +1,12 @@
-{ lib, buildGoPackage, fetchurl, makeWrapper
-, git, bash, gzip, openssh, pam
+{ lib
+, buildGoPackage
+, fetchurl
+, makeWrapper
+, git
+, bash
+, gzip
+, openssh
+, pam
 , sqliteSupport ? true
 , pamSupport ? true
 , nixosTests
@@ -37,16 +44,18 @@ buildGoPackage rec {
 
   buildInputs = optional pamSupport pam;
 
-  preBuild = let
-    tags = optional pamSupport "pam"
+  preBuild =
+    let
+      tags = optional pamSupport "pam"
         ++ optional sqliteSupport "sqlite sqlite_unlock_notify";
-    tagsString = concatStringsSep " " tags;
-  in ''
-    export buildFlagsArray=(
-      -tags="${tagsString}"
-      -ldflags='-X "main.Version=${version}" -X "main.Tags=${tagsString}"'
-    )
-  '';
+      tagsString = concatStringsSep " " tags;
+    in
+    ''
+      export buildFlagsArray=(
+        -tags="${tagsString}"
+        -ldflags='-X "main.Version=${version}" -X "main.Tags=${tagsString}"'
+      )
+    '';
 
   outputs = [ "out" "data" ];
 

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -9,11 +9,12 @@ with lib;
 
 buildGoPackage rec {
   pname = "gitea";
-  version = "1.13.5";
+  version = "1.13.6";
 
+  # not fetching directly from the git repo, because that lacks several vendor files for the web UI
   src = fetchurl {
     url = "https://github.com/go-gitea/gitea/releases/download/v${version}/gitea-src-${version}.tar.gz";
-    sha256 = "08c5gp4qp65mnq4ggzfmyc7n3zcp0js86fz4nj5p249zs9vn1ypd";
+    sha256 = "1f0fsqcmmqygv0r796ddr2fjhh333i9nr0cqk9x2b2kbs1z264vf";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
###### Motivation for this change

- minor version bump incl. security fixes, see https://github.com/go-gitea/gitea/releases/tag/v1.13.6
- re-formatted derivation with `nixpkgs-fmt` for a consistent style

needs a backport to stable

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).