### PR TITLE
knockpy: init at 5.0.0

### DIFF
--- a/pkgs/tools/security/knockpy/default.nix
+++ b/pkgs/tools/security/knockpy/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "knockpy";
+  version = "5.0.0";
+  disabled = python3.pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "guelfoweb";
+    repo = "knock";
+    rev = version;
+    sha256 = "1h7sibdxx8y53xm1wydyng418n4j6baiys257msq03cs04jlm7h9";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    beautifulsoup4
+    colorama
+    requests
+  ];
+
+  postPatch = ''
+    # https://github.com/guelfoweb/knock/pull/95
+    substituteInPlace setup.py \
+      --replace "bs4" "beautifulsoup4"
+  '';
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "knockpy" ];
+
+  meta = with lib; {
+    description = "Tool to scan subdomains";
+    homepage = "https://github.com/guelfoweb/knock";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5739,6 +5739,8 @@ in
 
   knockknock = callPackage ../tools/security/knockknock { };
 
+  knockpy = callPackage ../tools/security/knockpy { };
+
   kore = callPackage ../development/web/kore { };
 
   krakenx = callPackage ../tools/system/krakenx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to scan subdomains

https://github.com/guelfoweb/knock

Related to #81418

https://github.com/guelfoweb/knock/pull/95 was merged but there is no new release yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
