### PR TITLE
slowhttptest: init at 1.8.2

### DIFF
--- a/pkgs/tools/security/slowhttptest/default.nix
+++ b/pkgs/tools/security/slowhttptest/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "slowhttptest";
+  version = "1.8.2";
+
+  src = fetchFromGitHub {
+    owner = "shekyan";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xv2j3hl4zj0s2cxcsvlwgridh9ap4g84g7c4918d03id15wydcx";
+  };
+
+  buildInputs = [ openssl ];
+
+  meta = with lib; {
+    description = "Application Layer DoS attack simulator";
+    homepage = "https://github.com/shekyan/slowhttptest";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25285,6 +25285,8 @@ in
 
   slop = callPackage ../tools/misc/slop {};
 
+  slowhttptest = callPackage ../tools/security/slowhttptest { };
+
   slrn = callPackage ../applications/networking/newsreaders/slrn { };
 
   sniproxy = callPackage ../applications/networking/sniproxy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Application Layer DoS attack simulator

https://github.com/shekyan/slowhttptest

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
