### PR TITLE
sipvicious: init at 0.3.2

### DIFF
--- a/pkgs/tools/security/sipvicious/default.nix
+++ b/pkgs/tools/security/sipvicious/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+}:
+
+buildPythonApplication rec {
+  pname = "sipvicious";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "EnableSecurity";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hna4xyjhdwi6z2aqqp25ydkb1qznlil95w2iqrr576wcrciznd5";
+  };
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "sipvicious" ];
+
+  meta = with lib; {
+    description = " Set of tools to audit SIP based VoIP systems";
+    homepage = "https://github.com/EnableSecurity/sipvicious";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8082,6 +8082,8 @@ in
 
   sipsak = callPackage ../tools/networking/sipsak { };
 
+  sipvicious = python3Packages.callPackage ../tools/security/sipvicious { };
+
   siril = callPackage ../applications/science/astronomy/siril { };
 
   sisco.lv2 = callPackage ../applications/audio/sisco.lv2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Set of tools to audit SIP based VoIP systems

https://github.com/EnableSecurity/sipvicious

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
