### PR TITLE
python3Packages.hdbscan: unbreak

### DIFF
--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -1,8 +1,9 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , cython
 , numpy
-, nose
+, pytestCheckHook
 , scipy
 , scikitlearn
 , fetchPypi
@@ -18,11 +19,22 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "e3a418d0d36874f7b6a1bf0b7461f3857fc13a525fd48ba34caed2fe8973aa26";
   };
-
-  checkInputs = [ nose ];
+  patches = [
+    # This patch fixes compatibility with numpy 1.20. It will be in the next release
+    # after 0.8.27
+    (fetchpatch {
+      url = "https://github.com/scikit-learn-contrib/hdbscan/commit/5b67a4fba39c5aebe8187a6a418da677f89a63e0.patch";
+      sha256 = "07d7jdwk0b8kgaqkifd529sarji01j1jiih7cfccc5kxmlb5py9h";
+    })
+  ];
 
   nativeBuildInputs = [ cython ];
   propagatedBuildInputs = [ numpy scipy scikitlearn joblib six ];
+  preCheck = ''
+    cd hdbscan/tests
+    rm __init__.py
+  '';
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Hierarchical Density-Based Spatial Clustering of Applications with Noise, a clustering algorithm with a scikit-learn compatible API";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Required an upstream patch, which I just submitted https://github.com/scikit-learn-contrib/hdbscan/pull/468. ~It probably makes sense to give them some time to merge it into master, so I marked this as a draft.~ Patch was merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
