### PR TITLE
udunits: 2.2.27.6 -> unstable-2021-03-17

### DIFF
--- a/pkgs/development/libraries/udunits/default.nix
+++ b/pkgs/development/libraries/udunits/default.nix
@@ -1,26 +1,49 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook,
-  texinfo, bison, flex, expat, file
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, bison
+, expat
+, file
+, flex
+, texinfo
 }:
 
 stdenv.mkDerivation rec {
   pname = "udunits";
-  version = "2.2.27.6";
+  version = "unstable-2021-03-17";
 
   src = fetchFromGitHub {
     owner = "Unidata";
     repo = "UDUNITS-2";
-    rev = "v${version}";
-    sha256 = "0621pac24c842dyipzaa59rh6pza9phdqi3snd4cq4pib0wjw6gm";
+    rev = "c83da987387db1174cd2266b73dd5dd556f4476b";
+    hash = "sha256-+HW21+r65OroCxMK2/B5fe7zHs4hD4xyoJK2bhdJGyQ=";
   };
 
-  nativeBuildInputs = [ autoreconfHook texinfo bison flex file ];
-  buildInputs = [ expat ];
+  nativeBuildInputs = [
+    autoreconfHook
+    texinfo
+    bison
+    flex
+    file
+  ];
+  buildInputs = [
+    expat
+  ];
 
   meta = with lib; {
     homepage = "https://www.unidata.ucar.edu/software/udunits/";
     description = "A C-based package for the programatic handling of units of physical quantities";
-    license = licenses.bsdOriginal;
+    longDescription = ''
+      The UDUNITS package supports units of physical quantities. Its C library
+      provides for arithmetic manipulation of units and for conversion of
+      numeric values between compatible units. The package contains an extensive
+      unit database, which is in XML format and user-extendable. The package
+      also contains a command-line utility for investigating units and
+      converting values.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ AndersonTorres pSub ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ pSub ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
