### PR TITLE
deepspeech: init at 0.9.3

### DIFF
--- a/pkgs/misc/deepspeech/default.nix
+++ b/pkgs/misc/deepspeech/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchurl, autoPatchelfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "deepspeech";
+  version = "0.9.3";
+
+  src = fetchurl {
+    url = "https://github.com/mozilla/DeepSpeech/releases/download/v${version}/native_client.amd64.cpu.linux.tar.xz";
+    sha256 = "1qy2gspprcxi76jk06ljp028xl0wkk1m3mqaxyf5qbhhfbvvpfap";
+  };
+  setSourceRoot = "sourceRoot=`pwd`";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    install -D deepspeech $out/bin/deepspeech
+    install -D deepspeech.h $out/include/deepspeech.h
+    install -D libdeepspeech.so $out/lib/libdeepspeech.so
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/mozilla/DeepSpeech;
+    description = "Open source embedded (offline, on-device) speech-to-text engine, which can run in real time on broad range of devices";
+    license = licenses.mpl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ rvolosatovs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29186,6 +29186,8 @@ in
 
   dbus-map = callPackage ../tools/misc/dbus-map { };
 
+  deepspeech = callPackage ../misc/deepspeech { };
+
   dell-530cdn = callPackage ../misc/drivers/dell-530cdn {};
 
   demjson = with python3Packages; toPythonApplication demjson;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/98770

Since this does not build from source, but rather just uses patched versions of binaries, shall `-bin` prefix be added here?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
