### PR TITLE
flawfinder: init at 2.0.15

### DIFF
--- a/pkgs/development/tools/flawfinder/default.nix
+++ b/pkgs/development/tools/flawfinder/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchurl
+, installShellFiles
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "flawfinder";
+  version = "2.0.15";
+
+  src = fetchurl {
+    url = "https://dwheeler.com/flawfinder/flawfinder-${version}.tar.gz";
+    sha256 = "01j4szy8gwvikrfzfayfayjnc1za0jxsnxp5fsa6d06kn69wyr8a";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp ${pname} $out/bin
+    installManPage flawfinder.1
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tool to examines C/C++ source code for security flaws";
+    homepage = "https://dwheeler.com/flawfinder/";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4403,6 +4403,8 @@ in
 
   flamegraph = callPackage ../development/tools/flamegraph { };
 
+  flawfinder = callPackage ../development/tools/flawfinder { };
+
   flips = callPackage ../tools/compression/flips { };
 
   fmbt = callPackage ../development/tools/fmbt {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to examines C/C++ source code for security flaws

http://dwheeler.com/flawfinder

Related to #81418

Fixes #117382

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
