### PR TITLE
libpst: build as shared library, evolution: enable importing Outlook .pst data files

### DIFF
--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -10,6 +10,7 @@
 , gtk3
 , glib
 , libnotify
+, libpst
 , gspell
 , evolution-data-server
 , libgdata
@@ -80,6 +81,7 @@ stdenv.mkDerivation rec {
     libgweather
     libical
     libnotify
+    libpst
     librsvg
     libsecret
     nspr
@@ -99,7 +101,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DENABLE_AUTOAR=OFF"
     "-DENABLE_LIBCRYPTUI=OFF"
-    "-DENABLE_PST_IMPORT=OFF"
     "-DENABLE_YTNEF=OFF"
     "-DWITH_SPAMASSASSIN=${spamassassin}/bin/spamassassin"
     "-DWITH_SA_LEARN=${spamassassin}/bin/sa-learn"

--- a/pkgs/development/libraries/libpst/default.nix
+++ b/pkgs/development/libraries/libpst/default.nix
@@ -1,5 +1,15 @@
-{ lib, stdenv, fetchurl, autoreconfHook, boost, libgsf,
-  pkg-config, bzip2, xmlto, gettext, imagemagick, doxygen }:
+{ lib
+, stdenv
+, fetchurl
+, autoreconfHook
+, pkg-config
+, bzip2
+, doxygen
+, gettext
+, imagemagick
+, libgsf
+, xmlto
+}:
 
 stdenv.mkDerivation rec {
   name = "libpst-0.6.75";
@@ -9,14 +19,24 @@ stdenv.mkDerivation rec {
     sha256 = "11wrf47i3brlxg25wsfz17373q7m5fpjxn2lr41dj252ignqzaac";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    doxygen
+    gettext
+    xmlto
+  ];
+
   buildInputs = [
-    boost libgsf bzip2
-    xmlto gettext imagemagick doxygen
+    bzip2
+    imagemagick
+    libgsf
   ];
 
   configureFlags = [
     "--enable-python=no"
+    "--disable-static"
+    "--enable-libpst-shared"
   ];
 
   doCheck = true;
@@ -24,8 +44,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.five-ten-sg.com/libpst/";
     description = "A library to read PST (MS Outlook Personal Folders) files";
-    license = licenses.gpl2;
-    maintainers = [maintainers.tohl];
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.tohl ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to import outlook email .pst files into evolution mail.

###### Things done
Build libpst shared, add it to evolution buildInputs
```term
$ nix path-info -S evolution-old/
/nix/store/8p3ii0dwbsrx6dxrba1zzkh6mp1mi9gl-evolution-3.38.4	 1199130256
$ nix path-info -S evolution-new/
/nix/store/f11sln8v1zgc5z79f5mbj4wg3ksjxfp4-evolution-3.38.4	 1202443944
```
```term
$ nix path-info -S libpst-old/
/nix/store/1krnd7jmj84cyzcvb3wkncss1hiwn1j8-libpst-0.6.75	   67126848
$ nix path-info -S libpst-new/
/nix/store/ynvizdy0r3f3b1q1j33mmcfkk2l0vv51-libpst-0.6.75	   66852816
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
