### PR TITLE
tanka: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/applications/networking/cluster/tanka/default.nix
+++ b/pkgs/applications/networking/cluster/tanka/default.nix
@@ -2,20 +2,22 @@
 
 buildGoModule rec {
   pname = "tanka";
-  version = "0.14.0";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-y2HhtYKgC9Y397dZ14eQoPZxqS1fTOXVD8B4wdLIHzM=";
+    sha256 = "sha256-ckXvDB3TU9HAXowAAr/fRmX3mylVvPKW8I74R/vUaRY=";
   };
 
   vendorSha256 = "sha256-vpm2y/CxRNWkz6+AOMmmZH5AjRQWAa6WD5Fnx5lqJYw=";
 
   doCheck = false;
 
-  buildFlagsArray = [ "-ldflags=-s -w -X main.Version=${version}" ];
+  subPackages = [ "cmd/tk" ];
+
+  buildFlagsArray = [ "-ldflags=-s -w -extldflags \"-static\" -X github.com/grafana/tanka/pkg/tanka.CURRENT_VERSION=v${version}" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -26,7 +28,7 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "Flexible, reusable and concise configuration for Kubernetes";
-    homepage = "https://github.com/grafana/tanka/";
+    homepage = "https://tanka.dev";
     license = licenses.asl20;
     maintainers = with maintainers; [ mikefaille ];
     platforms = platforms.unix;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updating Tanka to the latest release.

Also fixing the issue where `tk --version` would print `dev` instead of the version string.
This is fixed by adding the `subPackage` attribute and additional ldflags arguments to `buildFlagsArray`.
The ldflags arguments were copied from the Makefile in the Tanka repository.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
