### PR TITLE
lzwolf: init at 20220104

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9469,6 +9469,12 @@
     githubId = 378734;
     name = "TG ⊗ Θ";
   };
+  tgunnoe = {
+    email = "t@gvno.net";
+    github = "tgunnoe";
+    githubId = 7254833;
+    name = "Taylor Gunnoe";
+  };
   th0rgal = {
     email = "thomas.marchand@tuta.io";
     github = "Th0rgal";

--- a/pkgs/games/lzwolf/default.nix
+++ b/pkgs/games/lzwolf/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, lib, fetchFromBitbucket, p7zip, cmake
+, SDL2, bzip2, zlib, libjpeg
+, libsndfile, mpg123
+, SDL2_net, SDL2_mixer }:
+
+stdenv.mkDerivation rec {
+  pname = "lzwolf";
+  version = "unstable-2022-01-04";
+
+  src = fetchFromBitbucket {
+    owner = "linuxwolf6";
+    repo = "lzwolf";
+    rev = "6e470316382b87378966f441e233760ce0ff478c";
+    sha256 = "sha256-IbZleY2FPyW3ORIGO2YFXQyAf1l9nDthpJjEKTTsilM=";
+  };
+  nativeBuildInputs = [ p7zip cmake ];
+  buildInputs = [
+    SDL2 bzip2 zlib libjpeg SDL2_mixer SDL2_net libsndfile mpg123
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DGPL=ON"
+  ];
+
+  doCheck = true;
+
+  installPhase = ''
+    install -Dm755 lzwolf "$out/lib/lzwolf/lzwolf"
+    for i in *.pk3; do
+      install -Dm644 "$i" "$out/lib/lzwolf/$i"
+    done
+    mkdir -p $out/bin
+    ln -s $out/lib/lzwolf/lzwolf $out/bin/lzwolf
+  '';
+
+  meta = with lib; {
+    homepage = "https://bitbucket.org/linuxwolf6/lzwolf";
+    description = "Enhanced fork of ECWolf, a Wolfenstein 3D source port";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ tgunnoe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6276,6 +6276,8 @@ in
 
   lzop = callPackage ../tools/compression/lzop { };
 
+  lzwolf = callPackage ../games/lzwolf { };
+
   macchanger = callPackage ../os-specific/linux/macchanger { };
 
   madlang = haskell.lib.justStaticExecutables haskellPackages.madlang;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
No Wolfenstein 3D source port exists in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
