### PR TITLE
compsize: use upstream's installer

### DIFF
--- a/pkgs/os-specific/linux/compsize/default.nix
+++ b/pkgs/os-specific/linux/compsize/default.nix
@@ -13,18 +13,19 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ btrfs-progs ];
 
-  installPhase = ''
-    mkdir -p $out/bin
+  installFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  preInstall = ''
     mkdir -p $out/share/man/man8
-    install -m 0755 compsize $out/bin
-    install -m 0444 compsize.8 $out/share/man/man8
   '';
 
   meta = with lib; {
     description = "btrfs: Find compression type/ratio on a file or set of files";
-    homepage    = "https://github.com/kilobyte/compsize";
-    license     = licenses.gpl2Plus;
+    homepage = "https://github.com/kilobyte/compsize";
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ CrazedProgrammer ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Drive-by cleanup - uses `install` from the Makefile instead of rolling our own.

Cc: @CrazedProgrammer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
