### PR TITLE
sqlx-cli: fix darwin build

### DIFF
--- a/pkgs/development/tools/rust/sqlx-cli/default.nix
+++ b/pkgs/development/tools/rust/sqlx-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, darwin }:
+{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, SystemConfiguration. CoreFoundation, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "sqlx-cli";

--- a/pkgs/development/tools/rust/sqlx-cli/default.nix
+++ b/pkgs/development/tools/rust/sqlx-cli/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl }:
+{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, darwin }:
 
 rustPlatform.buildRustPackage rec {
   pname = "sqlx-cli";
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = [ "-p sqlx-cli" ];
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks;
+    [ SystemConfiguration CoreFoundation Security ]);
 
   meta = with lib; {
     description =

--- a/pkgs/development/tools/rust/sqlx-cli/default.nix
+++ b/pkgs/development/tools/rust/sqlx-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, SystemConfiguration. CoreFoundation, Security }:
+{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, SystemConfiguration, CoreFoundation, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "sqlx-cli";
@@ -17,8 +17,7 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = [ "-p sqlx-cli" ];
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks;
-    [ SystemConfiguration CoreFoundation Security ]);
+  buildInputs = (lib.optional stdenv.isLinux openssl) ++ lib.optionals stdenv.isDarwin [ SystemConfiguration CoreFoundation Security ];
 
   meta = with lib; {
     description =

--- a/pkgs/development/tools/rust/sqlx-cli/default.nix
+++ b/pkgs/development/tools/rust/sqlx-cli/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = [ "-p sqlx-cli" ];
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = (lib.optional stdenv.isLinux openssl) ++ lib.optionals stdenv.isDarwin [ SystemConfiguration CoreFoundation Security ];
+  buildInputs = lib.optionals stdenv.isLinux [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ SystemConfiguration CoreFoundation Security ];
 
   meta = with lib; {
     description =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11206,7 +11206,7 @@ in
     jdk = oraclejdk;
   };
 
-  sqlx-cli = callPackage ../development/tools/rust/sqlx-cli { 
+  sqlx-cli = callPackage ../development/tools/rust/sqlx-cli {
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration CoreFoundation Security;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11206,7 +11206,9 @@ in
     jdk = oraclejdk;
   };
 
-  sqlx-cli = callPackage ../development/tools/rust/sqlx-cli { };
+  sqlx-cli = callPackage ../development/tools/rust/sqlx-cli { 
+    inherit (darwin.apple_sdk.frameworks) SystemConfiguration CoreFoundation Security;
+  };
 
   squeak = callPackage ../development/compilers/squeak { };
 


### PR DESCRIPTION
###### Motivation for this change

build is broken on darwin

###### Things done

just added missing frameworks

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
