### PR TITLE
koka: init at 2.1.1

### DIFF
--- a/pkgs/development/compilers/koka/default.nix
+++ b/pkgs/development/compilers/koka/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, buildPackages, cmake, gnumake, makeWrapper, mkDerivation, fetchFromGitHub
+, alex, array, base, bytestring, cond, containers, directory, extra
+, filepath, haskeline, hpack, hspec, hspec-core, json, lib, mtl
+, parsec, process, regex-compat, text, time }:
+
+let
+  version = "2.1.1";
+  src = fetchFromGitHub {
+    owner = "koka-lang";
+    repo = "koka";
+    rev = "v${version}";
+    sha256 = "sha256-cq+dljfTKJh5NgwQfxQQP9jRcg2PQxxBVEgQ59ll36o=";
+    fetchSubmodules = true;
+  };
+  kklib = stdenv.mkDerivation {
+    pname = "kklib";
+    inherit version;
+    src = "${src}/kklib";
+    nativeBuildInputs = [ cmake ];
+  };
+  runtimeDeps = [
+    buildPackages.stdenv.cc
+    buildPackages.stdenv.cc.bintools.bintools
+    gnumake
+    cmake
+  ];
+in
+mkDerivation rec {
+  pname = "koka";
+  inherit version src;
+  isLibrary = false;
+  isExecutable = true;
+  libraryToolDepends = [ hpack ];
+  executableHaskellDepends = [
+    array base bytestring cond containers directory haskeline mtl
+    parsec process text time kklib
+  ];
+  executableToolDepends = [ alex makeWrapper ];
+  postInstall = ''
+    mkdir -p $out/share/koka/v${version}
+    cp -a lib $out/share/koka/v${version}
+    cp -a contrib $out/share/koka/v${version}
+    cp -a kklib $out/share/koka/v${version}
+    wrapProgram "$out/bin/koka" \
+      --set CC "${lib.getBin buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc" \
+      --prefix PATH : "${lib.makeSearchPath "bin" runtimeDeps}"
+  '';
+  doCheck = false;
+  prePatch = "hpack";
+  description = "Koka language compiler and interpreter";
+  homepage = "https://github.com/koka-lang/koka";
+  license = lib.licenses.asl20;
+  maintainers = with lib.maintainers; [ siraben sternenseemann ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10590,6 +10590,8 @@ in
 
   knightos-z80e = callPackage ../development/tools/knightos/z80e { };
 
+  koka = haskellPackages.callPackage ../development/compilers/koka { };
+
   kotlin = callPackage ../development/compilers/kotlin { };
 
   lazarus = callPackage ../development/compilers/fpc/lazarus.nix {


### PR DESCRIPTION
###### Motivation for this change
Add Koka compiler https://github.com/koka-lang/koka

```ShellSession
$ koka /tmp/koka/samples/basic/caesar.kk 
compile: /tmp/koka/samples/basic/caesar.kk
loading: std/core
loading: std/core/types
loading: std/core/hnd
loading: std/num/double
loading: std/text/parse
loading: std/num/int32
check  : tmp/koka/samples/basic/caesar
linking: tmp_koka_samples_basic_caesar
created: out/v2.1.1/clang-debug/tmp_koka_samples_basic_caesar
 
plain  : Koka is a well-typed language
encoded: Krnd lv d zhoo-wbshg odqjxdjh
cracked: Koka is a well-typed language
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
