### PR TITLE
treewide: use stdenvNoCC when not building

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -241,7 +241,7 @@ in
       {
         etc."fish/generated_completions".source =
         let
-          patchedGenerator = pkgs.stdenv.mkDerivation {
+          patchedGenerator = pkgs.stdenvNoCC.mkDerivation {
             name = "fish_patched-completion-generator";
             srcs = [
               "${pkgs.fish}/share/fish/tools/create_manpage_completions.py"

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -168,7 +168,7 @@ let
     MALLOC_ARENA_MAX = "2";
   } // cfg.extraEnv;
 
-  gitlab-rake = pkgs.stdenv.mkDerivation {
+  gitlab-rake = pkgs.stdenvNoCC.mkDerivation {
     name = "gitlab-rake";
     buildInputs = [ pkgs.makeWrapper ];
     dontBuild = true;
@@ -183,7 +183,7 @@ let
      '';
   };
 
-  gitlab-rails = pkgs.stdenv.mkDerivation {
+  gitlab-rails = pkgs.stdenvNoCC.mkDerivation {
     name = "gitlab-rails";
     buildInputs = [ pkgs.makeWrapper ];
     dontBuild = true;

--- a/pkgs/applications/audio/clerk/default.nix
+++ b/pkgs/applications/audio/clerk/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , makeWrapper
 , rofi
@@ -10,7 +10,7 @@
 , libnotify
 }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "clerk";
   version = "unstable-2016-10-14";
 

--- a/pkgs/applications/audio/ocenaudio/default.nix
+++ b/pkgs/applications/audio/ocenaudio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenvNoCC
 , lib
 , fetchurl
 , autoPatchelfHook
@@ -9,7 +9,7 @@
 , bzip2
 , libpulseaudio }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "ocenaudio";
   version = "3.11.2";
 

--- a/pkgs/applications/audio/real_time_config_quick_scan/default.nix
+++ b/pkgs/applications/audio/real_time_config_quick_scan/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, perlPackages, makeWrapper }:
+{ lib, stdenvNoCC, fetchFromGitHub, perlPackages, makeWrapper }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "realTimeConfigQuickScan";
   version = "unstable-2020-07-23";
 

--- a/pkgs/applications/audio/redoflacs/default.nix
+++ b/pkgs/applications/audio/redoflacs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenvNoCC
 , lib
 , fetchFromGitHub
 , makeWrapper
@@ -7,7 +7,7 @@
 , sox
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "redoflacs";
   version = "0.30.20190903";
 

--- a/pkgs/applications/audio/split2flac/default.nix
+++ b/pkgs/applications/audio/split2flac/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper
 , shntool, cuetools
 , flac, faac, mp4v2, wavpack, mac
 , imagemagick, libiconv, enca, lame, pythonPackages, vorbis-tools
@@ -17,7 +17,7 @@ let
       ]}
   '';
 
-in stdenv.mkDerivation rec {
+in stdenvNoCC.mkDerivation rec {
   pname = "split2flac";
   version = "122";
 

--- a/pkgs/applications/blockchains/exodus/default.nix
+++ b/pkgs/applications/blockchains/exodus/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, fetchurl, unzip, glib, systemd, nss, nspr, gtk3-x11, pango,
+{ stdenvNoCC, lib, fetchurl, unzip, glib, systemd, nss, nspr, gtk3-x11, pango,
 atk, cairo, gdk-pixbuf, xorg, xorg_sys_opengl, util-linux, alsa-lib, dbus, at-spi2-atk,
 cups, vivaldi-ffmpeg-codecs, libpulseaudio, at-spi2-core, libxkbcommon, mesa }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "exodus";
   version = "21.10.25";
 

--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, rpmextract, autoPatchelfHook, wrapGAppsHook
+{ stdenvNoCC, lib, fetchurl, rpmextract, autoPatchelfHook, wrapGAppsHook
 
 # Dynamic libraries
 , alsa-lib, atk, at-spi2-atk, at-spi2-core, cairo, dbus, cups, expat
@@ -9,7 +9,7 @@
 , systemd
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "drawio";
   version = "16.1.2";
 

--- a/pkgs/applications/graphics/yed/default.nix
+++ b/pkgs/applications/graphics/yed/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchzip, makeWrapper, unzip, jre, wrapGAppsHook }:
+{ lib, stdenvNoCC, fetchzip, makeWrapper, unzip, jre, wrapGAppsHook }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "yEd";
   version = "3.21.1";
 

--- a/pkgs/applications/misc/koreader/default.nix
+++ b/pkgs/applications/misc/koreader/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv
+{ lib, stdenvNoCC
 , fetchurl
 , makeWrapper
 , dpkg
@@ -11,7 +11,7 @@
 , noto-fonts
 , nerdfonts }:
 let font-droid = nerdfonts.override { fonts = [ "DroidSansMono" ]; };
-in stdenv.mkDerivation rec {
+in stdenvNoCC.mkDerivation rec {
   pname = "koreader";
   version = "2021.12.1";
 

--- a/pkgs/applications/misc/pell/default.nix
+++ b/pkgs/applications/misc/pell/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, scsh, sox, libnotify }:
+{ lib, stdenvNoCC, fetchFromGitHub, scsh, sox, libnotify }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "pell";
   version = "0.0.4";
 

--- a/pkgs/applications/misc/xmind/default.nix
+++ b/pkgs/applications/misc/xmind/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchzip, fetchurl, gtk2, jre, libXtst, makeWrapper, makeDesktopItem, runtimeShell }:
+{ stdenvNoCC, lib, fetchzip, fetchurl, gtk2, jre, libXtst, makeWrapper, makeDesktopItem, runtimeShell }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "xmind";
   version = "8-update8";
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = let
-    targetDir = if stdenv.hostPlatform.system == "i686-linux"
+    targetDir = if stdenvNoCC.hostPlatform.system == "i686-linux"
       then "XMind_i386"
       else "XMind_amd64";
   in ''
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     cp "${desktopItem}/share/applications/XMind.desktop" $out/share/applications/XMind.desktop
     cp ${srcIcon} $out/share/icons/hicolor/scalable/apps/xmind.png
 
-    patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+    patchelf --set-interpreter $(cat ${stdenvNoCC.cc}/nix-support/dynamic-linker) \
       $out/libexec/XMind
 
     wrapProgram $out/libexec/XMind \

--- a/pkgs/applications/science/biology/macse/default.nix
+++ b/pkgs/applications/science/biology/macse/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, jre, makeWrapper }:
+{ lib, stdenvNoCC, fetchurl, jre, makeWrapper }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "macse";
   version = "2.03";
 

--- a/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
@@ -1,6 +1,6 @@
-{lib, stdenv, git, perl, ncurses, coreutils, fetchFromGitHub, makeWrapper, ...}:
+{lib, stdenvNoCC, git, perl, ncurses, coreutils, fetchFromGitHub, makeWrapper }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "diff-so-fancy";
   version = "1.4.3";
 

--- a/pkgs/applications/version-management/git-and-tools/git-extras/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-extras/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, unixtools, which }:
+{ lib, stdenvNoCC, fetchFromGitHub, unixtools, which }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "git-extras";
   version = "6.3.0";
 

--- a/pkgs/applications/version-management/git-and-tools/git-my/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-my/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "git-my";
   version = "1.1.2";
 

--- a/pkgs/applications/version-management/git-and-tools/git-radar/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-radar/default.nix
@@ -1,6 +1,6 @@
-{lib, stdenv, fetchFromGitHub}:
+{lib, stdenvNoCC, fetchFromGitHub}:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "git-radar";
   version = "0.6";
 

--- a/pkgs/applications/version-management/git-and-tools/git-reparent/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-reparent/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, git, gnused }:
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, git, gnused }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "git-reparent";
   version = "unstable-2017-09-03";
 

--- a/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, git, coreutils }:
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, git, coreutils }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "git-secrets";
   version = "1.3.0";
 

--- a/pkgs/applications/version-management/git-and-tools/git-standup/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-standup/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, git }:
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, git }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "git-standup";
   version = "2.3.2";
 

--- a/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, coreutils, git, gnugrep, gnused, makeWrapper, inotify-tools }:
+{ lib, stdenvNoCC, fetchFromGitHub, coreutils, git, gnugrep, gnused, makeWrapper, inotify-tools }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "git-sync";
   version = "unstable-2021-07-14";
 

--- a/pkgs/applications/version-management/git-and-tools/git-test/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-test/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, git }:
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, git }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "git-test";
   version = "1.0.4";
 

--- a/pkgs/applications/version-management/git-and-tools/svn2git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/svn2git/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, ruby, makeWrapper, git }:
+{ lib, stdenvNoCC, fetchFromGitHub, ruby, makeWrapper, git }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "svn2git";
   version = "2.4.0";
 
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ ruby makeWrapper ];
-
-  dontBuild = true;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/applications/version-management/gitolite/default.nix
+++ b/pkgs/applications/version-management/gitolite/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, git, lib, makeWrapper, nettools, perl, perlPackages }:
+{ stdenvNoCC, fetchFromGitHub, git, lib, makeWrapper, nettools, perl, perlPackages }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gitolite";
   version = "3.6.12";
 

--- a/pkgs/applications/version-management/yadm/default.nix
+++ b/pkgs/applications/version-management/yadm/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, git, gnupg, installShellFiles }:
+{ lib, stdenvNoCC, fetchFromGitHub, git, gnupg, installShellFiles }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "yadm";
   version = "3.1.1";
 

--- a/pkgs/applications/video/freetube/default.nix
+++ b/pkgs/applications/video/freetube/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchurl, appimageTools, makeWrapper, electron }:
+{ stdenvNoCC, lib, fetchurl, appimageTools, makeWrapper, electron }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "freetube";
   version = "0.15.1";
 

--- a/pkgs/applications/video/streamlink-twitch-gui/bin.nix
+++ b/pkgs/applications/video/streamlink-twitch-gui/bin.nix
@@ -3,7 +3,7 @@
 , lib
 , makeDesktopItem
 , makeWrapper
-, stdenv
+, stdenvNoCC
 , wrapGAppsHook
 , at-spi2-core
 , atk
@@ -30,14 +30,14 @@ let
   runtimeLibs = lib.makeLibraryPath [ libudev0-shim ];
   runtimeBins = lib.makeBinPath [ streamlink ];
   arch =
-    if stdenv.hostPlatform.system == "x86_64-linux"
+    if stdenvNoCC.hostPlatform.system == "x86_64-linux"
     then
       "linux64"
     else
       "linux32";
 
 in
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "${basename}-bin";
   version = "1.11.0";
 

--- a/pkgs/applications/window-managers/i3/layout-manager.nix
+++ b/pkgs/applications/window-managers/i3/layout-manager.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, vim, makeWrapper, jq, rofi, xrandr, xdotool, i3, gawk, libnotify }:
+{ lib, stdenvNoCC, fetchFromGitHub, vim, makeWrapper, jq, rofi, xrandr, xdotool, i3, gawk, libnotify }:
 
 let
   path = lib.makeBinPath [ vim jq rofi xrandr xdotool i3 gawk libnotify ];
 in
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "i3-layout-manager";
   version = "unstable-2020-05-04";
 

--- a/pkgs/applications/window-managers/sway/contrib.nix
+++ b/pkgs/applications/window-managers/sway/contrib.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv
+{ lib, stdenvNoCC
 
 , fetchurl
 , coreutils
@@ -16,7 +16,7 @@
 
 {
 
-grimshot = stdenv.mkDerivation rec {
+grimshot = stdenvNoCC.mkDerivation rec {
   pname = "grimshot";
   version = sway-unwrapped.version;
 

--- a/pkgs/data/documentation/mustache-spec/default.nix
+++ b/pkgs/data/documentation/mustache-spec/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenvNoCC, lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "mustache-spec";
   version = "1.0.2";
 

--- a/pkgs/data/documentation/scheme-manpages/default.nix
+++ b/pkgs/data/documentation/scheme-manpages/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "scheme-manpages-unstable";
   version = "2021-03-11";
 

--- a/pkgs/data/fonts/profont/default.nix
+++ b/pkgs/data/fonts/profont/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchzip, mkfontscale }:
+{ lib, stdenvNoCC, fetchzip, mkfontscale }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "profont";
   version = "2019-11";
 

--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -1,9 +1,9 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchurl
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "twemoji-color-font";
   version = "13.1.0";
 

--- a/pkgs/data/misc/wireless-regdb/default.nix
+++ b/pkgs/data/misc/wireless-regdb/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "wireless-regdb";
   version = "2021.08.28";
 

--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, substituteAll, fetchurl, fetchpatch, findXMLCatalogs, writeScriptBin, ruby, bash }:
+{ lib, stdenvNoCC, substituteAll, fetchurl, fetchpatch, findXMLCatalogs, writeScriptBin, ruby, bash }:
 
 let
 
   common = { pname, sha256, suffix ? "" }: let
     legacySuffix = if suffix == "-nons" then "" else "-ns";
-    self = stdenv.mkDerivation rec {
+    self = stdenvNoCC.mkDerivation rec {
       inherit pname;
       version = "1.79.2";
 

--- a/pkgs/data/themes/albatross/default.nix
+++ b/pkgs/data/themes/albatross/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "Albatross";
   version = "1.7.4";
 

--- a/pkgs/data/themes/cdetheme/default.nix
+++ b/pkgs/data/themes/cdetheme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, python2Packages }:
+{ lib, stdenvNoCC, fetchFromGitHub, python2Packages }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "cdetheme";
   version = "1.3";
 

--- a/pkgs/data/themes/clearlooks-phenix/default.nix
+++ b/pkgs/data/themes/clearlooks-phenix/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   version = "7.0.1";
   pname = "clearlooks-phenix";
 

--- a/pkgs/data/themes/equilux-theme/default.nix
+++ b/pkgs/data/themes/equilux-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gnome, glib, libxml2, gtk-engine-murrine, gdk-pixbuf, librsvg, bc }:
+{ lib, stdenvNoCC, fetchFromGitHub, gnome, glib, libxml2, gtk-engine-murrine, gdk-pixbuf, librsvg, bc }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "equilux-theme";
   version = "20181029";
 

--- a/pkgs/data/themes/marwaita-manjaro/default.nix
+++ b/pkgs/data/themes/marwaita-manjaro/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , gdk-pixbuf
 , gtk-engine-murrine
@@ -7,7 +7,7 @@
 , librsvg
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "marwaita-manjaro";
   version = "10.3";
 

--- a/pkgs/data/themes/marwaita-peppermint/default.nix
+++ b/pkgs/data/themes/marwaita-peppermint/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , gdk-pixbuf
 , gtk-engine-murrine
@@ -7,7 +7,7 @@
 , librsvg
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "marwaita-peppermint";
   version = "10.3";
 

--- a/pkgs/data/themes/marwaita-pop_os/default.nix
+++ b/pkgs/data/themes/marwaita-pop_os/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , gdk-pixbuf
 , gtk-engine-murrine
@@ -7,7 +7,7 @@
 , librsvg
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "marwaita-pop_os";
   version = "10.3";
 

--- a/pkgs/data/themes/marwaita-ubuntu/default.nix
+++ b/pkgs/data/themes/marwaita-ubuntu/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv
+{ lib, stdenvNoCC
 , fetchFromGitHub
 , gdk-pixbuf
 , gtk-engine-murrine
@@ -6,7 +6,7 @@
 , librsvg
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "marwaita-ubuntu";
   version = "1.7";
 

--- a/pkgs/data/themes/marwaita/default.nix
+++ b/pkgs/data/themes/marwaita/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , gdk-pixbuf
 , gtk-engine-murrine
@@ -7,7 +7,7 @@
 , librsvg
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "marwaita";
   version = "12.0";
 

--- a/pkgs/data/themes/materia-theme/default.nix
+++ b/pkgs/data/themes/materia-theme/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , meson
 , ninja
@@ -10,7 +10,7 @@
 , librsvg
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "materia-theme";
   version = "20210322";
 

--- a/pkgs/data/themes/numix-sx/default.nix
+++ b/pkgs/data/themes/numix-sx/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, gtk-engine-murrine }:
+{ lib, stdenvNoCC, fetchurl, gtk-engine-murrine }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   version = "2017-04-24";
   pname = "numix-sx-gtk-theme";
 

--- a/pkgs/data/themes/skeu/default.nix
+++ b/pkgs/data/themes/skeu/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv
+{ lib, stdenvNoCC
 , fetchFromGitHub
 , gdk-pixbuf
 , gtk-engine-murrine
@@ -6,7 +6,7 @@
 , librsvg
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "skeu";
   version = "0.5.1";
 

--- a/pkgs/data/themes/venta/default.nix
+++ b/pkgs/data/themes/venta/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , gdk-pixbuf
 , gtk-engine-murrine
@@ -7,7 +7,7 @@
 , librsvg
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "venta";
   version = "0.7.1";
 

--- a/pkgs/desktops/gnome/extensions/paperwm/default.nix
+++ b/pkgs/desktops/gnome/extensions/paperwm/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gnome-shell-extension-paperwm";
   version = "38.1";
 

--- a/pkgs/desktops/gnome/extensions/pidgin-im-integration/default.nix
+++ b/pkgs/desktops/gnome/extensions/pidgin-im-integration/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, glib, gnome }:
+{ lib, stdenvNoCC, fetchFromGitHub, glib, gnome }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gnome-shell-extension-pidgin-im-integration";
   version = "32";
 

--- a/pkgs/desktops/gnome/extensions/sound-output-device-chooser/default.nix
+++ b/pkgs/desktops/gnome/extensions/sound-output-device-chooser/default.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv
+{ lib, stdenvNoCC
 , substituteAll
 , fetchFromGitHub
 , libpulseaudio
 , python3
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gnome-shell-extension-sound-output-device-chooser";
   version = "39";
 

--- a/pkgs/desktops/gnome/extensions/window-corner-preview/default.nix
+++ b/pkgs/desktops/gnome/extensions/window-corner-preview/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gnome }:
+{ lib, stdenvNoCC, fetchFromGitHub, gnome }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gnome-shell-extension-window-corner-preview";
   version = "unstable-2019-04-03";
 

--- a/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
@@ -1,7 +1,7 @@
 { wrapGAppsHook
 , glib
 , lib
-, stdenv
+, stdenvNoCC
 , xorg
 , switchboard
 , switchboardPlugs
@@ -18,7 +18,7 @@ let
 
   testingName = lib.optionalString (testName != null) "${testName}-";
 in
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   name = "${testingName}${switchboard.name}-with-plugs";
 
   src = null;

--- a/pkgs/games/dxx-rebirth/assets.nix
+++ b/pkgs/games/dxx-rebirth/assets.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv, requireFile, gogUnpackHook }:
+{ lib, stdenvNoCC, requireFile, gogUnpackHook }:
 
 let
   generic = ver: source: let
     pname = "descent${toString ver}";
-  in stdenv.mkDerivation rec {
+  in stdenvNoCC.mkDerivation rec {
     name = "${pname}-assets-${version}";
     version = "2.0.0.7";
 

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, makeDesktopItem
+{ lib, stdenvNoCC, fetchurl, makeWrapper, makeDesktopItem
 , alsa-lib, libpulseaudio, libX11, libXcursor, libXinerama, libXrandr, libXi, libGL
 , libSM, libICE, libXext, factorio-utils
 , releaseType
@@ -64,7 +64,7 @@ let
   versions = importJSON ./versions.json;
   binDists = makeBinDists versions;
 
-  actual = binDists.${stdenv.hostPlatform.system}.${releaseType}.${branch} or (throw "Factorio ${releaseType}-${branch} binaries for ${stdenv.hostPlatform.system} are not available for download.");
+  actual = binDists.${stdenvNoCC.hostPlatform.system}.${releaseType}.${branch} or (throw "Factorio ${releaseType}-${branch} binaries for ${stdenvNoCC.hostPlatform.system} are not available for download.");
 
   makeBinDists = versions:
     let f = path: name: value:
@@ -242,4 +242,4 @@ let
     };
   };
 
-in stdenv.mkDerivation (releases.${releaseType})
+in stdenvNoCC.mkDerivation (releases.${releaseType})

--- a/pkgs/games/scummvm/games.nix
+++ b/pkgs/games/scummvm/games.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeDesktopItem, unzip, writeText
+{ stdenvNoCC, lib, fetchurl, makeDesktopItem, unzip, writeText
 , scummvm, runtimeShell }:
 
 let
@@ -25,7 +25,7 @@ let
     let
       attrs' = builtins.removeAttrs attrs [ "plong" "pshort" "pcode" "description" "docs" "files" "version" ];
       pname = lib.replaceStrings [ " " ":" ] [ "-" "" ] (lib.toLower plong);
-    in stdenv.mkDerivation ({
+    in stdenvNoCC.mkDerivation ({
       name = "${pname}-${version}";
 
       nativeBuildInputs = [ unzip ];

--- a/pkgs/games/steam/steamcmd.nix
+++ b/pkgs/games/steam/steamcmd.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchurl, steam-run, bash, coreutils
+{ lib, stdenvNoCC, fetchurl, steam-run, bash, coreutils
 , steamRoot ? "~/.local/share/Steam"
 }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "steamcmd";
   version = "20180104"; # According to steamcmd_linux.tar.gz mtime
 

--- a/pkgs/servers/grocy/default.nix
+++ b/pkgs/servers/grocy/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, unzip, nixosTests }:
+{ lib, stdenvNoCC, fetchurl, unzip, nixosTests }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "grocy";
   version = "3.1.3";
 

--- a/pkgs/servers/http/jetty/default.nix
+++ b/pkgs/servers/http/jetty/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "jetty";
   version = "9.4.43.v20210629";
   src = fetchurl {

--- a/pkgs/servers/jicofo/default.nix
+++ b/pkgs/servers/jicofo/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, dpkg, jre_headless, nixosTests }:
+{ lib, stdenvNoCC, fetchurl, dpkg, jre_headless, nixosTests }:
 
 let
   pname = "jicofo";
@@ -8,7 +8,7 @@ let
     sha256 = "MVlGD2l0e1a2AtYPU1fkBoEfdPhjf2nOehAcacQl4Jk=";
   };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   inherit pname version src;
 
   dontBuild = true;

--- a/pkgs/servers/jitsi-videobridge/default.nix
+++ b/pkgs/servers/jitsi-videobridge/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, dpkg, jre_headless, nixosTests }:
+{ lib, stdenvNoCC, fetchurl, makeWrapper, dpkg, jre_headless, nixosTests }:
 
 let
   pname = "jitsi-videobridge2";
@@ -8,7 +8,7 @@ let
     sha256 = "0SLaCIjMN2/+Iushyz8OQpRHHBYVqn6+DpwNGbQEzy4=";
   };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   inherit pname version src;
 
   dontBuild = true;

--- a/pkgs/servers/monitoring/icinga2/default.nix
+++ b/pkgs/servers/monitoring/icinga2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, lib, fetchFromGitHub, fetchpatch, cmake, flex, bison, systemd
+{ stdenv, stdenvNoCC, runCommand, lib, fetchFromGitHub, fetchpatch, cmake, flex, bison, systemd
 , boost, openssl, patchelf, mariadb-connector-c, postgresql, zlib, tzdata
 # Databases
 , withMysql ? true, withPostgresql ? false

--- a/pkgs/servers/monitoring/longview/default.nix
+++ b/pkgs/servers/monitoring/longview/default.nix
@@ -1,6 +1,6 @@
-{lib, stdenv, fetchFromGitHub, perl, perlPackages, makeWrapper, glibc }:
+{lib, stdenvNoCC, fetchFromGitHub, perl, perlPackages, makeWrapper, glibc }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   version = "1.1.5";
   pname = "longview";
 

--- a/pkgs/servers/monitoring/plugins/wmic-bin.nix
+++ b/pkgs/servers/monitoring/plugins/wmic-bin.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, autoPatchelfHook, popt }:
+{ stdenvNoCC, lib, fetchFromGitHub, autoPatchelfHook, popt }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "wmic-bin";
   version = "0.5.0";
 

--- a/pkgs/servers/monitoring/plugins/wmiplus/default.nix
+++ b/pkgs/servers/monitoring/plugins/wmiplus/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, perlPackages, txt2man
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, perlPackages, txt2man
 , monitoring-plugins
 , wmic-bin ? null }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "check-wmiplus";
   version = "1.65";
 

--- a/pkgs/servers/monitoring/prometheus/knot-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/knot-exporter.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, lib, python3, nixosTests }:
+{ stdenvNoCC, fetchFromGitHub, lib, python3, nixosTests }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "knot-exporter";
   version = "unstable-2021-08-21";
 

--- a/pkgs/servers/pulseaudio/hsphfpd.nix
+++ b/pkgs/servers/pulseaudio/hsphfpd.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, perlPackages }:
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, perlPackages }:
 
 let
   perlLibs = with perlPackages; [ NetDBus XMLTwig XMLParser ];
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "hsphfpd";
   version = "2020-12-05";
 

--- a/pkgs/servers/roundcube/default.nix
+++ b/pkgs/servers/roundcube/default.nix
@@ -1,6 +1,6 @@
-{ fetchurl, lib, stdenv, buildEnv, roundcube, roundcubePlugins }:
+{ fetchurl, lib, stdenvNoCC, buildEnv, roundcube, roundcubePlugins }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "roundcube";
   version = "1.5.2";
 

--- a/pkgs/servers/sickbeard/sickgear.nix
+++ b/pkgs/servers/sickbeard/sickgear.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, python3, makeWrapper }:
+{ lib, stdenvNoCC, fetchFromGitHub, python3, makeWrapper }:
 
 let
   pythonEnv = python3.withPackages(ps: with ps; [ cheetah3 ]);
-in stdenv.mkDerivation rec {
+in stdenvNoCC.mkDerivation rec {
   pname = "sickgear";
   version = "0.25.11";
 

--- a/pkgs/servers/tt-rss/theme-feedly/default.nix
+++ b/pkgs/servers/tt-rss/theme-feedly/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "tt-rss-theme-feedly";
   version = "2.8.2";
 

--- a/pkgs/servers/web-apps/discourse/mail_receiver/default.nix
+++ b/pkgs/servers/web-apps/discourse/mail_receiver/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, ruby, makeWrapper, replace }:
+{ stdenvNoCC, lib, fetchFromGitHub, ruby, makeWrapper, replace }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "discourse-mail-receiver";
   version = "4.0.7";
 

--- a/pkgs/servers/web-apps/jitsi-meet/default.nix
+++ b/pkgs/servers/web-apps/jitsi-meet/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, nixosTests }:
+{ lib, stdenvNoCC, fetchurl, nixosTests }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "jitsi-meet";
   version = "1.0.5415";
 

--- a/pkgs/servers/web-apps/wallabag/default.nix
+++ b/pkgs/servers/web-apps/wallabag/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "wallabag";
   version = "2.4.2";
 

--- a/pkgs/servers/web-apps/wiki-js/default.nix
+++ b/pkgs/servers/web-apps/wiki-js/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, lib, nixosTests }:
+{ stdenvNoCC, fetchurl, lib, nixosTests }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "wiki-js";
   version = "2.5.268";
 

--- a/pkgs/shells/zsh/fzf-zsh/default.nix
+++ b/pkgs/shells/zsh/fzf-zsh/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, fzf }:
+{ lib, stdenvNoCC, fetchFromGitHub, fzf }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "fzf-zsh-unstable";
   version = "2019-09-09";
 

--- a/pkgs/shells/zsh/gradle-completion/default.nix
+++ b/pkgs/shells/zsh/gradle-completion/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gradle-completion";
   version = "1.4.1";
 

--- a/pkgs/shells/zsh/zplug/default.nix
+++ b/pkgs/shells/zsh/zplug/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenvNoCC, lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "zplug";
   version = "2.4.2";
 

--- a/pkgs/shells/zsh/zsh-bd/default.nix
+++ b/pkgs/shells/zsh/zsh-bd/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub}:
+{ lib, stdenvNoCC, fetchFromGitHub}:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "zsh-bd";
   version = "2018-07-04";
 

--- a/pkgs/shells/zsh/zsh-you-should-use/default.nix
+++ b/pkgs/shells/zsh/zsh-you-should-use/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "zsh-you-should-use";
   version = "1.7.3";
 

--- a/pkgs/tools/text/epubcheck/default.nix
+++ b/pkgs/tools/text/epubcheck/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchzip
+{ lib, stdenvNoCC, fetchzip
 , jre, makeWrapper }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "epubcheck";
   version = "4.2.6";
 

--- a/pkgs/tools/text/gpt2tc/default.nix
+++ b/pkgs/tools/text/gpt2tc/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, autoPatchelfHook, python3 }:
+{ lib, stdenvNoCC, fetchurl, autoPatchelfHook, python3 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gpt2tc";
   version = "2021-04-24";
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -D -m755 -t $out/lib libnc${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -D -m755 -t $out/lib libnc${stdenvNoCC.hostPlatform.extensions.sharedLibrary}
     addAutoPatchelfSearchPath $out/lib
     install -D -m755 -t $out/bin gpt2tc
     install -T -m755 download_model.sh $out/bin/gpt2-download-model

--- a/pkgs/tools/text/jsawk/default.nix
+++ b/pkgs/tools/text/jsawk/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, spidermonkey_78 }:
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, spidermonkey_78 }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "jsawk";
   version = "1.5-pre";
   src = fetchFromGitHub {

--- a/pkgs/tools/text/txt2tags/default.nix
+++ b/pkgs/tools/text/txt2tags/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, python }:
+{ lib, stdenvNoCC, fetchurl, python }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   version = "2.6";
   pname = "txt2tags";
 

--- a/pkgs/tools/text/xml/basex/default.nix
+++ b/pkgs/tools/text/xml/basex/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, unzip, jre, coreutils, makeDesktopItem, copyDesktopItems }:
+{ lib, stdenvNoCC, fetchurl, unzip, jre, coreutils, makeDesktopItem, copyDesktopItems }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "basex";
   version = "9.6.3";
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ unzip copyDesktopItems ];
   buildInputs = [ jre ];
 
-  desktopItems = lib.optional (!stdenv.isDarwin) (makeDesktopItem {
+  desktopItems = lib.optional (!stdenvNoCC.isDarwin) (makeDesktopItem {
     name = "basex";
     exec = "basexgui %f";
     icon = "${./basex.svg}"; # icon copied from Ubuntu basex package
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
     # Use substitutions instead of wrapper scripts
     for file in "$out"/bin/*; do
-        sed -i -e "s|/usr/bin/env bash|${stdenv.shell}|" \
+        sed -i -e "s|/usr/bin/env bash|${stdenvNoCC.shell}|" \
                -e "s|java|${jre}/bin/java|" \
                -e "s|readlink|${coreutils}/bin/readlink|" \
                -e "s|dirname|${coreutils}/bin/dirname|" \


### PR DESCRIPTION
###### Motivation for this change
In many packages, the C compiler is not used, so stdenv could be stdenvNoCC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
