### PR TITLE
go-task: rename executable to `task`

### DIFF
--- a/pkgs/development/tools/go-task/default.nix
+++ b/pkgs/development/tools/go-task/default.nix
@@ -21,10 +21,6 @@ buildGoModule rec {
     "-ldflags=-s -w -X main.version=${version}"
   ];
 
-  postInstall = ''
-    mv $out/bin/task $out/bin/go-task
-  '';
-
   meta = with lib; {
     homepage = "https://taskfile.dev/";
     description = "A task runner / simpler Make alternative written in Go";

--- a/pkgs/development/tools/go-task/default.nix
+++ b/pkgs/development/tools/go-task/default.nix
@@ -20,6 +20,10 @@ buildGoModule rec {
   buildFlagsArray = [
     "-ldflags=-s -w -X main.version=${version}"
   ];
+  
+  postInstall = ''
+    ln -s $out/bin/task $out/bin/go-task
+  '';  
 
   meta = with lib; {
     homepage = "https://taskfile.dev/";

--- a/pkgs/development/tools/go-task/default.nix
+++ b/pkgs/development/tools/go-task/default.nix
@@ -20,10 +20,10 @@ buildGoModule rec {
   buildFlagsArray = [
     "-ldflags=-s -w -X main.version=${version}"
   ];
-  
+
   postInstall = ''
     ln -s $out/bin/task $out/bin/go-task
-  '';  
+  '';
 
   meta = with lib; {
     homepage = "https://taskfile.dev/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

As discussed in #116555 the `postInstall` hook renaming the executable to `go-task` is not needed anymore and can be safely removed.

After this commit the `go-task` executable will be available as `task`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tried following the [reviewer docs](https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions) but noticed that a PR is needed. I'm not really sure how to perform most of the actions stated above (given that I'm not using NixOS but `home-manager` on elementary).
