### PR TITLE
sfizz: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/applications/audio/sfizz/default.nix
+++ b/pkgs/applications/audio/sfizz/default.nix
@@ -1,20 +1,49 @@
-{ lib, stdenv, fetchFromGitHub , cmake, libjack2, libsndfile, pkg-config }:
+{ lib, stdenv, fetchFromGitHub
+, libjack2, libsndfile, xorg, freetype, libxkbcommon
+, cairo, glib, gnome3, flac, libogg, libvorbis, libopus
+, cmake, pkg-config
+}:
 
 stdenv.mkDerivation rec {
   pname = "sfizz";
-  version = "0.4.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "sfztools";
     repo = pname;
     rev = version;
-    sha256 = "0zpmvmh7n0064rxfqxb7z9rnz493k7yq7nl0vxppqnasg97jn5f3";
+    sha256 = "sha256-3RdY5+BPsdk6vctDy24w5aJsVOV9qzSgXs62Pm5UEKs=";
     fetchSubmodules = true;
   };
 
+  buildInputs = [
+    libjack2
+    libsndfile
+    flac
+    libogg
+    libvorbis
+    libopus
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXau
+    xorg.libXdmcp
+    xorg.xcbutil
+    xorg.xcbutilcursor
+    xorg.xcbutilrenderutil
+    xorg.xcbutilkeysyms
+    xorg.xcbutilimage
+    libxkbcommon
+    cairo
+    glib
+    gnome3.zenity
+    freetype
+  ];
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ libjack2 libsndfile ];
+  postPatch = ''
+  substituteInPlace editor/external/vstgui4/vstgui/lib/platform/linux/x11fileselector.cpp \
+    --replace '"/usr/bin/zenity' '"${gnome3.zenity}/bin/zenity'
+  '';
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"


### PR DESCRIPTION
###### Motivation for this change

The new version has new features, like a UI and tuning support.

This PR is a draft because currently the plugin is unable to open a file dialog. It seems like it tries to run `zenity` but can not find it. I don't know how to fix this issue.

cast @magnetophon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
