### PR TITLE
gradle: Add 7-rc-2, leave latest pointing at 6.8

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -65,9 +65,9 @@ in rec {
   gradle_latest = gradle_6_8;
 
   gradle_7 = gradleGen (gradleSpec {
-    version = "7.0-rc-1";
+    version = "7.0-rc-2";
     nativeVersion = "0.22-milestone-11";
-    sha256 = "147cxm03ka95d0nv5kf6rz9jdzjmkl7d1n271rgg0rdhssshgf0j";
+    sha256 = "0gzvigyvwwizx90vnzhdnbm5rdaki11inxna11s4y67xkn8hrnx5";
   });
 
   gradle_6_8 = gradleGen (gradleSpec {

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -1,6 +1,15 @@
 { lib, stdenv, fetchurl, unzip, jdk, java ? jdk, makeWrapper }:
 
-rec {
+let
+  gradleSpec = { version, nativeVersion, sha256 }: rec {
+    inherit nativeVersion;
+    name = "gradle-${version}";
+    src = fetchurl {
+      inherit sha256;
+      url = "https://services.gradle.org/distributions/${name}-bin.zip";
+    };
+  };
+in rec {
   gradleGen = {name, src, nativeVersion} : stdenv.mkDerivation {
     inherit name src nativeVersion;
 
@@ -52,35 +61,30 @@ rec {
     };
   };
 
+  # NOTE: Gradle 7 is a release candidate, so point to 6.8.
   gradle_latest = gradle_6_8;
 
-  gradle_6_8 = gradleGen rec {
-    name = "gradle-6.8.3";
+  gradle_7 = gradleGen (gradleSpec {
+    version = "7.0-rc-1";
+    nativeVersion = "0.22-milestone-11";
+    sha256 = "147cxm03ka95d0nv5kf6rz9jdzjmkl7d1n271rgg0rdhssshgf0j";
+  });
+
+  gradle_6_8 = gradleGen (gradleSpec {
+    version = "6.8.3";
     nativeVersion = "0.22-milestone-9";
+    sha256 = "01fjrk5nfdp6mldyblfmnkq2gv1rz1818kzgr0k2i1wzfsc73akz";
+  });
 
-    src = fetchurl {
-      url = "https://services.gradle.org/distributions/${name}-bin.zip";
-      sha256 = "01fjrk5nfdp6mldyblfmnkq2gv1rz1818kzgr0k2i1wzfsc73akz";
-    };
-  };
-
-  gradle_5_6 = gradleGen rec {
-    name = "gradle-5.6.4";
+  gradle_5_6 = gradleGen (gradleSpec {
+    version = "5.6.4";
     nativeVersion = "0.18";
+    sha256 = "1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d";
+  });
 
-    src = fetchurl {
-      url = "https://services.gradle.org/distributions/${name}-bin.zip";
-      sha256 = "1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d";
-    };
-  };
-
-  gradle_4_10 = gradleGen rec {
-    name = "gradle-4.10.3";
+  gradle_4_10 = gradleGen (gradleSpec {
+    version = "4.10.3";
     nativeVersion = "0.14";
-
-    src = fetchurl {
-      url = "https://services.gradle.org/distributions/${name}-bin.zip";
-      sha256 = "0vhqxnk0yj3q9jam5w4kpia70i4h0q4pjxxqwynh3qml0vrcn9l6";
-    };
-  };
+    sha256 = "0vhqxnk0yj3q9jam5w4kpia70i4h0q4pjxxqwynh3qml0vrcn9l6";
+  });
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12766,6 +12766,7 @@ in
   gradle_4 = gradle_4_10;
   gradle_5 = res.gradleGen.gradle_5_6;
   gradle_6 = res.gradleGen.gradle_6_8;
+  gradle_7 = res.gradleGen.gradle_7;
 
   gperf = callPackage ../development/tools/misc/gperf { };
   # 3.1 changed some parameters from int to size_t, leading to mismatches.


### PR DESCRIPTION
###### Motivation for this change

Gradle 7.0-rc-1 was released ([they tweeted the release](https://twitter.com/gradle/status/1374187076862812160)). I thought it's a good idea to exercise and add it to Nixpkgs. Note that `gradle_latest` is not affected by these changes.

I also added `gradleSpec` to DRY things up a bit.

Since I filed this PR, 7.0.-rc-2 was released, and the PR was updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @SuperSandro2000 @mstrangfeld 