### PR TITLE
tachyon: disable threading on aarch64 to avoid sage test hangs

### DIFF
--- a/pkgs/development/libraries/tachyon/default.nix
+++ b/pkgs/development/libraries/tachyon/default.nix
@@ -13,10 +13,10 @@ assert stdenv.isDarwin -> Carbon != null;
 
 stdenv.mkDerivation rec {
   pname = "tachyon";
-  version = "0.99b2";
+  version = "0.99b6";
   src = fetchurl {
     url = "http://jedi.ks.uiuc.edu/~johns/tachyon/files/${version}/${pname}-${version}.tar.gz";
-    sha256 = "04m0bniszyg7ryknj8laj3rl5sspacw5nr45x59j2swcsxmdvn1v";
+    sha256 = "15wv2748ngk2iid798a774sjxhhijq7kjm32yl897x54fsfazp7l";
   };
   buildInputs = lib.optionals stdenv.isDarwin [
     Carbon

--- a/pkgs/development/libraries/tachyon/default.nix
+++ b/pkgs/development/libraries/tachyon/default.nix
@@ -36,8 +36,11 @@ stdenv.mkDerivation rec {
   '';
   arch = if stdenv.hostPlatform.system == "x86_64-linux"   then "linux-64-thr"  else
          if stdenv.hostPlatform.system == "i686-linux"     then "linux-thr"     else
-         if stdenv.hostPlatform.system == "aarch64-linux"  then "linux-arm-thr" else
-         if stdenv.hostPlatform.system == "armv7l-linux"   then "linux-arm-thr" else
+         # 2021-03-29: multithread (-DTHR -D_REENTRANT) was disabled on linux-arm
+         # because it caused Sage's 3D plotting tests to hang indefinitely.
+         # see https://github.com/NixOS/nixpkgs/pull/117465
+         if stdenv.hostPlatform.system == "aarch64-linux"  then "linux-arm"     else
+         if stdenv.hostPlatform.system == "armv7l-linux"   then "linux-arm"     else
          if stdenv.hostPlatform.system == "x86_64-darwin"  then "macosx-thr"    else
          if stdenv.hostPlatform.system == "i686-darwin"    then "macosx-64-thr" else
          if stdenv.hostPlatform.system == "i686-cygwin"    then "win32"         else

--- a/pkgs/development/libraries/tachyon/make-archs.patch
+++ b/pkgs/development/libraries/tachyon/make-archs.patch
@@ -22,11 +22,11 @@ index 08afb85..dbeb691 100644
  	"RANLIB = ranlib" \
  	"LIBS = -L. -ltachyon $(MISCLIB) -lm -lpthread"
  
-+# Linux Arm using gcc, with threads
-+linux-arm-thr:
++# Linux Arm using gcc
++linux-arm:
 +	$(MAKE) all \
-+	"ARCH = linux-arm-thr" \
-+	"CFLAGS = -Wall -O3 -fomit-frame-pointer -ffast-math -DLinux -DTHR -D_REENTRANT $(MISCFLAGS)" \
++	"ARCH = linux-arm" \
++	"CFLAGS = -Wall -O3 -fomit-frame-pointer -ffast-math -DLinux $(MISCFLAGS)" \
 +	"ARFLAGS = r" \
 +	"STRIP = strip" \
 +	"RANLIB = ranlib" \

--- a/pkgs/development/libraries/tachyon/no-absolute-paths.patch
+++ b/pkgs/development/libraries/tachyon/no-absolute-paths.patch
@@ -1,5 +1,4 @@
 diff --git a/unix/Make-config b/unix/Make-config
-index ee4f388..c1d51d4 100644
 --- a/unix/Make-config
 +++ b/unix/Make-config
 @@ -18,7 +18,7 @@
@@ -11,7 +10,7 @@ index ee4f388..c1d51d4 100644
  
  
  
-@@ -30,7 +30,7 @@ SHELL=/bin/sh
+@@ -30,7 +30,7 @@
  
  # The following line should be set to -Ixxx where xxx is your X11 include path
  # Sun puts X11 in /usr/openwin/xxx
@@ -20,16 +19,20 @@ index ee4f388..c1d51d4 100644
  
  # Others typically use /usr/X11 or /usr/X11R6
  #X11INC= -I/usr/X11
-@@ -57,7 +57,7 @@ X11LIB= -lX11
+@@ -105,9 +105,9 @@
  ##########################################################################
- 
- # Standard MPICH installation location
+ # Customize MPI directories and includes as-needed.
+ # A typical MPICH installation location:
 -MPIDIR=/usr/local/mpi
+-MPIINC=$(MPIDIR)/include
+-MPILIB=$(MPIDIR)/lib
 +# MPIDIR=/usr/local/mpi
++# MPIINC=$(MPIDIR)/include
++# MPILIB=$(MPIDIR)/lib
  
- # UMR CS Dept
- #MPIDIR=/software/all/mpi
-@@ -108,9 +108,9 @@ MBOX=
+ # MPI defines and any flags needed by the local installation.
+ # Always list -DMPI at a minimum.  
+@@ -166,9 +166,9 @@
  #   http://www.ijg.org/files/
  ##########################################################################
  # Uncomment the following lines to disable JPEG support
@@ -42,7 +45,7 @@ index ee4f388..c1d51d4 100644
  
  # Uncomment the following lines to enable JPEG support
  #USEJPEG= -DUSEJPEG
-@@ -128,9 +128,9 @@ JPEGLIB=
+@@ -186,9 +186,9 @@
  #   http://www.libpng.org/
  ##########################################################################
  # Uncomment the following lines to disable PNG support


### PR DESCRIPTION
###### Motivation for this change

Something changed on master between [March 11th](https://github.com/NixOS/nixpkgs/pull/115980) and [March 20th](https://github.com/NixOS/nixpkgs/pull/117017) and Sage tests that use Tachyon for 3D graphics started hanging on aarch64 (the links are to succeeding and failing ofBorg testruns). I don't have an aarch64 machine so it's hard for me to bisect the problem, but disabling multithreading makes the bug go away.

@timokau, is this an acceptable solution?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
