### PR TITLE
nixUnstable: pre20210317_8a5203d -> pre20210324_d1cb956

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -213,13 +213,13 @@ in rec {
 
   nixUnstable = lib.lowPrio (callPackage common rec {
     name = "nix-2.4${suffix}";
-    suffix = "pre20210317_8a5203d";
+    suffix = "pre20210324_d1cb956";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "8a5203d3b836497c2c5f157f85008aa8bcb6a1d2";
-      sha256 = "IMzdmoWAX6Lerhslsf7h2814xjJolPnl2bICDixRgdk=";
+      rev = "d1cb956bf2e417baa08e55699a57c2bde3adf7d3";
+      sha256 = "06sh08v4bf1rfvgchgpld3gbyg477bz8pc0wh9pffvlz6w5g73xf";
     };
 
     inherit storeDir stateDir confDir boehmgc;


### PR DESCRIPTION
###### Motivation for this change

To bring back `nix flake info`. The relevant commit is https://github.com/NixOS/nix/commit/ef83ced4e170130cb6f9acd1d253351b02490658

###### Things done

Bumped `nixUnstable`.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @edolstra 