### PR TITLE
python3Packages.prance: unbreak

### DIFF
--- a/pkgs/development/python-modules/prance/default.nix
+++ b/pkgs/development/python-modules/prance/default.nix
@@ -6,10 +6,9 @@
 , requests
 , six
 , semver
-, pytest
+, pytestCheckHook
 , pytestcov
 , pytestrunner
-, sphinx
 , openapi-spec-validator
 }:
 
@@ -35,18 +34,28 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
     pytestcov
     openapi-spec-validator
   ];
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "tests_require = dev_require," "tests_require = None,"
+      --replace "tests_require = dev_require," "tests_require = None," \
+      --replace "chardet~=4.0" "" \
+      --replace "semver~=2.13" ""
+    substituteInPlace setup.cfg \
+      --replace "--cov-fail-under=90" ""
   '';
 
-  # many tests require network connection
-  doCheck = false;
+  # Disable tests that require network
+  disabledTestPaths = [
+    "tests/test_convert.py"
+  ];
+  disabledTests = [
+    "test_fetch_url_http"
+  ];
+  pythonImportsCheck = [ "prance" ];
 
   meta = with lib; {
     description = "Resolving Swagger/OpenAPI 2.0 and 3.0.0 Parser";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Unbreak and re-enable tests. https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.python38Packages.prance.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
