### PR TITLE
ocamlPackages.js_of_ocaml: 3.8.0 -> 3.9.1

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip, which, ocsigen_server, ocaml,
+{ stdenv, lib, fetchzip, fetchpatch, which, ocsigen_server, ocaml,
   lwt_react,
   opaline, ppx_deriving, findlib
 , ocaml-migrate-parsetree
@@ -22,6 +22,14 @@ stdenv.mkDerivation rec
     url = "https://github.com/ocsigen/eliom/archive/${version}.tar.gz";
     sha256 = "00m6v2k4mg8705dy41934lznl6gj91i6dk7p1nkaccm51nna25kz";
   };
+
+  patches = [
+    # Compatibility with js_of_ocaml >= 3.9.0, remove at next release
+    (fetchpatch {
+      url = "https://github.com/ocsigen/eliom/commit/4106a4217956f7b74a8ef3f73a1e1f55e02ade45.patch";
+      sha256 = "1cgbvpljn9x6zxirxf3rdjrsdwy319ykz3qq03c36cc40hy2w13p";
+    })
+  ];
 
   buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild
     ocaml-migrate-parsetree

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -1,16 +1,16 @@
 { lib, fetchurl, buildDunePackage
-, cmdliner, cppo, yojson, ppxlib
+, ocaml, cmdliner, cppo, yojson, ppxlib
 , menhir
 }:
 
 buildDunePackage rec {
   pname = "js_of_ocaml-compiler";
-  version = "3.8.0";
+  version = "3.9.1";
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-    sha256 = "069jyiayxcgwnips3adxb3d53mzd4rrq2783b9fgmsiyzm545lcy";
+    sha256 = "0ib551kfsjlp9vr3fk36hrbq7xxyl8bj6vcn3ccr0s370bsmgpm6";
   };
 
   nativeBuildInputs = [ cppo menhir ];


### PR DESCRIPTION
~~eliom is kind of holding back our update of js_of_ocaml. Since
js_of_ocaml 3.8.0 is not available for 4.12, let's update js_of_ocaml
for 4.12 only for now, since we wouldn't be able to support eliom there
anyways.~~

~~This unbreaks a lot of packages because --with-js_of_ocaml defaults to
true for a lot of packages, leading to a lot of breakage due to packages
like mtime. Updating js_of_ocaml is much simpler than conditionally
disabling the flag for 4.12.~~

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
