### PR TITLE
crypto-org-wallet: init at version 0.1.1

### DIFF
--- a/pkgs/applications/blockchains/crypto-org-wallet.nix
+++ b/pkgs/applications/blockchains/crypto-org-wallet.nix
@@ -6,8 +6,7 @@ let
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url =
-      "https://github.com/crypto-com/${pname}/releases/download/v${version}/${name}-x86_64.AppImage";
+    url = "https://github.com/crypto-com/${pname}/releases/download/v${version}/${name}-x86_64.AppImage";
     sha256 = "12076hf8dlz0hg1pb2ixwlslrh8gi6s1iawnvhnn6vz4jmjvq356";
   };
 

--- a/pkgs/applications/blockchains/crypto-org-wallet.nix
+++ b/pkgs/applications/blockchains/crypto-org-wallet.nix
@@ -2,13 +2,13 @@
 
 let
   pname = "chain-desktop-wallet";
-  version = "0.0.24";
+  version = "0.1.1";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url =
       "https://github.com/crypto-com/${pname}/releases/download/v${version}/${name}-x86_64.AppImage";
-    sha256 = "1v66hzikpww5mw563i16v9hp6320cxpyydigm6div7jbmw6n326h";
+    sha256 = "12076hf8dlz0hg1pb2ixwlslrh8gi6s1iawnvhnn6vz4jmjvq356";
   };
 
   appimageContents = appimageTools.extractType2 { inherit name src; };

--- a/pkgs/applications/blockchains/crypto-org-wallet.nix
+++ b/pkgs/applications/blockchains/crypto-org-wallet.nix
@@ -1,0 +1,34 @@
+{ lib, fetchurl, makeDesktopItem, appimageTools, imagemagick }:
+
+let
+  pname = "chain-desktop-wallet";
+  version = "0.0.24";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url =
+      "https://github.com/crypto-com/${pname}/releases/download/v${version}/${name}-x86_64.AppImage";
+    sha256 = "1v66hzikpww5mw563i16v9hp6320cxpyydigm6div7jbmw6n326h";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit name src; };
+in appimageTools.wrapType2 rec {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
+    ${imagemagick}/bin/convert ${appimageContents}/${pname}.png -resize 512x512 ${pname}_512.png
+    install -m 444 -D ${pname}_512.png $out/share/icons/hicolor/512x512/apps/${pname}.png
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun --no-sandbox %U' "Exec=$out/bin/${pname}"
+  '';
+
+  meta = with lib; {
+    description = "Crypto.org Chain desktop wallet (Beta)";
+    homepage = "https://github.com/crypto-com/chain-desktop-wallet";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ th0rgal ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28504,6 +28504,8 @@ in
 
   cryptoverif = callPackage ../applications/science/logic/cryptoverif { };
 
+  crypto-org-wallet = callPackage ../applications/blockchains/crypto-org-wallet.nix { };
+
   caprice32 = callPackage ../misc/emulators/caprice32 { };
 
   cubicle = callPackage ../applications/science/logic/cubicle {


### PR DESCRIPTION
###### Motivation for this change
Crypto.com recently released the crypto.org blockchain project. This application (still in beta) allows to create or access a CRO wallet.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
