### PR TITLE
python3Packages.cherrypy: unbreak

### DIFF
--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -18,6 +18,26 @@ buildPythonPackage rec {
     sha256 = "16f410izp2c4qhn4n3l5l3qirmkf43h2amjqms8hkl0shgfqwq2n";
   };
 
+  patches = [
+    # 1/3 Fix compatibility with pytest 6. Will be part of the next release after 18.6
+    (fetchpatch {
+      url = "https://github.com/cherrypy/cherrypy/pull/1897/commits/59c0e19d7df8680e36afc96756dce72435121448.patch";
+      sha256 = "1jachbvp505gndccdhny0c3grzdrmvmbzq4kw55jx93ay94ni6p0";
+    })
+    # 2/3 Fix compatibility with pytest 6. Will be part of the next release after 18.6
+    (fetchpatch {
+      url = "https://github.com/cherrypy/cherrypy/pull/1897/commits/4a6287b73539adcb7b0ae72d69644a1ced1f7eaa.patch";
+      sha256 = "0nz40qmgxknkbjsdzfzcqfxdsmsxx3v104fb0h04yvs76mqvw3i4";
+    })
+    # 3/3 Fix compatibility with pytest 6. Will be part of the next release after 18.6
+    (fetchpatch {
+      url = "https://github.com/cherrypy/cherrypy/commit/3bae7f06868553b006915f05ff14d86163f59a7d.patch";
+      sha256 = "1z0bv23ybyw87rf1i8alsdi3gc2bzmdj9d0kjsghdkvi3zdp4n8q";
+    })
+  ];
+
+  nativeBuildInputs = [ setuptools_scm ];
+
   propagatedBuildInputs = [
     # required
     cheroot portend more-itertools zc_lockfile
@@ -25,8 +45,6 @@ buildPythonPackage rec {
     # optional
     routes
   ];
-
-  nativeBuildInputs = [ setuptools_scm ];
 
   checkInputs = [
     objgraph pytest pytestcov pathpy requests_toolbelt pytest-services


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes compatibility with pytest6 by pulling in patches from upstream that have not yet been released. https://hydra.nixos.org/job/nixpkgs/trunk/python38Packages.cherrypy.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
