### PR TITLE
leveldb: fix static build and cleanup

### DIFF
--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -13,25 +13,28 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ snappy ];
 
-  nativeBuildInputs = []
-    ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs = lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  buildPhase = ''
-    make all
+  doCheck = true;
+
+  buildFlags = [ "all" ];
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isStatic ''
+    # remove shared objects from "all" target
+    sed -i '/^all:/ s/$(SHARED_LIBS) $(SHARED_PROGRAMS)//' Makefile
   '';
 
-  installPhase = "
-    mkdir -p $out/{bin,lib,include}
+  installPhase = ''
+    runHook preInstall
 
-    cp -r include $out
-    mkdir -p $out/include/leveldb/helpers
-    cp helpers/memenv/memenv.h $out/include/leveldb/helpers
+    install -D -t $out/include/leveldb include/leveldb/*
+    install -D helpers/memenv/memenv.h $out/include/leveldb/helpers
 
-    cp out-shared/lib* $out/lib
-    cp out-static/lib* $out/lib
+    install -D -t $out/lib out-{static,shared}/lib*
+    install -D -t $out/bin out-static/{leveldbutil,db_bench}
 
-    cp out-static/leveldbutil $out/bin
-  ";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/google/leveldb";


### PR DESCRIPTION
###### Motivation for this change

Needed to link leveldb into an executable.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files
- [x] Determined the impact on package closure size (400K due to `db_bench`)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
