### PR TITLE
python3Packages.piep: disable

### DIFF
--- a/pkgs/development/python-modules/piep/default.nix
+++ b/pkgs/development/python-modules/piep/default.nix
@@ -3,11 +3,13 @@
 , fetchPypi
 , nose
 , pygments
+, isPy3k
 }:
 
 buildPythonPackage rec {
   version = "0.9.2";
   pname = "piep";
+  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Mark as disabled on python3.
Package has never worked on python3: https://hydra.nixos.org/job/nixpkgs/trunk/python38Packages.piep.x86_64-linux/all?page=1
Upstream does not have python3 support https://github.com/timbertson/piep/issues/13

It may also be reasonable to simply remove this package. I believe it has no downstream dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
