### PR TITLE
unipicker: init at 767571c

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5038,6 +5038,12 @@
       fingerprint = "8992 44FC D291 5CA2 0A97  802C 156C 88A5 B0A0 4B2A";
     }];
   };
+  kiyengar = {
+    email = "hello@kiyengar.net";
+    github = "karthikiyengar";
+    githubId = 8260207;
+    name = "Karthik Iyengar";
+  };
   kkallio = {
     email = "tierpluspluslists@gmail.com";
     name = "Karn Kallio";

--- a/pkgs/applications/misc/unipicker/default.nix
+++ b/pkgs/applications/misc/unipicker/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, lib, fzf, xclip }:
+
+stdenv.mkDerivation rec {
+   pname = "unipicker";
+   version = "unstable-2018-07-10";
+
+   src = fetchFromGitHub {
+      owner = "jeremija";
+      repo = pname;
+      rev = "767571c87cdb1e654408d19fc4db98e5e6725c04";
+      sha256 = "1k4v53pm3xivwg9vq2kndpcmah0yn4679r5jzxvg38bbkfdk86c1";
+   };
+
+   buildInputs = [
+      fzf
+      xclip
+   ];
+
+   preInstall = ''
+      substituteInPlace unipicker --replace "/etc/unipickerrc" "$out/etc/unipickerrc"
+      substituteInPlace unipickerrc --replace "/usr/local" "$out"
+   '';
+
+   makeFlags = [
+      "PREFIX=$(out)"
+      "DESTDIR=$(out)"
+   ];
+
+   meta = with lib; {
+    description = "A CLI utility for searching unicode characters by description and optionally copying them to clipboard";
+    homepage = "https://github.com/jeremija/unipicker";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kiyengar ];
+    platforms = with platforms; unix;
+   };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25875,6 +25875,8 @@ in
 
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };
 
+  unipicker = callPackage ../applications/misc/unipicker { };
+
   unison = callPackage ../applications/networking/sync/unison {
     ocamlPackages = ocaml-ng.ocamlPackages_4_09;
     enableX11 = config.unison.enableX11 or true;


### PR DESCRIPTION
###### Motivation for this change
Introduces a new package for unipicker: https://github.com/jeremija/unipicker

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
