### PR TITLE
igraph: 0.8.5 -> 0.9.1

### DIFF
--- a/pkgs/development/libraries/igraph/default.nix
+++ b/pkgs/development/libraries/igraph/default.nix
@@ -1,20 +1,43 @@
-{ stdenv, lib, fetchFromGitHub,
-  pkg-config, autoreconfHook,
-  flex, yacc, zlib, libxml2 }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, arpack
+, bison
+, blas
+, cmake
+, flex
+, fop
+, glpk
+, gmp
+, lapack
+, libxml2
+, libxslt
+, pkg-config
+, python3
+, sourceHighlight
+, suitesparse
+, xmlto
+}:
 
 stdenv.mkDerivation rec {
   pname = "igraph";
-  version = "0.8.5";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "igraph";
     repo = pname;
     rev = version;
-    sha256 = "0cb0kp6mpmgz74kbymqw4xxads8ff7jh0n59dsm76xy6nn8hpqcz";
+    sha256 = "sha256-i6Zg6bfHZ9NHwqCouX9m9YqD0VtiWW8DEkxS0hdUyIE=";
   };
 
-  nativeBuildInputs = [ pkg-config autoreconfHook ];
-  buildInputs = [ flex yacc zlib libxml2 ];
+  patches = [
+    (fetchpatch {
+      name = "pkg-config-paths.patch";
+      url = "https://github.com/igraph/igraph/commit/980521cc948777df471893f7b6de8f3e3916a3c0.patch";
+      sha256 = "0mbq8v5h90c3dhgmyjazjvva3rn57qhnv7pkc9hlbqdln9gpqg0g";
+    })
+  ];
 
   # Normally, igraph wants us to call bootstrap.sh, which will call
   # tools/getversion.sh. Instead, we're going to put the version directly
@@ -22,16 +45,69 @@ stdenv.mkDerivation rec {
   # bootstrap. ~ C.
   postPatch = ''
     echo "${version}" > IGRAPH_VERSION
+  '' + lib.optionalString stdenv.isAarch64 ''
+    # https://github.com/igraph/igraph/issues/1694
+    substituteInPlace tests/CMakeLists.txt \
+      --replace "igraph_scg_grouping3" "" \
+      --replace "igraph_scg_semiprojectors2" ""
   '';
+
+  outputs = [ "out" "dev" "doc" ];
+
+  nativeBuildInputs = [
+    cmake
+    fop
+    libxml2
+    libxslt
+    pkg-config
+    python3
+    sourceHighlight
+    xmlto
+  ];
+
+  buildInputs = [
+    arpack
+    bison
+    blas
+    flex
+    glpk
+    gmp
+    lapack
+    libxml2
+    suitesparse
+  ];
+
+  cmakeFlags = [
+    "-DIGRAPH_USE_INTERNAL_BLAS=OFF"
+    "-DIGRAPH_USE_INTERNAL_LAPACK=OFF"
+    "-DIGRAPH_USE_INTERNAL_ARPACK=OFF"
+    "-DIGRAPH_USE_INTERNAL_GLPK=OFF"
+    "-DIGRAPH_USE_INTERNAL_CXSPARSE=OFF"
+    "-DIGRAPH_USE_INTERNAL_GMP=OFF"
+    "-DIGRAPH_GLPK_SUPPORT=ON"
+    "-DIGRAPH_GRAPHML_SUPPORT=ON"
+    "-DIGRAPH_ENABLE_LTO=ON"
+    "-DIGRAPH_ENABLE_TLS=ON"
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
 
   doCheck = true;
 
-  meta = {
+  preCheck = ''
+    # needed to find libigraph.so
+    export LD_LIBRARY_PATH="$PWD/src"
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/share"
+    cp -r doc "$out/share"
+  '';
+
+  meta = with lib; {
     description = "The network analysis package";
     homepage = "https://igraph.org/";
-    license = lib.licenses.gpl2;
-    # NB: Known to fail tests on aarch64.
-    platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
-    maintainers = [ lib.maintainers.MostAwesomeDude ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ MostAwesomeDude dotlambda ];
   };
 }

--- a/pkgs/development/python-modules/python-igraph/default.nix
+++ b/pkgs/development/python-modules/python-igraph/default.nix
@@ -1,32 +1,54 @@
-{ buildPythonPackage, fetchPypi, lib, isPy3k
-, pkg-config, igraph
-, texttable }:
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pkg-config
+, igraph
+, texttable
+, python
+}:
 
 buildPythonPackage rec {
   pname = "python-igraph";
-  version = "0.8.3";
-  disabled = !isPy3k; # fails to build
+  version = "0.9.1";
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ igraph ];
-  propagatedBuildInputs = [ texttable ];
+  disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e1f27622eddeb2bd5fdcbadb41ef048e884790bb050f9627c086dc609d0f1236";
+  src = fetchFromGitHub {
+    owner = "igraph";
+    repo = "python-igraph";
+    rev = version;
+    sha256 = "1ldyzza25zvwh144lw8x856z76s8gfvnbdm56fcmwkvm7aj81npw";
   };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    igraph
+    igraph.dev
+  ];
+
+  propagatedBuildInputs = [
+    texttable
+  ];
 
   # NB: We want to use our igraph, not vendored igraph, but even with
   # pkg-config on the PATH, their custom setup.py still needs to be explicitly
   # told to do it. ~ C.
   setupPyGlobalFlags = [ "--use-pkg-config" ];
 
-  doCheck = !isPy3k;
+  checkPhase = ''
+    ${python.interpreter} -m unittest
+  '';
 
-  meta = {
+  pythonImportsCheck = [ "igraph" ];
+
+  meta = with lib; {
     description = "High performance graph data structures and algorithms";
     homepage = "https://igraph.org/python/";
-    license = lib.licenses.gpl2;
-    maintainers = [ lib.maintainers.MostAwesomeDude ];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ MostAwesomeDude dotlambda ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

`$out/lib/pkgconfig/igraph.pc` contains incorrect paths:
```
prefix=/nix/store/ik8rwy9kp31mhm5dni74icr90msy6dzf-igraph-0.9.0
exec_prefix=/nix/store/ik8rwy9kp31mhm5dni74icr90msy6dzf-igraph-0.9.0
libdir=${exec_prefix}//nix/store/ik8rwy9kp31mhm5dni74icr90msy6dzf-igraph-0.9.0/lib
includedir=${prefix}//nix/store/ik8rwy9kp31mhm5dni74icr90msy6dzf-igraph-0.9.0/include

Name: libigraph
Description: A library for creating and manipulating graphs
Version: 0.9.0
URL: https://igraph.org
Libs: -L${libdir} -ligraph
Libs.private: -lm -lstdc++ -lxml2 -lz -lgmp -lblas -lglpk -llapack -larpack
Cflags: -I${includedir}/igraph
```
Does someone knowledgable about CMake and pkg-config have time to dig into that? Upstream seems to have wanted to fix something similar with https://github.com/igraph/igraph/commit/8bf4adbe32de8e0a746fbf8b31268ff040cbe175, but it doesn't work for us.