### PR TITLE
nixos/amdgpu: remove

### DIFF
--- a/nixos/modules/hardware/video/amdgpu.nix
+++ b/nixos/modules/hardware/video/amdgpu.nix
@@ -1,9 +1,0 @@
-{ config, lib, ... }:
-
-with lib;
-{
-  config = mkIf (elem "amdgpu" config.services.xserver.videoDrivers) {
-    boot.blacklistedKernelModules = [ "radeon" ];
-  };
-}
-

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -72,7 +72,6 @@
   ./hardware/opentabletdriver.nix
   ./hardware/wooting.nix
   ./hardware/uinput.nix
-  ./hardware/video/amdgpu.nix
   ./hardware/video/amdgpu-pro.nix
   ./hardware/video/ati.nix
   ./hardware/video/capture/mwprocapture.nix


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/111551#issuecomment-802082766

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).