### PR TITLE
python38Packages.pyxnat: unbreak

### DIFF
--- a/pkgs/development/python-modules/pyxnat/default.nix
+++ b/pkgs/development/python-modules/pyxnat/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
+, pythonOlder
 , nose
 , lxml
 , requests
@@ -10,7 +10,7 @@
 buildPythonPackage rec {
   pname = "pyxnat";
   version = "1.4";
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -18,6 +18,14 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ lxml requests ];
+
+  # future is not used, and pathlib is installed part of python38+
+  # w/o an external package
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "pathlib>=1.0" "" \
+      --replace "future>=0.16" ""
+  '';
 
   checkInputs = [ nose ];
   checkPhase = "nosetests pyxnat/tests";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.python38Packages.pyxnat.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
