### PR TITLE
oh-my-fish: init at 7+unstable=2021-03-03

### DIFF
--- a/pkgs/shells/fish/oh-my-fish/default.nix
+++ b/pkgs/shells/fish/oh-my-fish/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fish
+, runtimeShell
+, writeShellScript
+}:
+
+stdenv.mkDerivation rec {
+  pname = "oh-my-fish";
+  version = "7+unstable=2021-03-03";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "0b1396ad7962073fa25615bf03c43b53eddc2d56";
+    hash = "sha256-lwMo4+PcYR9kYJPWK+ALiMfBdxFSgB2vjtSn8QrmmEA=";
+  };
+
+  buildInputs = [
+    fish
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -pv $out/bin $out/share/${pname}
+    cp -vr * $out/share/${pname}
+
+    cat << EOF > $out/bin/omf-install
+    #!${runtimeShell}
+
+    ${fish}/bin/fish \\
+      $out/share/${pname}/bin/install \\
+      --noninteractive \\
+      --offline=$out/share/${pname}
+
+    EOF
+    chmod +x $out/bin/omf-install
+
+    runHook PostInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/oh-my-fish/oh-my-fish";
+    description = "The Fish Shell Framework";
+    longDescription = ''
+      Oh My Fish provides core infrastructure to allow you to install packages
+      which extend or modify the look of your shell. It's fast, extensible and
+      easy to use.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = fish.meta.platforms;
+  };
+}
+# TODO: customize the omf-install script

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10544,6 +10544,8 @@ with pkgs;
 
   fish = callPackage ../shells/fish { };
 
+  oh-my-fish = callPackage ../shells/fish/oh-my-fish { };
+
   wrapFish = callPackage ../shells/fish/wrapper.nix { };
 
   fishPlugins = recurseIntoAttrs (callPackage ../shells/fish/plugins { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/68886

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
