### PR TITLE
[20.09] traefik: add patch for CVE-2021-27375

### DIFF
--- a/pkgs/servers/traefik/default.nix
+++ b/pkgs/servers/traefik/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoModule, fetchFromGitHub, go-bindata, nixosTests }:
+{ stdenv, buildGoModule, fetchFromGitHub, go-bindata, nixosTests, fetchpatch }:
 
 buildGoModule rec {
   pname = "traefik";
@@ -12,6 +12,14 @@ buildGoModule rec {
   };
 
   vendorSha256 = "0kz7y64k07vlybzfjg6709fdy7krqlv1gkk01nvhs84sk8bnrcvn";
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-27375.patch";
+      url = "https://github.com/traefik/traefik/commit/bae28c5f5717ea3a80423f107fefe6948c14b7cd.patch";
+      sha256 = "0gbygblzc6l0rywznbl6in2h5mjk5d0x0aq6pqgag2vrjbyk9kfi";
+    })
+  ];
 
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-27375

Alternative to the bump proposed in #116942, fixing #116928

Sorry @Pamplemousse not meaning to tread on you...
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
