### PR TITLE
pull request template: cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,5 @@ Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-
 - [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
 - [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
 - [ ] Tested execution of all binary files (usually in `./result/bin/`)
-- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
-- [ ] Ensured that relevant documentation is up to date
+- [ ] Added a release notes entry if the change is major or breaking
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


### PR DESCRIPTION
Remove elements of the PR template that have a low signal/noise ratio,
and add one that I think would have a good signal/noise ratio.

-----
Remove:
Determined the impact on package closure size (by running `nix path-info
-S` before and after)
-----
Rationale:
This is rarely done in practice, and apart from for specific packages
this is usually not a good indicator of anything useful

It might make sense to re-introduce it with two holes to fill, but then
we would have to make a serious decision to never land without these two
numbers filled in or with too big a regression, because in practice this
box has been a no-op in many cases.

Maybe just integrating this check in nixpkgs-review would bring the most
benefit here?


-----
Remove:
Ensured that relevant documentation is up to date
-----
Rationale:
This is fuzzy, “relevant documentation” is way too often hard to find


-----
Add:
Added a release notes entry if applicable
-----
Rationale:
This is way too often forgotten, and is also a self-contained easy task
