### PR TITLE
zabbix.agent2: init at 5.0.5

### DIFF
--- a/nixos/modules/services/monitoring/zabbix-agent.nix
+++ b/nixos/modules/services/monitoring/zabbix-agent.nix
@@ -128,11 +128,16 @@ in
       {
         LogType = "console";
         Server = cfg.server;
-        ListenIP = cfg.listen.ip;
         ListenPort = cfg.listen.port;
-        LoadModule = builtins.attrNames cfg.modules;
       }
-      (mkIf (cfg.modules != {}) { LoadModulePath = "${moduleEnv}/lib"; })
+      (mkIf (cfg.modules != {}) {
+        LoadModule = builtins.attrNames cfg.modules;
+        LoadModulePath = "${moduleEnv}/lib";
+      })
+
+      # the default value for "ListenIP" is 0.0.0.0 but zabbix agent 2 cannot accept configuration files which
+      # explicitly set "ListenIP" to the default value...
+      (mkIf (cfg.listen.ip != "0.0.0.0") { ListenIP = cfg.listen.ip; })
     ];
 
     networking.firewall = mkIf cfg.openFirewall {

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -1,0 +1,66 @@
+{ lib, buildGoModule, fetchurl, autoreconfHook, pkg-config, libiconv, openssl, pcre, zlib }:
+
+import ./versions.nix ({ version, sha256 }:
+  buildGoModule {
+    pname = "zabbix-agent2";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
+      inherit sha256;
+    };
+
+    vendorSha256 = "1kb3lc9jjv0cpzq93k1b9y496i95fcnwhb03j0gwlyqmgsa6yn81";
+
+    nativeBuildInputs = [ autoreconfHook pkg-config];
+    buildInputs = [ libiconv openssl pcre zlib ];
+
+    inherit (buildGoModule.go) GOOS GOARCH;
+
+    # need to provide GO* env variables & patch for reproducibility
+    postPatch = ''
+      substituteInPlace src/go/Makefile.am \
+        --replace '`go env GOOS`' "$GOOS" \
+        --replace '`go env GOARCH`' "$GOARCH" \
+        --replace '`date +%H:%M:%S`' "00:00:00" \
+        --replace '`date +"%b %_d %Y"`' "Jan 1 1970"
+    '';
+
+    # manually configure the c dependencies
+    preConfigure = ''
+      ./configure \
+        --prefix=${placeholder "out"} \
+        --enable-agent2 \
+        --with-iconv \
+        --with-libpcre \
+        --with-openssl=${openssl.dev}
+    '';
+
+    # zabbix build process is complex to get right in nix...
+    # we need to manipulate a number of things for their build
+    # system to properly work
+    buildPhase = ''
+      cp -r vendor src/go/vendor
+      make
+    '';
+
+    installPhase = ''
+      install -Dm0644 src/go/conf/zabbix_agent2.conf $out/etc/zabbix_agent2.conf
+      install -Dm0755 src/go/bin/zabbix_agent2 $out/bin/zabbix_agent2
+    '';
+
+    # run `go mod vendor` from the correct directory
+    overrideModAttrs = (_oldAttrs : {
+      preConfigure = ''
+        cd src/go
+        '';
+    });
+
+    meta = with lib; {
+      description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
+      homepage = "https://www.zabbix.com/";
+      license = licenses.gpl2Plus;
+      maintainers = [ maintainers.aanderse ];
+      platforms = platforms.linux;
+    };
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17956,6 +17956,7 @@ in
 
   zabbixFor = version: rec {
     agent = (callPackages ../servers/monitoring/zabbix/agent.nix {}).${version};
+    agent2 = (callPackages ../servers/monitoring/zabbix/agent2.nix {}).${version};
     proxy-mysql = (callPackages ../servers/monitoring/zabbix/proxy.nix { mysqlSupport = true; }).${version};
     proxy-pgsql = (callPackages ../servers/monitoring/zabbix/proxy.nix { postgresqlSupport = true; }).${version};
     proxy-sqlite = (callPackages ../servers/monitoring/zabbix/proxy.nix { sqliteSupport = true; }).${version};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
There is a drop in replacement for `zabbix.agent`: `zabbix.agent2`. While `zabbix.agent` was written in `c`, `zabbix.agent2` is mostly written in `go` with a bit of `c` glue.

A **massive** thank you to @tomberek who packaged this with me. I was really lost on how to package this and he led me through the whole process. What a champion! :rocket:

I ran a full set of tests on this today on a server that was running `zabbix.agent`, so testing was thorough :+1: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
