### PR TITLE
tex-match: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1274,6 +1274,12 @@
     githubId = 50839;
     name = "Brian Jones";
   };
+  bootstrap-prime = {
+    email = "bootstrap.prime@gmail.com";
+    github = "bootstrap-prime";
+    githubId = 68566724;
+    name = "bootstrap-prime";
+  };
   commandodev = {
     email = "ben@perurbis.com";
     github = "commandodev";

--- a/pkgs/tools/typesetting/tex/tex-match/default.nix
+++ b/pkgs/tools/typesetting/tex/tex-match/default.nix
@@ -1,0 +1,27 @@
+{ rustPlatform, fetchFromGitHub, gtk3, pkg-config, glib, lib }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tex-match";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "zoeyfyi";
+    repo = "TeX-Match";
+    rev = "v${version}";
+    sha256 = "1yb81j7mbqqb8jcn78dx4ydp7ncbzvaczkli6cqay5jf5j6dbk1z";
+  };
+
+  nativeBuildInputs = [ pkg-config glib ];
+
+  buildInputs = [ gtk3 ];
+
+  cargoSha256 = "1sm2fd3dhs59rvmfjzrfz0qwqzyc9dllb8ph0wc2x0r3px16c71x";
+
+  meta = with lib; {
+    description = "Search through over 1000 different LaTeX symbols by sketching. A desktop version of detexify";
+    homepage = "https://tex-match.zoey.fyi/";
+    license = licenses.mit;
+    maintainers = [ maintainers.bootstrap-prime ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8529,6 +8529,8 @@ in
 
   texworks = libsForQt5.callPackage ../applications/editors/texworks { };
 
+  tex-match = callPackage ../tools/typesetting/tex/tex-match { };
+
   thc-hydra = callPackage ../tools/security/thc-hydra { };
 
   thc-ipv6 = callPackage ../tools/security/thc-ipv6 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I made packages for a thing I use frequently (tex-match) and a fun meme. 

###### Things done
- added self to maintainers
- added "uwuify" package to tools/text
- added tex-match package to tools/typesetting/tex

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
