### PR TITLE
nixos/rtl-sdr: blacklist DVB kernel modules

### DIFF
--- a/nixos/modules/hardware/rtl-sdr.nix
+++ b/nixos/modules/hardware/rtl-sdr.nix
@@ -6,14 +6,13 @@ let
 in {
   options.hardware.rtl-sdr = {
     enable = lib.mkEnableOption ''
-      Enables rtl-sdr udev rules and ensures 'plugdev' group exists.
-      This is a prerequisite to using devices supported by rtl-sdr without
-      being root, since rtl-sdr USB descriptors will be owned by plugdev
-      through udev.
+      Enables rtl-sdr udev rules, ensures 'plugdev' group exists, and blacklists DVB kernel modules.
+      This is a prerequisite to using devices supported by rtl-sdr without being root, since rtl-sdr USB descriptors will be owned by plugdev through udev.
     '';
   };
 
   config = lib.mkIf cfg.enable {
+    boot.blacklistedKernelModules = [ "dvb_usb_rtl28xxu" "e4000" "rtl2832" ];
     services.udev.packages = [ pkgs.rtl-sdr ];
     users.groups.plugdev = {};
   };


### PR DESCRIPTION
###### Motivation for this change
DVB kernel modules conflict with SDR.
https://osmocom.org/projects/rtl-sdr/repository/revisions/0847e93e0869feab50fd27c7afeb85d78ca04631/entry/debian/rtl-sdr-blacklist.conf

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).