### PR TITLE
signal-desktop: Re-enable database encryption, fixes SQLCipher

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -58,7 +58,9 @@ in stdenv.mkDerivation rec {
     gdk-pixbuf
     glib
     gnome2.GConf
-    gtk3
+    # Tracker3 breaks SQLCipher in signal-desktop, turning encrypted DB into plaintext ones.
+    # See https://github.com/NixOS/nixpkgs/issues/108772#issuecomment-806337688
+    (gtk3.override { trackerSupport = false; })
     libX11
     libXScrnSaver
     libXcomposite


### PR DESCRIPTION
###### Motivation for this change

To the best of my knowledge, https://github.com/NixOS/nixpkgs/pull/101537 enabled tracker3 on gtk3, which is known to break SQLCipher ; I'm not sure that Mailspring uses SQLCipher, but #106740 seems to indicate their own version of SQLite3 got replaced by another one.

This Archlinux issue tells more: https://bugs.archlinux.org/task/69990

Anyway, signal-desktop uses SQLCipher which replaces SQLite3 theorically, but the derivation do not disable tracker3, as a result, I suppose a lot of person got a borked state during an upgrade and had to kill their database, or applied this patch locally.

I tried to decrypt the database and provide the database decrypted to Signal, but it didn't really like it and further bugs appeared.
But I didn't try to re-encrypt a database and give it to a now encryption-aware signal-desktop, if this does not work easily, this patch might not be a good idea as it will break again the state of the users. Otherwise, stateVersion could help here (?).

I welcome any input regarding this delicate issue. :/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
