### PR TITLE
jamulus: clarify gpl2Plus; update github owner

### DIFF
--- a/pkgs/applications/audio/jamulus/default.nix
+++ b/pkgs/applications/audio/jamulus/default.nix
@@ -1,11 +1,11 @@
-{ mkDerivation, lib, fetchFromGitHub, fetchpatch, pkg-config, qtscript, qmake, libjack2
+{ mkDerivation, lib, fetchFromGitHub, pkg-config, qtscript, qmake, libjack2
 }:
 
 mkDerivation rec {
   pname = "jamulus";
   version = "3.7.0";
   src = fetchFromGitHub {
-    owner = "corrados";
+    owner = "jamulussoftware";
     repo = "jamulus";
     rev = "r${lib.replaceStrings [ "." ] [ "_" ] version}";
     sha256 = "sha256-8zCPT0jo4ExgmZWxGinumv3JauH4csM9DtuHmOiJQAM=";
@@ -20,7 +20,7 @@ mkDerivation rec {
     description = "Enables musicians to perform real-time jam sessions over the internet";
     longDescription = "You also need to enable JACK and should enable several real-time optimizations. See project website for details";
     homepage = "https://github.com/corrados/jamulus/wiki";
-    license = lib.licenses.gpl2; # linked in git repo, at least
+    license = lib.licenses.gpl2Plus; # readme says gpl2; .cpp and .h source files also say "... or (at your option) any later"
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.seb314 ];
   };

--- a/pkgs/applications/audio/jamulus/default.nix
+++ b/pkgs/applications/audio/jamulus/default.nix
@@ -20,7 +20,7 @@ mkDerivation rec {
     description = "Enables musicians to perform real-time jam sessions over the internet";
     longDescription = "You also need to enable JACK and should enable several real-time optimizations. See project website for details";
     homepage = "https://github.com/corrados/jamulus/wiki";
-    license = lib.licenses.gpl2Plus; # readme says gpl2; .cpp and .h source files also say "... or (at your option) any later"
+    license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.seb314 ];
   };


### PR DESCRIPTION
license clarified according to e.g.
https://github.com/jamulussoftware/jamulus/issues/1330#issuecomment-805271880
as suggested by
https://github.com/NixOS/nixpkgs#issuecomment-804793871

the github owner of jamulus was apparently changed:
https://github.com/corrados/jamulus
redirects to
https://github.com/jamulussoftware/jamulus
now.
I assume that creating this redirect requires control
of the original account; so that we can infer that the
transfer is intentional and "authorized" (and the new
repo is not some malicious malware fork or something)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
