### PR TITLE
[20.09] firefox-bin: 86.0.1 -> 87.0 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,975 @@
 {
-  version = "86.0.1";
+  version = "87.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ach/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ach/firefox-87.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "b9006b2c0251ae2264a60be3763dcf9610f3a8569f2a05f266e59c8232400e8c";
+      sha256 = "656c92c9a588aed2059f4f68968735f884db6ee94b0619d983bd4affd2100174";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/af/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/af/firefox-87.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "7f4268d613acee2e003fe8042dc2e969bd0f6f14b906b35ce6b8c727fbb13d76";
+      sha256 = "0f8fe2b470177df3525fbf533934c66a5e4abdaa3dfb7848962ac148b224592d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/an/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/an/firefox-87.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "8a892626b4f34413423f4da61d7e0099e215bc9e597092bbd625445e27998d17";
+      sha256 = "a96ae593965364871d35ba0fd6dcd1029254110ee59f4a7abe27cf6d273c7be6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ar/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ar/firefox-87.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "c837e97ca8b46de448fbc9fd2120ffbb735474ade8a6f64f7ded8dbdfc4c7406";
+      sha256 = "58eaefaba44b4b0592442e709604b597c74fd81390f8fcc410a8e605956a0bdd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ast/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ast/firefox-87.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "8c3b990b899d70c46827ac5a7f32faf9cf44bfba195283bf47d277ccc8da8cbe";
+      sha256 = "ca33473b77b8a57c305fe89cdd66b95810441aa54295ed687736a24c9160e45f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/az/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/az/firefox-87.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "8fa2a9e6cb6c70fd92b43e2ae145956337f87dd21b468ac375a90a7d18551bce";
+      sha256 = "6965f0b68279228a575dfb503eabae8d75f32e0fa8de119f4d48f0e9ec36d61c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/be/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/be/firefox-87.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "dddbf1e9eb8ecc928b534ef5fd77cb52edd0c67f68a522bbc377d5943cfaaa90";
+      sha256 = "a19d6d94cc15d269dbddccae06b4c92a3436e57d45dbebe8c6a2ff23df66fd28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/bg/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/bg/firefox-87.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "c4eac8234b58f40b40ec5be3fc37817f768d35804f2f923b9d0effa5cf906782";
+      sha256 = "885a44cf0acedc5ffbfcc73cce41f6eb2dcab13d070eeb156e64277b346a4fb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/bn/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/bn/firefox-87.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "41efed647c468ad3da21090e11a4bb861d26106471e0543c3709016d1ca2bd06";
+      sha256 = "09773257768f061819fa92ec229c1f94b217c04e78781d8e59a8dc1225f92be7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/br/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/br/firefox-87.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "53076688c25034f02b3c30455fbdbea0287bfdd8d5100c0f5edb77ad32955f36";
+      sha256 = "23ec95e130593c51384a64165c33f02c4c5af753313fbaf8fa0f94bca1184506";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/bs/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/bs/firefox-87.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "304d9fa41a95f6abf61c16f765ec4651a159af0cabb09b1ce76f805d27746dc4";
+      sha256 = "30455df45e86894fd5a75ef6b9989b64f49da8ac8bee9656ea2724cfca59555c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ca-valencia/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ca-valencia/firefox-87.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "e845d6cbff2cd88b9e1f7526e8aa9eac4aa53c116301ba861e1beb04f9deb4e7";
+      sha256 = "8ca8a4ee40ac57140560c3aeb664d60be5ecd8842f328544924a97d910c02303";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ca/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ca/firefox-87.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "5159eb68a571fb035c4621cbeae9d7a88d40172876a00b3ab6512a8701f43f59";
+      sha256 = "3cc1cd1c7657a704d3c6c1a42934eac75439c05af5617d2d24991d62d412237e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/cak/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/cak/firefox-87.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "efab62e54fa41a65d5989078ee594dc2c2e8c355bd656828321cc342cc167def";
+      sha256 = "160c598f55c012fc92c0882f7062a82b8057177398edfcdeb41c60aa83570f1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/cs/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/cs/firefox-87.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "1cc3e58c1c2790bd13346b752b2209bc8db08a9470960e06857913a70a7826dc";
+      sha256 = "1209d5401b55441126bcc64faa9d7692c92d2c009a40587923c048bec0cf2508";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/cy/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/cy/firefox-87.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "230d79e979cdc350164fe37ea4ba84183db935ba973efab1ab14b56f0a12344f";
+      sha256 = "d177530e3e31900a38e9127b5d60bcc3b937c76e8b12b13c289a29e2afd06c40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/da/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/da/firefox-87.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "04d50be5260cafde33729aca15cd9731f6fb1550da2db86719e6d672639607fb";
+      sha256 = "2e623b11e18d38dee391863115af75fae4119894a89606aa6f4194d04a1773c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/de/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/de/firefox-87.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "a4b5c447cb34b91ac5053153e73520d9f5fc8b06a390f5694cda6bc2131efe12";
+      sha256 = "a29837d6c062ded4aed732cee06fe23773a57d62aecbca1e1a56c9d7a37423df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/dsb/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/dsb/firefox-87.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "eea691c668126056cb1e4137cf4f6e8d40fe46f79a00c73ccd59723cfb63e404";
+      sha256 = "cf584f97b136444861845bf1db0fe9d65d809f4a167a0f8bed780f94048fbb12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/el/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/el/firefox-87.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "d6774ba0cdc0e89091cb57bc1669927f58ed9811617cfbd358567e2a85f977d2";
+      sha256 = "73d03707575ef3270f7419d031fc85babdc498b1576d316abac273cd88dde30b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/en-CA/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/en-CA/firefox-87.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "8cb49ea8e3db760de1f3d97f1583f4219c3039d09632f5ef186311145aa2c3c9";
+      sha256 = "1d11c8a1f23df4e88668beecee244f2d0743b006e46d96e4a6a35bffc341569d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/en-GB/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/en-GB/firefox-87.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "2ee2ead0c7765e9e5744dff5d7bdfe2ac890cb6859362426bf8244e393f1bb5a";
+      sha256 = "d885931198cf3958fca683ee4c301f25610f6b4d5777068fd812bd53048aecb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/en-US/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/en-US/firefox-87.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "d419da5168312f5d023481668fb4767a27799f02248b4ea90fef98a54ab73b86";
+      sha256 = "3c9207bee0a998634c4fd12293acfae207d16508749ad405bf1e8717d06acf02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/eo/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/eo/firefox-87.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0b73a3695f0291c3afdc1635976e6129f94d72d9a9a422ebd3a0cfbbb9343697";
+      sha256 = "3d57787fc840f80271f4d26810f347929a96479ca58bd416bf1f94e3499a07b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/es-AR/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/es-AR/firefox-87.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "4fe2c2428ce205054d16ee33f432dd865e4d919b63f7c2f0a458bd5b80c9c0b8";
+      sha256 = "294c83cce5bbead7c263e950ed8bb2787d4735f4086521726400ef97c5d26b35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/es-CL/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/es-CL/firefox-87.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f5d1850c5c10051b04a445001a2991e52a3c1b93002b3534030e85ee0a3c6b5f";
+      sha256 = "4e57c8a517084eee27edb6ad706a250ebb323419407f1ef9c9f9ae4f0dc8d8b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/es-ES/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/es-ES/firefox-87.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "b99f0532bdc3ab04c421442cf0ea4c24db19a87104ad7d2eff51acb0a383b154";
+      sha256 = "9cdea632b1c1365d3c6ec08e9acd154819d081f025473b027da8d5e873da66bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/es-MX/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/es-MX/firefox-87.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "56bc322d4c7c160fe1bf095039b5b6e31fcfa234bd5d66ba0995f22af49f5bae";
+      sha256 = "3698541ca4e9eb7f5c422082cbacd407870ffb170c9f9d0fe5f0c55dfe2b5449";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/et/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/et/firefox-87.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "962dcd00ed62c5ca6ef86ede3e965e699f403435de9ce933457dac940141c293";
+      sha256 = "86a1986a7c63f63c559d36d3d42e95def0eb8a89075879c3253156e80ed161c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/eu/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/eu/firefox-87.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "2ba0643490d449ad39b07e98713f8693ecc16b368cc459a9ea89a35a1ed74978";
+      sha256 = "5db12874991a1583ec09c934e18c93225b9831acc857d8c1b633f48c65e7a415";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/fa/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/fa/firefox-87.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "11566ef20d466b2930841f4fce2f92960ceeb1771b82449c274f6a4fcfb85e0d";
+      sha256 = "5066d7b66933924442d683aaa19aec9385b66eaf49a55b155653ffba57c287d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ff/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ff/firefox-87.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "110cbb0d3662bbc73273535abd2846091bb16dda3c221a60a2f7023ef756f764";
+      sha256 = "35c8271fa506fcb43c20ccafb928b109125f3a17f80870a82365bc36f787b5ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/fi/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/fi/firefox-87.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "decb87ed765911a9564e15dd97fc7e35164b0af1ab84167dcd598689c8972d30";
+      sha256 = "a3a0dc8cee1db20eb795aea5e94efafc96fc624e50159d8be7f449a093ffd291";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/fr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/fr/firefox-87.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "31fa08ae30af62b65b39c16718ee6c6f132cb157a92fc149a3d36870016abde1";
+      sha256 = "d9c1cdbbe2bacb06608f60745ab213cf80b27051c6b58f0ed7ef834b839da7fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/fy-NL/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/fy-NL/firefox-87.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "f75d128c1c6a1b3171132f20f42aca2b798180e1d58f20e264d4defa0e4508d8";
+      sha256 = "6f15a66cee03b494edf6a68641e0d5f886fe8528e23b9e129b11702cb9a4442e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ga-IE/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ga-IE/firefox-87.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "9902efeb4b30b0935be5dec5a7f85c4ec659b8d8f236e012b2d1187a52f3b667";
+      sha256 = "31fcb9d815afc52db6328b076d89eab85a89d4553748ee7741912d23c420fea2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/gd/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/gd/firefox-87.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "42c779be313524a365dd59013f5486e79b0378d0dc4fe805b5a6769d44ac98d0";
+      sha256 = "c9d0b868022bf5c0335ed488df0d6006541cdb7609f8854aedf22b931017ed31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/gl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/gl/firefox-87.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "cc5d2239946d4b01e31b6da4604a75862f501cc529aecd7962956d4af4dcc970";
+      sha256 = "b546355345950e17202c4f2676731b0fe126d4d551131648f10e8c61cb8a2f26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/gn/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/gn/firefox-87.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "4a94e0f10f9002721ac57e622da7ab43cd1788683288564e87f667069fdac427";
+      sha256 = "51c403ad0460db69e2ed6213410d9fe2cb6ae9a5f100bd4f5ac7d36cc68b65c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/gu-IN/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/gu-IN/firefox-87.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "f81a85e1bea666d339774e0cadd316fccf52752c11a0b5a53a82ac22d6d8dabf";
+      sha256 = "dad776c9a4809c574967bb18d1ef96ab8eb5e95df713fe88fce044b755951550";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/he/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/he/firefox-87.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "347130466e2f42d06707d56e486b4f262874e50c36b69e2badcb7287ff73376b";
+      sha256 = "972135a17b091e8338762c4f3e9c60d826dd8b4f4e65c22d6cb07daabac95558";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hi-IN/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/hi-IN/firefox-87.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "9600a709b7e4b2bb8f0c57cde08627aff892341cd68edda563cb4d0366ca13f6";
+      sha256 = "5eec4571d25c0c62a0d773af25b2be93d158e06302a6e5d47a0fa60f0819941a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/hr/firefox-87.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "bea906c0745f77fc99a830594a2eef1ce609b03596a93cefaaf49044edd483c3";
+      sha256 = "3183694fccb7a9560911d3d0813bf22ef79e1fdc8e72a5547258ff28b5ddbb6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hsb/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/hsb/firefox-87.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "56bf66c8f38567771b57e9f6008b0e86845cd71873b8ee4aa2c056e2c47d3f9c";
+      sha256 = "82c02b623b0833468950a174a6c46bbf6c657252f0f876abb48e5b839a51f0c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hu/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/hu/firefox-87.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "e7da1098e56e1ad7e1baa3b6075defc6169e28306846c77c8f26c424c748f565";
+      sha256 = "0db68343a32b3a69b323b8cf7eade47a453499e092eae5d57414739e2ea92619";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/hy-AM/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/hy-AM/firefox-87.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "ce3660bf256ed1cccb9c73d0c895907c68104f7f1cc28e7163363a060a747036";
+      sha256 = "65b9c3902feac56c5563fe24a8c1d0f3510fca9b90062f88e4072a0ef6258c06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ia/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ia/firefox-87.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "b6ebccd0e4c84d71e7da95ae99d6fa2e1a95fe94d6ed200fbf23ea7ff22aff70";
+      sha256 = "50023eb339a5886cabdf7b71a65ab130fd0a5609cf18ceec9266100ce96e7c92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/id/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/id/firefox-87.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "7d6844743e6a3e56a29f9d5ee599850bdef09f449de70f14e03664c02bebb31a";
+      sha256 = "9a7279bcaeed8c6f6c44c4af728eddada5a96fd3c0204d10cd647d09721ec4e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/is/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/is/firefox-87.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "28bc14cf54090b9f52ae8fcbc7703f201407520e72f5aa6cd0b9f953d4db1777";
+      sha256 = "697d1ac2cbc467d8526b8cf6a525b21a22fecb78f421936901ed3ecf91911146";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/it/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/it/firefox-87.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "1d1a9a7108ebcc0cb796dadbdd9ddf0d8943e5d21c6d56588f33c583e7517b8a";
+      sha256 = "4f51f5c632f21a0b589e2c358972f69107ccde6a32c5619e5b9273cd54198e98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ja/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ja/firefox-87.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "64342a2674eba04cda7f38e7382b7b2fa93efa1b5c555f0a01e6c59314913f31";
+      sha256 = "2ce4af36d057c26f8b9f95b3c578dc738ea9ee80fbbb20f0c7257312499fb3bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ka/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ka/firefox-87.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "38fd38b9a257ba42928e72fed0c3047e000d2a603d37eba1d879ac1d3a87c371";
+      sha256 = "9d4d54895d3237c7431c367a5c9fc07b99b11c91a1645e89fa7668111bb70ffd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/kab/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/kab/firefox-87.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "24570eeeaf5129ce8891320efe6a77203a3eb213285c71c9f2312da1c1d15303";
+      sha256 = "4e67ce270e0a56f5acbe61a22368bc011ccf420201716bd36f5aec42a5d477bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/kk/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/kk/firefox-87.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "cbc294b8e6988e2e010d08608fd1a822f05cf54bb3b3d6772eea13f1a17ee491";
+      sha256 = "c1f1feaad98c108f73d575c2b59c3ff2fa26f9fb97a8d30182aeb4bd587063b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/km/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/km/firefox-87.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "ba9acd0c686ea2ef2d6d8af279c6cd75852021d16aa9e6d8a0bb429de605d8fc";
+      sha256 = "f99973849aa9e9ca4f7534cc6eb3bb7ccd75cf95f600a4a124dd2750da16d2a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/kn/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/kn/firefox-87.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "bba2d328021359961fc0bdf7f5676fe47d72476b4bdb54cd41b09506f49ef0c5";
+      sha256 = "4625c75234dfdd35aaa383ebcef3ba9e093c73aec2ca524a0f7b5b28a2438de1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ko/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ko/firefox-87.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "983f9e165840452aae854b780a480c215f3e030801ff8184424d53b541e1c8b0";
+      sha256 = "d65454c1b36d26d7df7a1eb510f73e7fea47431c6e51dc2119ae6932e11f351e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/lij/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/lij/firefox-87.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "d57f27ef2a5ab4d8032cb823fa9cb6fc566baced92517dca8ed61560641af96d";
+      sha256 = "ef7668799697e1d9c35661f1f6c403307a6deb6b2f265a2906d8baa699c224a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/lt/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/lt/firefox-87.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "1866f926855aed60846004450b34fb341faddc992cfc603ad2b689019e888c8c";
+      sha256 = "bd34fdcad69d3e0c79e226899d0df49e5244a4072446fd1cb7a290261f8473c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/lv/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/lv/firefox-87.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "ac79432c516df059b15737c1bb492a3eec6dcd5261a2ebe17698720ae7085cae";
+      sha256 = "34c379fa36cb7d1de95c99bfae8476f57a40d6d041941ad1884a8314f8511499";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/mk/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/mk/firefox-87.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "5d9eefd2926d1554d1feb4526c460506315a805c7e149ca4f87e0ebcb24b3d12";
+      sha256 = "4a9020fd5864d35efda8ee36454d72392ef3d2e5c50f0bcd6e6f3326dc8fb984";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/mr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/mr/firefox-87.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "a5095a4eeea48bea9c52b843023756a9912a979aa8441aa2160785287bdefd1a";
+      sha256 = "6195db5fcfb95148c243d7fa4675fac0467f1093191bbb02dba714723a4f833a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ms/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ms/firefox-87.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "47b1bc88d7a5f3d0feddbdb0d9e30a5cd9e420b85f3fb360bd6429a4ca1e4bc2";
+      sha256 = "95410958dbe73ead9ef89fcd81bdc3bd0bc6079cb8997962fd43fa07c6b546c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/my/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/my/firefox-87.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "420e4b3ef4b31bd850374fdd4098e41d455d02ab2bbf52b5c575d28ea6350afe";
+      sha256 = "c43a08c4410d7d5d48c29ebbb96765d45dcd20335125bc664f5593d56440e8f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/nb-NO/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/nb-NO/firefox-87.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "6f6656a5370de01fc90eeeab8088d69d71c2e55cd9793b285f0bb88b61d44131";
+      sha256 = "7f39e801ca6ce05bf6398b914acff4a3cd9016503a4401f9b51f92bd4b2c6737";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ne-NP/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ne-NP/firefox-87.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "e7ac9e8e6914624349fd4cbb230faa96eed54502ec8019cdf2032606654e4464";
+      sha256 = "b3ccaa031229d8e369f1acedb49bd159d282cd771205beb2876a8c7d4fc90413";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/nl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/nl/firefox-87.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "a425e62f533d9e360ec2690946cd9ec5fa4f7da9ce6891558fb50a1bf3be6adc";
+      sha256 = "3647e87528883cd7bc3310000f77237dac6dc57b62b664c434b16b9bf736930c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/nn-NO/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/nn-NO/firefox-87.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "69c939c97646fcd628fe3facd0643c2d43790d7997b902a921190b6269dbf88e";
+      sha256 = "3a94b93c5bd68f82ff9d310295f6397b902390061d21c0560a0906415e7150f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/oc/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/oc/firefox-87.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "6a4c2ace18b9e00ee25a4600e115af847d305e60d89335203209d5a519ce89fc";
+      sha256 = "a6fcecb568052565e051879487b34fce54b0e3ca3cc761dd27749d949153523b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/pa-IN/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/pa-IN/firefox-87.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "d81d8fda4acd4ccad2cae15a47123cecdd91afa66f93cd635ea13ed6af074fa8";
+      sha256 = "14b10789c0d94e60c85be5594a0a11654a31e60518c78c04e4bea2b5e64843bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/pl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/pl/firefox-87.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "cb4b300ff0e8e8b0d874dce5349202b8b29e5a4ff79ab6044df74a53f5c72dc8";
+      sha256 = "44aadea74c71dc86d7a5e0cbc04acbe2e26e46add5daaf0f8b31c4a17b439346";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/pt-BR/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/pt-BR/firefox-87.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "654cc5d0a0e35823733e6c9d440c43e4483233a4423c6c9bcaf91cb8fcbeb5ae";
+      sha256 = "057eb47c7f45a1c0005a508bb36ee04b3edfce0e23e175fa311c9f1cc49b7e03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/pt-PT/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/pt-PT/firefox-87.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "a944bf18dc7490ce80779af4cce82c20521b48ddb691ed5504d70075116af0d7";
+      sha256 = "dd33f93ef7acd1e183902bd85b292b7073beb9fca3b46279f0405bcd06016771";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/rm/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/rm/firefox-87.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "674921eeca942cc77b08e8c33a273d327357d90df7be91140e468517a59a7cbd";
+      sha256 = "dd7649d8de678648f54a6dab7a66246abb6b514ccb5044eebff5f6689bae99d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ro/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ro/firefox-87.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "8cbc8f6246455b6deae4a8e619f065ba218b59e711747033b08adffbed8498d1";
+      sha256 = "bcbc82632f8a6802285f23bf0238738a5abe5e77d70596261cf7fbe6649c9560";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ru/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ru/firefox-87.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "6d2f6c1d4d8503ee78769c69c97a3cbefa6544a8a1ffb662f10460b6d78fa209";
+      sha256 = "bedcd965e2a460bbe2aef0fad6bfe524044ad29225d26009d5311b8796bcb64f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/si/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/si/firefox-87.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "af33afea872e8e2b8825a01d5fcbc40a5b7674813b60735855b5fd0b886c57ac";
+      sha256 = "bb93e1dc7621094f32e385632844169a8dc51369be8c5ca459dc17708e1d1ed8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sk/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/sk/firefox-87.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "7ecd39362865c864d6a5412bed20f8946019e3cb845923ce2ee30112d8e6444b";
+      sha256 = "d7dfbfcded930a7d8aa03e482c66004202824256255cf08aee5a84a41d825285";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/sl/firefox-87.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "93c000e695b37f389356d4f3c48c55de6839688826c507e0cf76fee105409dfa";
+      sha256 = "3ab06c56331850805e8e925deefb3cd0d21913fe88e04d6cd16ad9c59041d444";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/son/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/son/firefox-87.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "25df54b6e83be77fa22622905d17667a5db613eca263582daffea9c0079031cc";
+      sha256 = "6b93d5b1eeaf64ed591a285b1384d63dec16f388609c845e12f4565ed2bb32af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sq/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/sq/firefox-87.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "6c8eb230a6de1b5056e530bd76ef0d6f6f35ee29a9d814440c6c2a32460b2de1";
+      sha256 = "834a04d54a73886c58d0360c675b137b44a69b34003e5d77ba8516397e976874";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/sr/firefox-87.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "a7b82f4383608dae512dd528068d9b4b2d4ca194f118098b328fd1b817bed14c";
+      sha256 = "d629d7004fd5c3298e61ec154c7983b8b7bcc4ee8552ebbd53df81eec85e5cb0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/sv-SE/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/sv-SE/firefox-87.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "dd856d068f32271ad024649c945ea4665faabf81a4057a8c7efe4f1cce302eb2";
+      sha256 = "c3d19f42894dac47f78684ea1a9bc9d7a6fbfd51b4186bcb06679a6666a280e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ta/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/szl/firefox-87.0.tar.bz2";
+      locale = "szl";
+      arch = "linux-x86_64";
+      sha256 = "3572e4ef3dc20960e60f342e0dcbb4ca374c9184cf84c40d644c3677b8dbf4b8";
+    }
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ta/firefox-87.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "9cb7ec3e3150a3594ae1a460b70d81ce1ddb9fe42696710a0e7eb1baf7c5aa17";
+      sha256 = "b2f40c2f906fa1cdc67ba12faaab62468e71b9c9ec1c28790db56a4728e5f897";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/te/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/te/firefox-87.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "a3960a97ab3a7a28fe8c218457fe36a5f72827d602ebced3ff74d02f9941100a";
+      sha256 = "81f135e5b9e1c90cb22baee13c5ebd5d2a954f3d3a31be74489eb9bbf4dda7ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/th/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/th/firefox-87.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "c342893afcc7b68ba09c8875a55bec4ef2a8c5af40c0ae96a13a662eb0d73115";
+      sha256 = "dac4e7326e9a2b0c6eec8361ebcf23afc95087f5fabb964c7802856bd8de02cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/tl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/tl/firefox-87.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "3b0de00b254c2d984bbece1d3ca3acaffdc316a44d7270f4cff4c35425310913";
+      sha256 = "9be7f3be1ebdfc19c8da8a70b1eef8108c6508dc6c37b39824ef11756f62768c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/tr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/tr/firefox-87.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "db36a0260fe69a99d3c834e526a6bdd305334490dd3e644dbd8a48606487209e";
+      sha256 = "d7be3f1cab9759042cc30002063764dc66a9f622df71291daf93faa204090b02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/trs/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/trs/firefox-87.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "94bc2723028e39d161bb7e95a27e9ce935671c80646674aecc871205a6c602ae";
+      sha256 = "31b5dc1f40614975a8e3fa05caa0dd8dcab6b15dd0ff1ac4626d9c19b3e763ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/uk/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/uk/firefox-87.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "7ad9a53018e54fcdb860cacc5fad9eb34a08e879ab69d47af21eb31f3d6c2803";
+      sha256 = "a53842d484e2a632931a72b16b3c8e30c902dc1e46c3cf2a7711bea1fd0911b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/ur/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/ur/firefox-87.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "6d333e34bb8a332efbff91b9f7d69092b69e377c324693b765eb48b49a7ba108";
+      sha256 = "1353882717c9ae8e35523ab403870fb08f06ddec2df0730637195b1ee112e746";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/uz/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/uz/firefox-87.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "5d111ce8b55637ab03c94fef0ed2e5737bbeee4f80a1ca4ff1847c2e9133c31d";
+      sha256 = "43feb49aefcd292f61faadda2771251017c6104038ab1474d43f5cae1e8ee3ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/vi/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/vi/firefox-87.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "7fafefae0afc2142a01d7304cfeda60ce1f6302c29abe2d906391dcafea0f25a";
+      sha256 = "d74a8de627e877e9c28cd19832605e039398dcea312a4784099151972d380516";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/xh/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/xh/firefox-87.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "0d177c264ec9b357be2e616fb02958b4c9d7c6baf292f3c76bbeae84fd2202bf";
+      sha256 = "3251086b6f58c311906c49a6b499db17eaa3122a8ffcafb6f303db0489530560";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/zh-CN/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/zh-CN/firefox-87.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "2203d75b4a62bfe3cbb51c02665420700ea00686b7b9d4002b9a9a6ddca13f36";
+      sha256 = "4d3471f60685d251b10dd1dc06610bb3ebf9d7a4e03616a6f6d988278868dc05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-x86_64/zh-TW/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-x86_64/zh-TW/firefox-87.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "7d19a8791c79c0bd9fa03ea568f896221cf6432c826f4a59f99ec78139966817";
+      sha256 = "8fcfa5987a0cfa37d5408c88701378e970960d21d181342ea2a3d6c43f4e4cc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ach/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ach/firefox-87.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "caa9485d62e682e5b06e39528857975d1c862ef23e62c9f4147c5db4027c867f";
+      sha256 = "42ba93ba360aac202bd0b653a982dea3c1ea0d5cd6c530deef47c29c189c197f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/af/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/af/firefox-87.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "ea114ce9ca7f2c4e5675d25224ffaf7805ec9361097ff47649bd4371937032f7";
+      sha256 = "9aef316b230194ec02ebb1e7780e61d85b1a4cd398d56ec0c5238bfb9af8278d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/an/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/an/firefox-87.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "c022590875868195664c4920a3da7bec6bf9942a233190176827d603529a74f1";
+      sha256 = "a645abc8fafb548a495efdf9e88ce96af06d0fa4703ed5ea6b63ae79d309f3f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ar/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ar/firefox-87.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "66ac4afbde7ed45e1d0239e3364c62f788ac26c8bd652b5c571a9f965ae632ce";
+      sha256 = "c85e9eaf8480ec226eab70a8b434f56fbd5f4f8a7e57f13b341d478142e4ef99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ast/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ast/firefox-87.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "3962d9728bc8a0fde06ab64d6da1f40328938db7689db7b402919191c5286f3e";
+      sha256 = "96a1fe1ab748ba2f99a23fd149f1d0b60a27f4d96ad12bb2473ec0393597e968";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/az/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/az/firefox-87.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "84e786225936123aec5c0f2bb27df9dafcd1ceb2e50e8235749dbc081adfd4eb";
+      sha256 = "52d3bc8e60196814f7ed1d1732faf32b4129a25379e9f526db7e6b755bbd5746";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/be/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/be/firefox-87.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "0cfac785cbb8f0c179788dca2a54484473cdfd5e0618894665bbc70d4c2e36f5";
+      sha256 = "8cadf14d2ce8341e8a6a11a298203e121125d12ca63833642186b79ae79b5643";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/bg/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/bg/firefox-87.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "8c99908f307fa77fe6e92e58d26ea295471e6421181218fd0ca022c767e1f5f2";
+      sha256 = "b60d8361c16f9b200255e6a904fdbf8da00a6f33a95280e456b471d54cac75d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/bn/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/bn/firefox-87.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "28b303305691ea7f8228580135acde6c17d745719a96e82c60b8d6738fdf2bde";
+      sha256 = "1818bdfc297e2928255c006f8772478ce574c34748102ef64c5645ff59e3e2c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/br/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/br/firefox-87.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "83a76a0e7dad03453178dbb3a792aab03500359b623851b9a6ec9a4c1e0af084";
+      sha256 = "7989cb7ba1a6984891c6eaa48a35b09281d0b8c7532c46cb1c87008bff5b68fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/bs/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/bs/firefox-87.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "0700c7d655136ac51134a6da9def1747a27d84ee21b523dfcc6f30042f9b8632";
+      sha256 = "d618086558e44219582ff263d9555855bd562e0a8b9d588c2a03734d003e1138";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ca-valencia/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ca-valencia/firefox-87.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "d7738e186c6bd3f4a35c53bc6cf39876ad7774a45bbb3a44529c322f48a490b0";
+      sha256 = "8f74cf450192bc9dfd2877269f98663ebeb06fdd0cd6d25db3261e5d1f6b36c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ca/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ca/firefox-87.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "ca63b150369c02a048ddbfaaa2f2faeb2729fb46086937c97a93d684975e2837";
+      sha256 = "dee6a1ded1c10b4771294435c23e433ed209dfe55db9cbcc0454b0da23d26cec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/cak/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/cak/firefox-87.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "2a8a8ebe18dce87a021c71e87e2815b227b03e3251d141f044c083d7a4c942dd";
+      sha256 = "9e55f71f4040c21d79fabe4487cf5b660baca37c23875a31015e70a520fe0737";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/cs/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/cs/firefox-87.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "5e60175642fa8260c4125b90412564fbd49b8f91ca204c30dc687108273184db";
+      sha256 = "3121a7d49718ebf6c9a8babe0f57962547b54b99864f917d045f78ea4a4aede7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/cy/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/cy/firefox-87.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "ee6e49cc30f01f5604cdb317801ced10c24809ed64f6505f44b6a33cb359641a";
+      sha256 = "02c5a049462f3d4c0a538a62756af8b4e59b1acdfc4d92d43639ee3a27e568a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/da/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/da/firefox-87.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "8c447626d889aa067bd758a56e4dce720f01192e283c7e01997c6f85f0265f89";
+      sha256 = "8bc3ad5f69850d0fd4c91ef2296462fc2c641e8eb9835ac5ffe88a9dd518821a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/de/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/de/firefox-87.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "12d52ecbf5c4b9313c3e9cb61a353f812319142c6b20594f7fbee01a339d98ef";
+      sha256 = "2e9e562e10477f4a54d677bf2cd6becf87e4f40336fea8f4337f5e7d928f28f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/dsb/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/dsb/firefox-87.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "5064e20ca27adaf48d5c4041c12db3738c95b9143f667ddbc28230ef9387b28e";
+      sha256 = "fc1881741d5aeaa5cc34e9b86515c8ad637984d88814c48f8f014dfab55bf02c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/el/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/el/firefox-87.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "a625d2caf3be1a5039a90c3515d1598b5acb87a4e4df4e0ea22f0a63b0405ae7";
+      sha256 = "cc44c88c82adbdcde8690825851711b48212a49aa74b7485cc51d234a5027cfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/en-CA/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/en-CA/firefox-87.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "cc1c18c8d4d53495fc4236c95b353bbe40c3de16ded002b2bb991a824fc67210";
+      sha256 = "c6a32c84bd3ed42ee801a5780cf45a6061fc8b37de4220907a98d674831c0a00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/en-GB/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/en-GB/firefox-87.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "c76f7607b28bfee12eebf2aae7590fea71ed2a4f3bb0ce3903f0331187640122";
+      sha256 = "cbf4e049602873ae13eabc2176657bdfb95fd4277360991ab4ef2a4e7be697f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/en-US/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/en-US/firefox-87.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "fe6bb788d3c5264943ae5a287cee691f6aea8b3502f11e386f6d723a08dc545f";
+      sha256 = "9127aee106dd9f09fac0c3cb89c5d75553384da4ec9be5943b60a5f55f31fccc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/eo/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/eo/firefox-87.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "39af3debe06726ddd02a4914bfecda2d023d9445e7c735e8974ad73f45955298";
+      sha256 = "7f75cb2fa8c73bc98a4d5b0f60ddbc66eff63a9caa271b98bb8eb4897fecdd49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/es-AR/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/es-AR/firefox-87.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "2d66f2f28958157da1dfda56827f5330f6d7b9fb192899b2ad60ecd6d18e9505";
+      sha256 = "090b13b1698e70c0d13409ffac5b45a044356556e3ecab970fd34907e16cfc11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/es-CL/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/es-CL/firefox-87.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "cb69afb6ac3b47721176934047ec9ab3b1127b7d36da7b9ae9af9aec72bb8289";
+      sha256 = "1453a40f9c2ae6794dc886d1c5462e4341141fe84792e32a08b0e6c4ac5183c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/es-ES/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/es-ES/firefox-87.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "3c0ae2ce17078ef568ac71d5cf8ceb0769fdb8298ce17c58468cf57ab7a95af8";
+      sha256 = "3dc986b05c389dab03cacd1672c8621f1ec93e5781dd79ec18358e3a1f2e8f84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/es-MX/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/es-MX/firefox-87.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "cd07a75c8c96ac8d31cb988d9d394e5e2eb9bb6cfd6df33d6e60d38a6406a4a8";
+      sha256 = "e6b18f0adf5ff99d1c7f84dbabc00b44ad7c3c2a4b95586f58d18421f28dfa1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/et/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/et/firefox-87.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "cced1ea2d54c9d305b61ff1d1025aaa5f23bfe86fca3b0e915f2dcde1384d042";
+      sha256 = "573cabc8b8eed9e80d43ce960660737fad1f3bf43266d3e72ea475bec931eb9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/eu/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/eu/firefox-87.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "9105eebe6f606292b82eda26eb68b399dd13e1756f1ca88395f0b7714089ea4a";
+      sha256 = "5b3d1ecd842b30029fa1749ad7a1aa6486bf96f977d5f274ecababe7909c71b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/fa/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/fa/firefox-87.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "9956fc5949d1e111265dfcd71373d8ada4cb2f554b9ffa2dbda0c430296ece56";
+      sha256 = "41edf84920463d8c1f6ac8a8c0c5068143652129ec42377e3a3973d54e8477c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ff/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ff/firefox-87.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "02a6a2f711db26b74094744e9f198ddc05a1188fef0fa330949e9e5056c7ffba";
+      sha256 = "492d2b1307558b1b19b5d1d88bcc0eb151d00ebc1331356520068597614919f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/fi/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/fi/firefox-87.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "368c2a59f1446d61a7a27892ddaaa5f933cbbcb9e3f238db5f9e9cb77873e37c";
+      sha256 = "f495c5d6965c2fdfd06d23616f4b017c600e07efc22984be743c3eadcb5eceb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/fr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/fr/firefox-87.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "d543125a0e0402245064dc763eafcb3b00237c217a929b04f44db6755319ae2d";
+      sha256 = "ba0cbea290a3911a6bc24fd52e726234f90213b05756a57aeeb01a8ebcc7af73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/fy-NL/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/fy-NL/firefox-87.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "ad28252c39eac70b9ce15631c65dfe520950d36212a547587978c635bf835187";
+      sha256 = "9e9dfcea10f89836b3d63420f90f992b123dcec3beceb3eb739d47b15ced4a1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ga-IE/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ga-IE/firefox-87.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "a16c0117757cadacc408f95a81e38b7f7e9489a4b6ceef30b8a65796fa6a2ca2";
+      sha256 = "316b6877a46f452d628509bf94c4e729080d93cb8590d8c17f9ce030823a3b86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/gd/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/gd/firefox-87.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "83b61f8e5801607f7b71fe2fa5fd7aede2cd56e4b46b25057935afb23f28ba01";
+      sha256 = "34f2b2660f76ca13697ca029fe06cbdada7e8a0ee3f703c55b5290af4f59d687";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/gl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/gl/firefox-87.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "a603031b44679e8e9dfa14c2094690c786b4ded18d736bb16d683e978346fefe";
+      sha256 = "b61531887132193a3b68fc1394682305bf242bb8244f19c6e6dc158b0e6dda61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/gn/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/gn/firefox-87.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "5146bded3c264c6a77a9e4e9a1c5523e63858eed5077e8ded56d52b94fafa7fc";
+      sha256 = "286d7c949488a93370055dc650a70825df689b496de47382c7c326d0be16cf11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/gu-IN/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/gu-IN/firefox-87.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "d177f05815889cd026879d6ddb3c03d3c62bb3b2787ca68a97902671977400e7";
+      sha256 = "c04e2f3cd9514b8494122af0baa474b2e3ac91d62939ec1117f3b07efbffecc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/he/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/he/firefox-87.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "c3534b56a9fb43e959c8c6055f6af0c1ce9e512bee8786fa4a1028ba0813cd73";
+      sha256 = "9f4436ba36fe3d73f22c0837fa124e712c58169d9db1cccaad91187d895f4b95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hi-IN/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/hi-IN/firefox-87.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "a4885b1515cee1352bd534de17742af432502169d8cf2f34426950a5482647cc";
+      sha256 = "e1c3674ef1a401c6f8f5f9f3f4cfdc9a858fc670f71d0b09d79677820ed6ddb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/hr/firefox-87.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "1d9d49b4360efa296ec8b6750aaf8e09a24d749e3694d30dca446480b350a733";
+      sha256 = "7dc0f6c2cf38f90741a8c0a2f5df22b32abb6399d9b24cc827f1ae972a481b23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hsb/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/hsb/firefox-87.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "65b890ced9ffc672d92d8fe998ff4f5deb485f22ec4d1525525fac81ed30c2e6";
+      sha256 = "d59ee63de2bcb95575a782294cad35a0ea99eb4c8e4bde8539cd20326d85b41b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hu/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/hu/firefox-87.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "90e32c53ad910ecce1558c99f10514775b72efc207451e9c61127051c92fe450";
+      sha256 = "c9d13a693183290db6a62eda37da63f0d1535db5604a6f62d88b990ac3ea39ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/hy-AM/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/hy-AM/firefox-87.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "02c1dc969487809e432f4053b39b996ffcf51c81c7827146d3cd7a25ff050abf";
+      sha256 = "7edb84df00e57987f4cbef235a1fecc22b6dd7aaafe101f62e002e4e59caf56e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ia/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ia/firefox-87.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "81d027c3facbe67258151046d9aa53a7d832d1a120aa671532524c87b79efe80";
+      sha256 = "501cafeb34aef4d8dae63f47446abf8b04dcfee93b9931ec06f809823a6c675a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/id/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/id/firefox-87.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "7a54acb6b8f14cac3d2a7e21fba5990dbaab9d4efef8d2a55642ff120905cbd9";
+      sha256 = "9913aec5634c32300c2f556017be415ef6516a4380af3e597b2abd8e449e82a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/is/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/is/firefox-87.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "c1611ebeceaf431883e5dd61b15aef2954007feaea3cc7503573216ba4cbcb0e";
+      sha256 = "71b1bf3205043c5c23988de6955a51091ec812e82701d0f37c12e937ed774b69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/it/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/it/firefox-87.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "76042e19b820c69b1d7d39f3be87069142a4fb6c0327b8f67f78b87821454cc9";
+      sha256 = "7a842251175a2db53e0bec3b65c2db0007a1fe5d84ec126fa9029c6d9dbc732c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ja/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ja/firefox-87.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "6e2d8fe15275935a02e3f07ebf14b61f657a35cdff262d50e3a0f10e3ff587be";
+      sha256 = "6a8aa33e333fcfa9bb2a011d08af0d10b445be1a22dacc4458c121e8943b1f62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ka/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ka/firefox-87.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "93f59b3150795ee6a1d5cd446cd0147f5ccee359939fcecae63a262f28eea0ca";
+      sha256 = "f2d2cc7b079e0ca69de3568b10bdf6d7f74ef7f8b0bd05a89442be41df3d2239";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/kab/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/kab/firefox-87.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "d71c30914f32b0f5f25c1492e94d0a397997f946f1ff58c85997d9c6c55ddd4e";
+      sha256 = "7211457301c54fed01aa3b0735fc7f0814d4fbfeb7862ebe438f5cebf7fed6e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/kk/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/kk/firefox-87.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "9c3b1b80d46c75526c5c9b53229e74aa7cb7219a3110218ecbd099e1d05037ac";
+      sha256 = "8b18ac077d961279b2bb179ea37819de964e488ab528d4591ce2479ecae167ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/km/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/km/firefox-87.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "95b59cdaa6caeb5cfbcfc673faed614650dbd44458c79684ca7f2ee4ef678e4f";
+      sha256 = "6b06454f9e061ae6d099ffbb2079d92538b32eb619d12858c3d759f004c427c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/kn/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/kn/firefox-87.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "31d79f5609140fb213e19b60d638811ef576bb3db8be533aa92a02ffd22d4df5";
+      sha256 = "4b8d711f0f33c850d2bf39f16ef0da7e004374445ad8bb3e69e0b74ff0765cd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ko/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ko/firefox-87.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "f05215e9004a651b239475bf02de19709fb2ceacd99f0da22ba4ae91dfd899f6";
+      sha256 = "f6da2239dc4e457623a64f2ac5e56868e70115941ddd3c19093ba180a3aeea7a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/lij/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/lij/firefox-87.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "309ce372ace38efc2cd907df32d18fad97e8fe66728c52efcbc36a36e91163f4";
+      sha256 = "fc45263e353af69c7dc2e5d74edefa793b0f1d2bb86f496dd75ad66bdfc7ffe1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/lt/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/lt/firefox-87.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "1426fae07194ec4dde7fd797631cbb561726af5b1c255b72c13a96b54034a440";
+      sha256 = "f030574f0bfb8574ce07159fdd213f1e21c4293bf7e1961080e6ef10f7f14b42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/lv/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/lv/firefox-87.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "48be4205b0d9ba8de2545a73950a4c2836db3d046707ae5db7e2cba0dadaa3a5";
+      sha256 = "7648c4616260b09161a3431120fd99c97c5630347ad4ac196956eae4cb4b18f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/mk/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/mk/firefox-87.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "6cc5019e2d41510a67cec8850451fa16e868da753dceb8a38a0cec893814f07a";
+      sha256 = "c7bfcf5ee846d340d454d6cce2e66c0245bca10d1b74887170ba3820c392155a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/mr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/mr/firefox-87.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "ba73c1ceac1ad36912f6367a23bcdc4455627d16f2bb589cde4abb5304b06d67";
+      sha256 = "808207c6efa62312abf14091992022a3d37ba906c8003316d6af943228ba534a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ms/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ms/firefox-87.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "09935a83eb75eb9f89847d9b279c5728c524bef37d063969ec3e44346ef74c12";
+      sha256 = "f836343cd1116657b8f8f28f49df99b36a13a4255d0499945953b64934f80e64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/my/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/my/firefox-87.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "55b7adcbe1bb47dc49e1d51d99fa3b3a9aa3028a56fe2c53848ec9591503360a";
+      sha256 = "1c01f7dcea9ecbf1af3cc29cb38aa8cd928dc6c10f67fdb20f98a588951336de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/nb-NO/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/nb-NO/firefox-87.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "87e7f1d1ecb402f9484e40078a3460b18aa41d88f0bedf61edeb937474ab3e69";
+      sha256 = "f196268af59a118a4c5ca50b5c7f9ace27d642fd1952085dd693f09462eb27a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ne-NP/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ne-NP/firefox-87.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "0c5e84344df03c41ab835c3af847772d13fe48d3395fc2aeef020eab04f76baa";
+      sha256 = "6a80edda7e3b0f97282840eaacd9d4d003e6562c4931a14736bd1aba6ea8eb7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/nl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/nl/firefox-87.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "75f54fc189ee6f43277066a2600bd340375fa5820e64dc340a3ac93a1f0a6ea0";
+      sha256 = "495a43b18aa2078bd86468cbd1545ea04b0fc63c847a459156489c18432fe5ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/nn-NO/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/nn-NO/firefox-87.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e1dd0adfc33ac73890d849c685d3072a8bfbe6ad3b5ad0bcfa0a04c9ec817c1c";
+      sha256 = "a3d58b74e2ee2c97a2b4aa5855040f34f79024df55d8de6623991df61cfc3b46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/oc/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/oc/firefox-87.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "2eea8f40976373fa98d7d32c016dbf0e05fb8f53f3c0f038a087220ea91999a6";
+      sha256 = "c71e444eb03df8c4b28dc34d4cfc32db2471ba12389f448c28a9dc03fc0dbfb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/pa-IN/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/pa-IN/firefox-87.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "03c1dface09201be51bd8df92a420b67ce885a712231754dec5e42a4e5cb8cd8";
+      sha256 = "69eedac3a7f2912f179e2c5838f4dbe109c1b1c570ea1f375d5563a622553f13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/pl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/pl/firefox-87.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "1d4fad5713d1b6606551aa9b9527c4919e548fc9fb50b921404609dd7a43c76f";
+      sha256 = "106012905a00d898ad3fa43c733c1f568c0df2e74165276feb5b3f5eb79a3b20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/pt-BR/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/pt-BR/firefox-87.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "53defe8219ee88152a542e24526a3bb9d75e0117e606a3e976d798f441acd64e";
+      sha256 = "18434861a77abb7810008af068589250ae5621c1719ed4d37643c7aa3607070a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/pt-PT/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/pt-PT/firefox-87.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "d91483eca2e1972ce6a0ac97b0393a9cf28a36eb1e923cd863d37b8fc66f4edd";
+      sha256 = "b27fc0941804f4bedf10c15e26fd14fc381416a2c29fbe9b4d01f328e2164022";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/rm/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/rm/firefox-87.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "926234371843aae60cc81886ab7ebaca7bceb6f705ab9d2560ddf996e46f6aa3";
+      sha256 = "2283c43282caeee2798a93af96979e46a103b3ab7c645e72384fe19973c49534";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ro/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ro/firefox-87.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "9c63bcf8b603b65f355460d0de6827e363ec0797bddb9d446e116b641a5f430e";
+      sha256 = "6d7ba9b40f17f373c4eb151a4bbf6399d27a8e5071342d25a374afc67914bace";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ru/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ru/firefox-87.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f4cb8e70dd3c0b2bb97b28c6f85654786f65daf6705559a3dba87a5aa4f0ae18";
+      sha256 = "77341829394b41ed8cf63090c30b993e3a540b838bb476239398795eb026442b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/si/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/si/firefox-87.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "b305cfa2be37591ae0bf49de8da37ffa3a5c69b242196073d84124dd02dd094e";
+      sha256 = "b7aaa753f54ca1aa5172c39e9899c662f62cb81628f29d29ed8774c68697d1fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sk/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/sk/firefox-87.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "23772e40241f955d20a1579f283c6d648e180ae7da21ef0a914156733f89e6a6";
+      sha256 = "fc70db60786a652dfa0d8614c24bb4b5cb46849a468903723c9e9cdfebd9eb52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/sl/firefox-87.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "7213f902b853bbce4594db2f5555e437a82adaeb506a9d1421ff9015d29a9659";
+      sha256 = "392eccb8277c76b4178b6fb74c8974ad31e0b36fe8778b5933b37f6249d3c9b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/son/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/son/firefox-87.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "7b45520bd7305b28803bd4e2f22d41216707754ef46cf6981f0c299b03efeedc";
+      sha256 = "c95c7ff206a42cf5c4caba9a3377834c1b8b4d258de566efed15ab0815b64726";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sq/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/sq/firefox-87.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "11b0b971a705d483f3dd7fab066d034f0a30dd95e16bb7d7aece44d8ccabf450";
+      sha256 = "7eb9cbe937262ed47711df80143b49d369bfb185119a3fb51f8a723bb99b1f9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/sr/firefox-87.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "07369958e98d1959be2e52b33145ed1075dd85220de38fcaf617d207217a0066";
+      sha256 = "4d4b88503ccc6d5f5c16988c626027516681d265b32ee205324919a170caa1b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/sv-SE/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/sv-SE/firefox-87.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "7671a24d1b81b26c34a21cedea05b6c132963045d3cbc28ee264f9c56302cefd";
+      sha256 = "fe2fdf76541c95166fae7b9d1c0b3390552968ac0a8f47f2e23da750c8b8753a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ta/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/szl/firefox-87.0.tar.bz2";
+      locale = "szl";
+      arch = "linux-i686";
+      sha256 = "af91e1a4d0afefd890ce9ab04ac800427670a314089b67dc41e12bfa43ecf112";
+    }
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ta/firefox-87.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "bf605ceac99dfc2ed058ada9bb9fbd7ae56fdea3453d7dea23ca13dc284391bb";
+      sha256 = "043162612ff54115953c25333fcc03d801176db1d379cb7c94f22c0da5a1ae00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/te/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/te/firefox-87.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "8aea95f2069a59cbb575f386a7e90d04ecd0f4c4139aefc6dcba54b9b56e7aac";
+      sha256 = "2fca2c54dd357d8d5e3bb8804dbc3cfcc7fd1c17f538eaf1e1fd60c95baf7252";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/th/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/th/firefox-87.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "4985ee399155bd0854c9b9068fa747f396855b1251610c3261fc5c7da5e5894c";
+      sha256 = "b049f6cc876fce2d57387d2c90afff4f261baf38e582821656efd455fdbadc03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/tl/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/tl/firefox-87.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "d328338029e0282ca5e3c7e0bcff73faddfbb4bdcb47a2978622c80e2dd8d0b3";
+      sha256 = "be18fe1caae3a85e3a48b0a5a45cb175bd11c31d1cfbe726dbe4952c50338299";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/tr/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/tr/firefox-87.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "a438f5504b0fb62173a8a739645e7f269647e33316a35a96c5dce71d9d87bb0a";
+      sha256 = "5c43338e0fc0138c280f9231e05c14a553d2b0504053b5c090adb7ecb96cf8d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/trs/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/trs/firefox-87.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "41c90f6a5de249fc5b0dcec21d5d2684b5d3be2767d6073529101f31bec569a5";
+      sha256 = "510ee9988f4d1c6e0e50fc07d00d2aa80380f89f8db4b0655c7a9c0aaf07fc51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/uk/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/uk/firefox-87.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "06419fe5e671a6476500a8ecfe736237adbafdb39148d56d514fc7f07ff09e87";
+      sha256 = "a01aa11750b6027f01b45763d691c425b65aa577fe9fcae6f492b40bb8ff6056";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/ur/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/ur/firefox-87.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "f5c1729584fc7843da5febf2411196d4615d4d5b490dc9a0f7b0709496b61ad0";
+      sha256 = "f2e83dfd361dc8abfc3fab5554d1c545b216a05f57718aa1f8976f7c2dda3b17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/uz/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/uz/firefox-87.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "a1a898dae70288fac86c0ff36b92731e7b3400652b5bef485db73cd8ed933e8b";
+      sha256 = "4c570ba3aa3480efd63ba230b550d750a49289b3bafe9ede881b28184ac26ca1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/vi/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/vi/firefox-87.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "7c12e8fe3b30ae8b8bb106a3ce866b23dcdcdb7924ca41e8c9b3d541e0300963";
+      sha256 = "846862d789b275ba1184b1f65a95570043ee1f8e2f7da5678252c192a8d31966";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/xh/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/xh/firefox-87.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "97f40f99c9d0204db12d1da1e58088dac2fcd02be6f4fd5c477d20f0149d1f56";
+      sha256 = "5c5a88654bcec7a8c5bb7245567270542823a377c7843a6b14d8f12cf57b7b59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/zh-CN/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/zh-CN/firefox-87.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "309e7670632171133fef52c1426a1f42fb4e14c4d99a8f9543439b21105425f4";
+      sha256 = "b7774306c5941feb5b7abf4fbc3e3d3af854145fff741f561708b5ee94d1816b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/86.0.1/linux-i686/zh-TW/firefox-86.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/87.0/linux-i686/zh-TW/firefox-87.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "5993ffa86327a42ea91aa884e90bdb8626d4108a8299acb2f80623e8aaf3ed3e";
+      sha256 = "d115d7086947003940bc270b6a83aa612324f7913e044a194c1e05648e241b17";
     }
     ];
 }


### PR DESCRIPTION
(cherry picked from commit d7bba3e5da287ae8ea5cf0c510e74d6c126ff51e)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#117343 for 20.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
