### PR TITLE
buf: init at 0.40.0

### DIFF
--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, protobuf
+}:
+
+buildGoModule rec {
+  pname = "buf";
+  version = "0.40.0";
+
+  src = fetchFromGitHub {
+    owner = "bufbuild";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-N6o+1cfer8rgKJ3+CL25axJSjGV/YSG1sLIHXJzsC6o=";
+  };
+
+  patches = [
+    ./skip_test_requiring_network.patch
+  ];
+
+  preCheck = ''
+    export PATH=$PATH:$GOPATH/bin
+  '';
+
+  nativeBuildInputs = [ protobuf ];
+
+  vendorSha256 = "sha256-vl+WqtpegoAvylx/lcyfJk8DAOub8U4Lx3Pe3eW4M/E=";
+
+  meta = with lib; {
+    description = "Create consistent Protobuf APIs that preserve compatibility and comply with design best-practices";
+    homepage = "https://buf.build";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/development/tools/buf/skip_test_requiring_network.patch
+++ b/pkgs/development/tools/buf/skip_test_requiring_network.patch
@@ -1,0 +1,15 @@
+diff --git a/internal/buf/internal/buftesting/buftesting.go b/internal/buf/internal/buftesting/buftesting.go
+index dc8da0c..70ad299 100644
+--- a/internal/buf/internal/buftesting/buftesting.go
++++ b/internal/buf/internal/buftesting/buftesting.go
+@@ -100,6 +100,10 @@ func RunActualProtoc(
+ 
+ // GetGoogleapisDirPath gets the path to a clone of googleapis.
+ func GetGoogleapisDirPath(t *testing.T, buftestingDirPath string) string {
++	// Requires network access, which is not available during
++	// the nixpkgs sandboxed build
++	t.Skip()
++
+ 	googleapisDirPath := filepath.Join(buftestingDirPath, testGoogleapisDirPath)
+ 	require.NoError(
+ 		t,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -166,6 +166,8 @@ in
 
   breakpad = callPackage ../development/misc/breakpad { };
 
+  buf = callPackage ../development/tools/buf { };
+
   # Zip file format only allows times after year 1980, which makes e.g. Python wheel building fail with:
   # ValueError: ZIP does not support timestamps before 1980
   ensureNewerSourcesForZipFilesHook = ensureNewerSourcesHook { year = "1980"; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).