### PR TITLE
 thunderbird, thunderbird-bin: 78.8.1 -> 78.9.0 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.8.1";
+  version = "78.9.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/af/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/af/thunderbird-78.9.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "086a23b05a2baf8e8a1b44891017c6fef8c45d4e4802b519ceeda2bf62496649";
+      sha256 = "58bc04e46def73b3530323e56d143db324a5a80f426b37ff396e2e43cf8b0042";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ar/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ar/thunderbird-78.9.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "b5b643119f0d0336d61972d91f20764590d7453cb391165283e00dc980d3bdef";
+      sha256 = "9520899691eb7e4e7dad95ce643da5cb966c1058b3cc952b55bd66d7a09473ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ast/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ast/thunderbird-78.9.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "2e219961dc2b33f7680be0a6fbd03c0032fdbb557a3dedaf32773efb6cf7a061";
+      sha256 = "769e7cd3699577a1f69e62492c8058eca635ffaf6acab6ca3a4112301aab751f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/be/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/be/thunderbird-78.9.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "ce8a7e4f025b6064ff4eef01c634b2b7f52ec0ffa5eb7094f0483c7d6f31b939";
+      sha256 = "c1b35990af2731b52da57b4b6b0e4a7733ea2e8d499e95b3b086dde3bdccb657";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/bg/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/bg/thunderbird-78.9.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a7dff0d43d11473d47df6672da8515b5d1393eea581193fdb8b334cfd8c780e8";
+      sha256 = "708709a3acb4689de7870d21c258ccbc03a1fdb92a43164841571e6643bf2988";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/br/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/br/thunderbird-78.9.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "70b0a987b1677fe1b78b4105dc15aea80448e71cde8a2a31f32429111b07c92b";
+      sha256 = "e84f1dea6f550a1827399d0e7f658f376c816d3f7abe962ec58115d36c28c1c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ca/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ca/thunderbird-78.9.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "0e311309e7a9b03afd92fb3f38582ad318c10d3342238db42d30504123bca080";
+      sha256 = "8191514f74876406cf6f332a0063032206d1b6f29414941dee3082ce1bc6e711";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/cak/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/cak/thunderbird-78.9.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "86506acf4c23672469c6bc533019e0a2b4872efcad07468dd3c5a2f1b6ac7dd1";
+      sha256 = "9626ab3117cb4567ba65b24c5800f39fe7dc9c372c60f88ba0906eb72d63ffb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/cs/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/cs/thunderbird-78.9.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "6a63442f96a88c9b80b436eb280a5e67553751c946802bfe81db017eb1a11874";
+      sha256 = "294f60b4efa04fcc9bdea8c4107ac572613d63c742ae9492eb63f5eadcef1448";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/cy/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/cy/thunderbird-78.9.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "7b70af973f706976b87cac4e48623a3c3dad20538d2bc0bd4cdfd57bf1937f54";
+      sha256 = "865d631746754969d7dd59b096306aaacdb189b967e295676a3a7253a5af8ed3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/da/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/da/thunderbird-78.9.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "2b3eb2c351b4df91d2520ae4b93687eba47a6f7b6182086345cad0629ffc9538";
+      sha256 = "cb8b05cf1938326a4246f670bc324d83179f3ce1f3d4f3d8de57599da031ec9b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/de/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/de/thunderbird-78.9.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "ecd00d0713704e323acd7a1a0da88bfc3c92a85a99611f6af1b5425387428af0";
+      sha256 = "9dfc5b4490c8ba926ce30605e3575cf3b471fae1f1808fb5054667c2751956c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/dsb/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/dsb/thunderbird-78.9.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "8808ff0c67014db313413aea3e8dbe7c0e0501c878572f2db1765d4b8c6ebe3b";
+      sha256 = "1752031e919fc1604c1d70ff5a9036d8752a0de78c0d0539860c45390b09e13f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/el/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/el/thunderbird-78.9.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "f83554e57ccf5a3c56b6111a928e2e983c07bac131ba8a74e9449250b644fafa";
+      sha256 = "bc2c7b093dd00c352874c7ae6e3d88e455fe9b357caa0e358d51dde120398f41";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/en-CA/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/en-CA/thunderbird-78.9.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "138384402cfedf4d725b5e74f1c3150d078fd422d5440246e841b9ee5c458128";
+      sha256 = "5605286eb97815d5acfadc0a93888a1e8d08e9b8bb5e7b28328c9650f6a9d065";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/en-GB/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/en-GB/thunderbird-78.9.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "9058897455dad34af97f1f3e1ccd517244de9c2f9a51ff3a8d222d8439b5865c";
+      sha256 = "bc0a4c15cb3d4f1891e91a7bc5cde53065cca95fe5c72c18bd39e0bc618b5d01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/en-US/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/en-US/thunderbird-78.9.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "7ab2fdf949a7cfd7abbba7bb2307bad08fdebed24a0446514be89c308af587b7";
+      sha256 = "65e1539602d206cfb78cb7bdf864d251670242d775f62aad25a1a52dcf1e9e55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/es-AR/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/es-AR/thunderbird-78.9.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "71396deb4b1148a20af83bf7bf62dca00ec43b8cb64b5902f8bf52d861dd861b";
+      sha256 = "e246d1f0fda4091888dcac7c5e8d5367688d86e6f65237e942baee0c2c82136b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/es-ES/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/es-ES/thunderbird-78.9.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "6dd479e524e4bfa7ab1488d808bfde041c34d2a13de1003f1c2a2ee0db0fc772";
+      sha256 = "a24902cdd4eb9f70b435f52c9244769bc674fc16194a908976c28c8de3d94674";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/et/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/et/thunderbird-78.9.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "259ee045328d21c877ca67223f91e438496e6675cb97d825482a8213b3bbb161";
+      sha256 = "891fb76d3f9044ea44230d72c6b8bd4db63c63c71dc83506e91b31329e1b0c11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/eu/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/eu/thunderbird-78.9.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "18a4fadc4a8d167489924042510c06d58c599997e28f652eacc3e4c85841a932";
+      sha256 = "cfe8c0e314dffd57e653204aa5aebe790147f3a1060cc1f95da0045d1c188cd6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/fa/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/fa/thunderbird-78.9.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "0b397cd272cd386dc4d0cca7999198098a8cf4dc9088b93b05a7de75de9a9397";
+      sha256 = "66aba0dbc241d954b18da9c94c6c8d7b33dbc8721560a23def882cde249d17ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/fi/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/fi/thunderbird-78.9.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "9f1b5bed03fcf37f0e3a5155c36a691766ab88cb9604821b4f07ee9f25cfbc9c";
+      sha256 = "e05b5be90b40dd61a3686d3fb011745431f915a0d74e08a157668cfa1633d5f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/fr/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/fr/thunderbird-78.9.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "ff806999956ffe547bd987870a804942462276a10f1334df00797e56482dc4a5";
+      sha256 = "f4c80650f755a65c1371aa9bc35da6e1fc54f6c44dd6e6bed1f3ce8ce883656c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/fy-NL/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/fy-NL/thunderbird-78.9.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "50f7343fa2fa61fa46e7a05f86479743271bde3021efa27ba948923467fb0170";
+      sha256 = "4ada1d224c11081bc7cf7fec51e6cbef695650cdb9b860320da9a070d01bcaed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ga-IE/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ga-IE/thunderbird-78.9.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "e2912457c0e390f84f375fde8946c1eca15b036fb4016ca7cd608a9c61eb5060";
+      sha256 = "e2b6437b4b10a636d585dd591c933df370a5b70bc0a447564ab8dbb4df5c22b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/gd/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/gd/thunderbird-78.9.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "c5b2f349c98fa51f5b6dc57cc9d16f408d9659fa979c4ee86b5c51f2c163f8a5";
+      sha256 = "034b5dd31ac4df1ea8f19b52739fa632a53d063a6ca07e4d36194c55452aaef5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/gl/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/gl/thunderbird-78.9.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "0580beef930019c5312ba4ed38e6570f4d4b85857d4c002461b07f705e261b3e";
+      sha256 = "1afb41188de30c672d3a15e7b8e8b0690ac8358069824edf7215f99f73333d32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/he/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/he/thunderbird-78.9.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "d7ddfedb469437e7df9b0ef967e578047ca70b5d45dc5175ca08f5d1b920d5c1";
+      sha256 = "492f33bbc7f6d6e53aaaa3587d22156afb32d0753609818eeefe7ea53bea788b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/hr/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/hr/thunderbird-78.9.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "5c9c1535488e987113f356a94ffea5e5005f1eea92fb9eaa530793006d2df8cd";
+      sha256 = "a61743f3661eb8ce93cc58dc80ce5950534dd7c89e067a3460daa4502761e3b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/hsb/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/hsb/thunderbird-78.9.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "3dfc77687f2ad8f9bd9a452d519172953a44b3574057f871e466d3dfc2e78cc2";
+      sha256 = "cb1d4f8da3071ecd4ce4f9ae43d1e4d7dcd8edbc6dbf4917bcd1730cc5a0477d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/hu/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/hu/thunderbird-78.9.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "f043129670231c41cdeb8d742e50873306e34860fb702876105c88a80aef0629";
+      sha256 = "a4ae0452d90d3c5c7778732811d97243b9b4767208239c8a24d4b4d368630d22";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/hy-AM/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/hy-AM/thunderbird-78.9.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "7c4e3df3c4115e3de684970d68c5a3aad8a5ac1151ce802d4adbb381f5d76529";
+      sha256 = "cab2129d4c4e99592ce6f22d676a03ff1cc5d5bf579a2426d0079e0f86215ade";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/id/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/id/thunderbird-78.9.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "95776b92e84b5f1183129b3a7576542e807f701afbafd6e811522f709b30e933";
+      sha256 = "a1df4c7e0c359cab8b10692bfee5161d3bd44696ee06774985642604304f9b93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/is/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/is/thunderbird-78.9.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "ac74b9ecc8312aa833ba9db2ff7d017c0891105da5e64580b9af8797fb77ca84";
+      sha256 = "bf6ec8c88f65d565f7dcecb1f3177a5a1e476da62d8aec82d3419e3ed1794798";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/it/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/it/thunderbird-78.9.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "d3409725adfb192951a14569bf1d3c779162fbb1f33c7be944345e3df191ebe3";
+      sha256 = "e028a6fa97dd9d37945137602d45230108fa30d63edea8df8531089724646e19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ja/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ja/thunderbird-78.9.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "9c7bbe228994d06397cd4490b0e6c667b8ab14b94398ef9b0a0bc135d3c6c392";
+      sha256 = "6435637e0582123c1b941b1c6209aa1bfdec471d3ce76a861c82e876b7637fee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ka/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ka/thunderbird-78.9.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "39681dd197986b4535b6f08904aa140f5517b3663dd16f055d514be509bea217";
+      sha256 = "8d00d918c42450ac7a451a0a5a7407ecb334b51bd20c3f33871a29c82f338175";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/kab/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/kab/thunderbird-78.9.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "30f473c45c5d2d60271469ee60174ce10989edea02bfe61503dca4be04f783c6";
+      sha256 = "59af5f436ccf0d0914f800ff6cb31fb341d3d905d3d450ed43a09d8810e50bae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/kk/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/kk/thunderbird-78.9.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "b5dc4df14dd5de27a32332af867c233089081d43514d36a6955fb34dc46b0955";
+      sha256 = "70588dd395158e87bdf651a9ed2b1d92cc5792ed6c85160c2b1c2109d52a3ca2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ko/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ko/thunderbird-78.9.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "b151223ca74a4624912941ca5a33ea620ffadc4840a6b58b0459abc4b9fbcccf";
+      sha256 = "7a3473a4bd51f6931326c30c387546d4b900fd70a837e8d45380afd4597c10e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/lt/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/lt/thunderbird-78.9.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "9405ddf255265811d274bb1c5d05fa5066976d36f1a7e5687a9c4930488ec269";
+      sha256 = "1e36db5d910184872af4e7623c59c79f8e522955c5dd5cba4a689a5bc2d857b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ms/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ms/thunderbird-78.9.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "63daf0a4f33b6e04ca92b1b6df187c0fa52fad97863e66356fe6fc592610be0e";
+      sha256 = "058f825e44c24e837081bb05241c1ff47b390132dbd3cdb5b5d4ef51056bb2ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/nb-NO/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/nb-NO/thunderbird-78.9.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "94e855d4d4c7724cae5060f595ddc5c6afbbcce95a47544c4e13131fc5e6fed5";
+      sha256 = "7f6335ff85c29aa634b7909e4b7a2da007f333648a98ad9f3bd8833d00f2f0da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/nl/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/nl/thunderbird-78.9.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "d3fef411d76b25d4791814bc2c867df1ff4d6388514026a243715c0b01eb6cc8";
+      sha256 = "0056c1250401f89ab8d9423f23d3148bcf34801b34247d4bc44b89e8edd0552f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/nn-NO/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/nn-NO/thunderbird-78.9.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "b144ebaa2ec9a7596c671de0b00a2040b64681cbc92e6ede6f93b8dc85039f73";
+      sha256 = "f63e4305ba814a46edc4316af6ad02acd479306f2f1c02c1b04065ea20baf59f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/pa-IN/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/pa-IN/thunderbird-78.9.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "5231448246edb5051015c7f8f6f9c8b2d4373746d5a6dde94a9ebf4c672c60e8";
+      sha256 = "654902d560df0648cd2e9b7b1271d3606071865dd1cc4490741a5777be2c72c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/pl/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/pl/thunderbird-78.9.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "8250c42c98c9f5c8c2b071b0eb31b7b27e019513585bf0154bd9ea5c901a2aa9";
+      sha256 = "62c4352b987bef61f69bb0300c9cc37b95ca5e6fde57a06646b14bef6e58dd78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/pt-BR/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/pt-BR/thunderbird-78.9.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "625c7d2d6620c045b153866ee310d8d04fd9998cfc51f5f458de19d7fd7452b7";
+      sha256 = "139606374df552562100c01e8a330fc1f4f9e6dcbc6a39396137d2f069ad0fcd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/pt-PT/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/pt-PT/thunderbird-78.9.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "2ead9fe00dd88dbf7245275f2cee002cf3205dd3256303f582635ca33b3aa60e";
+      sha256 = "eb6526b6ee0f768949489ca587c321ed8aabd258296c58e596b7a5413b458ed7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/rm/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/rm/thunderbird-78.9.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "b4b40e417a4bb52aed6bbb7f042d5e164ea2e9f4acf8cde680d4f19f37862e1f";
+      sha256 = "36a22f1c8eb1a5c7fb0e9323a3c3eb03f8a63b2b6c62430780bf4508a7236c41";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ro/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ro/thunderbird-78.9.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "cd0e8aa8e6b02cd7a432e2e943e1a61a65f152bdb9902a1f948e514c46cb8304";
+      sha256 = "92ae47ebf2ab176d46e04172206241aeae8a6eebf72b5f32d021782aa1675be8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/ru/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/ru/thunderbird-78.9.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "00602137ac0d86bbc08ddac08cb2805daed3d8c2b78b2408b34107bbd61c4e32";
+      sha256 = "97680d44fae135e90368adb75ac27b4f23f1186d1435ba265a80027334f320ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/si/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/si/thunderbird-78.9.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "f1ad95430fcba364c0741c03fbbdbad602ad521959685ace7f3056fa801188af";
+      sha256 = "6ddf49c8696deb3ab9ac55453b93116c923ad0025c9c8463b56bdc81e6d00bb9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/sk/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/sk/thunderbird-78.9.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "30ebe0eaac08884d10f8cffa77d145600154b6969a212873bb189aea91187d54";
+      sha256 = "5e2be4cab9101a67c61eee16c8c84513b196dd19f6d0dfee3559796a8a031138";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/sl/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/sl/thunderbird-78.9.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "3f38b1934f6fd66efb97b83c83f76f09c649ef09108fe1a92515752b2d79c890";
+      sha256 = "ab9293a2a5caf948bf2e4b4680b9cf7440e7a272f9f028568e260c40d5a031ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/sq/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/sq/thunderbird-78.9.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "79780bad07999285a3ad37d85b82d7037fe4784b3a83f79f6907c73ad1a7ee55";
+      sha256 = "113171842441b9553e6da58c7ce3e3382fb9aa780892b8ee4436ff9b2bf3dc59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/sr/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/sr/thunderbird-78.9.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "68430529f488d89730864a267a20c5f86b1ffa0b473bdf153c43e06a95a81c5d";
+      sha256 = "1b46f1597ab5aec2bca98adf9664cafd72ff51db23722108cbd4c0c89a1a8e70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/sv-SE/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/sv-SE/thunderbird-78.9.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "3e2a8112b2da35af3402d0974a70c00ca6cde4cbf43f07141ff7b184d373d444";
+      sha256 = "41284557a6ae1b267eb3c2fdcc4a547834e833f55b5c1ad9c8bd9121c9d39dc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/th/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/th/thunderbird-78.9.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "9b94b35004bec519e8bc8fa152c677189fc37e78a3bdedc0d77afb81bffb0c58";
+      sha256 = "99a342f303c3a890ee68514841d563fe493e2459a4d6f6769c42f986e122b7ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/tr/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/tr/thunderbird-78.9.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "b1f0281f5a1a2454a38ccc66510b4de44c19f4300a990f994d5c0ac76b002782";
+      sha256 = "f827b3d8fb60540d00d20d4ec50dbd9e28af3798863fa4ccc1a862a08ebdd18d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/uk/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/uk/thunderbird-78.9.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "ae53f162d9016a3f2b3e104c86aefb34ed9e96ce14cc3feb1584ce61617c3b49";
+      sha256 = "d8e30faa9f43308c31504437ae2187d5c1ce00c16cd430f31eaacf8dbed71604";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/uz/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/uz/thunderbird-78.9.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "6d43cbdac67084253eda88d0cd58440229def6d03904b4e1a8c9b9133ed7bb55";
+      sha256 = "00e3e3a43519fa8136d3cde8527f3e9c44732ef6d5aac9cc2e1f28feaf940a50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/vi/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/vi/thunderbird-78.9.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "f29e5e685c3b072ece7ef6cd645b2596025848e9b72b00fbb49378b8f25ef3a9";
+      sha256 = "f16b0fca32c85e648be8c8d4c9ddb6d8fde726f1386d0dd29ec050b39d827fe2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/zh-CN/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/zh-CN/thunderbird-78.9.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e4789a8b85555be1fab438e694562bec0b2022a6955ad098b837c48d3954452c";
+      sha256 = "51007e8318fbf673eb63bf20be8daa35ef8e2d6fee9fd9356dbba98d843dc813";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-x86_64/zh-TW/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-x86_64/zh-TW/thunderbird-78.9.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "7d4246056adf297ac1bf3c7de20d067453e41350b089841d617e2ac6ecaab0ac";
+      sha256 = "ef7a5507b47725ba7bca853c1f5bf20eb36d31fbbc8c912596a5993f7dca57ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/af/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/af/thunderbird-78.9.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "1c09247e43ebfd2cd10995e76ff791b6c78d4545ebcfa37959b154e5307e17a7";
+      sha256 = "435ba6c5a5901fe1daa1b19c36f1071086d21e2f321a52afe1db0c03a0044635";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ar/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ar/thunderbird-78.9.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "bd7a46b42a8200f0515be9798bda145f398e2db32357ae8c46c1dc89cc823dd5";
+      sha256 = "4ac307dbe93e69e6dbb629756363900256ec735c1927cad74acb0c5f8e255b92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ast/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ast/thunderbird-78.9.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "418fc4d19a9d4ce982e534c7be95b79dd2c15311040e2c50e5644f3a5e3cf245";
+      sha256 = "3d9a01438e82350e5a60ee7944226d9a0f46384673ddae01f8f8fe445df40312";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/be/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/be/thunderbird-78.9.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "27b9271c984eb739cc4782050bf5f896da01ced7803dae8e81181ac4a8c0df86";
+      sha256 = "9a5b22648d8c7c05d5f0be0d1f450baadccf791353a23bc1b6889e8911d90c5a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/bg/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/bg/thunderbird-78.9.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "b63ca81e05c4a16497339374f297ced5033daa275fd48fe9884d4945f216771a";
+      sha256 = "77cf8d4912c2b5b34fa0235ddbb95cd90bcf83d1d528275b23de08dad59116c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/br/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/br/thunderbird-78.9.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "f213c17427b907a21a3c4eb2976eccca91423a1400260b22ea59c588a2e1e9d1";
+      sha256 = "9e7bcb749e0d88efd60e6bed2fc77e39deaf8a82db56c304529d44843657842d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ca/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ca/thunderbird-78.9.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "8bd818f98c17b8e954883c462064994c469fa805aadf74b6e0915824e1ad929a";
+      sha256 = "0206a127cbf5f9b1c4c4711d4d05591d175c9e96c2354790c220e9587c356aba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/cak/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/cak/thunderbird-78.9.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "6213c8b217db157f40e008af10780edef5a02ffdc2442240597a00252f4f58ea";
+      sha256 = "e47d892a90c3b9ec29365cc0173066234e21cd989c4b588e43fecb61b10d1f80";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/cs/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/cs/thunderbird-78.9.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "22491715bd72408d7c15d8fc137ccc496a0ea075217485a8e31abf73ca09bad7";
+      sha256 = "bdcfb9cf6e3207a41634eb54c472117c33b0df981d900c4dd0dbff0463ebe57a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/cy/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/cy/thunderbird-78.9.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "3d4f07b0055d92dcbaaafa139959de7071b2b3d74c49452bbb2556b1ed3ae82e";
+      sha256 = "5b0def675213d882ea653ffd7b5aa62f96000d4aaee8e06ad1fd5984ac99c8c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/da/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/da/thunderbird-78.9.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "409779e136c0efb3dff667e50b9ba318937d3e96ac918b8272741ea004ec3f5c";
+      sha256 = "617579da2580a0d9a5a6e64ef7c4b028fde31f82dcf8139104c380e51ec50227";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/de/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/de/thunderbird-78.9.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "ac5ca1fe2247cd4d05862c00592c86dda480108b7a40e284ccc67718a1762f78";
+      sha256 = "5cdee984aa63595fbcb00303f14fd19d124ef9b267d490d5263c7554f4ea0dc7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/dsb/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/dsb/thunderbird-78.9.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "769d47c388ef4dfced4ba770f78eeedcafdc834dc4fa4175eaa92710ddc2e0de";
+      sha256 = "fa05969bcc025056b8ba9c056af0051fed91a967ebf9e21ccab7654aaaa6ba1f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/el/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/el/thunderbird-78.9.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "1a2daf5b0ccc36acae027da2281998b4333ea4e9981c7106243c68188517f482";
+      sha256 = "03b58dbcabb41c0140c18f1ff31dd32e4d2d006c85af75d73bcd656587e787ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/en-CA/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/en-CA/thunderbird-78.9.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "3a55772b7bec93bec83de289b5b36129e8e0d988d54db3d66ffcaf8326786ae3";
+      sha256 = "6cd222aacb8eba184dc3eef308fe7b564c70da2ba6c38e6e4e328e999b7229a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/en-GB/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/en-GB/thunderbird-78.9.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "f41b610c6a3f4f5d3e2c648d05ca210cf9bdbb998b94f298f81dd84601c00be9";
+      sha256 = "9d3ca50977bd5c6f8a5bd998549db0dc2ccc6aa5d33c914e93d42e2ae69e8cbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/en-US/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/en-US/thunderbird-78.9.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "9598fd9175cc0d641387f6ac7f475d970b4f0864872b5d875d170039d6c97b39";
+      sha256 = "84721e190b6b95733a47a16853e1fe1e0c7b0e4693d3b7752aa59583fba92f97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/es-AR/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/es-AR/thunderbird-78.9.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "603106740e8db3a7c9220897b9146ef53937bd57a60258a04548e1afb41d983c";
+      sha256 = "dcadcd68506406f718871d7576b47086d59ca159a5bc6d878d022141029df2db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/es-ES/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/es-ES/thunderbird-78.9.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "e0f5f3d6aed26310bfee54099c73a13417be36eb737f6123526e94a5286f6336";
+      sha256 = "46526dd5b4bb123e774d3a3fa8fd88a8982cfb36a252b09fa98aa6cb773ff0d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/et/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/et/thunderbird-78.9.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "bc4a1dc96e8ba31d0817f369af4e3e10b672aa854538093ef1d02126bcff24bb";
+      sha256 = "de0b695be00721244ff20b2046bb376342fba7c422980443b217f5d4cfa83d48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/eu/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/eu/thunderbird-78.9.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "2c61d117e5fa23d62197f9b2c0512547356b65098eee5fd72285317caca6b51a";
+      sha256 = "543d45e256951cbf21bc61359e99daf2c80789a88641ae2231c1eb0ade133198";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/fa/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/fa/thunderbird-78.9.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "6b93377b457ec1e0dd343bc4d2193c6bb3030450e76757ac042c67e353075310";
+      sha256 = "6b95ebccf7ccca90c3310923f020ba6f05fa715d64c79acd770a491e15a9938f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/fi/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/fi/thunderbird-78.9.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "9e07a2060b821047c494e03d9ab74b8f3aeea322aa1e1bdde080637187f89e05";
+      sha256 = "145c2479a73955f9ffe6ebd2d41eced848770729f218381735aafe5c3cc0b3a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/fr/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/fr/thunderbird-78.9.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "d4ea501f5a42effdb758ca24f2da7bd4ca1d83a8ea6da467fd63cbef96f8b373";
+      sha256 = "9178d90f346d62b6aa0bb4b081b6bebc214d333d6a042c46ee1af7661ffc3b03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/fy-NL/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/fy-NL/thunderbird-78.9.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "9aa11144cf22a5db5200628ac5e55a55b83ffda35306cf1909aabac9fe4878c2";
+      sha256 = "fe3574999f0d1fff276fdfd7d432859d495c2b64137d33ee418ef1e4329b1b72";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ga-IE/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ga-IE/thunderbird-78.9.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "15af980b46c8cf80b60a999e2ca3b30c92719638af51d9e82133f58de61d7ed5";
+      sha256 = "1570882cd8345f86de38179713a7f7acb94768c4874e571a20314fb01154e1bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/gd/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/gd/thunderbird-78.9.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "cdeb93b31a1a9521dd7f91081f28c1a64e0e6a218f1c0015ae9c54d73cc91f0d";
+      sha256 = "9405a2a7ce52a48292bf4b6b20f3b1e96c12460a1e44a90ccdc31cdb21acda5e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/gl/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/gl/thunderbird-78.9.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "48d973991c0cbb9988339c185d1ea8fda4c6cea6f0667cfaf8f2bdeec4c55a23";
+      sha256 = "930a9a3e06bc28ede54ec43e8bb92cc30329d7f0271629b37ac3753191f7e133";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/he/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/he/thunderbird-78.9.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "c2f50a1fb3e877e3c08927eef96f104f5f970cb7629af21de3344e539617422b";
+      sha256 = "eb08c16b7df47fd501f61049b19f3f8f827870c8681b9230564276bc0cc9ada8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/hr/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/hr/thunderbird-78.9.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "ec3596067c8245cd5cef8fc649c3d1fd6d38bb802e2a05947ab9e62b8d393b91";
+      sha256 = "c866290def37d2e16274820d5846bec52afc7c7da1f8df812df930f0c68c6b56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/hsb/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/hsb/thunderbird-78.9.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "0209d678b9353513bcab3c647100c35d772d25b1969bb9970266c09f2db01e05";
+      sha256 = "0df5dc60047e68aadc7a96e194468d42e977c7a90d9faa8c4684f650763825f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/hu/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/hu/thunderbird-78.9.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "817cef3a34c40ed31a59421f89a94de5b7be165cd1bd93fca7b2560cad3e05eb";
+      sha256 = "e76e78c1c77b59eb7a3ffad0da149dcc7f64d6b0305f5a5a607ad2745d224e17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/hy-AM/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/hy-AM/thunderbird-78.9.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "ca49953791109563cdc81a3458a5b3dd15ebb49a255752052e927daad199b0fa";
+      sha256 = "0dde11bb6c6ba186925010cee97b59d3c64890b108ef478be5578218954a39cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/id/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/id/thunderbird-78.9.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "33fb9d6c721f79e4808f077573828c26b671434b0308db9c33386dbd975c4a53";
+      sha256 = "ceea16b87a7d8b44b187d950f4c9fc5326ed7a550c38e0f41645004a324669a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/is/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/is/thunderbird-78.9.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "d498ac95c289612a253962d1988ac9d1526864926c9a4b9cc2985fe1d84ae03d";
+      sha256 = "a98177d8f62b1ffe056ba3c1f2ec9d7b3f47ad8d47459328692e9bee5e1d02d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/it/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/it/thunderbird-78.9.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "cff73b132740bf3854977f62afe8076c7c660559cc8a96fbc36c4ffadd46d50e";
+      sha256 = "259b8e4e08828b544ba61541629025d4a711f44dc4c476b3e3971a633301b298";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ja/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ja/thunderbird-78.9.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "d8ffe86ccbc4de40a0909f55b750380454a2f51f450b4c8b49886612a49997fc";
+      sha256 = "6f2511dab5530e58664f386cb65b26d82fe581faee01b1a76cdd29e3ee3a1955";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ka/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ka/thunderbird-78.9.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "1bf02cd11b554b597b6f5facdd07b6ae7826ad24a2f1ceb432bca6fcd0396749";
+      sha256 = "368a85fcb387703df7422d1ce199a499d0e4796f4fdd4775aef27c5b36272fa7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/kab/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/kab/thunderbird-78.9.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "aa0295643ee24b0e76d5567c4f43f94ddf4a820cde2bd5be5a6dbc0b2f1c7271";
+      sha256 = "33bfd965c79bd6935516729f3eedd65be2b3f754c9225d6ffdb4af201b0d13a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/kk/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/kk/thunderbird-78.9.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "265e5000114d7f3d204885a5c4eb5ef71780699f185f570da90737001023d4b5";
+      sha256 = "20dfc052f78a58d4fd96a0df22b55559ca43d8792dfda372dfede1cb49c6b185";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ko/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ko/thunderbird-78.9.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a1622a295ab259400d61e9487f40b7e34c143b81afb1f354647a48cb56425d13";
+      sha256 = "63479eb7fcaea17ea29c98b624c36ac20ff2ab9e42bae1a355c78f05d5f9e313";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/lt/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/lt/thunderbird-78.9.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "423926d31fac238ec493de6f48d14530cf58bf0829b73505f7ea4138f6bdeb56";
+      sha256 = "2d50db9e0698c991e10a6ec6e627b02d0aca9e18b857aa290e4aab926e8ee88b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ms/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ms/thunderbird-78.9.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "acdfdeecc6c5ff04c1428185bbe63a6e38b1545daa9e69888b78e2b5ba3b9194";
+      sha256 = "66969627bd536d9a8e8d8717bab010ceb16350425d31ea114bc7e012ba1f0922";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/nb-NO/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/nb-NO/thunderbird-78.9.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "f62a4f2d2c8e93b58f3a0c35e6885c1e46a8b6ed1fd0414e719c480f99fa2cf8";
+      sha256 = "1db46ff207d356adaf761db2fac7961b20633dc6578ce562154a1bdb308256e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/nl/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/nl/thunderbird-78.9.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "c2dda812534a9155f79fc2249cafd8e77e572cc20bdaf1bbf637bea4daf5e612";
+      sha256 = "0259c04b35bd30b5feb44da31b639938504f1402879205263eb63f7a59153f11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/nn-NO/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/nn-NO/thunderbird-78.9.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "84fae5d60ec7223c0404033ad2e2b776c4a9353b55e0256c7ca7122aebc031a2";
+      sha256 = "1de52759f96302447829e0de40319394ac0b1802ec60c0c242cf85c0ca5110c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/pa-IN/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/pa-IN/thunderbird-78.9.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "0fa48cf1ab0d1e23e4d230fb6f78e7f6d07d99360e341c239ea572c201204870";
+      sha256 = "39e0f5794e508dbf02c6aaedaead4173f5ae55d350aa3caeb7a1ad300a69e4e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/pl/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/pl/thunderbird-78.9.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "90fa65f13718539a899dfae11aaaec05b9c1a4f56c8b835436f9401d7c453b01";
+      sha256 = "25bc49f2225c8aca7ea467a240234fa9ec2c7ec34f751537a199f6cbb30b390b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/pt-BR/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/pt-BR/thunderbird-78.9.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "f203c40580edbe2fc8645af1477bd1b750a64241702fda3bd0747efb7c44510b";
+      sha256 = "6091c0e84d89312db11a3714027881243db708ce3f28187e86076351786a3d70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/pt-PT/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/pt-PT/thunderbird-78.9.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "42b5b7f39b75550e39accb221d0728cf6181e4251d130859c85a139bc4b2267c";
+      sha256 = "45fae3c271d226dee2410f8f97eadb62783291c570bf12cd9f5fe5ab23acae23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/rm/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/rm/thunderbird-78.9.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "15165421181470218c152da68adea6e1f8a2abef4c7fd70f19d210620d29dab6";
+      sha256 = "56387dea25d3bc4742c297e0609be55a2db938d10a5e94db192018c706e7f398";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ro/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ro/thunderbird-78.9.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "974f8139cf98576a588088fef03788f513e6e45fa054d4d53cc2131254e0b794";
+      sha256 = "7e84c211675cbd59e805ffa499663b3c02dbc2075f2b734eaa9f41862e59c59f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/ru/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/ru/thunderbird-78.9.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "eae2f2f1e5bfcf389f34b9635c838cfcbfbc0d93e9daf6635c0faffea2df1d7f";
+      sha256 = "c9374d0b813baa7aa837e2283d75c9c47d75fca7bfc640be4782d90b480fa145";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/si/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/si/thunderbird-78.9.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "cac0bdfbbc3b5cb21e38473aae44e4f8d2ebf192b6c35d7e075c47e25684da48";
+      sha256 = "ac8ff38bf196886f8b95c34a07ed701416c58b78758517377f6d8eefc85050ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/sk/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/sk/thunderbird-78.9.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "6a30b2b648b24e3cd4e2c3b668e73802796f296a2f81aa8e470ec0909f8dbc87";
+      sha256 = "dd44494bec41af06317266ee7d8f8f16ac6c648728636aa68c93f57ca9594231";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/sl/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/sl/thunderbird-78.9.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "0d4e597db5264bef212cdc3e86564acad1ed4cad3cae9eb61e583025b401bfa2";
+      sha256 = "2be1af23f71b22812a90ab2be33649ad53bf2d14acbbcc9540b835eade0fd9bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/sq/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/sq/thunderbird-78.9.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "8a4dd36ac981c89924755526fae8634f20d0d7dbdbb6fc9c324a5badbf7394db";
+      sha256 = "5c65db4fcc190408aa8a1c5f0170ede3f86f1c9f07dacc6fd7a9aa54bff533d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/sr/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/sr/thunderbird-78.9.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "6002d49812cbba0289db444e84b8a139c0784056a26e3a0592fd1806ce865cbe";
+      sha256 = "7a42279c8a4352c18d583503b2324f5dd98b6c927582fa1d5e8cd72a5b1ca782";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/sv-SE/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/sv-SE/thunderbird-78.9.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "498303591a0d28ce2bbb59693fd55bdbf292c7feba8002c9cacdce7ec08b50d0";
+      sha256 = "3f508f801f1f4afc477ee1a0bd81d49d957429360b9691b5945a88b609dc9a21";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/th/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/th/thunderbird-78.9.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "6c31f40537ba39bdba93eb46f480f8a1a446a6b028834f6886934b102ce1b861";
+      sha256 = "bd50cac75236ee9e1ad7226c605b37cc2f4aa57eafc4978af9f2563aff7dda0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/tr/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/tr/thunderbird-78.9.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "b8f5a0be988b89dc7e8b14750d6aa0ccbdbf2c1a1c3abee376b94b1443223757";
+      sha256 = "af134487b9c2d6f84df56e2da1fcbc7b4abd3960fa3d11a366281768812fd9e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/uk/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/uk/thunderbird-78.9.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "036065e1fc91907370ffe75883b1d1e8fd1a416a9a726583c758d7a0765b84ad";
+      sha256 = "a094a6fe935b002805252ad4694a15231587a66c31cff3064c2842332f1e82ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/uz/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/uz/thunderbird-78.9.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "3b5d683b237a88018e5b1999aee497d766007a3c1743517ab0b54e43f37e52b1";
+      sha256 = "6b8b7622374c92036828990db1de3042e1a7cebf12974d30d73dcdd0e564d707";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/vi/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/vi/thunderbird-78.9.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "0d31b2bd82161ec51314e57405345a9a004b268371c16de06fa4d2160eda0230";
+      sha256 = "4ffcd1d5f21145f857ee525169fe59ee8a1cdef6a1c4f3cc1918be1fc7c66e6a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/zh-CN/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/zh-CN/thunderbird-78.9.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "3994c114510a6c7457c78d3755518b1332bcf1b48371d2b88c000f977b5bb3a0";
+      sha256 = "8cd65c054b6fefcbd0ac9a057e277009c732af6baef08ccb3f57bee73b75ae20";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.8.1/linux-i686/zh-TW/thunderbird-78.8.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.9.0/linux-i686/zh-TW/thunderbird-78.9.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "c38e5b2378bd0af57945e0e172e49b30fed491b91ffa79a946cce8f2bccf96f8";
+      sha256 = "1e39b1e38bfcc1735801dcd6c073ba1eeb344b23d9e859495947a37d95a4b3b8";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -73,13 +73,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.8.1";
+  version = "78.9.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "08dnjqcdd5bs7wpl5imir0nsmvaqkri67cas1sn7ab4nb1f61lfdz4xg4x5v6f39sm5yxw2cy6rg5fc5lbiqza5bgs00gfg79kgfn2i";
+      "35n9l1kjx52davwf1k5gdx2y81hws3mfb5755464z9db48n0vfj756jlg9d8f2m2s29js27bdswl64mralw4j085dl11661g7p9ypzs";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- High security fixes
- Other fixes

https://www.mozilla.org/en-US/security/advisories/mfsa2021-12/
https://www.thunderbird.net/en-US/thunderbird/78.9.0/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested only `thunderbird-bin`.
Compiling `thunderbird` now.
