### PR TITLE
gnome3.gnome-autoar: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/desktops/gnome-3/misc/gnome-autoar/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-autoar/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-autoar";
-  version = "0.3.0";
+  version = "0.3.1";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-autoar/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0ssqckfkyldwld88zizy446y2359rg40lnrcm3sjpjhc2b015hgj";
+    sha256 = "1y6hh5dldhdq7mpbmd571zl0yadfackvifhnxvykkqqddwz72y0f";
   };
 
   passthru = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-28650.
Changes: https://gitlab.gnome.org/GNOME/gnome-autoar/-/blob/0.3.1/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>21 packages built:</summary>
  <ul>
    <li>adapta-gtk-theme</li>
    <li>chrome-gnome-shell</li>
    <li>dropbox-cli</li>
    <li>gnome-recipes</li>
    <li>gnome3.file-roller</li>
    <li>gnome3.gnome-autoar</li>
    <li>gnome3.gnome-control-center</li>
    <li>gnome3.gnome-session</li>
    <li>gnome3.gnome-shell</li>
    <li>gnome3.gnome-terminal</li>
    <li>gnome3.gnome-tweak-tool</li>
    <li>gnome3.gnome-user-share</li>
    <li>gnome3.nautilus</li>
    <li>gnome3.nautilus-python</li>
    <li>gnome3.pomodoro</li>
    <li>gnomeExtensions.easyScreenCast</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.night-theme-switcher</li>
    <li>kgx</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.extra-elementary-contracts</li>
  </ul>
</details>