### PR TITLE
paperlike-go: init at unstable-2021-03-22

### DIFF
--- a/pkgs/tools/misc/paperlike-go/default.nix
+++ b/pkgs/tools/misc/paperlike-go/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule {
+  pname = "paperlike-go";
+  version = "unstable-2021-03-22";
+
+  src = fetchFromGitHub {
+    owner = "leoluk";
+    repo = "paperlike-go";
+    rev = "a7d89fd4d4cbcec7be016860e9063676ad4cca0f";
+    sha256 = "0ym340520a0j4gvgk4x091lcz1apsv9lnwx0nnha86qvzqcy528l";
+  };
+
+  subPackages = [ "cmd/paperlike-cli" ];
+
+  vendorSha256 = "00mn0zfivxp2h77s7gmyyjp8p5a1vysn73wwaalgajymvljxxx1r";
+
+  meta = with lib; {
+    description = "paperlike-go is a Linux Go library and CLI utility to control a Dasung Paperlike display via I2C DDC.";
+    homepage = "https://github.com/leoluk/paperlike-go";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.adisbladis ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21143,6 +21143,8 @@ in
 
   papis = with python3Packages; toPythonApplication papis;
 
+  paperlike-go = callPackage ../tools/misc/paperlike-go { };
+
   paps = callPackage ../tools/misc/paps { };
 
   pecita = callPackage ../data/fonts/pecita {};


### PR DESCRIPTION
###### Motivation for this change
Paperlike-go is a Linux Go library and CLI utility to control a Dasung Paperlike display via I2C DDC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
