### PR TITLE
elfutils: fixup dependencies

### DIFF
--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.hostPlatform.isMusl autoreconfHook
     ++ lib.optional (enableDebuginfod || stdenv.hostPlatform.isMusl) pkg-config;
   buildInputs = [ zlib bzip2 xz ]
-    ++ lib.optional stdenv.hostPlatform.isMusl [
+    ++ lib.optionals stdenv.hostPlatform.isMusl [
     argp-standalone
     musl-fts
     musl-obstack

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -61,8 +61,8 @@ stdenv.mkDerivation rec {
   # We need bzip2 in NativeInputs because otherwise we can't unpack the src,
   # as the host-bzip2 will be in the path.
   nativeBuildInputs = [ m4 bison flex gettext bzip2 ]
-    ++ lib.optional stdenv.hostPlatform.isMusl [ pkg-config autoreconfHook ]
-    ++ lib.optional enableDebuginfod [ pkg-config ];
+    ++ lib.optional stdenv.hostPlatform.isMusl autoreconfHook
+    ++ lib.optional (enableDebuginfod || stdenv.hostPlatform.isMusl) pkg-config;
   buildInputs = [ zlib bzip2 xz ]
     ++ lib.optional stdenv.hostPlatform.isMusl [
     argp-standalone


### PR DESCRIPTION
###### Motivation for this change

Fixup https://github.com/NixOS/nixpkgs/pull/112454

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
