### PR TITLE
vistafonts: fix build

### DIFF
--- a/pkgs/data/fonts/vista-fonts/default.nix
+++ b/pkgs/data/fonts/vista-fonts/default.nix
@@ -1,14 +1,22 @@
-{ lib, fetchzip, cabextract }:
+{ lib, stdenvNoCC, fetchurl, cabextract }:
 
-fetchzip {
-  name = "vista-fonts-1";
+stdenvNoCC.mkDerivation {
+  pname = "vista-fonts";
+  version = "1";
 
-  url = "https://web.archive.org/web/20171225132744/http://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe";
+  src = fetchurl {
+    url = "mirror://sourceforge/mscorefonts2/cabs/PowerPointViewer.exe";
+    sha256 = "07vhjdw8iip7gxk6wvp4myhvbn9619g10j9qvpbzz4ihima57ry4";
+  };
 
-  postFetch = ''
-    ${cabextract}/bin/cabextract --lowercase --filter ppviewer.cab $downloadedFile
-    ${cabextract}/bin/cabextract --lowercase --filter '*.TTF' ppviewer.cab
+  nativeBuildInputs = [ cabextract ];
 
+  unpackPhase = ''
+    cabextract --lowercase --filter ppviewer.cab $src
+    cabextract --lowercase --filter '*.TTF' ppviewer.cab
+  '';
+
+  installPhase = ''
     mkdir -p $out/share/fonts/truetype
     cp *.ttf $out/share/fonts/truetype
 
@@ -20,8 +28,6 @@ fetchzip {
         --subst-var-by fontname $name
     done
   '';
-
-  sha256 = "sha256-x7JSXS9Q1fzlJTVR+MAS3f2+cmo/H0s1qkY9FPjx2zI=";
 
   meta = {
     description = "Some TrueType fonts from Microsoft Windows Vista (Calibri, Cambria, Candara, Consolas, Constantia, Corbel)";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Build was previously failing with
```
/build/file: no valid cabinets found
```

Additonaly, a faster download mirror is used. The downloaded file is not identical to the one from the previous mirror, but the produced result is unchanged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
