### PR TITLE
rust: 1.50.0 -> 1.51.0

### DIFF
--- a/pkgs/development/compilers/rust/1_51.nix
+++ b/pkgs/development/compilers/rust/1_51.nix
@@ -19,8 +19,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.50.0";
-  rustcSha256 = "0pjs7j62maiyvkmhp9zrxl528g2n0fphp4rq6ap7aqdv0a6qz5wm";
+  rustcVersion = "1.51.0";
+  rustcSha256 = "0ixqkqglv3isxbvl4ldr4byrkx692wghsz3fasy1pn5kr2prnsvs";
 
   llvmSharedForBuild = pkgsBuildBuild.llvm_11.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvm_11.override { enableSharedLibraries = true; };
@@ -33,22 +33,22 @@ import ./default.nix {
 
   # Note: the version MUST be one version prior to the version we're
   # building
-  bootstrapVersion = "1.49.0";
+  bootstrapVersion = "1.50.0";
 
   # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
   bootstrapHashes = {
-    i686-unknown-linux-gnu = "5371bfa2c8e566aa283acdfa93d24b981c789d7c040ac1ca74e76bff1c7f6598";
-    x86_64-unknown-linux-gnu = "8b14446df82f3707d69cf58fed92f18e0bff91621c62baf89288ef70e3e92981";
-    x86_64-unknown-linux-musl = "f92a5a4adcfac4206a223d089a364a8375d1b6f112f3f2efa3f6d53d08a61904";
-    arm-unknown-linux-gnueabihf = "e5d93576eef874a9b22be9aa157cac5c8cdebebde8b57f0693248d4a589df42c";
-    armv7-unknown-linux-gnueabihf = "34ba3c979b144ef27d3c71d177cc1774551edf26e79d36719c86a51d9b9e34c0";
-    aarch64-unknown-linux-gnu = "b551bd482041307fa3373a687d6d6a2c4c0931c2e0a68b8b75dc80bc5cf5f002";
-    aarch64-unknown-linux-musl = "0a43d96a508c720520328112d609916d062f866a5c35f1db8f906284035d6d98";
-    x86_64-apple-darwin = "fe3e248bc4b0ee0a2595693687ad845c8a8bda824a56c9321520bcca02433716";
-    powerpc64le-unknown-linux-gnu = "365d7721dd2521e5dad12aa73651bad2be375e798e443636d2c523cad5b54359";
+    i686-unknown-linux-gnu = "dee56dc425ed5d8e8112f26fba3060fd324c49f1261e0b7e8e29f7d9b852b09a";
+    x86_64-unknown-linux-gnu = "fa889b53918980aea2dea42bfae4e858dcb2104c6fdca6e4fe359f3a49767701";
+    x86_64-unknown-linux-musl = "867cbfb35f5dc9b43e230132ea9e7bfa98d471a9248e41b08ced2266e5ccd00f";
+    arm-unknown-linux-gnueabihf = "1b72979244450e4047ab536448d6720699e1fae0ab1c4ade114099a3037e274b";
+    armv7-unknown-linux-gnueabihf = "f1dde566c4e6ca2e1133c84170e46e566765a21894e1038e1cdc32745d7274ef";
+    aarch64-unknown-linux-gnu = "1db7a4fbddc68cd29eb9bca9fa7d0d2d9e3d59ede7ddaad66222fb4336a6bacf";
+    aarch64-unknown-linux-musl = "adcc6c76a8967bacb6687b565d3cf739e35fde066b03edb745b05b52fa8b5b36";
+    x86_64-apple-darwin = "1bf5a7ecf6468ce1bf9fe49c8083b3f648b40c16fbfb7539d106fe28eb0e792e";
+    powerpc64le-unknown-linux-gnu = "e0472589d3f9ba7ebf27f033af320e0d5cfb70222955bd8ed73ce2c9a70ae535";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_50;
+  selectRustPackage = pkgs: pkgs.rust_1_51;
 
   rustcPatches = [
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11014,14 +11014,14 @@ in
   rust_1_45 = callPackage ../development/compilers/rust/1_45.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
-  rust_1_50 = callPackage ../development/compilers/rust/1_50.nix {
+  rust_1_51 = callPackage ../development/compilers/rust/1_51.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
-  rust = rust_1_50;
+  rust = rust_1_51;
 
   rustPackages_1_45 = rust_1_45.packages.stable;
-  rustPackages_1_50 = rust_1_50.packages.stable;
-  rustPackages = rustPackages_1_50;
+  rustPackages_1_51 = rust_1_51.packages.stable;
+  rustPackages = rustPackages_1_51;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;
 


### PR DESCRIPTION
###### Motivation for this change

update rustc to 1.51.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
