### PR TITLE
graphia: init at 2.2

### DIFF
--- a/pkgs/applications/science/misc/graphia/default.nix
+++ b/pkgs/applications/science/misc/graphia/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, cmake, fetchFromGitHub
+, wrapQtAppsHook, qtbase, qtquickcontrols2, qtgraphicaleffects
+}:
+
+stdenv.mkDerivation rec {
+  pname = "graphia";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "graphia-app";
+    repo = "graphia";
+    rev = version;
+    sha256 = "sha256:05givvvg743sawqy2vhljkfgn5v1s907sflsnsv11ddx6x51na1w";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+  buildInputs = [
+    qtbase
+    qtquickcontrols2
+    qtgraphicaleffects
+  ];
+
+  meta = with lib; {
+    description = "A visualisation tool for the creation and analysis of graphs.";
+    homepage = "https://graphia.app";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.bgamari ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14757,6 +14757,8 @@ in
 
   ghcid = haskellPackages.ghcid.bin;
 
+  graphia = libsForQt5.callPackage ../applications/science/misc/graphia { };
+
   icon-lang = callPackage ../development/interpreters/icon-lang { };
 
   libgit2 = callPackage ../development/libraries/git2 {


### PR DESCRIPTION

###### Motivation for this change

Graphia is a relatively new tool for graph visualisation and analysis,
in the same vain as gephi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
