### PR TITLE
python39Packages.asttokens: unbreak

### DIFF
--- a/pkgs/development/python-modules/asttokens/default.nix
+++ b/pkgs/development/python-modules/asttokens/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonPackage,
+{ lib, fetchPypi, fetchpatch, buildPythonPackage,
   setuptools_scm, toml, six, astroid, pytest
 }:
 
@@ -10,6 +10,16 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0a2ixiz04aw4p0aivxh47k3fa9ql804l3y5iv5gcih9aizi5fbm4";
   };
+
+  patches = [
+    # Fixes compatibility with python 3.9, will be included in the next release
+    # after 2.0.4
+    (fetchpatch {
+      url = "https://github.com/gristlabs/asttokens/commit/d8ff80ee7d2e64c5e1daf50cc38eb99663f1b1ac.patch";
+      sha256 = "19y8n8vpzr2ijldbq5rh19sf0vz5azqqpkb9bx0ljjg98h6k7kjj";
+      excludes = [ "setup.cfg" ];
+    })
+  ];
 
   propagatedBuildInputs = [ setuptools_scm toml six astroid ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://hydra.nixos.org/build/139259720

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
