### PR TITLE
python39Packages.ldap: unbreak

### DIFF
--- a/pkgs/development/python-modules/ldap/default.nix
+++ b/pkgs/development/python-modules/ldap/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage, fetchPypi
-, pyasn1, pyasn1-modules, pytest
+, pyasn1, pyasn1-modules
+, pythonAtLeast, pytestCheckHook
 , openldap, cyrus_sasl, lib, stdenv }:
 
 buildPythonPackage rec {
@@ -13,19 +14,21 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyasn1 pyasn1-modules ];
 
+  checkInputs = [ pytestCheckHook ];
   buildInputs = [ openldap cyrus_sasl ];
 
-  checkInputs = [ pytest ];
-
-  checkPhase = ''
+  preCheck = ''
     # Needed by tests to setup a mockup ldap server.
     export BIN="${openldap}/bin"
     export SBIN="${openldap}/bin"
     export SLAPD="${openldap}/libexec/slapd"
     export SCHEMA="${openldap}/etc/schema"
-
-    py.test
   '';
+
+  disabledTests = lib.optionals (pythonAtLeast "3.9") [
+    # See https://github.com/python-ldap/python-ldap/issues/407
+    "test_simple_bind_noarg"
+  ];
 
   doCheck = !stdenv.isDarwin;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This package recently started failing on hydra. I'm not entirely sure why, but I think it's connected to the upgrade of pytest from 6.1 to 6.2. https://hydra.nixos.org/job/nixpkgs/trunk/python39Packages.ldap.x86_64-linux

I looked at the way that upstream runs their tests, and they do not use pytest. They use this line: https://github.com/python-ldap/python-ldap/blob/master/tox.ini#L16-L17.

Bringing that into the nixpkgs build expression fixed the build for python39.
```
python3.9-python-ldap> Ran 292 tests in 27.414s
python3.9-python-ldap> OK (skipped=53, expected failures=3)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
