### PR TITLE
chipsec: 1.5.1 -> 1.6.1

### DIFF
--- a/pkgs/tools/security/chipsec/compile-ko.diff
+++ b/pkgs/tools/security/chipsec/compile-ko.diff
@@ -1,0 +1,13 @@
+diff --git i/setup.py w/setup.py
+index cfe2665..5795874 100755
+--- i/setup.py
++++ w/setup.py
+@@ -179,7 +179,7 @@ class build_ext(_build_ext):
+             driver_build_function = self._build_win_driver 
+             self._build_win_compression()
+ 
+-        if not self.skip_driver:
++        if True:
+             driver_build_function()
+ 
+     def get_source_files(self):

--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -10,14 +10,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "chipsec";
-  version = "1.5.10";
+  version = "1.6.1";
   disabled = !stdenv.isLinux;
 
   src = fetchFromGitHub {
     owner = "chipsec";
     repo = "chipsec";
     rev = version;
-    sha256 = "sha256-3ZFLBn0HtQo4/6pFNPinA9hHnkbW/Y1AxXgwzrAvNMk=";
+    sha256 = "01sp24z63r3nqxx57zc4873b8i5dqipy7yrxzrwjns531vznhiy2";
   };
 
   KERNEL_SRC_DIR = lib.optionalString withDriver "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";

--- a/pkgs/tools/security/chipsec/ko-path.diff
+++ b/pkgs/tools/security/chipsec/ko-path.diff
@@ -1,0 +1,13 @@
+diff --git c/chipsec/helper/linux/linuxhelper.py i/chipsec/helper/linux/linuxhelper.py
+index c51b5e6..4be05ea 100644
+--- c/chipsec/helper/linux/linuxhelper.py
++++ i/chipsec/helper/linux/linuxhelper.py
+@@ -152,7 +152,7 @@ class LinuxHelper(Helper):
+             else:
+                 a2 = "a2=0x{}".format(phys_mem_access_prot)
+ 
+-        driver_path = os.path.join(chipsec.file.get_main_dir(), "chipsec", "helper", "linux", "chipsec.ko" )
++        driver_path = os.path.join(chipsec.file.get_main_dir(), "drivers", "linux", "chipsec.ko" )
+         if not os.path.exists(driver_path):
+             driver_path += ".xz"
+             if not os.path.exists(driver_path):


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.5.10

Change log: https://github.com/chipsec/chipsec/releases/tag/1.5.10

This is the migration to Python3. 1.5.2 was the last release with support for Python 2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
