### PR TITLE
oapi-codegen: init at 1.5.6

### DIFF
--- a/pkgs/tools/networking/oapi-codegen/default.nix
+++ b/pkgs/tools/networking/oapi-codegen/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "oapi-codegen";
+  version = "1.5.6";
+
+  src = fetchFromGitHub {
+    owner = "deepmap";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-edIm1O+LQdmKhH8/5WuSsxVtOcf3VlkObGjIY+30mms=";
+  };
+
+  vendorSha256 = "sha256-lhWnPZavtBEa4A76rvr0xw3L5W6HYK1Uw+PW8z8gWuU=";
+
+  # Tests use network
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Go client and server OpenAPI 3 generator";
+    homepage    = "https://github.com/deepmap/oapi-codegen";
+    license     = licenses.asl20;
+    maintainers = [ maintainers.j4m3s ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6861,6 +6861,8 @@ in
 
   nzbhydra2 = callPackage ../servers/nzbhydra2 { };
 
+  oapi-codegen = callPackage ../tools/networking/oapi-codegen { };
+
   oathToolkit = callPackage ../tools/security/oath-toolkit { };
 
   oatpp = callPackage ../development/libraries/oatpp { };


### PR DESCRIPTION
###### Motivation for this change

Add  oapi-codegen
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
