### PR TITLE
kube-score: init at 1.10.1

### DIFF
--- a/pkgs/applications/networking/cluster/kube-score/default.nix
+++ b/pkgs/applications/networking/cluster/kube-score/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kube-score";
+  version = "1.10.1";
+
+  src = fetchFromGitHub {
+    owner = "zegl";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-TYsuSPWTiIlPscul/QO59+lt6sbjJdt7pJuJYO5R9Tc=";
+  };
+
+  vendorSha256 = "sha256-ob7mNheyeTcDWml4gi1SD3Pq+oWtJeySIUg2ZrCj0y0=";
+
+  meta = with lib; {
+    description = "Kubernetes object analysis with recommendations for improved reliability and security";
+    homepage    = "https://github.com/zegl/kube-score";
+    license     = licenses.mit;
+    maintainers = [ maintainers.j4m3s ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23643,6 +23643,8 @@ in
 
   kubecfg = callPackage ../applications/networking/cluster/kubecfg { };
 
+  kube-score = callPackage ../applications/networking/cluster/kube-score { };
+
   kubeval = callPackage ../applications/networking/cluster/kubeval { };
 
   kubeval-schema = callPackage ../applications/networking/cluster/kubeval/schema.nix { };


### PR DESCRIPTION
###### Motivation for this change

Add kube-score
###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
