### PR TITLE
python3Packages.executing: 0.4.3 -> 0.5.4

### DIFF
--- a/pkgs/development/python-modules/executing/default.nix
+++ b/pkgs/development/python-modules/executing/default.nix
@@ -1,15 +1,27 @@
-{ lib, buildPythonPackage, fetchzip, pytest, asttokens }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, asttokens
+}:
 
 buildPythonPackage rec {
   pname = "executing";
-  version = "0.4.3";
+  version = "0.5.4";
 
-  src = fetchzip {
-    url = "https://github.com/alexmojaki/executing/archive/v${version}.tar.gz";
-    sha256 = "1fqfc26nl703nsx2flzf7x4mgr3rpbd8pnn9c195rca648zhi3nh";
+  src = fetchFromGitHub {
+    owner = "alexmojaki";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1hqx94h6l2wg9sljiaajfay2nr62sqa819w3bxrz8cdki1abdygv";
   };
 
-  checkInputs = [ pytest asttokens ];
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
+  '';
+
+  # Tests appear to run fine (Ran 22 tests in 4.076s) with setuptoolsCheckPhase
+  # but crash with pytestCheckHook
+  checkInputs = [ asttokens ];
 
   meta = with lib; {
     description = "Get information about what a frame is currently doing, particularly the AST node being executed";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/117609#issuecomment-807449577

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
