### PR TITLE
python3Packages.boltons: 20.2.0 -> 20.2.1

### DIFF
--- a/pkgs/development/python-modules/boltons/default.nix
+++ b/pkgs/development/python-modules/boltons/default.nix
@@ -1,19 +1,35 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pytest }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "boltons";
-  version = "20.2.0";
+  version = "20.2.1";
 
   # No tests in PyPi Tarball
   src = fetchFromGitHub {
     owner = "mahmoud";
     repo = "boltons";
     rev = version;
-    sha256 = "08rd6av8dp5n1vz6nybmayl1mfsmj66cskiaybfshcgix29ca803";
+    sha256 = "0vw0h0z81gfxgjfijqiza92ic0siv9xy65mklgj5d0dzr1k9waw8";
   };
 
-  checkInputs = [ pytest ];
-  checkPhase = "pytest tests";
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/mahmoud/boltons/commit/754afddf141ea26956c88c7e13fe5e7ca7942654.patch";
+      sha256 = "14kcq8pl4pmgcnlnmj1sh1yrksgym0kn0kgz2648g192svqkbpz8";
+    })
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+  disabledTests = [
+    # This test is broken without this PR, which has not yet been merged
+    # https://github.com/mahmoud/boltons/pull/283
+    "test_frozendict_ior"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/mahmoud/boltons";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix for python3.9: https://hydra.nixos.org/job/nixpkgs/trunk/python39Packages.boltons.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
