### PR TITLE
python39Packages.pyregion: unbreak

### DIFF
--- a/pkgs/development/python-modules/pyregion/default.nix
+++ b/pkgs/development/python-modules/pyregion/default.nix
@@ -1,13 +1,13 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , fetchpatch
 , pyparsing
 , numpy
 , cython
 , astropy
 , astropy-helpers
-, pytest
+, pytestCheckHook
 , pytest-astropy
 }:
 
@@ -15,15 +15,18 @@ buildPythonPackage rec {
   pname = "pyregion";
   version = "2.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a8ac5f764b53ec332f6bc43f6f2193ca13e8b7d5a3fb2e20ced6b2ea42a9d094";
+  # pypi src contains cython-produced .c files which don't compile
+  # with python3.9
+  src = fetchFromGitHub {
+    owner = "astropy";
+    repo = pname;
+    rev = version;
+    sha256 = "1izar7z606czcyws9s8bjbpb1xhqshpv5009rlpc92hciw7jv4kg";
   };
 
   propagatedBuildInputs = [
     pyparsing
     numpy
-    cython
     astropy
   ];
 
@@ -36,9 +39,9 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [ astropy-helpers ];
+  nativeBuildInputs = [ astropy-helpers cython ];
 
-  checkInputs = [ pytest pytest-astropy ];
+  checkInputs = [ pytestCheckHook pytest-astropy ];
 
   # Disable automatic update of the astropy-helper module
   postPatch = ''
@@ -46,9 +49,11 @@ buildPythonPackage rec {
   '';
 
   # Tests must be run in the build directory
-  checkPhase = ''
-    cd build/lib.*
-    pytest
+  preCheck = ''
+    pushd build/lib.*
+  '';
+  postCheck = ''
+    popd
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://hydra.nixos.org/job/nixpkgs/trunk/python39Packages.pyregion.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
