### PR TITLE
vscode: fix upstream domain name

### DIFF
--- a/pkgs/applications/editors/vscode/update-vscode.sh
+++ b/pkgs/applications/editors/vscode/update-vscode.sh
@@ -19,18 +19,18 @@ fi
 VSCODE_VER=$(curl --fail --silent https://api.github.com/repos/Microsoft/vscode/releases/latest | jq --raw-output .tag_name)
 sed -i "s/version = \".*\"/version = \"${VSCODE_VER}\"/" "$ROOT/vscode.nix"
 
-VSCODE_LINUX_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/linux-x64/stable"
+VSCODE_LINUX_URL="https://update.code.visualstudio.com/${VSCODE_VER}/linux-x64/stable"
 VSCODE_LINUX_SHA256=$(nix-prefetch-url ${VSCODE_LINUX_URL})
 sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODE_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
 
-VSCODE_DARWIN_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/darwin/stable"
+VSCODE_DARWIN_URL="https://update.code.visualstudio.com/${VSCODE_VER}/darwin/stable"
 VSCODE_DARWIN_SHA256=$(nix-prefetch-url ${VSCODE_DARWIN_URL})
 sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODE_DARWIN_SHA256}\"/" "$ROOT/vscode.nix"
 
-VSCODE_LINUX_AARCH64_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/linux-arm64/stable"
+VSCODE_LINUX_AARCH64_URL="https://update.code.visualstudio.com/${VSCODE_VER}/linux-arm64/stable"
 VSCODE_LINUX_AARCH64_SHA256=$(nix-prefetch-url ${VSCODE_LINUX_AARCH64_URL})
 sed -i "s/aarch64-linux = \".\{52\}\"/aarch64-linux = \"${VSCODE_LINUX_AARCH64_SHA256}\"/" "$ROOT/vscode.nix"
 
-VSCODE_LINUX_ARMV7L_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/linux-armhf/stable"
+VSCODE_LINUX_ARMV7L_URL="https://update.code.visualstudio.com/${VSCODE_VER}/linux-armhf/stable"
 VSCODE_LINUX_ARMV7L_SHA256=$(nix-prefetch-url ${VSCODE_LINUX_ARMV7L_URL})
 sed -i "s/armv7l-linux = \".\{52\}\"/armv7l-linux = \"${VSCODE_LINUX_ARMV7L_SHA256}\"/" "$ROOT/vscode.nix"

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -34,7 +34,7 @@ in
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";
-      url = "https://vscode-update.azurewebsites.net/${version}/${plat}/stable";
+      url = "https://update.code.visualstudio.com/${version}/${plat}/stable";
       inherit sha256;
     };
 


### PR DESCRIPTION
The VS Code team recently retired a deprecated domain used for VS Code downloads. This breaks update-vscode.sh and customized package installations (such as used by home-manager). The new domain name is the one preferred by the VS Code team, as stated in this GitHub issue: https://github.com/microsoft/vscode/issues/119822

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

All builds of the vscode package are currently broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
