### PR TITLE
kubeconform: init at 0.4.6

### DIFF
--- a/pkgs/applications/networking/cluster/kubeconform/default.nix
+++ b/pkgs/applications/networking/cluster/kubeconform/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubeconform";
+  version = "0.4.6";
+
+  src = fetchFromGitHub {
+    owner = "yannh";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-lduHYYskEPUimEX54ymOyo5jY7GGBB42YTefDMNS4qo=";
+  };
+
+  vendorSha256 = null;
+
+  meta = with lib; {
+    description = "A FAST Kubernetes manifests validator, with support for Custom Resources!";
+    homepage    = "https://github.com/yannh/kubeconform/";
+    license     = licenses.asl20;
+    maintainers = [ maintainers.j4m3s ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23661,6 +23661,8 @@ in
 
   kubernix = callPackage ../applications/networking/cluster/kubernix { };
 
+  kubeconform = callPackage ../applications/networking/cluster/kubeconform { };
+
   kubectl = callPackage ../applications/networking/cluster/kubectl { };
 
   kubectl-doctor = callPackage ../applications/networking/cluster/kubectl-doctor { };


### PR DESCRIPTION
###### Motivation for this change

Add kubeconform
###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
