### PR TITLE
ly: 0.2.1 -> 0.5.2.1-1

### DIFF
--- a/pkgs/applications/display-managers/ly/default.nix
+++ b/pkgs/applications/display-managers/ly/default.nix
@@ -1,19 +1,26 @@
-{ stdenv, lib, fetchFromGitHub, linux-pam }:
+{ stdenv, lib, fetchFromGitHub, linux-pam, git, libxcb, ncurses }:
+
+# This package is intended to be reworked, it is temporarily using a fork since
+# the original developer used a non-standard method of specifying .gitmodules.
+# https://github.com/nullgemm/ly/pull/279
 
 stdenv.mkDerivation rec {
   pname = "ly";
-  version = "0.2.1";
+  version = "unstable-2021-03-25";
+
+  hardeningDisable = [ "all" ];
+
+  nativeBuildInputs = [ git ];
+
+  buildInputs = [ libxcb linux-pam ncurses ];
 
   src = fetchFromGitHub {
-    owner = "cylgom";
+    owner = "matthewcroughan";
     repo = "ly";
-    rev = version;
-    sha256 = "16gjcrd4a6i4x8q8iwlgdildm7cpdsja8z22pf2izdm6rwfki97d";
+    rev = "850c7b1112c44f4b0e9c0837d8b3d0c7fe02821f";
+    sha256 = "sha256-XLVfKnxr5GKMN6pRTOIaKW6KMH6hzW8KwboEFtuOkY0=";
     fetchSubmodules = true;
   };
-
-  buildInputs = [ linux-pam ];
-  makeFlags = [ "FLAGS=-Wno-error" ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -23,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "TUI display manager";
     license = licenses.wtfpl;
-    homepage = "https://github.com/cylgom/ly";
-    maintainers = [ maintainers.spacekookie ];
+    homepage = "https://github.com/nullgemm/ly";
+    maintainers = with maintainers; [ matthewcroughan nixinator ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates `ly` to the latest version from the developer. The `-1` is due to my fork, which actually allows this package to be compiled, since the developer used a non standard method of managing their .gitmodules which `fetchFromGitHub` can't reconcile. https://github.com/nullgemm/ly/pull/279

Currently, this package seems to be unable to read the `.desktop` files for `wayland-sessions` from the `/nix/store` as noted in https://github.com/nullgemm/ly/issues/193. The intent is to have @darthpjb patch/rewrite `ly` to work with NixOS, whilst fixing the code that requires hardening to be disabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
