### PR TITLE
libxkbcommon: build with wayland support tools

### DIFF
--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -1,9 +1,21 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, bison, doxygen
-, xkeyboard_config, libxcb, libxml2
+{ lib
+, stdenv
+, fetchurl
+, meson
+, ninja
+, pkg-config
+, bison
+, doxygen
+, xkeyboard_config
+, libxcb
+, libxml2
 , python3
 , libX11
-# To enable the "interactive-wayland" subcommand of xkbcli:
-, withWaylandSupport ? false, wayland, wayland-protocols
+  # To enable the "interactive-wayland" subcommand of xkbcli. This is the
+  # wayland equivalent of `xev` on X11.
+, withWaylandTools ? stdenv.isLinux
+, wayland
+, wayland-protocols
 }:
 
 stdenv.mkDerivation rec {
@@ -19,16 +31,16 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ meson ninja pkg-config bison doxygen ]
-    ++ lib.optional withWaylandSupport wayland;
+    ++ lib.optional withWaylandTools wayland;
   buildInputs = [ xkeyboard_config libxcb libxml2 ]
-    ++ lib.optionals withWaylandSupport [ wayland wayland-protocols ];
+    ++ lib.optionals withWaylandTools [ wayland wayland-protocols ];
   checkInputs = [ python3 ];
 
   mesonFlags = [
     "-Dxkb-config-root=${xkeyboard_config}/etc/X11/xkb"
     "-Dxkb-config-extra-path=/etc/xkb" # default=$sysconfdir/xkb ($out/etc)
     "-Dx-locale-root=${libX11.out}/share/X11/locale"
-    "-Denable-wayland=${lib.boolToString withWaylandSupport}"
+    "-Denable-wayland=${lib.boolToString withWaylandTools}"
   ];
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

As wayland is the future anyway, it really doesn't make sense to not have the wayland support tools built with libxkbcommon.

Size difference:
/nix/store/czvbssspmfmm40syq0ylbczf9c4lv6ss-libxkbcommon-1.0.3     45346264
/nix/store/g81gf06jmyxp0j4ymjnjlggz71pz9zcq-libxkbcommon-1.0.3     46533584

Very large rebuild, so staging first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
