### PR TITLE
uwuify: init at 0.2.1

### DIFF
--- a/pkgs/tools/misc/uwuify/default.nix
+++ b/pkgs/tools/misc/uwuify/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, libiconv }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "uwuify";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "Daniel-Liu-c0deb0t";
+    repo = "uwu";
+    rev = "v${version}";
+    sha256 = "sha256-tPmLqgrWi7wDoMjMrxodKp4S0ICwV9Kp7Pa151rHho0=";
+  };
+
+  cargoSha256 = "sha256-HUP6OEvoGJ/BtAl+yuGzqEp1bsxfGAh0UJtXz9/ZiK8=";
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+
+  meta = with lib; {
+    description = "Fast text uwuifier";
+    homepage = "https://github.com/Daniel-Liu-c0deb0t/uwu";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3352,6 +3352,8 @@ in
 
   usbview = callPackage ../tools/misc/usbview { };
 
+  uwuify = callPackage ../tools/misc/uwuify { };
+
   anthy = callPackage ../tools/inputmethods/anthy { };
 
   evdevremapkeys = callPackage ../tools/inputmethods/evdevremapkeys { };


### PR DESCRIPTION
###### motivation f-fow this change
Add uwuify package.

###### things done

<!-- p-pwease check nyani appwies. (˘ω˘) n-nyote that these awe nyot hawd w-wequiwements but mewewy sewve as infowmation fow w-weviewews. òωó -->

- [ ] tested using s-sandboxing ([nix.usesandbox](https://nixos.owg/nixos/manuaw/options.htmw#opt-nix.usesandbox) o-on nyixos, -.- ow o-option `sandbox` in [`nix.conf`](https://nixos.owg/nix/manuaw/#sec-conf-fiwe) on nyon-nixos winux)
- buiwt on pwatfowm(s)
   - [ ] nyixos
   - [x] m-macos
   - [ ] othew winux distwibutions
- [x] tested via one ow mowe nyixos test(s) if existing a-and appwicabwe f-fow the change (wook inside [nixos/tests](https://github.com/nixos/nixpkgs/bwob/mastew/nixos/tests))
- [ ] t-tested compiwation of aww pkgs that depend on this c-change using `nix-sheww -p nyixpkgs-weview --wun "nixpkgs-weview w-wip"`
- [x] tested e-execution of a-aww binawy fiwes (usuawwy i-in `./wesuwt/bin/`)
- [ ] detewmined t-the impact on package cwosuwe size (by wunning `nix p-path-info -s` b-befowe and aftew)
- [x] e-ensuwed that wewevant documentation is up to date
- [x] f-fits [contwibuting.md](https://github.com/nixos/nixpkgs/bwob/mastew/.github/contwibuting.md). rawr x3
