### PR TITLE
treewide: remove redundant stdenv

### DIFF
--- a/pkgs/applications/editors/neovim/neovim-qt.nix
+++ b/pkgs/applications/editors/neovim/neovim-qt.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub, cmake, doxygen, makeWrapper
+{ lib, mkDerivation, fetchFromGitHub, cmake, doxygen, makeWrapper
 , msgpack, neovim, pythonPackages, qtbase }:
 
 mkDerivation rec {

--- a/pkgs/applications/networking/cluster/helm/wrapper.nix
+++ b/pkgs/applications/networking/cluster/helm/wrapper.nix
@@ -1,6 +1,4 @@
-{ stdenv, symlinkJoin, lib, makeWrapper
-, writeText
-}:
+{ symlinkJoin, lib, makeWrapper, writeText }:
 
 helm:
 

--- a/pkgs/applications/networking/sync/rsync/base.nix
+++ b/pkgs/applications/networking/sync/rsync/base.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, fetchurl }:
 
 rec {
   version = "3.2.3";

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -15,7 +15,7 @@ assert enableXXHash -> xxHash != null;
 assert enableZstd -> zstd != null;
 
 let
-  base = import ./base.nix { inherit lib stdenv fetchurl; };
+  base = import ./base.nix { inherit lib fetchurl; };
 in
 stdenv.mkDerivation rec {
   name = "rsync-${base.version}";

--- a/pkgs/applications/networking/sync/rsync/rrsync.nix
+++ b/pkgs/applications/networking/sync/rsync/rrsync.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, perl, rsync }:
 
 let
-  base = import ./base.nix { inherit stdenv lib fetchurl; };
+  base = import ./base.nix { inherit lib fetchurl; };
 in
 stdenv.mkDerivation {
   name = "rrsync-${base.version}";

--- a/pkgs/development/gnuradio-modules/ais/default.nix
+++ b/pkgs/development/gnuradio-modules/ais/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , mkDerivation
 , fetchFromGitHub
 , cmake

--- a/pkgs/development/python-modules/urllib3/2.nix
+++ b/pkgs/development/python-modules/urllib3/2.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , brotli
 , buildPythonPackage
 , certifi

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , brotli
 , buildPythonPackage
 , certifi

--- a/pkgs/tools/X11/xkeysnail/default.nix
+++ b/pkgs/tools/X11/xkeysnail/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, python3Packages }:
+{ lib, fetchFromGitHub, makeWrapper, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
   pname = "xkeysnail";

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, skawarePackages
+{ lib, skawarePackages
 
 # Whether to build the TLS/SSL tools and what library to use
 # acceptable values: "bearssl", "libressl", false


### PR DESCRIPTION
###### Motivation for this change
Analogous to #110687 but went through the files manually. Evaluation succeeds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
