### PR TITLE
kubectl: only build kubectl and kubeadm

### DIFF
--- a/pkgs/applications/networking/cluster/kubectl/default.nix
+++ b/pkgs/applications/networking/cluster/kubectl/default.nix
@@ -1,7 +1,7 @@
 { stdenv, kubernetes, installShellFiles }:
-
 stdenv.mkDerivation {
-  name = "kubectl-${kubernetes.version}";
+  pname = "kubectl";
+  version = kubernetes.version;
 
   # kubectl is currently part of the main distribution but will eventially be
   # split out (see homepage)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23690,9 +23690,7 @@ in
 
   kubernix = callPackage ../applications/networking/cluster/kubernix { };
 
-  kubeconform = callPackage ../applications/networking/cluster/kubeconform { };
-
-  kubectl = callPackage ../applications/networking/cluster/kubectl { };
+  kubectl = callPackage ../applications/networking/cluster/kubectl { kubernetes = kubernetes.override { components = []; }; };
 
   kubectl-doctor = callPackage ../applications/networking/cluster/kubectl-doctor { };
 


### PR DESCRIPTION
overrides the kubernetes package so only the default components
(kubectl and kubeadm) are built to reduce the build time.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Reduce the build time for kubectl by only building the kubectl (and kubeadm) binary rather than all the components in k8s, since kubectl is the only one that gets installed anyway

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
