### PR TITLE
octant-desktop: init at 0.18.0

### DIFF
--- a/pkgs/applications/networking/cluster/octant/default.nix
+++ b/pkgs/applications/networking/cluster/octant/default.nix
@@ -6,7 +6,7 @@ let
     x86_64-linux = "Linux-64bit";
     aarch64-linux = "Linux-arm64";
     x86_64-darwin = "macOS-64bit";
-  }."${system}" or (throw "Unsupported system: ${system}");
+  }.${system} or (throw "Unsupported system: ${system}");
   baseurl = "https://github.com/vmware-tanzu/octant/releases/download";
   fetchsrc = version: sha256: fetchzip {
       url = "${baseurl}/v${version}/octant_${version}_${suffix}.tar.gz";
@@ -48,12 +48,14 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://octant.dev/";
     changelog = "https://github.com/vmware-tanzu/octant/blob/v${version}/CHANGELOG.md";
-    description = "Highly extensible platform for developers to better understand the complexity of Kubernetes clusters.";
+    description = "Highly extensible platform for developers to better understand the complexity of Kubernetes clusters";
     longDescription = ''
-      Octant is a tool for developers to understand how applications run on a Kubernetes cluster.
-      It aims to be part of the developer's toolkit for gaining insight and approaching complexity found in Kubernetes.
-      Octant offers a combination of introspective tooling, cluster navigation, and object management along with a
-      plugin system to further extend its capabilities.
+      Octant is a tool for developers to understand how applications run on a
+      Kubernetes cluster.
+      It aims to be part of the developer's toolkit for gaining insight and
+      approaching complexity found in Kubernetes. Octant offers a combination of
+      introspective tooling, cluster navigation, and object management along
+      with a plugin system to further extend its capabilities.
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ jk ];

--- a/pkgs/applications/networking/cluster/octant/desktop.nix
+++ b/pkgs/applications/networking/cluster/octant/desktop.nix
@@ -1,0 +1,78 @@
+{ lib, stdenv, appimageTools, fetchurl, gsettings-desktop-schemas, gtk3, undmg }:
+
+let
+  pname = "octant-desktop";
+  version = "0.18.0";
+  name = "${pname}-${version}";
+
+  inherit (stdenv.hostPlatform) system;
+
+  suffix = {
+    x86_64-linux = "AppImage";
+    x86_64-darwin = "dmg";
+  }.${system} or (throw "Unsupported system: ${system}");
+
+  src = fetchurl {
+    url = "https://github.com/vmware-tanzu/octant/releases/download/v${version}/Octant-${version}.${suffix}";
+    sha256 = {
+      x86_64-linux = "sha256-sQxplTJ3xfHELepx+t7FtMpPTxTDoqTAL8oUz4sLaW0=";
+      x86_64-darwin = "sha256-ov9j+SgGXCwUjQaX3eCxVvPwPgUIwtHJ6Lmx2crOfIM=";
+    }.${system};
+  };
+
+  linux = appimageTools.wrapType2 {
+    inherit name src passthru meta;
+
+    profile = ''
+      export LC_ALL=C.UTF-8
+      export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+    '';
+
+    multiPkgs = null; # no 32bit needed
+    extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
+    extraInstallCommands =
+      let appimageContents = appimageTools.extractType2 { inherit name src; }; in
+      ''
+        mv $out/bin/{${name},${pname}}
+        install -Dm444 ${appimageContents}/octant.desktop -t $out/share/applications
+        substituteInPlace $out/share/applications/octant.desktop \
+          --replace 'Exec=AppRun --no-sandbox' 'Exec=${pname}'
+        install -m 444 -D ${appimageContents}/octant.png \
+          $out/share/icons/hicolor/512x512/apps/octant.png
+      '';
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit name src passthru meta;
+
+    nativeBuildInputs = [ undmg ];
+    sourceRoot = "Octant.app";
+    installPhase = ''
+      mkdir -p $out/Applications/Octant.app
+      cp -R . $out/Applications/Octant.app
+    '';
+  };
+
+  passthru = { updateScript = ./update-desktop.sh; };
+
+  meta = with lib; {
+    homepage = "https://octant.dev/";
+    changelog = "https://github.com/vmware-tanzu/octant/blob/v${version}/CHANGELOG.md";
+    description = "Highly extensible platform for developers to better understand the complexity of Kubernetes clusters";
+    longDescription = ''
+      Octant is a tool for developers to understand how applications run on a
+      Kubernetes cluster.
+      It aims to be part of the developer's toolkit for gaining insight and
+      approaching complexity found in Kubernetes. Octant offers a combination of
+      introspective tooling, cluster navigation, and object management along
+      with a plugin system to further extend its capabilities.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+
+in
+if stdenv.isDarwin
+then darwin
+else linux

--- a/pkgs/applications/networking/cluster/octant/update-desktop.sh
+++ b/pkgs/applications/networking/cluster/octant/update-desktop.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused gawk nix-prefetch
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_DRV="$ROOT/desktop.nix"
+if [ ! -f "$NIX_DRV" ]; then
+  echo "ERROR: cannot find desktop.nix in $ROOT"
+  exit 1
+fi
+
+fetch_arch() {
+  VER="$1"; SUFFIX="$2"
+  URL="https://github.com/vmware-tanzu/octant/releases/download/v${VER}/Octant-${VER}.${SUFFIX}"
+  nix-prefetch "{ stdenv, fetchurl }:
+stdenv.mkDerivation rec {
+  pname = \"octant-desktop\"; version = \"${VER}\";
+  src = fetchurl { url = \"$URL\"; };
+}
+"
+}
+
+replace_sha() {
+  sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_DRV"
+}
+
+OCTANT_VER=$(curl -Ls -w "%{url_effective}" -o /dev/null https://github.com/vmware-tanzu/octant/releases/latest | awk -F'/' '{print $NF}' | sed 's/v//')
+
+OCTANT_DESKTOP_LINUX_X64_SHA256=$(fetch_arch "$OCTANT_VER" "AppImage")
+OCTANT_DESKTOP_DARWIN_X64_SHA256=$(fetch_arch "$OCTANT_VER" "dmg")
+
+sed -i "s/version = \".*\"/version = \"$OCTANT_VER\"/" "$NIX_DRV"
+
+replace_sha "x86_64-linux" "$OCTANT_DESKTOP_LINUX_X64_SHA256"
+replace_sha "x86_64-darwin" "$OCTANT_DESKTOP_DARWIN_X64_SHA256"

--- a/pkgs/applications/networking/cluster/octant/update.sh
+++ b/pkgs/applications/networking/cluster/octant/update.sh
@@ -28,11 +28,11 @@ replace_sha() {
 OCTANT_VER=$(curl -Ls -w "%{url_effective}" -o /dev/null https://github.com/vmware-tanzu/octant/releases/latest | awk -F'/' '{print $NF}' | sed 's/v//')
 
 OCTANT_LINUX_X64_SHA256=$(fetch_arch "$OCTANT_VER" "Linux-64bit")
-OCTANT_DARWIN_X64_SHA256=$(fetch_arch "$OCTANT_VER" "Linux-arm64")
-OCTANT_LINUX_AARCH64_SHA256=$(fetch_arch "$OCTANT_VER" "macOS-64bit")
+OCTANT_LINUX_AARCH64_SHA256=$(fetch_arch "$OCTANT_VER" "Linux-arm64")
+OCTANT_DARWIN_X64_SHA256=$(fetch_arch "$OCTANT_VER" "macOS-64bit")
 
 sed -i "s/version = \".*\"/version = \"$OCTANT_VER\"/" "$NIX_DRV"
 
 replace_sha "x86_64-linux" "$OCTANT_LINUX_X64_SHA256"
-replace_sha "x86_64-darwin" "$OCTANT_LINUX_AARCH64_SHA256"
-replace_sha "aarch64-linux" "$OCTANT_DARWIN_X64_SHA256"
+replace_sha "aarch64-linux" "$OCTANT_LINUX_AARCH64_SHA256"
+replace_sha "x86_64-darwin" "$OCTANT_DARWIN_X64_SHA256"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -548,6 +548,7 @@ in
   ociTools = callPackage ../build-support/oci-tools { };
 
   octant = callPackage ../applications/networking/cluster/octant { };
+  octant-desktop = callPackage ../applications/networking/cluster/octant/desktop.nix { };
   starboard-octant-plugin = callPackage ../applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix { };
 
   pathsFromGraph = ../build-support/kernel/paths-from-graph.pl;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

octant-desktop: init at 0.18.0
Unpacked from an AppImage or dmg depending on the platform

Based on the joplin-desktop package, thanks @hugoreeves

I've done a `nix-env -f . -iA octant-desktop` install and the icons and launch works fine in my rofi launcher
The starboard octant plugin I have installed to `~/.config/octant/plugins` also works well

I've done a build of the dmg version on NixOS and the structure looked alright.
Probably worth installing on an x86 mac to test it.

I've made sure that the "binary" for the app-image is called `octant-desktop` so that it doesn't clash with the cli copy of `octant`

Also:

octant cleanup
- Remove unneeded quotes around `${system}`
- Cleanup meta
- Correct the variable names in `update.sh`
  - Luckily even though the names were a jumble the correct shas were being put in the right places

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
