### PR TITLE
libmspack: 0.7.1alpha -> 0.10.1alpha

### DIFF
--- a/pkgs/development/libraries/libmspack/default.nix
+++ b/pkgs/development/libraries/libmspack/default.nix
@@ -1,17 +1,18 @@
 {lib, stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "libmspack-0.7.1alpha";
+  pname = "libmspack";
+  version = "0.10.1alpha";
 
   src = fetchurl {
-    url = "https://www.cabextract.org.uk/libmspack/${name}.tar.gz";
-    sha256 = "0zn4vwzk5ankgd0l88cipan19pzbzv0sm3fba17lvqwka3dp1acp";
+    url = "https://www.cabextract.org.uk/libmspack/${pname}-${version}.tar.gz";
+    sha256 = "13janaqsvm7aqc4agjgd4819pbgqv50j88bh5kci1z70wvg65j5s";
   };
 
   meta = {
     description = "A de/compression library for various Microsoft formats";
     homepage = "https://www.cabextract.org.uk/libmspack";
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.lgpl2Only;
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2019-1010305, CVE-2018-18586, CVE-2018-18585 and CVE-2018-18584.

https://www.cabextract.org.uk/libmspack/#vulns

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


The failures of the execution of `nixpkgs-review` for the `evolution*` packages are caused by an OOM issue on my builder. I did not attempt to build them again due to the time the builds take.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>evolution-ews</li>
    <li>evolutionWithPlugins</li>
  </ul>
</details>
<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>clamav</li>
    <li>libmspack</li>
    <li>libreoffice (libreoffice-still)</li>
    <li>libreoffice-fresh</li>
    <li>libreoffice-fresh-unwrapped</li>
    <li>libreoffice-qt</li>
    <li>libreoffice-still-unwrapped</li>
    <li>odpdown</li>
    <li>open-vm-tools</li>
    <li>open-vm-tools-headless</li>
    <li>unoconv</li>
  </ul>
</details>


