### PR TITLE
paperlike-go: unstable-2021-03-22 -> unstable-2021-03-26

### DIFF
--- a/pkgs/tools/misc/paperlike-go/default.nix
+++ b/pkgs/tools/misc/paperlike-go/default.nix
@@ -5,20 +5,20 @@
 
 buildGoModule {
   pname = "paperlike-go";
-  version = "unstable-2021-03-22";
+  version = "unstable-2021-03-26";
 
   src = fetchFromGitHub {
     owner = "leoluk";
     repo = "paperlike-go";
-    rev = "a7d89fd4d4cbcec7be016860e9063676ad4cca0f";
-    sha256 = "0ym340520a0j4gvgk4x091lcz1apsv9lnwx0nnha86qvzqcy528l";
+    rev = "bd658d88ea9a3b21e1b301b96253abab7cf56d79";
+    sha256 = "1h0n2n5w5pn3r08qf6hbmiib5m71br27y66ki9ajnaa890377qaj";
   };
 
   subPackages = [ "cmd/paperlike-cli" ];
 
   vendorSha256 = "00mn0zfivxp2h77s7gmyyjp8p5a1vysn73wwaalgajymvljxxx1r";
 
-  meta = with lib; {
+  meta = {
     description = "paperlike-go is a Linux Go library and CLI utility to control a Dasung Paperlike display via I2C DDC.";
     homepage = "https://github.com/leoluk/paperlike-go";
     license = lib.licenses.asl20;


### PR DESCRIPTION
###### Motivation for this change

This adds light controls.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
