### PR TITLE
llfuse: disable tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/llfuse/default.nix
+++ b/pkgs/development/python-modules/llfuse/default.nix
@@ -35,12 +35,12 @@ buildPythonPackage rec {
     ${python.interpreter} setup.py build_cython
   '';
 
+  # On Darwin, the test requires macFUSE to be installed outside of Nix.
+  doCheck = !stdenv.isDarwin;
   checkInputs = [ pytestCheckHook which ];
 
   disabledTests = [
     "test_listdir" # accesses /usr/bin
-  ] ++ lib.optionals stdenv.isDarwin [
-    "uses_fuse"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Fixes #117665. The tests require [macFUSE][1], an external dependency to be installed.

~I last tested this package in #116958, and this PR is probably safe too as no change has been made to it since. I'm building this change on my local machine right now, but it would take a while for it to complete as the latest `master` seems to require a rebuild of stdenv.~ Built and tested on macOS, no rebuilds on Linux.

[1]: https://osxfuse.github.io/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
