### PR TITLE
python3Packages.apptools: 4.5.0 -> 5.1.0

### DIFF
--- a/pkgs/development/python-modules/apptools/default.nix
+++ b/pkgs/development/python-modules/apptools/default.nix
@@ -1,34 +1,35 @@
-{ lib, fetchPypi, buildPythonPackage, fetchpatch
+{ lib, fetchPypi, buildPythonPackage
 , configobj, six, traitsui
-, nose, tables, pandas
+, pytestCheckHook, tables, pandas
+, pythonOlder, importlib-resources
 }:
 
 buildPythonPackage rec {
   pname = "apptools";
-  version = "4.5.0";
+  version = "5.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "10h52ibhr2aw076pivqxiajr9rpcr1mancg6xlpxzckcm3if02i6";
+    sha256 = "12x5lcs1cllpybz7f0i1lcwvmqsaa5n818wb2165lj049wqxx4yh";
   };
 
-  # PyTables issue; should be merged in next post-4.5.0 release (#117)
-  patches = [ (fetchpatch {
-      url = "https://github.com/enthought/apptools/commit/3734289d1a0ebd8513fa67f75288add31ed0113c.patch";
-      sha256 = "001012q1ib5cbib3nq1alh9ckzj588bfrywr8brkd1f6y1pgvngk";
-    })
+  propagatedBuildInputs = [
+    configobj
+    six
+    traitsui
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    importlib-resources
   ];
-
-  propagatedBuildInputs = [ configobj six traitsui ];
 
   checkInputs = [
-    nose
     tables
     pandas
+    pytestCheckHook
   ];
 
-  doCheck = true;
-  checkPhase = "HOME=$TMP nosetests";
+  preCheck = ''
+    export HOME=$TMP
+  '';
 
   meta = with lib; {
     description = "Set of packages that Enthought has found useful in creating a number of applications.";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix for py39: https://hydra.nixos.org/job/nixpkgs/trunk/python39Packages.apptools.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
