### PR TITLE
vscode-extensions.dotjoshjohnson.xml: init at 2.5.1

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -201,6 +201,20 @@ let
         };
       };
 
+      dotjoshjohnson.xml = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "xml";
+          publisher = "dotjoshjohnson";
+          version = "2.5.1";
+          sha256 = "1v4x6yhzny1f8f4jzm4g7vqmqg5bqchyx4n25mkgvw2xp6yls037";
+        };
+        meta = {
+          description = "XML Tools";
+          homepage = "https://github.com/DotJoshJohnson/vscode-xml";
+          license = lib.licenses.mit;
+        };
+      };
+
       dracula-theme.theme-dracula = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "theme-dracula";


### PR DESCRIPTION
###### Motivation for this change
[XML Formatting, XQuery, and XPath Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=DotJoshJohnson.xml&ssr=false#overview)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
