### PR TITLE
nixos-rebuild: Added a version check

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -262,7 +262,7 @@ fi
 # Use /etc/nixos/flake.nix if it exists. It can be a symlink to the
 # actual flake.
 # Also make sure we're using a new version of nix (not version 2.1, 2.2 or 2.3)
-if [[ -z $(nix --version | grep -o '2\.[1-3]') && -z $flake && -e /etc/nixos/flake.nix ]]; then
+if [[ -z $(nix --version | grep -o '2\.[1-3]\.') && -z $flake && -e /etc/nixos/flake.nix ]]; then
     flake="$(dirname "$(readlink -f /etc/nixos/flake.nix)")"
 fi
 

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -262,7 +262,7 @@ fi
 # Use /etc/nixos/flake.nix if it exists. It can be a symlink to the
 # actual flake.
 # Also make sure we're using a new version of nix (not version 2.1, 2.2 or 2.3)
-if [[ -z $flake && -e /etc/nixos/flake.nix && -z $(nix --version | grep '2\.[1-3]')]]; then
+if [[ -z $(nix --version | grep -o '2\.[1-3]') && -z $flake && -e /etc/nixos/flake.nix ]]; then
     flake="$(dirname "$(readlink -f /etc/nixos/flake.nix)")"
 fi
 

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -261,7 +261,8 @@ fi
 
 # Use /etc/nixos/flake.nix if it exists. It can be a symlink to the
 # actual flake.
-if [[ -z $flake && -e /etc/nixos/flake.nix ]]; then
+# Also make sure we're using a new version of nix (not version 2.1, 2.2 or 2.3)
+if [[ -z $flake && -e /etc/nixos/flake.nix && -z $(nix --version | grep '2\.[1-3]')]]; then
     flake="$(dirname "$(readlink -f /etc/nixos/flake.nix)")"
 fi
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Before this patch, if /etc/nixos/flake.nix existed, nixos-rebuild would
try to use flakes even if you had an unsupported version of nix. we now
do an additional version check to see if nix can use flakes in the first
place.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
