### PR TITLE
elan: 0.10.3 -> 0.11.0

### DIFF
--- a/pkgs/applications/science/logic/elan/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/applications/science/logic/elan/0001-dynamically-patchelf-binaries.patch
@@ -1,0 +1,40 @@
+diff --git a/src/elan-dist/src/component/package.rs b/src/elan-dist/src/component/package.rs
+index fd9fe74..0fefa39 100644
+--- a/src/elan-dist/src/component/package.rs
++++ b/src/elan-dist/src/component/package.rs
+@@ -50,11 +50,35 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
+         };
+ 
+         try!(entry.unpack(&full_path).chain_err(|| ErrorKind::ExtractingPackage));
++        nix_patchelf_if_needed(&full_path);
+     }
+ 
+     Ok(())
+ }
+ 
++fn nix_patchelf_if_needed(dest_path: &Path) {
++    let (is_bin, is_lib) = if let Some(p) = dest_path.parent() {
++        (p.ends_with("bin"), p.ends_with("lib"))
++    } else {
++        (false, false)
++    };
++
++    if is_bin {
++        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++            .arg("--set-interpreter")
++            .arg("@dynamicLinker@")
++            .arg(dest_path)
++            .output();
++    }
++    else if is_lib {
++        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++            .arg("--set-rpath")
++            .arg("@libPath@")
++            .arg(dest_path)
++            .output();
++    }
++}
++
+ #[derive(Debug)]
+ pub struct ZipPackage<'a>(temp::Dir<'a>);
+ 

--- a/pkgs/applications/science/logic/elan/default.nix
+++ b/pkgs/applications/science/logic/elan/default.nix
@@ -1,23 +1,45 @@
-{ lib, pkg-config, curl, openssl, zlib, fetchFromGitHub, rustPlatform }:
+{ stdenv, lib, runCommand, patchelf, makeWrapper, pkg-config, curl
+, openssl, gmp, zlib, fetchFromGitHub, rustPlatform }:
+
+let
+  libPath = lib.makeLibraryPath [ gmp ];
+in
 
 rustPlatform.buildRustPackage rec {
   pname = "elan";
-  version = "0.10.3";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "kha";
     repo = "elan";
     rev = "v${version}";
-    sha256 = "sha256-YkGfuqtvVfPcxJ8UqD5QidcNEy5brTWGEK4fR64Yz70=";
+    sha256 = "1sl69ygdwhf80sx6m76x5gp1kwsw0rr1lv814cgzm8hvyr6g0jqa";
   };
 
-  cargoSha256 = "sha256-2fYicpoEERwD4OjdpseKQOkDvZlb7NnOZcb6Tu+rQdA=";
+  cargoSha256 = "1f881maf8jizd5ip7pc1ncbiq7lpggp0byma13pvqk7gisnqyr4r";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config makeWrapper ];
 
+  OPENSSL_NO_VENDOR = 1;
   buildInputs = [ curl zlib openssl ];
 
   cargoBuildFlags = [ "--features no-self-update" ];
+
+  patches = lib.optionals stdenv.isLinux [
+    # Run patchelf on the downloaded binaries.
+    # This necessary because Lean 4 now dynamically links to GMP.
+    (runCommand "0001-dynamically-patchelf-binaries.patch" {
+        CC = stdenv.cc;
+        patchelf = patchelf;
+        libPath = "$ORIGIN/../lib:${libPath}";
+      } ''
+     export dynamicLinker=$(cat $CC/nix-support/dynamic-linker)
+     substitute ${./0001-dynamically-patchelf-binaries.patch} $out \
+       --subst-var patchelf \
+       --subst-var dynamicLinker \
+       --subst-var libPath
+    '')
+  ];
 
   postInstall = ''
     pushd $out/bin
@@ -26,6 +48,8 @@ rustPlatform.buildRustPackage rec {
       ln -s elan $link
     done
     popd
+
+    wrapProgram $out/bin/elan --prefix "LD_LIBRARY_PATH" : "${libPath}"
 
     # tries to create .elan
     export HOME=$(mktemp -d)


### PR DESCRIPTION
Also adapt the patchelf patch from rustup, since Lean 4 now dynamically links to gmp.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
