### PR TITLE
nixos/buildkite-agents: Allow agent concurrency

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agents.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agents.nix
@@ -37,6 +37,23 @@ let
         description = "Whether to enable this buildkite agent";
       };
 
+      count = mkOption {
+        default = 1;
+        type = types.int;
+        description = "How many instances of this agent to start";
+      };
+
+      extraServiceConfig = mkOption {
+        default = {};
+        type = types.attrs;
+        description = "Attributes recursively merged into each unit's serviceConfig";
+        example = literalExample ''
+          {
+            EnvironmentFile = "/run/secrets/buildkite/environment";
+          }
+        '';
+      };
+
       package = mkOption {
         default = pkgs.buildkite-agent;
         defaultText = "pkgs.buildkite-agent";
@@ -215,51 +232,53 @@ in
     "buildkite-agent-${name}" = {};
   });
 
-  config.systemd.services = mapAgents (name: cfg: {
-    "buildkite-agent-${name}" =
-      { description = "Buildkite Agent";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "network.target" ];
-        path = cfg.runtimePackages ++ [ cfg.package pkgs.coreutils ];
-        environment = config.networking.proxy.envVars // {
-          HOME = cfg.dataDir;
-          NIX_REMOTE = "daemon";
-        };
-
-        ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
-        ##     don't end up in the Nix store.
-        preStart = let
-          sshDir = "${cfg.dataDir}/.ssh";
-          tagStr = lib.concatStringsSep "," (lib.mapAttrsToList (name: value: "${name}=${value}") cfg.tags);
-        in
-          optionalString (cfg.privateSshKeyPath != null) ''
-            mkdir -m 0700 -p "${sshDir}"
-            cp -f "${toString cfg.privateSshKeyPath}" "${sshDir}/id_rsa"
-            chmod 600 "${sshDir}"/id_rsa
-          '' + ''
-            cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF
-            token="$(cat ${toString cfg.tokenPath})"
-            name="${cfg.name}"
-            shell="${cfg.shell}"
-            tags="${tagStr}"
-            build-path="${cfg.dataDir}/builds"
-            hooks-path="${cfg.hooksPath}"
-            ${cfg.extraConfig}
-            EOF
-          '';
-
-        serviceConfig =
-          { ExecStart = "${cfg.package}/bin/buildkite-agent start --config ${cfg.dataDir}/buildkite-agent.cfg";
-            User = "buildkite-agent-${name}";
-            RestartSec = 5;
-            Restart = "on-failure";
-            TimeoutSec = 10;
-            # set a long timeout to give buildkite-agent a chance to finish current builds
-            TimeoutStopSec = "2 min";
-            KillMode = "mixed";
+  config.systemd.services = mapAgents (name: cfg:
+    mkMerge ((flip map) (range 1 cfg.count) (n: {
+      "buildkite-agent-${name}-${toString n}" =
+        { description = "Buildkite Agent";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network.target" ];
+          path = cfg.runtimePackages ++ [ cfg.package pkgs.coreutils ];
+          environment = config.networking.proxy.envVars // {
+            HOME = cfg.dataDir;
+            NIX_REMOTE = "daemon";
           };
-      };
-  });
+
+          ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
+          ##     don't end up in the Nix store.
+          preStart = let
+            sshDir = "${cfg.dataDir}/.ssh";
+            tagStr = lib.concatStringsSep "," (lib.mapAttrsToList (name: value: "${name}=${value}") cfg.tags);
+          in
+            optionalString (cfg.privateSshKeyPath != null) ''
+              mkdir -m 0700 -p "${sshDir}"
+              cp -f "${toString cfg.privateSshKeyPath}" "${sshDir}/id_rsa"
+              chmod 600 "${sshDir}"/id_rsa
+            '' + ''
+              cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF
+              token="$(cat ${toString cfg.tokenPath})"
+              name="${cfg.name}"
+              shell="${cfg.shell}"
+              tags="${tagStr}"
+              build-path="${cfg.dataDir}/builds"
+              plugins-path="${cfg.dataDir}/plugins"
+              hooks-path="${cfg.hooksPath}"
+              ${cfg.extraConfig}
+              EOF
+            '';
+
+          serviceConfig =
+            { ExecStart = "${cfg.package}/bin/buildkite-agent start --config ${cfg.dataDir}/buildkite-agent.cfg";
+              User = "buildkite-agent-${name}";
+              RestartSec = 5;
+              Restart = "on-failure";
+              TimeoutSec = 10;
+              # set a long timeout to give buildkite-agent a chance to finish current builds
+              TimeoutStopSec = "2 min";
+              KillMode = "mixed";
+            } // cfg.extraServiceConfig;
+        };
+    })));
 
   config.assertions = mapAgents (name: cfg: [
       { assertion = cfg.hooksPath == (hooksDir cfg) || all (v: v == null) (attrValues cfg.hooks);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is a fairly naive implementation of what upstream recommends: https://buildkite.com/docs/tutorials/parallel-builds#running-multiple-agents

The basic idea is that you can set `count` to a number for any agent configuration, and you get multiple units with the same config.

Also added `extraServiceConfig` to get merged into each unit, so make it easier to set things like EnvironmentFile, which we use for things like tokens.

###### Things done

* Added option `services.buildkite-agents.<name>.count`
* Added option `services.buildkite-agents.<name>.extraServiceConfig`
* Added tests for new options

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
