### PR TITLE
qemu: set localstatedir

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./fix-qemu-ga.patch
     ./9p-ignore-noatime.patch
+    ./do-not-create-local-statedir.patch
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {
@@ -119,6 +120,7 @@ stdenv.mkDerivation rec {
       "--enable-docs"
       "--enable-tools"
       "--enable-guest-agent"
+      "--localstatedir=/var"
       "--sysconfdir=/etc"
     ]
     ++ optional numaSupport "--enable-numa"

--- a/pkgs/applications/virtualization/qemu/do-not-create-local-statedir.patch
+++ b/pkgs/applications/virtualization/qemu/do-not-create-local-statedir.patch
@@ -1,0 +1,11 @@
+diff -Naur a/qga/meson.build b/qga/meson.build
+--- a/qga/meson.build
++++ b/qga/meson.build
+@@ -82,7 +82,6 @@
+     endif
+   endif
+ else
+-   install_subdir('run', install_dir: get_option('localstatedir'))
+ endif
+ 
+ alias_target('qemu-ga', all_qga)


### PR DESCRIPTION
###### Motivation for this change

Inspired by https://github.com/NixOS/nixpkgs/pull/112886 ; here's a version with a patch.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
