### PR TITLE
doxygen: 1.8.20 -> 1.9.1

### DIFF
--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "doxygen";
-  version = "1.8.20";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "doxygen";
     repo = "doxygen";
     rev = "Release_${lib.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "17chvi3i80rj4750smpizf562xjzd2xcv5rfyh997pyvc1zbq5rh";
+    sha256 = "0z5wj6plax78a3sshsq1rfjfn1fhq8dnnbpvdk3yv92198bg53xi";
   };
 
   nativeBuildInputs = [
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isSunOS libiconv
     ++ lib.optionals stdenv.isDarwin [ CoreServices libiconv ];
 
+
+  # Last verified as of v1.9.1 that this will race on codegen.
+  enableParallelBuild = false;
+
   cmakeFlags =
     [ "-DICONV_INCLUDE_DIR=${libiconv}/include" ] ++
     lib.optional (qt5 != null) "-Dbuild_wizard=YES";
@@ -35,6 +39,7 @@ stdenv.mkDerivation rec {
   meta = {
     license = lib.licenses.gpl2Plus;
     homepage = "http://doxygen.nl/";
+    changelog = "https://www.doxygen.nl/manual/changelog.html";
     description = "Source code documentation generator tool";
 
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

Unfortunately, the cmake files are not parallel safe (even on the current
version), so this also disables parallel building.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).