### PR TITLE
python3Packages.zeroconf: 0.28.8 -> 0.29.0

### DIFF
--- a/pkgs/development/python-modules/httpsig/default.nix
+++ b/pkgs/development/python-modules/httpsig/default.nix
@@ -1,9 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, setuptools_scm
+, setuptools-scm
 , pycryptodome
 , requests
+, six
 }:
 
 buildPythonPackage rec {
@@ -15,13 +16,17 @@ buildPythonPackage rec {
     sha256 = "1rkc3zwsq53rjsmc47335m4viljiwdbmw3y2zry4z70j8q1dbmki";
   };
 
-  buildInputs = [ setuptools_scm ];
-  propagatedBuildInputs = [ pycryptodome requests ];
+  buildInputs = [
+    setuptools-scm
+  ];
 
-  # Jailbreak pycryptodome
-  preBuild = ''
-    substituteInPlace setup.py --replace "==3.4.7" ""
-  '';
+  propagatedBuildInputs = [
+    pycryptodome
+    requests
+    six
+  ];
+
+  pythonImportsCheck = [ "httpsig" ];
 
   meta = with lib; {
     description = "Sign HTTP requests with secure signatures";

--- a/pkgs/development/python-modules/pynetdicom/default.nix
+++ b/pkgs/development/python-modules/pynetdicom/default.nix
@@ -35,12 +35,19 @@ buildPythonPackage rec {
     "test_associate_reject"
     "TestEchoSCP"
     "TestEchoSCPCLI"
+    "TestFindSCP"
+    "TestFindSCPCLI"
+    "TestGetSCP"
+    "TestGetSCPCLI"
+    "TestMoveSCP"
+    "TestMoveSCPCLI"
+    "TestQRGetServiceClass"
+    "TestQRMoveServiceClass"
     "TestStoreSCP"
     "TestStoreSCPCLI"
     "TestStoreSCU"
     "TestStoreSCUCLI"
-    "TestQRGetServiceClass"
-    "TestQRMoveServiceClass"
+    "TestState"
   ];
 
   pythonImportsCheck = [ "pynetdicom" ];

--- a/pkgs/development/python-modules/pynetdicom/default.nix
+++ b/pkgs/development/python-modules/pynetdicom/default.nix
@@ -10,13 +10,13 @@
 
 buildPythonPackage rec {
   pname = "pynetdicom";
-  version = "1.5.5";
+  version = "1.5.6";
 
   src = fetchFromGitHub {
     owner = "pydicom";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0zjpscxdhlcv99py7jx5r6dw32nzbcr49isrzkdr6g3zwyxwzbfm";
+    sha256 = "sha256-xYwnv30I0+CAx4QODSeMNhdlM2NuM8v4J3rx99NdYCc=";
   };
 
   propagatedBuildInputs = [
@@ -32,6 +32,7 @@ buildPythonPackage rec {
   disabledTests = [
     # Some tests needs network capabilities
     "test_str_types_empty"
+    "test_associate_reject"
     "TestEchoSCP"
     "TestEchoSCPCLI"
     "TestStoreSCP"
@@ -49,7 +50,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/pydicom/pynetdicom";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
-    # Tests are not passing on Darwin, thus it's assumed that it doesn't work
-    broken = stdenv.isDarwin;
+    # Tests are not passing on Darwin/Aarch64, thus it's assumed that it doesn't work
+    broken = stdenv.isDarwin || stdenv.isAarch64;
   };
 }

--- a/pkgs/development/python-modules/python-miio/default.nix
+++ b/pkgs/development/python-modules/python-miio/default.nix
@@ -36,7 +36,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace 'croniter = "^0"' 'croniter = "*"' \
-      --replace 'defusedxml = "^0.6"' 'defusedxml = "*"'
+      --replace 'defusedxml = "^0.6"' 'defusedxml = "*"' \
+      --replace 'zeroconf = "^0.28"' 'zeroconf = "*"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/zeroconf/default.nix
+++ b/pkgs/development/python-modules/zeroconf/default.nix
@@ -3,27 +3,26 @@
 , buildPythonPackage
 , fetchPypi
 , ifaddr
-, typing
-, isPy27
 , pythonOlder
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "zeroconf";
-  version = "0.28.8";
-  disabled = isPy27;
+  version = "0.29.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0narq8haa3b375vfblbyil77n8bw0wxqnanl91pl0wwwm884mqjb";
+    sha256 = "sha256-eu+7ZYtFKx/X5REkNk+TjG9eQtbqiT+iVXvqjAbFQK8=";
   };
 
-  propagatedBuildInputs = [ ifaddr ]
-    ++ lib.optionals (pythonOlder "3.5") [ typing ];
+  propagatedBuildInputs = [ ifaddr ];
 
   checkInputs = [ pytestCheckHook ];
+
   pytestFlagsArray = [ "zeroconf/test.py" ];
+
   disabledTests = [
     # disable tests that expect some sort of networking in the build container
     "test_launch_and_close"
@@ -33,6 +32,7 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     "test_lots_of_names"
   ];
+
   __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "zeroconf" ];
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python implementation of multicast DNS service discovery";
     homepage = "https://github.com/jstasiak/python-zeroconf";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Only;
     maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/tools/security/expliot/default.nix
+++ b/pkgs/tools/security/expliot/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonApplication rec {
   pname = "expliot";
-  version = "0.9.6";
+  version = "0.9.7";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitLab {
     owner = "expliot_framework";
     repo = pname;
     rev = version;
-    sha256 = "1wn8fyrvis0gw80zzmpivinw6mz5n33inhv39iallsl3is8xpgpa";
+    sha256 = "sha256-k43PvH9BXcvxe7O5iCGzLuxv/WkB9YelH/d/1S7BpU0=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.29.0

 Change log: https://github.com/jstasiak/python-zeroconf#0290

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
