### PR TITLE
python3Packages.certbot: 1.12.0 -> 1.13.0

### DIFF
--- a/pkgs/development/python-modules/acme/default.nix
+++ b/pkgs/development/python-modules/acme/default.nix
@@ -10,7 +10,6 @@
 , requests-toolbelt
 , six
 , werkzeug
-, mock
 , ndg-httpsclient
 }:
 
@@ -21,7 +20,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     cryptography pyasn1 pyopenssl pyRFC3339 pytz requests requests-toolbelt six
-    werkzeug mock ndg-httpsclient josepy
+    werkzeug ndg-httpsclient josepy
   ];
 
   # does not contain any tests

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -3,19 +3,19 @@
 , python, runCommand
 , fetchFromGitHub
 , ConfigArgParse, acme, configobj, cryptography, distro, josepy, parsedatetime, pyRFC3339, pyopenssl, pytz, requests, six, zope_component, zope_interface
-, dialog, mock, gnureadline
-, pytest_xdist, pytest, pytestCheckHook, dateutil
+, dialog, gnureadline
+, pytest_xdist, pytestCheckHook, dateutil
 }:
 
 buildPythonPackage rec {
   pname = "certbot";
-  version = "1.12.0";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-lMQkVc2UzC5GqEy88rcaJ74CaT3+YWveNDCXql/McRM=";
+    sha256 = "1cwhhybj2fjalhhyd184ndn3bid3qib1yy5a93m146cqqgwpw4j6";
   };
 
   sourceRoot = "source/${pname}";
@@ -37,16 +37,19 @@ buildPythonPackage rec {
     zope_interface
   ];
 
-  buildInputs = [ dialog mock gnureadline ];
+  buildInputs = [ dialog gnureadline ];
 
   checkInputs = [
     dateutil
-    pytest
     pytestCheckHook
     pytest_xdist
   ];
 
-  pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
+  pytestFlagsArray = [
+    "-o cache_dir=$(mktemp -d)"
+    # See https://github.com/certbot/certbot/issues/8746
+    "-W ignore::ResourceWarning"
+  ];
 
   doCheck = true;
 

--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -22,6 +22,8 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [ acme setuptools_scm josepy idna ];
 
+  checkInputs = with python3Packages; [ mock ];
+
   meta = with lib; {
     homepage = "https://github.com/zenhack/simp_le";
     description = "Simple Let's Encrypt client";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
unbreak on hydra: https://hydra.nixos.org/job/nixpkgs/trunk/python38Packages.certbot.x86_64-linux
issue filed upstream: https://github.com/certbot/certbot/issues/8746

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
