### PR TITLE
rpm: 4.16.1.2 -> 4.16.1.3

### DIFF
--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "rpm";
-  version = "4.16.1.2";
+  version = "4.16.1.3";
 
   src = fetchurl {
     url = "http://ftp.rpm.org/releases/rpm-${lib.versions.majorMinor version}.x/rpm-${version}.tar.bz2";
-    sha256 = "1k6ank2aad7r503w12m6m494mxr6iccj52wqhwbc94pwxsf34mw3";
+    sha256 = "07g2g0adgjm29wqy94iqhpp5dk0hacfw1yf7kzycrrxnfbwwfgai";
   };
 
   outputs = [ "out" "dev" "man" ];
@@ -73,8 +73,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://www.rpm.org/";
-    license = licenses.gpl2;
+    homepage = "https://www.rpm.org/";
+    license = with licenses; [ gpl2Plus lgpl21Plus ];
     description = "The RPM Package Manager";
     maintainers = with maintainers; [ copumpkin ];
     platforms = platforms.linux ++ platforms.darwin;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-3421, CVE-2021-20271 and CVE-2021-20266.
Release notes: https://rpm.org/wiki/Releases/4.16.1.3.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I got two failures while attempting to build all the dependents but none of them are related to this change.
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>gnunet-gtk</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>aliza</li>
    <li>lattice-diamond</li>
  </ul>
</details>
<details>
  <summary>48 packages built:</summary>
  <ul>
    <li>bluejeans-gui</li>
    <li>clair</li>
    <li>clmagma</li>
    <li>createrepo_c</li>
    <li>dell-530cdn</li>
    <li>diffoscope</li>
    <li>doodle</li>
    <li>drawio</li>
    <li>dsseries</li>
    <li>dtrx</li>
    <li>ec2-utils</li>
    <li>epkowa</li>
    <li>epm</li>
    <li>epson-201106w</li>
    <li>epson-workforce-635-nx625-series</li>
    <li>epson_201207w</li>
    <li>flatpak-builder</li>
    <li>gnunet</li>
    <li>gutenprintBin</li>
    <li>hpmyroom</li>
    <li>hydra-unstable</li>
    <li>intel-ocl</li>
    <li>libdnf</li>
    <li>libextractor</li>
    <li>libmodulemd</li>
    <li>libsolv</li>
    <li>megacli</li>
    <li>microdnf</li>
    <li>mkl</li>
    <li>nice-dcv-client</li>
    <li>nix-template-rpm</li>
    <li>perl530Packages.RPM2</li>
    <li>perl532Packages.RPM2</li>
    <li>postscript-lexmark</li>
    <li>python38Packages.libmodulemd</li>
    <li>python38Packages.mkl-service</li>
    <li>python38Packages.osc</li>
    <li>rpm (python38Packages.rpm)</li>
    <li>python39Packages.libmodulemd</li>
    <li>python39Packages.mkl-service</li>
    <li>python39Packages.osc</li>
    <li>python39Packages.rpm</li>
    <li>rpm-ostree</li>
    <li>rpmextract</li>
    <li>scaleft</li>
    <li>snowsql</li>
    <li>vk-messenger</li>
    <li>yandex-disk</li>
  </ul>
</details>