### PR TITLE
vscode-extensions.hashicorp.terraform: 2.8.3 -> 2.9.1

### DIFF
--- a/pkgs/misc/vscode-extensions/terraform/default.nix
+++ b/pkgs/misc/vscode-extensions/terraform/default.nix
@@ -3,13 +3,13 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "terraform";
     publisher = "hashicorp";
-    version = "2.8.3";
+    version = "2.9.1";
   };
 
   vsix = fetchurl {
     name = "${mktplcRef.publisher}-${mktplcRef.name}.zip";
     url = "https://github.com/hashicorp/vscode-terraform/releases/download/v${mktplcRef.version}/terraform-${mktplcRef.version}.vsix";
-    sha256 = "1cng82q9079qmn5q71h9knh9qzhqrl3phaamkqfjy1jallgi43b1";
+    sha256 = "1i4pzxw57hf2g7x62hfsb588b1lz3zjjh8ny96qqrif2bj2h887z";
   };
 
   patches = [ ./fix-terraform-ls.patch ];

--- a/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
+++ b/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
@@ -1,25 +1,38 @@
 diff --git a/out/extension.js b/out/extension.js
-index 4a2c6a9..158fe28 100644
+index e44cef2..fba0899 100644
 --- a/out/extension.js
 +++ b/out/extension.js
-@@ -215,19 +215,7 @@ function pathToBinary() {
-         if (!_pathToBinaryPromise) {
-             let command = vscodeUtils_1.config('terraform').get('languageServer.pathToBinary');
-             if (!command) { // Skip install/upgrade if user has set custom binary path
--                const installDir = `${extensionPath}/lsp`;
--                const installer = new languageServerInstaller_1.LanguageServerInstaller(reporter);
+@@ -141,24 +141,6 @@ function updateLanguageServer() {
+     return __awaiter(this, void 0, void 0, function* () {
+         const delay = 1000 * 60 * 24;
+         setTimeout(updateLanguageServer, delay); // check for new updates every 24hrs
+-        // skip install if a language server binary path is set
+-        if (!vscodeUtils_1.config('terraform').get('languageServer.pathToBinary')) {
+-            const installer = new languageServerInstaller_1.LanguageServerInstaller(installPath, reporter);
+-            const install = yield installer.needsInstall();
+-            if (install) {
+-                yield stopClients();
 -                try {
--                    yield installer.install(installDir);
+-                    yield installer.install();
 -                }
 -                catch (err) {
 -                    reporter.sendTelemetryException(err);
 -                    throw err;
 -                }
 -                finally {
--                    yield installer.cleanupZips(installDir);
+-                    yield installer.cleanupZips();
 -                }
--                command = `${installDir}/terraform-ls`;
-+                command = 'TERRAFORM-LS-PATH';
+-            }
+-        }
+         return startClients(); // on repeat runs with no install, this will be a no-op
+     });
+ }
+@@ -256,7 +238,7 @@ function pathToBinary() {
+                 reporter.sendTelemetryEvent('usePathToBinary');
              }
              else {
-                 reporter.sendTelemetryEvent('usePathToBinary');
+-                command = path.join(installPath, 'terraform-ls');
++                command = 'TERRAFORM-LS-PATH';
+             }
+             _pathToBinaryPromise = Promise.resolve(command);
+         }


### PR DESCRIPTION
###### Motivation for this change

Had to patch out the auto update of the language server since the nix store is read only. Tested on VS Code, generates no errors and works fine.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
