### PR TITLE
rekor-cli, rekor-server: init at 0.1.1

### DIFF
--- a/pkgs/tools/security/rekor/default.nix
+++ b/pkgs/tools/security/rekor/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "rekor-cli";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "sigstore";
+    repo = "rekor";
+    rev = "v${version}";
+    sha256 = "1hvkfvc747g5r4h8vb1d8ikqxmlyxsycnlh78agmmjpxlasspmbk";
+  };
+
+  vendorSha256 = "0vdir9ia3hv27rkm6jnvhsfc3mxw36xfvwqnfd34rgzmzcfxlrbv";
+
+  subPackages = [ "cmd/cli" ];
+
+  # Will not be needed with the next version as the package as been renamed upstream
+  postInstall = ''
+    if [ -f "$out/bin/cli" ]; then
+      mv "$out/bin/cli" "$out/bin/rekor-client"
+    fi
+  '';
+
+  meta = with lib; {
+    description = "CLI client for Sigstore, the Signature Transparency Log";
+    homepage = "https://github.com/sigstore/rekor";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lesuisse ];
+  };
+}

--- a/pkgs/tools/security/rekor/default.nix
+++ b/pkgs/tools/security/rekor/default.nix
@@ -1,31 +1,51 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
-buildGoModule rec {
-  pname = "rekor-cli";
-  version = "0.1.1";
+let
+  generic = { pname, subPackages, description, postInstall }:
+    buildGoModule rec {
+      inherit pname;
+      version = "0.1.1";
 
-  src = fetchFromGitHub {
-    owner = "sigstore";
-    repo = "rekor";
-    rev = "v${version}";
-    sha256 = "1hvkfvc747g5r4h8vb1d8ikqxmlyxsycnlh78agmmjpxlasspmbk";
-  };
+      src = fetchFromGitHub {
+        owner = "sigstore";
+        repo = "rekor";
+        rev = "v${version}";
+        sha256 = "1hvkfvc747g5r4h8vb1d8ikqxmlyxsycnlh78agmmjpxlasspmbk";
+      };
 
-  vendorSha256 = "0vdir9ia3hv27rkm6jnvhsfc3mxw36xfvwqnfd34rgzmzcfxlrbv";
+      vendorSha256 = "0vdir9ia3hv27rkm6jnvhsfc3mxw36xfvwqnfd34rgzmzcfxlrbv";
 
-  subPackages = [ "cmd/cli" ];
+      inherit subPackages postInstall;
 
-  # Will not be needed with the next version as the package as been renamed upstream
-  postInstall = ''
-    if [ -f "$out/bin/cli" ]; then
-      mv "$out/bin/cli" "$out/bin/rekor-client"
-    fi
-  '';
-
-  meta = with lib; {
+      meta = with lib; {
+        inherit description;
+        homepage = "https://github.com/sigstore/rekor";
+        changelog = "https://github.com/sigstore/rekor/releases/tag/v${version}";
+        license = licenses.asl20;
+        maintainers = with maintainers; [ lesuisse ];
+      };
+    };
+in {
+  rekor-cli = generic {
+    pname = "rekor-cli";
+    subPackages = [ "cmd/cli" ];
+    # Will not be needed with the next version, the package as been renamed upstream
+    postInstall = ''
+      if [ -f "$out/bin/cli" ]; then
+        mv "$out/bin/cli" "$out/bin/rekor-client"
+      fi
+    '';
     description = "CLI client for Sigstore, the Signature Transparency Log";
-    homepage = "https://github.com/sigstore/rekor";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ lesuisse ];
+  };
+  rekor-server = generic {
+    pname = "rekor-server";
+    subPackages = [ "cmd/server" ];
+    # Will not be needed with the next version, the package as been renamed upstream
+    postInstall = ''
+      if [ -f "$out/bin/server" ]; then
+        mv "$out/bin/server" "$out/bin/rekor-server"
+      fi
+    '';
+    description = "Sigstore server, the Signature Transparency Log";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7679,6 +7679,8 @@ in
 
   retext = libsForQt5.callPackage ../applications/editors/retext { };
 
+  rekor-cli = callPackage ../tools/security/rekor { };
+
   richgo = callPackage ../development/tools/richgo {  };
 
   rs = callPackage ../tools/text/rs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7679,7 +7679,9 @@ in
 
   retext = libsForQt5.callPackage ../applications/editors/retext { };
 
-  rekor-cli = callPackage ../tools/security/rekor { };
+  inherit (callPackage ../tools/security/rekor { })
+    rekor-cli
+    rekor-server;
 
   richgo = callPackage ../development/tools/richgo {  };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Introduce [Rekor CLI and server](https://github.com/sigstore/rekor) at their latest version. Rekor is part of the [sigstore project](https://sigstore.dev/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
