### PR TITLE
[20.09] python3Packages.pygments: add patch for CVE-2021-27291

### DIFF
--- a/pkgs/development/python-modules/Pygments/default.nix
+++ b/pkgs/development/python-modules/Pygments/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , docutils
 }:
 
@@ -12,6 +13,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-27291.patch";
+      url = "https://github.com/pygments/pygments/commit/2e7e8c4a7b318f4032493773732754e418279a14.patch";
+      sha256 = "0ap7jgkmvkkzijabsgnfrwl376cjsxa4jmzvqysrkwpjq3q4rxpa";
+      excludes = ["CHANGES"];
+    })
+  ];
 
   propagatedBuildInputs = [ docutils ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-27291

I'm quite confident in patching this:

 - the changes are entirely changes to regexes, in files which have largely been untouched in 4 years and likely have a fairly stable internal interface.
 - I've built it successfully with the tests enabled on linux x86_64 and macos 10.14 (I'll do another PR with some hackery to allow us to enable the pygments tests permanently)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
