### PR TITLE
cosign: init at 0.1.0

### DIFF
--- a/pkgs/tools/security/cosign/default.nix
+++ b/pkgs/tools/security/cosign/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "cosign";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "sigstore";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0rgq29vi0h378j0bqs53gjgp246rqxfpk6rwskzrmawgry0zr8pk";
+  };
+
+  vendorSha256 = "0pcp3wdvwq06ajdfbgadyq0ipfj65n276hj88p5v6wqfn821ahd6";
+
+  subPackages = [ "cmd/cosign" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/sigstore/cosign";
+    changelog = "https://github.com/sigstore/cosign/releases/tag/v${version}";
+    description = "Container Signing CLI with support for ephemeral keys and Sigstore signing";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lesuisse ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1237,6 +1237,8 @@ in
 
   corsmisc = callPackage ../tools/security/corsmisc { };
 
+  cosign = callPackage ../tools/security/cosign { };
+
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
   cpuid = callPackage ../os-specific/linux/cpuid { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Introduce [cosign](https://github.com/sigstore/cosign) at the latest version. cosign is part of the [sigstore project](https://sigstore.dev/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
