### PR TITLE
[20.09] libmspack: 0.7.1alpha -> 0.10.1alpha

### DIFF
--- a/pkgs/development/libraries/libmspack/default.nix
+++ b/pkgs/development/libraries/libmspack/default.nix
@@ -1,17 +1,18 @@
-{stdenv, fetchurl}:
+{ stdenv, lib, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libmspack-0.7.1alpha";
+  pname = "libmspack";
+  version = "0.10.1alpha";
 
   src = fetchurl {
-    url = "https://www.cabextract.org.uk/libmspack/${name}.tar.gz";
-    sha256 = "0zn4vwzk5ankgd0l88cipan19pzbzv0sm3fba17lvqwka3dp1acp";
+    url = "https://www.cabextract.org.uk/libmspack/${pname}-${version}.tar.gz";
+    sha256 = "13janaqsvm7aqc4agjgd4819pbgqv50j88bh5kci1z70wvg65j5s";
   };
 
   meta = {
     description = "A de/compression library for various Microsoft formats";
     homepage = "https://www.cabextract.org.uk/libmspack";
-    license = stdenv.lib.licenses.lgpl2;
-    platforms = stdenv.lib.platforms.unix;
+    license = lib.licenses.lgpl2Only;
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2019-1010305, CVE-2018-18586, CVE-2018-18585 and CVE-2018-18584.

(cherry picked from commit d945ac0367b517e0dc0d7976bba3a4b239c6aa2b)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
