### PR TITLE
vistafonts-chs: fix build

### DIFF
--- a/pkgs/data/fonts/vista-fonts-chs/default.nix
+++ b/pkgs/data/fonts/vista-fonts-chs/default.nix
@@ -1,15 +1,23 @@
-{ lib, fetchzip, buildPackages }:
+{ lib, stdenvNoCC, fetchurl, cabextract }:
 
-# Modified from vista-fonts
+stdenvNoCC.mkDerivation {
+  pname = "vista-fonts-chs";
+  version = "1";
 
-fetchzip {
-  name = "vista-fonts-chs-1";
+  src = fetchurl {
+    url = "http://web.archive.org/web/20161221192937if_/http://download.microsoft.com/download/d/6/e/d6e2ff26-5821-4f35-a18b-78c963b1535d/VistaFont_CHS.EXE";
+    # Alternative mirror:
+    # http://www.eeo.cn/download/font/VistaFont_CHS.EXE
+    sha256 = "1qwm30b8aq9piyqv07hv8b5bac9ms40rsdf8pwix5dyk8020i8xi";
+  };
 
-  url = "http://download.microsoft.com/download/d/6/e/d6e2ff26-5821-4f35-a18b-78c963b1535d/VistaFont_CHS.EXE";
+  nativeBuildInputs = [ cabextract ];
 
-  postFetch = ''
-    ${buildPackages.cabextract}/bin/cabextract --lowercase --filter '*.TTF' $downloadedFile
+  unpackPhase = ''
+    cabextract --lowercase --filter '*.TTF' $src
+  '';
 
+  installPhase = ''
     mkdir -p $out/share/fonts/truetype
     cp *.ttf $out/share/fonts/truetype
 
@@ -19,8 +27,6 @@ fetchzip {
     substitute ${./no-op.conf} $out/etc/fonts/conf.d/30-msyahei.conf \
       --subst-var-by fontname "Microsoft YaHei"
   '';
-
-  sha256 = "1zwrgck84k80gpg7493jdnxnv9ajxk5c7qndinnmqydnrw239zbw";
 
   meta = {
     description = "TrueType fonts from Microsoft Windows Vista For Simplified Chinese (Microsoft YaHei)";


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix the broken download link and the install script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
