### PR TITLE
vendir: init at 0.17.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8327,6 +8327,12 @@
     githubId = 4958190;
     name = "Rushmore Mushambi";
   };
+  russell = {
+    email = "russell.sim@gmail.com";
+    github = "russell";
+    githubId = 2660;
+    name = "Russell Sim";
+  };
   ruuda = {
     email = "dev+nix@veniogames.com";
     github = "ruuda";

--- a/pkgs/development/tools/vendir/default.nix
+++ b/pkgs/development/tools/vendir/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "vendir";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "vmware-tanzu";
+    repo = "carvel-vendir";
+    rev = "v${version}";
+    sha256 = "14yd14z4666alwsn2jhcvg2kijvw4qjr4h3gikchiir38w520fs9";
+  };
+
+  vendorSha256 = null;
+
+  subPackages = [ "cmd/vendir" ];
+
+  meta = with lib; {
+    description = "CLI tool to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively";
+    homepage = "https://carvel.dev/vendir/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ russell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20578,6 +20578,8 @@ in
 
   v4l-utils = qt5.callPackage ../os-specific/linux/v4l-utils { };
 
+  vendir = callPackage ../development/tools/vendir { };
+
   vndr = callPackage ../development/tools/vndr { };
 
   windows = callPackages ../os-specific/windows {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Vendir is a tool for vendoring files into a git repository, it works well with tooling that otherwise doesn't provide mechanisms to import files from other repositories like Jsonnet.

Vendir is part of the carvel collection of kubernetes tooling with ytt and kapp which are already in nixpkgs 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
