### PR TITLE
gnomeExtensions.appindicator: 35 -> 36

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/appindicator/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/appindicator/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-appindicator";
-  version = "35";
+  version = "36";
 
   src = fetchFromGitHub {
     owner = "Ubuntu";
     repo = "gnome-shell-extension-appindicator";
     rev = "v${version}";
-    sha256 = "sha256-xVoXVVEULZZnoYEXl1x96Tjs8hOvs9/sOAUVMj9kKCo=";
+    sha256 = "1nx1lgrrp3w5z5hymb91frjdvdkk7x677my5v4jjd330ihqa02dq";
   };
 
   # This package has a Makefile, but it's used for building a zip for


### PR DESCRIPTION
###### Motivation for this change

Add support for GOME version 40. #117081

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
