### PR TITLE
tabnine: 3.2.64 -> 3.3.101

### DIFF
--- a/pkgs/development/tools/tabnine/default.nix
+++ b/pkgs/development/tools/tabnine/default.nix
@@ -1,20 +1,23 @@
 { stdenv, lib, fetchurl, unzip }:
 
 let
-  version = "3.2.63";
+  version = "3.3.101";
   src =
     if stdenv.hostPlatform.system == "x86_64-darwin" then
-      fetchurl {
-        url = "https://update.tabnine.com/bundles/${version}/x86_64-apple-darwin/TabNine.zip";
-        sha256 = "0y0wb3jdr2qk4k21c11w8c9a5fl0h2rm1wm7m8hqdywy4lz9ppgy";
-      }
+      fetchurl
+        {
+          url = "https://update.tabnine.com/bundles/${version}/x86_64-apple-darwin/TabNine.zip";
+          sha256 = "KrFDQSs7hMCioeqPKTNODe3RKnwNV8XafdYDUaxou/Y=";
+        }
     else if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        url = "https://update.tabnine.com/bundles/${version}/x86_64-unknown-linux-musl/TabNine.zip";
-        sha256 = "0zzk2w5azk5f0svjxlj2774x01xdflb767xxvbglj4223dgyx2x5";
-      }
+      fetchurl
+        {
+          url = "https://update.tabnine.com/bundles/${version}/x86_64-unknown-linux-musl/TabNine.zip";
+          sha256 = "vbeuZf/phOj83xTha+AzpKIvvrjwMar7q2teAmr5ESQ=";
+        }
     else throw "Not supported on ${stdenv.hostPlatform.system}";
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "tabnine";
 
   inherit version src;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
