### PR TITLE
Add a fourth hint for `nix run`

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -133,6 +133,9 @@ let
       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allow${allow_attr} = true; }
       to ~/.config/nixpkgs/config.nix.
+
+      d) If you are using `nix run`, in addition to one of the fixes above, you
+      may need to use the `--impure` flag as well.
     '';
 
   remediate_insecure = attrs:

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -135,8 +135,9 @@ let
       to ~/.config/nixpkgs/config.nix.
 
       d) If you are using the unstable `nix` commands (e.g., `nix run`, `nix
-      build`, `nix shell`, etc.), in addition to one of the fixes above, you
-      may need to use the `--impure` flag as well.
+      build`, `nix shell`, etc.), then nix will evaluate in "restrict-eval" mode which
+      denies it the ability to read a user's local configuration. Add `--impure`
+      to enable reading from the user's nix config directory.
     '';
 
   remediate_insecure = attrs:

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -134,7 +134,8 @@ let
         { allow${allow_attr} = true; }
       to ~/.config/nixpkgs/config.nix.
 
-      d) If you are using `nix run`, in addition to one of the fixes above, you
+      d) If you are using the unstable `nix` commands (e.g., `nix run`, `nix
+      build`, `nix shell`, etc.), in addition to one of the fixes above, you
       may need to use the `--impure` flag as well.
     '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Attempting to run `postman` via `nix run nixpkgs#postman`, I got an [error message](https://github.com/NixOS/nixpkgs/blob/d600f006643e074c2ef1d72e462e218b647a096c/pkgs/stdenv/generic/check-meta.nix#L122-L136) about unfree packages, but the mitigations listed weren't helping. With some discussion from [this discourse topic](https://discourse.nixos.org/t/nix-run-does-not-install-unfree-packages-nixpkgs-allow-unfree-doesnt-seem-to-help/12039), I understood that I needed the `--impure flag`, but the error message does not mention that.

This PR just adds a bit of text to that error message block about instituting one of the recommended fixes, then making sure to use `--impure` with `nix run`.

I am not sure how to test this change; some help with that would be appreciated.

Closes #116340.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
