### PR TITLE
[20.09] qt5.qtwebengine: 5.15.2 -> 5.15.3-a059e740

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -16,7 +16,7 @@ top-level attribute to `top-level/all-packages.nix`.
 
 {
   newScope,
-  stdenv, fetchurl, fetchpatch, fetchFromGitHub, makeSetupHook, makeWrapper,
+  stdenv, fetchurl, fetchpatch, fetchgit, fetchFromGitHub, makeSetupHook, makeWrapper,
   bison, cups ? null, harfbuzz, libGL, perl,
   gstreamer, gst-plugins-base, gtk3, dconf,
   llvmPackages_5,
@@ -48,6 +48,27 @@ let
       };
       version = "5.212.0-alpha4";
     };
+
+    # Even if developed in the public, QtWebEngine does not have official
+    # releases or new tags since the Qt company made 5.15.3 proprietary.
+    # Apparently they care more about licensing than the security of their users.
+    # See https://lists.qt-project.org/pipermail/interest/2021-March/036387.html
+    qtwebengine =
+      let
+        branchName = "5.15.3";
+        rev = "a059e7404a6db799f4da0ad696e65ae9c854b4b0";
+      in
+      {
+        version = "${branchName}-${substring 0 8 rev}";
+
+        src = fetchgit {
+          url = "https://github.com/qt/qtwebengine.git";
+          sha256 = "19l1i4sk3pvnwbvz5s97jchqawfz8k1xmjza29bgvkp1zz96r0jx";
+          inherit rev branchName;
+          fetchSubmodules = true;
+          leaveDotGit = true;
+        };
+      };
   };
 
   patches = {
@@ -79,7 +100,15 @@ let
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
-    qtwebengine = optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;
+    qtwebengine = [
+      # Fix crashes with non en_US.UTF-8 locales
+      (fetchpatch {
+        url = "https://github.com/qt/qtwebengine/commit/199ea00a9eea13315a652c62778738629185b059.patch";
+        sha256 = "1b5k2g1v8913cvsgvp6ja4mcprjlk5vcwqzi0p1qq7b1wyi4f0g2";
+      })
+    ] ++ optionals stdenv.isDarwin [
+      ./qtwebengine-darwin-no-platform-check.patch
+    ];
     qtwebkit = [
       (fetchpatch {
         name = "qtwebkit-bison-3.7-build.patch";

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -2,6 +2,7 @@
 , qtdeclarative, qtquickcontrols, qtlocation, qtwebchannel
 
 , bison, coreutils, flex, git, gperf, ninja, pkgconfig, python2, which
+, nodejs, qtbase, perl
 
 , xorg, libXcursor, libXScrnSaver, libXrandr, libXtst
 , fontconfig, freetype, harfbuzz, icu, dbus, libdrm
@@ -24,7 +25,15 @@ qtModule {
   name = "qtwebengine";
   qtInputs = [ qtdeclarative qtquickcontrols qtlocation qtwebchannel ];
   nativeBuildInputs = [
-    bison coreutils flex git gperf ninja pkgconfig python2 which gn
+    bison coreutils flex git gperf ninja pkgconfig python2 which gn nodejs
+
+    # qmake looks for syncqt instead of syncqt.pl and fails with a cryptic
+    # error if it can't find it. syncqt.pl also has a /usr/bin/env shebang, so
+    # it can't be directly used in a sandboxed build environment.
+    (writeScriptBin "syncqt" ''
+      #!${stdenv.shell}
+      exec ${perl}/bin/perl ${qtbase.dev}/bin/syncqt.pl "$@"
+    '')
   ] ++ optional stdenv.isDarwin xcbuild;
   doCheck = true;
   outputs = [ "bin" "dev" "out" ];
@@ -39,9 +48,17 @@ qtModule {
   hardeningDisable = [ "format" ];
 
   postPatch =
-    # Patch Chromium build tools
     ''
-      ( cd src/3rdparty/chromium; patchShebangs . )
+      # Patch Chromium build tools
+      (
+        cd src/3rdparty/chromium;
+
+        # Manually fix unsupported shebangs
+        substituteInPlace third_party/harfbuzz-ng/src/src/update-unicode-tables.make \
+          --replace "/usr/bin/env -S make -f" "/usr/bin/make -f" || true
+
+        patchShebangs .
+      )
     ''
     # Prevent Chromium build script from making the path to `clang` relative to
     # the build directory.  `clang_base_path` is the value of `QMAKE_CLANG_DIR`
@@ -113,7 +130,7 @@ qtModule {
     if [ -d "$PWD/tools/qmake" ]; then
         QMAKEPATH="$PWD/tools/qmake''${QMAKEPATH:+:}$QMAKEPATH"
     fi
-   '';
+  '';
 
   qmakeFlags = if stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64
     then [ "--" "-system-ffmpeg" ] ++ optional enableProprietaryCodecs "-proprietary-codecs"

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -14,12 +14,12 @@ let
 
 in buildPythonPackage rec {
   pname = "PyQtWebEngine";
-  version = "5.15.2";
+  version = "5.15.4";
   format = "other";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "0d56ak71r14w4f9r96vaj34qcn2rbln3s6ildvvyc707fjkzwwjd";
+    sha256 = "06fc35hzg346a9c86dk7vzm1fakkgzn5l52jfq3bix3587sjip6f";
   };
 
   inherit patches;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14914,7 +14914,7 @@ in
   qt515 = recurseIntoAttrs (makeOverridable
     (import ../development/libraries/qt-5/5.15) {
       inherit newScope;
-      inherit stdenv fetchurl fetchpatch fetchFromGitHub makeSetupHook makeWrapper;
+      inherit stdenv fetchurl fetchpatch fetchgit fetchFromGitHub makeSetupHook makeWrapper;
       inherit bison;
       inherit cups;
       inherit dconf;


### PR DESCRIPTION
###### Motivation for this change

Backport of security update.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
