### PR TITLE
nodepy-runtime: init at 1.7.3; pythonPackages.localimport: init at 1.7.3

### DIFF
--- a/pkgs/development/python-modules/localimport/default.nix
+++ b/pkgs/development/python-modules/localimport/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "localimport";
+  version = "1.7.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-p7ACOzJRwH9hICMcxtVt/r+twEoFsDxPKGuarFnFIbo=";
+  };
+
+  pythonImportsCheck = [ "localimport" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/NiklasRosenstein/py-localimport";
+    description = "Isolated import of Python modules";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/development/python-modules/nodepy-runtime/default.nix
+++ b/pkgs/development/python-modules/nodepy-runtime/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, localimport
+, pathlib2
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "nodepy-runtime";
+  version = "2.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-6tSsD76EpCZxkdulv1BcUZtIXGWLG6PuII25J8STygE=";
+  };
+
+  propagatedBuildInputs = [
+    localimport
+    pathlib2
+    six
+  ];
+
+  pythonImportsCheck = [
+    "nodepy"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nodepy/nodepy";
+    description = "Runtime for Python inspired by Node.JS";
+    longDescription = ''
+      Node.py is a Python runtime and package manager compatible with CPython
+      2.7 and 3.3 – 3.6. It provides a separate import mechanism for modules
+      inspired by Node.js, bringing dependency management and ease of deployment
+      for Python applications up to par with other languages without virtual
+      environments.
+
+      Node.py comes with a built-in package manager that builds on Pip for
+      standard Python dependencies but also adds the capability to install
+      packages that are specifically developed for Node.py. To install the
+      dependencies of the package manager you must specify the [pm] install
+      extra.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2756,6 +2756,8 @@ in
 
   nix-template = callPackage ../tools/package-management/nix-template { };
 
+  nodepy-runtime = with python3.pkgs; toPythonApplication nodepy-runtime;
+
   nixpkgs-pytools = with python3.pkgs; toPythonApplication nixpkgs-pytools;
 
   noteshrink = callPackage ../tools/misc/noteshrink { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3990,6 +3990,8 @@ in {
 
   lmtpd = callPackage ../development/python-modules/lmtpd { };
 
+  localimport = callPackage ../development/python-modules/localimport { };
+
   localzone = callPackage ../development/python-modules/localzone { };
 
   locket = callPackage ../development/python-modules/locket { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4627,6 +4627,8 @@ in {
 
   nodeenv = callPackage ../development/python-modules/nodeenv { };
 
+  nodepy-runtime = callPackage ../development/python-modules/nodepy-runtime { };
+
   node-semver = callPackage ../development/python-modules/node-semver { };
 
   noise = callPackage ../development/python-modules/noise { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
