### PR TITLE
python3Packages.python-dynamodb-lock: init at 0.9.3

### DIFF
--- a/pkgs/development/python-modules/python-dynamodb-lock/default.nix
+++ b/pkgs/development/python-modules/python-dynamodb-lock/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, boto3
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "python-dynamodb-lock";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "whatnick";
+    repo = "python_dynamodb_lock";
+    rev = "v${version}";
+    sha256 = "1jpn8mpxzx00cm9gm8z40rh0j0iw5akrm02qc8cd9v8z8dj7ysjf";
+  };
+
+  patches = [
+    # Fixes compatibility of the test suite with python3.9
+    (fetchpatch {
+      url = "https://github.com/rmcgibbo/python_dynamodb_lock/commit/35a77d79b4b8afc6d3947af3110de05be83e0c19.patch";
+      sha256 = "0jfwd01vcgszqp4mml7rzsaxnns48j5n2cfphqr07f1cw0gbs41c";
+    })
+  ];
+
+  propagatedBuildInputs = [ boto3 ];
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "python_dynamodb_lock" ];
+
+  meta = with lib; {
+    description = "Python package that emulates the dynamodb-lock-client java library from awslabs";
+    homepage = "https://github.com/whatnick/python_dynamodb_lock";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ rmcgibbo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6653,6 +6653,8 @@ in {
 
   python-dotenv = callPackage ../development/python-modules/python-dotenv { };
 
+  python-dynamodb-lock = callPackage ../development/python-modules/python-dynamodb-lock { };
+
   python-editor = callPackage ../development/python-modules/python-editor { };
 
   pythonefl = callPackage ../development/python-modules/python-efl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/whatnick/python_dynamodb_lock, https://github.com/mohankishore/python_dynamodb_lock/issues/819

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
