### PR TITLE
i3wm.i3-auto-layout: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6176,6 +6176,12 @@
     github = "meutraa";
     githubId = 68550871;
   };
+  mephistophiles = {
+    email = "mussitantesmortem@gmail.com";
+    name = "Maxim Zhukov";
+    github = "Mephistophiles";
+    githubId = 4850908;
+  };
   mfossen = {
     email = "msfossen@gmail.com";
     github = "mfossen";

--- a/pkgs/applications/window-managers/i3/auto-layout.nix
+++ b/pkgs/applications/window-managers/i3/auto-layout.nix
@@ -1,0 +1,26 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "i3-auto-layout";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "chmln";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ps08lga6qkgc8cgf5cx2lgwlqcnd2yazphh9xd2fznnzrllfxxz";
+  };
+
+  cargoSha256 = "1ch5mh515rlqmr65x96xcvrx6iaigqgjxc7sbwbznzkc5kmvwhc0";
+
+  # Currently no tests are implemented, so we avoid building the package twice
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Automatic, optimal tiling for i3wm";
+    homepage = "https://github.com/chmln/i3-auto-layout";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mephistophiles ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23334,6 +23334,8 @@ in
     xcb-util-cursor = if stdenv.isDarwin then xcb-util-cursor-HEAD else xcb-util-cursor;
   };
 
+  i3-auto-layout = callPackage ../applications/window-managers/i3/auto-layout.nix { };
+
   i3-gaps = callPackage ../applications/window-managers/i3/gaps.nix { };
 
   i3altlayout = callPackage ../applications/window-managers/i3/altlayout.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding a new layout helper for i3wm. (https://github.com/chmln/i3-auto-layout)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
