### PR TITLE
apkid: init at 2.1.1, python3Packages.yara-python: init at 4.0.5

### DIFF
--- a/pkgs/development/python-modules/yara-python/default.nix
+++ b/pkgs/development/python-modules/yara-python/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, yara
+}:
+
+buildPythonPackage rec {
+  pname = "yara-python";
+  version = "4.0.5";
+
+  src = fetchFromGitHub {
+    owner = "VirusTotal";
+    repo = "yara-python";
+    rev = "v${version}";
+    sha256 = "1qd0aw5p48ay77hgj0hgzpvbmq1933mknk134aqdb32036rlc5sq";
+  };
+
+  buildInputs = [
+    yara
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  setupPyBuildFlags = [
+    "--dynamic-linking"
+  ];
+
+  pytestFlagsArray = [ "tests.py" ];
+
+  pythonImportsCheck = [ "yara" ];
+
+  meta = with lib; {
+    description = "Python interface for YARA";
+    homepage = "https://github.com/VirusTotal/yara-python";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/tools/apkid/default.nix
+++ b/pkgs/development/tools/apkid/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "apkid";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "rednaga";
+    repo = "APKiD";
+    rev = "v${version}";
+    sha256 = "1p6kdjjw2jhwr875445w43k46n6zwpz0l0phkl8d3y1v4gi5l6dx";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    yara-python
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  preBuild = ''
+    # Prepare the YARA rules
+    ${python3.interpreter} prep-release.py
+  '';
+
+  postPatch = ''
+    # The next release will have support for later yara-python releases
+    substituteInPlace setup.py \
+      --replace "yara-python==3.11.0" "yara-python"
+  '';
+
+  pythonImportsCheck = [ "apkid" ];
+
+  meta = with lib; {
+    description = "Android Application Identifier";
+    homepage = "https://github.com/rednaga/APKiD";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation rec {
     description = "The pattern matching swiss knife for malware researchers";
     homepage = "http://Virustotal.github.io/yara/";
     license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -6,8 +6,11 @@
 , pkg-config
 , protobufc
 , withCrypto ? true, openssl
-, enableMagic ? true, file
 , enableCuckoo ? true, jansson
+, enableDex ? true
+, enableDotNet ? true
+, enableMacho ? true
+, enableMagic ? true, file
 }:
 
 stdenv.mkDerivation rec {
@@ -46,8 +49,11 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     (lib.withFeature withCrypto "crypto")
-    (lib.enableFeature enableMagic "magic")
     (lib.enableFeature enableCuckoo "cuckoo")
+    (lib.enableFeature enableDex "dex")
+    (lib.enableFeature enableDotNet "dotnet")
+    (lib.enableFeature enableMacho "macho")
+    (lib.enableFeature enableMagic "magic")
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -959,6 +959,8 @@ in
     lua = lua5_3;
   };
 
+  apkid = callPackage ../development/tools/apkid { };
+
   apktool = callPackage ../development/tools/apktool {
     inherit (androidenv.androidPkgs_9_0) build-tools;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9107,6 +9107,8 @@ in {
 
   Yapsy = callPackage ../development/python-modules/yapsy { };
 
+  yara-python = callPackage ../development/python-modules/yara-python { };
+
   yarg = callPackage ../development/python-modules/yarg { };
 
   yarl = callPackage ../development/python-modules/yarl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Android Application Identifier

https://github.com/rednaga/APKiD

It requires the Python interface for YARA (https://github.com/VirusTotal/yara-python).

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
