### PR TITLE
radarr: change sed separator in update script

### DIFF
--- a/pkgs/servers/radarr/update.sh
+++ b/pkgs/servers/radarr/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl nix-prefetch jq
+#!nix-shell -i bash -p curl gnused nix-prefetch jq
 
 set -e
 
@@ -17,7 +17,7 @@ updateHash()
     hash=$(nix-prefetch-url --type sha256 $url)
     sriHash="$(nix to-sri --type sha256 $hash)"
 
-    sed -i "s/$hashKey = \"[a-zA-Z0-9\/+-=]*\";/$hashKey = \"$sriHash\";/g" "$dirname/default.nix"
+    sed -i "s|$hashKey = \"[a-zA-Z0-9\/+-=]*\";|$hashKey = \"$sriHash\";|g" "$dirname/default.nix"
 }
 
 updateVersion()


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I just realized that a base64 string can contain `/` characters and if we also use `/` as a separator for `sed` it will most certainly break at some point. So I replaced it with `|` and also added `gnused` package to the script just to be safe. 

I am sorry I missed that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
