### PR TITLE
carla: Fix NSM compatibility

### DIFF
--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -86,5 +86,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.minijackson ];
     platforms = platforms.linux;
+    badPlatforms = [ platforms.aarch64 ];
   };
 }

--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -67,6 +67,11 @@ stdenv.mkDerivation rec {
         --prefix PATH : "$program_PATH:${which}/bin" \
         --set PYTHONNOUSERSITE true
     done
+
+    # Hardcode --with-appname argument to `carla` since python wrapper is being wrapped again by QT wrapper.
+    # This resolves issues with NSM
+    # see https://github.com/jackaudio/new-session-manager/issues/73
+    sed -i 's/--with-appname="$0"/--with-appname="carla"/g' $out/bin/.carla-wrapped
   '';
 
   meta = with lib; {


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/117781


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
