### PR TITLE
python3Packages.labmath: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/labmath/default.nix
+++ b/pkgs/development/python-modules/labmath/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "labmath";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-/fZ61tJ6PVZsubr3OXlbg/VxyyKimz36uPV+r33kgD0=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "labmath/DESCRIPTION.rst" "PKG-INFO"
+  '';
+
+  pythonImportsCheck = [ "labmath" ];
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/labmath";
+    description = "Module for basic math in the general vicinity of computational number theory";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/labmath/default.nix
+++ b/pkgs/development/python-modules/labmath/default.nix
@@ -20,6 +20,5 @@ buildPythonPackage rec {
     description = "Module for basic math in the general vicinity of computational number theory";
     license = licenses.mit;
     maintainers = with maintainers; [ siraben ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3712,6 +3712,8 @@ in {
 
   labgrid = callPackage ../development/python-modules/labgrid { };
 
+  labmath = callPackage ../development/python-modules/labmath { };
+
   lammps-cython = callPackage ../development/python-modules/lammps-cython { };
 
   langcodes = callPackage ../development/python-modules/langcodes { };


### PR DESCRIPTION
###### Motivation for this change
```ShellSession
$ nix-shell -I nixpkgs=. -p "python3.withPackages (p: [ p.labmath ])" \
    --command "python3 -c 'from labmath import *; print([totient(n) for n in range(1, 24)])'"
[1, 1, 2, 2, 4, 2, 6, 4, 6, 4, 10, 4, 12, 6, 8, 8, 16, 6, 18, 8, 12, 10, 22]
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
