### PR TITLE
pycoin: expose cli via top-level entry

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26886,6 +26886,8 @@ in
 
   ethabi = callPackage ../applications/blockchains/ethabi.nix { };
 
+  pycoin = with python3Packages; toPythonApplication pycoin;
+
   stellar-core = callPackage ../applications/blockchains/stellar-core.nix { };
 
   sumokoin = callPackage ../applications/blockchains/sumokoin.nix { boost = boost165; };


### PR DESCRIPTION
###### Motivation for this change

pycoin is a python crypto currency library, which was added to nixpkgs python modules in commit 2b11dcd789f60961473830b7202f9b44810a455c .  However, it also brings some command line tools, which may be accessed by building it as python application.  This commit adds the corresponding entry to `all-packages.nix`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Besides the default version of Python 3 (currently 3.8 in nixpkgs master), I successfully built the package with Python 2.7, 3.6, 3.7 and 3.9 (3.10 fails as a dependency is broken).  I tested the following actions with each of those builds:

- Invoke each executable in `/bin/` with `--help`.
- Use `/bin/b58` to convert a base58 key to its hex representation.
- Use `/bin/ku` to generate a new Bitcoin secret/public keypair, to compute the public key from a secret key, and to show information on a public key.
- Use `/bin/tx` to list a Bitcoin public key's transactions, to download and dissect a transaction, and to show a transaction's unspent outputs.
- Use `/bin/tx` to generate and sign a new transaction for Bitcoin network.

Since pycoin's transaction signing mechanism is deterministic, the new transaction is bitwise the same for all versions of Python used.  The new Bitcoin transaction got accepted by the network.

Notifying pycoin maintainer: @nyanloutre