### PR TITLE
pythonPackages.pygments: enable tests

### DIFF
--- a/pkgs/development/python-modules/Pygments/2_5.nix
+++ b/pkgs/development/python-modules/Pygments/2_5.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , fetchpatch
 , docutils
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -25,8 +26,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ docutils ];
 
-  # Circular dependency with sphinx
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
 
   meta = {
     homepage = "https://pygments.org/";

--- a/pkgs/development/python-modules/Pygments/default.nix
+++ b/pkgs/development/python-modules/Pygments/default.nix
@@ -2,6 +2,8 @@
 , buildPythonPackage
 , fetchPypi
 , docutils
+, pytestCheckHook
+, doCheck ? true
 }:
 
 buildPythonPackage rec {
@@ -15,8 +17,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ docutils ];
 
-  # Circular dependency with sphinx
-  doCheck = false;
+  inherit doCheck;
+  checkInputs = [ pytestCheckHook ];
 
   meta = {
     homepage = "https://pygments.org/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6415,16 +6415,22 @@ in {
 
   pytest_5 = callPackage
     ../development/python-modules/pytest/5.nix {
-      # hypothesis tests require pytest that causes dependency cycle
+      # hypothesis & pygments tests require pytest that causes dependency cycle
       hypothesis = self.hypothesis.override {
+        doCheck = false;
+      };
+      pygments = self.pygments.override {
         doCheck = false;
       };
     };
 
   pytest_6 =
     callPackage ../development/python-modules/pytest {
-      # hypothesis tests require pytest that causes dependency cycle
+      # hypothesis & pygments tests require pytest that causes dependency cycle
       hypothesis = self.hypothesis.override {
+        doCheck = false;
+      };
+      pygments = self.pygments.override {
         doCheck = false;
       };
     };


### PR DESCRIPTION
###### Motivation for this change
In #117810 I was annoyed by tests being disabled for `pygments`, so I implemented the same trick as used for `hypothesis` to allow only `pytest` to be built with an untested `pygments`.

As for the 2.5.x branch, used in `python2Packages`, the advice over circular dependencies appears to be outdated - I didn't have a problem just enabling these.

I've done a full re-eval successfully (obviously not a full rebuild) and built a number of key packages.. is there anything else I've missed?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
