### PR TITLE
locate.nix: write /etc/updatedb.conf

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -43,6 +43,9 @@ in {
         The format is described in
         <citerefentry><refentrytitle>systemd.time</refentrytitle>
         <manvolnum>7</manvolnum></citerefentry>.
+
+        To disable automatic updates, set to <literal>"never"</literal>
+        and run <command>updatedb</command> manually.
       '';
     };
 
@@ -192,6 +195,18 @@ in {
       { LOCATE_PATH = cfg.output;
       };
 
+    environment.etc = {
+      # write /etc/updatedb.conf for manual calls to `updatedb`
+      "updatedb.conf" = {
+        text = ''
+          PRUNEFS="${lib.concatStringsSep " " cfg.pruneFS}"
+          PRUNENAMES="${lib.concatStringsSep " " cfg.pruneNames}"
+          PRUNEPATHS="${lib.concatStringsSep " " cfg.prunePaths}"
+          PRUNE_BIND_MOUNTSFR="${lib.boolToString cfg.pruneBindMounts}"
+        '';
+      };
+    };
+
     warnings = optional (isMLocate && cfg.localuser != null) "mlocate does not support the services.locate.localuser option; updatedb will run as root. (Silence with services.locate.localuser = null.)"
             ++ optional (isFindutils && cfg.pruneNames != []) "findutils locate does not support pruning by directory component"
             ++ optional (isFindutils && cfg.pruneBindMounts) "findutils locate does not support skipping bind mounts";
@@ -238,7 +253,7 @@ in {
         serviceConfig.ReadWritePaths = dirOf cfg.output;
       };
 
-    systemd.timers.update-locatedb =
+    systemd.timers.update-locatedb = mkIf (cfg.interval != "never")
       { description = "Update timer for locate database";
         partOf      = [ "update-locatedb.service" ];
         wantedBy    = [ "timers.target" ];


### PR DESCRIPTION
###### Motivation for this change

1\. allow to run `sudo updatedb` manually, using the config file `/etc/updatedb.conf`
the config file is only used by `pkgs.mlocate`, not by `pkgs.findutils`

2\. allow to disable automatic updates with `interval = "never"`

sample config
```nix
{
  services.locate.enable = true;
  services.locate.interval = "never";
  services.locate.pruneNames = (lib.splitString " " ".bzr .hg .git .svn .cache");
  services.locate.locate = pkgs.mlocate; # use mlocate from redhat at https://pagure.io/mlocate
  services.locate.localuser = null; # mlocate
}
```

###### problems

```
updatedb --help

The configuration defaults to values read from
`/nix/store/xxxxxxxxxxxxxxxxxxxxx-mlocate-0.26/etc/updatedb.conf'.
```

* that file does not exist
* the global config in `/etc/updatedb.conf` is ignored

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
