### PR TITLE
python3Packages.urllib3: 1.26.3 -> 1.26.4,  python2Packages.urllib3: add patch for CVE-2021-28363 

### DIFF
--- a/pkgs/development/python-modules/urllib3/2.nix
+++ b/pkgs/development/python-modules/urllib3/2.nix
@@ -4,6 +4,7 @@
 , certifi
 , cryptography
 , dateutil
+, fetchpatch
 , fetchPypi
 , idna
 , mock
@@ -25,6 +26,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-28363.patch";
+      url = "https://github.com/urllib3/urllib3/commit/8d65ea1ecf6e2cdc27d42124e587c1b83a3118b0.patch";
+      sha256 = "1lqhrd11p03iv14bp89rh67ynf000swmwsfvr3jpfdycdqr3ka9q";
+    })
+  ];
 
   propagatedBuildInputs = [
     brotli

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -19,11 +19,11 @@
 
 buildPythonPackage rec {
   pname = "urllib3";
-  version = "1.26.3";
+  version = "1.26.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73";
+    sha256 = "0dw9w9bs3hmr5dp3r3h43jyzzb1g1046ag7lj8pqf58i4kvj3c77";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-28363

We keep two `urllib3` s, one for py3, one for py2. Bumped the py3 one, applied the patch for the py2 one.

Temporarily enabling tests gets same ~4 unrelated flaky failures as my machine got before, both for the bump and the patched `urllib3`.

I'm quite confident in the patch because:

 - it's a single line code addition
 - it includes a test ~which passes when tests are temporarily enabled~ wait, no, it is skipped for py2 - I will try to think if there's anything I can do about it...

(there still exists another `urllib3` for `kodi`, not addressed here, I assume people who have boutique dependencies know what they're getting themselves in for...)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
