### PR TITLE
opensnitch: init at 1.3.6

### DIFF
--- a/pkgs/tools/networking/opensnitch/daemon.nix
+++ b/pkgs/tools/networking/opensnitch/daemon.nix
@@ -1,0 +1,50 @@
+{ buildGoModule
+, fetchFromGitHub
+, fetchpatch
+, pkg-config
+, libnetfilter_queue
+, libnfnetlink
+, lib
+}:
+
+buildGoModule rec {
+  pname = "opensnitch";
+  version = "1.3.6";
+
+  src = fetchFromGitHub {
+    owner = "evilsocket";
+    repo = "opensnitch";
+    rev = "v${version}";
+    sha256 = "sha256-Cgo+bVQQeUZuYYhA1WSqlLyQQGAeXbbNno9LS7oNvhI=";
+  };
+
+  patches = [
+    # https://github.com/evilsocket/opensnitch/pull/384 don't require
+    # a configuration file in /etc
+    (fetchpatch {
+      name = "dont-require-config-in-etc.patch";
+      url = "https://github.com/evilsocket/opensnitch/commit/8a3f63f36aa92658217bbbf46d39e6d20b2c0791.patch";
+      sha256 = "sha256-WkwjKTQZppR0nqvRO4xiQoKZ307NvuUwoRx+boIpuTg=";
+    })
+  ];
+
+  modRoot = "daemon";
+
+  postBuild = ''
+    mv $GOPATH/bin/daemon $GOPATH/bin/opensnitchd
+  '';
+
+  vendorSha256 = "sha256-LMwQBFkHg1sWIUITLOX2FZi5QUfOivvrkcl9ELO3Trk=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libnetfilter_queue libnfnetlink ];
+
+  meta = with lib; {
+    description = "An application firewall";
+    homepage = "https://github.com/evilsocket/opensnitch/wiki";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.raboof ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/opensnitch/ui.nix
+++ b/pkgs/tools/networking/opensnitch/ui.nix
@@ -1,0 +1,46 @@
+{ python3Packages
+, fetchFromGitHub
+, wrapQtAppsHook
+, lib
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "opensnitch-ui";
+  version = "1.3.6";
+
+  src = fetchFromGitHub {
+    owner = "evilsocket";
+    repo = "opensnitch";
+    rev = "v${version}";
+    sha256 = "sha256-Cgo+bVQQeUZuYYhA1WSqlLyQQGAeXbbNno9LS7oNvhI=";
+  };
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  propagatedBuildInputs = with python3Packages; [
+    grpcio-tools
+    pyqt5
+    unidecode
+    unicode-slugify
+    pyinotify
+  ];
+
+  preConfigure = ''
+    cd ui
+  '';
+
+  preCheck = ''
+    export PYTHONPATH=opensnitch:$PYTHONPATH
+  '';
+
+  dontWrapQtApps = true;
+  makeWrapperArgs = [ "\${qtWrapperArgs[@]}" ];
+
+  meta = with lib; {
+    description = "An application firewall";
+    homepage = "https://github.com/evilsocket/opensnitch/wiki";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.raboof ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6880,6 +6880,10 @@ in
 
   openfortivpn = callPackage ../tools/networking/openfortivpn { };
 
+  opensnitch = callPackage ../tools/networking/opensnitch/daemon.nix { };
+
+  opensnitch-ui = libsForQt5.callPackage ../tools/networking/opensnitch/ui.nix { };
+
   obexfs = callPackage ../tools/bluetooth/obexfs { };
 
   obexftp = callPackage ../tools/bluetooth/obexftp { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).