### PR TITLE
jq: add configuration option to disable regex support

### DIFF
--- a/pkgs/development/tools/jq/default.nix
+++ b/pkgs/development/tools/jq/default.nix
@@ -1,26 +1,53 @@
-{ lib, stdenv, nixosTests, fetchurl, oniguruma }:
+{ lib, stdenv, fetchpatch, fetchFromGitHub, autoreconfHook
+, onigurumaSupport ? true, oniguruma }:
 
 stdenv.mkDerivation rec {
   pname = "jq";
   version = "1.6";
 
-  src = fetchurl {
-    url =
-      "https://github.com/stedolan/jq/releases/download/jq-${version}/jq-${version}.tar.gz";
-    sha256 = "0wmapfskhzfwranf6515nzmm84r7kwljgfs7dg6bjgxakbicis2x";
+  src = fetchFromGitHub {
+    owner = "stedolan";
+    repo = "jq";
+    rev = "${pname}-${version}";
+    hash = "sha256-CIE8vumQPGK+TFAncmpBijANpFALLTadOvkob0gVzro";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-tests-when-building-without-regex-supports.patch";
+      url =
+        "https://github.com/stedolan/jq/pull/2292/commits/f6a69a6e52b68a92b816a28eb20719a3d0cb51ae.patch";
+      sha256 = "pTM5FZ6hFs5Rdx+W2dICSS2lcoLY1Q//Lan3Hu8Gr58=";
+    })
+  ];
 
   outputs = [ "bin" "doc" "man" "dev" "lib" "out" ];
 
-  buildInputs = [ oniguruma ];
+  # Upstream script that writes the version that's eventually compiled
+  # and printed in `jq --help` relies on a .git directory which our src
+  # doesn't keep.
+  preConfigure = ''
+    echo "#!/bin/sh" > scripts/version
+    echo "echo ${version}" >> scripts/version
+    patchShebangs scripts/version
+  '';
+
+  # paranoid mode: make sure we never use vendored version of oniguruma
+  # Note: it must be run after automake, or automake will complain
+  preBuild = ''
+    rm -r ./modules/oniguruma
+  '';
+
+  buildInputs = lib.optionals onigurumaSupport [ oniguruma ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   configureFlags = [
     "--bindir=\${bin}/bin"
     "--sbindir=\${bin}/bin"
     "--datadir=\${doc}/share"
     "--mandir=\${man}/share/man"
-  ]
-  # jq is linked to libjq:
+  ] ++ lib.optional (!onigurumaSupport) "--with-oniguruma=no"
+    # jq is linked to libjq:
     ++ lib.optional (!stdenv.isDarwin) "LDFLAGS=-Wl,-rpath,\\\${libdir}";
 
   doInstallCheck = true;
@@ -30,6 +57,8 @@ stdenv.mkDerivation rec {
     $bin/bin/jq --help >/dev/null
     $bin/bin/jq -r '.values[1]' <<< '{"values":["hello","world"]}' | grep '^world$' > /dev/null
   '';
+
+  passthru = { inherit onigurumaSupport; };
 
   meta = with lib; {
     description = "A lightweight and flexible command-line JSON processor";

--- a/pkgs/development/tools/jq/default.nix
+++ b/pkgs/development/tools/jq/default.nix
@@ -15,8 +15,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "fix-tests-when-building-without-regex-supports.patch";
-      url =
-        "https://github.com/stedolan/jq/pull/2292/commits/f6a69a6e52b68a92b816a28eb20719a3d0cb51ae.patch";
+      url = "https://github.com/stedolan/jq/pull/2292/commits/f6a69a6e52b68a92b816a28eb20719a3d0cb51ae.patch";
       sha256 = "pTM5FZ6hFs5Rdx+W2dICSS2lcoLY1Q//Lan3Hu8Gr58=";
     })
   ];


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
