### PR TITLE
python3Packages.pytenable: init at 1.2.8

### DIFF
--- a/pkgs/development/python-modules/pytenable/default.nix
+++ b/pkgs/development/python-modules/pytenable/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, defusedxml
+, fetchFromGitHub
+, marshmallow
+, pytest-datafiles
+, pytest-vcr
+, pytestCheckHook
+, python-box
+, python-dateutil
+, requests
+, requests-pkcs12
+, responses
+, restfly
+, semver
+}:
+
+buildPythonPackage rec {
+  pname = "pytenable";
+  version = "1.2.8";
+
+  src = fetchFromGitHub {
+    owner = "tenable";
+    repo = "pyTenable";
+    rev = version;
+    sha256 = "12x0w1c4blm73ixv07w90jkydl7d8dx5l27ih9vc1yv9v2zzb53k";
+  };
+
+  propagatedBuildInputs = [
+    semver
+  ];
+
+  buildInputs = [
+    defusedxml
+    marshmallow
+    python-box
+    python-dateutil
+    requests
+    requests-pkcs12
+    restfly
+  ];
+
+  checkInputs = [
+    responses
+    pytest-datafiles
+    pytest-vcr
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Disable tests that requires a Docker container
+    "test_uploads_docker_push_name_typeerror"
+    "test_uploads_docker_push_tag_typeerror"
+    "test_uploads_docker_push_cs_name_typeerror"
+    "test_uploads_docker_push_cs_tag_typeerror"
+  ];
+
+  pythonImportsCheck = [ "tenable" ];
+
+  meta = with lib; {
+    description = "Python library for the Tenable.io and TenableSC API";
+    homepage = "https://github.com/tenable/pyTenable";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/python-box/default.nix
+++ b/pkgs/development/python-modules/python-box/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, msgpack
+, pytestCheckHook
+, pythonOlder
+, pyyaml
+, ruamel_yaml
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "python-box";
+  version = "5.3.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "cdgriffith";
+    repo = "Box";
+    rev = version;
+    sha256 = "0fhmkjdcacpwyg7fajqfvnv3n9xd9rxjdpvi8z3j73a1gls36gf4";
+  };
+
+  propagatedBuildInputs = [
+    msgpack
+    pyyaml
+    ruamel_yaml
+    toml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "box" ];
+
+  meta = with lib; {
+    description = "Python dictionaries with advanced dot notation access";
+    homepage = "https://github.com/cdgriffith/Box";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/requests-pkcs12/default.nix
+++ b/pkgs/development/python-modules/requests-pkcs12/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyopenssl
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "requests-pkcs12";
+  version = "1.9";
+
+  src = fetchFromGitHub {
+    owner = "m-click";
+    repo = "requests_pkcs12";
+    rev = version;
+    sha256 = "09nm3c6v911d1vwwi0f7mzapbkq7rnsl7026pb13j6ma8pkxznms";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    pyopenssl
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "requests_pkcs12" ];
+
+  meta = with lib; {
+    description = "PKCS#12 support for the Python requests library";
+    homepage = "https://github.com/m-click/requests_pkcs12";
+    license = with licenses; [ isc ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/restfly/default.nix
+++ b/pkgs/development/python-modules/restfly/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, arrow
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-datafiles
+, pytest-vcr
+, pytestCheckHook
+, python-box
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "restfly";
+  version = "1.3.5";
+
+  src = fetchFromGitHub {
+    owner = "stevemcgrath";
+    repo = pname;
+    rev = version;
+    sha256 = "0cq07wj6g3kg7i4qyjp3n3pv13k9p4p43rd6kn139wsn1mh8fr56";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    arrow
+    python-box
+  ];
+
+  checkInputs = [
+    pytest-datafiles
+    pytest-vcr
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "restfly" ];
+
+  meta = with lib; {
+    description = "Python RESTfly API Library Framework";
+    homepage = "https://github.com/stevemcgrath/restfly";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6631,6 +6631,8 @@ in {
 
   python-binance = callPackage ../development/python-modules/python-binance { };
 
+  python-box = callPackage ../development/python-modules/python-box { };
+
   python-constraint = callPackage ../development/python-modules/python-constraint { };
 
   python-crontab = callPackage ../development/python-modules/python-crontab { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6388,6 +6388,8 @@ in {
 
   pyte = callPackage ../development/python-modules/pyte { };
 
+  pytenable = callPackage ../development/python-modules/pytenable { };
+
   pytelegrambotapi = callPackage ../development/python-modules/pyTelegramBotAPI { };
 
   pytesseract = callPackage ../development/python-modules/pytesseract { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7206,6 +7206,8 @@ in {
 
   requests_oauthlib = callPackage ../development/python-modules/requests-oauthlib { };
 
+  requests-pkcs12 = callPackage ../development/python-modules/requests-pkcs12 { };
+
   requests-toolbelt = callPackage ../development/python-modules/requests-toolbelt { };
 
   requests_toolbelt = self.requests-toolbelt; # Old attr, 2017-09-26
@@ -7219,6 +7221,8 @@ in {
   responses = callPackage ../development/python-modules/responses { };
 
   respx = callPackage ../development/python-modules/respx { };
+
+  restfly = callPackage ../development/python-modules/restfly { };
 
   restrictedpython = callPackage ../development/python-modules/restrictedpython { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for the Tenable.io and TenableSC API

https://github.com/tenable/pyTenable

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
