### PR TITLE
nyxt: 2020-10-23 -> 2021-03-27

### DIFF
--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -124,9 +124,8 @@ let lispPackages = rec {
   };
   nyxt = pkgs.lispPackages.buildLispPackage rec {
     baseName = "nyxt";
-    version = "2020-10-23";
+    version = "2021-03-27";
 
-    buildSystems = [ "nyxt" "nyxt-ext" ];
 
     description = "Browser";
 
@@ -143,58 +142,55 @@ let lispPackages = rec {
     };
 
     deps = with pkgs.lispPackages; [
-      alexandria
-      bordeaux-threads
-      chanl
-      cl-annot
-      cl-ansi-text
-      cl-containers
-      cl-css
-      cl-json
-      cl-markup
-      cl-ppcre
-      cl-ppcre-unicode
-      cl-prevalence
-      cl-webkit2
-      closer-mop
-      cluffer
-      dbus
-      dexador
-      enchant
-      fset
-      hu_dot_dwim_dot_defclass-star
-      ironclad
-      local-time
-      log4cl
-      lparallel
-      mk-string-metrics
-      osicat
-      parenscript
-      plump
-      prove-asdf
-      quri
-      serapeum
-      sqlite
-      str
-      swank
-      trivia
-      trivial-clipboard
-      trivial-features
-      trivial-package-local-nicknames
-      trivial-types
-      unix-opts
+            alexandria
+            bordeaux-threads
+            calispel
+            cl-css
+            cl-json
+            cl-markup
+            cl-ppcre
+            cl-ppcre-unicode
+            cl-prevalence
+            closer-mop
+            cl-containers
+            cluffer
+            moptilities
+            dexador
+            enchant
+            file-attributes
+            iolib
+            local-time
+            log4cl
+            mk-string-metrics
+            osicat
+            parenscript
+            quri
+            serapeum
+            str
+            plump
+            swank
+            trivia
+            trivial-clipboard
+            trivial-features
+            trivial-package-local-nicknames
+            trivial-types
+            unix-opts
+            cl-html-diff
+            hu_dot_dwim_dot_defclass-star
+            cl-custom-hash-table
+            fset
+            cl-cffi-gtk
+            cl-webkit2
     ];
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nyxt";
-      rev = "f744af5233b3636460ce71650de2b0c7dcb9fa8e";
-      sha256 = "1m4jic7nbm2jmxlm8k0zqg62z91g2f2s86by086brgfw056idjmz";
-      # date = 2020-10-23T19:06:04+02:00;
+      rev = "8ef171fd1eb62d168defe4a2d7115393230314d1";
+      sha256 = "sha256:1dz55mdmj68kmllih7ab70nmp0mwzqp9lh3im7kcjfmc1r64irdv";
+      # date = 2021-03-27T09:10:00+00:00;
     };
 
     packageName = "nyxt";
-
-    asdFilesToKeep = [ "nyxt.asd" "nyxt-ext.asd" ];
 
     propagatedBuildInputs = [
       pkgs.libressl.out

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd-ext-code-blocks.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd-ext-code-blocks.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''_3bmd-ext-code-blocks'';
-  version = ''3bmd-20201220-git'';
+  baseName = "_3bmd-ext-code-blocks";
+  version = "3bmd-20201220-git";
 
-  description = ''extension to 3bmd implementing github style ``` delimited code blocks, with support for syntax highlighting using colorize, pygments, or chroma'';
+  description = "extension to 3bmd implementing github style ``` delimited code blocks, with support for syntax highlighting using colorize, pygments, or chroma";
 
   deps = [ args."_3bmd" args."alexandria" args."colorize" args."esrap" args."html-encode" args."split-sequence" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/3bmd/2020-12-20/3bmd-20201220-git.tgz'';
-    sha256 = ''0hcx8p8la3fmwhj8ddqik7bwrn9rvf5mcv6m77glimwckh51na71'';
+    url = "http://beta.quicklisp.org/archive/3bmd/2020-12-20/3bmd-20201220-git.tgz";
+    sha256 = "0hcx8p8la3fmwhj8ddqik7bwrn9rvf5mcv6m77glimwckh51na71";
   };
 
   packageName = "3bmd-ext-code-blocks";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''_3bmd'';
-  version = ''20201220-git'';
+  baseName = "_3bmd";
+  version = "20201220-git";
 
-  description = ''markdown processor in CL using esrap parser.'';
+  description = "markdown processor in CL using esrap parser.";
 
   deps = [ args."alexandria" args."esrap" args."split-sequence" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/3bmd/2020-12-20/3bmd-20201220-git.tgz'';
-    sha256 = ''0hcx8p8la3fmwhj8ddqik7bwrn9rvf5mcv6m77glimwckh51na71'';
+    url = "http://beta.quicklisp.org/archive/3bmd/2020-12-20/3bmd-20201220-git.tgz";
+    sha256 = "0hcx8p8la3fmwhj8ddqik7bwrn9rvf5mcv6m77glimwckh51na71";
   };
 
   packageName = "3bmd";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/access.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/access.nix
@@ -1,18 +1,19 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''access'';
-  version = ''20210124-git'';
+  baseName = "access";
+  version = "20210124-git";
 
   parasites = [ "access-test" ];
 
-  description = ''A library providing functions that unify data-structure access for Common Lisp:
-      access and (setf access)'';
+  description = "A library providing functions that unify data-structure access for Common Lisp:
+      access and (setf access)";
 
   deps = [ args."alexandria" args."anaphora" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."flexi-streams" args."iterate" args."lisp-unit2" args."named-readtables" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/access/2021-01-24/access-20210124-git.tgz'';
-    sha256 = ''1n4j15v1ikspchcbb0bn15kk3lh78f6bxk56cs4arimm8bisyqlq'';
+    url = "http://beta.quicklisp.org/archive/access/2021-01-24/access-20210124-git.tgz";
+    sha256 = "1n4j15v1ikspchcbb0bn15kk3lh78f6bxk56cs4arimm8bisyqlq";
   };
 
   packageName = "access";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/acclimation.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/acclimation.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''acclimation'';
-  version = ''20200925-git'';
+  baseName = "acclimation";
+  version = "20200925-git";
 
-  description = ''Library supporting internationalization'';
+  description = "Library supporting internationalization";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/acclimation/2020-09-25/acclimation-20200925-git.tgz'';
-    sha256 = ''11vw1h5zxicj5qxb1smiyjxafw8xk0isnzcf5g0lqis3y9ssqxbw'';
+    url = "http://beta.quicklisp.org/archive/acclimation/2020-09-25/acclimation-20200925-git.tgz";
+    sha256 = "11vw1h5zxicj5qxb1smiyjxafw8xk0isnzcf5g0lqis3y9ssqxbw";
   };
 
   packageName = "acclimation";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''alexandria'';
-  version = ''20200925-git'';
+  baseName = "alexandria";
+  version = "20200925-git";
 
-  description = ''Alexandria is a collection of portable public domain utilities.'';
+  description = "Alexandria is a collection of portable public domain utilities.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/alexandria/2020-09-25/alexandria-20200925-git.tgz'';
-    sha256 = ''1cpvnzfs807ah07hrk8kplim6ryzqs4r35ym03cpky5xdl8c89fl'';
+    url = "http://beta.quicklisp.org/archive/alexandria/2020-09-25/alexandria-20200925-git.tgz";
+    sha256 = "1cpvnzfs807ah07hrk8kplim6ryzqs4r35ym03cpky5xdl8c89fl";
   };
 
   packageName = "alexandria";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/anaphora.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/anaphora.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''anaphora'';
-  version = ''20210124-git'';
+  baseName = "anaphora";
+  version = "20210124-git";
 
   parasites = [ "anaphora/test" ];
 
-  description = ''The Anaphoric Macro Package from Hell'';
+  description = "The Anaphoric Macro Package from Hell";
 
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/anaphora/2021-01-24/anaphora-20210124-git.tgz'';
-    sha256 = ''0b4xwrnv007sfcqkxkarrbf99v3md8h199z1z69r4vx7r5pq2i4v'';
+    url = "http://beta.quicklisp.org/archive/anaphora/2021-01-24/anaphora-20210124-git.tgz";
+    sha256 = "0b4xwrnv007sfcqkxkarrbf99v3md8h199z1z69r4vx7r5pq2i4v";
   };
 
   packageName = "anaphora";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/arnesi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/arnesi.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''arnesi'';
-  version = ''20170403-git'';
+  baseName = "arnesi";
+  version = "20170403-git";
 
   parasites = [ "arnesi/cl-ppcre-extras" "arnesi/slime-extras" ];
 
-  description = ''A bag-of-tools utilities library used to aid in implementing the bese.it toolkit'';
+  description = "A bag-of-tools utilities library used to aid in implementing the bese.it toolkit";
 
   deps = [ args."alexandria" args."cl-ppcre" args."closer-mop" args."collectors" args."iterate" args."swank" args."symbol-munger" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/arnesi/2017-04-03/arnesi-20170403-git.tgz'';
-    sha256 = ''01kirjpgv5pgbcdxjrnw3ld4jw7wrqm3rgqnxwac4gxaphr2s6q4'';
+    url = "http://beta.quicklisp.org/archive/arnesi/2017-04-03/arnesi-20170403-git.tgz";
+    sha256 = "01kirjpgv5pgbcdxjrnw3ld4jw7wrqm3rgqnxwac4gxaphr2s6q4";
   };
 
   packageName = "arnesi";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/array-utils.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/array-utils.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''array-utils'';
-  version = ''20201220-git'';
+  baseName = "array-utils";
+  version = "20201220-git";
 
-  description = ''A few utilities for working with arrays.'';
+  description = "A few utilities for working with arrays.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/array-utils/2020-12-20/array-utils-20201220-git.tgz'';
-    sha256 = ''11y6k8gzzcj00jyccg2k9nh6rvivcvh23z4yzjfly7adygd3n717'';
+    url = "http://beta.quicklisp.org/archive/array-utils/2020-12-20/array-utils-20201220-git.tgz";
+    sha256 = "11y6k8gzzcj00jyccg2k9nh6rvivcvh23z4yzjfly7adygd3n717";
   };
 
   packageName = "array-utils";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/asdf-package-system.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/asdf-package-system.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''asdf-package-system'';
-  version = ''20150608-git'';
+  baseName = "asdf-package-system";
+  version = "20150608-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/asdf-package-system/2015-06-08/asdf-package-system-20150608-git.tgz'';
-    sha256 = ''17lfwfc15hcag8a2jsaxkx42wmz2mwkvxf6vb2h9cim7dwsnyy29'';
+    url = "http://beta.quicklisp.org/archive/asdf-package-system/2015-06-08/asdf-package-system-20150608-git.tgz";
+    sha256 = "17lfwfc15hcag8a2jsaxkx42wmz2mwkvxf6vb2h9cim7dwsnyy29";
   };
 
   packageName = "asdf-package-system";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/asdf-system-connections.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/asdf-system-connections.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''asdf-system-connections'';
-  version = ''20170124-git'';
+  baseName = "asdf-system-connections";
+  version = "20170124-git";
 
-  description = ''Allows for ASDF system to be connected so that auto-loading may occur.'';
+  description = "Allows for ASDF system to be connected so that auto-loading may occur.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/asdf-system-connections/2017-01-24/asdf-system-connections-20170124-git.tgz'';
-    sha256 = ''0h8237bq3niw6glcsps77n1ykcmc5bjkcrbjyxjgkmcb1c5kwwpq'';
+    url = "http://beta.quicklisp.org/archive/asdf-system-connections/2017-01-24/asdf-system-connections-20170124-git.tgz";
+    sha256 = "0h8237bq3niw6glcsps77n1ykcmc5bjkcrbjyxjgkmcb1c5kwwpq";
   };
 
   packageName = "asdf-system-connections";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/babel.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/babel.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''babel'';
-  version = ''20200925-git'';
+  baseName = "babel";
+  version = "20200925-git";
 
-  description = ''Babel, a charset conversion library.'';
+  description = "Babel, a charset conversion library.";
 
   deps = [ args."alexandria" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/babel/2020-09-25/babel-20200925-git.tgz'';
-    sha256 = ''1hpjm2whw7zla9igzj50y3nibii0mfg2a6y6nslaf5vpkni88jfi'';
+    url = "http://beta.quicklisp.org/archive/babel/2020-09-25/babel-20200925-git.tgz";
+    sha256 = "1hpjm2whw7zla9igzj50y3nibii0mfg2a6y6nslaf5vpkni88jfi";
   };
 
   packageName = "babel";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/blackbird.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/blackbird.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''blackbird'';
-  version = ''20160531-git'';
+  baseName = "blackbird";
+  version = "20160531-git";
 
-  description = ''A promise implementation for Common Lisp.'';
+  description = "A promise implementation for Common Lisp.";
 
   deps = [ args."vom" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/blackbird/2016-05-31/blackbird-20160531-git.tgz'';
-    sha256 = ''0l053fb5fdz1q6dyfgys6nmbairc3aig4wjl5abpf8b1paf7gzq9'';
+    url = "http://beta.quicklisp.org/archive/blackbird/2016-05-31/blackbird-20160531-git.tgz";
+    sha256 = "0l053fb5fdz1q6dyfgys6nmbairc3aig4wjl5abpf8b1paf7gzq9";
   };
 
   packageName = "blackbird";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/bordeaux-threads.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/bordeaux-threads.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''bordeaux-threads'';
-  version = ''v0.8.8'';
+  baseName = "bordeaux-threads";
+  version = "v0.8.8";
 
   parasites = [ "bordeaux-threads/test" ];
 
-  description = ''Bordeaux Threads makes writing portable multi-threaded apps simple.'';
+  description = "Bordeaux Threads makes writing portable multi-threaded apps simple.";
 
   deps = [ args."alexandria" args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/bordeaux-threads/2020-06-10/bordeaux-threads-v0.8.8.tgz'';
-    sha256 = ''1ppb7lvr796k1j4hi0jnp717v9zxy6vq4f5cyzgn7svg1ic6l0pp'';
+    url = "http://beta.quicklisp.org/archive/bordeaux-threads/2020-06-10/bordeaux-threads-v0.8.8.tgz";
+    sha256 = "1ppb7lvr796k1j4hi0jnp717v9zxy6vq4f5cyzgn7svg1ic6l0pp";
   };
 
   packageName = "bordeaux-threads";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/buildnode-xhtml.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/buildnode-xhtml.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''buildnode-xhtml'';
-  version = ''buildnode-20170403-git'';
+  baseName = "buildnode-xhtml";
+  version = "buildnode-20170403-git";
 
-  description = ''Tool for building up an xml dom of an excel spreadsheet nicely.'';
+  description = "Tool for building up an xml dom of an excel spreadsheet nicely.";
 
   deps = [ args."alexandria" args."babel" args."buildnode" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."closure-common" args."closure-html" args."collectors" args."cxml" args."flexi-streams" args."iterate" args."named-readtables" args."puri" args."split-sequence" args."swank" args."symbol-munger" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/buildnode/2017-04-03/buildnode-20170403-git.tgz'';
-    sha256 = ''1gb3zsp4g31iscvvhvb99z0i7lfn1g3493q6sgpr46fmn2vdwwb6'';
+    url = "http://beta.quicklisp.org/archive/buildnode/2017-04-03/buildnode-20170403-git.tgz";
+    sha256 = "1gb3zsp4g31iscvvhvb99z0i7lfn1g3493q6sgpr46fmn2vdwwb6";
   };
 
   packageName = "buildnode-xhtml";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/buildnode.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/buildnode.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''buildnode'';
-  version = ''20170403-git'';
+  baseName = "buildnode";
+  version = "20170403-git";
 
   parasites = [ "buildnode-test" ];
 
-  description = ''Tool for building up an xml dom nicely.'';
+  description = "Tool for building up an xml dom nicely.";
 
   deps = [ args."alexandria" args."babel" args."buildnode-xhtml" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."closure-common" args."closure-html" args."collectors" args."cxml" args."flexi-streams" args."iterate" args."lisp-unit2" args."named-readtables" args."puri" args."split-sequence" args."swank" args."symbol-munger" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/buildnode/2017-04-03/buildnode-20170403-git.tgz'';
-    sha256 = ''1gb3zsp4g31iscvvhvb99z0i7lfn1g3493q6sgpr46fmn2vdwwb6'';
+    url = "http://beta.quicklisp.org/archive/buildnode/2017-04-03/buildnode-20170403-git.tgz";
+    sha256 = "1gb3zsp4g31iscvvhvb99z0i7lfn1g3493q6sgpr46fmn2vdwwb6";
   };
 
   packageName = "buildnode";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/calispel.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/calispel.nix
@@ -1,18 +1,19 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''calispel'';
-  version = ''20170830-git'';
+  baseName = "calispel";
+  version = "20170830-git";
 
   parasites = [ "calispel-test" ];
 
-  description = ''Thread-safe message-passing channels, in the style of
-the occam programming language.'';
+  description = "Thread-safe message-passing channels, in the style of
+the occam programming language.";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."eager-future2" args."jpl-queues" args."jpl-util" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/calispel/2017-08-30/calispel-20170830-git.tgz'';
-    sha256 = ''0qwmzmyh63jlw5bdv4wf458n1dz9k77gd5b4ix1kd6xrzx247k7i'';
+    url = "http://beta.quicklisp.org/archive/calispel/2017-08-30/calispel-20170830-git.tgz";
+    sha256 = "0qwmzmyh63jlw5bdv4wf458n1dz9k77gd5b4ix1kd6xrzx247k7i";
   };
 
   packageName = "calispel";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/caveman.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/caveman.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''caveman'';
-  version = ''20200325-git'';
+  baseName = "caveman";
+  version = "20200325-git";
 
-  description = ''Web Application Framework for Common Lisp'';
+  description = "Web Application Framework for Common Lisp";
 
   deps = [ args."alexandria" args."anaphora" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."circular-streams" args."cl_plus_ssl" args."cl-annot" args."cl-ansi-text" args."cl-base64" args."cl-colors" args."cl-colors2" args."cl-cookie" args."cl-emb" args."cl-fad" args."cl-ppcre" args."cl-project" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."clack-test" args."clack-v1-compat" args."dexador" args."dissect" args."do-urlencode" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."let-plus" args."local-time" args."map-set" args."marshal" args."md5" args."myway" args."named-readtables" args."proc-parse" args."prove" args."quri" args."rfc2388" args."rove" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/caveman/2020-03-25/caveman-20200325-git.tgz'';
-    sha256 = ''0s134lamlyll4ad0380rj0hkiy9gakly7cb6sjr1yg2yd6ydz1py'';
+    url = "http://beta.quicklisp.org/archive/caveman/2020-03-25/caveman-20200325-git.tgz";
+    sha256 = "0s134lamlyll4ad0380rj0hkiy9gakly7cb6sjr1yg2yd6ydz1py";
   };
 
   packageName = "caveman";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-grovel.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-grovel.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cffi-grovel'';
-  version = ''cffi_0.23.0'';
+  baseName = "cffi-grovel";
+  version = "cffi_0.23.0";
 
-  description = ''The CFFI Groveller'';
+  description = "The CFFI Groveller";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-toolchain" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz'';
-    sha256 = ''1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck'';
+    url = "http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz";
+    sha256 = "1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck";
   };
 
   packageName = "cffi-grovel";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-toolchain.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-toolchain.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cffi-toolchain'';
-  version = ''cffi_0.23.0'';
+  baseName = "cffi-toolchain";
+  version = "cffi_0.23.0";
 
-  description = ''The CFFI toolchain'';
+  description = "The CFFI toolchain";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz'';
-    sha256 = ''1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck'';
+    url = "http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz";
+    sha256 = "1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck";
   };
 
   packageName = "cffi-toolchain";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-uffi-compat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-uffi-compat.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cffi-uffi-compat'';
-  version = ''cffi_0.23.0'';
+  baseName = "cffi-uffi-compat";
+  version = "cffi_0.23.0";
 
-  description = ''UFFI Compatibility Layer for CFFI'';
+  description = "UFFI Compatibility Layer for CFFI";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz'';
-    sha256 = ''1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck'';
+    url = "http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz";
+    sha256 = "1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck";
   };
 
   packageName = "cffi-uffi-compat";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cffi'';
-  version = ''cffi_0.23.0'';
+  baseName = "cffi";
+  version = "cffi_0.23.0";
 
   parasites = [ "cffi/c2ffi" "cffi/c2ffi-generator" ];
 
-  description = ''The Common Foreign Function Interface'';
+  description = "The Common Foreign Function Interface";
 
   deps = [ args."alexandria" args."babel" args."cl-json" args."cl-ppcre" args."trivial-features" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz'';
-    sha256 = ''1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck'';
+    url = "http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz";
+    sha256 = "1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck";
   };
 
   packageName = "cffi";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/chanl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/chanl.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''chanl'';
-  version = ''20210124-git'';
+  baseName = "chanl";
+  version = "20210124-git";
 
   parasites = [ "chanl/examples" "chanl/tests" ];
 
-  description = ''Communicating Sequential Process support for Common Lisp'';
+  description = "Communicating Sequential Process support for Common Lisp";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/chanl/2021-01-24/chanl-20210124-git.tgz'';
-    sha256 = ''1lb0k5nh51f8hskpm1pma5ds4lk1zpbk9czpw9bk8hdykr178mzc'';
+    url = "http://beta.quicklisp.org/archive/chanl/2021-01-24/chanl-20210124-git.tgz";
+    sha256 = "1lb0k5nh51f8hskpm1pma5ds4lk1zpbk9czpw9bk8hdykr178mzc";
   };
 
   packageName = "chanl";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/chipz.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/chipz.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''chipz'';
-  version = ''20190202-git'';
+  baseName = "chipz";
+  version = "20190202-git";
 
-  description = ''A library for decompressing deflate, zlib, and gzip data'';
+  description = "A library for decompressing deflate, zlib, and gzip data";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/chipz/2019-02-02/chipz-20190202-git.tgz'';
-    sha256 = ''1vk8nml2kvkpwydcnm49gz2j9flvl8676kbvci5qa7qm286dhn5a'';
+    url = "http://beta.quicklisp.org/archive/chipz/2019-02-02/chipz-20190202-git.tgz";
+    sha256 = "1vk8nml2kvkpwydcnm49gz2j9flvl8676kbvci5qa7qm286dhn5a";
   };
 
   packageName = "chipz";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/chunga.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/chunga.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''chunga'';
-  version = ''20200427-git'';
+  baseName = "chunga";
+  version = "20200427-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/chunga/2020-04-27/chunga-20200427-git.tgz'';
-    sha256 = ''0p6dlnan6raincd682brcjbklyvmkfkhz0yzp2bkfw67s9615bkk'';
+    url = "http://beta.quicklisp.org/archive/chunga/2020-04-27/chunga-20200427-git.tgz";
+    sha256 = "0p6dlnan6raincd682brcjbklyvmkfkhz0yzp2bkfw67s9615bkk";
   };
 
   packageName = "chunga";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/circular-streams.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/circular-streams.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''circular-streams'';
-  version = ''20161204-git'';
+  baseName = "circular-streams";
+  version = "20161204-git";
 
-  description = ''Circularly readable streams for Common Lisp'';
+  description = "Circularly readable streams for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/circular-streams/2016-12-04/circular-streams-20161204-git.tgz'';
-    sha256 = ''1i29b9sciqs5x59hlkdj2r4siyqgrwj5hb4lnc80jgfqvzbq4128'';
+    url = "http://beta.quicklisp.org/archive/circular-streams/2016-12-04/circular-streams-20161204-git.tgz";
+    sha256 = "1i29b9sciqs5x59hlkdj2r4siyqgrwj5hb4lnc80jgfqvzbq4128";
   };
 
   packageName = "circular-streams";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-aa.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-aa.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-aa'';
-  version = ''cl-vectors-20180228-git'';
+  baseName = "cl-aa";
+  version = "cl-vectors-20180228-git";
 
-  description = ''cl-aa: polygon rasterizer'';
+  description = "cl-aa: polygon rasterizer";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-vectors/2018-02-28/cl-vectors-20180228-git.tgz'';
-    sha256 = ''0fcypjfzqra8ryb4nx1vx1fqy7fwvyz3f443qkjg2z81akhkscly'';
+    url = "http://beta.quicklisp.org/archive/cl-vectors/2018-02-28/cl-vectors-20180228-git.tgz";
+    sha256 = "0fcypjfzqra8ryb4nx1vx1fqy7fwvyz3f443qkjg2z81akhkscly";
   };
 
   packageName = "cl-aa";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-annot.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-annot.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-annot'';
-  version = ''20150608-git'';
+  baseName = "cl-annot";
+  version = "20150608-git";
 
-  description = ''Python-like Annotation Syntax for Common Lisp'';
+  description = "Python-like Annotation Syntax for Common Lisp";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-annot/2015-06-08/cl-annot-20150608-git.tgz'';
-    sha256 = ''0ixsp20rk498phv3iivipn3qbw7a7x260x63hc6kpv2s746lpdg3'';
+    url = "http://beta.quicklisp.org/archive/cl-annot/2015-06-08/cl-annot-20150608-git.tgz";
+    sha256 = "0ixsp20rk498phv3iivipn3qbw7a7x260x63hc6kpv2s746lpdg3";
   };
 
   packageName = "cl-annot";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-anonfun.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-anonfun.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-anonfun'';
-  version = ''20111203-git'';
+  baseName = "cl-anonfun";
+  version = "20111203-git";
 
-  description = ''Anonymous function helpers for Common Lisp'';
+  description = "Anonymous function helpers for Common Lisp";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-anonfun/2011-12-03/cl-anonfun-20111203-git.tgz'';
-    sha256 = ''16r3v3yba41smkqpz0qvzabkxashl39klfb6vxhzbly696x87p1m'';
+    url = "http://beta.quicklisp.org/archive/cl-anonfun/2011-12-03/cl-anonfun-20111203-git.tgz";
+    sha256 = "16r3v3yba41smkqpz0qvzabkxashl39klfb6vxhzbly696x87p1m";
   };
 
   packageName = "cl-anonfun";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ansi-text.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ansi-text.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-ansi-text'';
-  version = ''20210124-git'';
+  baseName = "cl-ansi-text";
+  version = "20210124-git";
 
-  description = ''ANSI control string characters, focused on color'';
+  description = "ANSI control string characters, focused on color";
 
   deps = [ args."alexandria" args."cl-colors2" args."cl-ppcre" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-ansi-text/2021-01-24/cl-ansi-text-20210124-git.tgz'';
-    sha256 = ''1l7slqk26xznfyn0zpp5l32v6xfpj4qj42h4x4ds5s1yncq306cm'';
+    url = "http://beta.quicklisp.org/archive/cl-ansi-text/2021-01-24/cl-ansi-text-20210124-git.tgz";
+    sha256 = "1l7slqk26xznfyn0zpp5l32v6xfpj4qj42h4x4ds5s1yncq306cm";
   };
 
   packageName = "cl-ansi-text";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-repl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-repl.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-async-repl'';
-  version = ''cl-async-20210228-git'';
+  baseName = "cl-async-repl";
+  version = "cl-async-20210228-git";
 
-  description = ''REPL integration for CL-ASYNC.'';
+  description = "REPL integration for CL-ASYNC.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-async" args."cl-async-base" args."cl-async-util" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-async/2021-02-28/cl-async-20210228-git.tgz'';
-    sha256 = ''08r8jlvj2zbc1f864imb864adkqhspgm5s8drjykqhv1d3hrsvy4'';
+    url = "http://beta.quicklisp.org/archive/cl-async/2021-02-28/cl-async-20210228-git.tgz";
+    sha256 = "08r8jlvj2zbc1f864imb864adkqhspgm5s8drjykqhv1d3hrsvy4";
   };
 
   packageName = "cl-async-repl";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-ssl.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-async-ssl'';
-  version = ''cl-async-20210228-git'';
+  baseName = "cl-async-ssl";
+  version = "cl-async-20210228-git";
 
-  description = ''SSL Wrapper around cl-async socket implementation.'';
+  description = "SSL Wrapper around cl-async socket implementation.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-async" args."cl-async-base" args."cl-async-util" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-async/2021-02-28/cl-async-20210228-git.tgz'';
-    sha256 = ''08r8jlvj2zbc1f864imb864adkqhspgm5s8drjykqhv1d3hrsvy4'';
+    url = "http://beta.quicklisp.org/archive/cl-async/2021-02-28/cl-async-20210228-git.tgz";
+    sha256 = "08r8jlvj2zbc1f864imb864adkqhspgm5s8drjykqhv1d3hrsvy4";
   };
 
   packageName = "cl-async-ssl";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-async'';
-  version = ''20210228-git'';
+  baseName = "cl-async";
+  version = "20210228-git";
 
   parasites = [ "cl-async-base" "cl-async-util" ];
 
-  description = ''Asynchronous operations for Common Lisp.'';
+  description = "Asynchronous operations for Common Lisp.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."uiop" args."vom" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-async/2021-02-28/cl-async-20210228-git.tgz'';
-    sha256 = ''08r8jlvj2zbc1f864imb864adkqhspgm5s8drjykqhv1d3hrsvy4'';
+    url = "http://beta.quicklisp.org/archive/cl-async/2021-02-28/cl-async-20210228-git.tgz";
+    sha256 = "08r8jlvj2zbc1f864imb864adkqhspgm5s8drjykqhv1d3hrsvy4";
   };
 
   packageName = "cl-async";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-base64.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-base64.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-base64'';
-  version = ''20201016-git'';
+  baseName = "cl-base64";
+  version = "20201016-git";
 
   parasites = [ "cl-base64/test" ];
 
-  description = ''Base64 encoding and decoding with URI support.'';
+  description = "Base64 encoding and decoding with URI support.";
 
   deps = [ args."kmrcl" args."ptester" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-base64/2020-10-16/cl-base64-20201016-git.tgz'';
-    sha256 = ''1wd2sgvfrivrbzlhs1vgj762jqz7sk171ssli6gl1kfwbnphzx9z'';
+    url = "http://beta.quicklisp.org/archive/cl-base64/2020-10-16/cl-base64-20201016-git.tgz";
+    sha256 = "1wd2sgvfrivrbzlhs1vgj762jqz7sk171ssli6gl1kfwbnphzx9z";
   };
 
   packageName = "cl-base64";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-cairo.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-cairo.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cffi-gtk-cairo'';
-  version = ''cl-cffi-gtk-20201220-git'';
+  baseName = "cl-cffi-gtk-cairo";
+  version = "cl-cffi-gtk-20201220-git";
 
-  description = ''A Lisp binding to Cairo'';
+  description = "A Lisp binding to Cairo";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-glib" args."iterate" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz'';
-    sha256 = ''15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1'';
+    url = "http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz";
+    sha256 = "15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1";
   };
 
   packageName = "cl-cffi-gtk-cairo";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gdk-pixbuf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gdk-pixbuf.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cffi-gtk-gdk-pixbuf'';
-  version = ''cl-cffi-gtk-20201220-git'';
+  baseName = "cl-cffi-gtk-gdk-pixbuf";
+  version = "cl-cffi-gtk-20201220-git";
 
-  description = ''A Lisp binding to GDK Pixbuf 2'';
+  description = "A Lisp binding to GDK Pixbuf 2";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz'';
-    sha256 = ''15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1'';
+    url = "http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz";
+    sha256 = "15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1";
   };
 
   packageName = "cl-cffi-gtk-gdk-pixbuf";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gdk.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gdk.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cffi-gtk-gdk'';
-  version = ''cl-cffi-gtk-20201220-git'';
+  baseName = "cl-cffi-gtk-gdk";
+  version = "cl-cffi-gtk-20201220-git";
 
-  description = ''A Lisp binding to GDK 3'';
+  description = "A Lisp binding to GDK 3";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz'';
-    sha256 = ''15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1'';
+    url = "http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz";
+    sha256 = "15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1";
   };
 
   packageName = "cl-cffi-gtk-gdk";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gio.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gio.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cffi-gtk-gio'';
-  version = ''cl-cffi-gtk-20201220-git'';
+  baseName = "cl-cffi-gtk-gio";
+  version = "cl-cffi-gtk-20201220-git";
 
-  description = ''A Lisp binding to GIO 2'';
+  description = "A Lisp binding to GIO 2";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz'';
-    sha256 = ''15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1'';
+    url = "http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz";
+    sha256 = "15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1";
   };
 
   packageName = "cl-cffi-gtk-gio";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-glib.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-glib.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cffi-gtk-glib'';
-  version = ''cl-cffi-gtk-20201220-git'';
+  baseName = "cl-cffi-gtk-glib";
+  version = "cl-cffi-gtk-20201220-git";
 
-  description = ''A Lisp binding to GLib 2'';
+  description = "A Lisp binding to GLib 2";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."iterate" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz'';
-    sha256 = ''15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1'';
+    url = "http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz";
+    sha256 = "15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1";
   };
 
   packageName = "cl-cffi-gtk-glib";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gobject.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gobject.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cffi-gtk-gobject'';
-  version = ''cl-cffi-gtk-20201220-git'';
+  baseName = "cl-cffi-gtk-gobject";
+  version = "cl-cffi-gtk-20201220-git";
 
-  description = ''A Lisp binding GObject 2'';
+  description = "A Lisp binding GObject 2";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-glib" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz'';
-    sha256 = ''15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1'';
+    url = "http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz";
+    sha256 = "15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1";
   };
 
   packageName = "cl-cffi-gtk-gobject";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-pango.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-pango.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cffi-gtk-pango'';
-  version = ''cl-cffi-gtk-20201220-git'';
+  baseName = "cl-cffi-gtk-pango";
+  version = "cl-cffi-gtk-20201220-git";
 
-  description = ''A Lisp binding to Pango'';
+  description = "A Lisp binding to Pango";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz'';
-    sha256 = ''15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1'';
+    url = "http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz";
+    sha256 = "15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1";
   };
 
   packageName = "cl-cffi-gtk-pango";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cffi-gtk'';
-  version = ''20201220-git'';
+  baseName = "cl-cffi-gtk";
+  version = "20201220-git";
 
-  description = ''A Lisp binding to GTK 3'';
+  description = "A Lisp binding to GTK 3";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz'';
-    sha256 = ''15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1'';
+    url = "http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-12-20/cl-cffi-gtk-20201220-git.tgz";
+    sha256 = "15vc0d7nirh0m6rkvzby2zb7qcpyvsxzs5yw5h6h3madyl8qm9b1";
   };
 
   packageName = "cl-cffi-gtk";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-change-case.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-change-case.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-change-case'';
-  version = ''20210228-git'';
+  baseName = "cl-change-case";
+  version = "20210228-git";
 
   parasites = [ "cl-change-case/test" ];
 
-  description = ''Convert strings between camelCase, param-case, PascalCase and more'';
+  description = "Convert strings between camelCase, param-case, PascalCase and more";
 
   deps = [ args."cl-ppcre" args."cl-ppcre-unicode" args."cl-unicode" args."fiveam" args."flexi-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-change-case/2021-02-28/cl-change-case-20210228-git.tgz'';
-    sha256 = ''15x8zxwa3pxs02fh0qxmbvz6vi59x6ha09p5hs4rgd6axs0k4pmi'';
+    url = "http://beta.quicklisp.org/archive/cl-change-case/2021-02-28/cl-change-case-20210228-git.tgz";
+    sha256 = "15x8zxwa3pxs02fh0qxmbvz6vi59x6ha09p5hs4rgd6axs0k4pmi";
   };
 
   packageName = "cl-change-case";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cli.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cli.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cli'';
-  version = ''20151218-git'';
+  baseName = "cl-cli";
+  version = "20151218-git";
 
-  description = ''Command line parser'';
+  description = "Command line parser";
 
   deps = [ args."split-sequence" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cli/2015-12-18/cl-cli-20151218-git.tgz'';
-    sha256 = ''0d097wjprljghkai1yacvjqmjm1mwpa46yxbacjnwps8pqwh18ay'';
+    url = "http://beta.quicklisp.org/archive/cl-cli/2015-12-18/cl-cli-20151218-git.tgz";
+    sha256 = "0d097wjprljghkai1yacvjqmjm1mwpa46yxbacjnwps8pqwh18ay";
   };
 
   packageName = "cl-cli";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-colors.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-colors.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-colors'';
-  version = ''20180328-git'';
+  baseName = "cl-colors";
+  version = "20180328-git";
 
   parasites = [ "cl-colors-tests" ];
 
-  description = ''Simple color library for Common Lisp'';
+  description = "Simple color library for Common Lisp";
 
   deps = [ args."alexandria" args."anaphora" args."let-plus" args."lift" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-colors/2018-03-28/cl-colors-20180328-git.tgz'';
-    sha256 = ''0anrb3zsi03dixfsjz92y06w93kpn0d0c5142fhx72f5kafwvc4a'';
+    url = "http://beta.quicklisp.org/archive/cl-colors/2018-03-28/cl-colors-20180328-git.tgz";
+    sha256 = "0anrb3zsi03dixfsjz92y06w93kpn0d0c5142fhx72f5kafwvc4a";
   };
 
   packageName = "cl-colors";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-colors2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-colors2.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-colors2'';
-  version = ''20200218-git'';
+  baseName = "cl-colors2";
+  version = "20200218-git";
 
   parasites = [ "cl-colors2/tests" ];
 
-  description = ''Simple color library for Common Lisp'';
+  description = "Simple color library for Common Lisp";
 
   deps = [ args."alexandria" args."cl-ppcre" args."clunit2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-colors2/2020-02-18/cl-colors2-20200218-git.tgz'';
-    sha256 = ''0rpf8j232qv254zhkvkz3ja20al1kswvcqhvvv0r2ag6dks56j29'';
+    url = "http://beta.quicklisp.org/archive/cl-colors2/2020-02-18/cl-colors2-20200218-git.tgz";
+    sha256 = "0rpf8j232qv254zhkvkz3ja20al1kswvcqhvvv0r2ag6dks56j29";
   };
 
   packageName = "cl-colors2";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-containers.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-containers.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-containers'';
-  version = ''20200427-git'';
+  baseName = "cl-containers";
+  version = "20200427-git";
 
   parasites = [ "cl-containers/with-moptilities" "cl-containers/with-utilities" ];
 
-  description = ''A generic container library for Common Lisp'';
+  description = "A generic container library for Common Lisp";
 
   deps = [ args."asdf-system-connections" args."metatilities-base" args."moptilities" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-containers/2020-04-27/cl-containers-20200427-git.tgz'';
-    sha256 = ''0llaymnlss0dhwyqgr2s38w1hjb2as1x1nn57qcvdphnm7qs50fy'';
+    url = "http://beta.quicklisp.org/archive/cl-containers/2020-04-27/cl-containers-20200427-git.tgz";
+    sha256 = "0llaymnlss0dhwyqgr2s38w1hjb2as1x1nn57qcvdphnm7qs50fy";
   };
 
   packageName = "cl-containers";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cookie.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cookie.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-cookie'';
-  version = ''20191007-git'';
+  baseName = "cl-cookie";
+  version = "20191007-git";
 
-  description = ''HTTP cookie manager'';
+  description = "HTTP cookie manager";
 
   deps = [ args."alexandria" args."babel" args."cl-ppcre" args."cl-utilities" args."local-time" args."proc-parse" args."quri" args."split-sequence" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cookie/2019-10-07/cl-cookie-20191007-git.tgz'';
-    sha256 = ''1xcb69n3qfp37nwj0mj2whf3yj5xfsgh9sdw6c64gxqkiiq9nfhh'';
+    url = "http://beta.quicklisp.org/archive/cl-cookie/2019-10-07/cl-cookie-20191007-git.tgz";
+    sha256 = "1xcb69n3qfp37nwj0mj2whf3yj5xfsgh9sdw6c64gxqkiiq9nfhh";
   };
 
   packageName = "cl-cookie";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-css.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-css.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-css'';
-  version = ''20140914-git'';
+  baseName = "cl-css";
+  version = "20140914-git";
 
-  description = ''Simple inline CSS generator'';
+  description = "Simple inline CSS generator";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-css/2014-09-14/cl-css-20140914-git.tgz'';
-    sha256 = ''16zjm10qqyv5v0ysvicbiscplrwlfr0assbf01gp73j1m108rn7n'';
+    url = "http://beta.quicklisp.org/archive/cl-css/2014-09-14/cl-css-20140914-git.tgz";
+    sha256 = "16zjm10qqyv5v0ysvicbiscplrwlfr0assbf01gp73j1m108rn7n";
   };
 
   packageName = "cl-css";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-csv.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-csv.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-csv'';
-  version = ''20201016-git'';
+  baseName = "cl-csv";
+  version = "20201016-git";
 
   parasites = [ "cl-csv/speed-test" "cl-csv/test" ];
 
-  description = ''Facilities for reading and writing CSV format files'';
+  description = "Facilities for reading and writing CSV format files";
 
   deps = [ args."alexandria" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."flexi-streams" args."iterate" args."lisp-unit2" args."named-readtables" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-csv/2020-10-16/cl-csv-20201016-git.tgz'';
-    sha256 = ''1w12ads26v5sgcmy6rjm6ys9lml7l6rz86w776s2an2maci9kzmf'';
+    url = "http://beta.quicklisp.org/archive/cl-csv/2020-10-16/cl-csv-20201016-git.tgz";
+    sha256 = "1w12ads26v5sgcmy6rjm6ys9lml7l6rz86w776s2an2maci9kzmf";
   };
 
   packageName = "cl-csv";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-custom-hash-table.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-custom-hash-table.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-custom-hash-table'';
-  version = ''20201220-git'';
+  baseName = "cl-custom-hash-table";
+  version = "20201220-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-custom-hash-table/2020-12-20/cl-custom-hash-table-20201220-git.tgz'';
-    sha256 = ''1id16p7vdcgxzvrgk8h6fqi284hgd8cilbnbgsbrbd70n7nj8jg3'';
+    url = "http://beta.quicklisp.org/archive/cl-custom-hash-table/2020-12-20/cl-custom-hash-table-20201220-git.tgz";
+    sha256 = "1id16p7vdcgxzvrgk8h6fqi284hgd8cilbnbgsbrbd70n7nj8jg3";
   };
 
   packageName = "cl-custom-hash-table";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-custom-hash-table.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-custom-hash-table.nix
@@ -1,0 +1,25 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-custom-hash-table'';
+  version = ''20201220-git'';
+
+  description = ''System lacks description'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-custom-hash-table/2020-12-20/cl-custom-hash-table-20201220-git.tgz'';
+    sha256 = ''1id16p7vdcgxzvrgk8h6fqi284hgd8cilbnbgsbrbd70n7nj8jg3'';
+  };
+
+  packageName = "cl-custom-hash-table";
+
+  asdFilesToKeep = ["cl-custom-hash-table.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-custom-hash-table DESCRIPTION System lacks description SHA256
+    1id16p7vdcgxzvrgk8h6fqi284hgd8cilbnbgsbrbd70n7nj8jg3 URL
+    http://beta.quicklisp.org/archive/cl-custom-hash-table/2020-12-20/cl-custom-hash-table-20201220-git.tgz
+    MD5 bd0f2f4a8e808911133af19c03e5c511 NAME cl-custom-hash-table FILENAME
+    cl-custom-hash-table DEPS NIL DEPENDENCIES NIL VERSION 20201220-git
+    SIBLINGS (cl-custom-hash-table-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-dbi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-dbi.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-dbi'';
-  version = ''20210228-git'';
+  baseName = "cl-dbi";
+  version = "20210228-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."closer-mop" args."dbi" args."split-sequence" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz'';
-    sha256 = ''0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk'';
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
+    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
   };
 
   packageName = "cl-dbi";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-difflib.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-difflib.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-difflib'';
-  version = ''20130128-git'';
+  baseName = "cl-difflib";
+  version = "20130128-git";
 
-  description = ''A Lisp library for computing differences between sequences.'';
+  description = "A Lisp library for computing differences between sequences.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-difflib/2013-01-28/cl-difflib-20130128-git.tgz'';
-    sha256 = ''1bgb0nmm93x90c7v1q1ah1v5dfm2anhkim7nh88sg7kg50y4ksm6'';
+    url = "http://beta.quicklisp.org/archive/cl-difflib/2013-01-28/cl-difflib-20130128-git.tgz";
+    sha256 = "1bgb0nmm93x90c7v1q1ah1v5dfm2anhkim7nh88sg7kg50y4ksm6";
   };
 
   packageName = "cl-difflib";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-dot.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-dot.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-dot'';
-  version = ''20200925-git'';
+  baseName = "cl-dot";
+  version = "20200925-git";
 
-  description = ''Generate Dot Output from Arbitrary Lisp Data'';
+  description = "Generate Dot Output from Arbitrary Lisp Data";
 
   deps = [ args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dot/2020-09-25/cl-dot-20200925-git.tgz'';
-    sha256 = ''01vx4yzasmgswrlyagjr2cz76g906jsijdwikdf8wvxyyq77gkla'';
+    url = "http://beta.quicklisp.org/archive/cl-dot/2020-09-25/cl-dot-20200925-git.tgz";
+    sha256 = "01vx4yzasmgswrlyagjr2cz76g906jsijdwikdf8wvxyyq77gkla";
   };
 
   packageName = "cl-dot";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-emb.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-emb.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-emb'';
-  version = ''20190521-git'';
+  baseName = "cl-emb";
+  version = "20190521-git";
 
-  description = ''A templating system for Common Lisp'';
+  description = "A templating system for Common Lisp";
 
   deps = [ args."cl-ppcre" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-emb/2019-05-21/cl-emb-20190521-git.tgz'';
-    sha256 = ''1d6bi2mx1kw7an3maxjp4ldrhkwfdb58va9whxblz2xjlbykdv8d'';
+    url = "http://beta.quicklisp.org/archive/cl-emb/2019-05-21/cl-emb-20190521-git.tgz";
+    sha256 = "1d6bi2mx1kw7an3maxjp4ldrhkwfdb58va9whxblz2xjlbykdv8d";
   };
 
   packageName = "cl-emb";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fad.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fad.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-fad'';
-  version = ''20210124-git'';
+  baseName = "cl-fad";
+  version = "20210124-git";
 
   parasites = [ "cl-fad-test" ];
 
-  description = ''Portable pathname library'';
+  description = "Portable pathname library";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-ppcre" args."unit-test" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-fad/2021-01-24/cl-fad-20210124-git.tgz'';
-    sha256 = ''17vkvkwg4wpyny5x2nsazgpip5nxxahsjngaxjyrj5z15d4lkrm0'';
+    url = "http://beta.quicklisp.org/archive/cl-fad/2021-01-24/cl-fad-20210124-git.tgz";
+    sha256 = "17vkvkwg4wpyny5x2nsazgpip5nxxahsjngaxjyrj5z15d4lkrm0";
   };
 
   packageName = "cl-fad";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fuse-meta-fs.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fuse-meta-fs.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-fuse-meta-fs'';
-  version = ''20190710-git'';
+  baseName = "cl-fuse-meta-fs";
+  version = "20190710-git";
 
-  description = ''CFFI bindings to FUSE (Filesystem in user space)'';
+  description = "CFFI bindings to FUSE (Filesystem in user space)";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-fuse" args."cl-utilities" args."iterate" args."pcall" args."pcall-queue" args."trivial-backtrace" args."trivial-features" args."trivial-utf-8" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-fuse-meta-fs/2019-07-10/cl-fuse-meta-fs-20190710-git.tgz'';
-    sha256 = ''1c2nyxj7q8njxydn4xiagvnb21zhb1l07q7nhfw0qs2qk6dkasq7'';
+    url = "http://beta.quicklisp.org/archive/cl-fuse-meta-fs/2019-07-10/cl-fuse-meta-fs-20190710-git.tgz";
+    sha256 = "1c2nyxj7q8njxydn4xiagvnb21zhb1l07q7nhfw0qs2qk6dkasq7";
   };
 
   packageName = "cl-fuse-meta-fs";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fuse.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fuse.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-fuse'';
-  version = ''20200925-git'';
+  baseName = "cl-fuse";
+  version = "20200925-git";
 
-  description = ''CFFI bindings to FUSE (Filesystem in user space)'';
+  description = "CFFI bindings to FUSE (Filesystem in user space)";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-utilities" args."iterate" args."trivial-backtrace" args."trivial-features" args."trivial-utf-8" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-fuse/2020-09-25/cl-fuse-20200925-git.tgz'';
-    sha256 = ''1c5cn0l0md77asw804qssylcbbphw81mfpbijydd0s25q6xga7dp'';
+    url = "http://beta.quicklisp.org/archive/cl-fuse/2020-09-25/cl-fuse-20200925-git.tgz";
+    sha256 = "1c5cn0l0md77asw804qssylcbbphw81mfpbijydd0s25q6xga7dp";
   };
 
   packageName = "cl-fuse";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-hooks.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-hooks.nix
@@ -1,18 +1,19 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-hooks'';
-  version = ''architecture.hooks-20181210-git'';
+  baseName = "cl-hooks";
+  version = "architecture.hooks-20181210-git";
 
   parasites = [ "cl-hooks/test" ];
 
-  description = ''This system provides the hooks extension point
-mechanism (as known, e.g., from GNU Emacs).'';
+  description = "This system provides the hooks extension point
+mechanism (as known, e.g., from GNU Emacs).";
 
   deps = [ args."alexandria" args."anaphora" args."closer-mop" args."fiveam" args."let-plus" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/architecture.hooks/2018-12-10/architecture.hooks-20181210-git.tgz'';
-    sha256 = ''04l8rjmgsd7i580rpm1wndz1jcvfqrmwllnkh3h7als3azi3q2ns'';
+    url = "http://beta.quicklisp.org/archive/architecture.hooks/2018-12-10/architecture.hooks-20181210-git.tgz";
+    sha256 = "04l8rjmgsd7i580rpm1wndz1jcvfqrmwllnkh3h7als3azi3q2ns";
   };
 
   packageName = "cl-hooks";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-html-diff.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-html-diff.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-html-diff'';
-  version = ''20130128-git'';
+  baseName = "cl-html-diff";
+  version = "20130128-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."cl-difflib" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-html-diff/2013-01-28/cl-html-diff-20130128-git.tgz'';
-    sha256 = ''0dbqfgfl2qmlk91fncjj804md2crvj0bsvkdxfrsybrhn6dmikci'';
+    url = "http://beta.quicklisp.org/archive/cl-html-diff/2013-01-28/cl-html-diff-20130128-git.tgz";
+    sha256 = "0dbqfgfl2qmlk91fncjj804md2crvj0bsvkdxfrsybrhn6dmikci";
   };
 
   packageName = "cl-html-diff";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-html-parse.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-html-parse.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-html-parse'';
-  version = ''20200925-git'';
+  baseName = "cl-html-parse";
+  version = "20200925-git";
 
-  description = ''HTML Parser'';
+  description = "HTML Parser";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-html-parse/2020-09-25/cl-html-parse-20200925-git.tgz'';
-    sha256 = ''14pfd4gwjb8ywr79dqrcznw6h8a1il3g5b6cm5x9aiyr49zdv15f'';
+    url = "http://beta.quicklisp.org/archive/cl-html-parse/2020-09-25/cl-html-parse-20200925-git.tgz";
+    sha256 = "14pfd4gwjb8ywr79dqrcznw6h8a1il3g5b6cm5x9aiyr49zdv15f";
   };
 
   packageName = "cl-html-parse";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-html5-parser.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-html5-parser.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-html5-parser'';
-  version = ''20190521-git'';
+  baseName = "cl-html5-parser";
+  version = "20190521-git";
 
-  description = ''A HTML5 parser for Common Lisp'';
+  description = "A HTML5 parser for Common Lisp";
 
   deps = [ args."cl-ppcre" args."flexi-streams" args."string-case" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-html5-parser/2019-05-21/cl-html5-parser-20190521-git.tgz'';
-    sha256 = ''055jz0yqgjncvy2dxvnwg4iwdvmfsvkch46v58nymz5gi8gaaz7p'';
+    url = "http://beta.quicklisp.org/archive/cl-html5-parser/2019-05-21/cl-html5-parser-20190521-git.tgz";
+    sha256 = "055jz0yqgjncvy2dxvnwg4iwdvmfsvkch46v58nymz5gi8gaaz7p";
   };
 
   packageName = "cl-html5-parser";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-interpol.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-interpol.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-interpol'';
-  version = ''20201220-git'';
+  baseName = "cl-interpol";
+  version = "20201220-git";
 
   parasites = [ "cl-interpol-test" ];
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."cl-ppcre" args."cl-unicode" args."flexi-streams" args."named-readtables" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-interpol/2020-12-20/cl-interpol-20201220-git.tgz'';
-    sha256 = ''1q3zxsbl5br08lv481jsqmq8r9yayp44x6icixcxx5sdz6fbcd3d'';
+    url = "http://beta.quicklisp.org/archive/cl-interpol/2020-12-20/cl-interpol-20201220-git.tgz";
+    sha256 = "1q3zxsbl5br08lv481jsqmq8r9yayp44x6icixcxx5sdz6fbcd3d";
   };
 
   packageName = "cl-interpol";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-jpeg.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-jpeg.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-jpeg'';
-  version = ''20170630-git'';
+  baseName = "cl-jpeg";
+  version = "20170630-git";
 
-  description = ''A self-contained baseline JPEG codec implementation'';
+  description = "A self-contained baseline JPEG codec implementation";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-jpeg/2017-06-30/cl-jpeg-20170630-git.tgz'';
-    sha256 = ''1wwzn2valhh5ka7qkmab59pb1ijagcj296553fp8z03migl0sil0'';
+    url = "http://beta.quicklisp.org/archive/cl-jpeg/2017-06-30/cl-jpeg-20170630-git.tgz";
+    sha256 = "1wwzn2valhh5ka7qkmab59pb1ijagcj296553fp8z03migl0sil0";
   };
 
   packageName = "cl-jpeg";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-json.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-json.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-json'';
-  version = ''20141217-git'';
+  baseName = "cl-json";
+  version = "20141217-git";
 
   parasites = [ "cl-json.test" ];
 
-  description = ''JSON in Lisp. JSON (JavaScript Object Notation) is a lightweight data-interchange format.'';
+  description = "JSON in Lisp. JSON (JavaScript Object Notation) is a lightweight data-interchange format.";
 
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-json/2014-12-17/cl-json-20141217-git.tgz'';
-    sha256 = ''00cfppyi6njsbpv1x03jcv4zwplg0q1138174l3wjkvi3gsql17g'';
+    url = "http://beta.quicklisp.org/archive/cl-json/2014-12-17/cl-json-20141217-git.tgz";
+    sha256 = "00cfppyi6njsbpv1x03jcv4zwplg0q1138174l3wjkvi3gsql17g";
   };
 
   packageName = "cl-json";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-l10n-cldr.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-l10n-cldr.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-l10n-cldr'';
-  version = ''20120909-darcs'';
+  baseName = "cl-l10n-cldr";
+  version = "20120909-darcs";
 
-  description = ''The necessary CLDR files for cl-l10n packaged in a QuickLisp friendly way.'';
+  description = "The necessary CLDR files for cl-l10n packaged in a QuickLisp friendly way.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-l10n-cldr/2012-09-09/cl-l10n-cldr-20120909-darcs.tgz'';
-    sha256 = ''03l81bx8izvzwzw0qah34l4k47l4gmhr917phhhl81qp55x7zbiv'';
+    url = "http://beta.quicklisp.org/archive/cl-l10n-cldr/2012-09-09/cl-l10n-cldr-20120909-darcs.tgz";
+    sha256 = "03l81bx8izvzwzw0qah34l4k47l4gmhr917phhhl81qp55x7zbiv";
   };
 
   packageName = "cl-l10n-cldr";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-l10n.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-l10n.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-l10n'';
-  version = ''20161204-darcs'';
+  baseName = "cl-l10n";
+  version = "20161204-darcs";
 
   parasites = [ "cl-l10n/test" ];
 
-  description = ''Portable CL Locale Support'';
+  description = "Portable CL Locale Support";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cl-fad" args."cl-l10n-cldr" args."cl-ppcre" args."closer-mop" args."closure-common" args."cxml" args."flexi-streams" args."hu_dot_dwim_dot_stefil" args."iterate" args."local-time" args."metabang-bind" args."parse-number" args."puri" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-l10n/2016-12-04/cl-l10n-20161204-darcs.tgz'';
-    sha256 = ''1r8jgwks21az78c5kdxgw5llk9ml423vjkv1f93qg1vx3zma6vzl'';
+    url = "http://beta.quicklisp.org/archive/cl-l10n/2016-12-04/cl-l10n-20161204-darcs.tgz";
+    sha256 = "1r8jgwks21az78c5kdxgw5llk9ml423vjkv1f93qg1vx3zma6vzl";
   };
 
   packageName = "cl-l10n";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-libuv.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-libuv.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-libuv'';
-  version = ''20200610-git'';
+  baseName = "cl-libuv";
+  version = "20200610-git";
 
-  description = ''Low-level libuv bindings for Common Lisp.'';
+  description = "Low-level libuv bindings for Common Lisp.";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-libuv/2020-06-10/cl-libuv-20200610-git.tgz'';
-    sha256 = ''1ywk1z1ibyk3z0irg5azjrjk3x08ixv30fx4qa0p500fmbfhha19'';
+    url = "http://beta.quicklisp.org/archive/cl-libuv/2020-06-10/cl-libuv-20200610-git.tgz";
+    sha256 = "1ywk1z1ibyk3z0irg5azjrjk3x08ixv30fx4qa0p500fmbfhha19";
   };
 
   packageName = "cl-libuv";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-locale.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-locale.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-locale'';
-  version = ''20151031-git'';
+  baseName = "cl-locale";
+  version = "20151031-git";
 
-  description = ''Simple i18n library for Common Lisp'';
+  description = "Simple i18n library for Common Lisp";
 
   deps = [ args."alexandria" args."anaphora" args."arnesi" args."cl-annot" args."cl-syntax" args."cl-syntax-annot" args."closer-mop" args."collectors" args."iterate" args."named-readtables" args."symbol-munger" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-locale/2015-10-31/cl-locale-20151031-git.tgz'';
-    sha256 = ''14j4xazrx2v5cj4q4irfwra0ksvl2l0s7073fimpwc0xqjfsnjpg'';
+    url = "http://beta.quicklisp.org/archive/cl-locale/2015-10-31/cl-locale-20151031-git.tgz";
+    sha256 = "14j4xazrx2v5cj4q4irfwra0ksvl2l0s7073fimpwc0xqjfsnjpg";
   };
 
   packageName = "cl-locale";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-markup.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-markup.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-markup'';
-  version = ''20131003-git'';
+  baseName = "cl-markup";
+  version = "20131003-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-markup/2013-10-03/cl-markup-20131003-git.tgz'';
-    sha256 = ''1ik3a5k6axq941zbf6zyig553i5gnypbcxdq9l7bfxp8w18vbj0r'';
+    url = "http://beta.quicklisp.org/archive/cl-markup/2013-10-03/cl-markup-20131003-git.tgz";
+    sha256 = "1ik3a5k6axq941zbf6zyig553i5gnypbcxdq9l7bfxp8w18vbj0r";
   };
 
   packageName = "cl-markup";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-mysql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-mysql.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-mysql'';
-  version = ''20200610-git'';
+  baseName = "cl-mysql";
+  version = "20200610-git";
 
-  description = ''Common Lisp MySQL library bindings'';
+  description = "Common Lisp MySQL library bindings";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-mysql/2020-06-10/cl-mysql-20200610-git.tgz'';
-    sha256 = ''0fzyqzz01zn9fy8v766lib3dghg9yq5wawa0hcmxslms7knzxz7w'';
+    url = "http://beta.quicklisp.org/archive/cl-mysql/2020-06-10/cl-mysql-20200610-git.tgz";
+    sha256 = "0fzyqzz01zn9fy8v766lib3dghg9yq5wawa0hcmxslms7knzxz7w";
   };
 
   packageName = "cl-mysql";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-paths-ttf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-paths-ttf.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-paths-ttf'';
-  version = ''cl-vectors-20180228-git'';
+  baseName = "cl-paths-ttf";
+  version = "cl-vectors-20180228-git";
 
-  description = ''cl-paths-ttf: vectorial paths manipulation'';
+  description = "cl-paths-ttf: vectorial paths manipulation";
 
   deps = [ args."cl-paths" args."zpb-ttf" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-vectors/2018-02-28/cl-vectors-20180228-git.tgz'';
-    sha256 = ''0fcypjfzqra8ryb4nx1vx1fqy7fwvyz3f443qkjg2z81akhkscly'';
+    url = "http://beta.quicklisp.org/archive/cl-vectors/2018-02-28/cl-vectors-20180228-git.tgz";
+    sha256 = "0fcypjfzqra8ryb4nx1vx1fqy7fwvyz3f443qkjg2z81akhkscly";
   };
 
   packageName = "cl-paths-ttf";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-paths.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-paths.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-paths'';
-  version = ''cl-vectors-20180228-git'';
+  baseName = "cl-paths";
+  version = "cl-vectors-20180228-git";
 
-  description = ''cl-paths: vectorial paths manipulation'';
+  description = "cl-paths: vectorial paths manipulation";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-vectors/2018-02-28/cl-vectors-20180228-git.tgz'';
-    sha256 = ''0fcypjfzqra8ryb4nx1vx1fqy7fwvyz3f443qkjg2z81akhkscly'';
+    url = "http://beta.quicklisp.org/archive/cl-vectors/2018-02-28/cl-vectors-20180228-git.tgz";
+    sha256 = "0fcypjfzqra8ryb4nx1vx1fqy7fwvyz3f443qkjg2z81akhkscly";
   };
 
   packageName = "cl-paths";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-pdf'';
-  version = ''20210228-git'';
+  baseName = "cl-pdf";
+  version = "20210228-git";
 
-  description = ''Common Lisp PDF Generation Library'';
+  description = "Common Lisp PDF Generation Library";
 
   deps = [ args."iterate" args."uiop" args."zpb-ttf" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-pdf/2021-02-28/cl-pdf-20210228-git.tgz'';
-    sha256 = ''1m1nq91p49gfc9iccja2wbhglrv0mgzhqvliss7jr0j6icv66x3y'';
+    url = "http://beta.quicklisp.org/archive/cl-pdf/2021-02-28/cl-pdf-20210228-git.tgz";
+    sha256 = "1m1nq91p49gfc9iccja2wbhglrv0mgzhqvliss7jr0j6icv66x3y";
   };
 
   packageName = "cl-pdf";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-postgres'';
-  version = ''postmodern-20210124-git'';
+  baseName = "cl-postgres";
+  version = "postmodern-20210124-git";
 
   parasites = [ "cl-postgres/simple-date-tests" "cl-postgres/tests" ];
 
-  description = ''Low-level client library for PostgreSQL'';
+  description = "Low-level client library for PostgreSQL";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-ppcre" args."fiveam" args."ironclad" args."md5" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz'';
-    sha256 = ''1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc'';
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz";
+    sha256 = "1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc";
   };
 
   packageName = "cl-postgres";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres_plus_local-time.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres_plus_local-time.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-postgres_plus_local-time'';
-  version = ''local-time-20210124-git'';
+  baseName = "cl-postgres_plus_local-time";
+  version = "local-time-20210124-git";
 
-  description = ''Integration between cl-postgres and local-time'';
+  description = "Integration between cl-postgres and local-time";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-ppcre" args."ironclad" args."local-time" args."md5" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/local-time/2021-01-24/local-time-20210124-git.tgz'';
-    sha256 = ''0bz5z0rd8gfd22bpqkalaijxlrk806zc010cvgd4qjapbrxzjg3s'';
+    url = "http://beta.quicklisp.org/archive/local-time/2021-01-24/local-time-20210124-git.tgz";
+    sha256 = "0bz5z0rd8gfd22bpqkalaijxlrk806zc010cvgd4qjapbrxzjg3s";
   };
 
   packageName = "cl-postgres+local-time";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-template.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-template.nix
@@ -1,19 +1,20 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-ppcre-template'';
-  version = ''cl-unification-20200925-git'';
+  baseName = "cl-ppcre-template";
+  version = "cl-unification-20200925-git";
 
-  description = ''A system used to conditionally load the CL-PPCRE Template.
+  description = "A system used to conditionally load the CL-PPCRE Template.
 
 This system is not required and it is handled only if CL-PPCRE is
 available.  If it is, then the library provides the
-REGULAR-EXPRESSION-TEMPLATE.'';
+REGULAR-EXPRESSION-TEMPLATE.";
 
   deps = [ args."cl-ppcre" args."cl-unification" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-unification/2020-09-25/cl-unification-20200925-git.tgz'';
-    sha256 = ''05i1bmbabfgym9v28cbl37yr0r1m4a4k4a844z6wlq6qf45vzais'';
+    url = "http://beta.quicklisp.org/archive/cl-unification/2020-09-25/cl-unification-20200925-git.tgz";
+    sha256 = "05i1bmbabfgym9v28cbl37yr0r1m4a4k4a844z6wlq6qf45vzais";
   };
 
   packageName = "cl-ppcre-template";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-unicode.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-unicode.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-ppcre-unicode'';
-  version = ''cl-ppcre-20190521-git'';
+  baseName = "cl-ppcre-unicode";
+  version = "cl-ppcre-20190521-git";
 
   parasites = [ "cl-ppcre-unicode-test" ];
 
-  description = ''Perl-compatible regular expression library (Unicode)'';
+  description = "Perl-compatible regular expression library (Unicode)";
 
   deps = [ args."cl-ppcre" args."cl-ppcre-test" args."cl-unicode" args."flexi-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-ppcre/2019-05-21/cl-ppcre-20190521-git.tgz'';
-    sha256 = ''0p6jcvf9afnsg80a1zqsp7fyz0lf1fxzbin7rs9bl4i6jvm0hjqx'';
+    url = "http://beta.quicklisp.org/archive/cl-ppcre/2019-05-21/cl-ppcre-20190521-git.tgz";
+    sha256 = "0p6jcvf9afnsg80a1zqsp7fyz0lf1fxzbin7rs9bl4i6jvm0hjqx";
   };
 
   packageName = "cl-ppcre-unicode";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-ppcre'';
-  version = ''20190521-git'';
+  baseName = "cl-ppcre";
+  version = "20190521-git";
 
   parasites = [ "cl-ppcre-test" ];
 
-  description = ''Perl-compatible regular expression library'';
+  description = "Perl-compatible regular expression library";
 
   deps = [ args."flexi-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-ppcre/2019-05-21/cl-ppcre-20190521-git.tgz'';
-    sha256 = ''0p6jcvf9afnsg80a1zqsp7fyz0lf1fxzbin7rs9bl4i6jvm0hjqx'';
+    url = "http://beta.quicklisp.org/archive/cl-ppcre/2019-05-21/cl-ppcre-20190521-git.tgz";
+    sha256 = "0p6jcvf9afnsg80a1zqsp7fyz0lf1fxzbin7rs9bl4i6jvm0hjqx";
   };
 
   packageName = "cl-ppcre";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-prevalence.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-prevalence.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-prevalence'';
-  version = ''20210228-git'';
+  baseName = "cl-prevalence";
+  version = "20210228-git";
 
-  description = ''Common Lisp Prevalence Package'';
+  description = "Common Lisp Prevalence Package";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."s-sysdeps" args."s-xml" args."split-sequence" args."usocket" args."usocket-server" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-prevalence/2021-02-28/cl-prevalence-20210228-git.tgz'';
-    sha256 = ''0irx60xa7ivlnjg1qzhl7x5sgdjqk53nrx0nji29q639h71czfpl'';
+    url = "http://beta.quicklisp.org/archive/cl-prevalence/2021-02-28/cl-prevalence-20210228-git.tgz";
+    sha256 = "0irx60xa7ivlnjg1qzhl7x5sgdjqk53nrx0nji29q639h71czfpl";
   };
 
   packageName = "cl-prevalence";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-project.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-project.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-project'';
-  version = ''20200715-git'';
+  baseName = "cl-project";
+  version = "20200715-git";
 
-  description = ''Generate a skeleton for modern project'';
+  description = "Generate a skeleton for modern project";
 
   deps = [ args."alexandria" args."anaphora" args."cl-ansi-text" args."cl-colors" args."cl-colors2" args."cl-emb" args."cl-ppcre" args."let-plus" args."local-time" args."prove" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-project/2020-07-15/cl-project-20200715-git.tgz'';
-    sha256 = ''044rx97wc839a8q2wv271s07bnsasl6x5fx4gr5pvy34jbrhp306'';
+    url = "http://beta.quicklisp.org/archive/cl-project/2020-07-15/cl-project-20200715-git.tgz";
+    sha256 = "044rx97wc839a8q2wv271s07bnsasl6x5fx4gr5pvy34jbrhp306";
   };
 
   packageName = "cl-project";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-protobufs.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-protobufs.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-protobufs'';
-  version = ''20200325-git'';
+  baseName = "cl-protobufs";
+  version = "20200325-git";
 
-  description = ''Protobufs for Common Lisp'';
+  description = "Protobufs for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."closer-mop" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-protobufs/2020-03-25/cl-protobufs-20200325-git.tgz'';
-    sha256 = ''1sgvp038bvd3mq2f0xh4wawf8h21jmw449yjyahidh1zfqdibpin'';
+    url = "http://beta.quicklisp.org/archive/cl-protobufs/2020-03-25/cl-protobufs-20200325-git.tgz";
+    sha256 = "1sgvp038bvd3mq2f0xh4wawf8h21jmw449yjyahidh1zfqdibpin";
   };
 
   packageName = "cl-protobufs";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-qprint.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-qprint.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-qprint'';
-  version = ''20150804-git'';
+  baseName = "cl-qprint";
+  version = "20150804-git";
 
-  description = ''Encode and decode quoted-printable encoded strings.'';
+  description = "Encode and decode quoted-printable encoded strings.";
 
   deps = [ args."flexi-streams" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-qprint/2015-08-04/cl-qprint-20150804-git.tgz'';
-    sha256 = ''042nq9airkc4yaqzpmly5iszmkbwfn38wsgi9k361ldf1y54lq28'';
+    url = "http://beta.quicklisp.org/archive/cl-qprint/2015-08-04/cl-qprint-20150804-git.tgz";
+    sha256 = "042nq9airkc4yaqzpmly5iszmkbwfn38wsgi9k361ldf1y54lq28";
   };
 
   packageName = "cl-qprint";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-reexport.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-reexport.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-reexport'';
-  version = ''20210228-git'';
+  baseName = "cl-reexport";
+  version = "20210228-git";
 
-  description = ''Reexport external symbols in other packages.'';
+  description = "Reexport external symbols in other packages.";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-reexport/2021-02-28/cl-reexport-20210228-git.tgz'';
-    sha256 = ''1ay0ng5nnbq200g4wxs0h7byx24za4yk208nhfsmksahk5qj1qra'';
+    url = "http://beta.quicklisp.org/archive/cl-reexport/2021-02-28/cl-reexport-20210228-git.tgz";
+    sha256 = "1ay0ng5nnbq200g4wxs0h7byx24za4yk208nhfsmksahk5qj1qra";
   };
 
   packageName = "cl-reexport";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-slice.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-slice.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-slice'';
-  version = ''20171130-git'';
+  baseName = "cl-slice";
+  version = "20171130-git";
 
   parasites = [ "cl-slice-tests" ];
 
-  description = ''DSL for array slices in Common Lisp.'';
+  description = "DSL for array slices in Common Lisp.";
 
   deps = [ args."alexandria" args."anaphora" args."clunit" args."let-plus" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-slice/2017-11-30/cl-slice-20171130-git.tgz'';
-    sha256 = ''0nay95qsnck40kdxjgjdii5rcgrdhf880pg9ajmbxilgw84xb2zn'';
+    url = "http://beta.quicklisp.org/archive/cl-slice/2017-11-30/cl-slice-20171130-git.tgz";
+    sha256 = "0nay95qsnck40kdxjgjdii5rcgrdhf880pg9ajmbxilgw84xb2zn";
   };
 
   packageName = "cl-slice";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-smtp.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-smtp.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-smtp'';
-  version = ''20210228-git'';
+  baseName = "cl-smtp";
+  version = "20210228-git";
 
-  description = ''Common Lisp smtp client.'';
+  description = "Common Lisp smtp client.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl_plus_ssl" args."cl-base64" args."flexi-streams" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-smtp/2021-02-28/cl-smtp-20210228-git.tgz'';
-    sha256 = ''1x965jyhifx8hss2v6qc6lr54nlckchs712dny376krwkl43jh5g'';
+    url = "http://beta.quicklisp.org/archive/cl-smtp/2021-02-28/cl-smtp-20210228-git.tgz";
+    sha256 = "1x965jyhifx8hss2v6qc6lr54nlckchs712dny376krwkl43jh5g";
   };
 
   packageName = "cl-smtp";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-speedy-queue.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-speedy-queue.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-speedy-queue'';
-  version = ''20150302-git'';
+  baseName = "cl-speedy-queue";
+  version = "20150302-git";
 
-  description = ''cl-speedy-queue is a portable, non-consing, optimized queue implementation.'';
+  description = "cl-speedy-queue is a portable, non-consing, optimized queue implementation.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-speedy-queue/2015-03-02/cl-speedy-queue-20150302-git.tgz'';
-    sha256 = ''1w83vckk0ldr61vpkwg4i8l2b2yx54cs4ak62j4lxhshax105rqr'';
+    url = "http://beta.quicklisp.org/archive/cl-speedy-queue/2015-03-02/cl-speedy-queue-20150302-git.tgz";
+    sha256 = "1w83vckk0ldr61vpkwg4i8l2b2yx54cs4ak62j4lxhshax105rqr";
   };
 
   packageName = "cl-speedy-queue";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-store.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-store.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-store'';
-  version = ''20200925-git'';
+  baseName = "cl-store";
+  version = "20200925-git";
 
   parasites = [ "cl-store-tests" ];
 
-  description = ''Serialization package'';
+  description = "Serialization package";
 
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-store/2020-09-25/cl-store-20200925-git.tgz'';
-    sha256 = ''0vqlrci1634jgfg6c1dzwvx58qjjwbcbwdbpm7xxw2s823xl9jf3'';
+    url = "http://beta.quicklisp.org/archive/cl-store/2020-09-25/cl-store-20200925-git.tgz";
+    sha256 = "0vqlrci1634jgfg6c1dzwvx58qjjwbcbwdbpm7xxw2s823xl9jf3";
   };
 
   packageName = "cl-store";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syntax-annot.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syntax-annot.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-syntax-annot'';
-  version = ''cl-syntax-20150407-git'';
+  baseName = "cl-syntax-annot";
+  version = "cl-syntax-20150407-git";
 
-  description = ''CL-Syntax Reader Syntax for cl-annot'';
+  description = "CL-Syntax Reader Syntax for cl-annot";
 
   deps = [ args."alexandria" args."cl-annot" args."cl-syntax" args."named-readtables" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-syntax/2015-04-07/cl-syntax-20150407-git.tgz'';
-    sha256 = ''1pz9a7hiql493ax5qgs9zb3bmvf0nnmmgdx14s4j2apdy2m34v8n'';
+    url = "http://beta.quicklisp.org/archive/cl-syntax/2015-04-07/cl-syntax-20150407-git.tgz";
+    sha256 = "1pz9a7hiql493ax5qgs9zb3bmvf0nnmmgdx14s4j2apdy2m34v8n";
   };
 
   packageName = "cl-syntax-annot";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syntax-anonfun.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syntax-anonfun.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-syntax-anonfun'';
-  version = ''cl-syntax-20150407-git'';
+  baseName = "cl-syntax-anonfun";
+  version = "cl-syntax-20150407-git";
 
-  description = ''CL-Syntax Reader Syntax for cl-anonfun'';
+  description = "CL-Syntax Reader Syntax for cl-anonfun";
 
   deps = [ args."cl-anonfun" args."cl-syntax" args."named-readtables" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-syntax/2015-04-07/cl-syntax-20150407-git.tgz'';
-    sha256 = ''1pz9a7hiql493ax5qgs9zb3bmvf0nnmmgdx14s4j2apdy2m34v8n'';
+    url = "http://beta.quicklisp.org/archive/cl-syntax/2015-04-07/cl-syntax-20150407-git.tgz";
+    sha256 = "1pz9a7hiql493ax5qgs9zb3bmvf0nnmmgdx14s4j2apdy2m34v8n";
   };
 
   packageName = "cl-syntax-anonfun";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syntax-markup.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syntax-markup.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-syntax-markup'';
-  version = ''cl-syntax-20150407-git'';
+  baseName = "cl-syntax-markup";
+  version = "cl-syntax-20150407-git";
 
-  description = ''CL-Syntax Reader Syntax for CL-Markup'';
+  description = "CL-Syntax Reader Syntax for CL-Markup";
 
   deps = [ args."cl-markup" args."cl-syntax" args."named-readtables" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-syntax/2015-04-07/cl-syntax-20150407-git.tgz'';
-    sha256 = ''1pz9a7hiql493ax5qgs9zb3bmvf0nnmmgdx14s4j2apdy2m34v8n'';
+    url = "http://beta.quicklisp.org/archive/cl-syntax/2015-04-07/cl-syntax-20150407-git.tgz";
+    sha256 = "1pz9a7hiql493ax5qgs9zb3bmvf0nnmmgdx14s4j2apdy2m34v8n";
   };
 
   packageName = "cl-syntax-markup";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syntax.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syntax.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-syntax'';
-  version = ''20150407-git'';
+  baseName = "cl-syntax";
+  version = "20150407-git";
 
-  description = ''Reader Syntax Coventions for Common Lisp and SLIME'';
+  description = "Reader Syntax Coventions for Common Lisp and SLIME";
 
   deps = [ args."named-readtables" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-syntax/2015-04-07/cl-syntax-20150407-git.tgz'';
-    sha256 = ''1pz9a7hiql493ax5qgs9zb3bmvf0nnmmgdx14s4j2apdy2m34v8n'';
+    url = "http://beta.quicklisp.org/archive/cl-syntax/2015-04-07/cl-syntax-20150407-git.tgz";
+    sha256 = "1pz9a7hiql493ax5qgs9zb3bmvf0nnmmgdx14s4j2apdy2m34v8n";
   };
 
   packageName = "cl-syntax";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syslog.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syslog.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-syslog'';
-  version = ''20190202-git'';
+  baseName = "cl-syslog";
+  version = "20190202-git";
 
-  description = ''Common Lisp syslog interface.'';
+  description = "Common Lisp syslog interface.";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."global-vars" args."local-time" args."split-sequence" args."trivial-features" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-syslog/2019-02-02/cl-syslog-20190202-git.tgz'';
-    sha256 = ''1kzz613y9fvx33svlwc65vjaj1cafnxz8icds80ww7il7y6alwgh'';
+    url = "http://beta.quicklisp.org/archive/cl-syslog/2019-02-02/cl-syslog-20190202-git.tgz";
+    sha256 = "1kzz613y9fvx33svlwc65vjaj1cafnxz8icds80ww7il7y6alwgh";
   };
 
   packageName = "cl-syslog";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-test-more.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-test-more.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-test-more'';
-  version = ''prove-20200218-git'';
+  baseName = "cl-test-more";
+  version = "prove-20200218-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."anaphora" args."cl-ansi-text" args."cl-colors" args."cl-colors2" args."cl-ppcre" args."let-plus" args."prove" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/prove/2020-02-18/prove-20200218-git.tgz'';
-    sha256 = ''1sv3zyam9sdmyis5lyv0khvw82q7bcpsycpj9b3bsv9isb4j30zn'';
+    url = "http://beta.quicklisp.org/archive/prove/2020-02-18/prove-20200218-git.tgz";
+    sha256 = "1sv3zyam9sdmyis5lyv0khvw82q7bcpsycpj9b3bsv9isb4j30zn";
   };
 
   packageName = "cl-test-more";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-typesetting.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-typesetting.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-typesetting'';
-  version = ''20210228-git'';
+  baseName = "cl-typesetting";
+  version = "20210228-git";
 
-  description = ''Common Lisp Typesetting system'';
+  description = "Common Lisp Typesetting system";
 
   deps = [ args."cl-pdf" args."iterate" args."zpb-ttf" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-typesetting/2021-02-28/cl-typesetting-20210228-git.tgz'';
-    sha256 = ''13rmzyzp0glq35jq3qdlmrsdssa6csqp5g455li4wi7kq8clrwnp'';
+    url = "http://beta.quicklisp.org/archive/cl-typesetting/2021-02-28/cl-typesetting-20210228-git.tgz";
+    sha256 = "13rmzyzp0glq35jq3qdlmrsdssa6csqp5g455li4wi7kq8clrwnp";
   };
 
   packageName = "cl-typesetting";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-unicode.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-unicode.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-unicode'';
-  version = ''20210228-git'';
+  baseName = "cl-unicode";
+  version = "20210228-git";
 
   parasites = [ "cl-unicode/base" "cl-unicode/build" "cl-unicode/test" ];
 
-  description = ''Portable Unicode Library'';
+  description = "Portable Unicode Library";
 
   deps = [ args."cl-ppcre" args."flexi-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-unicode/2021-02-28/cl-unicode-20210228-git.tgz'';
-    sha256 = ''0phy5wppb7m78dixrf2vjq8vas4drfd4qg38al6q8ymkl0yfy5js'';
+    url = "http://beta.quicklisp.org/archive/cl-unicode/2021-02-28/cl-unicode-20210228-git.tgz";
+    sha256 = "0phy5wppb7m78dixrf2vjq8vas4drfd4qg38al6q8ymkl0yfy5js";
   };
 
   packageName = "cl-unicode";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-unification.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-unification.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-unification'';
-  version = ''20200925-git'';
+  baseName = "cl-unification";
+  version = "20200925-git";
 
-  description = ''The CL-UNIFICATION system.
+  description = "The CL-UNIFICATION system.
 
-The system contains the definitions for the 'unification' machinery.'';
+The system contains the definitions for the 'unification' machinery.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-unification/2020-09-25/cl-unification-20200925-git.tgz'';
-    sha256 = ''05i1bmbabfgym9v28cbl37yr0r1m4a4k4a844z6wlq6qf45vzais'';
+    url = "http://beta.quicklisp.org/archive/cl-unification/2020-09-25/cl-unification-20200925-git.tgz";
+    sha256 = "05i1bmbabfgym9v28cbl37yr0r1m4a4k4a844z6wlq6qf45vzais";
   };
 
   packageName = "cl-unification";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-utilities.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-utilities.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-utilities'';
-  version = ''1.2.4'';
+  baseName = "cl-utilities";
+  version = "1.2.4";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-utilities/2010-10-06/cl-utilities-1.2.4.tgz'';
-    sha256 = ''1z2ippnv2wgyxpz15zpif7j7sp1r20fkjhm4n6am2fyp6a3k3a87'';
+    url = "http://beta.quicklisp.org/archive/cl-utilities/2010-10-06/cl-utilities-1.2.4.tgz";
+    sha256 = "1z2ippnv2wgyxpz15zpif7j7sp1r20fkjhm4n6am2fyp6a3k3a87";
   };
 
   packageName = "cl-utilities";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-vectors.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-vectors.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-vectors'';
-  version = ''20180228-git'';
+  baseName = "cl-vectors";
+  version = "20180228-git";
 
-  description = ''cl-paths: vectorial paths manipulation'';
+  description = "cl-paths: vectorial paths manipulation";
 
   deps = [ args."cl-aa" args."cl-paths" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-vectors/2018-02-28/cl-vectors-20180228-git.tgz'';
-    sha256 = ''0fcypjfzqra8ryb4nx1vx1fqy7fwvyz3f443qkjg2z81akhkscly'';
+    url = "http://beta.quicklisp.org/archive/cl-vectors/2018-02-28/cl-vectors-20180228-git.tgz";
+    sha256 = "0fcypjfzqra8ryb4nx1vx1fqy7fwvyz3f443qkjg2z81akhkscly";
   };
 
   packageName = "cl-vectors";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-webkit2'';
-  version = ''cl-webkit-20210228-git'';
+  baseName = "cl-webkit2";
+  version = "cl-webkit-20210228-git";
 
-  description = ''An FFI binding to WebKit2GTK+'';
+  description = "An FFI binding to WebKit2GTK+";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-webkit/2021-02-28/cl-webkit-20210228-git.tgz'';
-    sha256 = ''1r6i64g37palar4hij6c5m240xbn2dwzwaashv015nhjwmra1ms1'';
+    url = "http://beta.quicklisp.org/archive/cl-webkit/2021-02-28/cl-webkit-20210228-git.tgz";
+    sha256 = "1r6i64g37palar4hij6c5m240xbn2dwzwaashv015nhjwmra1ms1";
   };
 
   packageName = "cl-webkit2";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-who.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-who.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-who'';
-  version = ''20190710-git'';
+  baseName = "cl-who";
+  version = "20190710-git";
 
   parasites = [ "cl-who-test" ];
 
-  description = ''(X)HTML generation macros'';
+  description = "(X)HTML generation macros";
 
   deps = [ args."flexi-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-who/2019-07-10/cl-who-20190710-git.tgz'';
-    sha256 = ''0pbigwn38xikdwvjy9696z9f00dwg565y3wh6ja51q681y8zh9ir'';
+    url = "http://beta.quicklisp.org/archive/cl-who/2019-07-10/cl-who-20190710-git.tgz";
+    sha256 = "0pbigwn38xikdwvjy9696z9f00dwg565y3wh6ja51q681y8zh9ir";
   };
 
   packageName = "cl-who";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-xmlspam.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-xmlspam.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl-xmlspam'';
-  version = ''20101006-http'';
+  baseName = "cl-xmlspam";
+  version = "20101006-http";
 
-  description = ''Streaming pattern matching for XML'';
+  description = "Streaming pattern matching for XML";
 
   deps = [ args."alexandria" args."babel" args."cl-ppcre" args."closure-common" args."cxml" args."puri" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-xmlspam/2010-10-06/cl-xmlspam-20101006-http.tgz'';
-    sha256 = ''1mx1a6ab4irncrx5pamh7zng35m4c5wh0pw68avaz7fbz81s953h'';
+    url = "http://beta.quicklisp.org/archive/cl-xmlspam/2010-10-06/cl-xmlspam-20101006-http.tgz";
+    sha256 = "1mx1a6ab4irncrx5pamh7zng35m4c5wh0pw68avaz7fbz81s953h";
   };
 
   packageName = "cl-xmlspam";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cl_plus_ssl'';
-  version = ''cl+ssl-20210228-git'';
+  baseName = "cl_plus_ssl";
+  version = "cl+ssl-20210228-git";
 
-  description = ''Common Lisp interface to OpenSSL.'';
+  description = "Common Lisp interface to OpenSSL.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."flexi-streams" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl+ssl/2021-02-28/cl+ssl-20210228-git.tgz'';
-    sha256 = ''1njppcg5fm8l0lhf7nf8nfyaz9vsr922y0vfxqdp9hp7qfid8yll'';
+    url = "http://beta.quicklisp.org/archive/cl+ssl/2021-02-28/cl+ssl-20210228-git.tgz";
+    sha256 = "1njppcg5fm8l0lhf7nf8nfyaz9vsr922y0vfxqdp9hp7qfid8yll";
   };
 
   packageName = "cl+ssl";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-handler-hunchentoot.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-handler-hunchentoot.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clack-handler-hunchentoot'';
-  version = ''clack-20191007-git'';
+  baseName = "clack-handler-hunchentoot";
+  version = "clack-20191007-git";
 
-  description = ''Clack handler for Hunchentoot.'';
+  description = "Clack handler for Hunchentoot.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-fad" args."cl-ppcre" args."clack-socket" args."flexi-streams" args."hunchentoot" args."md5" args."rfc2388" args."split-sequence" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
-    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
+    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
+    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
   };
 
   packageName = "clack-handler-hunchentoot";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clack-socket'';
-  version = ''clack-20191007-git'';
+  baseName = "clack-socket";
+  version = "clack-20191007-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
-    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
+    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
+    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
   };
 
   packageName = "clack-socket";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-test.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-test.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clack-test'';
-  version = ''clack-20191007-git'';
+  baseName = "clack-test";
+  version = "clack-20191007-git";
 
-  description = ''Testing Clack Applications.'';
+  description = "Testing Clack Applications.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-annot" args."cl-base64" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."dexador" args."dissect" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."local-time" args."md5" args."named-readtables" args."proc-parse" args."quri" args."rfc2388" args."rove" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
-    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
+    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
+    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
   };
 
   packageName = "clack-test";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-v1-compat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-v1-compat.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clack-v1-compat'';
-  version = ''clack-20191007-git'';
+  baseName = "clack-v1-compat";
+  version = "clack-20191007-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."circular-streams" args."cl_plus_ssl" args."cl-annot" args."cl-base64" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."clack-test" args."dexador" args."dissect" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."local-time" args."marshal" args."md5" args."named-readtables" args."proc-parse" args."quri" args."rfc2388" args."rove" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."uiop" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
-    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
+    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
+    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
   };
 
   packageName = "clack-v1-compat";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clack'';
-  version = ''20191007-git'';
+  baseName = "clack";
+  version = "20191007-git";
 
-  description = ''Web application environment for Common Lisp'';
+  description = "Web application environment for Common Lisp";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
-    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
+    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
+    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
   };
 
   packageName = "clack";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clfswm.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clfswm.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clfswm'';
-  version = ''20161204-git'';
+  baseName = "clfswm";
+  version = "20161204-git";
 
-  description = ''CLFSWM: Fullscreen Window Manager'';
+  description = "CLFSWM: Fullscreen Window Manager";
 
   deps = [ args."clx" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clfswm/2016-12-04/clfswm-20161204-git.tgz'';
-    sha256 = ''1jgz127721dgcv3qm1knc335gy04vzh9gl0hshp256rxi82cpp73'';
+    url = "http://beta.quicklisp.org/archive/clfswm/2016-12-04/clfswm-20161204-git.tgz";
+    sha256 = "1jgz127721dgcv3qm1knc335gy04vzh9gl0hshp256rxi82cpp73";
   };
 
   packageName = "clfswm";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''closer-mop'';
-  version = ''20210228-git'';
+  baseName = "closer-mop";
+  version = "20210228-git";
 
-  description = ''Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.'';
+  description = "Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/closer-mop/2021-02-28/closer-mop-20210228-git.tgz'';
-    sha256 = ''0x3rp2v84zzw5mhcxrgbq2kcb9gs4jn1l9rh4ylsnih89l9lqc6i'';
+    url = "http://beta.quicklisp.org/archive/closer-mop/2021-02-28/closer-mop-20210228-git.tgz";
+    sha256 = "0x3rp2v84zzw5mhcxrgbq2kcb9gs4jn1l9rh4ylsnih89l9lqc6i";
   };
 
   packageName = "closer-mop";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/closure-common.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/closure-common.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''closure-common'';
-  version = ''20181018-git'';
+  baseName = "closure-common";
+  version = "20181018-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."babel" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/closure-common/2018-10-18/closure-common-20181018-git.tgz'';
-    sha256 = ''18bp7jnxma9hscp09fa723ws9nnynjil935rp8dy9hp6ypghpxpn'';
+    url = "http://beta.quicklisp.org/archive/closure-common/2018-10-18/closure-common-20181018-git.tgz";
+    sha256 = "18bp7jnxma9hscp09fa723ws9nnynjil935rp8dy9hp6ypghpxpn";
   };
 
   packageName = "closure-common";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/closure-html.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/closure-html.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''closure-html'';
-  version = ''20180711-git'';
+  baseName = "closure-html";
+  version = "20180711-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."babel" args."closure-common" args."flexi-streams" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/closure-html/2018-07-11/closure-html-20180711-git.tgz'';
-    sha256 = ''0ljcrz1wix77h1ywp0bixm3pb5ncmr1vdiwh8m1qzkygwpfjr8aq'';
+    url = "http://beta.quicklisp.org/archive/closure-html/2018-07-11/closure-html-20180711-git.tgz";
+    sha256 = "0ljcrz1wix77h1ywp0bixm3pb5ncmr1vdiwh8m1qzkygwpfjr8aq";
   };
 
   packageName = "closure-html";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql-postgresql-socket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql-postgresql-socket.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clsql-postgresql-socket'';
-  version = ''clsql-20210228-git'';
+  baseName = "clsql-postgresql-socket";
+  version = "clsql-20210228-git";
 
-  description = ''Common Lisp SQL PostgreSQL Socket Driver'';
+  description = "Common Lisp SQL PostgreSQL Socket Driver";
 
   deps = [ args."clsql" args."md5" args."uffi" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz'';
-    sha256 = ''0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4'';
+    url = "http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz";
+    sha256 = "0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4";
   };
 
   packageName = "clsql-postgresql-socket";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql-postgresql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql-postgresql.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clsql-postgresql'';
-  version = ''clsql-20210228-git'';
+  baseName = "clsql-postgresql";
+  version = "clsql-20210228-git";
 
-  description = ''Common Lisp PostgreSQL API Driver'';
+  description = "Common Lisp PostgreSQL API Driver";
 
   deps = [ args."clsql" args."clsql-uffi" args."uffi" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz'';
-    sha256 = ''0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4'';
+    url = "http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz";
+    sha256 = "0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4";
   };
 
   packageName = "clsql-postgresql";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql-sqlite3.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql-sqlite3.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clsql-sqlite3'';
-  version = ''clsql-20210228-git'';
+  baseName = "clsql-sqlite3";
+  version = "clsql-20210228-git";
 
-  description = ''Common Lisp Sqlite3 Driver'';
+  description = "Common Lisp Sqlite3 Driver";
 
   deps = [ args."clsql" args."clsql-uffi" args."uffi" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz'';
-    sha256 = ''0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4'';
+    url = "http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz";
+    sha256 = "0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4";
   };
 
   packageName = "clsql-sqlite3";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql-uffi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql-uffi.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clsql-uffi'';
-  version = ''clsql-20210228-git'';
+  baseName = "clsql-uffi";
+  version = "clsql-20210228-git";
 
-  description = ''Common UFFI Helper functions for Common Lisp SQL Interface Library'';
+  description = "Common UFFI Helper functions for Common Lisp SQL Interface Library";
 
   deps = [ args."clsql" args."uffi" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz'';
-    sha256 = ''0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4'';
+    url = "http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz";
+    sha256 = "0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4";
   };
 
   packageName = "clsql-uffi";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clsql.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clsql'';
-  version = ''20210228-git'';
+  baseName = "clsql";
+  version = "20210228-git";
 
-  description = ''Common Lisp SQL Interface library'';
+  description = "Common Lisp SQL Interface library";
 
   deps = [ args."uffi" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz'';
-    sha256 = ''0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4'';
+    url = "http://beta.quicklisp.org/archive/clsql/2021-02-28/clsql-20210228-git.tgz";
+    sha256 = "0g7racshjy47xbfijymddjwnphp0c93z2lnlgi330g257s9l7vd4";
   };
 
   packageName = "clsql";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clss.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clss.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clss'';
-  version = ''20191130-git'';
+  baseName = "clss";
+  version = "20191130-git";
 
-  description = ''A DOM tree searching engine based on CSS selectors.'';
+  description = "A DOM tree searching engine based on CSS selectors.";
 
   deps = [ args."array-utils" args."documentation-utils" args."plump" args."trivial-indent" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clss/2019-11-30/clss-20191130-git.tgz'';
-    sha256 = ''0cbjzsc90fpa8zqv5s0ri7ncbv6f8azgbbfsxswqfphbibkcpcka'';
+    url = "http://beta.quicklisp.org/archive/clss/2019-11-30/clss-20191130-git.tgz";
+    sha256 = "0cbjzsc90fpa8zqv5s0ri7ncbv6f8azgbbfsxswqfphbibkcpcka";
   };
 
   packageName = "clss";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump-2-3-tree.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump-2-3-tree.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clump-2-3-tree'';
-  version = ''clump-20160825-git'';
+  baseName = "clump-2-3-tree";
+  version = "clump-20160825-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."acclimation" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz'';
-    sha256 = ''1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl'';
+    url = "http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz";
+    sha256 = "1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl";
   };
 
   packageName = "clump-2-3-tree";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump-binary-tree.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump-binary-tree.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clump-binary-tree'';
-  version = ''clump-20160825-git'';
+  baseName = "clump-binary-tree";
+  version = "clump-20160825-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."acclimation" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz'';
-    sha256 = ''1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl'';
+    url = "http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz";
+    sha256 = "1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl";
   };
 
   packageName = "clump-binary-tree";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clump'';
-  version = ''20160825-git'';
+  baseName = "clump";
+  version = "20160825-git";
 
-  description = ''Library for operations on different kinds of trees'';
+  description = "Library for operations on different kinds of trees";
 
   deps = [ args."acclimation" args."clump-2-3-tree" args."clump-binary-tree" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz'';
-    sha256 = ''1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl'';
+    url = "http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz";
+    sha256 = "1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl";
   };
 
   packageName = "clump";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clunit'';
-  version = ''20171019-git'';
+  baseName = "clunit";
+  version = "20171019-git";
 
-  description = ''CLUnit is a Common Lisp unit testing framework.'';
+  description = "CLUnit is a Common Lisp unit testing framework.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clunit/2017-10-19/clunit-20171019-git.tgz'';
-    sha256 = ''1rapyh0fbjnksj8j3y6imzya1kw80882w18j0fv9iq1hlp718zs5'';
+    url = "http://beta.quicklisp.org/archive/clunit/2017-10-19/clunit-20171019-git.tgz";
+    sha256 = "1rapyh0fbjnksj8j3y6imzya1kw80882w18j0fv9iq1hlp718zs5";
   };
 
   packageName = "clunit";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit2.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clunit2'';
-  version = ''20201016-git'';
+  baseName = "clunit2";
+  version = "20201016-git";
 
-  description = ''CLUnit is a Common Lisp unit testing framework.'';
+  description = "CLUnit is a Common Lisp unit testing framework.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clunit2/2020-10-16/clunit2-20201016-git.tgz'';
-    sha256 = ''1mj3c125drq9a3pxrh0r8q3gqgq68yk7qi0zbqh4mkpavl1aspdp'';
+    url = "http://beta.quicklisp.org/archive/clunit2/2020-10-16/clunit2-20201016-git.tgz";
+    sha256 = "1mj3c125drq9a3pxrh0r8q3gqgq68yk7qi0zbqh4mkpavl1aspdp";
   };
 
   packageName = "clunit2";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clx.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clx.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''clx'';
-  version = ''20200715-git'';
+  baseName = "clx";
+  version = "20200715-git";
 
   parasites = [ "clx/test" ];
 
-  description = ''An implementation of the X Window System protocol in Lisp.'';
+  description = "An implementation of the X Window System protocol in Lisp.";
 
   deps = [ args."fiasco" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clx/2020-07-15/clx-20200715-git.tgz'';
-    sha256 = ''1fvx6m3imvkkd0z5a3jmm2v6mkrndwsidhykrs229rqx343zg8ra'';
+    url = "http://beta.quicklisp.org/archive/clx/2020-07-15/clx-20200715-git.tgz";
+    sha256 = "1fvx6m3imvkkd0z5a3jmm2v6mkrndwsidhykrs229rqx343zg8ra";
   };
 
   packageName = "clx";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/collectors.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/collectors.nix
@@ -1,18 +1,19 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''collectors'';
-  version = ''20161204-git'';
+  baseName = "collectors";
+  version = "20161204-git";
 
   parasites = [ "collectors-test" ];
 
-  description = ''A library providing various collector type macros
-   pulled from arnesi into its own library and stripped of dependencies'';
+  description = "A library providing various collector type macros
+   pulled from arnesi into its own library and stripped of dependencies";
 
   deps = [ args."alexandria" args."closer-mop" args."iterate" args."lisp-unit2" args."symbol-munger" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/collectors/2016-12-04/collectors-20161204-git.tgz'';
-    sha256 = ''0cf2y2yxraqs9v54gbj8hhp7s522gz8qfwwc5hvlhl2s7540b2zf'';
+    url = "http://beta.quicklisp.org/archive/collectors/2016-12-04/collectors-20161204-git.tgz";
+    sha256 = "0cf2y2yxraqs9v54gbj8hhp7s522gz8qfwwc5hvlhl2s7540b2zf";
   };
 
   packageName = "collectors";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/colorize.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/colorize.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''colorize'';
-  version = ''20180228-git'';
+  baseName = "colorize";
+  version = "20180228-git";
 
-  description = ''A Syntax highlighting library'';
+  description = "A Syntax highlighting library";
 
   deps = [ args."alexandria" args."html-encode" args."split-sequence" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/colorize/2018-02-28/colorize-20180228-git.tgz'';
-    sha256 = ''1g0xbryavsf17zy9iy0sbqsb4lyva04h93sbaj3iwv12w50fwz2h'';
+    url = "http://beta.quicklisp.org/archive/colorize/2018-02-28/colorize-20180228-git.tgz";
+    sha256 = "1g0xbryavsf17zy9iy0sbqsb4lyva04h93sbaj3iwv12w50fwz2h";
   };
 
   packageName = "colorize";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/command-line-arguments.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/command-line-arguments.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''command-line-arguments'';
-  version = ''20200325-git'';
+  baseName = "command-line-arguments";
+  version = "20200325-git";
 
-  description = ''small library to deal with command-line arguments'';
+  description = "small library to deal with command-line arguments";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/command-line-arguments/2020-03-25/command-line-arguments-20200325-git.tgz'';
-    sha256 = ''0ny0c0aw3mfjpmf31pnd9zfnylqh8ji2yi636w1f352c13z2w5sz'';
+    url = "http://beta.quicklisp.org/archive/command-line-arguments/2020-03-25/command-line-arguments-20200325-git.tgz";
+    sha256 = "0ny0c0aw3mfjpmf31pnd9zfnylqh8ji2yi636w1f352c13z2w5sz";
   };
 
   packageName = "command-line-arguments";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/css-lite.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/css-lite.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''css-lite'';
-  version = ''20120407-git'';
+  baseName = "css-lite";
+  version = "20120407-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/css-lite/2012-04-07/css-lite-20120407-git.tgz'';
-    sha256 = ''1gf1qqaxhly6ixh9ykqhg9b52s8p5wlwi46vp2k29qy7gmx4f1qg'';
+    url = "http://beta.quicklisp.org/archive/css-lite/2012-04-07/css-lite-20120407-git.tgz";
+    sha256 = "1gf1qqaxhly6ixh9ykqhg9b52s8p5wlwi46vp2k29qy7gmx4f1qg";
   };
 
   packageName = "css-lite";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/css-selectors-simple-tree.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/css-selectors-simple-tree.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''css-selectors-simple-tree'';
-  version = ''css-selectors-20160628-git'';
+  baseName = "css-selectors-simple-tree";
+  version = "css-selectors-20160628-git";
 
-  description = ''An implementation of css selectors that interacts with cl-html5-parser's simple-tree'';
+  description = "An implementation of css selectors that interacts with cl-html5-parser's simple-tree";
 
   deps = [ args."alexandria" args."babel" args."buildnode" args."cl-html5-parser" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."closure-common" args."closure-html" args."collectors" args."css-selectors" args."cxml" args."flexi-streams" args."iterate" args."named-readtables" args."puri" args."split-sequence" args."string-case" args."swank" args."symbol-munger" args."trivial-features" args."trivial-gray-streams" args."yacc" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/css-selectors/2016-06-28/css-selectors-20160628-git.tgz'';
-    sha256 = ''0y9q719w5cv4g7in731q5p98n7pznb05vr7i7wi92mmpah2g1w4b'';
+    url = "http://beta.quicklisp.org/archive/css-selectors/2016-06-28/css-selectors-20160628-git.tgz";
+    sha256 = "0y9q719w5cv4g7in731q5p98n7pznb05vr7i7wi92mmpah2g1w4b";
   };
 
   packageName = "css-selectors-simple-tree";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/css-selectors-stp.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/css-selectors-stp.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''css-selectors-stp'';
-  version = ''css-selectors-20160628-git'';
+  baseName = "css-selectors-stp";
+  version = "css-selectors-20160628-git";
 
-  description = ''An implementation of css selectors that interacts with cxml-stp'';
+  description = "An implementation of css selectors that interacts with cxml-stp";
 
   deps = [ args."alexandria" args."babel" args."buildnode" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."closure-common" args."closure-html" args."collectors" args."css-selectors" args."cxml" args."cxml-stp" args."flexi-streams" args."iterate" args."named-readtables" args."parse-number" args."puri" args."split-sequence" args."swank" args."symbol-munger" args."trivial-features" args."trivial-gray-streams" args."xpath" args."yacc" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/css-selectors/2016-06-28/css-selectors-20160628-git.tgz'';
-    sha256 = ''0y9q719w5cv4g7in731q5p98n7pznb05vr7i7wi92mmpah2g1w4b'';
+    url = "http://beta.quicklisp.org/archive/css-selectors/2016-06-28/css-selectors-20160628-git.tgz";
+    sha256 = "0y9q719w5cv4g7in731q5p98n7pznb05vr7i7wi92mmpah2g1w4b";
   };
 
   packageName = "css-selectors-stp";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/css-selectors.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/css-selectors.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''css-selectors'';
-  version = ''20160628-git'';
+  baseName = "css-selectors";
+  version = "20160628-git";
 
   parasites = [ "css-selectors-test" ];
 
-  description = ''An implementation of css selectors'';
+  description = "An implementation of css selectors";
 
   deps = [ args."alexandria" args."babel" args."buildnode" args."buildnode-xhtml" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."closure-common" args."closure-html" args."collectors" args."cxml" args."flexi-streams" args."iterate" args."lisp-unit2" args."named-readtables" args."puri" args."split-sequence" args."swank" args."symbol-munger" args."trivial-features" args."trivial-gray-streams" args."yacc" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/css-selectors/2016-06-28/css-selectors-20160628-git.tgz'';
-    sha256 = ''0y9q719w5cv4g7in731q5p98n7pznb05vr7i7wi92mmpah2g1w4b'';
+    url = "http://beta.quicklisp.org/archive/css-selectors/2016-06-28/css-selectors-20160628-git.tgz";
+    sha256 = "0y9q719w5cv4g7in731q5p98n7pznb05vr7i7wi92mmpah2g1w4b";
   };
 
   packageName = "css-selectors";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cxml-stp.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cxml-stp.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cxml-stp'';
-  version = ''20200325-git'';
+  baseName = "cxml-stp";
+  version = "20200325-git";
 
   parasites = [ "cxml-stp/test" ];
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."babel" args."cl-ppcre" args."closure-common" args."cxml" args."cxml_slash_test" args."parse-number" args."puri" args."rt" args."trivial-features" args."trivial-gray-streams" args."xpath" args."xpath_slash_test" args."yacc" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cxml-stp/2020-03-25/cxml-stp-20200325-git.tgz'';
-    sha256 = ''1y26bksmysvxifqx4lslpbsdvmcqkf7di36a3yyqnjgrb5r0jv1n'';
+    url = "http://beta.quicklisp.org/archive/cxml-stp/2020-03-25/cxml-stp-20200325-git.tgz";
+    sha256 = "1y26bksmysvxifqx4lslpbsdvmcqkf7di36a3yyqnjgrb5r0jv1n";
   };
 
   packageName = "cxml-stp";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cxml.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cxml.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''cxml'';
-  version = ''20200610-git'';
+  baseName = "cxml";
+  version = "20200610-git";
 
   parasites = [ "cxml/dom" "cxml/klacks" "cxml/test" "cxml/xml" ];
 
-  description = ''Closure XML - a Common Lisp XML parser'';
+  description = "Closure XML - a Common Lisp XML parser";
 
   deps = [ args."alexandria" args."babel" args."closure-common" args."puri" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cxml/2020-06-10/cxml-20200610-git.tgz'';
-    sha256 = ''0545rh4mfxqx2yn9b48s0hzd5w80kars7hpykbg0lgf7ys5218mq'';
+    url = "http://beta.quicklisp.org/archive/cxml/2020-06-10/cxml-20200610-git.tgz";
+    sha256 = "0545rh4mfxqx2yn9b48s0hzd5w80kars7hpykbg0lgf7ys5218mq";
   };
 
   packageName = "cxml";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-mysql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-mysql.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''dbd-mysql'';
-  version = ''cl-dbi-20210228-git'';
+  baseName = "dbd-mysql";
+  version = "cl-dbi-20210228-git";
 
-  description = ''Database driver for MySQL.'';
+  description = "Database driver for MySQL.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-mysql" args."closer-mop" args."dbi" args."split-sequence" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz'';
-    sha256 = ''0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk'';
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
+    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
   };
 
   packageName = "dbd-mysql";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-postgres.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''dbd-postgres'';
-  version = ''cl-dbi-20210228-git'';
+  baseName = "dbd-postgres";
+  version = "cl-dbi-20210228-git";
 
-  description = ''Database driver for PostgreSQL.'';
+  description = "Database driver for PostgreSQL.";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-ppcre" args."closer-mop" args."dbi" args."ironclad" args."md5" args."split-sequence" args."trivial-garbage" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz'';
-    sha256 = ''0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk'';
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
+    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
   };
 
   packageName = "dbd-postgres";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-sqlite3.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-sqlite3.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''dbd-sqlite3'';
-  version = ''cl-dbi-20210228-git'';
+  baseName = "dbd-sqlite3";
+  version = "cl-dbi-20210228-git";
 
-  description = ''Database driver for SQLite3.'';
+  description = "Database driver for SQLite3.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."closer-mop" args."dbi" args."iterate" args."split-sequence" args."sqlite" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz'';
-    sha256 = ''0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk'';
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
+    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
   };
 
   packageName = "dbd-sqlite3";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi-test.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi-test.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''dbi-test'';
-  version = ''cl-dbi-20210228-git'';
+  baseName = "dbi-test";
+  version = "cl-dbi-20210228-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."closer-mop" args."dbi" args."dissect" args."rove" args."split-sequence" args."trivial-gray-streams" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz'';
-    sha256 = ''0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk'';
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
+    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
   };
 
   packageName = "dbi-test";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''dbi'';
-  version = ''cl-20210228-git'';
+  baseName = "dbi";
+  version = "cl-20210228-git";
 
   parasites = [ "dbi/test" ];
 
-  description = ''Database independent interface for Common Lisp'';
+  description = "Database independent interface for Common Lisp";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-mysql" args."cl-postgres" args."closer-mop" args."dbd-mysql" args."dbd-postgres" args."dbd-sqlite3" args."dbi-test" args."rove" args."split-sequence" args."sqlite" args."trivial-garbage" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz'';
-    sha256 = ''0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk'';
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
+    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
   };
 
   packageName = "dbi";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbus.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbus.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''dbus'';
-  version = ''20200610-git'';
+  baseName = "dbus";
+  version = "20200610-git";
 
-  description = ''A D-BUS client library for Common Lisp'';
+  description = "A D-BUS client library for Common Lisp";
 
   deps = [ args."alexandria" args."asdf-package-system" args."babel" args."cl-xmlspam" args."flexi-streams" args."ieee-floats" args."iolib" args."ironclad" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/dbus/2020-06-10/dbus-20200610-git.tgz'';
-    sha256 = ''1njwjf1z9xngsfmlddmbcan49vcjqvvxfkhbi62xcxwbn9rgqn79'';
+    url = "http://beta.quicklisp.org/archive/dbus/2020-06-10/dbus-20200610-git.tgz";
+    sha256 = "1njwjf1z9xngsfmlddmbcan49vcjqvvxfkhbi62xcxwbn9rgqn79";
   };
 
   packageName = "dbus";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''dexador'';
-  version = ''20210228-git'';
+  baseName = "dexador";
+  version = "20210228-git";
 
-  description = ''Yet another HTTP client for Common Lisp'';
+  description = "Yet another HTTP client for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-cookie" args."cl-ppcre" args."cl-reexport" args."cl-utilities" args."fast-http" args."fast-io" args."flexi-streams" args."local-time" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/dexador/2021-02-28/dexador-20210228-git.tgz'';
-    sha256 = ''0glzvi7nbr58izpwr8xzxvlcc78zmgwqaik374rmcy6w89q5ksw7'';
+    url = "http://beta.quicklisp.org/archive/dexador/2021-02-28/dexador-20210228-git.tgz";
+    sha256 = "0glzvi7nbr58izpwr8xzxvlcc78zmgwqaik374rmcy6w89q5ksw7";
   };
 
   packageName = "dexador";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dissect.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dissect.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''dissect'';
-  version = ''20200427-git'';
+  baseName = "dissect";
+  version = "20200427-git";
 
-  description = ''A lib for introspecting the call stack and active restarts.'';
+  description = "A lib for introspecting the call stack and active restarts.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/dissect/2020-04-27/dissect-20200427-git.tgz'';
-    sha256 = ''1d7sri20jma9r105lxv0sx2q60kb8zp7bf023kain3rnyqr74v8a'';
+    url = "http://beta.quicklisp.org/archive/dissect/2020-04-27/dissect-20200427-git.tgz";
+    sha256 = "1d7sri20jma9r105lxv0sx2q60kb8zp7bf023kain3rnyqr74v8a";
   };
 
   packageName = "dissect";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''djula'';
-  version = ''20210124-git'';
+  baseName = "djula";
+  version = "20210124-git";
 
-  description = ''An implementation of Django templates for Common Lisp.'';
+  description = "An implementation of Django templates for Common Lisp.";
 
   deps = [ args."access" args."alexandria" args."anaphora" args."arnesi" args."babel" args."cl-annot" args."cl-interpol" args."cl-locale" args."cl-ppcre" args."cl-slice" args."cl-syntax" args."cl-syntax-annot" args."cl-unicode" args."closer-mop" args."collectors" args."flexi-streams" args."gettext" args."iterate" args."let-plus" args."local-time" args."named-readtables" args."parser-combinators" args."split-sequence" args."symbol-munger" args."trivial-backtrace" args."trivial-features" args."trivial-gray-streams" args."trivial-types" args."yacc" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/djula/2021-01-24/djula-20210124-git.tgz'';
-    sha256 = ''0hkyp5himz73r2l3vbwkwsd1as4f75ih6wh7v1wbabpbjwh2j2vx'';
+    url = "http://beta.quicklisp.org/archive/djula/2021-01-24/djula-20210124-git.tgz";
+    sha256 = "0hkyp5himz73r2l3vbwkwsd1as4f75ih6wh7v1wbabpbjwh2j2vx";
   };
 
   packageName = "djula";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/do-urlencode.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/do-urlencode.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''do-urlencode'';
-  version = ''20181018-git'';
+  baseName = "do-urlencode";
+  version = "20181018-git";
 
-  description = ''Percent Encoding (aka URL Encoding) library'';
+  description = "Percent Encoding (aka URL Encoding) library";
 
   deps = [ args."alexandria" args."babel" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/do-urlencode/2018-10-18/do-urlencode-20181018-git.tgz'';
-    sha256 = ''1cajd219s515y65kp562c6xczqaq0p4lyp13iv00z6i44rijmfp2'';
+    url = "http://beta.quicklisp.org/archive/do-urlencode/2018-10-18/do-urlencode-20181018-git.tgz";
+    sha256 = "1cajd219s515y65kp562c6xczqaq0p4lyp13iv00z6i44rijmfp2";
   };
 
   packageName = "do-urlencode";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/documentation-utils.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/documentation-utils.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''documentation-utils'';
-  version = ''20190710-git'';
+  baseName = "documentation-utils";
+  version = "20190710-git";
 
-  description = ''A few simple tools to help you with documenting your library.'';
+  description = "A few simple tools to help you with documenting your library.";
 
   deps = [ args."trivial-indent" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/documentation-utils/2019-07-10/documentation-utils-20190710-git.tgz'';
-    sha256 = ''1n3z8sw75k2jjpsg6ch5g9s4v56y96dbs4338ajrfdsk3pk4wgj3'';
+    url = "http://beta.quicklisp.org/archive/documentation-utils/2019-07-10/documentation-utils-20190710-git.tgz";
+    sha256 = "1n3z8sw75k2jjpsg6ch5g9s4v56y96dbs4338ajrfdsk3pk4wgj3";
   };
 
   packageName = "documentation-utils";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/drakma.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/drakma.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''drakma'';
-  version = ''v2.0.7'';
+  baseName = "drakma";
+  version = "v2.0.7";
 
-  description = ''Full-featured http/https client based on usocket'';
+  description = "Full-featured http/https client based on usocket";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-ppcre" args."flexi-streams" args."puri" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/drakma/2019-11-30/drakma-v2.0.7.tgz'';
-    sha256 = ''1r0sh0nsx7fq24yybazjw8n7grk1b85l52x523axwchnnaj58kzw'';
+    url = "http://beta.quicklisp.org/archive/drakma/2019-11-30/drakma-v2.0.7.tgz";
+    sha256 = "1r0sh0nsx7fq24yybazjw8n7grk1b85l52x523axwchnnaj58kzw";
   };
 
   packageName = "drakma";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/eager-future2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/eager-future2.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''eager-future2'';
-  version = ''20191130-git'';
+  baseName = "eager-future2";
+  version = "20191130-git";
 
-  description = ''Parallel programming library providing the futures/promises synchronization mechanism'';
+  description = "Parallel programming library providing the futures/promises synchronization mechanism";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/eager-future2/2019-11-30/eager-future2-20191130-git.tgz'';
-    sha256 = ''01pvgcp6d4hz1arpvsv73m8xnbv8qm2d0qychpxc72d0m71p6ks0'';
+    url = "http://beta.quicklisp.org/archive/eager-future2/2019-11-30/eager-future2-20191130-git.tgz";
+    sha256 = "01pvgcp6d4hz1arpvsv73m8xnbv8qm2d0qychpxc72d0m71p6ks0";
   };
 
   packageName = "eager-future2";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/enchant.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/enchant.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''enchant'';
-  version = ''cl-20190521-git'';
+  baseName = "enchant";
+  version = "cl-20190521-git";
 
-  description = ''Programming interface for Enchant spell-checker library'';
+  description = "Programming interface for Enchant spell-checker library";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-enchant/2019-05-21/cl-enchant-20190521-git.tgz'';
-    sha256 = ''16ag48fr74m536an8fak5z0lfjdb265gv1ajai1lqg0vq2l5mr14'';
+    url = "http://beta.quicklisp.org/archive/cl-enchant/2019-05-21/cl-enchant-20190521-git.tgz";
+    sha256 = "16ag48fr74m536an8fak5z0lfjdb265gv1ajai1lqg0vq2l5mr14";
   };
 
   packageName = "enchant";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap-peg.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap-peg.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''esrap-peg'';
-  version = ''20191007-git'';
+  baseName = "esrap-peg";
+  version = "20191007-git";
 
-  description = ''A wrapper around Esrap to allow generating Esrap grammars from PEG definitions'';
+  description = "A wrapper around Esrap to allow generating Esrap grammars from PEG definitions";
 
   deps = [ args."alexandria" args."cl-unification" args."esrap" args."iterate" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/esrap-peg/2019-10-07/esrap-peg-20191007-git.tgz'';
-    sha256 = ''0285ngcm73rpzmr0ydy6frps2b4q6n4jymjv3ncwsh81x5blfvis'';
+    url = "http://beta.quicklisp.org/archive/esrap-peg/2019-10-07/esrap-peg-20191007-git.tgz";
+    sha256 = "0285ngcm73rpzmr0ydy6frps2b4q6n4jymjv3ncwsh81x5blfvis";
   };
 
   packageName = "esrap-peg";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''esrap'';
-  version = ''20201220-git'';
+  baseName = "esrap";
+  version = "20201220-git";
 
   parasites = [ "esrap/tests" ];
 
-  description = ''A Packrat / Parsing Grammar / TDPL parser for Common Lisp.'';
+  description = "A Packrat / Parsing Grammar / TDPL parser for Common Lisp.";
 
   deps = [ args."alexandria" args."fiveam" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/esrap/2020-12-20/esrap-20201220-git.tgz'';
-    sha256 = ''0yhi4ay98i81nqv9yjlj321azwmiylsw0afdd6y1c1zflfcrzkrk'';
+    url = "http://beta.quicklisp.org/archive/esrap/2020-12-20/esrap-20201220-git.tgz";
+    sha256 = "0yhi4ay98i81nqv9yjlj321azwmiylsw0afdd6y1c1zflfcrzkrk";
   };
 
   packageName = "esrap";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/external-program.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/external-program.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''external-program'';
-  version = ''20190307-git'';
+  baseName = "external-program";
+  version = "20190307-git";
 
   parasites = [ "external-program-test" ];
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."fiveam" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/external-program/2019-03-07/external-program-20190307-git.tgz'';
-    sha256 = ''1nl3mngh7vp2l9mfbdhni4nc164zznafnl74p1kv9j07n5fcpnyz'';
+    url = "http://beta.quicklisp.org/archive/external-program/2019-03-07/external-program-20190307-git.tgz";
+    sha256 = "1nl3mngh7vp2l9mfbdhni4nc164zznafnl74p1kv9j07n5fcpnyz";
   };
 
   packageName = "external-program";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-csv.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-csv.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fare-csv'';
-  version = ''20171227-git'';
+  baseName = "fare-csv";
+  version = "20171227-git";
 
-  description = ''Robust CSV parser and printer'';
+  description = "Robust CSV parser and printer";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fare-csv/2017-12-27/fare-csv-20171227-git.tgz'';
-    sha256 = ''1hkzg05kq2c4xihsfx4wk1k6mmjq2fw40id8vy0315rpa47a5i7x'';
+    url = "http://beta.quicklisp.org/archive/fare-csv/2017-12-27/fare-csv-20171227-git.tgz";
+    sha256 = "1hkzg05kq2c4xihsfx4wk1k6mmjq2fw40id8vy0315rpa47a5i7x";
   };
 
   packageName = "fare-csv";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-mop.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-mop.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fare-mop'';
-  version = ''20151218-git'';
+  baseName = "fare-mop";
+  version = "20151218-git";
 
-  description = ''Utilities using the MOP; notably make informative pretty-printing trivial'';
+  description = "Utilities using the MOP; notably make informative pretty-printing trivial";
 
   deps = [ args."closer-mop" args."fare-utils" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fare-mop/2015-12-18/fare-mop-20151218-git.tgz'';
-    sha256 = ''0bvrwqvacy114xsblrk2w28qk6b484a3p0w14mzl264b3wjrdna9'';
+    url = "http://beta.quicklisp.org/archive/fare-mop/2015-12-18/fare-mop-20151218-git.tgz";
+    sha256 = "0bvrwqvacy114xsblrk2w28qk6b484a3p0w14mzl264b3wjrdna9";
   };
 
   packageName = "fare-mop";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-extras.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-extras.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fare-quasiquote-extras'';
-  version = ''fare-quasiquote-20200925-git'';
+  baseName = "fare-quasiquote-extras";
+  version = "fare-quasiquote-20200925-git";
 
-  description = ''fare-quasiquote plus extras'';
+  description = "fare-quasiquote plus extras";
 
   deps = [ args."alexandria" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."lisp-namespace" args."named-readtables" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fare-quasiquote/2020-09-25/fare-quasiquote-20200925-git.tgz'';
-    sha256 = ''0k25kx4gvr046bcnv5mqxbb4483v9p2lk7dvzjkgj2cxrvczmj8b'';
+    url = "http://beta.quicklisp.org/archive/fare-quasiquote/2020-09-25/fare-quasiquote-20200925-git.tgz";
+    sha256 = "0k25kx4gvr046bcnv5mqxbb4483v9p2lk7dvzjkgj2cxrvczmj8b";
   };
 
   packageName = "fare-quasiquote-extras";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-optima.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-optima.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fare-quasiquote-optima'';
-  version = ''fare-quasiquote-20200925-git'';
+  baseName = "fare-quasiquote-optima";
+  version = "fare-quasiquote-20200925-git";
 
-  description = ''fare-quasiquote extension for optima'';
+  description = "fare-quasiquote extension for optima";
 
   deps = [ args."alexandria" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-readtable" args."fare-utils" args."lisp-namespace" args."named-readtables" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fare-quasiquote/2020-09-25/fare-quasiquote-20200925-git.tgz'';
-    sha256 = ''0k25kx4gvr046bcnv5mqxbb4483v9p2lk7dvzjkgj2cxrvczmj8b'';
+    url = "http://beta.quicklisp.org/archive/fare-quasiquote/2020-09-25/fare-quasiquote-20200925-git.tgz";
+    sha256 = "0k25kx4gvr046bcnv5mqxbb4483v9p2lk7dvzjkgj2cxrvczmj8b";
   };
 
   packageName = "fare-quasiquote-optima";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-readtable.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-readtable.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fare-quasiquote-readtable'';
-  version = ''fare-quasiquote-20200925-git'';
+  baseName = "fare-quasiquote-readtable";
+  version = "fare-quasiquote-20200925-git";
 
-  description = ''Using fare-quasiquote with named-readtable'';
+  description = "Using fare-quasiquote with named-readtable";
 
   deps = [ args."fare-quasiquote" args."fare-utils" args."named-readtables" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fare-quasiquote/2020-09-25/fare-quasiquote-20200925-git.tgz'';
-    sha256 = ''0k25kx4gvr046bcnv5mqxbb4483v9p2lk7dvzjkgj2cxrvczmj8b'';
+    url = "http://beta.quicklisp.org/archive/fare-quasiquote/2020-09-25/fare-quasiquote-20200925-git.tgz";
+    sha256 = "0k25kx4gvr046bcnv5mqxbb4483v9p2lk7dvzjkgj2cxrvczmj8b";
   };
 
   packageName = "fare-quasiquote-readtable";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fare-quasiquote'';
-  version = ''20200925-git'';
+  baseName = "fare-quasiquote";
+  version = "20200925-git";
 
-  description = ''Portable, matchable implementation of quasiquote'';
+  description = "Portable, matchable implementation of quasiquote";
 
   deps = [ args."fare-utils" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fare-quasiquote/2020-09-25/fare-quasiquote-20200925-git.tgz'';
-    sha256 = ''0k25kx4gvr046bcnv5mqxbb4483v9p2lk7dvzjkgj2cxrvczmj8b'';
+    url = "http://beta.quicklisp.org/archive/fare-quasiquote/2020-09-25/fare-quasiquote-20200925-git.tgz";
+    sha256 = "0k25kx4gvr046bcnv5mqxbb4483v9p2lk7dvzjkgj2cxrvczmj8b";
   };
 
   packageName = "fare-quasiquote";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-utils.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-utils.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fare-utils'';
-  version = ''20170124-git'';
+  baseName = "fare-utils";
+  version = "20170124-git";
 
-  description = ''Basic functions and macros, interfaces, pure and stateful datastructures'';
+  description = "Basic functions and macros, interfaces, pure and stateful datastructures";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fare-utils/2017-01-24/fare-utils-20170124-git.tgz'';
-    sha256 = ''0jhb018ccn3spkgjywgd0524m5qacn8x15fdiban4zz3amj9dapq'';
+    url = "http://beta.quicklisp.org/archive/fare-utils/2017-01-24/fare-utils-20170124-git.tgz";
+    sha256 = "0jhb018ccn3spkgjywgd0524m5qacn8x15fdiban4zz3amj9dapq";
   };
 
   packageName = "fare-utils";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fast-http.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fast-http.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fast-http'';
-  version = ''20191007-git'';
+  baseName = "fast-http";
+  version = "20191007-git";
 
-  description = ''A fast HTTP protocol parser in Common Lisp'';
+  description = "A fast HTTP protocol parser in Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."cl-utilities" args."flexi-streams" args."proc-parse" args."smart-buffer" args."trivial-features" args."trivial-gray-streams" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fast-http/2019-10-07/fast-http-20191007-git.tgz'';
-    sha256 = ''00qnl56cfss2blm4pp03dwv84bmkyd0kbarhahclxbn8f7pgwf32'';
+    url = "http://beta.quicklisp.org/archive/fast-http/2019-10-07/fast-http-20191007-git.tgz";
+    sha256 = "00qnl56cfss2blm4pp03dwv84bmkyd0kbarhahclxbn8f7pgwf32";
   };
 
   packageName = "fast-http";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fast-io.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fast-io.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fast-io'';
-  version = ''20200925-git'';
+  baseName = "fast-io";
+  version = "20200925-git";
 
-  description = ''Alternative I/O mechanism to a stream or vector'';
+  description = "Alternative I/O mechanism to a stream or vector";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."static-vectors" args."trivial-features" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fast-io/2020-09-25/fast-io-20200925-git.tgz'';
-    sha256 = ''1rgyr6y20fp3jqnx5snpjf9lngzalip2a28l04ssypwagmhaa975'';
+    url = "http://beta.quicklisp.org/archive/fast-io/2020-09-25/fast-io-20200925-git.tgz";
+    sha256 = "1rgyr6y20fp3jqnx5snpjf9lngzalip2a28l04ssypwagmhaa975";
   };
 
   packageName = "fast-io";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiasco.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiasco.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fiasco'';
-  version = ''20200610-git'';
+  baseName = "fiasco";
+  version = "20200610-git";
 
   parasites = [ "fiasco-self-tests" ];
 
-  description = ''A Common Lisp test framework that treasures your failures, logical continuation of Stefil.'';
+  description = "A Common Lisp test framework that treasures your failures, logical continuation of Stefil.";
 
   deps = [ args."alexandria" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fiasco/2020-06-10/fiasco-20200610-git.tgz'';
-    sha256 = ''1wb0ibw6ka9fbsb40zjipn7vh3jbzyfsvcc9gq19nqhbqa8gy9r4'';
+    url = "http://beta.quicklisp.org/archive/fiasco/2020-06-10/fiasco-20200610-git.tgz";
+    sha256 = "1wb0ibw6ka9fbsb40zjipn7vh3jbzyfsvcc9gq19nqhbqa8gy9r4";
   };
 
   packageName = "fiasco";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/file-attributes.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/file-attributes.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''file-attributes'';
-  version = ''20200925-git'';
+  baseName = "file-attributes";
+  version = "20200925-git";
 
-  description = ''Access to file attributes (uid, gid, atime, mtime, mod)'';
+  description = "Access to file attributes (uid, gid, atime, mtime, mod)";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."documentation-utils" args."trivial-features" args."trivial-indent" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/file-attributes/2020-09-25/file-attributes-20200925-git.tgz'';
-    sha256 = ''0wq3gs36zwl8dzknj3c794l60vg1zpf0siwhd7ad9pn81v3mdan7'';
+    url = "http://beta.quicklisp.org/archive/file-attributes/2020-09-25/file-attributes-20200925-git.tgz";
+    sha256 = "0wq3gs36zwl8dzknj3c794l60vg1zpf0siwhd7ad9pn81v3mdan7";
   };
 
   packageName = "file-attributes";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiveam.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiveam.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fiveam'';
-  version = ''20200925-git'';
+  baseName = "fiveam";
+  version = "20200925-git";
 
   parasites = [ "fiveam/test" ];
 
-  description = ''A simple regression testing framework'';
+  description = "A simple regression testing framework";
 
   deps = [ args."alexandria" args."net_dot_didierverna_dot_asdf-flv" args."trivial-backtrace" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fiveam/2020-09-25/fiveam-20200925-git.tgz'';
-    sha256 = ''0j9dzjs4prlx33f5idbcic4amx2mcgnjcyrpc3dd4b7lrw426l0d'';
+    url = "http://beta.quicklisp.org/archive/fiveam/2020-09-25/fiveam-20200925-git.tgz";
+    sha256 = "0j9dzjs4prlx33f5idbcic4amx2mcgnjcyrpc3dd4b7lrw426l0d";
   };
 
   packageName = "fiveam";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/flexi-streams.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/flexi-streams.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''flexi-streams'';
-  version = ''20200925-git'';
+  baseName = "flexi-streams";
+  version = "20200925-git";
 
   parasites = [ "flexi-streams-test" ];
 
-  description = ''Flexible bivalent streams for Common Lisp'';
+  description = "Flexible bivalent streams for Common Lisp";
 
   deps = [ args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/flexi-streams/2020-09-25/flexi-streams-20200925-git.tgz'';
-    sha256 = ''1hmsryfkjnk4gdv803s3hpp71fpdybfl1jb5hgngxpd5lsrq0gb2'';
+    url = "http://beta.quicklisp.org/archive/flexi-streams/2020-09-25/flexi-streams-20200925-git.tgz";
+    sha256 = "1hmsryfkjnk4gdv803s3hpp71fpdybfl1jb5hgngxpd5lsrq0gb2";
   };
 
   packageName = "flexi-streams";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/form-fiddle.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/form-fiddle.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''form-fiddle'';
-  version = ''20190710-git'';
+  baseName = "form-fiddle";
+  version = "20190710-git";
 
-  description = ''A collection of utilities to destructure lambda forms.'';
+  description = "A collection of utilities to destructure lambda forms.";
 
   deps = [ args."documentation-utils" args."trivial-indent" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/form-fiddle/2019-07-10/form-fiddle-20190710-git.tgz'';
-    sha256 = ''12zmqm2vls043kaka7jp6pnsvkxlyv6x183yjyrs8jk461qfydwl'';
+    url = "http://beta.quicklisp.org/archive/form-fiddle/2019-07-10/form-fiddle-20190710-git.tgz";
+    sha256 = "12zmqm2vls043kaka7jp6pnsvkxlyv6x183yjyrs8jk461qfydwl";
   };
 
   packageName = "form-fiddle";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fset.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fset.nix
@@ -1,19 +1,20 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''fset'';
-  version = ''20200925-git'';
+  baseName = "fset";
+  version = "20200925-git";
 
   parasites = [ "fset/test" ];
 
-  description = ''A functional set-theoretic collections library.
+  description = "A functional set-theoretic collections library.
 See: http://www.ergy.com/FSet.html
-'';
+";
 
   deps = [ args."misc-extensions" args."mt19937" args."named-readtables" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fset/2020-09-25/fset-20200925-git.tgz'';
-    sha256 = ''19fr6ds1a493b0kbsligpn7i771r1yfshbbkdp0hxs4l792l05wv'';
+    url = "http://beta.quicklisp.org/archive/fset/2020-09-25/fset-20200925-git.tgz";
+    sha256 = "19fr6ds1a493b0kbsligpn7i771r1yfshbbkdp0hxs4l792l05wv";
   };
 
   packageName = "fset";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/gettext.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/gettext.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''gettext'';
-  version = ''20171130-git'';
+  baseName = "gettext";
+  version = "20171130-git";
 
-  description = ''An pure Common Lisp implementation of gettext runtime. gettext is an internationalization and localization (i18n) system commonly used for writing multilingual programs on Unix-like computer operating systems.'';
+  description = "An pure Common Lisp implementation of gettext runtime. gettext is an internationalization and localization (i18n) system commonly used for writing multilingual programs on Unix-like computer operating systems.";
 
   deps = [ args."flexi-streams" args."split-sequence" args."trivial-gray-streams" args."yacc" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/gettext/2017-11-30/gettext-20171130-git.tgz'';
-    sha256 = ''0nb8i66sb5qmpnk6rk2adlr87m322bra0xpirp63872mybd3y6yd'';
+    url = "http://beta.quicklisp.org/archive/gettext/2017-11-30/gettext-20171130-git.tgz";
+    sha256 = "0nb8i66sb5qmpnk6rk2adlr87m322bra0xpirp63872mybd3y6yd";
   };
 
   packageName = "gettext";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/global-vars.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/global-vars.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''global-vars'';
-  version = ''20141106-git'';
+  baseName = "global-vars";
+  version = "20141106-git";
 
-  description = ''Define efficient global variables.'';
+  description = "Define efficient global variables.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/global-vars/2014-11-06/global-vars-20141106-git.tgz'';
-    sha256 = ''0bjgmsifs9vrq409rfrsgrhlxwklvls1dpvh2d706i0incxq957j'';
+    url = "http://beta.quicklisp.org/archive/global-vars/2014-11-06/global-vars-20141106-git.tgz";
+    sha256 = "0bjgmsifs9vrq409rfrsgrhlxwklvls1dpvh2d706i0incxq957j";
   };
 
   packageName = "global-vars";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/html-encode.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/html-encode.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''html-encode'';
-  version = ''1.2'';
+  baseName = "html-encode";
+  version = "1.2";
 
-  description = ''A library for encoding text in various web-savvy encodings.'';
+  description = "A library for encoding text in various web-savvy encodings.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/html-encode/2010-10-06/html-encode-1.2.tgz'';
-    sha256 = ''06mf8wn95yf5swhmzk4vp0xr4ylfl33dgfknkabbkd8n6jns8gcf'';
+    url = "http://beta.quicklisp.org/archive/html-encode/2010-10-06/html-encode-1.2.tgz";
+    sha256 = "06mf8wn95yf5swhmzk4vp0xr4ylfl33dgfknkabbkd8n6jns8gcf";
   };
 
   packageName = "html-encode";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/http-body.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/http-body.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''http-body'';
-  version = ''20190813-git'';
+  baseName = "http-body";
+  version = "20190813-git";
 
-  description = ''HTTP POST data parser for Common Lisp'';
+  description = "HTTP POST data parser for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-annot" args."cl-ppcre" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."fast-http" args."fast-io" args."flexi-streams" args."jonathan" args."named-readtables" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."trivial-types" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/http-body/2019-08-13/http-body-20190813-git.tgz'';
-    sha256 = ''1mc4xinqnvjr7cdyaywdb5lv9k34pal7lhp6f9a660r1rbxybvy8'';
+    url = "http://beta.quicklisp.org/archive/http-body/2019-08-13/http-body-20190813-git.tgz";
+    sha256 = "1mc4xinqnvjr7cdyaywdb5lv9k34pal7lhp6f9a660r1rbxybvy8";
   };
 
   packageName = "http-body";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_asdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_asdf.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''hu_dot_dwim_dot_asdf'';
-  version = ''20200925-darcs'';
+  baseName = "hu_dot_dwim_dot_asdf";
+  version = "20200925-darcs";
 
-  description = ''Various ASDF extensions such as attached test and documentation system, explicit development support, etc.'';
+  description = "Various ASDF extensions such as attached test and documentation system, explicit development support, etc.";
 
   deps = [ args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/hu.dwim.asdf/2020-09-25/hu.dwim.asdf-20200925-darcs.tgz'';
-    sha256 = ''1812gk65x8yy8s817zhzga52zvdlagws4sw6a8f6zk7yaaa6br8h'';
+    url = "http://beta.quicklisp.org/archive/hu.dwim.asdf/2020-09-25/hu.dwim.asdf-20200925-darcs.tgz";
+    sha256 = "1812gk65x8yy8s817zhzga52zvdlagws4sw6a8f6zk7yaaa6br8h";
   };
 
   packageName = "hu.dwim.asdf";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''hu_dot_dwim_dot_defclass-star'';
-  version = ''stable-git'';
+  baseName = "hu_dot_dwim_dot_defclass-star";
+  version = "stable-git";
 
-  description = ''Simplify class like definitions with defclass* and friends.'';
+  description = "Simplify class like definitions with defclass* and friends.";
 
   deps = [ args."hu_dot_dwim_dot_asdf" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-02-28/hu.dwim.defclass-star-stable-git.tgz'';
-    sha256 = ''1zj4c9pz7y69gclyd7kzf6d6s1r0am49czgvp2axbv7w50j5caf9'';
+    url = "http://beta.quicklisp.org/archive/hu.dwim.defclass-star/2021-02-28/hu.dwim.defclass-star-stable-git.tgz";
+    sha256 = "1zj4c9pz7y69gclyd7kzf6d6s1r0am49czgvp2axbv7w50j5caf9";
   };
 
   packageName = "hu.dwim.defclass-star";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''hu_dot_dwim_dot_stefil'';
-  version = ''20200218-darcs'';
+  baseName = "hu_dot_dwim_dot_stefil";
+  version = "20200218-darcs";
 
   parasites = [ "hu.dwim.stefil/test" ];
 
-  description = ''A Simple Test Framework In Lisp.'';
+  description = "A Simple Test Framework In Lisp.";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz'';
-    sha256 = ''16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf'';
+    url = "http://beta.quicklisp.org/archive/hu.dwim.stefil/2020-02-18/hu.dwim.stefil-20200218-darcs.tgz";
+    sha256 = "16p25pq9fhk0dny6r43yl9z24g6qm6dag9zf2cila9v9jh3r76qf";
   };
 
   packageName = "hu.dwim.stefil";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hunchentoot.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hunchentoot.nix
@@ -1,20 +1,21 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''hunchentoot'';
-  version = ''v1.3.0'';
+  baseName = "hunchentoot";
+  version = "v1.3.0";
 
   parasites = [ "hunchentoot-dev" "hunchentoot-test" ];
 
-  description = ''Hunchentoot is a HTTP server based on USOCKET and
+  description = "Hunchentoot is a HTTP server based on USOCKET and
   BORDEAUX-THREADS.  It supports HTTP 1.1, serves static files, has a
   simple framework for user-defined handlers and can be extended
-  through subclassing.'';
+  through subclassing.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-fad" args."cl-ppcre" args."cl-who" args."cxml-stp" args."drakma" args."flexi-streams" args."md5" args."rfc2388" args."split-sequence" args."swank" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" args."xpath" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/hunchentoot/2020-06-10/hunchentoot-v1.3.0.tgz'';
-    sha256 = ''08znpi5lq2dhgv6mhvabk3w4ggrg31dbv4k6gmshr18xd2lq43i8'';
+    url = "http://beta.quicklisp.org/archive/hunchentoot/2020-06-10/hunchentoot-v1.3.0.tgz";
+    sha256 = "08znpi5lq2dhgv6mhvabk3w4ggrg31dbv4k6gmshr18xd2lq43i8";
   };
 
   packageName = "hunchentoot";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/idna.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/idna.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''idna'';
-  version = ''20120107-git'';
+  baseName = "idna";
+  version = "20120107-git";
 
-  description = ''IDNA (international domain names) string encoding and decoding routines'';
+  description = "IDNA (international domain names) string encoding and decoding routines";
 
   deps = [ args."split-sequence" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/idna/2012-01-07/idna-20120107-git.tgz'';
-    sha256 = ''0q9hja9v5q7z89p0bzm2whchn05hymn3255fr5zj3fkja8akma5c'';
+    url = "http://beta.quicklisp.org/archive/idna/2012-01-07/idna-20120107-git.tgz";
+    sha256 = "0q9hja9v5q7z89p0bzm2whchn05hymn3255fr5zj3fkja8akma5c";
   };
 
   packageName = "idna";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/ieee-floats.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/ieee-floats.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''ieee-floats'';
-  version = ''20170830-git'';
+  baseName = "ieee-floats";
+  version = "20170830-git";
 
   parasites = [ "ieee-floats-tests" ];
 
-  description = ''Convert floating point values to IEEE 754 binary representation'';
+  description = "Convert floating point values to IEEE 754 binary representation";
 
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/ieee-floats/2017-08-30/ieee-floats-20170830-git.tgz'';
-    sha256 = ''15c4q4w3cda82vqlpvdfrnah6ms6vxbjf4a0chd10daw72rwayqk'';
+    url = "http://beta.quicklisp.org/archive/ieee-floats/2017-08-30/ieee-floats-20170830-git.tgz";
+    sha256 = "15c4q4w3cda82vqlpvdfrnah6ms6vxbjf4a0chd10daw72rwayqk";
   };
 
   packageName = "ieee-floats";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/inferior-shell.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/inferior-shell.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''inferior-shell'';
-  version = ''20200925-git'';
+  baseName = "inferior-shell";
+  version = "20200925-git";
 
   parasites = [ "inferior-shell/test" ];
 
-  description = ''spawn local or remote processes and shell pipes'';
+  description = "spawn local or remote processes and shell pipes";
 
   deps = [ args."alexandria" args."closer-mop" args."fare-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."hu_dot_dwim_dot_stefil" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/inferior-shell/2020-09-25/inferior-shell-20200925-git.tgz'';
-    sha256 = ''1hykybcmdpcjk0irl4f1lmqc4aawpp1zfvh27qp6mldsibra7l80'';
+    url = "http://beta.quicklisp.org/archive/inferior-shell/2020-09-25/inferior-shell-20200925-git.tgz";
+    sha256 = "1hykybcmdpcjk0irl4f1lmqc4aawpp1zfvh27qp6mldsibra7l80";
   };
 
   packageName = "inferior-shell";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/introspect-environment.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/introspect-environment.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''introspect-environment'';
-  version = ''20200715-git'';
+  baseName = "introspect-environment";
+  version = "20200715-git";
 
-  description = ''Small interface to portable but nonstandard introspection of CL environments.'';
+  description = "Small interface to portable but nonstandard introspection of CL environments.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/introspect-environment/2020-07-15/introspect-environment-20200715-git.tgz'';
-    sha256 = ''1m2vqpbrvjb0mkmi2n5rg3j0dr68hyv23lbw6s474hylx02nw5ns'';
+    url = "http://beta.quicklisp.org/archive/introspect-environment/2020-07-15/introspect-environment-20200715-git.tgz";
+    sha256 = "1m2vqpbrvjb0mkmi2n5rg3j0dr68hyv23lbw6s474hylx02nw5ns";
   };
 
   packageName = "introspect-environment";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''iolib'';
-  version = ''v0.8.3'';
+  baseName = "iolib";
+  version = "v0.8.3";
 
   parasites = [ "iolib/multiplex" "iolib/os" "iolib/pathnames" "iolib/sockets" "iolib/streams" "iolib/syscalls" "iolib/trivial-sockets" "iolib/zstreams" ];
 
-  description = ''I/O library.'';
+  description = "I/O library.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."idna" args."iolib_dot_asdf" args."iolib_dot_base" args."iolib_dot_common-lisp" args."iolib_dot_conf" args."iolib_dot_grovel" args."split-sequence" args."swap-bytes" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz'';
-    sha256 = ''12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c'';
+    url = "http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz";
+    sha256 = "12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c";
   };
 
   packageName = "iolib";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_asdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_asdf.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''iolib_dot_asdf'';
-  version = ''iolib-v0.8.3'';
+  baseName = "iolib_dot_asdf";
+  version = "iolib-v0.8.3";
 
-  description = ''A few ASDF component classes.'';
+  description = "A few ASDF component classes.";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz'';
-    sha256 = ''12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c'';
+    url = "http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz";
+    sha256 = "12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c";
   };
 
   packageName = "iolib.asdf";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_base.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_base.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''iolib_dot_base'';
-  version = ''iolib-v0.8.3'';
+  baseName = "iolib_dot_base";
+  version = "iolib-v0.8.3";
 
-  description = ''Base IOlib package, used instead of CL.'';
+  description = "Base IOlib package, used instead of CL.";
 
   deps = [ args."alexandria" args."iolib_dot_asdf" args."iolib_dot_common-lisp" args."iolib_dot_conf" args."split-sequence" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz'';
-    sha256 = ''12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c'';
+    url = "http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz";
+    sha256 = "12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c";
   };
 
   packageName = "iolib.base";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_common-lisp.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_common-lisp.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''iolib_dot_common-lisp'';
-  version = ''iolib-v0.8.3'';
+  baseName = "iolib_dot_common-lisp";
+  version = "iolib-v0.8.3";
 
-  description = ''Slightly modified Common Lisp.'';
+  description = "Slightly modified Common Lisp.";
 
   deps = [ args."alexandria" args."iolib_dot_asdf" args."iolib_dot_conf" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz'';
-    sha256 = ''12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c'';
+    url = "http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz";
+    sha256 = "12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c";
   };
 
   packageName = "iolib.common-lisp";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_conf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_conf.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''iolib_dot_conf'';
-  version = ''iolib-v0.8.3'';
+  baseName = "iolib_dot_conf";
+  version = "iolib-v0.8.3";
 
-  description = ''Compile-time configuration for IOLib.'';
+  description = "Compile-time configuration for IOLib.";
 
   deps = [ args."alexandria" args."iolib_dot_asdf" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz'';
-    sha256 = ''12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c'';
+    url = "http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz";
+    sha256 = "12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c";
   };
 
   packageName = "iolib.conf";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_grovel.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_grovel.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''iolib_dot_grovel'';
-  version = ''iolib-v0.8.3'';
+  baseName = "iolib_dot_grovel";
+  version = "iolib-v0.8.3";
 
-  description = ''The CFFI Groveller'';
+  description = "The CFFI Groveller";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."iolib_dot_asdf" args."iolib_dot_base" args."iolib_dot_common-lisp" args."iolib_dot_conf" args."split-sequence" args."trivial-features" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz'';
-    sha256 = ''12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c'';
+    url = "http://beta.quicklisp.org/archive/iolib/2018-02-28/iolib-v0.8.3.tgz";
+    sha256 = "12gsvsjyxmclwidcjvyrfvd0773ib54a3qzmf33hmgc9knxlli7c";
   };
 
   packageName = "iolib.grovel";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''ironclad'';
-  version = ''v0.54'';
+  baseName = "ironclad";
+  version = "v0.54";
 
   parasites = [ "ironclad/tests" ];
 
-  description = ''A cryptographic toolkit written in pure Common Lisp'';
+  description = "A cryptographic toolkit written in pure Common Lisp";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."rt" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/ironclad/2021-01-24/ironclad-v0.54.tgz'';
-    sha256 = ''01mpsnjx8cgn3wx2n0dkv8v83z93da9zrxncn58ghbpyq3z1i4w2'';
+    url = "http://beta.quicklisp.org/archive/ironclad/2021-01-24/ironclad-v0.54.tgz";
+    sha256 = "01mpsnjx8cgn3wx2n0dkv8v83z93da9zrxncn58ghbpyq3z1i4w2";
   };
 
   packageName = "ironclad";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iterate.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iterate.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''iterate'';
-  version = ''20210228-git'';
+  baseName = "iterate";
+  version = "20210228-git";
 
   parasites = [ "iterate/tests" ];
 
-  description = ''Jonathan Amsterdam's iterator/gatherer/accumulator facility'';
+  description = "Jonathan Amsterdam's iterator/gatherer/accumulator facility";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/iterate/2021-02-28/iterate-20210228-git.tgz'';
-    sha256 = ''1bd6m1lxmd6an75z7j61sms4v54bfxmg1n1w7zd7fm2kb15vai46'';
+    url = "http://beta.quicklisp.org/archive/iterate/2021-02-28/iterate-20210228-git.tgz";
+    sha256 = "1bd6m1lxmd6an75z7j61sms4v54bfxmg1n1w7zd7fm2kb15vai46";
   };
 
   packageName = "iterate";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/jonathan.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/jonathan.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''jonathan'';
-  version = ''20200925-git'';
+  baseName = "jonathan";
+  version = "20200925-git";
 
-  description = ''High performance JSON encoder and decoder. Currently support: SBCL, CCL.'';
+  description = "High performance JSON encoder and decoder. Currently support: SBCL, CCL.";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-annot" args."cl-ppcre" args."cl-syntax" args."cl-syntax-annot" args."fast-io" args."named-readtables" args."proc-parse" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/jonathan/2020-09-25/jonathan-20200925-git.tgz'';
-    sha256 = ''1y5v3g351nsy7px0frdr2asmcy0lyfbj73ic1f5yf4q65hrgvryx'';
+    url = "http://beta.quicklisp.org/archive/jonathan/2020-09-25/jonathan-20200925-git.tgz";
+    sha256 = "1y5v3g351nsy7px0frdr2asmcy0lyfbj73ic1f5yf4q65hrgvryx";
   };
 
   packageName = "jonathan";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/jpl-queues.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/jpl-queues.nix
@@ -1,16 +1,17 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''jpl-queues'';
-  version = ''0.1'';
+  baseName = "jpl-queues";
+  version = "0.1";
 
-  description = ''A few different kinds of queues, with optional
-multithreading synchronization.'';
+  description = "A few different kinds of queues, with optional
+multithreading synchronization.";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."jpl-util" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/jpl-queues/2010-10-06/jpl-queues-0.1.tgz'';
-    sha256 = ''1wvvv7j117h9a42qaj1g4fh4mji28xqs7s60rn6d11gk9jl76h96'';
+    url = "http://beta.quicklisp.org/archive/jpl-queues/2010-10-06/jpl-queues-0.1.tgz";
+    sha256 = "1wvvv7j117h9a42qaj1g4fh4mji28xqs7s60rn6d11gk9jl76h96";
   };
 
   packageName = "jpl-queues";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/jpl-util.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/jpl-util.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''jpl-util'';
-  version = ''cl-20151031-git'';
+  baseName = "jpl-util";
+  version = "cl-20151031-git";
 
-  description = ''Sundry utilities for J.P. Larocque.'';
+  description = "Sundry utilities for J.P. Larocque.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-jpl-util/2015-10-31/cl-jpl-util-20151031-git.tgz'';
-    sha256 = ''1a3sfamgrqgsf0ql3fkbpmjbs837v1b3nxqxp4mkisp6yxanmhzx'';
+    url = "http://beta.quicklisp.org/archive/cl-jpl-util/2015-10-31/cl-jpl-util-20151031-git.tgz";
+    sha256 = "1a3sfamgrqgsf0ql3fkbpmjbs837v1b3nxqxp4mkisp6yxanmhzx";
   };
 
   packageName = "jpl-util";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/kmrcl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/kmrcl.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''kmrcl'';
-  version = ''20201016-git'';
+  baseName = "kmrcl";
+  version = "20201016-git";
 
   parasites = [ "kmrcl/test" ];
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/kmrcl/2020-10-16/kmrcl-20201016-git.tgz'';
-    sha256 = ''0i0k61385hrzbg15qs1wprz6sis7mx2abxv1hqcc2f53rqm9b2hf'';
+    url = "http://beta.quicklisp.org/archive/kmrcl/2020-10-16/kmrcl-20201016-git.tgz";
+    sha256 = "0i0k61385hrzbg15qs1wprz6sis7mx2abxv1hqcc2f53rqm9b2hf";
   };
 
   packageName = "kmrcl";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lack-component'';
-  version = ''lack-20201016-git'';
+  baseName = "lack-component";
+  version = "lack-20201016-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lack/2020-10-16/lack-20201016-git.tgz'';
-    sha256 = ''124c3k8116m5gc0rp4vvkqcvz35lglrbwdq4i929hbq65xyx5gan'';
+    url = "http://beta.quicklisp.org/archive/lack/2020-10-16/lack-20201016-git.tgz";
+    sha256 = "124c3k8116m5gc0rp4vvkqcvz35lglrbwdq4i929hbq65xyx5gan";
   };
 
   packageName = "lack-component";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lack-middleware-backtrace'';
-  version = ''lack-20201016-git'';
+  baseName = "lack-middleware-backtrace";
+  version = "lack-20201016-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lack/2020-10-16/lack-20201016-git.tgz'';
-    sha256 = ''124c3k8116m5gc0rp4vvkqcvz35lglrbwdq4i929hbq65xyx5gan'';
+    url = "http://beta.quicklisp.org/archive/lack/2020-10-16/lack-20201016-git.tgz";
+    sha256 = "124c3k8116m5gc0rp4vvkqcvz35lglrbwdq4i929hbq65xyx5gan";
   };
 
   packageName = "lack-middleware-backtrace";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lack-util'';
-  version = ''lack-20201016-git'';
+  baseName = "lack-util";
+  version = "lack-20201016-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lack/2020-10-16/lack-20201016-git.tgz'';
-    sha256 = ''124c3k8116m5gc0rp4vvkqcvz35lglrbwdq4i929hbq65xyx5gan'';
+    url = "http://beta.quicklisp.org/archive/lack/2020-10-16/lack-20201016-git.tgz";
+    sha256 = "124c3k8116m5gc0rp4vvkqcvz35lglrbwdq4i929hbq65xyx5gan";
   };
 
   packageName = "lack-util";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lack'';
-  version = ''20201016-git'';
+  baseName = "lack";
+  version = "20201016-git";
 
-  description = ''A minimal Clack'';
+  description = "A minimal Clack";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack-component" args."lack-util" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lack/2020-10-16/lack-20201016-git.tgz'';
-    sha256 = ''124c3k8116m5gc0rp4vvkqcvz35lglrbwdq4i929hbq65xyx5gan'';
+    url = "http://beta.quicklisp.org/archive/lack/2020-10-16/lack-20201016-git.tgz";
+    sha256 = "124c3k8116m5gc0rp4vvkqcvz35lglrbwdq4i929hbq65xyx5gan";
   };
 
   packageName = "lack";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/let-plus.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/let-plus.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''let-plus'';
-  version = ''20191130-git'';
+  baseName = "let-plus";
+  version = "20191130-git";
 
   parasites = [ "let-plus/tests" ];
 
-  description = ''Destructuring extension of LET*.'';
+  description = "Destructuring extension of LET*.";
 
   deps = [ args."alexandria" args."anaphora" args."lift" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/let-plus/2019-11-30/let-plus-20191130-git.tgz'';
-    sha256 = ''0zj0fgb7lvczgpz4jq8q851p77kma7ikn7hd2jk2c37iv4nmz29p'';
+    url = "http://beta.quicklisp.org/archive/let-plus/2019-11-30/let-plus-20191130-git.tgz";
+    sha256 = "0zj0fgb7lvczgpz4jq8q851p77kma7ikn7hd2jk2c37iv4nmz29p";
   };
 
   packageName = "let-plus";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lev.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lev.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lev'';
-  version = ''20150505-git'';
+  baseName = "lev";
+  version = "20150505-git";
 
-  description = ''libev bindings for Common Lisp'';
+  description = "libev bindings for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lev/2015-05-05/lev-20150505-git.tgz'';
-    sha256 = ''0lkkzb221ks4f0qjgh6pr5lyvb4884a87p96ir4m36x411pyk5xl'';
+    url = "http://beta.quicklisp.org/archive/lev/2015-05-05/lev-20150505-git.tgz";
+    sha256 = "0lkkzb221ks4f0qjgh6pr5lyvb4884a87p96ir4m36x411pyk5xl";
   };
 
   packageName = "lev";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-client.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-client.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lfarm-client'';
-  version = ''lfarm-20150608-git'';
+  baseName = "lfarm-client";
+  version = "lfarm-20150608-git";
 
-  description = ''Client component of lfarm, a library for distributing work across machines.'';
+  description = "Client component of lfarm, a library for distributing work across machines.";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-store" args."flexi-streams" args."lfarm-common" args."lparallel" args."split-sequence" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lfarm/2015-06-08/lfarm-20150608-git.tgz'';
-    sha256 = ''1rkjcfam4601yczs13pi2qgi5jql0c150dxja53hkcnqhkyqgl66'';
+    url = "http://beta.quicklisp.org/archive/lfarm/2015-06-08/lfarm-20150608-git.tgz";
+    sha256 = "1rkjcfam4601yczs13pi2qgi5jql0c150dxja53hkcnqhkyqgl66";
   };
 
   packageName = "lfarm-client";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-common.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-common.nix
@@ -1,16 +1,17 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lfarm-common'';
-  version = ''lfarm-20150608-git'';
+  baseName = "lfarm-common";
+  version = "lfarm-20150608-git";
 
-  description = ''(private) Common components of lfarm, a library for distributing
-work across machines.'';
+  description = "(private) Common components of lfarm, a library for distributing
+work across machines.";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-store" args."flexi-streams" args."split-sequence" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lfarm/2015-06-08/lfarm-20150608-git.tgz'';
-    sha256 = ''1rkjcfam4601yczs13pi2qgi5jql0c150dxja53hkcnqhkyqgl66'';
+    url = "http://beta.quicklisp.org/archive/lfarm/2015-06-08/lfarm-20150608-git.tgz";
+    sha256 = "1rkjcfam4601yczs13pi2qgi5jql0c150dxja53hkcnqhkyqgl66";
   };
 
   packageName = "lfarm-common";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-server.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-server.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lfarm-server'';
-  version = ''lfarm-20150608-git'';
+  baseName = "lfarm-server";
+  version = "lfarm-20150608-git";
 
-  description = ''Server component of lfarm, a library for distributing work across machines.'';
+  description = "Server component of lfarm, a library for distributing work across machines.";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-store" args."flexi-streams" args."lfarm-common" args."split-sequence" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lfarm/2015-06-08/lfarm-20150608-git.tgz'';
-    sha256 = ''1rkjcfam4601yczs13pi2qgi5jql0c150dxja53hkcnqhkyqgl66'';
+    url = "http://beta.quicklisp.org/archive/lfarm/2015-06-08/lfarm-20150608-git.tgz";
+    sha256 = "1rkjcfam4601yczs13pi2qgi5jql0c150dxja53hkcnqhkyqgl66";
   };
 
   packageName = "lfarm-server";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-ssl.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lfarm-ssl'';
-  version = ''lfarm-20150608-git'';
+  baseName = "lfarm-ssl";
+  version = "lfarm-20150608-git";
 
-  description = ''SSL support for lfarm'';
+  description = "SSL support for lfarm";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl_plus_ssl" args."cl-store" args."flexi-streams" args."lfarm-common" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lfarm/2015-06-08/lfarm-20150608-git.tgz'';
-    sha256 = ''1rkjcfam4601yczs13pi2qgi5jql0c150dxja53hkcnqhkyqgl66'';
+    url = "http://beta.quicklisp.org/archive/lfarm/2015-06-08/lfarm-20150608-git.tgz";
+    sha256 = "1rkjcfam4601yczs13pi2qgi5jql0c150dxja53hkcnqhkyqgl66";
   };
 
   packageName = "lfarm-ssl";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lift.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lift.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lift'';
-  version = ''20190521-git'';
+  baseName = "lift";
+  version = "20190521-git";
 
-  description = ''LIsp Framework for Testing'';
+  description = "LIsp Framework for Testing";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lift/2019-05-21/lift-20190521-git.tgz'';
-    sha256 = ''0cinilin9bxzsj3mzd4488zx2irvyl5qpbykv0xbyfz2mjh94ac9'';
+    url = "http://beta.quicklisp.org/archive/lift/2019-05-21/lift-20190521-git.tgz";
+    sha256 = "0cinilin9bxzsj3mzd4488zx2irvyl5qpbykv0xbyfz2mjh94ac9";
   };
 
   packageName = "lift";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-namespace.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-namespace.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lisp-namespace'';
-  version = ''20171130-git'';
+  baseName = "lisp-namespace";
+  version = "20171130-git";
 
-  description = ''Provides LISP-N --- extensible namespaces in Common Lisp.'';
+  description = "Provides LISP-N --- extensible namespaces in Common Lisp.";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lisp-namespace/2017-11-30/lisp-namespace-20171130-git.tgz'';
-    sha256 = ''0vxk06c5434kcjv9p414yk23gs4rkibfq695is9y7wglck31fz2j'';
+    url = "http://beta.quicklisp.org/archive/lisp-namespace/2017-11-30/lisp-namespace-20171130-git.tgz";
+    sha256 = "0vxk06c5434kcjv9p414yk23gs4rkibfq695is9y7wglck31fz2j";
   };
 
   packageName = "lisp-namespace";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-unit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-unit2.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lisp-unit2'';
-  version = ''20180131-git'';
+  baseName = "lisp-unit2";
+  version = "20180131-git";
 
   parasites = [ "lisp-unit2-test" ];
 
-  description = ''Common Lisp library that supports unit testing.'';
+  description = "Common Lisp library that supports unit testing.";
 
   deps = [ args."alexandria" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."flexi-streams" args."iterate" args."named-readtables" args."symbol-munger" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lisp-unit2/2018-01-31/lisp-unit2-20180131-git.tgz'';
-    sha256 = ''04kwrg605mqzf3ghshgbygvvryk5kipl6gyc5kdaxafjxvhxaak7'';
+    url = "http://beta.quicklisp.org/archive/lisp-unit2/2018-01-31/lisp-unit2-20180131-git.tgz";
+    sha256 = "04kwrg605mqzf3ghshgbygvvryk5kipl6gyc5kdaxafjxvhxaak7";
   };
 
   packageName = "lisp-unit2";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/local-time.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/local-time.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''local-time'';
-  version = ''20210124-git'';
+  baseName = "local-time";
+  version = "20210124-git";
 
   parasites = [ "local-time/test" ];
 
-  description = ''A library for manipulating dates and times, based on a paper by Erik Naggum'';
+  description = "A library for manipulating dates and times, based on a paper by Erik Naggum";
 
   deps = [ args."hu_dot_dwim_dot_stefil" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/local-time/2021-01-24/local-time-20210124-git.tgz'';
-    sha256 = ''0bz5z0rd8gfd22bpqkalaijxlrk806zc010cvgd4qjapbrxzjg3s'';
+    url = "http://beta.quicklisp.org/archive/local-time/2021-01-24/local-time-20210124-git.tgz";
+    sha256 = "0bz5z0rd8gfd22bpqkalaijxlrk806zc010cvgd4qjapbrxzjg3s";
   };
 
   packageName = "local-time";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/log4cl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/log4cl.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''log4cl'';
-  version = ''20200925-git'';
+  baseName = "log4cl";
+  version = "20200925-git";
 
   parasites = [ "log4cl/syslog" "log4cl/test" ];
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."stefil" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/log4cl/2020-09-25/log4cl-20200925-git.tgz'';
-    sha256 = ''1z98ly71hsbd46i0dqqv2s3cm9y8bi0pl3yg8a168vz629c6mdrf'';
+    url = "http://beta.quicklisp.org/archive/log4cl/2020-09-25/log4cl-20200925-git.tgz";
+    sha256 = "1z98ly71hsbd46i0dqqv2s3cm9y8bi0pl3yg8a168vz629c6mdrf";
   };
 
   packageName = "log4cl";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lparallel.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lparallel.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lparallel'';
-  version = ''20160825-git'';
+  baseName = "lparallel";
+  version = "20160825-git";
 
-  description = ''Parallelism for Common Lisp'';
+  description = "Parallelism for Common Lisp";
 
   deps = [ args."alexandria" args."bordeaux-threads" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lparallel/2016-08-25/lparallel-20160825-git.tgz'';
-    sha256 = ''0wwwwszbj6m0b2rsp8mpn4m6y7xk448bw8fb7gy0ggmsdfgchfr1'';
+    url = "http://beta.quicklisp.org/archive/lparallel/2016-08-25/lparallel-20160825-git.tgz";
+    sha256 = "0wwwwszbj6m0b2rsp8mpn4m6y7xk448bw8fb7gy0ggmsdfgchfr1";
   };
 
   packageName = "lparallel";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lquery.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lquery.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''lquery'';
-  version = ''20201220-git'';
+  baseName = "lquery";
+  version = "20201220-git";
 
-  description = ''A library to allow jQuery-like HTML/DOM manipulation.'';
+  description = "A library to allow jQuery-like HTML/DOM manipulation.";
 
   deps = [ args."array-utils" args."clss" args."documentation-utils" args."form-fiddle" args."plump" args."trivial-indent" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lquery/2020-12-20/lquery-20201220-git.tgz'';
-    sha256 = ''0mfnk1p73aihraklw802j5mjgc8cjxva0mdf0c4p7b253crf15jx'';
+    url = "http://beta.quicklisp.org/archive/lquery/2020-12-20/lquery-20201220-git.tgz";
+    sha256 = "0mfnk1p73aihraklw802j5mjgc8cjxva0mdf0c4p7b253crf15jx";
   };
 
   packageName = "lquery";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/map-set.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/map-set.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''map-set'';
-  version = ''20190307-hg'';
+  baseName = "map-set";
+  version = "20190307-hg";
 
-  description = ''Set-like data structure.'';
+  description = "Set-like data structure.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/map-set/2019-03-07/map-set-20190307-hg.tgz'';
-    sha256 = ''1x7yh4gzdvypr1q45qgmjln5pjlh82bfpk6sqyrihrldmwwnbzg9'';
+    url = "http://beta.quicklisp.org/archive/map-set/2019-03-07/map-set-20190307-hg.tgz";
+    sha256 = "1x7yh4gzdvypr1q45qgmjln5pjlh82bfpk6sqyrihrldmwwnbzg9";
   };
 
   packageName = "map-set";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/marshal.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/marshal.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''marshal'';
-  version = ''cl-20201016-git'';
+  baseName = "marshal";
+  version = "cl-20201016-git";
 
-  description = ''marshal: Simple (de)serialization of Lisp datastructures.'';
+  description = "marshal: Simple (de)serialization of Lisp datastructures.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-marshal/2020-10-16/cl-marshal-20201016-git.tgz'';
-    sha256 = ''03j52yhgpc2myypgy07213l20rznxvf6m3sfbzy2wyapcmv7nxnz'';
+    url = "http://beta.quicklisp.org/archive/cl-marshal/2020-10-16/cl-marshal-20201016-git.tgz";
+    sha256 = "03j52yhgpc2myypgy07213l20rznxvf6m3sfbzy2wyapcmv7nxnz";
   };
 
   packageName = "marshal";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/md5.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/md5.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''md5'';
-  version = ''20180228-git'';
+  baseName = "md5";
+  version = "20180228-git";
 
-  description = ''The MD5 Message-Digest Algorithm RFC 1321'';
+  description = "The MD5 Message-Digest Algorithm RFC 1321";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/md5/2018-02-28/md5-20180228-git.tgz'';
-    sha256 = ''1261ix6bmkjyx8bkpj6ksa0kgyrhngm31as77dyy3vfg6dvrsnd4'';
+    url = "http://beta.quicklisp.org/archive/md5/2018-02-28/md5-20180228-git.tgz";
+    sha256 = "1261ix6bmkjyx8bkpj6ksa0kgyrhngm31as77dyy3vfg6dvrsnd4";
   };
 
   packageName = "md5";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/metabang-bind.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/metabang-bind.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''metabang-bind'';
-  version = ''20200218-git'';
+  baseName = "metabang-bind";
+  version = "20200218-git";
 
-  description = ''Bind is a macro that generalizes multiple-value-bind, let, let*, destructuring-bind, structure and slot accessors, and a whole lot more.'';
+  description = "Bind is a macro that generalizes multiple-value-bind, let, let*, destructuring-bind, structure and slot accessors, and a whole lot more.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/metabang-bind/2020-02-18/metabang-bind-20200218-git.tgz'';
-    sha256 = ''0mfjzfsv8v6i9ahwldfzznl29i42cmh5srmpgq64ar1vp6bdn1hq'';
+    url = "http://beta.quicklisp.org/archive/metabang-bind/2020-02-18/metabang-bind-20200218-git.tgz";
+    sha256 = "0mfjzfsv8v6i9ahwldfzznl29i42cmh5srmpgq64ar1vp6bdn1hq";
   };
 
   packageName = "metabang-bind";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/metatilities-base.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/metatilities-base.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''metatilities-base'';
-  version = ''20191227-git'';
+  baseName = "metatilities-base";
+  version = "20191227-git";
 
-  description = ''These are metabang.com's Common Lisp basic utilities.'';
+  description = "These are metabang.com's Common Lisp basic utilities.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/metatilities-base/2019-12-27/metatilities-base-20191227-git.tgz'';
-    sha256 = ''1mal51p7mknya2ljcwl3wdjvnirw5vvzic6qcnci7qhmfrb1awil'';
+    url = "http://beta.quicklisp.org/archive/metatilities-base/2019-12-27/metatilities-base-20191227-git.tgz";
+    sha256 = "1mal51p7mknya2ljcwl3wdjvnirw5vvzic6qcnci7qhmfrb1awil";
   };
 
   packageName = "metatilities-base";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
@@ -1,18 +1,19 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''mgl-pax'';
-  version = ''20210228-git'';
+  baseName = "mgl-pax";
+  version = "20210228-git";
 
   parasites = [ "mgl-pax/test" ];
 
-  description = ''Exploratory programming tool and documentation
-  generator.'';
+  description = "Exploratory programming tool and documentation
+  generator.";
 
   deps = [ args."_3bmd" args."_3bmd-ext-code-blocks" args."alexandria" args."babel" args."bordeaux-threads" args."cl-fad" args."colorize" args."esrap" args."html-encode" args."ironclad" args."named-readtables" args."pythonic-string-reader" args."split-sequence" args."swank" args."trivial-features" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/mgl-pax/2021-02-28/mgl-pax-20210228-git.tgz'';
-    sha256 = ''1dyhbnd69lb6ih89pvg8nn6pwsg25v5xjsfk1i5l1fdib14612cw'';
+    url = "http://beta.quicklisp.org/archive/mgl-pax/2021-02-28/mgl-pax-20210228-git.tgz";
+    sha256 = "1dyhbnd69lb6ih89pvg8nn6pwsg25v5xjsfk1i5l1fdib14612cw";
   };
 
   packageName = "mgl-pax";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/misc-extensions.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/misc-extensions.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''misc-extensions'';
-  version = ''20150608-git'';
+  baseName = "misc-extensions";
+  version = "20150608-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/misc-extensions/2015-06-08/misc-extensions-20150608-git.tgz'';
-    sha256 = ''0pkvi1l5djwpvm0p8m0bcdjm61gxvzy0vgn415gngdixvbbchdqj'';
+    url = "http://beta.quicklisp.org/archive/misc-extensions/2015-06-08/misc-extensions-20150608-git.tgz";
+    sha256 = "0pkvi1l5djwpvm0p8m0bcdjm61gxvzy0vgn415gngdixvbbchdqj";
   };
 
   packageName = "misc-extensions";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mk-string-metrics.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mk-string-metrics.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''mk-string-metrics'';
-  version = ''20180131-git'';
+  baseName = "mk-string-metrics";
+  version = "20180131-git";
 
-  description = ''efficient implementations of various string metric algorithms'';
+  description = "efficient implementations of various string metric algorithms";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/mk-string-metrics/2018-01-31/mk-string-metrics-20180131-git.tgz'';
-    sha256 = ''10xb9n6568nh019nq3phijbc7l6hkv69yllfiqvc1zzsprxpkwc4'';
+    url = "http://beta.quicklisp.org/archive/mk-string-metrics/2018-01-31/mk-string-metrics-20180131-git.tgz";
+    sha256 = "10xb9n6568nh019nq3phijbc7l6hkv69yllfiqvc1zzsprxpkwc4";
   };
 
   packageName = "mk-string-metrics";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/moptilities.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/moptilities.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''moptilities'';
-  version = ''20170403-git'';
+  baseName = "moptilities";
+  version = "20170403-git";
 
-  description = ''Common Lisp MOP utilities'';
+  description = "Common Lisp MOP utilities";
 
   deps = [ args."closer-mop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/moptilities/2017-04-03/moptilities-20170403-git.tgz'';
-    sha256 = ''0az01wx60ll3nybqlp21f5bps3fnpqhvvfg6d9x84969wdj7q4q8'';
+    url = "http://beta.quicklisp.org/archive/moptilities/2017-04-03/moptilities-20170403-git.tgz";
+    sha256 = "0az01wx60ll3nybqlp21f5bps3fnpqhvvfg6d9x84969wdj7q4q8";
   };
 
   packageName = "moptilities";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/more-conditions.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/more-conditions.nix
@@ -1,18 +1,19 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''more-conditions'';
-  version = ''20180831-git'';
+  baseName = "more-conditions";
+  version = "20180831-git";
 
   parasites = [ "more-conditions/test" ];
 
-  description = ''This system provides some generic condition classes in
-                conjunction with support functions and macros.'';
+  description = "This system provides some generic condition classes in
+                conjunction with support functions and macros.";
 
   deps = [ args."alexandria" args."closer-mop" args."fiveam" args."let-plus" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/more-conditions/2018-08-31/more-conditions-20180831-git.tgz'';
-    sha256 = ''0wa989kv3sl977g9szxkx52fdnww6aj2a9i77363f90iq02vj97x'';
+    url = "http://beta.quicklisp.org/archive/more-conditions/2018-08-31/more-conditions-20180831-git.tgz";
+    sha256 = "0wa989kv3sl977g9szxkx52fdnww6aj2a9i77363f90iq02vj97x";
   };
 
   packageName = "more-conditions";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mt19937.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mt19937.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''mt19937'';
-  version = ''1.1.1'';
+  baseName = "mt19937";
+  version = "1.1.1";
 
-  description = ''Portable MT19937 Mersenne Twister random number generator'';
+  description = "Portable MT19937 Mersenne Twister random number generator";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/mt19937/2011-02-19/mt19937-1.1.1.tgz'';
-    sha256 = ''1iw636b0iw5ygkv02y8i41lh7xj0acglv0hg5agryn0zzi2nf1xv'';
+    url = "http://beta.quicklisp.org/archive/mt19937/2011-02-19/mt19937-1.1.1.tgz";
+    sha256 = "1iw636b0iw5ygkv02y8i41lh7xj0acglv0hg5agryn0zzi2nf1xv";
   };
 
   packageName = "mt19937";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/myway.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/myway.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''myway'';
-  version = ''20200325-git'';
+  baseName = "myway";
+  version = "20200325-git";
 
-  description = ''Sinatra-compatible routing library.'';
+  description = "Sinatra-compatible routing library.";
 
   deps = [ args."alexandria" args."babel" args."cl-ppcre" args."cl-utilities" args."map-set" args."quri" args."split-sequence" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/myway/2020-03-25/myway-20200325-git.tgz'';
-    sha256 = ''07r0mq9n0gmm7n20mkpsnmjvcr4gj9nckpnh1c2mddrb3sag8n15'';
+    url = "http://beta.quicklisp.org/archive/myway/2020-03-25/myway-20200325-git.tgz";
+    sha256 = "07r0mq9n0gmm7n20mkpsnmjvcr4gj9nckpnh1c2mddrb3sag8n15";
   };
 
   packageName = "myway";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/named-readtables.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/named-readtables.nix
@@ -1,18 +1,19 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''named-readtables'';
-  version = ''20210124-git'';
+  baseName = "named-readtables";
+  version = "20210124-git";
 
   parasites = [ "named-readtables/test" ];
 
-  description = ''Library that creates a namespace for named readtable
-  akin to the namespace of packages.'';
+  description = "Library that creates a namespace for named readtable
+  akin to the namespace of packages.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/named-readtables/2021-01-24/named-readtables-20210124-git.tgz'';
-    sha256 = ''00lbcv1qdb9ldq2kbf1rkn5sh657px9dgqrcynbwjzvla4czadl4'';
+    url = "http://beta.quicklisp.org/archive/named-readtables/2021-01-24/named-readtables-20210124-git.tgz";
+    sha256 = "00lbcv1qdb9ldq2kbf1rkn5sh657px9dgqrcynbwjzvla4czadl4";
   };
 
   packageName = "named-readtables";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/net-telent-date.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/net-telent-date.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''net-telent-date'';
-  version = ''net-telent-date_0.42'';
+  baseName = "net-telent-date";
+  version = "net-telent-date_0.42";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/net-telent-date/2010-10-06/net-telent-date_0.42.tgz'';
-    sha256 = ''06vdlddwi6kx999n1093chwgw0ksbys4j4w9i9zqvw768wxp4li1'';
+    url = "http://beta.quicklisp.org/archive/net-telent-date/2010-10-06/net-telent-date_0.42.tgz";
+    sha256 = "06vdlddwi6kx999n1093chwgw0ksbys4j4w9i9zqvw768wxp4li1";
   };
 
   packageName = "net-telent-date";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/net_dot_didierverna_dot_asdf-flv.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/net_dot_didierverna_dot_asdf-flv.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''net_dot_didierverna_dot_asdf-flv'';
-  version = ''asdf-flv-version-2.1'';
+  baseName = "net_dot_didierverna_dot_asdf-flv";
+  version = "asdf-flv-version-2.1";
 
-  description = ''ASDF extension to provide support for file-local variables.'';
+  description = "ASDF extension to provide support for file-local variables.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/asdf-flv/2016-04-21/asdf-flv-version-2.1.tgz'';
-    sha256 = ''12k0d4xyv6s9vy6gq18p8c9bm334jsfjly22lhg680kx2zr7y0lc'';
+    url = "http://beta.quicklisp.org/archive/asdf-flv/2016-04-21/asdf-flv-version-2.1.tgz";
+    sha256 = "12k0d4xyv6s9vy6gq18p8c9bm334jsfjly22lhg680kx2zr7y0lc";
   };
 
   packageName = "net.didierverna.asdf-flv";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/nibbles.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/nibbles.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''nibbles'';
-  version = ''20210124-git'';
+  baseName = "nibbles";
+  version = "20210124-git";
 
   parasites = [ "nibbles/tests" ];
 
-  description = ''A library for accessing octet-addressed blocks of data in big- and little-endian orders'';
+  description = "A library for accessing octet-addressed blocks of data in big- and little-endian orders";
 
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/nibbles/2021-01-24/nibbles-20210124-git.tgz'';
-    sha256 = ''0y3h4k7665w7b8ivmql9w6rz3ivfa3h8glk45sn6mwix55xmzp26'';
+    url = "http://beta.quicklisp.org/archive/nibbles/2021-01-24/nibbles-20210124-git.tgz";
+    sha256 = "0y3h4k7665w7b8ivmql9w6rz3ivfa3h8glk45sn6mwix55xmzp26";
   };
 
   packageName = "nibbles";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/optima.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/optima.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''optima'';
-  version = ''20150709-git'';
+  baseName = "optima";
+  version = "20150709-git";
 
-  description = ''Optimized Pattern Matching Library'';
+  description = "Optimized Pattern Matching Library";
 
   deps = [ args."alexandria" args."closer-mop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/optima/2015-07-09/optima-20150709-git.tgz'';
-    sha256 = ''0vqyqrnx2d8qwa2jlg9l2wn6vrykraj8a1ysz0gxxxnwpqc29hdc'';
+    url = "http://beta.quicklisp.org/archive/optima/2015-07-09/optima-20150709-git.tgz";
+    sha256 = "0vqyqrnx2d8qwa2jlg9l2wn6vrykraj8a1ysz0gxxxnwpqc29hdc";
   };
 
   packageName = "optima";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''osicat'';
-  version = ''20210228-git'';
+  baseName = "osicat";
+  version = "20210228-git";
 
   parasites = [ "osicat/tests" ];
 
-  description = ''A lightweight operating system interface'';
+  description = "A lightweight operating system interface";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."rt" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/osicat/2021-02-28/osicat-20210228-git.tgz'';
-    sha256 = ''0g9frahjr2i6fvwd3bzvcz9icx4n4mnwcmsz6gvg5s6wmq5ny6wb'';
+    url = "http://beta.quicklisp.org/archive/osicat/2021-02-28/osicat-20210228-git.tgz";
+    sha256 = "0g9frahjr2i6fvwd3bzvcz9icx4n4mnwcmsz6gvg5s6wmq5ny6wb";
   };
 
   packageName = "osicat";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/parenscript.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/parenscript.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''parenscript'';
-  version = ''Parenscript-2.7.1'';
+  baseName = "parenscript";
+  version = "Parenscript-2.7.1";
 
-  description = ''Lisp to JavaScript transpiler'';
+  description = "Lisp to JavaScript transpiler";
 
   deps = [ args."anaphora" args."cl-ppcre" args."named-readtables" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/parenscript/2018-12-10/Parenscript-2.7.1.tgz'';
-    sha256 = ''1vbldjzj9py8vqyk0f3rb795cjai0h7p858dflm4l8p0kp4mll6f'';
+    url = "http://beta.quicklisp.org/archive/parenscript/2018-12-10/Parenscript-2.7.1.tgz";
+    sha256 = "1vbldjzj9py8vqyk0f3rb795cjai0h7p858dflm4l8p0kp4mll6f";
   };
 
   packageName = "parenscript";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/parse-declarations-1_dot_0.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/parse-declarations-1_dot_0.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''parse-declarations-1_dot_0'';
-  version = ''parse-declarations-20101006-darcs'';
+  baseName = "parse-declarations-1_dot_0";
+  version = "parse-declarations-20101006-darcs";
 
-  description = ''Library to parse and rebuild declarations.'';
+  description = "Library to parse and rebuild declarations.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/parse-declarations/2010-10-06/parse-declarations-20101006-darcs.tgz'';
-    sha256 = ''0r85b0jfacd28kr65kw9c13dx4i6id1dpmby68zjy63mqbnyawrd'';
+    url = "http://beta.quicklisp.org/archive/parse-declarations/2010-10-06/parse-declarations-20101006-darcs.tgz";
+    sha256 = "0r85b0jfacd28kr65kw9c13dx4i6id1dpmby68zjy63mqbnyawrd";
   };
 
   packageName = "parse-declarations-1.0";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/parse-number.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/parse-number.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''parse-number'';
-  version = ''v1.7'';
+  baseName = "parse-number";
+  version = "v1.7";
 
   parasites = [ "parse-number/tests" ];
 
-  description = ''Number parsing library'';
+  description = "Number parsing library";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/parse-number/2018-02-28/parse-number-v1.7.tgz'';
-    sha256 = ''11ji8856ipmqki5i4cw1zgx8hahfi8x1raz1xb20c4rmgad6nsha'';
+    url = "http://beta.quicklisp.org/archive/parse-number/2018-02-28/parse-number-v1.7.tgz";
+    sha256 = "11ji8856ipmqki5i4cw1zgx8hahfi8x1raz1xb20c4rmgad6nsha";
   };
 
   packageName = "parse-number";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/parser-combinators.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/parser-combinators.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''parser-combinators'';
-  version = ''cl-20131111-git'';
+  baseName = "parser-combinators";
+  version = "cl-20131111-git";
 
-  description = ''An implementation of parser combinators for Common Lisp'';
+  description = "An implementation of parser combinators for Common Lisp";
 
   deps = [ args."alexandria" args."iterate" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-parser-combinators/2013-11-11/cl-parser-combinators-20131111-git.tgz'';
-    sha256 = ''0wg1a7favbwqcxyqcy2zxi4l11qsp4ar9fvddmx960grf2d72lds'';
+    url = "http://beta.quicklisp.org/archive/cl-parser-combinators/2013-11-11/cl-parser-combinators-20131111-git.tgz";
+    sha256 = "0wg1a7favbwqcxyqcy2zxi4l11qsp4ar9fvddmx960grf2d72lds";
   };
 
   packageName = "parser-combinators";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/parser_dot_common-rules.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/parser_dot_common-rules.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''parser_dot_common-rules'';
-  version = ''20200715-git'';
+  baseName = "parser_dot_common-rules";
+  version = "20200715-git";
 
   parasites = [ "parser.common-rules/test" ];
 
-  description = ''Provides common parsing rules that are useful in many grammars.'';
+  description = "Provides common parsing rules that are useful in many grammars.";
 
   deps = [ args."alexandria" args."anaphora" args."esrap" args."fiveam" args."let-plus" args."split-sequence" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/parser.common-rules/2020-07-15/parser.common-rules-20200715-git.tgz'';
-    sha256 = ''17nw0shhb8079b26ldwpfxggkzs6ysfqm4s4nr1rfhba9mkvxdxy'';
+    url = "http://beta.quicklisp.org/archive/parser.common-rules/2020-07-15/parser.common-rules-20200715-git.tgz";
+    sha256 = "17nw0shhb8079b26ldwpfxggkzs6ysfqm4s4nr1rfhba9mkvxdxy";
   };
 
   packageName = "parser.common-rules";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/pcall-queue.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/pcall-queue.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''pcall-queue'';
-  version = ''pcall-0.3'';
+  baseName = "pcall-queue";
+  version = "pcall-0.3";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/pcall/2010-10-06/pcall-0.3.tgz'';
-    sha256 = ''02idx1wnv9770fl2nh179sb8njw801g70b5mf8jqhqm2gwsb731y'';
+    url = "http://beta.quicklisp.org/archive/pcall/2010-10-06/pcall-0.3.tgz";
+    sha256 = "02idx1wnv9770fl2nh179sb8njw801g70b5mf8jqhqm2gwsb731y";
   };
 
   packageName = "pcall-queue";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/pcall.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/pcall.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''pcall'';
-  version = ''0.3'';
+  baseName = "pcall";
+  version = "0.3";
 
   parasites = [ "pcall-tests" ];
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."fiveam" args."pcall-queue" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/pcall/2010-10-06/pcall-0.3.tgz'';
-    sha256 = ''02idx1wnv9770fl2nh179sb8njw801g70b5mf8jqhqm2gwsb731y'';
+    url = "http://beta.quicklisp.org/archive/pcall/2010-10-06/pcall-0.3.tgz";
+    sha256 = "02idx1wnv9770fl2nh179sb8njw801g70b5mf8jqhqm2gwsb731y";
   };
 
   packageName = "pcall";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/plump.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/plump.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''plump'';
-  version = ''20210124-git'';
+  baseName = "plump";
+  version = "20210124-git";
 
-  description = ''An XML / XHTML / HTML parser that aims to be as lenient as possible.'';
+  description = "An XML / XHTML / HTML parser that aims to be as lenient as possible.";
 
   deps = [ args."array-utils" args."documentation-utils" args."trivial-indent" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/plump/2021-01-24/plump-20210124-git.tgz'';
-    sha256 = ''0br64xiz4mgmmsvkfmi43k2q16rmc6hbqf976x8cdafs3h266jdm'';
+    url = "http://beta.quicklisp.org/archive/plump/2021-01-24/plump-20210124-git.tgz";
+    sha256 = "0br64xiz4mgmmsvkfmi43k2q16rmc6hbqf976x8cdafs3h266jdm";
   };
 
   packageName = "plump";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''postmodern'';
-  version = ''20210124-git'';
+  baseName = "postmodern";
+  version = "20210124-git";
 
   parasites = [ "postmodern/tests" ];
 
-  description = ''PostgreSQL programming API'';
+  description = "PostgreSQL programming API";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_plus_local-time" args."cl-postgres_slash_tests" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."fiveam" args."flexi-streams" args."global-vars" args."ironclad" args."local-time" args."md5" args."s-sql" args."s-sql_slash_tests" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz'';
-    sha256 = ''1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc'';
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz";
+    sha256 = "1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc";
   };
 
   packageName = "postmodern";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/proc-parse.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/proc-parse.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''proc-parse'';
-  version = ''20190813-git'';
+  baseName = "proc-parse";
+  version = "20190813-git";
 
-  description = ''Procedural vector parser'';
+  description = "Procedural vector parser";
 
   deps = [ args."alexandria" args."babel" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/proc-parse/2019-08-13/proc-parse-20190813-git.tgz'';
-    sha256 = ''126l7mqxjcgw2limddgrdq63cdhwkhaxabxl9l0bjadf92nczg0j'';
+    url = "http://beta.quicklisp.org/archive/proc-parse/2019-08-13/proc-parse-20190813-git.tgz";
+    sha256 = "126l7mqxjcgw2limddgrdq63cdhwkhaxabxl9l0bjadf92nczg0j";
   };
 
   packageName = "proc-parse";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/prove-asdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/prove-asdf.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''prove-asdf'';
-  version = ''prove-20200218-git'';
+  baseName = "prove-asdf";
+  version = "prove-20200218-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/prove/2020-02-18/prove-20200218-git.tgz'';
-    sha256 = ''1sv3zyam9sdmyis5lyv0khvw82q7bcpsycpj9b3bsv9isb4j30zn'';
+    url = "http://beta.quicklisp.org/archive/prove/2020-02-18/prove-20200218-git.tgz";
+    sha256 = "1sv3zyam9sdmyis5lyv0khvw82q7bcpsycpj9b3bsv9isb4j30zn";
   };
 
   packageName = "prove-asdf";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/prove.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/prove.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''prove'';
-  version = ''20200218-git'';
+  baseName = "prove";
+  version = "20200218-git";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."anaphora" args."cl-ansi-text" args."cl-colors" args."cl-colors2" args."cl-ppcre" args."let-plus" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/prove/2020-02-18/prove-20200218-git.tgz'';
-    sha256 = ''1sv3zyam9sdmyis5lyv0khvw82q7bcpsycpj9b3bsv9isb4j30zn'';
+    url = "http://beta.quicklisp.org/archive/prove/2020-02-18/prove-20200218-git.tgz";
+    sha256 = "1sv3zyam9sdmyis5lyv0khvw82q7bcpsycpj9b3bsv9isb4j30zn";
   };
 
   packageName = "prove";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/ptester.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/ptester.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''ptester'';
-  version = ''20160929-git'';
+  baseName = "ptester";
+  version = "20160929-git";
 
-  description = ''Portable test harness package'';
+  description = "Portable test harness package";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/ptester/2016-09-29/ptester-20160929-git.tgz'';
-    sha256 = ''04rlq1zljhxc65pm31bah3sq3as24l0sdivz440s79qlnnyh13hz'';
+    url = "http://beta.quicklisp.org/archive/ptester/2016-09-29/ptester-20160929-git.tgz";
+    sha256 = "04rlq1zljhxc65pm31bah3sq3as24l0sdivz440s79qlnnyh13hz";
   };
 
   packageName = "ptester";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/puri.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/puri.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''puri'';
-  version = ''20201016-git'';
+  baseName = "puri";
+  version = "20201016-git";
 
   parasites = [ "puri/test" ];
 
-  description = ''Portable Universal Resource Indentifier Library'';
+  description = "Portable Universal Resource Indentifier Library";
 
   deps = [ args."ptester" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/puri/2020-10-16/puri-20201016-git.tgz'';
-    sha256 = ''16h7gip6d0564s9yba3jg0rjzndmysv531hcrngvi3j3sandjfzx'';
+    url = "http://beta.quicklisp.org/archive/puri/2020-10-16/puri-20201016-git.tgz";
+    sha256 = "16h7gip6d0564s9yba3jg0rjzndmysv531hcrngvi3j3sandjfzx";
   };
 
   packageName = "puri";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/pythonic-string-reader.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/pythonic-string-reader.nix
@@ -1,16 +1,17 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''pythonic-string-reader'';
-  version = ''20180711-git'';
+  baseName = "pythonic-string-reader";
+  version = "20180711-git";
 
-  description = ''A simple and unintrusive read table modification that allows for
-simple string literal definition that doesn't require escaping characters.'';
+  description = "A simple and unintrusive read table modification that allows for
+simple string literal definition that doesn't require escaping characters.";
 
   deps = [ args."named-readtables" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/pythonic-string-reader/2018-07-11/pythonic-string-reader-20180711-git.tgz'';
-    sha256 = ''0gr6sbkmfwca9r0xa5vczjm4s9psbrqy5hvijkp5g42b0b7x5myx'';
+    url = "http://beta.quicklisp.org/archive/pythonic-string-reader/2018-07-11/pythonic-string-reader-20180711-git.tgz";
+    sha256 = "0gr6sbkmfwca9r0xa5vczjm4s9psbrqy5hvijkp5g42b0b7x5myx";
   };
 
   packageName = "pythonic-string-reader";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/query-fs.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/query-fs.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''query-fs'';
-  version = ''20200610-git'';
+  baseName = "query-fs";
+  version = "20200610-git";
 
-  description = ''High-level virtual FS using CL-Fuse-Meta-FS to represent results of queries'';
+  description = "High-level virtual FS using CL-Fuse-Meta-FS to represent results of queries";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-fuse" args."cl-fuse-meta-fs" args."cl-ppcre" args."cl-utilities" args."command-line-arguments" args."iterate" args."pcall" args."pcall-queue" args."trivial-backtrace" args."trivial-features" args."trivial-utf-8" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/query-fs/2020-06-10/query-fs-20200610-git.tgz'';
-    sha256 = ''1kcq2xs5dqwbhapknrynanwqn3c9h4cpi7hf362il2p6v6y4r413'';
+    url = "http://beta.quicklisp.org/archive/query-fs/2020-06-10/query-fs-20200610-git.tgz";
+    sha256 = "1kcq2xs5dqwbhapknrynanwqn3c9h4cpi7hf362il2p6v6y4r413";
   };
 
   packageName = "query-fs";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/quri.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/quri.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''quri'';
-  version = ''20210228-git'';
+  baseName = "quri";
+  version = "20210228-git";
 
-  description = ''Yet another URI library for Common Lisp'';
+  description = "Yet another URI library for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."cl-utilities" args."split-sequence" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/quri/2021-02-28/quri-20210228-git.tgz'';
-    sha256 = ''03hq6x715kv37c089b73f6j8b0f4ywhxr37wbw9any2jcgrswx0g'';
+    url = "http://beta.quicklisp.org/archive/quri/2021-02-28/quri-20210228-git.tgz";
+    sha256 = "03hq6x715kv37c089b73f6j8b0f4ywhxr37wbw9any2jcgrswx0g";
   };
 
   packageName = "quri";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/rfc2388.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/rfc2388.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''rfc2388'';
-  version = ''20180831-git'';
+  baseName = "rfc2388";
+  version = "20180831-git";
 
-  description = ''Implementation of RFC 2388'';
+  description = "Implementation of RFC 2388";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/rfc2388/2018-08-31/rfc2388-20180831-git.tgz'';
-    sha256 = ''1r7vvrlq2wl213bm2aknkf34ynpl8y4nbkfir79srrdsl1337z33'';
+    url = "http://beta.quicklisp.org/archive/rfc2388/2018-08-31/rfc2388-20180831-git.tgz";
+    sha256 = "1r7vvrlq2wl213bm2aknkf34ynpl8y4nbkfir79srrdsl1337z33";
   };
 
   packageName = "rfc2388";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''rove'';
-  version = ''20200325-git'';
+  baseName = "rove";
+  version = "20200325-git";
 
-  description = ''Yet another testing framework intended to be a successor of Prove'';
+  description = "Yet another testing framework intended to be a successor of Prove";
 
   deps = [ args."bordeaux-threads" args."dissect" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/rove/2020-03-25/rove-20200325-git.tgz'';
-    sha256 = ''0zn8d3408rgy2nibia5hdfbf80ix1fgssywx01izx7z99l5x50z5'';
+    url = "http://beta.quicklisp.org/archive/rove/2020-03-25/rove-20200325-git.tgz";
+    sha256 = "0zn8d3408rgy2nibia5hdfbf80ix1fgssywx01izx7z99l5x50z5";
   };
 
   packageName = "rove";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/rt.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/rt.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''rt'';
-  version = ''20101006-git'';
+  baseName = "rt";
+  version = "20101006-git";
 
-  description = ''MIT Regression Tester'';
+  description = "MIT Regression Tester";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/rt/2010-10-06/rt-20101006-git.tgz'';
-    sha256 = ''1jncar0xwkqk8yrc2dln389ivvgzs7ijdhhs3zpfyi5d21f0qa1v'';
+    url = "http://beta.quicklisp.org/archive/rt/2010-10-06/rt-20101006-git.tgz";
+    sha256 = "1jncar0xwkqk8yrc2dln389ivvgzs7ijdhhs3zpfyi5d21f0qa1v";
   };
 
   packageName = "rt";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''s-sql'';
-  version = ''postmodern-20210124-git'';
+  baseName = "s-sql";
+  version = "postmodern-20210124-git";
 
   parasites = [ "s-sql/tests" ];
 
-  description = ''Lispy DSL for SQL'';
+  description = "Lispy DSL for SQL";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_slash_tests" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."fiveam" args."global-vars" args."ironclad" args."md5" args."postmodern" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz'';
-    sha256 = ''1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc'';
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz";
+    sha256 = "1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc";
   };
 
   packageName = "s-sql";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sysdeps.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sysdeps.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''s-sysdeps'';
-  version = ''20210228-git'';
+  baseName = "s-sysdeps";
+  version = "20210228-git";
 
-  description = ''An abstraction layer over platform dependent functionality'';
+  description = "An abstraction layer over platform dependent functionality";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."split-sequence" args."usocket" args."usocket-server" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/s-sysdeps/2021-02-28/s-sysdeps-20210228-git.tgz'';
-    sha256 = ''0pybgicif1qavvix9183g4ahjrgcax3qf2ab523cas8l79lr1xkw'';
+    url = "http://beta.quicklisp.org/archive/s-sysdeps/2021-02-28/s-sysdeps-20210228-git.tgz";
+    sha256 = "0pybgicif1qavvix9183g4ahjrgcax3qf2ab523cas8l79lr1xkw";
   };
 
   packageName = "s-sysdeps";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-xml.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-xml.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''s-xml'';
-  version = ''20150608-git'';
+  baseName = "s-xml";
+  version = "20150608-git";
 
   parasites = [ "s-xml.examples" "s-xml.test" ];
 
-  description = ''Simple Common Lisp XML Parser'';
+  description = "Simple Common Lisp XML Parser";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/s-xml/2015-06-08/s-xml-20150608-git.tgz'';
-    sha256 = ''0cy36wqzasqma4maw9djq1vdwsp5hxq8svlbnhbv9sq9zzys5viq'';
+    url = "http://beta.quicklisp.org/archive/s-xml/2015-06-08/s-xml-20150608-git.tgz";
+    sha256 = "0cy36wqzasqma4maw9djq1vdwsp5hxq8svlbnhbv9sq9zzys5viq";
   };
 
   packageName = "s-xml";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/salza2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/salza2.nix
@@ -1,16 +1,17 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''salza2'';
-  version = ''2.0.9'';
+  baseName = "salza2";
+  version = "2.0.9";
 
-  description = ''Create compressed data in the ZLIB, DEFLATE, or GZIP
-  data formats'';
+  description = "Create compressed data in the ZLIB, DEFLATE, or GZIP
+  data formats";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/salza2/2013-07-20/salza2-2.0.9.tgz'';
-    sha256 = ''1m0hksgvq3njd9xa2nxlm161vgzw77djxmisq08v9pz2bz16v8va'';
+    url = "http://beta.quicklisp.org/archive/salza2/2013-07-20/salza2-2.0.9.tgz";
+    sha256 = "1m0hksgvq3njd9xa2nxlm161vgzw77djxmisq08v9pz2bz16v8va";
   };
 
   packageName = "salza2";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''serapeum'';
-  version = ''20210228-git'';
+  baseName = "serapeum";
+  version = "20210228-git";
 
-  description = ''Utilities beyond Alexandria.'';
+  description = "Utilities beyond Alexandria.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."parse-declarations-1_dot_0" args."parse-number" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-features" args."trivial-file-size" args."trivial-garbage" args."trivial-macroexpand-all" args."type-i" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/serapeum/2021-02-28/serapeum-20210228-git.tgz'';
-    sha256 = ''1dici8bmvrx5h74disrlvwns8f8jl746i4cyzyclswhv208x2m3x'';
+    url = "http://beta.quicklisp.org/archive/serapeum/2021-02-28/serapeum-20210228-git.tgz";
+    sha256 = "1dici8bmvrx5h74disrlvwns8f8jl746i4cyzyclswhv208x2m3x";
   };
 
   packageName = "serapeum";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date-time.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date-time.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''simple-date-time'';
-  version = ''20160421-git'';
+  baseName = "simple-date-time";
+  version = "20160421-git";
 
-  description = ''date and time library for common lisp'';
+  description = "date and time library for common lisp";
 
   deps = [ args."cl-ppcre" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/simple-date-time/2016-04-21/simple-date-time-20160421-git.tgz'';
-    sha256 = ''1db9n7pspxkqkzz12829a1lp7v4ghrnlb7g3wh04yz6m224d3i4h'';
+    url = "http://beta.quicklisp.org/archive/simple-date-time/2016-04-21/simple-date-time-20160421-git.tgz";
+    sha256 = "1db9n7pspxkqkzz12829a1lp7v4ghrnlb7g3wh04yz6m224d3i4h";
   };
 
   packageName = "simple-date-time";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''simple-date'';
-  version = ''postmodern-20210124-git'';
+  baseName = "simple-date";
+  version = "postmodern-20210124-git";
 
   parasites = [ "simple-date/tests" ];
 
-  description = ''Simple date library that can be used with postmodern'';
+  description = "Simple date library that can be used with postmodern";
 
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz'';
-    sha256 = ''1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc'';
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz";
+    sha256 = "1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc";
   };
 
   packageName = "simple-date";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-tasks.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-tasks.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''simple-tasks'';
-  version = ''20190710-git'';
+  baseName = "simple-tasks";
+  version = "20190710-git";
 
-  description = ''A very simple task scheduling framework.'';
+  description = "A very simple task scheduling framework.";
 
   deps = [ args."alexandria" args."array-utils" args."bordeaux-threads" args."dissect" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/simple-tasks/2019-07-10/simple-tasks-20190710-git.tgz'';
-    sha256 = ''12y5phnbj9s2fsrz1ab6xj857zf1fv8kjk7jj2mdjs6k2d8gk8v3'';
+    url = "http://beta.quicklisp.org/archive/simple-tasks/2019-07-10/simple-tasks-20190710-git.tgz";
+    sha256 = "12y5phnbj9s2fsrz1ab6xj857zf1fv8kjk7jj2mdjs6k2d8gk8v3";
   };
 
   packageName = "simple-tasks";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/smart-buffer.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/smart-buffer.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''smart-buffer'';
-  version = ''20160628-git'';
+  baseName = "smart-buffer";
+  version = "20160628-git";
 
-  description = ''Smart octets buffer'';
+  description = "Smart octets buffer";
 
   deps = [ args."flexi-streams" args."trivial-gray-streams" args."uiop" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/smart-buffer/2016-06-28/smart-buffer-20160628-git.tgz'';
-    sha256 = ''1wp50snkc8739n91xlnfnq1dzz3kfp0awgp92m7xbpcw3hbaib1s'';
+    url = "http://beta.quicklisp.org/archive/smart-buffer/2016-06-28/smart-buffer-20160628-git.tgz";
+    sha256 = "1wp50snkc8739n91xlnfnq1dzz3kfp0awgp92m7xbpcw3hbaib1s";
   };
 
   packageName = "smart-buffer";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/split-sequence.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/split-sequence.nix
@@ -1,18 +1,19 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''split-sequence'';
-  version = ''v2.0.0'';
+  baseName = "split-sequence";
+  version = "v2.0.0";
 
   parasites = [ "split-sequence/tests" ];
 
-  description = ''Splits a sequence into a list of subsequences
-  delimited by objects satisfying a test.'';
+  description = "Splits a sequence into a list of subsequences
+  delimited by objects satisfying a test.";
 
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/split-sequence/2019-05-21/split-sequence-v2.0.0.tgz'';
-    sha256 = ''09cmmswzl1kahvlzgqv8lqm9qcnz5iqg8f26fw3mm9rb3dcp7aba'';
+    url = "http://beta.quicklisp.org/archive/split-sequence/2019-05-21/split-sequence-v2.0.0.tgz";
+    sha256 = "09cmmswzl1kahvlzgqv8lqm9qcnz5iqg8f26fw3mm9rb3dcp7aba";
   };
 
   packageName = "split-sequence";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/sqlite.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/sqlite.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''sqlite'';
-  version = ''cl-20190813-git'';
+  baseName = "sqlite";
+  version = "cl-20190813-git";
 
-  description = ''CL-SQLITE package is an interface to the SQLite embedded relational database engine.'';
+  description = "CL-SQLITE package is an interface to the SQLite embedded relational database engine.";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."iterate" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-sqlite/2019-08-13/cl-sqlite-20190813-git.tgz'';
-    sha256 = ''07zla2h7i7ggmzsyj33f12vpxvcbbvq6x022c2dy13flx8a83rmk'';
+    url = "http://beta.quicklisp.org/archive/cl-sqlite/2019-08-13/cl-sqlite-20190813-git.tgz";
+    sha256 = "07zla2h7i7ggmzsyj33f12vpxvcbbvq6x022c2dy13flx8a83rmk";
   };
 
   packageName = "sqlite";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-vectors.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-vectors.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''static-vectors'';
-  version = ''v1.8.6'';
+  baseName = "static-vectors";
+  version = "v1.8.6";
 
   parasites = [ "static-vectors/test" ];
 
-  description = ''Create vectors allocated in static memory.'';
+  description = "Create vectors allocated in static memory.";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."fiveam" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/static-vectors/2020-06-10/static-vectors-v1.8.6.tgz'';
-    sha256 = ''0s549cxd8a8ix6jl4dfxj2nh01nl9f4hgnlmb88w7iixanxn58mc'';
+    url = "http://beta.quicklisp.org/archive/static-vectors/2020-06-10/static-vectors-v1.8.6.tgz";
+    sha256 = "0s549cxd8a8ix6jl4dfxj2nh01nl9f4hgnlmb88w7iixanxn58mc";
   };
 
   packageName = "static-vectors";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/stefil.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/stefil.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''stefil'';
-  version = ''20181210-git'';
+  baseName = "stefil";
+  version = "20181210-git";
 
   parasites = [ "stefil-test" ];
 
-  description = ''Stefil - Simple Test Framework In Lisp'';
+  description = "Stefil - Simple Test Framework In Lisp";
 
   deps = [ args."alexandria" args."iterate" args."metabang-bind" args."swank" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/stefil/2018-12-10/stefil-20181210-git.tgz'';
-    sha256 = ''10dr8yjrjc2pyx55knds5llh9k716khlvbkmpxh0vn8rdmxmz96g'';
+    url = "http://beta.quicklisp.org/archive/stefil/2018-12-10/stefil-20181210-git.tgz";
+    sha256 = "10dr8yjrjc2pyx55knds5llh9k716khlvbkmpxh0vn8rdmxmz96g";
   };
 
   packageName = "stefil";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''str'';
-  version = ''cl-20210124-git'';
+  baseName = "str";
+  version = "cl-20210124-git";
 
-  description = ''Modern, consistent and terse Common Lisp string manipulation library.'';
+  description = "Modern, consistent and terse Common Lisp string manipulation library.";
 
   deps = [ args."cl-change-case" args."cl-ppcre" args."cl-ppcre-unicode" args."cl-unicode" args."flexi-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-str/2021-01-24/cl-str-20210124-git.tgz'';
-    sha256 = ''07y24mx8gmhwz6px63llgsz15aqicqa4m8gd5zwxy708xggv73jc'';
+    url = "http://beta.quicklisp.org/archive/cl-str/2021-01-24/cl-str-20210124-git.tgz";
+    sha256 = "07y24mx8gmhwz6px63llgsz15aqicqa4m8gd5zwxy708xggv73jc";
   };
 
   packageName = "str";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/string-case.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/string-case.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''string-case'';
-  version = ''20180711-git'';
+  baseName = "string-case";
+  version = "20180711-git";
 
-  description = ''string-case is a macro that generates specialised decision trees to dispatch on string equality'';
+  description = "string-case is a macro that generates specialised decision trees to dispatch on string equality";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/string-case/2018-07-11/string-case-20180711-git.tgz'';
-    sha256 = ''1n36ign4bv0idw14zyayn6i0n3iaff9yw92kpjh3qmdcq3asv90z'';
+    url = "http://beta.quicklisp.org/archive/string-case/2018-07-11/string-case-20180711-git.tgz";
+    sha256 = "1n36ign4bv0idw14zyayn6i0n3iaff9yw92kpjh3qmdcq3asv90z";
   };
 
   packageName = "string-case";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''stumpwm'';
-  version = ''20210228-git'';
+  baseName = "stumpwm";
+  version = "20210228-git";
 
-  description = ''A tiling, keyboard driven window manager'';
+  description = "A tiling, keyboard driven window manager";
 
   deps = [ args."alexandria" args."cl-ppcre" args."clx" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/stumpwm/2021-02-28/stumpwm-20210228-git.tgz'';
-    sha256 = ''0vfhn90vfyhlbjkfkzx0i7i6qh79p9q4c4hhsym80niz508xw5v8'';
+    url = "http://beta.quicklisp.org/archive/stumpwm/2021-02-28/stumpwm-20210228-git.tgz";
+    sha256 = "0vfhn90vfyhlbjkfkzx0i7i6qh79p9q4c4hhsym80niz508xw5v8";
   };
 
   packageName = "stumpwm";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/swank.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/swank.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''swank'';
-  version = ''slime-v2.26.1'';
+  baseName = "swank";
+  version = "slime-v2.26.1";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/slime/2020-12-20/slime-v2.26.1.tgz'';
-    sha256 = ''12q3la9lwzs01x0ii5vss0i8i78lgyjrn3adr3rs027f4b7386ny'';
+    url = "http://beta.quicklisp.org/archive/slime/2020-12-20/slime-v2.26.1.tgz";
+    sha256 = "12q3la9lwzs01x0ii5vss0i8i78lgyjrn3adr3rs027f4b7386ny";
   };
 
   packageName = "swank";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/swap-bytes.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/swap-bytes.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''swap-bytes'';
-  version = ''v1.2'';
+  baseName = "swap-bytes";
+  version = "v1.2";
 
   parasites = [ "swap-bytes/test" ];
 
-  description = ''Optimized byte-swapping primitives.'';
+  description = "Optimized byte-swapping primitives.";
 
   deps = [ args."fiveam" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/swap-bytes/2019-11-30/swap-bytes-v1.2.tgz'';
-    sha256 = ''05g37m4cpsszh16jz7kiscd6m6l66ms73f3s6s94i56c49jfxdy8'';
+    url = "http://beta.quicklisp.org/archive/swap-bytes/2019-11-30/swap-bytes-v1.2.tgz";
+    sha256 = "05g37m4cpsszh16jz7kiscd6m6l66ms73f3s6s94i56c49jfxdy8";
   };
 
   packageName = "swap-bytes";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/symbol-munger.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/symbol-munger.nix
@@ -1,16 +1,17 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''symbol-munger'';
-  version = ''20150407-git'';
+  baseName = "symbol-munger";
+  version = "20150407-git";
 
-  description = ''Functions to convert between the spacing and
-  capitalization conventions of various environments'';
+  description = "Functions to convert between the spacing and
+  capitalization conventions of various environments";
 
   deps = [ args."alexandria" args."iterate" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/symbol-munger/2015-04-07/symbol-munger-20150407-git.tgz'';
-    sha256 = ''0dccli8557kvyy2rngh646rmavf96p7xqn5bry65d7c1f61lyqv6'';
+    url = "http://beta.quicklisp.org/archive/symbol-munger/2015-04-07/symbol-munger-20150407-git.tgz";
+    sha256 = "0dccli8557kvyy2rngh646rmavf96p7xqn5bry65d7c1f61lyqv6";
   };
 
   packageName = "symbol-munger";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivia'';
-  version = ''20210228-git'';
+  baseName = "trivia";
+  version = "20210228-git";
 
-  description = ''NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase'';
+  description = "NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase";
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."iterate" args."lisp-namespace" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz'';
-    sha256 = ''0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6'';
+    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
+    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
   };
 
   packageName = "trivia";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_balland2006.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_balland2006.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivia_dot_balland2006'';
-  version = ''trivia-20210228-git'';
+  baseName = "trivia_dot_balland2006";
+  version = "trivia-20210228-git";
 
-  description = ''Optimizer for Trivia based on (Balland 2006)'';
+  description = "Optimizer for Trivia based on (Balland 2006)";
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."iterate" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz'';
-    sha256 = ''0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6'';
+    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
+    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
   };
 
   packageName = "trivia.balland2006";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level0.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level0.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivia_dot_level0'';
-  version = ''trivia-20210228-git'';
+  baseName = "trivia_dot_level0";
+  version = "trivia-20210228-git";
 
-  description = ''Bootstrapping Pattern Matching Library for implementing Trivia'';
+  description = "Bootstrapping Pattern Matching Library for implementing Trivia";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz'';
-    sha256 = ''0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6'';
+    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
+    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
   };
 
   packageName = "trivia.level0";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level1.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level1.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivia_dot_level1'';
-  version = ''trivia-20210228-git'';
+  baseName = "trivia_dot_level1";
+  version = "trivia-20210228-git";
 
-  description = ''Core patterns of Trivia'';
+  description = "Core patterns of Trivia";
 
   deps = [ args."alexandria" args."trivia_dot_level0" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz'';
-    sha256 = ''0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6'';
+    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
+    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
   };
 
   packageName = "trivia.level1";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level2.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivia_dot_level2'';
-  version = ''trivia-20210228-git'';
+  baseName = "trivia_dot_level2";
+  version = "trivia-20210228-git";
 
-  description = ''NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase'';
+  description = "NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase";
 
   deps = [ args."alexandria" args."closer-mop" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz'';
-    sha256 = ''0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6'';
+    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
+    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
   };
 
   packageName = "trivia.level2";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivia_dot_quasiquote'';
-  version = ''trivia-20210228-git'';
+  baseName = "trivia_dot_quasiquote";
+  version = "trivia-20210228-git";
 
-  description = ''fare-quasiquote extension for trivia'';
+  description = "fare-quasiquote extension for trivia";
 
   deps = [ args."alexandria" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-readtable" args."fare-utils" args."lisp-namespace" args."named-readtables" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz'';
-    sha256 = ''0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6'';
+    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
+    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
   };
 
   packageName = "trivia.quasiquote";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivia_dot_trivial'';
-  version = ''trivia-20210228-git'';
+  baseName = "trivia_dot_trivial";
+  version = "trivia-20210228-git";
 
-  description = ''Base level system of Trivia with a trivial optimizer.
+  description = "Base level system of Trivia with a trivial optimizer.
  Systems that intend to enhance Trivia should depend on this package, not the TRIVIA system,
- in order to avoid the circular dependency.'';
+ in order to avoid the circular dependency.";
 
   deps = [ args."alexandria" args."closer-mop" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz'';
-    sha256 = ''0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6'';
+    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
+    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
   };
 
   packageName = "trivia.trivial";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-backtrace.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-backtrace.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-backtrace'';
-  version = ''20200610-git'';
+  baseName = "trivial-backtrace";
+  version = "20200610-git";
 
-  description = ''trivial-backtrace'';
+  description = "trivial-backtrace";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-backtrace/2020-06-10/trivial-backtrace-20200610-git.tgz'';
-    sha256 = ''0slz2chal6vpiqx9zmjh4cnihhw794rq3267s7kz7livpiv52rks'';
+    url = "http://beta.quicklisp.org/archive/trivial-backtrace/2020-06-10/trivial-backtrace-20200610-git.tgz";
+    sha256 = "0slz2chal6vpiqx9zmjh4cnihhw794rq3267s7kz7livpiv52rks";
   };
 
   packageName = "trivial-backtrace";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-clipboard.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-clipboard.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-clipboard'';
-  version = ''20210228-git'';
+  baseName = "trivial-clipboard";
+  version = "20210228-git";
 
-  description = ''trivial-clipboard let access system clipboard.'';
+  description = "trivial-clipboard let access system clipboard.";
 
   deps = [ args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-clipboard/2021-02-28/trivial-clipboard-20210228-git.tgz'';
-    sha256 = ''1fmxkz97qrjkc320w849r1411f7j2ghf3g9xh5lczcapgjwq8f0l'';
+    url = "http://beta.quicklisp.org/archive/trivial-clipboard/2021-02-28/trivial-clipboard-20210228-git.tgz";
+    sha256 = "1fmxkz97qrjkc320w849r1411f7j2ghf3g9xh5lczcapgjwq8f0l";
   };
 
   packageName = "trivial-clipboard";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-cltl2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-cltl2.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-cltl2'';
-  version = ''20200325-git'';
+  baseName = "trivial-cltl2";
+  version = "20200325-git";
 
-  description = ''Compatibility package exporting CLtL2 functionality'';
+  description = "Compatibility package exporting CLtL2 functionality";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-cltl2/2020-03-25/trivial-cltl2-20200325-git.tgz'';
-    sha256 = ''0hahi36v47alsvamg62d0cgay8l0razcgxl089ifj6sqy7s8iwys'';
+    url = "http://beta.quicklisp.org/archive/trivial-cltl2/2020-03-25/trivial-cltl2-20200325-git.tgz";
+    sha256 = "0hahi36v47alsvamg62d0cgay8l0razcgxl089ifj6sqy7s8iwys";
   };
 
   packageName = "trivial-cltl2";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-features.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-features.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-features'';
-  version = ''20210228-git'';
+  baseName = "trivial-features";
+  version = "20210228-git";
 
-  description = ''Ensures consistent *FEATURES* across multiple CLs.'';
+  description = "Ensures consistent *FEATURES* across multiple CLs.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-features/2021-02-28/trivial-features-20210228-git.tgz'';
-    sha256 = ''1najk88r8nlpbxm8mjfj8b22f9chr9h2hxg9wqz87kkmhg4rfwwj'';
+    url = "http://beta.quicklisp.org/archive/trivial-features/2021-02-28/trivial-features-20210228-git.tgz";
+    sha256 = "1najk88r8nlpbxm8mjfj8b22f9chr9h2hxg9wqz87kkmhg4rfwwj";
   };
 
   packageName = "trivial-features";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-file-size.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-file-size.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-file-size'';
-  version = ''20200427-git'';
+  baseName = "trivial-file-size";
+  version = "20200427-git";
 
   parasites = [ "trivial-file-size/tests" ];
 
-  description = ''Stat a file's size.'';
+  description = "Stat a file's size.";
 
   deps = [ args."fiveam" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-file-size/2020-04-27/trivial-file-size-20200427-git.tgz'';
-    sha256 = ''1vspkgygrldbjb4gdm1fsn04j50rwil41x0fvvm4fxm84rwrscsa'';
+    url = "http://beta.quicklisp.org/archive/trivial-file-size/2020-04-27/trivial-file-size-20200427-git.tgz";
+    sha256 = "1vspkgygrldbjb4gdm1fsn04j50rwil41x0fvvm4fxm84rwrscsa";
   };
 
   packageName = "trivial-file-size";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-garbage.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-garbage.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-garbage'';
-  version = ''20200925-git'';
+  baseName = "trivial-garbage";
+  version = "20200925-git";
 
   parasites = [ "trivial-garbage/tests" ];
 
-  description = ''Portable finalizers, weak hash-tables and weak pointers.'';
+  description = "Portable finalizers, weak hash-tables and weak pointers.";
 
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-garbage/2020-09-25/trivial-garbage-20200925-git.tgz'';
-    sha256 = ''00iw2iw6qzji9b2gwy798l54jdk185sxh1k7m2qd9srs8s730k83'';
+    url = "http://beta.quicklisp.org/archive/trivial-garbage/2020-09-25/trivial-garbage-20200925-git.tgz";
+    sha256 = "00iw2iw6qzji9b2gwy798l54jdk185sxh1k7m2qd9srs8s730k83";
   };
 
   packageName = "trivial-garbage";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-gray-streams.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-gray-streams.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-gray-streams'';
-  version = ''20210124-git'';
+  baseName = "trivial-gray-streams";
+  version = "20210124-git";
 
-  description = ''Compatibility layer for Gray Streams (see http://www.cliki.net/Gray%20streams).'';
+  description = "Compatibility layer for Gray Streams (see http://www.cliki.net/Gray%20streams).";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-gray-streams/2021-01-24/trivial-gray-streams-20210124-git.tgz'';
-    sha256 = ''0swqcw3649279qyn5lc42xqgi13jc4kd7hf3iasf4vfli8lhb3n6'';
+    url = "http://beta.quicklisp.org/archive/trivial-gray-streams/2021-01-24/trivial-gray-streams-20210124-git.tgz";
+    sha256 = "0swqcw3649279qyn5lc42xqgi13jc4kd7hf3iasf4vfli8lhb3n6";
   };
 
   packageName = "trivial-gray-streams";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-indent.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-indent.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-indent'';
-  version = ''20191007-git'';
+  baseName = "trivial-indent";
+  version = "20191007-git";
 
-  description = ''A very simple library to allow indentation hints for SWANK.'';
+  description = "A very simple library to allow indentation hints for SWANK.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-indent/2019-10-07/trivial-indent-20191007-git.tgz'';
-    sha256 = ''0v5isxg6lfbgcpmndb3c515d7bswhwqgjm97li85w39krnw1bfmv'';
+    url = "http://beta.quicklisp.org/archive/trivial-indent/2019-10-07/trivial-indent-20191007-git.tgz";
+    sha256 = "0v5isxg6lfbgcpmndb3c515d7bswhwqgjm97li85w39krnw1bfmv";
   };
 
   packageName = "trivial-indent";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-macroexpand-all.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-macroexpand-all.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-macroexpand-all'';
-  version = ''20171023-git'';
+  baseName = "trivial-macroexpand-all";
+  version = "20171023-git";
 
-  description = ''Call each implementation's macroexpand-all equivalent'';
+  description = "Call each implementation's macroexpand-all equivalent";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-macroexpand-all/2017-10-23/trivial-macroexpand-all-20171023-git.tgz'';
-    sha256 = ''0h5h9zn32pn26x7ll9h08g0csr2f5hvk1wgbr7kdhx5zbrszd7zm'';
+    url = "http://beta.quicklisp.org/archive/trivial-macroexpand-all/2017-10-23/trivial-macroexpand-all-20171023-git.tgz";
+    sha256 = "0h5h9zn32pn26x7ll9h08g0csr2f5hvk1wgbr7kdhx5zbrszd7zm";
   };
 
   packageName = "trivial-macroexpand-all";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-main-thread.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-main-thread.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-main-thread'';
-  version = ''20190710-git'';
+  baseName = "trivial-main-thread";
+  version = "20190710-git";
 
-  description = ''Compatibility library to run things in the main thread.'';
+  description = "Compatibility library to run things in the main thread.";
 
   deps = [ args."alexandria" args."array-utils" args."bordeaux-threads" args."dissect" args."simple-tasks" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-main-thread/2019-07-10/trivial-main-thread-20190710-git.tgz'';
-    sha256 = ''1zj12rc29rrff5grmi7sjxfzdv78khbb4sg43hy2cb33hykpvg2h'';
+    url = "http://beta.quicklisp.org/archive/trivial-main-thread/2019-07-10/trivial-main-thread-20190710-git.tgz";
+    sha256 = "1zj12rc29rrff5grmi7sjxfzdv78khbb4sg43hy2cb33hykpvg2h";
   };
 
   packageName = "trivial-main-thread";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-mimes.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-mimes.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-mimes'';
-  version = ''20200715-git'';
+  baseName = "trivial-mimes";
+  version = "20200715-git";
 
-  description = ''Tiny library to detect mime types in files.'';
+  description = "Tiny library to detect mime types in files.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-mimes/2020-07-15/trivial-mimes-20200715-git.tgz'';
-    sha256 = ''10mk1v5ad0m3bg5pl7lqhh827jvg5jb896807vmi8wznwk7zaif1'';
+    url = "http://beta.quicklisp.org/archive/trivial-mimes/2020-07-15/trivial-mimes-20200715-git.tgz";
+    sha256 = "10mk1v5ad0m3bg5pl7lqhh827jvg5jb896807vmi8wznwk7zaif1";
   };
 
   packageName = "trivial-mimes";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-package-local-nicknames.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-package-local-nicknames.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-package-local-nicknames'';
-  version = ''20200610-git'';
+  baseName = "trivial-package-local-nicknames";
+  version = "20200610-git";
 
-  description = ''Portability library for package-local nicknames'';
+  description = "Portability library for package-local nicknames";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-package-local-nicknames/2020-06-10/trivial-package-local-nicknames-20200610-git.tgz'';
-    sha256 = ''1wabkcwz0v144rb2w3rvxlcj264indfnvlyigk1wds7nq0c8lwk5'';
+    url = "http://beta.quicklisp.org/archive/trivial-package-local-nicknames/2020-06-10/trivial-package-local-nicknames-20200610-git.tgz";
+    sha256 = "1wabkcwz0v144rb2w3rvxlcj264indfnvlyigk1wds7nq0c8lwk5";
   };
 
   packageName = "trivial-package-local-nicknames";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-types.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-types.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-types'';
-  version = ''20120407-git'';
+  baseName = "trivial-types";
+  version = "20120407-git";
 
-  description = ''Trivial type definitions'';
+  description = "Trivial type definitions";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-types/2012-04-07/trivial-types-20120407-git.tgz'';
-    sha256 = ''0y3lfbbvi2qp2cwswzmk1awzqrsrrcfkcm1qn744bgm1fiqhxbxx'';
+    url = "http://beta.quicklisp.org/archive/trivial-types/2012-04-07/trivial-types-20120407-git.tgz";
+    sha256 = "0y3lfbbvi2qp2cwswzmk1awzqrsrrcfkcm1qn744bgm1fiqhxbxx";
   };
 
   packageName = "trivial-types";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-utf-8.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-utf-8.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-utf-8'';
-  version = ''20200925-git'';
+  baseName = "trivial-utf-8";
+  version = "20200925-git";
 
   parasites = [ "trivial-utf-8/doc" "trivial-utf-8/tests" ];
 
-  description = ''A small library for doing UTF-8-based input and output.'';
+  description = "A small library for doing UTF-8-based input and output.";
 
   deps = [ args."mgl-pax" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-utf-8/2020-09-25/trivial-utf-8-20200925-git.tgz'';
-    sha256 = ''06v9jif4f5xyl5jd7ldg69ds7cypf72xl7nda5q55fssmgcydi1b'';
+    url = "http://beta.quicklisp.org/archive/trivial-utf-8/2020-09-25/trivial-utf-8-20200925-git.tgz";
+    sha256 = "06v9jif4f5xyl5jd7ldg69ds7cypf72xl7nda5q55fssmgcydi1b";
   };
 
   packageName = "trivial-utf-8";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-with-current-source-form.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-with-current-source-form.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''trivial-with-current-source-form'';
-  version = ''20200427-git'';
+  baseName = "trivial-with-current-source-form";
+  version = "20200427-git";
 
-  description = ''Helps macro writers produce better errors for macro users'';
+  description = "Helps macro writers produce better errors for macro users";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-with-current-source-form/2020-04-27/trivial-with-current-source-form-20200427-git.tgz'';
-    sha256 = ''05zkj42f071zhg7swfyklg44k0zc893c9li9virkigzmvhids84f'';
+    url = "http://beta.quicklisp.org/archive/trivial-with-current-source-form/2020-04-27/trivial-with-current-source-form-20200427-git.tgz";
+    sha256 = "05zkj42f071zhg7swfyklg44k0zc893c9li9virkigzmvhids84f";
   };
 
   packageName = "trivial-with-current-source-form";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/type-i.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/type-i.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''type-i'';
-  version = ''20191227-git'';
+  baseName = "type-i";
+  version = "20191227-git";
 
-  description = ''Type Inference Utility on Fundamentally 1-arg Predicates'';
+  description = "Type Inference Utility on Fundamentally 1-arg Predicates";
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/type-i/2019-12-27/type-i-20191227-git.tgz'';
-    sha256 = ''0f8q6klqjgz1kdyhisfkk07izvgs04jchlv2kl3srjxfr5dj5jl5'';
+    url = "http://beta.quicklisp.org/archive/type-i/2019-12-27/type-i-20191227-git.tgz";
+    sha256 = "0f8q6klqjgz1kdyhisfkk07izvgs04jchlv2kl3srjxfr5dj5jl5";
   };
 
   packageName = "type-i";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/uax-15.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/uax-15.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''uax-15'';
-  version = ''20210228-git'';
+  baseName = "uax-15";
+  version = "20210228-git";
 
   parasites = [ "uax-15/tests" ];
 
-  description = ''Common lisp implementation of Unicode normalization functions :nfc, :nfd, :nfkc and :nfkd (Uax-15)'';
+  description = "Common lisp implementation of Unicode normalization functions :nfc, :nfd, :nfkc and :nfkd (Uax-15)";
 
   deps = [ args."cl-ppcre" args."fiveam" args."split-sequence" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/uax-15/2021-02-28/uax-15-20210228-git.tgz'';
-    sha256 = ''1vf590djzyika6200zqw4mbqrajcmv7g5swydimnvk7xqzpa8ksp'';
+    url = "http://beta.quicklisp.org/archive/uax-15/2021-02-28/uax-15-20210228-git.tgz";
+    sha256 = "1vf590djzyika6200zqw4mbqrajcmv7g5swydimnvk7xqzpa8ksp";
   };
 
   packageName = "uax-15";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/uffi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/uffi.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''uffi'';
-  version = ''20180228-git'';
+  baseName = "uffi";
+  version = "20180228-git";
 
-  description = ''Universal Foreign Function Library for Common Lisp'';
+  description = "Universal Foreign Function Library for Common Lisp";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/uffi/2018-02-28/uffi-20180228-git.tgz'';
-    sha256 = ''1kknzwxsbg2ydy2w0n88y2bq37lqqwg02ffsmz57gqbxvlk26479'';
+    url = "http://beta.quicklisp.org/archive/uffi/2018-02-28/uffi-20180228-git.tgz";
+    sha256 = "1kknzwxsbg2ydy2w0n88y2bq37lqqwg02ffsmz57gqbxvlk26479";
   };
 
   packageName = "uffi";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/uiop.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/uiop.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''uiop'';
-  version = ''3.3.4'';
+  baseName = "uiop";
+  version = "3.3.4";
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/uiop/2020-02-18/uiop-3.3.4.tgz'';
-    sha256 = ''0n0fp55ivwi6gzhaywdkngnk2snpp9nn3mz5rq3pnrwldi9q7aav'';
+    url = "http://beta.quicklisp.org/archive/uiop/2020-02-18/uiop-3.3.4.tgz";
+    sha256 = "0n0fp55ivwi6gzhaywdkngnk2snpp9nn3mz5rq3pnrwldi9q7aav";
   };
 
   packageName = "uiop";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/unit-test.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/unit-test.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''unit-test'';
-  version = ''20120520-git'';
+  baseName = "unit-test";
+  version = "20120520-git";
 
-  description = ''unit-testing framework for common lisp'';
+  description = "unit-testing framework for common lisp";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/unit-test/2012-05-20/unit-test-20120520-git.tgz'';
-    sha256 = ''1bwbx9d2z9qll46ksfh7bgd0dgh4is2dyfhkladq53qycvjywv9l'';
+    url = "http://beta.quicklisp.org/archive/unit-test/2012-05-20/unit-test-20120520-git.tgz";
+    sha256 = "1bwbx9d2z9qll46ksfh7bgd0dgh4is2dyfhkladq53qycvjywv9l";
   };
 
   packageName = "unit-test";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/unix-options.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/unix-options.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''unix-options'';
-  version = ''20151031-git'';
+  baseName = "unix-options";
+  version = "20151031-git";
 
-  description = ''Easy to use command line option parser'';
+  description = "Easy to use command line option parser";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/unix-options/2015-10-31/unix-options-20151031-git.tgz'';
-    sha256 = ''0c9vbvvyx5qwvns87624gzxjcbdkbkcwssg29cxjfv3ci3qwqcd5'';
+    url = "http://beta.quicklisp.org/archive/unix-options/2015-10-31/unix-options-20151031-git.tgz";
+    sha256 = "0c9vbvvyx5qwvns87624gzxjcbdkbkcwssg29cxjfv3ci3qwqcd5";
   };
 
   packageName = "unix-options";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/unix-opts.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/unix-opts.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''unix-opts'';
-  version = ''20210124-git'';
+  baseName = "unix-opts";
+  version = "20210124-git";
 
   parasites = [ "unix-opts/tests" ];
 
-  description = ''minimalistic parser of command line arguments'';
+  description = "minimalistic parser of command line arguments";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/unix-opts/2021-01-24/unix-opts-20210124-git.tgz'';
-    sha256 = ''1gjjav035n6297vgc4wi3i64516b8sdyi0d02q0nwicciwg6mwsn'';
+    url = "http://beta.quicklisp.org/archive/unix-opts/2021-01-24/unix-opts-20210124-git.tgz";
+    sha256 = "1gjjav035n6297vgc4wi3i64516b8sdyi0d02q0nwicciwg6mwsn";
   };
 
   packageName = "unix-opts";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/usocket-server.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/usocket-server.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''usocket-server'';
-  version = ''usocket-0.8.3'';
+  baseName = "usocket-server";
+  version = "usocket-0.8.3";
 
-  description = ''Universal socket library for Common Lisp (server side)'';
+  description = "Universal socket library for Common Lisp (server side)";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."split-sequence" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/usocket/2019-12-27/usocket-0.8.3.tgz'';
-    sha256 = ''19gl72r9jqms8slzn7i7bww2cqng9mhiqqhhccadlrx2xv6d3lm7'';
+    url = "http://beta.quicklisp.org/archive/usocket/2019-12-27/usocket-0.8.3.tgz";
+    sha256 = "19gl72r9jqms8slzn7i7bww2cqng9mhiqqhhccadlrx2xv6d3lm7";
   };
 
   packageName = "usocket-server";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/usocket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/usocket.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''usocket'';
-  version = ''0.8.3'';
+  baseName = "usocket";
+  version = "0.8.3";
 
-  description = ''Universal socket library for Common Lisp'';
+  description = "Universal socket library for Common Lisp";
 
   deps = [ args."split-sequence" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/usocket/2019-12-27/usocket-0.8.3.tgz'';
-    sha256 = ''19gl72r9jqms8slzn7i7bww2cqng9mhiqqhhccadlrx2xv6d3lm7'';
+    url = "http://beta.quicklisp.org/archive/usocket/2019-12-27/usocket-0.8.3.tgz";
+    sha256 = "19gl72r9jqms8slzn7i7bww2cqng9mhiqqhhccadlrx2xv6d3lm7";
   };
 
   packageName = "usocket";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-items.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-items.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''utilities_dot_print-items'';
-  version = ''20190813-git'';
+  baseName = "utilities_dot_print-items";
+  version = "20190813-git";
 
   parasites = [ "utilities.print-items/test" ];
 
-  description = ''A protocol for flexible and composable printing.'';
+  description = "A protocol for flexible and composable printing.";
 
   deps = [ args."alexandria" args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/utilities.print-items/2019-08-13/utilities.print-items-20190813-git.tgz'';
-    sha256 = ''12l4kzz621qfcg8p5qzyxp4n4hh9wdlpiziykwb4c80g32rdwkc2'';
+    url = "http://beta.quicklisp.org/archive/utilities.print-items/2019-08-13/utilities.print-items-20190813-git.tgz";
+    sha256 = "12l4kzz621qfcg8p5qzyxp4n4hh9wdlpiziykwb4c80g32rdwkc2";
   };
 
   packageName = "utilities.print-items";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-tree.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-tree.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''utilities_dot_print-tree'';
-  version = ''20200325-git'';
+  baseName = "utilities_dot_print-tree";
+  version = "20200325-git";
 
   parasites = [ "utilities.print-tree/test" ];
 
-  description = ''This system provides simple facilities for printing tree structures.'';
+  description = "This system provides simple facilities for printing tree structures.";
 
   deps = [ args."alexandria" args."fiveam" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/utilities.print-tree/2020-03-25/utilities.print-tree-20200325-git.tgz'';
-    sha256 = ''1nam8g2ppzkzpkwwhmil9y68is43ljpvc7hd64zxp4zsaqab5dww'';
+    url = "http://beta.quicklisp.org/archive/utilities.print-tree/2020-03-25/utilities.print-tree-20200325-git.tgz";
+    sha256 = "1nam8g2ppzkzpkwwhmil9y68is43ljpvc7hd64zxp4zsaqab5dww";
   };
 
   packageName = "utilities.print-tree";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/uuid.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/uuid.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''uuid'';
-  version = ''20200715-git'';
+  baseName = "uuid";
+  version = "20200715-git";
 
-  description = ''UUID Generation'';
+  description = "UUID Generation";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."trivial-utf-8" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/uuid/2020-07-15/uuid-20200715-git.tgz'';
-    sha256 = ''1ymir6hgax1vbbcgyprnwbsx224ih03a55v10l35xridwyzhzrx0'';
+    url = "http://beta.quicklisp.org/archive/uuid/2020-07-15/uuid-20200715-git.tgz";
+    sha256 = "1ymir6hgax1vbbcgyprnwbsx224ih03a55v10l35xridwyzhzrx0";
   };
 
   packageName = "uuid";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/vom.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/vom.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''vom'';
-  version = ''20160825-git'';
+  baseName = "vom";
+  version = "20160825-git";
 
-  description = ''A tiny logging utility.'';
+  description = "A tiny logging utility.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/vom/2016-08-25/vom-20160825-git.tgz'';
-    sha256 = ''0mvln0xx8qnrsmaj7c0f2ilgahvf078qvhqag7qs3j26xmamjm93'';
+    url = "http://beta.quicklisp.org/archive/vom/2016-08-25/vom-20160825-git.tgz";
+    sha256 = "0mvln0xx8qnrsmaj7c0f2ilgahvf078qvhqag7qs3j26xmamjm93";
   };
 
   packageName = "vom";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/woo.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/woo.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''woo'';
-  version = ''20200427-git'';
+  baseName = "woo";
+  version = "20200427-git";
 
-  description = ''An asynchronous HTTP server written in Common Lisp'';
+  description = "An asynchronous HTTP server written in Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-utilities" args."clack-socket" args."fast-http" args."fast-io" args."flexi-streams" args."lev" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."swap-bytes" args."trivial-features" args."trivial-gray-streams" args."trivial-utf-8" args."vom" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/woo/2020-04-27/woo-20200427-git.tgz'';
-    sha256 = ''1mmgwgf9n74zab96x1n4faij30l2vk19xy74fcp0xnpj4lrp7v29'';
+    url = "http://beta.quicklisp.org/archive/woo/2020-04-27/woo-20200427-git.tgz";
+    sha256 = "1mmgwgf9n74zab96x1n4faij30l2vk19xy74fcp0xnpj4lrp7v29";
   };
 
   packageName = "woo";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/wookie.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/wookie.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''wookie'';
-  version = ''20191130-git'';
+  baseName = "wookie";
+  version = "20191130-git";
 
-  description = ''An evented webserver for Common Lisp.'';
+  description = "An evented webserver for Common Lisp.";
 
   deps = [ args."alexandria" args."babel" args."blackbird" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chunga" args."cl-async" args."cl-async-base" args."cl-async-ssl" args."cl-async-util" args."cl-fad" args."cl-libuv" args."cl-ppcre" args."cl-utilities" args."do-urlencode" args."fast-http" args."fast-io" args."flexi-streams" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/wookie/2019-11-30/wookie-20191130-git.tgz'';
-    sha256 = ''13f9fi7yv28lag79z03jrnm7aih2x5zwvh4hw9cadw75956975d2'';
+    url = "http://beta.quicklisp.org/archive/wookie/2019-11-30/wookie-20191130-git.tgz";
+    sha256 = "13f9fi7yv28lag79z03jrnm7aih2x5zwvh4hw9cadw75956975d2";
   };
 
   packageName = "wookie";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xembed.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xembed.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''xembed'';
-  version = ''clx-20191130-git'';
+  baseName = "xembed";
+  version = "clx-20191130-git";
 
-  description = ''An implementation of the XEMBED protocol that integrates with CLX.'';
+  description = "An implementation of the XEMBED protocol that integrates with CLX.";
 
   deps = [ args."clx" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clx-xembed/2019-11-30/clx-xembed-20191130-git.tgz'';
-    sha256 = ''1ik5gxzhn9j7827jg6g8rk2wa5jby11n2db24y6wrf0ldnbpj7jd'';
+    url = "http://beta.quicklisp.org/archive/clx-xembed/2019-11-30/clx-xembed-20191130-git.tgz";
+    sha256 = "1ik5gxzhn9j7827jg6g8rk2wa5jby11n2db24y6wrf0ldnbpj7jd";
   };
 
   packageName = "xembed";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xkeyboard.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xkeyboard.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''xkeyboard'';
-  version = ''clx-20120811-git'';
+  baseName = "xkeyboard";
+  version = "clx-20120811-git";
 
   parasites = [ "xkeyboard-test" ];
 
-  description = ''XKeyboard is X11 extension for clx of the same name.'';
+  description = "XKeyboard is X11 extension for clx of the same name.";
 
   deps = [ args."clx" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clx-xkeyboard/2012-08-11/clx-xkeyboard-20120811-git.tgz'';
-    sha256 = ''11q70drx3xn7rvk528qlnzpnxd6hg6801kc54ys3jz1l7074458n'';
+    url = "http://beta.quicklisp.org/archive/clx-xkeyboard/2012-08-11/clx-xkeyboard-20120811-git.tgz";
+    sha256 = "11q70drx3xn7rvk528qlnzpnxd6hg6801kc54ys3jz1l7074458n";
   };
 
   packageName = "xkeyboard";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xml_dot_location.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xml_dot_location.nix
@@ -1,18 +1,19 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''xml_dot_location'';
-  version = ''20200325-git'';
+  baseName = "xml_dot_location";
+  version = "20200325-git";
 
   parasites = [ "xml.location/test" ];
 
-  description = ''This system provides a convenient interface for
- manipulating XML data. It is inspired by the xmltio library.'';
+  description = "This system provides a convenient interface for
+ manipulating XML data. It is inspired by the xmltio library.";
 
   deps = [ args."alexandria" args."anaphora" args."babel" args."cl-ppcre" args."closer-mop" args."closure-common" args."cxml" args."cxml-stp" args."iterate" args."let-plus" args."lift" args."more-conditions" args."parse-number" args."puri" args."split-sequence" args."trivial-features" args."trivial-gray-streams" args."xpath" args."yacc" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/xml.location/2020-03-25/xml.location-20200325-git.tgz'';
-    sha256 = ''0wfccj1p1al0w9pc5rhxpsvm3wb2lr5fc4cfjyg751pwsasjikwx'';
+    url = "http://beta.quicklisp.org/archive/xml.location/2020-03-25/xml.location-20200325-git.tgz";
+    sha256 = "0wfccj1p1al0w9pc5rhxpsvm3wb2lr5fc4cfjyg751pwsasjikwx";
   };
 
   packageName = "xml.location";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xmls.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xmls.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''xmls'';
-  version = ''3.0.2'';
+  baseName = "xmls";
+  version = "3.0.2";
 
   parasites = [ "xmls/test" "xmls/unit-test" ];
 
-  description = ''System lacks description'';
+  description = "System lacks description";
 
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/xmls/2018-04-30/xmls-3.0.2.tgz'';
-    sha256 = ''1r7mvw62zjcg45j3hm8jlbiisad2b415pghn6qcmhl03dmgp7kgi'';
+    url = "http://beta.quicklisp.org/archive/xmls/2018-04-30/xmls-3.0.2.tgz";
+    sha256 = "1r7mvw62zjcg45j3hm8jlbiisad2b415pghn6qcmhl03dmgp7kgi";
   };
 
   packageName = "xmls";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xpath.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xpath.nix
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''xpath'';
-  version = ''plexippus-20190521-git'';
+  baseName = "xpath";
+  version = "plexippus-20190521-git";
 
   parasites = [ "xpath/test" ];
 
-  description = ''An implementation of the XML Path Language (XPath) Version 1.0'';
+  description = "An implementation of the XML Path Language (XPath) Version 1.0";
 
   deps = [ args."alexandria" args."babel" args."cl-ppcre" args."closure-common" args."cxml" args."parse-number" args."puri" args."trivial-features" args."trivial-gray-streams" args."yacc" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/plexippus-xpath/2019-05-21/plexippus-xpath-20190521-git.tgz'';
-    sha256 = ''15357w1rlmahld4rh8avix7m40mwiiv7n2vlyc57ldw2k1m0n7xa'';
+    url = "http://beta.quicklisp.org/archive/plexippus-xpath/2019-05-21/plexippus-xpath-20190521-git.tgz";
+    sha256 = "15357w1rlmahld4rh8avix7m40mwiiv7n2vlyc57ldw2k1m0n7xa";
   };
 
   packageName = "xpath";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xsubseq.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xsubseq.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''xsubseq'';
-  version = ''20170830-git'';
+  baseName = "xsubseq";
+  version = "20170830-git";
 
-  description = ''Efficient way to manage "subseq"s in Common Lisp'';
+  description = "Efficient way to manage \"subseq\"s in Common Lisp";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/xsubseq/2017-08-30/xsubseq-20170830-git.tgz'';
-    sha256 = ''1am63wkha97hyvkqf4ydx3q07mqpa0chkx65znr7kmqi83a8waml'';
+    url = "http://beta.quicklisp.org/archive/xsubseq/2017-08-30/xsubseq-20170830-git.tgz";
+    sha256 = "1am63wkha97hyvkqf4ydx3q07mqpa0chkx65znr7kmqi83a8waml";
   };
 
   packageName = "xsubseq";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/yacc.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/yacc.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''yacc'';
-  version = ''cl-20101006-darcs'';
+  baseName = "yacc";
+  version = "cl-20101006-darcs";
 
-  description = ''A LALR(1) parser generator for Common Lisp'';
+  description = "A LALR(1) parser generator for Common Lisp";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-yacc/2010-10-06/cl-yacc-20101006-darcs.tgz'';
-    sha256 = ''0cymvl0arp4yahqcnhxggs1z2g42bf6z4ix75ba7wbsi52zirjp7'';
+    url = "http://beta.quicklisp.org/archive/cl-yacc/2010-10-06/cl-yacc-20101006-darcs.tgz";
+    sha256 = "0cymvl0arp4yahqcnhxggs1z2g42bf6z4ix75ba7wbsi52zirjp7";
   };
 
   packageName = "yacc";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/yason.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/yason.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''yason'';
-  version = ''v0.7.8'';
+  baseName = "yason";
+  version = "v0.7.8";
 
-  description = ''JSON parser/encoder'';
+  description = "JSON parser/encoder";
 
   deps = [ args."alexandria" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/yason/2019-12-27/yason-v0.7.8.tgz'';
-    sha256 = ''11d51i2iw4nxsparwbh3s6w9zyms3wi0z0fprwz1d3sqlf03j6f1'';
+    url = "http://beta.quicklisp.org/archive/yason/2019-12-27/yason-v0.7.8.tgz";
+    sha256 = "11d51i2iw4nxsparwbh3s6w9zyms3wi0z0fprwz1d3sqlf03j6f1";
   };
 
   packageName = "yason";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/zpb-ttf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/zpb-ttf.nix
@@ -1,15 +1,16 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''zpb-ttf'';
-  version = ''release-1.0.4'';
+  baseName = "zpb-ttf";
+  version = "release-1.0.4";
 
-  description = ''Access TrueType font metrics and outlines from Common Lisp'';
+  description = "Access TrueType font metrics and outlines from Common Lisp";
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/zpb-ttf/2021-01-24/zpb-ttf-release-1.0.4.tgz'';
-    sha256 = ''186jzhmklby2pkmwv3zxw09qh8023f7w5ng2ql46l6abx146s3ll'';
+    url = "http://beta.quicklisp.org/archive/zpb-ttf/2021-01-24/zpb-ttf-release-1.0.4.tgz";
+    sha256 = "186jzhmklby2pkmwv3zxw09qh8023f7w5ng2ql46l6abx146s3ll";
   };
 
   packageName = "zpb-ttf";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -11,6 +11,7 @@ blackbird
 bordeaux-threads
 calispel
 caveman
+cl-custom-hash-table
 cffi
 cffi-grovel
 cffi-uffi-compat

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -3967,6 +3967,14 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "cl-custom-hash-table" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-custom-hash-table" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-custom-hash-table.nix {
+         inherit fetchurl;
+       }));
+
+
   "caveman" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."caveman" or (x: {}))

--- a/pkgs/development/lisp-modules/quicklisp-to-nix/nix-package.emb
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix/nix-package.emb
@@ -1,17 +1,18 @@
+/* Generated file. */
 args @ { fetchurl, ... }:
 rec {
-  baseName = ''<% @var filename %>'';
-  version = ''<% @var version %>'';<% @if parasites %>
+  baseName = "<% @var filename %>";
+  version = "<% @var version %>";<% @if parasites %>
 
   parasites = [<% (dolist (p (getf env :parasites)) (format t " \"~A\"" p)) %> ];<% @endif %>
 
-  description = ''<% @var description %>'';
+  description = <%= (format nil "~s" (cl-emb::getf-emb "description")) %>;
 
   deps = [ <% @loop deps %>args."<% @var filename %>" <% @endloop %>];
 
   src = fetchurl {
-    url = ''<% @var url %>'';
-    sha256 = ''<% @var sha256 %>'';
+    url = "<% @var url %>";
+    sha256 = "<% @var sha256 %>";
   };
 
   packageName = "<% @var name %>";


### PR DESCRIPTION
###### Motivation for this change

Nyxt was too old, some changes needed to build a newer one

Will eventually self-merge

@atlas-engineer @nlewo @bqv 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
