### PR TITLE
whatsapp-for-linux: init-at 1.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1036,6 +1036,16 @@
     githubId = 75235;
     name = "Michael Walker";
   };
+  bartuka = {
+    email = "wand@hey.com";
+    github = "wandersoncferreira";
+    githubId = 17708295;
+    name = "Wanderson Ferreira";
+    keys = [{
+      longkeyid = "rsa4096/0x56840A614DBE37AE";
+      fingerprint = "A3E1 C409 B705 50B3 BF41  492B 5684 0A61 4DBE 37AE";
+    }];
+  };
   basvandijk = {
     email = "v.dijk.bas@gmail.com";
     github = "basvandijk";

--- a/pkgs/applications/networking/instant-messengers/whatsapp-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/whatsapp-for-linux/default.nix
@@ -1,0 +1,38 @@
+{ fetchFromGitHub, lib, stdenv, gnome3, cmake, pkg-config,
+  libappindicator-gtk3, gst_all_1, pcre }:
+
+stdenv.mkDerivation rec {
+  pname = "whatsapp-for-linux";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "eneshecan";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1gzahls4givd2kbjdwx6yb3jv7a3r1krw40qihiz7hkamkrpaiaz";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    gnome3.gtkmm
+    gnome3.webkitgtk
+    libappindicator-gtk3
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-libav
+    pcre
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/eneshecan/whatsapp-for-linux";
+    description = "Whatsapp desktop messaging app";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ bartuka ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13340,6 +13340,8 @@ in
 
   vtable-dumper = callPackage ../development/tools/misc/vtable-dumper { };
 
+  whatsapp-for-linux = callPackage ../applications/networking/instant-messengers/whatsapp-for-linux { };
+
   whatstyle = callPackage ../development/tools/misc/whatstyle {
     inherit (llvmPackages) clang-unwrapped;
   };


### PR DESCRIPTION
Whataspp is widely used in several contries as default messaging
system. We can rely on browser-based solution but an app is preferred
method for several users.


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
