### PR TITLE
maintainers: pshendry -> polendri

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7615,6 +7615,12 @@
       fingerprint = "2CD2 B030 BD22 32EF DF5A  008A 3618 20A4 5DB4 1E9A";
     }];
   };
+  polendri = {
+    email = "paul@ijj.li";
+    github = "polendri";
+    githubId = 1829032;
+    name = "Paul Hendry";
+  };
   polyrod = {
     email = "dc1mdp@gmail.com";
     github = "polyrod";
@@ -7722,12 +7728,6 @@
     github = "psanford";
     githubId = 33375;
     name = "Peter Sanford";
-  };
-  pshendry = {
-    email = "paul@pshendry.com";
-    github = "pshendry";
-    githubId = 1829032;
-    name = "Paul Hendry";
   };
   psibi = {
     email = "sibi@psibi.in";

--- a/pkgs/applications/kde/libksane.nix
+++ b/pkgs/applications/kde/libksane.nix
@@ -9,7 +9,7 @@ mkDerivation {
   pname = "libksane";
   meta = with lib; {
     license = licenses.gpl2;
-    maintainers = with maintainers; [ pshendry ];
+    maintainers = with maintainers; [ polendri ];
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ki18n ktextwidgets kwallet kwidgetsaddons sane-backends ];

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -47,7 +47,7 @@ let
         description = "Open Source Continuous File Synchronization";
         changelog = "https://github.com/syncthing/syncthing/releases/tag/v${version}";
         license = licenses.mpl20;
-        maintainers = with maintainers; [ pshendry joko peterhoeg andrew-d ];
+        maintainers = with maintainers; [ joko peterhoeg andrew-d ];
         platforms = platforms.unix;
       };
     };

--- a/pkgs/applications/office/skanlite/default.nix
+++ b/pkgs/applications/office/skanlite/default.nix
@@ -24,7 +24,7 @@ mkDerivation rec {
     description = "KDE simple image scanning application";
     homepage    = "https://apps.kde.org/skanlite";
     license     = licenses.gpl2Plus;
-    maintainers = with maintainers; [ pshendry ];
+    maintainers = with maintainers; [ polendri ];
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- Update to my personal GitHub handle and email address (note unchanged GitHub ID)
- Remove myself as a `syncthing` maintainer since it's been years since I've been able to contribute to that package

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
