### PR TITLE
gtk-doc + json-glib: fix cross-compilation

### DIFF
--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -32,6 +32,13 @@ python3.pkgs.buildPythonApplication rec {
     passthru.respect_xml_catalog_files_var_patch
   ];
 
+  strictDeps = true;
+
+  depsBuildBuild = [
+    python3
+    pkg-config
+  ];
+
   nativeBuildInputs = [
     pkg-config
     gettext


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/117181.

I first thought that the patch for gtk-doc didn't make sense, but I think it does. Still have to disable building docs for json-glib, since it also uses introspection, which doesn't support cross-compilation (well).

Important for cross-compilation, since glib is used in a lot of (GUI) applications.

Please let me know if this is the right approach. I think we should disable introspection on cross-compiled packages until we have proper support for it, so we can at least get cross-compilation working for most of the system. However, I'm not 100% sure if that's the right approach. If there are objections, I'd like an explanation of why we need introspection / what it's useful for.

I'm planning on doing more fixes as I get further with cross-compiling. I've quite a lot done, but it needs tidying up and a good look before I want to send them here. Also, I'd like some feedback on this approach before pushing all of that into nixpkgs.

Cc @Ericson2314 @samueldr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
