### PR TITLE
md2gemini: init at 1.8.1

### DIFF
--- a/pkgs/development/python-modules/cjkwrap/default.nix
+++ b/pkgs/development/python-modules/cjkwrap/default.nix
@@ -1,0 +1,19 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "CJKwrap";
+  version = "2.2";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b603sg6c2gv9vmlxwr6r1qvhadqk3qp6vifmijris504zjx5ix2";
+  };
+
+  pythonImportsCheck = [ "cjkwrap" ];
+
+  meta = with lib; {
+    description = "A library for wrapping and filling CJK text";
+    homepage = "https://f.gallai.re/cjkwrap";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.kaction ];
+  };
+}

--- a/pkgs/development/python-modules/md2gemini/default.nix
+++ b/pkgs/development/python-modules/md2gemini/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, mistune_2_0, cjkwrap, wcwidth
+, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "md2gemini";
+  version = "1.8.1";
+
+  propagatedBuildInputs = [ mistune_2_0 cjkwrap wcwidth ];
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "md2gemini" ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mfa0f0m762168fbsxjr1cx9yhj82dr8z1d28jl6hj9bkqnvvwiy";
+  };
+
+  meta = with lib; {
+    description = "Markdown to Gemini text format conversion library";
+    homepage = "https://github.com/makeworld-the-better-one/md2gemini";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.kaction ];
+  };
+}

--- a/pkgs/development/python-modules/mistune/common.nix
+++ b/pkgs/development/python-modules/mistune/common.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi, nose, version, sha256 }:
+
+buildPythonPackage rec {
+  inherit version;
+  pname = "mistune";
+
+  src = fetchPypi {
+    inherit pname version sha256;
+  };
+
+  buildInputs = [ nose ];
+
+  meta = with lib; {
+    description = "The fastest markdown parser in pure Python";
+    homepage = "https://github.com/lepture/mistune";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/mistune/common.nix
+++ b/pkgs/development/python-modules/mistune/common.nix
@@ -9,6 +9,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ nose ];
+  pythonImportsCheck = [ "mistune" ];
 
   meta = with lib; {
     description = "The fastest markdown parser in pure Python";

--- a/pkgs/development/python-modules/mistune/default.nix
+++ b/pkgs/development/python-modules/mistune/default.nix
@@ -1,23 +1,11 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, nose
-}:
-
-buildPythonPackage rec {
-  pname = "mistune";
-  version = "0.8.4";
-
-  src = fetchPypi {
-    inherit pname version;
+self: rec {
+  mistune_0_8 = self.callPackage ./common.nix {
+    version = "0.8.4";
     sha256 = "59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e";
   };
-
-  buildInputs = [ nose ];
-
-  meta = with lib; {
-    description = "The fastest markdown parser in pure Python";
-    homepage = "https://github.com/lepture/mistune";
-    license = licenses.bsd3;
+  mistune_2_0 = self.callPackage ./common.nix {
+    version = "2.0.0a4";
+    sha256 = "0i6cblmjl58kdmaa21xm0l1ls0kvjpfy45sf73fw3ws6305f628k";
   };
+  mistune = mistune_0_8;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6001,6 +6001,8 @@ in
 
   m2r = python3Packages.callPackage ../tools/text/m2r { };
 
+  md2gemini = with python3.pkgs; toPythonApplication md2gemini;
+
   mdbook = callPackage ../tools/text/mdbook {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4020,7 +4020,11 @@ in {
 
   mistletoe = callPackage ../development/python-modules/mistletoe { };
 
-  mistune = callPackage ../development/python-modules/mistune { };
+  inherit (import ../development/python-modules/mistune self)
+    mistune
+    mistune_0_8
+    mistune_2_0
+  ;
 
   mitmproxy = callPackage ../development/python-modules/mitmproxy { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3949,6 +3949,8 @@ in {
 
   mcstatus = callPackage ../development/python-modules/mcstatus { };
 
+  md2gemini = callPackage ../development/python-modules/md2gemini { };
+
   MDP = callPackage ../development/python-modules/mdp { };
 
   measurement = callPackage ../development/python-modules/measurement { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1303,6 +1303,10 @@ in {
 
   citeproc-py = callPackage ../development/python-modules/citeproc-py { };
 
+  cjkwrap = callPackage ../development/python-modules/cjkwrap { };
+
+  cjson = callPackage ../development/python-modules/cjson { };
+
   ckcc-protocol = callPackage ../development/python-modules/ckcc-protocol { };
 
   class-registry = callPackage ../development/python-modules/class-registry { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
