### PR TITLE
qt5.qtwebengine: fix source exceeding output limit

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -59,14 +59,29 @@ let
         rev = "a059e7404a6db799f4da0ad696e65ae9c854b4b0";
       in
       {
-        version = "${branchName}-${lib.substring 0 8 rev}";
+        version = "${branchName}-${lib.substring 0 7 rev}";
 
         src = fetchgit {
           url = "https://github.com/qt/qtwebengine.git";
-          sha256 = "19l1i4sk3pvnwbvz5s97jchqawfz8k1xmjza29bgvkp1zz96r0jx";
+          sha256 = "1vdgxfbmx4z4qrm2g61dl64gqn3fv5f83jwpp7h1gyfx5z2qvfmv";
           inherit rev branchName;
           fetchSubmodules = true;
           leaveDotGit = true;
+          name = "qtwebengine-${substring 0 7 rev}.tar.gz";
+          postFetch = ''
+            # remove submodule .git directory
+            rm -rf $out/src/3rdparty/.git
+
+            # compress to not exceed the 2GB output limit
+            mv $out source
+            # try to make a deterministic tarball
+            tar -I 'gzip -n' \
+              --sort name \
+              --mtime 1970-01-01 \
+              --owner=root --group=root \
+              --numeric-owner --mode=go=rX,u+rw,a-s \
+              -cf $out source
+          '';
         };
       };
   };


### PR DESCRIPTION
###### Motivation for this change

This hack reduces the source derivation size from 3.7G to 450M by
removing the src/3rparty submodule .git directory and compressing
the whole directory. This is needed to avoid the 2G limit on hydra.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc: @vcunat
