### PR TITLE
nixos/hydra: gc-check-reachability no longer exists in nix 2.4

### DIFF
--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -281,11 +281,10 @@ in
       keep-derivations = true
 
 
-      ${optionalString (versionOlder (getVersion config.nix.package.out) "2.4pre") ''
-        # The default (`true') slows Nix down a lot since the build farm
-        # has so many GC roots.
-        gc-check-reachability = false
-      ''}
+    '' + optionalString (versionOlder (getVersion config.nix.package.out) "2.4pre") ''
+      # The default (`true') slows Nix down a lot since the build farm
+      # has so many GC roots.
+      gc-check-reachability = false
     '';
 
     systemd.services.hydra-init =

--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -280,9 +280,12 @@ in
       keep-outputs = true
       keep-derivations = true
 
-      # The default (`true') slows Nix down a lot since the build farm
-      # has so many GC roots.
-      gc-check-reachability = false
+
+      ${optionalString (versionOlder (getVersion config.nix.package.out) "2.4pre") ''
+        # The default (`true') slows Nix down a lot since the build farm
+        # has so many GC roots.
+        gc-check-reachability = false
+      ''}
     '';
 
     systemd.services.hydra-init =


### PR DESCRIPTION
nixos/hydra: gc-check-reachability no longer exists in nix 2.4

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
