### PR TITLE
crystal2nix: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/development/compilers/crystal2nix/default.nix
+++ b/pkgs/development/compilers/crystal2nix/default.nix
@@ -2,13 +2,13 @@
 
 crystal.buildCrystalPackage rec {
   pname = "crystal2nix";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "peterhoeg";
     repo = "crystal2nix";
     rev = "v${version}";
-    sha256 = "sha256-K1ElG8VC/D0axmSRaufH3cE50xNQisAmFucDkV+5O0s=";
+    sha256 = "sha256-LKZychkhWy/rVdrP3Yo6g8CL1pGdiZlBykzFjnWh0fg=";
   };
 
   format = "shards";


### PR DESCRIPTION
###### Motivation for this change

0.1.1 adds support for dependencies that lock a specific commit in the new v2 format.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Cc: @NixOS/crystal-lang 