### PR TITLE
nixos/fprintd: add TOD support

### DIFF
--- a/nixos/modules/services/security/fprintd.nix
+++ b/nixos/modules/services/security/fprintd.nix
@@ -5,6 +5,7 @@ with lib;
 let
 
   cfg = config.services.fprintd;
+  fprintdPkg = if cfg.tod.enable then pkgs.fprintd-tod else pkgs.fprintd;
 
 in
 
@@ -17,25 +18,30 @@ in
 
     services.fprintd = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable fprintd daemon and PAM module for fingerprint readers handling.
-        '';
-      };
+      enable = mkEnableOption "fprintd daemon and PAM module for fingerprint readers handling";
 
       package = mkOption {
         type = types.package;
-        default = pkgs.fprintd;
-        defaultText = "pkgs.fprintd";
+        default = fprintdPkg;
+        defaultText = "if cfg.tod.enable then pkgs.fprintd-tod else pkgs.fprintd";
         description = ''
           fprintd package to use.
         '';
       };
 
-    };
+      tod = {
 
+        enable = mkEnableOption "Touch OEM Drivers library support";
+
+        driver = mkOption {
+          type = types.package;
+          example = literalExample "pkgs.libfprint-2-tod1-goodix";
+          description = ''
+            Touch OEM Drivers (TOD) package to use.
+          '';
+        };
+      };
+    };
   };
 
 
@@ -48,6 +54,10 @@ in
     environment.systemPackages = [ cfg.package ];
 
     systemd.packages = [ cfg.package ];
+
+    systemd.services.fprintd.environment = mkIf cfg.tod.enable {
+      FP_TOD_DRIVERS_DIR = "${cfg.tod.driver}${cfg.tod.driver.driverPath}";
+    };
 
   };
 

--- a/pkgs/development/libraries/libfprint-2-tod1-goodix/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-goodix/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation {
     cp lib/udev/rules.d/60-libfprint-2-tod1-goodix.rules "$out/usr/lib/udev/rules.d/"
   '';
 
+  passthru.driverPath = "/usr/lib/libfprint-2/tod-1";
+
   meta = with lib; {
     description = "Goodix driver module for libfprint-2-tod Touch OEM Driver";
     homepage = "https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-goodix/+git/libfprint-2-tod1-goodix/";

--- a/pkgs/development/libraries/libfprint-2-tod1-goodix/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-goodix/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   src = fetchgit {
     url = "https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-goodix/+git/libfprint-2-tod1-goodix";
-    rev = "882735c6366fbe30149eea5cfd6d0ddff880f0e4"; # droped-lp1880058 on 20202-11-25
+    rev = "882735c6366fbe30149eea5cfd6d0ddff880f0e4"; # droped-lp1880058 on 2020-11-25
     sha256 = "sha256-Uv+Rr4V31DyaZFOj79Lpyfl3G6zVWShh20roI0AvMPU=";
   };
 
@@ -18,14 +18,14 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    mkdir -p "$out/usr/lib/libfprint-2/tod-1/"
-    mkdir -p "$out/usr/lib/udev/rules.d/"
+    mkdir -p "$out/lib/libfprint-2/tod-1/"
+    mkdir -p "$out/lib/udev/rules.d/"
 
-    cp usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-53xc-$version.so "$out/usr/lib/libfprint-2/tod-1/"
-    cp lib/udev/rules.d/60-libfprint-2-tod1-goodix.rules "$out/usr/lib/udev/rules.d/"
+    cp usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-53xc-$version.so "$out/lib/libfprint-2/tod-1/"
+    cp lib/udev/rules.d/60-libfprint-2-tod1-goodix.rules "$out/lib/udev/rules.d/"
   '';
 
-  passthru.driverPath = "/usr/lib/libfprint-2/tod-1";
+  passthru.driverPath = "/lib/libfprint-2/tod-1";
 
   meta = with lib; {
     description = "Goodix driver module for libfprint-2-tod Touch OEM Driver";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#104915 introduces TOD support. This PR is covering this functionality in the `fprintd` module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
