### PR TITLE
python3Packages.pypandoc: vendor patches, test w/o pandoc-citeproc

### DIFF
--- a/pkgs/applications/editors/apostrophe/default.nix
+++ b/pkgs/applications/editors/apostrophe/default.nix
@@ -2,7 +2,7 @@
 , wrapGAppsHook, pkg-config, desktop-file-utils
 , appstream-glib, pythonPackages, glib, gobject-introspection
 , gtk3, webkitgtk, glib-networking, gnome3, gspell, texlive
-, shared-mime-info, haskellPackages, libhandy
+, shared-mime-info, libhandy
 }:
 
 let
@@ -38,7 +38,6 @@ in stdenv.mkDerivation rec {
     gappsWrapperArgs+=(
       --prefix PYTHONPATH : "$out/lib/python${pythonEnv.pythonVersion}/site-packages/"
       --prefix PATH : "${texlive}/bin"
-      --prefix PATH : "${haskellPackages.pandoc-citeproc}/bin"
       --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
     )
   '';

--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -1,5 +1,6 @@
-{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch
-, pandoc, haskellPackages, texlive }:
+{ lib, substituteAll, buildPythonPackage, fetchFromGitHub
+, pandoc, texlive
+}:
 
 buildPythonPackage rec {
   pname = "pypandoc";
@@ -12,25 +13,18 @@ buildPythonPackage rec {
     sha256 = "1lpslfns6zxx7b0xr13bzg921lwrj5am8za0b2dviywk6iiib0ld";
   };
 
-  # https://github.com/bebraw/pypandoc/pull/204
   patches = [
-    (fetchpatch {
-      url = "https://github.com/sternenseemann/pypandoc/commit/e422e277dd667c77dae11fad931dbb6015e9a784.patch";
-      sha256 = "11l11kh2a4k0h1g4yvijb60076kzxlkrvda3x6dc1s8fz352bpg3";
+    (substituteAll {
+      src = ./static-pandoc-path.patch;
+      pandoc = "${lib.getBin pandoc}/bin/pandoc";
     })
+    ./skip-tests.patch
+    ./new-pandoc-headings.patch
   ];
 
-  postPatch = ''
-    # set pandoc path statically
-    sed -i '/^__pandoc_path = None$/c__pandoc_path = "${pandoc}/bin/pandoc"' pypandoc/__init__.py
-
-    # Skip test that requires network access
-    sed -i '/test_basic_conversion_from_http_url/i\\    @unittest.skip\("no network access during checkPhase"\)' tests.py
-  '';
-
-  preCheck = ''
-    export PATH="${haskellPackages.pandoc-citeproc}/bin:${texlive.combined.scheme-small}/bin:$PATH"
-  '';
+  checkInputs = [
+    texlive.combined.scheme-small
+  ];
 
   meta = with lib; {
     description = "Thin wrapper for pandoc";

--- a/pkgs/development/python-modules/pypandoc/new-pandoc-headings.patch
+++ b/pkgs/development/python-modules/pypandoc/new-pandoc-headings.patch
@@ -1,0 +1,22 @@
+diff --git a/tests.py b/tests.py
+index aede281..c400888 100755
+--- a/tests.py
++++ b/tests.py
+@@ -295,7 +295,7 @@ class TestPypandoc(unittest.TestCase):
+ 
+     def test_unicode_input(self):
+         # make sure that pandoc always returns unicode and does not mishandle it
+-        expected = u'üäöîôû{0}======{0}{0}'.format(os.linesep)
++        expected = u'# üäöîôû'.format(os.linesep)
+         written = pypandoc.convert_text(u'<h1>üäöîôû</h1>', 'md', format='html')
+         self.assertTrue(isinstance(written, unicode_type))
+         self.assertEqualExceptForNewlineEnd(expected, written)
+@@ -305,7 +305,7 @@ class TestPypandoc(unittest.TestCase):
+         self.assertTrue(isinstance(written, unicode_type))
+ 
+         # Only use german umlauts in th next test, as iso-8859-15 covers that
+-        expected = u'üäö€{0}===={0}{0}'.format(os.linesep)
++        expected = u'# üäö€'.format(os.linesep)
+         bytes = u'<h1>üäö€</h1>'.encode("iso-8859-15")
+ 
+         # Without encoding, this fails as we expect utf-8 per default

--- a/pkgs/development/python-modules/pypandoc/skip-tests.patch
+++ b/pkgs/development/python-modules/pypandoc/skip-tests.patch
@@ -1,0 +1,20 @@
+diff --git a/tests.py b/tests.py
+index deb50e0..aede281 100755
+--- a/tests.py
++++ b/tests.py
+@@ -179,6 +179,7 @@ class TestPypandoc(unittest.TestCase):
+             received = pypandoc.convert_file(file_url, 'rst')
+             self.assertEqualExceptForNewlineEnd(expected, received)
+ 
++    @unittest.skip("no network access during checkPhase")
+     def test_basic_conversion_from_http_url(self):
+         url = 'https://raw.githubusercontent.com/bebraw/pypandoc/master/README.md'
+         received = pypandoc.convert_file(url, 'html')
+@@ -247,6 +248,7 @@ class TestPypandoc(unittest.TestCase):
+ 
+         self.assertRaises(RuntimeError, f)
+ 
++    @unittest.skip("pandoc-citeproc has been deprecated")
+     def test_conversion_with_citeproc_filter(self):
+         # we just want to get a temp file name, where we can write to
+         filters = ['pandoc-citeproc']

--- a/pkgs/development/python-modules/pypandoc/static-pandoc-path.patch
+++ b/pkgs/development/python-modules/pypandoc/static-pandoc-path.patch
@@ -1,0 +1,10 @@
+diff --git a/pypandoc/__init__.py b/pypandoc/__init__.py
+index 6d5b79b..65437aa 100644
+--- a/pypandoc/__init__.py
++++ b/pypandoc/__init__.py
+@@ -582,4 +582,4 @@ def clean_pandocpath_cache():
+ 
+ 
+ __version = None
+-__pandoc_path = None
++__pandoc_path = "@pandoc@"


### PR DESCRIPTION
* Translate all seds in postPatch into patches (for setting the static
  path and skipping the test that needs network access)
* The patch for the changed pandoc heading generation was simplified:
  Since we know our pandoc version is always that new, we can skip the
  version check.
* Skip the test for pandoc-citeproc: pandoc-citeproc has been deprecated
  in favor of pandoc --citeproc by the upstream pandoc developer.
  pypandoc's testsuite doesn't reflect this yet (although it should
  support --citeproc theoretically) to avoid depending on
  pandoc-citeproc for the checkPhase (as we expect it to break again or
  continue to be broken) we skip the test requiring pandoc-citeproc.

The breakage of pypandoc due to pandoc-citeproc was pointed out here:
https://github.com/NixOS/nixpkgs/pull/116635#issuecomment-809258707
Thank you!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
