### PR TITLE
charles: 4.2.8 -> 4.6.1

### DIFF
--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -3,11 +3,12 @@ lib, stdenv
 , makeWrapper
 , makeDesktopItem
 , fetchurl
+, jdk11
 , jdk8
 }:
 
 let
-  generic = { version, sha256, ... }@attrs:
+  generic = { version, sha256, platform ? "", jdk, ... }@attrs:
   let
     desktopItem = makeDesktopItem {
       categories = "Network;Development;WebDevelopment;Java;";
@@ -25,13 +26,13 @@ let
       inherit version;
 
       src = fetchurl {
-        url = "https://www.charlesproxy.com/assets/release/${version}/charles-proxy-${version}.tar.gz";
+        url = "https://www.charlesproxy.com/assets/release/${version}/charles-proxy-${version}${platform}.tar.gz";
         inherit sha256;
       };
       buildInputs = [ makeWrapper ];
 
       installPhase = ''
-        makeWrapper ${jdk8.jre}/bin/java $out/bin/charles \
+        makeWrapper ${jdk}/bin/java $out/bin/charles \
           --add-flags "-Xmx1024M -Dcharles.config='~/.charles.config' -jar $out/share/java/charles.jar"
 
         for fn in lib/*.jar; do
@@ -56,12 +57,15 @@ let
 
 in {
   charles4 = (generic {
-    version = "4.2.8";
-    sha256 = "1jzjdhzxgrq7pdfryfkg0hsjpyni14ma4x8jbdk1rqll78ccr080";
+    version = "4.6.1";
+    sha256 = "1kl83jjj5wjhdpj34gcj04vf1asxlqlfx9zi91ln4v90swlaaclv";
+    platform = "_amd64";
+    jdk = jdk11;
   });
   charles3 = (generic {
     version = "3.12.3";
     sha256 = "13zk82ny1w5zd9qcs9qkq0kdb22ni5byzajyshpxdfm4zv6p32ss";
+    jdk = jdk8.jre;
   });
 }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[upstream changelog
](https://www.charlesproxy.com/documentation/version-history/)

Note that as of 4.5, charles 4 now requires jdk11, and also has a different download path. I've updated that such that charles 3 will still build. (I did also test jdk11 with charles 3 to see if that was functional, but it doesn't appear to be)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
