### PR TITLE
add protoc-gen-* for https://github.com/twitchtv/twirp

### DIFF
--- a/pkgs/development/tools/protoc-gen-go/default.nix
+++ b/pkgs/development/tools/protoc-gen-go/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "protoc-gen-go";
+  version = "1.26.0";
+
+  src = fetchFromGitHub {
+    owner = "protocolbuffers";
+    repo = "protobuf-go";
+    rev = "v${version}";
+    sha256 = "sha256-n2LHI8DXQFFWhTPOFCegBgwi/0tFvRE226AZfRW8Bnc=";
+  };
+
+  vendorSha256 = "sha256-yb8l4ooZwqfvenlxDRg95rqiL+hmsn0weS/dPv/oD2Y=";
+
+  subPackages = [ "cmd/protoc-gen-go" ];
+
+  meta = with lib; {
+    description = "Go support for Google's protocol buffers";
+    homepage = "https://google.golang.org/protobuf";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/development/tools/protoc-gen-twirp/default.nix
+++ b/pkgs/development/tools/protoc-gen-twirp/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "protoc-gen-twirp";
+  version = "7.1.1";
+
+  src = fetchFromGitHub {
+    owner = "twitchtv";
+    repo = "twirp";
+    rev = "v${version}";
+    sha256 = "sha256-GN7akAp0zzS8wVhgXlT1ceFUFKH4Sz74XQ8ofIE8T/k=";
+  };
+
+  goPackagePath = "github.com/twitchtv/twirp";
+
+  subPackages = [
+    "protoc-gen-twirp"
+    "protoc-gen-twirp_python"
+  ];
+
+  meta = with lib; {
+    description = "A simple RPC framework with protobuf service definitions";
+    homepage = "https://github.com/twitchtv/twirp";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/development/tools/protoc-gen-twirp_php/default.nix
+++ b/pkgs/development/tools/protoc-gen-twirp_php/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchgit }:
+
+buildGoModule rec {
+  pname = "protoc-gen-twirp_php";
+  version = "0.6.0";
+
+  # fetchFromGitHub currently not possible, because go.mod and go.sum are export-ignored
+  src = fetchgit {
+    url = "https://github.com/twirphp/twirp.git";
+    rev = "v${version}";
+    sha256 = "sha256-WnvCdAJIMA4A+f7H61qcVbKNn23bNVOC15vMCEKc+CI=";
+  };
+
+  vendorSha256 = "sha256-LIMxrWXlK7+JIRmtukdXPqfw8H991FCAOuyEf7ZLSTs=";
+
+  subPackages = [ "protoc-gen-twirp_php" ];
+
+  preBuild = ''
+    go generate ./...
+  '';
+
+  meta = with lib; {
+    description = "PHP port of Twitch's Twirp RPC framework";
+    homepage = "https://github.com/twirphp/twirp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/development/tools/protoc-gen-twirp_swagger/default.nix
+++ b/pkgs/development/tools/protoc-gen-twirp_swagger/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule {
+  pname = "protoc-gen-twirp_swagger";
+  version = "unstable-2021-03-29";
+
+  src = fetchFromGitHub {
+    owner = "elliots";
+    repo = "protoc-gen-twirp_swagger";
+    rev = "f21ef47d69e37c1602a7fb26146de05c092d30b6";
+    sha256 = "sha256-uHU15NbHK7SYgNS3VK21H/OqDo/JyyTZdXw3i9lsgLY=";
+  };
+
+  vendorSha256 = "sha256-g0+9l83Fc0XPzsZAKjLBrjD+tv2+Fot57hcilqAhOZk=";
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Swagger generator for twirp";
+    homepage = "https://github.com/elliots/protoc-gen-twirp_swagger";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/development/tools/protoc-gen-twirp_typescript/default.nix
+++ b/pkgs/development/tools/protoc-gen-twirp_typescript/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule {
+  pname = "protoc-gen-twirp_typescript";
+  version = "unstable-2021-03-29";
+
+  src = fetchFromGitHub {
+    owner = "larrymyers";
+    repo = "protoc-gen-twirp_typescript";
+    rev = "97fd63e543beb2d9f6a90ff894981affe0f2faf1";
+    sha256 = "sha256-LfF/n96LwRX8aoPHzCRI/QbDmZR9yMhE5yGhFAqa8nA=";
+  };
+
+  vendorSha256 = "sha256-WISWuq1neVX4xQkoamc6FznZahOQHwgkYmERJF40OFQ=";
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Protobuf Plugin for Generating a Twirp Typescript Client";
+    homepage = "https://github.com/larrymyers/protoc-gen-twirp_typescript";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -261,6 +261,8 @@ in
 
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };
 
+  protoc-gen-twirp_php = callPackage ../development/tools/protoc-gen-twirp_php { };
+
   ptags = callPackage ../development/tools/misc/ptags { };
 
   ptouch-print = callPackage ../misc/ptouch-print { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -263,6 +263,8 @@ in
 
   protoc-gen-twirp_php = callPackage ../development/tools/protoc-gen-twirp_php { };
 
+  protoc-gen-twirp_swagger = callPackage ../development/tools/protoc-gen-twirp_swagger { };
+
   ptags = callPackage ../development/tools/misc/ptags { };
 
   ptouch-print = callPackage ../misc/ptouch-print { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -265,6 +265,8 @@ in
 
   protoc-gen-twirp_swagger = callPackage ../development/tools/protoc-gen-twirp_swagger { };
 
+  protoc-gen-twirp_typescript = callPackage ../development/tools/protoc-gen-twirp_typescript { };
+
   ptags = callPackage ../development/tools/misc/ptags { };
 
   ptouch-print = callPackage ../misc/ptouch-print { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -259,6 +259,8 @@ in
 
   protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};
 
+  protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };
+
   ptags = callPackage ../development/tools/misc/ptags { };
 
   ptouch-print = callPackage ../misc/ptouch-print { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -259,6 +259,8 @@ in
 
   protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};
 
+  protoc-gen-go = callPackage ../development/tools/protoc-gen-go { };
+
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };
 
   protoc-gen-twirp_php = callPackage ../development/tools/protoc-gen-twirp_php { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add protoc-generators for

- [Twirp](https://github.com/twitchtv/twirp) 
- [Go protobuf generator plugin](https://google.golang.org/protobuf)
- [Twirp PHP](https://github.com/twirphp/twirp)
- [Twirp Swagger](https://github.com/elliots/protoc-gen-twirp_swagger)
- [Twirp Typescript](https://github.com/larrymyers/protoc-gen-twirp_typescript)

I've been using these generators for a few months now and wanted to add them to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/6nywxgvn8igpffargykrcwsqrw3b46x1-protoc-gen-go-1.26.0	   7.3M
/nix/store/v2ipwdha5s1nbvk1zphhrhanbni823zw-protoc-gen-twirp-7.1.1	   8.6M
/nix/store/c4hbclyc19navmdzkinsksyngdg5xaj7-protoc-gen-twirp_php-0.6.0	  39.6M
/nix/store/dp041dlkqvr0zbgb9kq3aa80hviyzy3v-protoc-gen-twirp_swagger-unstable-2021-03-29	  37.6M
/nix/store/76jxxb66fg7wakwbqbvi2iz4vg6qnylm-protoc-gen-twirp_typescript-unstable-2021-03-29	   5.4M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
