### PR TITLE
ombi: init at 4.0.1292

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10358,6 +10358,12 @@
     githubId = 1322287;
     name = "William O'Hanley";
   };
+  woky = {
+    email = "pampu.andrei@pm.me";
+    github = "andreisergiu98";
+    githubId = 11740700;
+    name = "Andrei Pampu";
+  };
   wolfangaukang = {
     email = "liquid.query960@4wrd.cc";
     github = "wolfangaukang";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -511,6 +511,7 @@
   ./services/misc/nzbget.nix
   ./services/misc/nzbhydra2.nix
   ./services/misc/octoprint.nix
+  ./services/misc/ombi.nix
   ./services/misc/osrm.nix
   ./services/misc/packagekit.nix
   ./services/misc/paperless.nix

--- a/nixos/modules/services/misc/ombi.nix
+++ b/nixos/modules/services/misc/ombi.nix
@@ -1,0 +1,80 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let cfg = config.services.ombi;
+
+in {
+  options = {
+    services.ombi = {
+      enable = mkEnableOption ''
+        Ombi.
+        Optionally see <link xlink:href="https://docs.ombi.app/info/reverse-proxy"/>
+        on how to set up a reverse proxy
+      '';
+
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/ombi";
+        description = "The directory where Ombi stores its data files.";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 5000;
+        description = "The port for the Ombi web interface.";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Open ports in the firewall for the Ombi web interface.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "ombi";
+        description = "User account under which Ombi runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "ombi";
+        description = "Group under which Ombi runs.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.tmpfiles.rules = [
+      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
+    ];
+
+    systemd.services.ombi = {
+      description = "Ombi";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${pkgs.ombi}/bin/Ombi --storage '${cfg.dataDir}' --host 'http://*:${toString cfg.port}'";
+        Restart = "on-failure";
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    users.users = mkIf (cfg.user == "ombi") {
+      ombi = {
+        group = cfg.group;
+        home = cfg.dataDir;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "ombi") { ombi = { }; };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -287,6 +287,7 @@ in
   nzbget = handleTest ./nzbget.nix {};
   nzbhydra2 = handleTest ./nzbhydra2.nix {};
   oh-my-zsh = handleTest ./oh-my-zsh.nix {};
+  ombi = handleTest ./ombi.nix {};
   openarena = handleTest ./openarena.nix {};
   openldap = handleTest ./openldap.nix {};
   opensmtpd = handleTest ./opensmtpd.nix {};

--- a/nixos/tests/ombi.nix
+++ b/nixos/tests/ombi.nix
@@ -1,0 +1,18 @@
+import ./make-test-python.nix ({ lib, ... }:
+
+with lib;
+
+{
+  name = "ombi";
+  meta.maintainers = with maintainers; [ woky ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    { services.ombi.enable = true; };
+
+  testScript = ''
+    machine.wait_for_unit("ombi.service")
+    machine.wait_for_open_port("5000")
+    machine.succeed("curl --fail http://localhost:5000/")
+  '';
+})

--- a/pkgs/servers/ombi/default.nix
+++ b/pkgs/servers/ombi/default.nix
@@ -1,0 +1,65 @@
+{ lib, stdenv, fetchurl, makeWrapper, patchelf, openssl, libunwind, zlib, krb5, icu }:
+
+let
+  os = if stdenv.isDarwin then "osx" else "linux";
+  arch = {
+    x86_64-linux = "x64";
+    aarch64-linux = "arm64";
+    x86_64-darwin = "x64";
+  }."${stdenv.hostPlatform.system}" or (throw
+    "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  hash = {
+    x64-linux_hash = "sha256-Cuvz9Mhwpg8RIaiSXib+QW00DM66qPRQulrchRL2BSk=";
+    arm64-linux_hash = "sha256-uyVwa73moHWMZScNNSOU17lALuK3PC/cvTZPJ9qg7JQ=";
+    x64-osx_hash = "sha256-FGXLsfEuCW94D786LJ/wvA9TakOn5sG2M1rDXPQicYw=";
+  }."${arch}-${os}_hash";
+
+  rpath = lib.makeLibraryPath [
+    stdenv.cc.cc openssl libunwind zlib krb5 icu
+  ];
+
+  dynamicLinker = stdenv.cc.bintools.dynamicLinker;
+
+in stdenv.mkDerivation rec {
+  pname = "ombi";
+  version = "4.0.1292";
+
+  sourceRoot = ".";
+
+  src = fetchurl {
+    url = "https://github.com/Ombi-app/Ombi/releases/download/v${version}/${os}-${arch}.tar.gz";
+    sha256 = hash;
+  };
+
+  buildInputs = [ makeWrapper patchelf ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/${pname}-${version}}
+    cp -r * $out/share/${pname}-${version}
+
+    makeWrapper $out/share/${pname}-${version}/Ombi $out/bin/Ombi \
+      --run "cd $out/share/${pname}-${version}"
+  '';
+
+  dontPatchELF = true;
+  postFixup = ''
+    patchelf --set-interpreter "${dynamicLinker}" \
+      --set-rpath "$ORIGIN:${rpath}" $out/share/${pname}-${version}/Ombi
+
+    find $out -type f -name "*.so" -exec \
+      patchelf --set-rpath '$ORIGIN:${rpath}' {} ';'
+  '';
+
+  passthru = {
+    updateScript = ./update.sh;
+  };
+
+  meta = with lib; {
+    description = "Self-hosted web application that automatically gives your shared Plex or Emby users the ability to request content by themselves";
+    homepage = "https://ombi.io/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ woky ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/servers/ombi/default.nix
+++ b/pkgs/servers/ombi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, patchelf, openssl, libunwind, zlib, krb5, icu }:
+{ lib, stdenv, fetchurl, makeWrapper, patchelf, openssl, libunwind, zlib, krb5, icu, nixosTests }:
 
 let
   os = if stdenv.isDarwin then "osx" else "linux";
@@ -53,6 +53,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = ./update.sh;
+    tests.smoke-test = nixosTests.ombi;
   };
 
   meta = with lib; {

--- a/pkgs/servers/ombi/update.sh
+++ b/pkgs/servers/ombi/update.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused nix-prefetch jq
+
+set -e
+
+dirname="$(dirname "$0")"
+
+updateHash()
+{
+    version=$1
+    arch=$2
+    os=$3
+
+    hashKey="${arch}-${os}_hash"
+
+    url="https://github.com/Ombi-app/Ombi/releases/download/v$version/$os-$arch.tar.gz"
+    hash=$(nix-prefetch-url --type sha256 $url)
+    sriHash="$(nix to-sri --type sha256 $hash)"
+
+    sed -i "s|$hashKey = \"[a-zA-Z0-9\/+-=]*\";|$hashKey = \"$sriHash\";|g" "$dirname/default.nix"
+}
+
+updateVersion()
+{
+    sed -i "s/version = \"[0-9.]*\";/version = \"$1\";/g" "$dirname/default.nix"
+}
+
+currentVersion=$(cd $dirname && nix eval --raw '(with import ../../.. {}; ombi.version)')
+
+latestTag=$(curl https://api.github.com/repos/Ombi-App/Ombi/tags | jq -r '.[] | .name' | sort --version-sort | tail -1)
+latestVersion="$(expr $latestTag : 'v\(.*\)')"
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "Ombi is up-to-date: ${currentVersion}"
+    exit 0
+fi
+
+updateVersion $latestVersion
+
+updateHash $latestVersion x64 linux
+updateHash $latestVersion arm64 linux
+updateHash $latestVersion x64 osx

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6927,6 +6927,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreFoundation;
   };
 
+  ombi = callPackage ../servers/ombi { };
+
   omping = callPackage ../applications/networking/omping { };
 
   onefetch = callPackage ../tools/misc/onefetch {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I was using docker to run ombi for some time, but I wanted a native package for it.
This is a prerelease version, I chose it over stable because it works better, the stable version is pretty buggy and unmaintained for some time. As soon as v4 stable is released I will update the script.

I also created a service and a startup test for it. 

If you want to test this build, specify an existing and writable directory where Ombi can create its configuration files using the `--storage` flag, otherwise it will exit with an error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
