### PR TITLE
[20.09] backport python3Packages.furl: fix build

### DIFF
--- a/pkgs/development/python-modules/furl/default.nix
+++ b/pkgs/development/python-modules/furl/default.nix
@@ -1,4 +1,12 @@
-{ stdenv, buildPythonPackage, fetchPypi, flake8, six, orderedmultidict, pytest }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, flake8
+, orderedmultidict
+, pytestCheckHook
+, six
+}:
 
 buildPythonPackage rec {
   pname = "furl";
@@ -9,17 +17,33 @@ buildPythonPackage rec {
     sha256 = "08dnw3bs1mk0f1ccn466a5a7fi1ivwrp0jspav9arqpf3wd27q60";
   };
 
-  checkInputs = [ flake8 pytest ];
+  patches = [
+    (fetchpatch {
+      name = "tests_overcome_bpo42967.patch";
+      url = "https://github.com/gruns/furl/files/6030371/tests_overcome_bpo42967.patch.txt";
+      sha256 = "1l0lxmcp9x73kxy0ky2bh7zxa4n1cf1qxyyax97n90d1s3dc7k2q";
+    })
+  ];
 
-  propagatedBuildInputs = [ six orderedmultidict ];
+  propagatedBuildInputs = [
+    orderedmultidict
+    six
+  ];
 
-  # see https://github.com/gruns/furl/issues/121
-  checkPhase = ''
-    pytest -k 'not join'
-  '';
+  checkInputs = [
+    flake8
+    pytestCheckHook
+  ];
 
-  meta = with stdenv.lib; {
-    description = "furl is a small Python library that makes parsing and manipulating URLs easy";
+  disabledTests = [
+     # see https://github.com/gruns/furl/issues/121
+    "join"
+  ];
+
+  pythonImportsCheck = [ "furl" ];
+
+  meta = with lib; {
+    description = "Python library that makes parsing and manipulating URLs easy";
     homepage = "https://github.com/gruns/furl";
     license = licenses.unlicense;
     maintainers = with maintainers; [ vanzef ];


### PR DESCRIPTION
###### Things done

Backport 5c8b025584e8f61f3047cb8ecf20a3d713403f00 from https://github.com/NixOS/nixpkgs/pull/113406, to fix python3Modules.furl and dependent packages.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
