### PR TITLE
nullfs: init at 0.3

### DIFF
--- a/pkgs/tools/filesystems/nullfs/default.nix
+++ b/pkgs/tools/filesystems/nullfs/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
+
 stdenv.mkDerivation rec {
   pname = "nullfs";
   version = "0.3-git";
@@ -8,8 +9,34 @@ stdenv.mkDerivation rec {
   # * this is an improved version of https://github.com/xrgtn/nullfs
   name = "${pname}-${version}+linux-${kernel.version}";
   moduleName = "nullfs";
+  src = fetchFromGitHub {
+    owner = "abbbi";
+    repo = "nullfsvfs";
+    rev = "802930fb0e66c3e0ba7c81f2c87caa1dcd874b3f";
+    sha256 = "13qqc29jaa9s8hb7bvkrv4vfzy9cfmjdpmd4rysppi8x6cdlzhva";
+  };
+
+  hardeningDisable = [ "pic" "format" ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildPhase = ''
+    # workaround for 'permission denied' with M="$src"
+    mkdir "$out"
+    cp -r "$src" "$out/build"
+    chmod +w "$out/build"
+    make -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" M="$out/build" modules
+  '';
+  installPhase = ''
+    # install to userspace
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/extra
+    xz $out/build/${moduleName}.ko
+    mv $out/build/${moduleName}.ko.xz $out/lib/modules/${kernel.modDirVersion}/extra/
+    # remove temp files
+    chmod -R +w $out/build
+    rm -r $out/build
+  '';
   meta = with lib; {
-    description = "a virtual black hole file system that behaves like /dev/null";
+    description = "Virtual black hole file system that behaves like /dev/null";
     longDescription = ''
       usage:
       modprobe nullfs
@@ -20,30 +47,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl1;
     platforms = platforms.linux;
   };
-  src = fetchFromGitHub {
-    owner = "abbbi";
-    repo = "nullfsvfs";
-    rev = "802930fb0e66c3e0ba7c81f2c87caa1dcd874b3f";
-    sha256 = "13qqc29jaa9s8hb7bvkrv4vfzy9cfmjdpmd4rysppi8x6cdlzhva";
-  };
-  hardeningDisable = [ "pic" "format" ];
-  nativeBuildInputs = kernel.moduleBuildDependencies;
-  buildPhase = ''
-    # workaround for 'permission denied' with M="$src"
-    mkdir "$out"
-    cp -r "$src" "$out/build"
-    chmod +w "$out/build"
-    make -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" M="$out/build" modules
-  '';
-  installPhase = ''
-    # install to initrd
-    #make -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" M="$out/build" INSTALL_MOD_PATH="$out" modules_install
-    # install to userspace
-    mkdir -p $out/lib/modules/${kernel.modDirVersion}/extra
-    xz $out/build/${moduleName}.ko
-    mv $out/build/${moduleName}.ko.xz $out/lib/modules/${kernel.modDirVersion}/extra/
-    # remove temp files
-    chmod -R +w $out/build
-    rm -rf $out/build
-  '';
 }

--- a/pkgs/tools/filesystems/nullfs/default.nix
+++ b/pkgs/tools/filesystems/nullfs/default.nix
@@ -1,0 +1,49 @@
+{ lib, stdenv, fetchFromGitHub, kernel }:
+stdenv.mkDerivation rec {
+  pname = "nullfs";
+  version = "0.3-git";
+  # why rename from nullfsvfs to nullfs?
+  # * shorter
+  # * the module name is nullfs
+  # * this is an improved version of https://github.com/xrgtn/nullfs
+  name = "${pname}-${version}+linux-${kernel.version}";
+  moduleName = "nullfs";
+  meta = with lib; {
+    description = "a virtual black hole file system that behaves like /dev/null";
+    longDescription = ''
+      usage:
+      modprobe nullfs
+      mkdir /tmp/nullfs
+      mount -t nullfs nullfs /tmp/nullfs
+    '';
+    homepage = "https://github.com/abbbi/nullfsvfs";
+    license = licenses.gpl1;
+    platforms = platforms.linux;
+  };
+  src = fetchFromGitHub {
+    owner = "abbbi";
+    repo = "nullfsvfs";
+    rev = "802930fb0e66c3e0ba7c81f2c87caa1dcd874b3f";
+    sha256 = "13qqc29jaa9s8hb7bvkrv4vfzy9cfmjdpmd4rysppi8x6cdlzhva";
+  };
+  hardeningDisable = [ "pic" "format" ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  buildPhase = ''
+    # workaround for 'permission denied' with M="$src"
+    mkdir "$out"
+    cp -r "$src" "$out/build"
+    chmod +w "$out/build"
+    make -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" M="$out/build" modules
+  '';
+  installPhase = ''
+    # install to initrd
+    #make -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" M="$out/build" INSTALL_MOD_PATH="$out" modules_install
+    # install to userspace
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/extra
+    xz $out/build/${moduleName}.ko
+    mv $out/build/${moduleName}.ko.xz $out/lib/modules/${kernel.modDirVersion}/extra/
+    # remove temp files
+    chmod -R +w $out/build
+    rm -rf $out/build
+  '';
+}

--- a/pkgs/tools/filesystems/nullfs/default.nix
+++ b/pkgs/tools/filesystems/nullfs/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 
 stdenv.mkDerivation rec {
-
   pname = "nullfs";
   version = "0.3";
   name = "${pname}-${version}+linux-${kernel.version}";
@@ -33,6 +32,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
     # workaround for broken Makefile
     make -j$NIX_BUILD_CORES -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" M="$out/build" modules
+    runHook postBuild
   '';
 
   installPhase = ''
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
       mount -t nullfs nullfs /tmp/nullfs
     '';
     homepage = "https://github.com/abbbi/nullfsvfs";
-    license = licenses.gpl1;
+    license = licenses.gpl1Only;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/nullfs/default.nix
+++ b/pkgs/tools/filesystems/nullfs/default.nix
@@ -19,11 +19,13 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "pic" "format" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  buildPhase = ''
+  preBuild = ''
     # workaround for 'permission denied' with M="$src"
     mkdir "$out"
     cp -r "$src" "$out/build"
     chmod +w "$out/build"
+  '';
+  buildPhase = ''
     make -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" M="$out/build" modules
   '';
   installPhase = ''

--- a/pkgs/tools/filesystems/nullfs/default.nix
+++ b/pkgs/tools/filesystems/nullfs/default.nix
@@ -1,19 +1,22 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 
 stdenv.mkDerivation rec {
+
   pname = "nullfs";
-  version = "0.3-git";
+  version = "0.3";
+  name = "${pname}-${version}+linux-${kernel.version}";
+  moduleName = pname;
+
   # why rename from nullfsvfs to nullfs?
   # * shorter
   # * the module name is nullfs
   # * this is an improved version of https://github.com/xrgtn/nullfs
-  name = "${pname}-${version}+linux-${kernel.version}";
-  moduleName = "nullfs";
+
   src = fetchFromGitHub {
     owner = "abbbi";
     repo = "nullfsvfs";
-    rev = "802930fb0e66c3e0ba7c81f2c87caa1dcd874b3f";
-    sha256 = "13qqc29jaa9s8hb7bvkrv4vfzy9cfmjdpmd4rysppi8x6cdlzhva";
+    rev = version;
+    sha256 = "01jm22arnff1s58ky76a5061mpwhnz322mp3dva3lyl2vimf3ncw";
   };
 
   hardeningDisable = [ "pic" "format" ];
@@ -25,11 +28,15 @@ stdenv.mkDerivation rec {
     cp -r "$src" "$out/build"
     chmod +w "$out/build"
   '';
+
   buildPhase = ''
-    make -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" M="$out/build" modules
+    runHook preBuild
+    # workaround for broken Makefile
+    make -j$NIX_BUILD_CORES -C "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" M="$out/build" modules
   '';
+
   installPhase = ''
-    # install to userspace
+    # install to userspace (not initrd)
     mkdir -p $out/lib/modules/${kernel.modDirVersion}/extra
     xz $out/build/${moduleName}.ko
     mv $out/build/${moduleName}.ko.xz $out/lib/modules/${kernel.modDirVersion}/extra/
@@ -37,6 +44,7 @@ stdenv.mkDerivation rec {
     chmod -R +w $out/build
     rm -r $out/build
   '';
+
   meta = with lib; {
     description = "Virtual black hole file system that behaves like /dev/null";
     longDescription = ''

--- a/pkgs/tools/filesystems/nullfs/default.nix
+++ b/pkgs/tools/filesystems/nullfs/default.nix
@@ -40,6 +40,11 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Virtual black hole file system that behaves like /dev/null";
     longDescription = ''
+      configuration.nix:
+      {
+        boot.extraModulePackages = [ pkgs.nullfs ];
+      }
+
       usage:
       modprobe nullfs
       mkdir /tmp/nullfs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30599,4 +30599,6 @@ in
   lc3tools = callPackage ../development/tools/lc3tools {};
 
   zktree = callPackage ../applications/misc/zktree {};
+
+  nullfs = callPackage ../tools/filesystems/nullfs {};
 }


### PR DESCRIPTION
###### Motivation for this change

this package is useful for running tests that generate many large files, but the file contents are never used

```nix
# configuration.nix
{
  nixpkgs.overlays = [ ( self: super: {
    nullfs = pkgs.callPackage ./extra-pkgs/nullfs { kernel = pkgs.linux; };
  } ) ];
  boot.extraModulePackages = [
    pkgs.nullfs
  ];
}
```
~~(maybe add this to `meta.longDescription`?)~~ yes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
