### PR TITLE
giph: Init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5384,6 +5384,12 @@
     githubId = 4158274;
     name = "Michiel Leenaars";
   };
+  legendofmiracles = {
+    email = "legendofmiracles@protonmail.com";
+    github = "legendofmiracles";
+    githubId = 30902201;
+    name = "legendofmiracles";
+  };
   lejonet = {
     email = "daniel@kuehn.se";
     github = "lejonet";

--- a/pkgs/applications/video/giph/default.nix
+++ b/pkgs/applications/video/giph/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, ffmpeg
+, xdotool
+, withSlop ? true
+, slop
+, withNotify ? true
+, libnotify
+, withPgrep ? true
+, procps
+}:
+
+stdenv.mkDerivation rec {
+  pname = "giph";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "phisch";
+    repo = "giph";
+    rev = version;
+    sha256 = "19l46m1f32b3bagzrhaqsfnl5n3wbrmg3sdy6fdss4y1yf6nqayk";
+  };
+
+  postPatch = ''
+    substituteInPlace src/giph \
+      --replace '=(ffmpeg' '=(${ffmpeg}/bin/ffmpeg' \
+      --replace '="$(xdotool' '="$(${xdotool}/bin/xdotool' \
+  '' + lib.optionalString withSlop ''
+      --replace '=(ffmpeg' '=(${ffmpeg}/bin/ffmpeg' \
+  '' + lib.optionalString withNotify ''
+      --replace '=(notify-send' '=(${libnotify}/bin/notify-send' \
+  '' + lib.optionalString withPgrep ''
+      --replace '"$(pgrep' '"$(${procps}/bin/pgrep'
+  '';
+
+  buildInputs = [
+    ffmpeg
+    xdotool
+  ]
+  ++ lib.optional
+    withSlop
+    slop
+  ++ lib.optional
+    withNotify
+    libnotify
+  ++ lib.optional
+    withPgrep
+    procps;
+
+  dontConfigure = true;
+
+  dontBuild = true;
+
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/phisch/giph";
+    description = "Simple gif recorder";
+    license = licenses.mit;
+    maintainers = [ maintainers.legendofmiracles ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2471,6 +2471,8 @@ in
 
   genromfs = callPackage ../tools/filesystems/genromfs { };
 
+  giph = callPackage ../applications/video/giph/default.nix {};
+
   gh-ost = callPackage ../tools/misc/gh-ost { };
 
   ghidra-bin = callPackage ../tools/security/ghidra { };


### PR DESCRIPTION
###### Motivation for this change
Adds giph to the repos

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Big thanks to オップナー2608 from the unofficial discord for writing the actual default.nix file, after I asked a nooby question :D 