### PR TITLE
linuxPackages: 5.4 -> 5.10

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -24,6 +24,9 @@
     </para>
    </listitem>
    <listitem>
+    <para>The default Linux kernel was updated to the 5.10 LTS series, coming from the 5.4 LTS series.</para>
+   </listitem>
+   <listitem>
     <para>GNOME desktop environment was upgraded to 3.38, see its <link xlink:href="https://help.gnome.org/misc/release-notes/3.38/">release notes</link>.</para>
    </listitem>
    <listitem>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19892,7 +19892,7 @@ in
   });
 
   # The current default kernel / kernel modules.
-  linuxPackages = linuxPackages_5_4;
+  linuxPackages = linuxPackages_5_10;
   linux = linuxPackages.kernel;
 
   # Update this when adding the newest kernel major version!


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The 5.10 series is the next longterm version of the linux kernel and
I've been using it on multiple x86_64 machines ever since it came out.

I think it is time to switch over the default now, so we get some
additional testing in time for NixOS 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [x] `boot.nix`
    ```
    /nix/store/0q8g4gzm25irhiv2j9m1kp0535warf12-vm-test-run-boot-bios-cdrom
    /nix/store/4nkdszk98139f515pm8fra77gjhsmd26-vm-test-run-boot-netboot-bios
    /nix/store/w4ydxjb0p84n6y1k6qmp5mx6hc1phpg2-vm-test-run-boot-bios-usb
    /nix/store/gc8nij0x5bn4xdaigwy1nblgdf18d9sn-vm-test-run-boot-uefi-cdrom
    /nix/store/a2wwz48904pqq8q20wcnc6v03qcbd24m-vm-test-run-boot-netboot-uefi
    /nix/store/xfw73f3hcnxfbqy45q9c37j10jw5c92f-vm-test-run-boot-uefi-usb
    ```
  - [ ] `installer.nix`
    - getting `error: interrupted by the user` already on master, even when the terminal running the tests is not focused/visible
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
