### PR TITLE
python3Packages.pillow: 8.1.1 -> 8.1.2

### DIFF
--- a/pkgs/development/python-modules/pillow/6.nix
+++ b/pkgs/development/python-modules/pillow/6.nix
@@ -25,5 +25,23 @@ import ./generic.nix (rec {
     '';
     license = "http://www.pythonware.com/products/pil/license.htm";
     maintainers = with maintainers; [ goibhniu prikhi SuperSandro2000 ];
+    knownVulnerabilities = [
+      "CVE-2020-10177"
+      "CVE-2020-10378"
+      "CVE-2020-10379"
+      "CVE-2020-10994"
+      "CVE-2020-11538"
+      "CVE-2020-35653"
+      "CVE-2020-35654"
+      "CVE-2020-35655"
+      "CVE-2021-25289"
+      "CVE-2021-25290"
+      "CVE-2021-25291"
+      "CVE-2021-25292"
+      "CVE-2021-25293"
+      "CVE-2021-27921"
+      "CVE-2021-27922"
+      "CVE-2021-27923"
+    ];
   };
 } // args )

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -5,13 +5,13 @@
 
 import ./generic.nix (rec {
   pname = "Pillow";
-  version = "8.1.1";
+  version = "8.1.2";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "086g7nhv52wclrwnzbzs2x3nvyzs2hfq1bvgivsrp5f7r7wiiz7n";
+    sha256 = "0i7w0fi24za3naz3k3qav6lrhf034nzdy6m9025djlj80476cz5h";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-27921
https://nvd.nist.gov/vuln/detail/CVE-2021-27922
https://nvd.nist.gov/vuln/detail/CVE-2021-27923

Confusing that the CVE states "Pillow before 8.1.1" is vulnerable, but the pillow release notes themselves say it's fixed by 8.1.2. Probably a miscommunication when filing the CVE.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
