### PR TITLE
aacgain: build with -Wno-narrowing

### DIFF
--- a/pkgs/applications/audio/aacgain/default.nix
+++ b/pkgs/applications/audio/aacgain/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
+  # -Wnarrowing is enabled by default in recent GCC versions,
+  # causing compilation to fail.
+  NIX_CFLAGS_COMPILE = "-Wno-narrowing";
+
   postPatch = ''
     (
       cd mp4v2


### PR DESCRIPTION
In recent GCC versions, -Wnarrowing is enabled by default, and compilation of
aacgain fails due to -Werror. This commit disables the warning again.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
