### PR TITLE
xcbuild: fix missing library for PlistBuddy

### DIFF
--- a/pkgs/development/tools/xcbuild/default.nix
+++ b/pkgs/development/tools/xcbuild/default.nix
@@ -51,6 +51,7 @@ in stdenv.mkDerivation {
   postInstall = ''
     mv $out/usr/* $out
     rmdir $out/usr
+    cp liblinenoise.* $out/lib/
   '';
 
   NIX_CFLAGS_COMPILE = "-Wno-error";


### PR DESCRIPTION
Executing the `PlistBuddy` binary currently aborts on Darwin, because a dynamically linked library is missing:

```
dyld: Library not loaded: /nix/store/144qrs12839p8a0dj9cyvdhxf2s7dvjs-xcbuild-0.1.2-pre/lib/liblinenoise.dylib
  Referenced from: /nix/store/144qrs12839p8a0dj9cyvdhxf2s7dvjs-xcbuild-0.1.2-pre/bin/PlistBuddy
  Reason: image not found
fish: Job 1, '/nix/store/144qrs12839p8a0dj9cy…' terminated by signal SIGABRT (Abbruch)
```

The reason is that `liblinenoise.dylib` is introduced to the build as third party code, but the resulting library is not installed. I fixed this by manually installing the library. Execution of `PlistBuddy` works as expected now.

###### Additional Remarks

* The package currently does not build on Linux, so I did not test `PlistBuddy` there.
* There is a TODO comment above the `postInstall` attribute asking for a `cmake` fix for the installation in `$out/usr`. I looked into this and unfortunately, the `/usr` part is hardcoded in multiple `CMakeLists.txt` throughout the source. I feel that patching those is more brittle than the solution currently in use, so I would vote to remove this comment here. I can amend the PR if needed.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).