### PR TITLE
python: mypy-protobuf: 1.23 -> 2.4

### DIFF
--- a/pkgs/development/python-modules/mypy-protobuf/default.nix
+++ b/pkgs/development/python-modules/mypy-protobuf/default.nix
@@ -1,12 +1,14 @@
-{ lib, fetchPypi, buildPythonApplication, protobuf }:
+{ lib, fetchPypi, buildPythonApplication, protobuf, pythonOlder }:
 
 buildPythonApplication rec {
   pname = "mypy-protobuf";
-  version = "1.23";
+  version = "2.4";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "cf79c77e828a2de9bdc74b43ad4abd4c2a3a30f0471b46e9b4e01b9877f166fb";
+    sha256 = "77e10c476cdd3ee14535c2357e64deac6b1a69f33eb500d795b064acda48c66f";
   };
 
   propagatedBuildInputs = [ protobuf ];


### PR DESCRIPTION
Updates mypy-protobuf to the latest version.
Note: The major version change drops compatibility with python <= 3.5
https://github.com/dropbox/mypy-protobuf/blob/master/CHANGELOG.md

###### Motivation for this change
There are new features in the 2.4 version of this package (specifically protobuf optional field generation).

###### Things done
Updates `pkgs/development/python-modules/mypy-protobuf/default.nix`:
- Increments version number
- Updates `sha256` hash
- Disables for python versions below 3.6.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python38Packages.mypy-protobuf</li>
    <li>python38Packages.ortools</li>
    <li>python39Packages.mypy-protobuf</li>
    <li>python39Packages.ortools</li>
  </ul>
</details>

- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
