### PR TITLE
wine{Unstable,Staging}: 6.4 -> 6.5

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,9 +44,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.4";
+    version = "6.5";
     url = "https://dl.winehq.org/wine/source/6.x/wine-${version}.tar.xz";
-    sha256 = "sha256-Gy0rRT2Q1sLXEk5H+urlDlxUwl9pvuHQZTGEMmECTI8=";
+    sha256 = "sha256-BgD9IIwGkl1mNNKfVDu6CmQ2HDTpvXYJwvDiCWEK00c=";
     inherit (stable) mono gecko32 gecko64;
 
     patches = [
@@ -58,7 +58,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-gTt75rRoP/HTeD5k/8bW3jjnn8M5atmP9RFqmBQaAfk=";
+    sha256 = "sha256-u6wDavrFirN1e0fFra4ui3i4PnJF0gcENYoIyNwhIYc=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
###### Motivation for this change

New upstream release.

###### Things done

```
11 packages updated:
lutris lutris lutris-original pipelight winePackages.unstable (6.4 → 6.5) wineUnstable (6.4 → 6.5) wine-staging (6.4-staging → 6.5-staging) winePackages.staging (6.4-staging → 6.5-staging) wineStaging (6.4-staging → 6.5-staging) wineWowPackages.unstable (6.4 → 6.5) wineWowPackages.staging (6.4-staging → 6.5-staging)
[...]
9 packages built:
lutris lutris-free lutris-unwrapped pipelight wineStaging winePackages.staging wineUnstable wineWowPackages.staging wineWowPackages.unstable
```


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
