### PR TITLE
gitAndTools.git-bug: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "git-bug";
-  version = "0.7.1"; # the `rev` below pins the version of the source to get
-  rev = "2d64b85db71a17ff3277bbbf7ac9d8e81f8e416c";
+  version = "0.7.2"; # the `rev` below pins the version of the source to get
+  rev = "cc4a93c8ce931b1390c61035b888ad17110b7bd6";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "MichaelMure";
     repo = "git-bug";
-    sha256 = "01ab3mlwh5g1vr3x85fppflg18gb8ip9mjfsp2b5rfigd9lxyyns";
+    sha256 = "0r6wh0y1fj3d3fbbrzq5n9k6z94xvwqww3xfbslkgyrin5bmziiq";
   };
 
-  vendorSha256 = "0c8b47lj4wl3s21lm0vx4z7hznylm8c4fb8b8gxm278kn3zys607";
+  vendorSha256 = "15hhsrwwjc4krfc2d0r15lys3vr9rb9xk62pan4jr9ycbv0dny90";
 
   doCheck = false;
 
@@ -32,7 +32,7 @@ buildGoModule rec {
   meta = with stdenv.lib; {
     description = "Distributed bug tracker embedded in Git";
     homepage = "https://github.com/MichaelMure/git-bug";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ royneary ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-28955.

(cherry picked from commit 45cea67242b7cae37afa572fae35db6e12ea6809)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
