### PR TITLE
tfk8s: 0.1.2 -> 0.1.3

### DIFF
--- a/pkgs/tools/misc/tfk8s/default.nix
+++ b/pkgs/tools/misc/tfk8s/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "tfk8s";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "jrhouston";
     repo = "tfk8s";
     rev = "v${version}";
-    sha256 = "sha256-gszvWetreafIP9I8hi9zz24TOTSsGzDsm/vXJS6n4Q4=";
+    sha256 = "sha256-3iI5gYfpkxfVylBgniaMeQ73uR8dAjVrdg/eBLRxUR4";
   };
 
   vendorSha256 = "sha256-wS5diDQFkt8IAp13d8Yeh8ihLvKWdR0Mbw0fMZpqqKE=";


### PR DESCRIPTION
It builds fine for x86-64.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
