### PR TITLE
wapiti: init at 3.0.4

### DIFF
--- a/pkgs/development/python-modules/yaswfp/default.nix
+++ b/pkgs/development/python-modules/yaswfp/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "yaswfp";
+  version = "unstable-20210331";
+
+  src = fetchFromGitHub {
+    owner = "facundobatista";
+    repo = pname;
+    rev = "2a2cc6ca4c0b4d52bd2e658fb5f80fdc0db4924c";
+    sha256 = "1dxdz89hlycy1rnn269fwl1f0qxgxqarkc0ivs2m77f8xba2qgj9";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "yaswfp" ];
+
+  meta = with lib; {
+    description = "Python SWF Parser";
+    homepage = "https://github.com/facundobatista/yaswfp";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/wapiti/default.nix
+++ b/pkgs/tools/security/wapiti/default.nix
@@ -1,0 +1,106 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "wapiti";
+  version = "3.0.4";
+
+  src = fetchFromGitHub {
+    owner = "wapiti-scanner";
+    repo = pname;
+    rev = version;
+    sha256 = "0wnz4nq1q5y74ksb1kcss9vdih0kbrmnkfbyc2ngd9id1ixfamxb";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    pytest-runner
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    beautifulsoup4
+    browser-cookie3
+    Mako
+    markupsafe
+    pysocks
+    requests
+    six
+    tld
+    yaswfp
+  ] ++ lib.optionals (python3.pythonOlder "3.8") [ importlib-metadata ];
+
+  checkInputs = with python3.pkgs; [
+    responses
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # Is already fixed in the repo. Will be part of the next release
+    substituteInPlace setup.py \
+      --replace "importlib_metadata==2.0.0" "importlib_metadata"
+  '';
+
+  disabledTests = [
+    # Tests requires network access
+    "test_attr"
+    "test_bad_separator_used"
+    "test_blind"
+    "test_chunked_timeout"
+    "test_cookies_detection"
+    "test_csrf_cases"
+    "test_detection"
+    "test_direct"
+    "test_escape_with_style"
+    "test_explorer_filtering"
+    "test_false"
+    "test_frame"
+    "test_headers_detection"
+    "test_html_detection"
+    "test_implies_detection"
+    "test_inclusion_detection"
+    "test_meta_detection"
+    "test_no_crash"
+    "test_options"
+    "test_out_of_band"
+    "test_partial_tag_name_escape"
+    "test_prefix_and_suffix_detection"
+    "test_qs_limit"
+    "test_rare_tag_and_event"
+    "test_redirect_detection"
+    "test_request_object"
+    "test_script"
+    "test_ssrf"
+    "test_tag_name_escape"
+    "test_timeout"
+    "test_title_false_positive"
+    "test_title_positive"
+    "test_true_positive_request_count"
+    "test_url_detection"
+    "test_warning"
+    "test_whole"
+    "test_xss_inside_tag_input"
+    "test_xss_inside_tag_link"
+    "test_xss_uppercase_no_script"
+    "test_xss_with_strong_csp"
+    "test_xss_with_weak_csp"
+    "test_xxe"
+  ];
+
+  pythonImportsCheck = [ "wapitiCore" ];
+
+  meta = with lib; {
+    description = "Web application vulnerability scanner";
+    longDescription = ''
+      Wapiti allows you to audit the security of your websites or web applications.
+      It performs "black-box" scans (it does not study the source code) of the web
+      application by crawling the webpages of the deployed webapp, looking for
+      scripts and forms where it can inject data. Once it gets the list of URLs,
+      forms and their inputs, Wapiti acts like a fuzzer, injecting payloads to see
+      if a script is vulnerable.
+    '';
+    homepage = "https://wapiti-scanner.github.io/";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26242,6 +26242,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  wapiti = callPackage ../tools/security/wapiti { };
+
   way-cooler = throw ("way-cooler is abandoned by its author: " +
     "https://way-cooler.org/blog/2020/01/09/way-cooler-post-mortem.html");
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9002,6 +9002,8 @@ in {
 
   yarl = callPackage ../development/python-modules/yarl { };
 
+  yaswfp = callPackage ../development/python-modules/yaswfp { };
+
   yattag = callPackage ../development/python-modules/yattag { };
 
   ydiff = callPackage ../development/python-modules/ydiff { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Wapiti allows you to audit the security of your websites or web applications.

It performs "black-box" scans (it does not study the source code) of the web application by crawling the webpages of the deployed webapp, looking for scripts and forms where it can inject data.

Once it gets the list of URLs, forms and their inputs, Wapiti acts like a fuzzer, injecting payloads to see if a script is vulnerable.

https://wapiti-scanner.github.io/

`yaswfp` is required. This module was not updated for some time now and this could be a blocker.

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
