### PR TITLE
[20.09] gstreamer: 1.16.2 -> 1.16.3

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -87,22 +87,16 @@ let
   inherit (stdenv.lib) optional optionals;
 in stdenv.mkDerivation rec {
   pname = "gst-plugins-bad";
-  version = "1.16.2";
+  version = "1.16.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0x0y0hm0ga3zqi5q4090hw5sjh59y1ry9ak16qsaascm72i7mjzi";
+    sha256 = "0kaifdk997h63v10h26bvh2m37qhxxj0zcnmlm9hm3v525qfbvw4";
   };
 
   patches = [
-    # Fix build with neon 0.31
-    # https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1165
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/commit/f10b424418e448211e3427a76fcd046e157ef0b7.patch";
-      sha256 = "0l1f6kqcl04q7w12a2b4qibcvjz6gqhs0csdv2wbvfd6zndpjm6p";
-    })
     ./fix_pkgconfig_includedir.patch
     # https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1235
     ./opencv-4.3.patch

--- a/pkgs/development/libraries/gstreamer/bad/opencv-4.3.patch
+++ b/pkgs/development/libraries/gstreamer/bad/opencv-4.3.patch
@@ -1,12 +1,12 @@
 diff --git a/ext/opencv/meson.build b/ext/opencv/meson.build
-index f38b55d..05b142e 100644
+index 2e1380313..05b142edc 100644
 --- a/ext/opencv/meson.build
 +++ b/ext/opencv/meson.build
 @@ -65,7 +65,7 @@ if opencv_found
      endif
    endforeach
  else
--  opencv_dep = dependency('opencv4', version : ['>= 4.0.0', '< 4.2.0'], required : false)
+-  opencv_dep = dependency('opencv4', version : ['>= 4.0.0', '< 4.3.0'], required : false)
 +  opencv_dep = dependency('opencv4', version : ['>= 4.0.0', '< 4.4.0'], required : false)
    opencv_found = opencv_dep.found()
    if opencv_found

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -42,13 +42,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-plugins-base";
-  version = "1.16.2";
+  version = "1.16.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0sl1hxlyq46r02k7z70v09vx1gi4rcypqmzra9jid93lzvi76gmi";
+    sha256 = "0729xrzxqd5xr33hgmjc2p1gx4nfhffxhfvx23zrxk5v1f5nf0lz";
   };
 
   patches = [

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -25,14 +25,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gstreamer";
-  version = "1.16.2";
+  version = "1.16.3";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0kp93622y29pck8asvil1fmzf55s2gx76wv475a6izc3cwj49w73";
+    sha256 = "1is3jpjwgcckh77pyh11a13phv72w9s9c7gpn04fam74d1wh6bv9";
   };
 
   patches = [

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gstreamer-editing-services";
-  version = "1.16.2";
+  version = "1.16.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "05hcf3prna8ajjnqd53221gj9syarrrjbgvjcbhicv0c38csc1hf";
+    sha256 = "19lvm4vynmbprd4pwnw0srac3k7iyh01zlbskscm7nzilswcn1cv";
   };
 
   patches = [

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -46,13 +46,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "gst-plugins-good";
-  version = "1.16.2";
+  version = "1.16.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "068k3cbv1yf3gbllfdzqsg263kzwh21y8dpwr0wvgh15vapkpfs0";
+    sha256 = "0pzq565ijl5z3mphvix34878m7hck6a58rdpj7sp7rixwwzkm8nk";
   };
 
   patches = [ ./fix_pkgconfig_includedir.patch ];

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-libav";
-  version = "1.16.2";
+  version = "1.16.3";
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1wpfilc98bad9nsv3y1qapxp35dvn2mvwvrmqwrsj58cf09gc967";
+    sha256 = "1v1q2n1rn5scag2dwp0rd399jvmacg35c2awr2bxx48al2qmw36i";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-rtsp-server";
-  version = "1.16.2";
+  version = "1.16.3";
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0vn23nxwvs96g7gcxw5zbnw23hkhky8a8r42wq68411vgf1s41yy";
+    sha256 = "187ywrzm628sr7m4rdizs21379javka5kmc8iz2i7m96523np237";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-plugins-ugly";
-  version = "1.16.2";
+  version = "1.16.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1jpvc32x6q01zjkfgh6gmq6aaikiyfwwnhj7bmvn52syhrdl202m";
+    sha256 = "1w23b3zvgslpyl6sc28krikjb0q7bhml0x48019ixx35h1l22g20";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gstreamer-vaapi";
-  version = "1.16.2";
+  version = "1.16.3";
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "00f6sx700qm1ximi1ag2c27m35dywwhhg6awhz85va34mfqff78r";
+    sha256 = "1glyzgqyaw9pb1rpbj4fx7swywsqc5759dfyhzcprs9z30y0n83p";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-validate";
-  version = "1.16.2";
+  version = "1.16.3";
 
   src = fetchurl {
     url = "${meta.homepage}/src/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1jpfrzg3yc6kp66bgq3jy14xsj3x71mk2zh0k16yf0326awwqqa8";
+    sha256 = "0azr9dy5kwnry4bzchlhn99z44b7jcs94rnafsj6mbr4ff44w1n2";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "gst-python";
-  version = "1.16.2";
+  version = "1.16.3";
 
   format = "other";
 
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-python/${pname}-${version}.tar.xz";
-    sha256 = "1a48ca66izmm8hnp608jv5isg3jxb0vlfmhns0bg9nbkilag7390";
+    sha256 = "07qnqwr8g4q9b2rbcnhlb1svgpsqc6fz19k5p6lsmk15dhjhm81n";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.openwall.com/lists/oss-security/2021/01/20/1

Fixes: CVE-2021-3185
Closes: #113446
Supersedes: #116641

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
