### PR TITLE
julia: init julia_16

### DIFF
--- a/pkgs/development/compilers/julia/0001-reduce-precompile-failure-severity-to-a-warning-3990.patch
+++ b/pkgs/development/compilers/julia/0001-reduce-precompile-failure-severity-to-a-warning-3990.patch
@@ -1,0 +1,194 @@
+From 93b89b9486c2f5b6f780d59405b26e810412308f Mon Sep 17 00:00:00 2001
+From: Jameson Nash <vtjnash@gmail.com>
+Date: Thu, 11 Mar 2021 14:36:57 -0500
+Subject: [PATCH] reduce precompile() failure severity to a warning (#39905)
+
+Many users (including Base) are calling `@assert`, despite that this is
+not what assert should be used to mark, for many reasons.
+
+This happened to also reveal a small number of errors, so also detect
+those (for fixing later).
+
+Refs: https://github.com/JuliaLang/julia/commit/c0f9666d0b94b213c7ff9e64a7b4e5268aa0e18b#commitcomment-47782674
+---
+ base/compiler/abstractinterpretation.jl |   1 +
+ base/essentials.jl                      |  13 ---
+ base/loading.jl                         |  29 ++++-
+ contrib/generate_precompile.jl          | 147 +++++++++++++-----------
+ test/ambiguous.jl                       |   4 +-
+ 5 files changed, 108 insertions(+), 86 deletions(-)
+
+diff --git a/base/compiler/abstractinterpretation.jl b/base/compiler/abstractinterpretation.jl
+index 4fd1a26b31..d2dd2226d1 100644
+--- a/base/compiler/abstractinterpretation.jl
++++ b/base/compiler/abstractinterpretation.jl
+@@ -970,6 +970,7 @@ end
+
+ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, fargs::Union{Nothing,Vector{Any}},
+         argtypes::Vector{Any}, sv::InferenceState, max_methods::Int)
++    @nospecialize f
+     la = length(argtypes)
+     if f === ifelse && fargs isa Vector{Any} && la == 4
+         cnd = argtypes[2]
+diff --git a/base/essentials.jl b/base/essentials.jl
+index 636db9df67..1a0e971d3a 100644
+--- a/base/essentials.jl
++++ b/base/essentials.jl
+@@ -483,19 +483,6 @@ sizeof(x) = Core.sizeof(x)
+ # simple Array{Any} operations needed for bootstrap
+ @eval setindex!(A::Array{Any}, @nospecialize(x), i::Int) = arrayset($(Expr(:boundscheck)), A, x, i)
+
+-"""
+-    precompile(f, args::Tuple{Vararg{Any}})
+-
+-Compile the given function `f` for the argument tuple (of types) `args`, but do not execute it.
+-"""
+-function precompile(@nospecialize(f), args::Tuple)
+-    ccall(:jl_compile_hint, Int32, (Any,), Tuple{Core.Typeof(f), args...}) != 0
+-end
+-
+-function precompile(argt::Type)
+-    ccall(:jl_compile_hint, Int32, (Any,), argt) != 0
+-end
+-
+ """
+     esc(e)
+
+diff --git a/base/loading.jl b/base/loading.jl
+index 41e5e8a55b..6fab289b3e 100644
+--- a/base/loading.jl
++++ b/base/loading.jl
+@@ -1218,11 +1218,9 @@ function include_package_for_output(pkg::PkgId, input::String, depot_path::Vecto
+     end
+ end
+
+-@assert precompile(include_package_for_output, (PkgId,String,Vector{String},Vector{String},Vector{String},typeof(_concrete_dependencies),Nothing))
+-@assert precompile(include_package_for_output, (PkgId,String,Vector{String},Vector{String},Vector{String},typeof(_concrete_dependencies),String))
+-
+ const PRECOMPILE_TRACE_COMPILE = Ref{String}()
+ function create_expr_cache(pkg::PkgId, input::String, output::String, concrete_deps::typeof(_concrete_dependencies), internal_stderr::IO = stderr, internal_stdout::IO = stdout)
++    @nospecialize internal_stderr internal_stdout
+     rm(output, force=true)   # Remove file if it exists
+     depot_path = map(abspath, DEPOT_PATH)
+     dl_load_path = map(abspath, DL_LOAD_PATH)
+@@ -1261,9 +1259,6 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, concrete_d
+     return io
+ end
+
+-@assert precompile(create_expr_cache, (PkgId, String, String, typeof(_concrete_dependencies), typeof(stderr), typeof(stdout)))
+-@assert precompile(create_expr_cache, (PkgId, String, String, typeof(_concrete_dependencies), typeof(stderr), typeof(stdout)))
+-
+ function compilecache_dir(pkg::PkgId)
+     entrypath, entryfile = cache_file_entry(pkg)
+     return joinpath(DEPOT_PATH[1], entrypath)
+@@ -1294,6 +1289,7 @@ This can be used to reduce package load times. Cache files are stored in
+ for important notes.
+ """
+ function compilecache(pkg::PkgId, internal_stderr::IO = stderr, internal_stdout::IO = stdout)
++    @nospecialize internal_stderr internal_stdout
+     path = locate_package(pkg)
+     path === nothing && throw(ArgumentError("$pkg not found during precompilation"))
+     return compilecache(pkg, path, internal_stderr, internal_stdout)
+@@ -1302,6 +1298,7 @@ end
+ const MAX_NUM_PRECOMPILE_FILES = Ref(10)
+
+ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, internal_stdout::IO = stdout)
++    @nospecialize internal_stderr internal_stdout
+     # decide where to put the resulting cache file
+     cachepath = compilecache_dir(pkg)
+
+@@ -1810,3 +1807,23 @@ macro __DIR__()
+     _dirname = dirname(String(__source__.file::Symbol))
+     return isempty(_dirname) ? pwd() : abspath(_dirname)
+ end
++
++"""
++    precompile(f, args::Tuple{Vararg{Any}})
++
++Compile the given function `f` for the argument tuple (of types) `args`, but do not execute it.
++"""
++function precompile(@nospecialize(f), args::Tuple)
++    precompile(Tuple{Core.Typeof(f), args...})
++end
++
++function precompile(argt::Type)
++    if ccall(:jl_compile_hint, Int32, (Any,), argt) == 0
++        @warn "Inactive precompile statement" maxlog=100 form=argt _module=nothing _file=nothing _line=0
++    end
++    true
++end
++
++precompile(include_package_for_output, (PkgId, String, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), Nothing))
++precompile(include_package_for_output, (PkgId, String, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), String))
++precompile(create_expr_cache, (PkgId, String, String, typeof(_concrete_dependencies), IO, IO))
+diff --git a/contrib/generate_precompile.jl b/contrib/generate_precompile.jl
+index f5de8eac94..dc9bb2cd8e 100644
+--- a/contrib/generate_precompile.jl
++++ b/contrib/generate_precompile.jl
+@@ -108,7 +108,7 @@ have_repl =  haskey(Base.loaded_modules,
+                     Base.PkgId(Base.UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL"))
+ if have_repl
+     hardcoded_precompile_statements *= """
+-    @assert precompile(Tuple{typeof(getproperty), REPL.REPLBackend, Symbol})
++    precompile(Tuple{typeof(getproperty), REPL.REPLBackend, Symbol})
+     """
+ end
+
+@@ -117,9 +117,9 @@ Distributed = get(Base.loaded_modules,
+           nothing)
+ if Distributed !== nothing
+     hardcoded_precompile_statements *= """
+-    @assert precompile(Tuple{typeof(Distributed.remotecall),Function,Int,Module,Vararg{Any, 100}})
+-    @assert precompile(Tuple{typeof(Distributed.procs)})
+-    @assert precompile(Tuple{typeof(Distributed.finalize_ref), Distributed.Future})
++    precompile(Tuple{typeof(Distributed.remotecall),Function,Int,Module,Vararg{Any, 100}})
++    precompile(Tuple{typeof(Distributed.procs)})
++    precompile(Tuple{typeof(Distributed.finalize_ref), Distributed.Future})
+     """
+ # This is disabled because it doesn't give much benefit
+ # and the code in Distributed is poorly typed causing many invalidations
+@@ -164,9 +164,9 @@ FileWatching = get(Base.loaded_modules,
+           nothing)
+ if FileWatching !== nothing
+     hardcoded_precompile_statements *= """
+-    @assert precompile(Tuple{typeof(FileWatching.watch_file), String, Float64})
+-    @assert precompile(Tuple{typeof(FileWatching.watch_file), String, Int})
+-    @assert precompile(Tuple{typeof(FileWatching._uv_hook_close), FileWatching.FileMonitor})
++    precompile(Tuple{typeof(FileWatching.watch_file), String, Float64})
++    precompile(Tuple{typeof(FileWatching.watch_file), String, Int})
++    precompile(Tuple{typeof(FileWatching._uv_hook_close), FileWatching.FileMonitor})
+     """
+ end
+
+@@ -322,5 +322,5 @@ function generate_precompile_statements()
+     if have_repl
+         # Seems like a reasonable number right now, adjust as needed
+         # comment out if debugging script
+-        @assert n_succeeded > 1200
++        n_succeeded > 1200 || @warn "Only $n_succeeded precompile statements"
+     end
+
+diff --git a/test/ambiguous.jl b/test/ambiguous.jl
+index 25a3264489..bad5f19f38 100644
+--- a/test/ambiguous.jl
++++ b/test/ambiguous.jl
+@@ -66,7 +66,7 @@ end
+ ## Other ways of accessing functions
+ # Test that non-ambiguous cases work
+ let io = IOBuffer()
+-    @test precompile(ambig, (Int, Int)) == true
++    @test @test_logs precompile(ambig, (Int, Int))
+     cf = @eval @cfunction(ambig, Int, (Int, Int))
+     @test ccall(cf, Int, (Int, Int), 1, 2) == 4
+     @test length(code_lowered(ambig, (Int, Int))) == 1
+@@ -75,7 +75,7 @@ end
+
+ # Test that ambiguous cases fail appropriately
+ let io = IOBuffer()
+-    @test precompile(ambig, (UInt8, Int)) == false
++    @test @test_logs (:warn,) precompile(ambig, (UInt8, Int))
+     cf = @eval @cfunction(ambig, Int, (UInt8, Int))  # test for a crash (doesn't throw an error)
+     @test_throws(MethodError(ambig, (UInt8(1), Int(2)), get_world_counter()),
+                  ccall(cf, Int, (UInt8, Int), 1, 2))
+--
+2.29.2

--- a/pkgs/development/compilers/julia/1.6.nix
+++ b/pkgs/development/compilers/julia/1.6.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
       "prefix=$(out)"
       "SHELL=${stdenv.shell}"
 
-      "USE_SYSTEM_BLAS=1"
+      (lib.optionalString (!stdenv.isDarwin) "USE_SYSTEM_BLAS=1")
       "USE_BLAS64=${if blas.isILP64 then "1" else "0"}"
 
       "USE_SYSTEM_LAPACK=1"

--- a/pkgs/development/compilers/julia/1.6.nix
+++ b/pkgs/development/compilers/julia/1.6.nix
@@ -2,7 +2,7 @@
 # build tools
 , gfortran, m4, makeWrapper, patchelf, perl, which, python3, cmake
 # libjulia dependencies
-, libunwind, readline, utf8proc, zlib, gmp
+, libunwind, utf8proc, gmp
 # standard library dependencies
 , curl, fftwSinglePrec, fftw, libgit2, libnghttp2, mpfr, openlibm, openspecfun, pcre2
 # linear algebra
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Even though we set "USE_SYSTEM_UTF8PROC=1", a patch is still necessary to
+    # use the nixpkgs version of utf8proc.
     ./use-system-utf8proc-julia-1.3.patch
 
     # Julia recompiles a precompiled file if the mtime stored *in* the

--- a/pkgs/development/compilers/julia/1.6.nix
+++ b/pkgs/development/compilers/julia/1.6.nix
@@ -1,0 +1,164 @@
+{ lib, stdenv, fetchzip
+# build tools
+, gfortran, m4, makeWrapper, patchelf, perl, which, python3, cmake
+# libjulia dependencies
+, libunwind, readline, utf8proc, zlib, gmp
+# standard library dependencies
+, curl, fftwSinglePrec, fftw, libgit2, libnghttp2, mpfr, openlibm, openspecfun, pcre2
+# linear algebra
+, blas, lapack, arpack
+# Darwin frameworks
+, CoreServices, ApplicationServices
+}:
+
+assert (!blas.isILP64) && (!lapack.isILP64);
+
+with lib;
+
+let
+  majorVersion = "1";
+  minorVersion = "6";
+  maintenanceVersion = "0";
+  src_sha256 = "14qhd0vp2y9c6126niz37vkz3n7skd6h565fai3khhd0li63vka6";
+  version = "${majorVersion}.${minorVersion}.${maintenanceVersion}";
+in
+
+stdenv.mkDerivation rec {
+  pname = "julia";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz";
+    sha256 = src_sha256;
+  };
+
+  patches = [
+    ./use-system-utf8proc-julia-1.3.patch
+
+    # Julia recompiles a precompiled file if the mtime stored *in* the
+    # .ji file differs from the mtime of the .ji file.  This
+    # doesn't work in Nix because Nix changes the mtime of files in
+    # the Nix store to 1. So patch Julia to accept mtimes of 1.
+    ./allow_nix_mtime.patch
+
+    # There's a weird error where n_succeeded would fail here: https://github.com/JuliaLang/julia/blame/3276c11b7e6ebf0c3867022765c8b233c0cbefe5/contrib/generate_precompile.jl#L378
+    # but this has since been fixed upstream. This patch is the output of
+    #   $ git format-patch -1 93b89b9486c2f5b6f780d59405b26e810412308f
+    # but with some healthy redaction to help the patch application work.
+    ./0001-reduce-precompile-failure-severity-to-a-warning-3990.patch
+  ];
+
+  postPatch = ''
+    patchShebangs . contrib
+  '';
+
+  dontUseCmakeConfigure = true;
+  enableParallelBuilding = true;
+
+  buildInputs = [blas lapack libunwind utf8proc]
+                ++ lib.optionals stdenv.isDarwin [CoreServices ApplicationServices];
+
+  nativeBuildInputs = [cmake curl gfortran m4 makeWrapper patchelf perl python3 which];
+
+  makeFlags =
+    let
+      arch = head (splitString "-" stdenv.system);
+      march = {
+        x86_64 = stdenv.hostPlatform.gcc.arch or "x86-64";
+        i686 = "pentium4";
+        aarch64 = "armv8-a";
+      }.${arch}
+              or (throw "unsupported architecture: ${arch}");
+      # Julia requires Pentium 4 (SSE2) or better
+      cpuTarget = { x86_64 = "x86-64"; i686 = "pentium4"; aarch64 = "generic"; }.${arch}
+                  or (throw "unsupported architecture: ${arch}");
+    # Julia applies a lot of patches to its dependencies, so for now do not use the system LLVM
+    # https://github.com/JuliaLang/julia/tree/master/deps/patches
+    in [
+      "ARCH=${arch}"
+      "MARCH=${march}"
+      "JULIA_CPU_TARGET=${cpuTarget}"
+      "PREFIX=$(out)"
+      "prefix=$(out)"
+      "SHELL=${stdenv.shell}"
+
+      "USE_SYSTEM_BLAS=1"
+      "USE_BLAS64=${if blas.isILP64 then "1" else "0"}"
+
+      "USE_SYSTEM_LAPACK=1"
+
+      "USE_SYSTEM_ARPACK=1"
+      "USE_SYSTEM_FFTW=1"
+      "USE_SYSTEM_GMP=1"
+      "USE_SYSTEM_LIBGIT2=1"
+      "USE_SYSTEM_LIBUNWIND=1"
+
+      "USE_SYSTEM_MPFR=1"
+      "USE_SYSTEM_OPENLIBM=1"
+      "USE_SYSTEM_OPENSPECFUN=1"
+      "USE_SYSTEM_PATCHELF=1"
+      "USE_SYSTEM_PCRE=1"
+      "PCRE_CONFIG=${pcre2.dev}/bin/pcre2-config"
+      "PCRE_INCL_PATH=${pcre2.dev}/include/pcre2.h"
+      "USE_SYSTEM_READLINE=1"
+      "USE_SYSTEM_UTF8PROC=1"
+      "USE_SYSTEM_ZLIB=1"
+
+      "USE_BINARYBUILDER=0"
+    ];
+
+  LD_LIBRARY_PATH = makeLibraryPath [
+    arpack
+    blas
+    curl
+    fftw
+    fftwSinglePrec
+    gmp
+    lapack
+    libgit2
+    libnghttp2
+    libunwind
+    mpfr
+    openlibm
+    openspecfun
+    pcre2
+    utf8proc
+  ];
+
+  # Julia's tests require read/write access to $HOME
+  preCheck = ''
+    export HOME="$NIX_BUILD_TOP"
+  '';
+
+  preBuild = ''
+    sed -e '/^install:/s@[^ ]*/doc/[^ ]*@@' -i Makefile
+    sed -e '/[$](DESTDIR)[$](docdir)/d' -i Makefile
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+  '';
+
+  postInstall = ''
+    # Symlink shared libraries from LD_LIBRARY_PATH into lib/julia,
+    # as using a wrapper with LD_LIBRARY_PATH causes segmentation
+    # faults when program returns an error:
+    #   $ julia -e 'throw(Error())'
+    find $(echo $LD_LIBRARY_PATH | sed 's|:| |g') -maxdepth 1 -name '*.${if stdenv.isDarwin then "dylib" else "so"}*' | while read lib; do
+      if [[ ! -e $out/lib/julia/$(basename $lib) ]]; then
+        ln -sv $lib $out/lib/julia/$(basename $lib)
+      fi
+    done
+  '';
+
+  passthru = {
+    inherit majorVersion minorVersion maintenanceVersion;
+    site = "share/julia/site/v${majorVersion}.${minorVersion}";
+  };
+
+  meta = {
+    description = "High-level performance-oriented dynamical language for technical computing";
+    homepage = "https://julialang.org/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ raskin rob garrison ];
+    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
+    broken = stdenv.isi686;
+  };
+}

--- a/pkgs/development/compilers/julia/1.6.nix
+++ b/pkgs/development/compilers/julia/1.6.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   buildInputs = [ blas lapack libunwind utf8proc ]
-    ++ lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];
+    ++ optionals stdenv.isDarwin [ CoreServices ApplicationServices ];
 
   nativeBuildInputs = [ cmake curl gfortran m4 makeWrapper patchelf perl python3 which ];
 
@@ -156,8 +156,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "High-level performance-oriented dynamical language for technical computing";
     homepage = "https://julialang.org/";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ raskin rob garrison ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ raskin rob garrison ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
     broken = stdenv.isi686;
   };

--- a/pkgs/development/compilers/julia/1.6.nix
+++ b/pkgs/development/compilers/julia/1.6.nix
@@ -55,10 +55,10 @@ stdenv.mkDerivation rec {
   dontUseCmakeConfigure = true;
   enableParallelBuilding = true;
 
-  buildInputs = [blas lapack libunwind utf8proc]
-                ++ lib.optionals stdenv.isDarwin [CoreServices ApplicationServices];
+  buildInputs = [ blas lapack libunwind utf8proc ]
+    ++ lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];
 
-  nativeBuildInputs = [cmake curl gfortran m4 makeWrapper patchelf perl python3 which];
+  nativeBuildInputs = [ cmake curl gfortran m4 makeWrapper patchelf perl python3 which ];
 
   makeFlags =
     let

--- a/pkgs/development/compilers/julia/1.6.nix
+++ b/pkgs/development/compilers/julia/1.6.nix
@@ -19,7 +19,6 @@ let
   majorVersion = "1";
   minorVersion = "6";
   maintenanceVersion = "0";
-  src_sha256 = "14qhd0vp2y9c6126niz37vkz3n7skd6h565fai3khhd0li63vka6";
   version = "${majorVersion}.${minorVersion}.${maintenanceVersion}";
 in
 
@@ -29,7 +28,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     url = "https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz";
-    sha256 = src_sha256;
+    sha256 = "14qhd0vp2y9c6126niz37vkz3n7skd6h565fai3khhd0li63vka6";
   };
 
   patches = [

--- a/pkgs/development/compilers/julia/update-1.6.py
+++ b/pkgs/development/compilers/julia/update-1.6.py
@@ -11,11 +11,11 @@ assert latest[0] == "v"
 major, minor, patch = latest[1:].split(".")
 assert major == "1"
 # When a new minor version comes out we'll have to refactor/copy this update script.
-assert minor == "5"
+assert minor == "6"
 
 sha256 = subprocess.check_output(["nix-prefetch-url", "--unpack", f"https://github.com/JuliaLang/julia/releases/download/v{major}.{minor}.{patch}/julia-{major}.{minor}.{patch}-full.tar.gz"], text=True).strip()
 
-nix_path = os.path.join(os.path.dirname(__file__), "1.5.nix")
+nix_path = os.path.join(os.path.dirname(__file__), "1.6.nix")
 nix0 = open(nix_path, "r").read()
 nix1 = re.sub("maintenanceVersion = \".*\";", f"maintenanceVersion = \"{patch}\";", nix0)
 nix2 = re.sub("src_sha256 = \".*\";", f"src_sha256 = \"{sha256}\";", nix1)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10717,8 +10717,12 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
   };
 
+  julia_16 = callPackage ../development/compilers/julia/1.6.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
+  };
+
   julia_1 = julia_10;
-  julia = julia_15;
+  julia = julia_16;
 
   jwasm =  callPackage ../development/compilers/jwasm { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Julia version 1.6.0 has just been released (https://docs.julialang.org/en/v1/NEWS/#Julia-v1.6-Release-Notes). This PR introduces `julia_16` and sets `julia` to be `julia_16`. It also modifies the update script, `update-1.5.py`, to now update versions 1.6.x. This means that `julia_15` will require manual updates in the future, but I don't anticipate that to be a common use case.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

The `1.6.nix` derivation is based on the `1.5.nix` version with the following changes:
* Using nixpkgs's `gmp` instead of the vendored and patched julia version. Using the vendored `gmp` leads to errors (https://discourse.nixos.org/t/rpath-of-binary-contains-a-forbidden-reference-to-build/12200). Using the nixpkgs `gmp` may leave us open to this bug: https://github.com/JuliaLang/julia/issues/8286, but it seems minor. We are also using non-vendored versions for other packages that julia patches in small ways, eg. libgit2, libunwind, and pcre2.
* Patched `contrib/generate_precompile.jl` with an upstream fix. It just converts a hard error into a warning in the build/test process. This is contained in pkgs/development/compilers/julia/0001-reduce-precompile-failure-severity-to-a-warning-3990.patch.
* Added new dependencies to `LD_LIBRARY_PATH`:
  - curl
  - gmp
  - libnghttp2
  - libunwind
  - utf8proc
* Trim `buildInputs` to only the essentials.
* Set `enableParallelBuilding = true;` for faster builds.
* Remove `postPatch` hacks that are no longer necessary to get the test suite passing.
* Use `python3` instead of `python2` in `nativeBuildInputs`.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
