### PR TITLE
innernet: init at 1.0.0

### DIFF
--- a/pkgs/tools/networking/innernet/default.nix
+++ b/pkgs/tools/networking/innernet/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, llvmPackages, linuxHeaders, sqlite, darwin ? null }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "innernet";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "tonarino";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-OomCSA02ypFVzkYMcmkFREWB6x7oxgpt7x2zRANIDMw=";
+  };
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+
+  nativeBuildInputs = with llvmPackages; [ llvm clang ];
+  buildInputs = [ sqlite ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+  cargoSha256 = "sha256-xNw3IMnWKMlOijohurLoaYmSnqY/+doTm9wDIl5AMxc=";
+
+  meta = with lib; {
+    description = "A private network system that uses WireGuard under the hood";
+    homepage = "https://github.com/tonarino/innernet";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tomberek _0x4A6F ];
+  };
+}

--- a/pkgs/tools/networking/innernet/default.nix
+++ b/pkgs/tools/networking/innernet/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, llvmPackages, linuxHeaders, sqlite, darwin ? null }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub, llvmPackages, linuxHeaders, sqlite, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "innernet";
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   nativeBuildInputs = with llvmPackages; [ llvm clang ];
-  buildInputs = [ sqlite ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+  buildInputs = [ sqlite ] ++ lib.optionals stdenv.isDarwin [ Security ];
   cargoSha256 = "sha256-xNw3IMnWKMlOijohurLoaYmSnqY/+doTm9wDIl5AMxc=";
 
   meta = with lib; {

--- a/pkgs/tools/networking/innernet/default.nix
+++ b/pkgs/tools/networking/innernet/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = with llvmPackages; [ llvm clang ];
   buildInputs = [ sqlite ] ++ lib.optionals stdenv.isDarwin [ Security ];
-  cargoSha256 = "sha256-xNw3IMnWKMlOijohurLoaYmSnqY/+doTm9wDIl5AMxc=";
+  cargoSha256 = "sha256-GYNk3j8fjKSo3Qk6Qy0l6kNINK3FxlSYoEkJSx7kVpk=";
 
   meta = with lib; {
     description = "A private network system that uses WireGuard under the hood";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5460,6 +5460,8 @@ in
 
   infamousPlugins = callPackage ../applications/audio/infamousPlugins { };
 
+  innernet = callPackage ../tools/networking/innernet { };
+
   innoextract = callPackage ../tools/archivers/innoextract { };
 
   input-utils = callPackage ../os-specific/linux/input-utils { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5460,7 +5460,9 @@ in
 
   infamousPlugins = callPackage ../applications/audio/infamousPlugins { };
 
-  innernet = callPackage ../tools/networking/innernet { };
+  innernet = callPackage ../tools/networking/innernet {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   innoextract = callPackage ../tools/archivers/innoextract { };
 


### PR DESCRIPTION
###### Motivation for this change
Trying to package rust application and read https://blog.tonari.no/introducing-innernet

###### Things done
Not sure if bringing in linuxHeaders in this fashion is the right way.
Not sure if LLVM and CLANG options are brought in the right way.

Note: did not test any functionality yet

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
