### PR TITLE
pgo-client: init at 4.6.2

### DIFF
--- a/pkgs/applications/networking/cluster/pgo-client/default.nix
+++ b/pkgs/applications/networking/cluster/pgo-client/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "pgo-client";
+  version = "4.6.2";
+
+  src = fetchFromGitHub {
+    owner = "CrunchyData";
+    repo = "postgres-operator";
+    rev = "v${version}";
+    sha256 = "sha256-zPFsLKbuVq2wMjFsqjBGiatPBwGR/X6q3mj8o5BE+r0=";
+  };
+
+  vendorSha256 = "sha256-DU1kc7YDQ+denj6tHVGt79s494aBFZ2KM7PVSn951KI=";
+
+  subPackages = [ "cmd/pgo" ];
+
+  meta = with lib; {
+    description = "A CLI client for Crunchy PostgreSQL Kubernetes Operator";
+    homepage = "https://github.com/CrunchyData/postgres-operator";
+    changelog = "https://github.com/CrunchyData/postgres-operator/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = [ maintainers.bryanasdev000 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23649,6 +23649,8 @@ in
 
   k9s = callPackage ../applications/networking/cluster/k9s { };
 
+  pgo-client = callPackage ../applications/networking/cluster/pgo-client { };
+
   popeye = callPackage ../applications/networking/cluster/popeye { };
 
   kube-capacity = callPackage ../applications/networking/cluster/kube-capacity { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add pgo client, a client for Crunchy PostgreSQL Kubernetes Operator  to our repository.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
