### PR TITLE
Revert "pyre: remove"

### DIFF
--- a/pkgs/development/tools/pyre/default.nix
+++ b/pkgs/development/tools/pyre/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, writeScript
-, dune, python3, rsync, buck, watchman, sqlite }:
+{ lib, stdenv, fetchFromGitHub, ocamlPackages, writeScript
+, dune_1, python3, rsync, buck, watchman, sqlite }:
 let
   # Manually set version - the setup script requires
   # hg and git + keeping the .git directory around.
@@ -39,7 +39,7 @@ let
     ppx_deriving_yojson
     ocamlbuild
     ppxlib
-    dune
+    dune_1
     ounit
     base64
     sqlite.dev
@@ -71,7 +71,7 @@ let
     install -D ./_build/default/main.exe $out/bin/pyre.bin
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A performant type-checker for Python 3";
     homepage = https://pyre-check.org;
     license = licenses.mit;

--- a/pkgs/development/tools/pyre/default.nix
+++ b/pkgs/development/tools/pyre/default.nix
@@ -1,0 +1,137 @@
+{ stdenv, fetchFromGitHub, ocamlPackages, writeScript
+, dune, python3, rsync, buck, watchman, sqlite }:
+let
+  # Manually set version - the setup script requires
+  # hg and git + keeping the .git directory around.
+  pyre-version = "0.0.22";  # also change typeshed revision below with $pyre-src/.typeshed-version
+  pyre-src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "pyre-check";
+    rev = "v${pyre-version}";
+    sha256 = "057vy6zmgwsi0ag9n4m6sszhahmfk2s1ywm36nyfs7w4d0wnk92s";
+  };
+  versionFile = writeScript "version.ml" ''
+    cat > "./version.ml" <<EOF
+    open Core
+    let build_info () =
+    "pyre-nixpkgs ${pyre-version}"
+    let version () =
+    "${pyre-version}"
+
+    let log_version_banner () =
+      Log.info "Running as pid: %d" (Pid.to_int (Unix.getpid ()));
+      Log.info "Version: %s" (version ());
+      Log.info "Build info: %s" (build_info ())
+    EOF
+  '';
+ pyre-bin = stdenv.mkDerivation {
+  name = "pyre-${pyre-version}";
+
+  src = pyre-src;
+
+  buildInputs = with ocamlPackages; [
+    ocaml
+    findlib
+    menhir
+    yojson
+    core
+    sedlex
+    ppx_deriving_yojson
+    ocamlbuild
+    ppxlib
+    dune
+    ounit
+    base64
+    sqlite.dev
+    # python36Packages.python36Full # TODO
+  ];
+
+  preBuild = ''
+    # build requires HOME to be set
+    export HOME=$TMPDIR
+
+    # "external" because https://github.com/facebook/pyre-check/pull/8/files
+    sed "s/%VERSION%/external/" dune.in > dune
+
+    ln -sf ${versionFile} ./scripts/generate-version-number.sh
+
+    mkdir $(pwd)/build
+    export OCAMLFIND_DESTDIR=$(pwd)/build
+    export OCAMLPATH=$OCAMLPATH:$(pwd)/build
+  '';
+
+  buildFlags = [ "release" ];
+
+  doCheck = true;
+  # ./scripts/run-python-tests.sh # TODO: once typeshed and python bits are added
+
+  # Note that we're not installing the typeshed yet.
+  # Improvement for a future version.
+  installPhase = ''
+    install -D ./_build/default/main.exe $out/bin/pyre.bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A performant type-checker for Python 3";
+    homepage = https://pyre-check.org;
+    license = licenses.mit;
+    platforms = ocamlPackages.ocaml.meta.platforms;
+    maintainers = with maintainers; [ teh ];
+  };
+};
+typeshed = stdenv.mkDerivation {
+  pname = "typeshed";
+  version = pyre-version;
+  src = fetchFromGitHub {
+    owner = "python";
+    repo = "typeshed";
+    rev = "0b49ce75b478fdf283dda5dd1368759ac342dfe2";
+    sha256 = "1w5aqbbcfk5ki8n9fgdikkyadjb318ipqyi517s9xnwlzi1jv0fh";
+  };
+  phases = [ "unpackPhase" "installPhase" ];
+  installPhase = "cp -r $src $out";
+};
+in python3.pkgs.buildPythonApplication {
+  pname = "pyre-check";
+  version = pyre-version;
+  src = pyre-src;
+  patches = [ ./pyre-bdist-wheel.patch ];
+
+  # The build-pypi-package script does some funky stuff with build
+  # directories - easier to patch it a bit than to replace it
+  # completely though:
+  postPatch = ''
+    mkdir ./build
+    substituteInPlace scripts/build-pypi-package.sh \
+        --replace 'NIX_BINARY_FILE' '${pyre-bin}/bin/pyre.bin' \
+        --replace 'BUILD_ROOT="$(mktemp -d)"' "BUILD_ROOT=$PWD/build"
+    for file in client/pyre.py client/commands/initialize.py client/commands/tests/initialize_test.py; do
+      substituteInPlace "$file" \
+          --replace '"watchman"' '"${watchman}/bin/watchman"'
+    done
+    substituteInPlace client/buck.py \
+        --replace '"buck"' '"${buck}/bin/buck"'
+    substituteInPlace client/tests/buck_test.py \
+        --replace '"buck"' '"${buck}/bin/buck"'
+  '';
+
+  buildInputs = [ pyre-bin ];
+  nativeBuildInputs = [ rsync ]; # only required for build-pypi-package.sh
+  propagatedBuildInputs = with python3.pkgs; [
+    docutils
+    typeshed
+    click-log
+    ipython
+    sqlalchemy
+    munch
+    xxhash
+    ujson
+  ];
+  buildPhase = ''
+    bash scripts/build-pypi-package.sh --version ${pyre-version} --bundle-typeshed ${typeshed}
+    cp -r build/dist dist
+  '';
+  checkPhase = ''
+    bash scripts/run-python-tests.sh
+  '';
+}

--- a/pkgs/development/tools/pyre/pyre-bdist-wheel.patch
+++ b/pkgs/development/tools/pyre/pyre-bdist-wheel.patch
@@ -1,0 +1,43 @@
+diff --git a/scripts/build-pypi-package.sh b/scripts/build-pypi-package.sh
+index 1035591..bb8cbae 100755
+--- a/scripts/build-pypi-package.sh
++++ b/scripts/build-pypi-package.sh
+@@ -98,7 +98,7 @@ rsync -avm --filter='- tests/' --filter='+ */' --filter='-! *.py' "${SCRIPTS_DIR
+ sed -i -e "/__version__/s/= \".*\"/= \"${PACKAGE_VERSION}\"/" "${BUILD_ROOT}/${MODULE_NAME}/version.py"
+ 
+ # Copy binary files.
+-BINARY_FILE="${SCRIPTS_DIRECTORY}/../_build/default/main.exe"
++BINARY_FILE="NIX_BINARY_FILE"
+ if [[ ! -f "${BINARY_FILE}" ]]; then
+   echo "The binary file ${BINARY_FILE} does not exist."
+   echo "Have you run 'make' in the toplevel directory?"
+@@ -146,7 +146,7 @@ def find_typeshed_files(base):
+         result.append((target, files))
+     return result
+ 
+-with open('README.md') as f:
++with open('README.md', encoding='utf8') as f:
+     long_description = f.read()
+ 
+ setup(
+@@ -205,20 +205,3 @@ fi
+ 
+ # Build.
+ python3 setup.py bdist_wheel
+-
+-# Move artifact outside the build directory.
+-mkdir -p "${SCRIPTS_DIRECTORY}/dist"
+-files_count="$(find "${BUILD_ROOT}/dist/" -type f | wc -l | tr -d ' ')"
+-[[ "${files_count}" == '1' ]] || \
+-  die "${files_count} files created in ${BUILD_ROOT}/dist, but only one was expected"
+-source_file="$(find "${BUILD_ROOT}/dist/" -type f)"
+-destination="$(basename "${source_file}")"
+-destination="${destination/%-any.whl/-${WHEEL_DISTRIBUTION_PLATFORM}.whl}"
+-mv "${source_file}" "${SCRIPTS_DIRECTORY}/dist/${destination}"
+-
+-# Cleanup.
+-cd "${SCRIPTS_DIRECTORY}"
+-rm -rf "${BUILD_ROOT}"
+-
+-printf '\nAll done. Build artifact available at:\n  %s\n' "${SCRIPTS_DIRECTORY}/dist/${destination}"
+-exit 0

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10462,6 +10462,8 @@ in
     ocamlPackages = ocaml-ng.ocamlPackages_4_07;
   };
 
+  pyre = callPackage ../development/tools/pyre { };
+
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
 
   glslang = callPackage ../development/compilers/glslang { };


### PR DESCRIPTION
###### Motivation for this change
This reverts commit fa4b5185b3967c4a8f8806722e886bf3922c0f03. Pyre was under constant heavy changes which put a lot of burden on maintainers (#70001). Hopefully we can get things working again on the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
