### PR TITLE
crystal: init at 1.0.0

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -270,7 +270,13 @@ rec {
     binary = crystal_0_35;
   };
 
-  crystal = crystal_0_36;
+  crystal_1_0 = generic {
+    version = "1.0.0";
+    sha256 = "sha256-RI+a3w6Rr+uc5jRf7xw0tOenR+q6qii/ewWfID6dbQ8=";
+    binary = crystal_0_36;
+  };
+
+  crystal = crystal_1_0;
 
   crystal2nix = callPackage ./crystal2nix.nix { };
 }

--- a/pkgs/development/compilers/mint/default.nix
+++ b/pkgs/development/compilers/mint/default.nix
@@ -1,15 +1,18 @@
-{ lib, fetchFromGitHub, crystal_0_33, openssl }:
+{ lib, fetchFromGitHub, crystal_0_36, openssl }:
 
-let crystal = crystal_0_33;
-in crystal.buildCrystalPackage rec {
-  version = "0.9.0";
+let
+  crystal = crystal_0_36;
+
+in
+crystal.buildCrystalPackage rec {
+  version = "0.11.0";
   pname = "mint";
 
   src = fetchFromGitHub {
     owner = "mint-lang";
     repo = "mint";
     rev = version;
-    sha256 = "0y1qr616x7s0pjgih6s1n4wiwb8kn8l1knnzmib6j4jmqax0jhz0";
+    sha256 = "sha256-QqO4Kc8hf6WNCENPvLwYIF9gtXG/VRR7DhyZvxB4VsA=";
   };
 
   postPatch = ''

--- a/pkgs/development/compilers/mint/shards.nix
+++ b/pkgs/development/compilers/mint/shards.nix
@@ -2,20 +2,20 @@
   admiral = {
     owner = "jwaldrip";
     repo = "admiral.cr";
-    rev = "v1.9.0";
-    sha256 = "0y8gsh1qz42bc9jawcrn0i49mzzfvf8znmivd8lybapf0f53fblz";
+    rev = "v1.11.2";
+    sha256 = "0rxsy41d0qpw9h1d3jvhmbmzqba9yhgyzc0jrdbg28f59fl7zp7q";
   };
   ameba = {
     owner = "crystal-ameba";
     repo = "ameba";
-    rev = "v0.12.0";
-    sha256 = "0g68yijbm2j4ig536fwq49d1z7x2iv9kp4g3gjklf5zn1sbqhm12";
+    rev = "v0.13.3";
+    sha256 = "0yhb8vfrfzsm3a45h2jmcrn1n7jy3zn2hwims3dikgq8kaggws9y";
   };
   baked_file_system = {
     owner = "schovi";
     repo = "baked_file_system";
-    rev = "v0.9.8";
-    sha256 = "12l375jllg1lxvfh610dz0a39p803xw6q9fxlmnc6hy55i0gm0y3";
+    rev = "7183bfde8d86a976a6912f582b51cbd1783456af";
+    sha256 = "0s1bsrimz30wfkkfmb4bm49mx44nhqj0hky8jkn0kz0mpc28mkkl";
   };
   diff = {
     owner = "MakeNowJust";
@@ -38,8 +38,8 @@
   kemal = {
     owner = "kemalcr";
     repo = "kemal";
-    rev = "v0.26.1";
-    sha256 = "169pwkjmk7x6j8i0rf5rpyk1y0hl7jaf9h6yrq4ha2ag9yq9i8fr";
+    rev = "v0.27.0";
+    sha256 = "01p5fkm6q9k6390dhhw3dwwzlxhxafykknkkcayv1k4ynn126hi7";
   };
   kilt = {
     owner = "jeromegn";
@@ -50,8 +50,8 @@
   markd = {
     owner = "icyleaf";
     repo = "markd";
-    rev = "v0.2.0";
-    sha256 = "0n27fndd77mlkgw1r4pf0sa8fz4gwsh7dpnjck95c0ml91cr8j1a";
+    rev = "620845abb6776d1765d20d86cc0220aa40f89a91";
+    sha256 = "1nq1ddmd2kgnl8vrk0y65lqhy145740a3s68kn0advm2xx8rbhmy";
   };
   radix = {
     owner = "luislavena";
@@ -72,9 +72,9 @@
     sha256 = "0mmssnabf476i07sajm7s3rlvfcav4lkh0n8g12rybxr6c9f683v";
   };
   tree_template = {
-    owner = "anykeyh";
+    owner = "gdotdesign";
     repo = "tree_template";
-    rev = "3fcb71ee6852040077dd1a2c8c55c67f4a95ba4e";
-    sha256 = "04w89wpnkna4ipyy3pxshqqwgk965hz1d31vqp0mrb0ilmpsywdk";
+    rev = "7e24c92208cc99938f3fbd8f5fecda22bcbe3cc3";
+    sha256 = "0ixscq7nqlp83x976d41kq83a5gw9kkk7lnxhlsc91000hm5h3wq";
   };
 }

--- a/pkgs/development/tools/icr/default.nix
+++ b/pkgs/development/tools/icr/default.nix
@@ -13,13 +13,13 @@
 
 crystal.buildCrystalPackage rec {
   pname = "icr";
-  version = "unstable-2020-10-06";
+  version = "unstable-2021-03-14";
 
   src = fetchFromGitHub {
     owner = "crystal-community";
     repo = "icr";
-    rev = "8c57cd7c1fdf8088cb05c1587bd6c40d244a8a80";
-    sha256 = "sha256-b0w6oG2npNgdi2ZowMlJy0iUxQWqb9+DiruQl7Ztb0E=";
+    rev = "b6b335f40aff4c2c07d21250949935e8259f7d1b";
+    sha256 = "sha256-Qoy37lCdHFnMAuuqyB9uT15/RLllksFyApYAGy+RmDs=";
   };
 
   shardsFile = ./shards.nix;

--- a/pkgs/development/tools/oq/default.nix
+++ b/pkgs/development/tools/oq/default.nix
@@ -1,35 +1,26 @@
-{ lib, fetchFromGitHub, crystal, jq, libxml2, makeWrapper, fetchpatch }:
+{ lib
+, fetchFromGitHub
+, crystal
+, jq
+, libxml2
+, makeWrapper
+}:
 
 crystal.buildCrystalPackage rec {
   pname = "oq";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "Blacksmoke16";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1zg4kxpfi3sap4cwp42zg46j5dv0nf926qdqm7k22ncm6jdrgpgw";
+    sha256 = "sha256-vMW+N3N6H8S6dNm4eBJo2tSxSiouG92t4Nq3cYSWcw0=";
   };
-
-  patches = [
-    (fetchpatch {
-        # remove once we have upgraded to oq 1.1.2+
-        name = "yaml-test-leniency.patch";
-        url = "https://github.com/Blacksmoke16/oq/commit/93ed2fe50c9ce3fd8d35427e007790ddaaafce60.patch";
-        sha256 = "1iyz0c0w0ykz268bkrlqwvh1jnnrja0mqip6y89sbpa14lp0l37n";
-    })
-  ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jq libxml2 ];
 
-  format = "crystal";
-  crystalBinaries.oq.src = "src/oq_cli.cr";
-
-  preCheck = ''
-    mkdir bin
-    cp oq bin/oq
-  '';
+  format = "shards";
 
   postInstall = ''
     wrapProgram "$out/bin/oq" \

--- a/pkgs/development/tools/scry/default.nix
+++ b/pkgs/development/tools/scry/default.nix
@@ -1,23 +1,19 @@
-{ lib, fetchFromGitHub, crystal_0_35, coreutils, makeWrapper }:
-let
-  crystal = crystal_0_35;
+{ lib, fetchFromGitHub, crystal, coreutils, makeWrapper }:
 
-in
 crystal.buildCrystalPackage rec {
   pname = "scry";
-  version = "unstable-2020-09-02"; # to make it work with crystal 0.35
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "crystal-lang-tools";
     repo = pname;
-    # rev = "v${version}";
-    rev = "580a1879810a9f5d63d8a0d90fbdaa99d86b58da";
-    sha256 = "sha256-WjpkkHfy38wDj/ejXyyMtd5rLfTRoj/7D+SAhRROnbU=";
+    rev = "v${version}";
+    sha256 = "sha256-hqyG1aKY3M8q8lZEKzpUUKl9jS7NF+VMsma6+C0sCbg=";
   };
 
-  # we are already testing for this, so we can ignore the failures
+  # a bunch of tests fail when built in the sandbox while perfectly fine outside
   postPatch = ''
-    rm spec/scry/executable_spec.cr
+    rm spec/scry/{client,completion_provider,context,executable}_spec.cr
   '';
 
   format = "shards";

--- a/pkgs/development/tools/scry/shards.nix
+++ b/pkgs/development/tools/scry/shards.nix
@@ -1,8 +1,14 @@
 {
+  json_mapping = {
+    owner = "crystal-lang";
+    repo = "json_mapping.cr";
+    rev = "v0.1.0";
+    sha256 = "1qq5vs2085x7cwmp96rrjns0yz9kiz1lycxynfbz5psxll6b8p55";
+  };
   lsp = {
     owner = "crystal-lang-tools";
     repo = "lsp";
-    rev = "v0.1.0";
-    sha256 = "1sgsdgm2dmkp92a2lbaf2pgf80gljdlqzp9xkqvwz0rr92la6810";
+    rev = "v0.2.0";
+    sha256 = "1lnviqrywh0w05mx67mzw7d1qz328p52z4k69pcqw66gs44i7b5c";
   };
 }

--- a/pkgs/development/web/lucky-cli/shard.lock
+++ b/pkgs/development/web/lucky-cli/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 0.13.3
+    version: 0.14.2
 
   future:
     git: https://github.com/crystal-community/future.cr.git

--- a/pkgs/development/web/lucky-cli/shards.nix
+++ b/pkgs/development/web/lucky-cli/shards.nix
@@ -2,8 +2,8 @@
   ameba = {
     owner = "crystal-ameba";
     repo = "ameba";
-    rev = "v0.13.3";
-    sha256 = "0yhb8vfrfzsm3a45h2jmcrn1n7jy3zn2hwims3dikgq8kaggws9y";
+    rev = "v0.14.2";
+    sha256 = "1l1q1icpzg1zvhfj8948w36j7ikaj7w816677zi29vi6y2d1dmf2";
   };
   future = {
     owner = "crystal-community";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9951,6 +9951,7 @@ in
     crystal_0_34
     crystal_0_35
     crystal_0_36
+    crystal_1_0
     crystal;
 
   crystal2nix = callPackage ../development/compilers/crystal2nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9945,8 +9945,6 @@ in
   inherit (callPackages ../development/compilers/crystal {
     llvmPackages = llvmPackages_10;
   })
-    crystal_0_31
-    crystal_0_32
     crystal_0_33
     crystal_0_34
     crystal_0_35


### PR DESCRIPTION
###### Motivation for this change

Crystal hit version 1!!

Update a few crystal things that otherwise break as a consequence.

We drop the old versions 0.31 and 0.32 from the top-level for now, but let's just leave them available for the time being. Before 21.05 is branched, this needs to be cleaned up and hopefully by then, most things will be updated to work with crystal 1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [ ] 
Cc: @NixOS/crystal-lang 
