### PR TITLE
frangipanni: init at 0.4.0

### DIFF
--- a/pkgs/tools/text/frangipanni/default.nix
+++ b/pkgs/tools/text/frangipanni/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "frangipanni";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "birchb1024";
+    repo = "frangipanni";
+    rev = "v${version}";
+    sha256 = "sha256-NgRDXrAsfnj1cqO+2AN8nSuxS9KGNIl+pJkCADmDOqY=";
+  };
+
+  vendorSha256 = "sha256-TSN5M/UCTtfoTf1hDCfrJMCFdSwL/NVXssgt4aefom8=";
+
+  meta = with lib; {
+    description = "Convert lines of text into a tree structure";
+    homepage = "https://github.com/birchb1024/frangipanni";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2381,6 +2381,8 @@ in
 
   firestarter = callPackage ../applications/misc/firestarter { };
 
+  frangipanni = callPackage ../tools/text/frangipanni { };
+
   fselect = callPackage ../tools/misc/fselect { };
 
   fsmon = callPackage ../tools/misc/fsmon { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [frangipanni](https://github.com/birchb1024/frangipanni)

```ShellSession
$ find .github | ./result/bin/frangipanni 
github
    labeler.yml
    CODEOWNERS
    workflows
        labels.yml
        editorconfig.yml
        pending
            clear.yml
            set.yml
        rebase.yml
        manual
            nixos.yml
            nixpkgs.yml
        merge-staging.yml
    stale.yml
    PULL_REQUEST_TEMPLATE.md
    STALE-BOT.md
    ISSUE_TEMPLATE
        md
        out_of_date_package_report.md
        bug_report.md
        packaging_request.md
    CONTRIBUTING.md
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
