### PR TITLE
perlPackages.NetCIDRLite: add patch to prevent leading zeroes in ipv4 octets

### DIFF
--- a/pkgs/development/perl-modules/Net-CIDR-Lite-prevent-leading-zeroes-ipv4.patch
+++ b/pkgs/development/perl-modules/Net-CIDR-Lite-prevent-leading-zeroes-ipv4.patch
@@ -1,0 +1,53 @@
+From 734d31aa2f65b69f5558b9b0dd67af0461ca7f80 Mon Sep 17 00:00:00 2001
+From: Stig Palmquist <stig@stig.io>
+Date: Tue, 30 Mar 2021 12:13:37 +0200
+Subject: [PATCH] Security: Prevent leading zeroes in ipv4 octets
+
+https://blog.urth.org/2021/03/29/security-issues-in-perl-ip-address-distros/
+Related to CVE-2021-28918
+---
+ Lite.pm  |  2 +-
+ t/base.t | 13 ++++++++++++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/Lite.pm b/Lite.pm
+index fd6df73..d44f881 100644
+--- a/Lite.pm
++++ b/Lite.pm
+@@ -181,7 +181,7 @@ sub _pack_ipv4 {
+     my @nums = split /\./, shift(), -1;
+     return unless @nums == 4;
+     for (@nums) {
+-        return unless /^\d{1,3}$/ and $_ <= 255;
++        return unless /^\d{1,3}$/ and !/^0\d{1,2}$/ and $_ <= 255;
+     }
+     pack("CC*", 0, @nums);
+ }
+diff --git a/t/base.t b/t/base.t
+index cf32c5e..292456d 100644
+--- a/t/base.t
++++ b/t/base.t
+@@ -8,7 +8,7 @@
+ use Test;
+ use strict;
+ $|++;
+-BEGIN { plan tests => 39 };
++BEGIN { plan tests => 42 };
+ use Net::CIDR::Lite;
+ ok(1); # If we made it this far, we are ok.
+ 
+@@ -133,3 +133,14 @@ ok(join(', ', @list_short_range), '10.0.0.1-2, 10.0.0.5');
+ })->list_short_range;
+ ok(join(', ', @list_short_range), '10.0.0.250-255, 10.0.1.0-20, 10.0.1.22, 10.0.2.250-255, 10.0.3.0-255, 10.0.4.0-255, 10.0.5.0-8');
+ 
++
++# Tests for vulnerability: https://blog.urth.org/2021/03/29/security-issues-in-perl-ip-address-distros/
++eval { Net::CIDR::Lite->new("010.0.0.0/8") };
++ok($@=~/Can't determine ip format/);
++
++my $err_octal = Net::CIDR::Lite->new;
++eval { $err_octal->add("010.0.0.0/8") };
++ok($@=~/Can't determine ip format/);
++
++eval { $err_octal->add("10.01.0.0/8") };
++ok($@=~/Can't determine ip format/);

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15119,6 +15119,11 @@ let
       url = "mirror://cpan/authors/id/D/DO/DOUGW/Net-CIDR-Lite-0.21.tar.gz";
       sha256 = "cfa125e8a2aef9259bc3a44e07cbdfb7894b64d22e7c0cee92aee2f5c7915093";
     };
+    patches = [
+      # Fix for security issue: prevent leading zeroes in ipv4 octets
+      # https://blog.urth.org/2021/03/29/security-issues-in-perl-ip-address-distros/
+      ../development/perl-modules/Net-CIDR-Lite-prevent-leading-zeroes-ipv4.patch
+    ];
     meta = {
       description = "Perl extension for merging IPv4 or IPv6 CIDR addresses";
     };


### PR DESCRIPTION
###### Motivation for this change

https://blog.urth.org/2021/03/29/security-issues-in-perl-ip-address-distros/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
