### PR TITLE
input-fonts: update hash

### DIFF
--- a/pkgs/data/fonts/input-fonts/default.nix
+++ b/pkgs/data/fonts/input-fonts/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "input-fonts";
-  version = "2019-11-25"; # date of the download and checksum
+  version = "2021-03-30"; # date of the download and checksum
 
   src = requireFile {
     name = "Input-Font.zip";
-    url = "https://input.fontbureau.com/download/";
-    sha256 = "10rax2a7vzidcs7kyfg5lv5bwp9i7kvjpdcsd10p0517syijkp3b";
+    url = "https://input.djr.com/download/";
+    sha256 = "0g7b0iwbbfcmmp4pqq9cgw50p3k12kqqaq1fnqlxg30mx9xjj5wn";
   };
 
   nativeBuildInputs = [ unzip ];
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "15sdhqqqd4jgk80fw7ncx49avi9cxbdgyrvnrfya0066x4q4r6lv";
+  outputHash = "jKljb+EaQd6CXzdXa3iJEeMHk7n6pDJ/aDlIOLmnSSk=";
 
   meta = with lib; {
     description = "Fonts for Code, from Font Bureau";
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
       generous spacing, large punctuation, and easily distinguishable
       characters — but without the limitations of a fixed width.
     '';
-    homepage = "https://input.fontbureau.com";
+    homepage = "https://input.djr.com/";
     license = licenses.unfree;
     maintainers = with maintainers; [ romildo ];
     platforms = platforms.all;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
