### PR TITLE
ocamlPackages.mirage-crypto: allow compiling with ocaml-freestanding

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -1,4 +1,7 @@
-{ lib, fetchurl, buildDunePackage, ounit, cstruct, dune-configurator, eqaf, pkg-config }:
+{ lib, fetchurl, buildDunePackage, ounit, cstruct, dune-configurator, eqaf, pkg-config
+, withFreestanding ? false
+, ocaml-freestanding
+}:
 
 buildDunePackage rec {
   minimumOCamlVersion = "4.08";
@@ -11,13 +14,21 @@ buildDunePackage rec {
     sha256 = "8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc";
   };
 
+  patches = [
+    ./makefile-no-opam.patch
+  ];
+
   useDune2 = true;
 
   doCheck = true;
   checkInputs = [ ounit ];
 
   nativeBuildInputs = [ dune-configurator pkg-config ];
-  propagatedBuildInputs = [ cstruct eqaf ];
+  propagatedBuildInputs = [
+    cstruct eqaf
+  ] ++ lib.optionals withFreestanding [
+    ocaml-freestanding
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/mirage/mirage-crypto";

--- a/pkgs/development/ocaml-modules/mirage-crypto/makefile-no-opam.patch
+++ b/pkgs/development/ocaml-modules/mirage-crypto/makefile-no-opam.patch
@@ -1,0 +1,11 @@
+diff --git a/freestanding/Makefile b/freestanding/Makefile
+index 74fcb59..f732082 100644
+--- a/freestanding/Makefile
++++ b/freestanding/Makefile
+@@ -1,4 +1,6 @@
++ifneq (, $(shell command -v opam))
+ PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
++endif
+ 
+ EXISTS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists ocaml-freestanding; echo $$?)
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#23955

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
