### PR TITLE
ocamlPackages.mirage-clock-freestanding: init at 3.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-clock/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-clock/default.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
 
   useDune2 = true;
 
+  minimumOCamlVersion = "4.06";
+
   src = fetchurl {
     url = "https://github.com/mirage/mirage-clock/releases/download/v${version}/mirage-clock-v${version}.tbz";
     sha256 = "0cqa07aqkamw0dvis1fl46brvk81zvb92iy5076ik62gv9n5a0mn";

--- a/pkgs/development/ocaml-modules/mirage-clock/freestanding.nix
+++ b/pkgs/development/ocaml-modules/mirage-clock/freestanding.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildDunePackage
+, mirage-clock
+}:
+
+buildDunePackage {
+  pname = "mirage-clock-freestanding";
+
+  inherit (mirage-clock)
+    version
+    src
+    useDune2
+    minimumOCamlVersion
+    ;
+
+  propagatedBuildInputs = [
+    mirage-clock
+  ];
+
+  meta = mirage-clock.meta // {
+    description = "Paravirtual implementation of the MirageOS Clock interface";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -681,6 +681,8 @@ let
 
     mirage-clock = callPackage ../development/ocaml-modules/mirage-clock { };
 
+    mirage-clock-freestanding = callPackage ../development/ocaml-modules/mirage-clock/freestanding.nix { };
+
     mirage-clock-unix = callPackage ../development/ocaml-modules/mirage-clock/unix.nix { };
 
     mirage-console = callPackage ../development/ocaml-modules/mirage-console { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#23955

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
