### PR TITLE
ocamlPackages: init a bunch of libraries for the MirageOS xen target

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-bootvar-xen/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-bootvar-xen/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, mirage-xen
+, parse-argv
+, lwt
+}:
+
+buildDunePackage rec {
+  pname = "mirage-bootvar-xen";
+  version = "0.8.0";
+
+  minimumOCamlVersion = "4.08";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-bootvar-xen/releases/download/v${version}/mirage-bootvar-xen-v${version}.tbz";
+    sha256 = "0nk80giq9ng3svbnm68fjby2f1dnarddm3lk7mw7w59av71q0rcv";
+  };
+
+  propagatedBuildInputs = [
+    mirage-xen
+    lwt
+    parse-argv
+  ];
+
+  meta = with lib; {
+    description = "Handle boot-time arguments for Xen platform";
+    license = licenses.isc;
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://github.com/mirage/mirage-bootvar-xen";
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-net-xen/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-net-xen/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildDunePackage
+, netchannel
+, ppx_sexp_conv
+, lwt
+, cstruct
+, mirage-net
+, mirage-xen
+, io-page
+, lwt-dllist
+, logs
+}:
+
+buildDunePackage {
+  pname = "mirage-net-xen";
+
+  inherit (netchannel)
+    src
+    version
+    useDune2
+    minimumOCamlVersion
+    meta
+    ;
+
+  nativeBuildInputs = [
+    ppx_sexp_conv
+  ];
+
+  propagatedBuildInputs = [
+    lwt
+    cstruct
+    netchannel
+    mirage-net
+    mirage-xen
+    io-page
+    lwt-dllist
+    logs
+  ];
+}

--- a/pkgs/development/ocaml-modules/mirage-xen/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-xen/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, pkg-config
+, cstruct
+, lwt
+, shared-memory-ring-lwt
+, xenstore
+, lwt-dllist
+, mirage-profile
+, mirage-runtime
+, logs
+, fmt
+, ocaml-freestanding
+, bheap
+, duration
+, io-page
+}:
+
+buildDunePackage rec {
+  pname = "mirage-xen";
+  version = "6.0.0";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-xen/releases/download/v${version}/mirage-xen-v${version}.tbz";
+    sha256 = "f991e972059b27993c287ad010d9281fee061efaa1dd475d0955179f93710fbd";
+  };
+
+  patches = [
+    ./makefile-no-opam.patch
+    ./pkg-config.patch
+  ];
+
+  # can't handle OCAMLFIND_DESTDIR with substituteAll
+  postPatch = ''
+    substituteInPlace lib/bindings/mirage-xen.pc \
+      --replace "@out@" "$out" \
+      --replace "@OCAMLFIND_DESTDIR@" "$OCAMLFIND_DESTDIR"
+  '';
+
+  minimumOCamlVersion = "4.08";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [
+    cstruct
+    lwt
+    shared-memory-ring-lwt
+    xenstore
+    lwt-dllist
+    mirage-profile
+    mirage-runtime
+    io-page
+    logs
+    fmt
+    bheap
+    duration
+    (ocaml-freestanding.override { target = "xen"; })
+  ];
+
+  # Move pkg-config files into their well-known location.
+  # This saves us an extra setup hook and causes no issues
+  # since we patch all relative paths out of the .pc file.
+  postInstall = ''
+    mv $OCAMLFIND_DESTDIR/pkgconfig $out/lib/pkgconfig
+  '';
+
+  meta = with lib; {
+    description = "Xen core platform libraries for MirageOS";
+    license = licenses.isc;
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://github.com/mirage/mirage-xen";
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-xen/makefile-no-opam.patch
+++ b/pkgs/development/ocaml-modules/mirage-xen/makefile-no-opam.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/bindings/Makefile b/lib/bindings/Makefile
+index 4e413c0..67c7bdc 100644
+--- a/lib/bindings/Makefile
++++ b/lib/bindings/Makefile
+@@ -1,4 +1,6 @@
+-PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
++ifneq (, $(shell command -v opam))
++	PKG_CONFIG_PATH ?= $(shell opam config var prefix)/lib/pkgconfig
++endif
+ 
+ CC ?= cc
+ FREESTANDING_CFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags ocaml-freestanding)

--- a/pkgs/development/ocaml-modules/mirage-xen/pkg-config.patch
+++ b/pkgs/development/ocaml-modules/mirage-xen/pkg-config.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/bindings/mirage-xen.pc b/lib/bindings/mirage-xen.pc
+index a03a217..8499aa4 100644
+--- a/lib/bindings/mirage-xen.pc
++++ b/lib/bindings/mirage-xen.pc
+@@ -1,6 +1,6 @@
+-prefix=${pcfiledir}/../..
++prefix=@out@
+ exec_prefix=${prefix}
+-libdir=${exec_prefix}/lib
++libdir=@OCAMLFIND_DESTDIR@
+ 
+ Name: mirage-xen
+ Version: 6.0.0

--- a/pkgs/development/ocaml-modules/netchannel/default.nix
+++ b/pkgs/development/ocaml-modules/netchannel/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, ppx_sexp_conv
+, ppx_cstruct
+, lwt
+, mirage-net
+, io-page
+, mirage-xen
+, ipaddr
+, mirage-profile
+, shared-memory-ring
+, sexplib
+, logs
+, rresult
+}:
+
+buildDunePackage rec {
+  pname = "netchannel";
+  version = "2.0.0";
+
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-net-xen/releases/download/v${version}/mirage-net-xen-v${version}.tbz";
+    sha256 = "ec3906ef1804ef6a9e36b91f4ae73ce4849e9e0d1d36a80fe66b5f905fab93ad";
+  };
+
+  nativeBuildInputs = [
+    ppx_cstruct
+  ];
+
+  propagatedBuildInputs = [
+    ppx_sexp_conv
+    lwt
+    mirage-net
+    io-page
+    mirage-xen
+    ipaddr
+    mirage-profile
+    shared-memory-ring
+    sexplib
+    logs
+    rresult
+  ];
+
+  meta = with lib; {
+    description = "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol";
+    license = licenses.isc;
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://github.com/mirage/mirage-net-xen";
+  };
+}

--- a/pkgs/development/ocaml-modules/shared-memory-ring/default.nix
+++ b/pkgs/development/ocaml-modules/shared-memory-ring/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, ppx_cstruct
+, mirage-profile
+, cstruct
+, ounit
+}:
+
+buildDunePackage rec {
+  pname = "shared-memory-ring";
+  version = "3.1.0";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/shared-memory-ring/releases/download/v${version}/shared-memory-ring-v${version}.tbz";
+    sha256 = "06350ph3rdfvybi0cgs3h3rdkmjspk3c4375rxvbdg0kza1w22x1";
+  };
+
+  nativeBuildInputs = [
+    ppx_cstruct
+  ];
+
+  propagatedBuildInputs = [
+    mirage-profile
+    cstruct
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    ounit
+  ];
+
+  meta = with lib; {
+    description = "Shared memory rings for RPC and bytestream communications";
+    license = licenses.isc;
+    homepage = "https://github.com/mirage/shared-memory-ring";
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/shared-memory-ring/lwt.nix
+++ b/pkgs/development/ocaml-modules/shared-memory-ring/lwt.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildDunePackage
+, shared-memory-ring
+, ppx_cstruct
+, cstruct
+, lwt
+, lwt-dllist
+, mirage-profile
+, ounit
+}:
+
+buildDunePackage {
+  pname = "shared-memory-ring-lwt";
+
+  inherit (shared-memory-ring) version src useDune2;
+
+  buildInputs = [
+    ppx_cstruct
+  ];
+
+  propagatedBuildInputs = [
+    shared-memory-ring
+    cstruct
+    lwt
+    lwt-dllist
+    mirage-profile
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    ounit
+  ];
+
+  meta = shared-memory-ring.meta // {
+    description = "Shared memory rings for RPC and bytestream communications using Lwt";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -675,6 +675,8 @@ let
 
     mirage-bootvar-unix = callPackage ../development/ocaml-modules/mirage-bootvar-unix { };
 
+    mirage-bootvar-xen = callPackage ../development/ocaml-modules/mirage-bootvar-xen { };
+
     mirage-channel = callPackage ../development/ocaml-modules/mirage-channel { };
 
     mirage-clock = callPackage ../development/ocaml-modules/mirage-clock { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -717,6 +717,8 @@ let
 
     mirage-net = callPackage ../development/ocaml-modules/mirage-net { };
 
+    mirage-net-xen = callPackage ../development/ocaml-modules/mirage-net-xen { };
+
     mirage-profile = callPackage ../development/ocaml-modules/mirage-profile { };
 
     mirage-protocols = callPackage ../development/ocaml-modules/mirage-protocols { };
@@ -754,6 +756,8 @@ let
     mtime =  callPackage ../development/ocaml-modules/mtime { };
 
     mustache =  callPackage ../development/ocaml-modules/mustache { };
+
+    netchannel = callPackage ../development/ocaml-modules/netchannel { };
 
     nocrypto =  callPackage ../development/ocaml-modules/nocrypto { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1138,6 +1138,10 @@ let
 
     sha = callPackage ../development/ocaml-modules/sha { };
 
+    shared-memory-ring = callPackage ../development/ocaml-modules/shared-memory-ring { };
+
+    shared-memory-ring-lwt = callPackage ../development/ocaml-modules/shared-memory-ring/lwt.nix { };
+
     sodium = callPackage ../development/ocaml-modules/sodium { };
 
     spelll = callPackage ../development/ocaml-modules/spelll { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -739,6 +739,8 @@ let
 
     mirage-unix = callPackage ../development/ocaml-modules/mirage-unix { };
 
+    mirage-xen = callPackage ../development/ocaml-modules/mirage-xen { };
+
     mirage-vnetif = callPackage ../development/ocaml-modules/mirage-vnetif { };
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#23955

cc @Ericson2314 as well, I'd love to hear your thoughts on the `pkg-config` specific changes to the `findlib` setup hook.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
