### PR TITLE
update coqPackages.equations

### DIFF
--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -6,6 +6,7 @@ with lib; mkCoqDerivation {
   repo = "Coq-Equations";
   inherit version;
   defaultVersion = switch coq.coq-version [
+    { case = "8.13"; out = "1.2.4+coq8.13"; }
     { case = "8.12"; out = "1.2.3+coq8.12"; }
     { case = "8.11"; out = "1.2.3+coq8.11"; }
     { case = "8.10"; out = "1.2.1+coq8.10-2"; }
@@ -36,6 +37,8 @@ with lib; mkCoqDerivation {
     release."1.2.3+coq8.12".version   = "1.2.3";
     release."1.2.3+coq8.12".rev       = "v1.2.3-8.12";
     release."1.2.3+coq8.12".sha256    = "1y0jkvzyz5ssv5vby41p1i8zs7nsdc8g3pzyq73ih9jz8h252643";
+    release."1.2.4+coq8.13".rev       = "v1.2.4-8.13";
+    release."1.2.4+coq8.13".sha256    = "0j3syp3fzb9n8xg3jadgryzcaaf6vi1n320fv7naadyzb2hn42al";
 
   mlPlugin = true;
   preBuild = "coq_makefile -f _CoqProject -o Makefile";

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -38,7 +38,7 @@ with lib; mkCoqDerivation {
     release."1.2.3+coq8.12".rev       = "v1.2.3-8.12";
     release."1.2.3+coq8.12".sha256    = "1y0jkvzyz5ssv5vby41p1i8zs7nsdc8g3pzyq73ih9jz8h252643";
     release."1.2.4+coq8.13".rev       = "v1.2.4-8.13";
-    release."1.2.4+coq8.13".sha256    = "0j3syp3fzb9n8xg3jadgryzcaaf6vi1n320fv7naadyzb2hn42al";
+    release."1.2.4+coq8.13".sha256    = "0i014lshsdflzw6h0qxra9d2f0q82vffxv2f29awbb9ad0p4rq4q";
 
   mlPlugin = true;
   preBuild = "coq_makefile -f _CoqProject -o Makefile";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This library can be used with the new version of Coq that was released a couple of weeks ago.  I just added the new version numbers and checksums.

###### Things done

I have made sure it compiles and can be loaded into Coq with

```
NIX_PATH=~/HACK nix-shell --packages coqPackages_8_13.{coq,equations)
coqtop
From Equations Require Import Equations.
```

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
