### PR TITLE
LLVM: Move aliases to aliases.nix and switch to llvmPackages_latest

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/base.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/base.nix
@@ -1,7 +1,7 @@
 { pname, version, src, binaryName, desktopName
 , autoPatchelfHook, fetchurl, makeDesktopItem, lib, stdenv, wrapGAppsHook
 , alsaLib, at-spi2-atk, at-spi2-core, atk, cairo, cups, dbus, expat, fontconfig
-, freetype, gdk-pixbuf, glib, gtk3, libcxx, libdrm, libnotify, libpulseaudio, libuuid
+, freetype, gdk-pixbuf, glib, gtk3, llvmPackages, libdrm, libnotify, libpulseaudio, libuuid
 , libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
 , libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb
 , mesa, nspr, nss, pango, systemd, libappindicator-gtk3, libdbusmenu
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
   dontWrapGApps = true;
 
   libPath = lib.makeLibraryPath [
-    libcxx systemd libpulseaudio
+    llvmPackages.libcxx systemd libpulseaudio
     stdenv.cc.cc alsaLib atk at-spi2-atk at-spi2-core cairo cups dbus expat fontconfig freetype
     gdk-pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
     libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -2,7 +2,7 @@
 , file, atk, alsaLib, cairo, fontconfig, gdk-pixbuf, glib, gnome3, gtk2-x11, gtk3
 , heimdal, krb5, libsoup, libvorbis, speex, openssl, zlib, xorg, pango, gtk2
 , gnome2, nss, nspr, gtk_engines, freetype, dconf, libpng12, libxml2
-, libjpeg, libredirect, tzdata, cacert, systemd, libcxxabi, libcxx, e2fsprogs, symlinkJoin
+, libjpeg, libredirect, tzdata, cacert, systemd, llvmPackages, e2fsprogs, symlinkJoin
 , libpulseaudio, pcsclite
 
 , homepage, version, prefix, hash
@@ -77,8 +77,8 @@ stdenv.mkDerivation rec {
     gtk_engines
     heimdal
     krb5
-    libcxx
-    libcxxabi
+    llvmPackages.libcxx
+    llvmPackages.libcxxabi
     libjpeg
     libpng12
     libsoup

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -988,5 +988,11 @@ mapAliases ({
   inherit (libsForQt5)
     sddm
   ;
+  inherit (llvmPackages_latest)
+    lld
+    lldb
+    libcxx
+    libcxxabi
+  ;
 
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1362,7 +1362,9 @@ in
 
   gitless = callPackage ../applications/version-management/gitless { python = python3; };
 
-  gitter = callPackage  ../applications/networking/instant-messengers/gitter { };
+  gitter = callPackage  ../applications/networking/instant-messengers/gitter {
+    inherit (pkgs.llvmPackages) libcxx;
+  };
 
   gjs = callPackage ../development/libraries/gjs { };
 
@@ -2536,7 +2538,9 @@ in
 
   grim = callPackage ../tools/graphics/grim { };
 
-  gringo = callPackage ../tools/misc/gringo { };
+  gringo = callPackage ../tools/misc/gringo {
+    inherit (pkgs.llvmPackages) libcxx;
+  };
 
   grobi = callPackage ../tools/X11/grobi { };
 
@@ -9260,7 +9264,9 @@ in
 
   uptimed = callPackage ../tools/system/uptimed { };
 
-  upwork = callPackage ../applications/misc/upwork { };
+  upwork = callPackage ../applications/misc/upwork {
+    inherit (llvmPackages) libcxx;
+  };
 
   urjtag = callPackage ../tools/misc/urjtag { };
 
@@ -9887,10 +9893,11 @@ in
 
   chez-matchable = callPackage ../development/chez-modules/chez-matchable { };
 
+  # TODO: Move to pkgs/top-level/aliases.nix and switch to llvmPackages_latest:
   clang = llvmPackages.clang;
   clang-manpages = llvmPackages.clang-manpages;
 
-  clang-sierraHack = clang.override {
+  clang-sierraHack = llvmPackages.clang.override {
     name = "clang-wrapper-with-reexport-hack";
     bintools = darwin.binutils.override {
       useMacosReexportHack = true;
@@ -10767,7 +10774,6 @@ in
       Cocoa AudioToolbox OpenGL Foundation ForceFeedback;
   };
 
-  lld = llvmPackages.lld;
   lld_5 = llvmPackages_5.lld;
   lld_6 = llvmPackages_6.lld;
   lld_7 = llvmPackages_7.lld;
@@ -10776,7 +10782,6 @@ in
   lld_10 = llvmPackages_10.lld;
   lld_11 = llvmPackages_11.lld;
 
-  lldb = llvmPackages_latest.lldb;
   lldb_5 = llvmPackages_5.lldb;
   lldb_6 = llvmPackages_6.lldb;
   lldb_7 = llvmPackages_7.lldb;
@@ -10785,6 +10790,7 @@ in
   lldb_10 = llvmPackages_10.lldb;
   lldb_11 = llvmPackages_11.lldb;
 
+  # TODO: Move to pkgs/top-level/aliases.nix and switch to llvmPackages_latest:
   llvm = llvmPackages.llvm;
   llvm-manpages = llvmPackages.llvm-manpages;
 
@@ -11815,7 +11821,9 @@ in
   dust = callPackage ../development/interpreters/pixie/dust.nix { };
 
   buildRubyGem = callPackage ../development/ruby-modules/gem { };
-  defaultGemConfig = callPackage ../development/ruby-modules/gem-config { };
+  defaultGemConfig = callPackage ../development/ruby-modules/gem-config {
+    inherit (llvmPackages) libcxx;
+  };
   bundix = callPackage ../development/ruby-modules/bundix { };
   bundler = callPackage ../development/ruby-modules/bundler { };
   bundlerEnv = callPackage ../development/ruby-modules/bundler-env { };
@@ -12124,6 +12132,7 @@ in
     runJdk = jdk11_headless;
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
     bazel_self = bazel_3;
+    inherit (llvmPackages) libcxx;
   };
 
   bazel_4 = callPackage ../development/tools/build-managers/bazel/bazel_4 {
@@ -12134,6 +12143,7 @@ in
     runJdk = jdk11_headless;
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
     bazel_self = bazel_4;
+    inherit (llvmPackages) libcxx;
   };
 
   bazel-buildtools = callPackage ../development/tools/build-managers/bazel/buildtools { };
@@ -12392,9 +12402,6 @@ in
   cvise = python3Packages.callPackage ../development/tools/misc/cvise {
     inherit (llvmPackages_11) llvm clang-unwrapped;
   };
-
-  libcxx = llvmPackages.libcxx;
-  libcxxabi = llvmPackages.libcxxabi;
 
   librarian-puppet-go = callPackage ../development/tools/librarian-puppet-go { };
 
@@ -16776,6 +16783,8 @@ in
 
     inherit (pkgs.darwin) libobjc;
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices OpenGL Cocoa AGL;
+
+    inherit (pkgs.llvmPackages) libcxx;
   };
 
   qmake48Hook = makeSetupHook
@@ -17999,6 +18008,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Cocoa Foundation;
     inherit (darwin) libobjc;
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
+    inherit (llvmPackages) libcxx;
   };
 
   rWrapper = callPackage ../development/r-modules/wrapper.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16780,10 +16780,8 @@ in
 
     # XXX: mariadb doesn't built on fbsd as of nov 2015
     libmysqlclient = if (!stdenv.isFreeBSD) then libmysqlclient else null;
-
     inherit (pkgs.darwin) libobjc;
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices OpenGL Cocoa AGL;
-
     inherit (pkgs.llvmPackages) libcxx;
   };
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -51,6 +51,7 @@ in
 
   maloader = callPackage ../os-specific/darwin/maloader {
     inherit (darwin) opencflite;
+    inherit (pkgs.llvmPackages) libcxx;
   };
 
   insert_dylib = callPackage ../os-specific/darwin/insert_dylib { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -309,7 +309,9 @@ let
 
     easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
-    eigen = callPackage ../development/ocaml-modules/eigen { };
+    eigen = callPackage ../development/ocaml-modules/eigen {
+      inherit (pkgs.llvmPackages) libcxx;
+    };
 
     either = callPackage ../development/ocaml-modules/either { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1708,7 +1708,9 @@ in {
 
   datashape = callPackage ../development/python-modules/datashape { };
 
-  datatable = callPackage ../development/python-modules/datatable { };
+  datatable = callPackage ../development/python-modules/datatable {
+    inherit (pkgs.llvmPackages) libcxx;
+  };
 
   dateparser = if isPy27 then
     callPackage ../development/python-modules/dateparser/0.x.nix { }
@@ -3681,7 +3683,9 @@ in {
   kivy-garden = callPackage ../development/python-modules/kivy-garden { };
 
   kiwisolver = if isPy3k then
-    callPackage ../development/python-modules/kiwisolver { }
+    callPackage ../development/python-modules/kiwisolver {
+      inherit (llvmPackages) libcxx;
+    }
   else
     callPackage ../development/python-modules/kiwisolver/1_1.nix { };
 
@@ -4700,7 +4704,9 @@ in {
 
   num2words = callPackage ../development/python-modules/num2words { };
 
-  numba = callPackage ../development/python-modules/numba { };
+  numba = callPackage ../development/python-modules/numba {
+    inherit (pkgs.llvmPackages) libcxx;
+  };
 
   numcodecs = callPackage ../development/python-modules/numcodecs { };
 
@@ -4886,7 +4892,9 @@ in {
   pamqp = callPackage ../development/python-modules/pamqp { };
 
   pandas = if isPy3k then
-    callPackage ../development/python-modules/pandas { }
+    callPackage ../development/python-modules/pandas {
+      inherit (pkgs.llvmPackages) libcxx;
+    }
   else
     callPackage ../development/python-modules/pandas/2.nix { };
 
@@ -5356,6 +5364,7 @@ in {
     # If a protobuf upgrade causes many Python packages to fail, please pin it here to the previous version.
     doCheck = !isPy3k;
     inherit (pkgs) protobuf;
+    inherit (pkgs.llvmPackages) libcxx;
   };
 
   protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };
@@ -5434,7 +5443,9 @@ in {
 
   py3buddy = toPythonModule (callPackage ../development/python-modules/py3buddy { });
 
-  py3exiv2 = callPackage ../development/python-modules/py3exiv2 { };
+  py3exiv2 = callPackage ../development/python-modules/py3exiv2 {
+    inherit (pkgs.llvmPackages) libcxx;
+  };
 
   py3status = callPackage ../development/python-modules/py3status { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/116736#issuecomment-808227014.

Unfortunately `clang` and `llvm` (s. "TODO" in the diff) are used to widely so moving those attributes requires someone who knows how to do mass renames (via `rnix-parser`, etc.).

E.g. this is still very inconsistent (mixing `llvmPackages` and `llvmPackages_latest`):
```nix
  clang = llvmPackages.clang;
  clang-manpages = llvmPackages.clang-manpages;
  clang-tools = callPackage ../development/tools/clang-tools {
    llvmPackages = llvmPackages_latest;
  };
  clang-analyzer = callPackage ../development/tools/analysis/clang-analyzer {
    llvmPackages = llvmPackages_latest;
    inherit (llvmPackages_latest) clang;
  };
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
