### PR TITLE
eval-config.nix: there is no _module in lib.evalModules`s return

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -61,7 +61,7 @@ in rec {
     args = extraArgs;
     specialArgs =
       { modulesPath = builtins.toString ../modules; } // specialArgs;
-  }) config options _module;
+  }) config options;
 
   # These are the extra arguments passed to every module.  In
   # particular, Nixpkgs is passed through the "pkgs" argument.
@@ -69,5 +69,5 @@ in rec {
     inherit baseModules extraModules modules;
   };
 
-  inherit (_module.args) pkgs;
+  inherit (config._module.args) pkgs;
 }


### PR DESCRIPTION
Also `inherit (_module.args) pkgs;` might be removed, it was broken for long time which ensures nobody uses it