### PR TITLE
nginxMainline: 1.19.8 -> 1.19.9

### DIFF
--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.19.8";
-  sha256 = "01cb6hsaik1sfjihbrldmwrcn54gk4plfy350sl1b4rml6qik29h";
+  version = "1.19.9";
+  sha256 = "0hfqqyfgqa6wqazmb3d434nb3r5p8szfisa0m6nfh9lqdbqdyd9f";
 }


### PR DESCRIPTION
###### Motivation for this change
```
Changes with nginx 1.19.9                                        30 Mar 2021

    *) Bugfix: nginx could not be built with the mail proxy module, but
       without the ngx_mail_ssl_module; the bug had appeared in 1.19.8.

    *) Bugfix: "upstream sent response body larger than indicated content
       length" errors might occur when working with gRPC backends; the bug
       had appeared in 1.19.1.

    *) Bugfix: nginx might not close a connection till keepalive timeout
       expiration if the connection was closed by the client while
       discarding the request body.

    *) Bugfix: nginx might not detect that a connection was already closed
       by the client when waiting for auth_delay or limit_req delay, or when
       working with backends.

    *) Bugfix: in the eventport method.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
