### PR TITLE
moodle-dl: init at 2.1.2.5

### DIFF
--- a/pkgs/tools/networking/moodle-dl/default.nix
+++ b/pkgs/tools/networking/moodle-dl/default.nix
@@ -1,0 +1,34 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "moodle-dl";
+  version = "2.1.2.5";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1gc4037dwyi48h4vi0bam23rr7pfyn6jrz334radz0r6rk94y8lz";
+  };
+
+  # nixpkgs (and the GitHub upstream for readchar) are missing 2.0.1
+  postPatch = ''
+    substituteInPlace setup.py --replace 'readchar>=2.0.1' 'readchar>=2.0.0'
+  '';
+
+  propagatedBuildInputs = with python3Packages; [
+    sentry-sdk
+    colorama
+    readchar
+    youtube-dl
+    certifi
+    html2text
+    requests
+    slixmpp
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/C0D3D3V/Moodle-Downloader-2";
+    maintainers = [ maintainers.kmein ];
+    description = "A Moodle downloader that downloads course content fast from Moodle";
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2726,6 +2726,8 @@ in
 
   monsoon = callPackage ../tools/security/monsoon {};
 
+  moodle-dl = callPackage ../tools/networking/moodle-dl { };
+
   mousetweaks = callPackage ../applications/accessibility/mousetweaks {
     inherit (pkgs.xorg) libX11 libXtst libXfixes;
   };


### PR DESCRIPTION
###### Motivation for this change
This package was missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
