### PR TITLE
xfsprogs: 5.10.0 -> 5.11.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -235,7 +235,7 @@
    </listitem>
    <listitem>
      <para>
-       xfsprogs was update from 4.19 to 5.10. It now enables reflink support by default on filesystem creation.
+       xfsprogs was update from 4.19 to 5.11. It now enables reflink support by default on filesystem creation.
        Support for reflinks was added with an experimental status to kernel 4.9 and deemed stable in kernel 4.16.
        If you want to be able to mount XFS filesystems created with this release of xfsprogs on kernel releases older than those, you need to format them
        with <literal>mkfs.xfs -m reflink=0</literal>.

--- a/pkgs/tools/filesystems/xfsprogs/default.nix
+++ b/pkgs/tools/filesystems/xfsprogs/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "xfsprogs";
-  version = "5.10.0";
+  version = "5.11.0";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/fs/xfs/xfsprogs/${pname}-${version}.tar.xz";
-    sha256 = "1schqzjx836jd54l10pqds7hyli2m77df3snk95xbr23dpj1fh70";
+    sha256 = "0lxks616nmdk8zkdbwpq5sf9zz19smgy5rpmp3hpk2mvrl7kk70f";
   };
 
   outputs = [ "bin" "dev" "out" "doc" ];
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://xfs.org/";
     description = "SGI XFS utilities";
-    license = licenses.lgpl21;
+    license = with licenses; [ gpl2Only lgpl21 gpl3Plus ];  # see https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/tree/debian/copyright
     platforms = platforms.linux;
     maintainers = with maintainers; [ dezgeg ajs124 ];
   };


### PR DESCRIPTION
###### Motivation for this change
Upstream release with a bunch of features and fixes. This allows upgrading XFSv5 filesystems to add bigtime etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s): `installer.lvm`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
