### PR TITLE
i3-ratiosplit: init at 0.1.0

### DIFF
--- a/pkgs/applications/window-managers/i3/i3-ratiosplit.nix
+++ b/pkgs/applications/window-managers/i3/i3-ratiosplit.nix
@@ -1,0 +1,26 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "i3-ratiosplit";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "333fred";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0yfmr5zk2c2il9d31yjjbr48sqgcq6hp4a99hl5mjm2ajyhy5bz3";
+  };
+
+  cargoSha256 = "0d5qd1wid5l1pl3ckrlfgdb980myi5gxcir39caywb9pkbnfndz6";
+
+  # Currently no tests are implemented, so we avoid building the package twice
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Resize newly created windows";
+    homepage = "https://github.com/333fred/i3-ratiosplit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ svrana ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23377,6 +23377,8 @@ in
 
   i3-layout-manager = callPackage ../applications/window-managers/i3/layout-manager.nix { };
 
+  i3-ratiosplit =  callPackage ../applications/window-managers/i3/i3-ratiosplit.nix { };
+
   i3-resurrect = python3Packages.callPackage ../applications/window-managers/i3/i3-resurrect.nix { };
 
   i3blocks = callPackage ../applications/window-managers/i3/blocks.nix { };


### PR DESCRIPTION

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
