### PR TITLE
[20.09] python3Packages.pillow: add patches for multiple vulnerabilities

### DIFF
--- a/pkgs/development/python-modules/pillow/7.2.0-CVE-2021-25287-CVE-2021-25288.patch
+++ b/pkgs/development/python-modules/pillow/7.2.0-CVE-2021-25287-CVE-2021-25288.patch
@@ -1,0 +1,90 @@
+Based on upstream 3bf5eddb89afdf690eceaa52bc4d3546ba9a5f87, modified by ris to
+apply without 46b7e86bab79450ec0a2866c6c0c679afb659d17
+
+Requires binary parts of original commit to be supplied separately.
+
+diff --git a/Tests/test_file_jpeg2k.py b/Tests/test_file_jpeg2k.py
+index 13ae09af59..5523d068b2 100644
+--- a/Tests/test_file_jpeg2k.py
++++ b/Tests/test_file_jpeg2k.py
+@@ -231,3 +231,19 @@ def test_parser_feed():
+ 
+     # Assert
+     assert p.image.size == (640, 480)
++
++
++@pytest.mark.parametrize(
++    "test_file",
++    [
++        "Tests/images/crash-4fb027452e6988530aa5dabee76eecacb3b79f8a.j2k",
++        "Tests/images/crash-7d4c83eb92150fb8f1653a697703ae06ae7c4998.j2k",
++        "Tests/images/crash-ccca68ff40171fdae983d924e127a721cab2bd50.j2k",
++        "Tests/images/crash-d2c93af851d3ab9a19e34503626368b2ecde9c03.j2k",
++    ],
++)
++def test_crashes(test_file):
++    with open(test_file, "rb") as f:
++        with Image.open(f) as im:
++            # Valgrind should not complain here
++            im.load()
+diff --git a/src/libImaging/Jpeg2KDecode.c b/src/libImaging/Jpeg2KDecode.c
+index a2a7354dbe..aa4fc58f7a 100644
+--- a/src/libImaging/Jpeg2KDecode.c
++++ b/src/libImaging/Jpeg2KDecode.c
+@@ -644,7 +644,7 @@ j2k_decode_entry(Imaging im, ImagingCodecState state) {
+     j2k_unpacker_t unpack = NULL;
+     size_t buffer_size = 0, tile_bytes = 0;
+     unsigned n, tile_height, tile_width;
+-    int components;
++    int total_component_width = 0;
+ 
+     stream = opj_stream_create(BUFFER_SIZE, OPJ_TRUE);
+ 
+@@ -814,23 +814,40 @@ j2k_decode_entry(Imaging im, ImagingCodecState state) {
+             goto quick_exit;
+         }
+ 
++        if (tile_info.nb_comps != image->numcomps) {
++            state->errcode = IMAGING_CODEC_BROKEN;
++            state->state = J2K_STATE_FAILED;
++            goto quick_exit;
++        }
++
+         /* Sometimes the tile_info.datasize we get back from openjpeg
+-           is less than numcomps*w*h, and we overflow in the
++           is less than sum(comp_bytes)*w*h, and we overflow in the
+            shuffle stage */
+ 
+         tile_width = tile_info.x1 - tile_info.x0;
+         tile_height = tile_info.y1 - tile_info.y0;
+-        components = tile_info.nb_comps == 3 ? 4 : tile_info.nb_comps;
+-        if (( tile_width > UINT_MAX / components ) ||
+-            ( tile_height > UINT_MAX / components ) ||
+-            ( tile_width > UINT_MAX / (tile_height * components )) ||
+-            ( tile_height > UINT_MAX / (tile_width * components ))) {
++
++        /* Total component width = sum (component_width) e.g, it's
++         legal for an la file to have a 1 byte width for l, and 4 for
++         a. and then a malicious file could have a smaller tile_bytes
++        */
++
++        for (n=0; n < tile_info.nb_comps; n++) {
++            // see csize /acsize calcs
++            int csize = (image->comps[n].prec + 7) >> 3;
++            csize = (csize == 3) ? 4 : csize;
++            total_component_width += csize;
++        }
++        if ((tile_width > UINT_MAX / total_component_width) ||
++            (tile_height > UINT_MAX / total_component_width) ||
++            (tile_width > UINT_MAX / (tile_height * total_component_width)) ||
++            (tile_height > UINT_MAX / (tile_width * total_component_width))) {
+             state->errcode = IMAGING_CODEC_BROKEN;
+             state->state = J2K_STATE_FAILED;
+             goto quick_exit;
+         }
+ 
+-        tile_bytes = tile_width * tile_height * components;
++        tile_bytes = tile_width * tile_height * total_component_width;
+ 
+         if (tile_bytes > tile_info.data_size) {
+             tile_info.data_size = tile_bytes;

--- a/pkgs/development/python-modules/pillow/7.2.0-CVE-2021-25289.patch
+++ b/pkgs/development/python-modules/pillow/7.2.0-CVE-2021-25289.patch
@@ -1,0 +1,28 @@
+Based on 3fee28eb9479bf7d59e0fa08068f9cc4a6e2f04c, modified to apply cleanly
+
+diff --git a/Tests/test_tiff_crashes.py b/Tests/test_tiff_crashes.py
+index d0de4b305d..eb25334669 100644
+--- a/Tests/test_tiff_crashes.py
++++ b/Tests/test_tiff_crashes.py
+@@ -24,6 +24,8 @@
+         "Tests/images/crash_1.tif",
+         "Tests/images/crash_2.tif",
+         "Tests/images/crash-2020-10-test.tif",
++        "Tests/images/crash-1152ec2d1a1a71395b6f2ce6721c38924d025bf3.tif",
++        "Tests/images/crash-0e16d3bfb83be87356d026d66919deaefca44dac.tif",
+     ],
+ )
+ @pytest.mark.filterwarnings("ignore:Possibly corrupt EXIF data")
+diff --git a/src/libImaging/TiffDecode.c b/src/libImaging/TiffDecode.c
+index 7f14b5a34c..2f92824c3b 100644
+--- a/src/libImaging/TiffDecode.c
++++ b/src/libImaging/TiffDecode.c
+@@ -239,7 +239,7 @@ _decodeStripYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
+         img.row_offset = state->y; 
+         rows_to_read = min(rows_per_strip, img.height - state->y);
+ 
+-        if (TIFFRGBAImageGet(&img, (UINT32 *)state->buffer, img.width, rows_to_read) == -1) {
++        if (!TIFFRGBAImageGet(&img, (UINT32 *)state->buffer, img.width, rows_to_read)) {
+             TRACE(("Decode Error, y: %d\n", state->y ));
+             state->errcode = IMAGING_CODEC_BROKEN;
+             goto decodeycbcr_err;

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -86,6 +86,7 @@ buildPythonPackage rec {
       url = "https://github.com/python-pillow/Pillow/commit/480f6819b592d7f07b9a9a52a7656c10bbe07442.patch";
       sha256 = "0d7797g0lib3szz5w41b7winpdxcnbf35y4fpyklb49f753wl972";
     })
+    ./7.2.0-CVE-2021-25287-CVE-2021-25288.patch
   ];
 
   # patching mechanism doesn't work with binary files, but the commits contain
@@ -205,6 +206,26 @@ buildPythonPackage rec {
       commit = "480f6819b592d7f07b9a9a52a7656c10bbe07442";
       sha256 = "1y6317hfvmlcnkbf2qy6a7i8zxgydi9s8lagb21fn2a3k1igymha";
       path = "Tests/images/oom-8ed3316a4109213ca96fb8a256a0bfefdece1461.icns";
+    }
+    { # needed by 7.2.0-CVE-2021-25287-CVE-2021-25288.patch
+      commit = "3bf5eddb89afdf690eceaa52bc4d3546ba9a5f87";
+      sha256 = "1rsjr6nsljghs6v0vp671bffpw3sj5b57g23mcd0acj4qsm9rjdy";
+      path = "Tests/images/crash-4fb027452e6988530aa5dabee76eecacb3b79f8a.j2k";
+    }
+    { # needed by 7.2.0-CVE-2021-25287-CVE-2021-25288.patch
+      commit = "3bf5eddb89afdf690eceaa52bc4d3546ba9a5f87";
+      sha256 = "13immd1h2cwcj9vf1g7v1yrhwnbk50dqz447fzjz4m1zsp17627i";
+      path = "Tests/images/crash-7d4c83eb92150fb8f1653a697703ae06ae7c4998.j2k";
+    }
+    { # needed by 7.2.0-CVE-2021-25287-CVE-2021-25288.patch
+      commit = "3bf5eddb89afdf690eceaa52bc4d3546ba9a5f87";
+      sha256 = "0xdnaayjj6n9mzpxpprq6508p0w618l2c6y2jgbs36gmj21smpis";
+      path = "Tests/images/crash-ccca68ff40171fdae983d924e127a721cab2bd50.j2k";
+    }
+    { # needed by 7.2.0-CVE-2021-25287-CVE-2021-25288.patch
+      commit = "3bf5eddb89afdf690eceaa52bc4d3546ba9a5f87";
+      sha256 = "1czlvbdc89bcq48cgf1kay3ncbgag4i1pz555g8cm4dxxirv5j0x";
+      path = "Tests/images/crash-d2c93af851d3ab9a19e34503626368b2ecde9c03.j2k";
     }
   ];
 

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -49,6 +49,43 @@ buildPythonPackage rec {
       url = "https://github.com/python-pillow/Pillow/commit/9a2c9f722f78773e608d44710873437baf3f17d1.patch";
       sha256 = "15dhzd3i8xwx2iaff2qp6z3h0b2yrzcmqi6x7ngld96805gf7v2q";
     })
+    ./7.2.0-CVE-2021-25289.patch
+    (fetchpatch {
+      name = "CVE-2021-25290.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/86f02f7c70862a0954bfe8133736d352db978eaa.patch";
+      sha256 = "0rwwbkqj10p7r2877nx4x3qwrfgrjww8p05wyvvvvfqp1yv63vxh";
+    })
+    (fetchpatch {
+      name = "CVE-2021-25291.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/cbdce6c5d054fccaf4af34b47f212355c64ace7a.patch";
+      sha256 = "1fr3mgb57j8qyfcl3cxrc18y3g4ry6pgl7n6whi7h1wnk40ggar6";
+    })
+    (fetchpatch {
+      name = "CVE-2021-25292.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/3bce145966374dd39ce58a6fc0083f8d1890719c.patch";
+      sha256 = "0bsjw2d9d3z6crawqncvjdvsnk37s05km1b7s6qb035jgzgqlxqx";
+    })
+    (fetchpatch {
+      name = "CVE-2021-25293.prerequisite-1.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/46b7e86bab79450ec0a2866c6c0c679afb659d17.patch";
+      sha256 = "1z0g64pdfzw20zmfwbfkpw327a2la9z8v65dcbqx3yanm08ispy2";
+      includes = ["src/libImaging/SgiRleDecode.c"];
+    })
+    (fetchpatch {
+      name = "CVE-2021-25293.prerequisite-2.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/1cbb12fb6e44da0d6d6d58254d0d96930d04af5e.patch";
+      sha256 = "0nq8ps5g8b4qrhvla5kq38p56cj28fjsyyxap4x0gqk7wcmvkyy9";
+    })
+    (fetchpatch {
+      name = "CVE-2021-25293.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/4853e522bddbec66022c0915b9a56255d0188bf9.patch";
+      sha256 = "1p74ynanbamf88w4wzf1gm2wd7gy6h3y8qdmijz14f1z4dy8yv9g";
+    })
+    (fetchpatch {
+      name = "CVE-2021-27921.CVE-2021-27922.CVE-2021-27923.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/480f6819b592d7f07b9a9a52a7656c10bbe07442.patch";
+      sha256 = "0d7797g0lib3szz5w41b7winpdxcnbf35y4fpyklb49f753wl972";
+    })
   ];
 
   # patching mechanism doesn't work with binary files, but the commits contain
@@ -83,6 +120,91 @@ buildPythonPackage rec {
       commit = "7e95c63fa7f503f185d3d9eb16b9cee1e54d1e46";
       sha256 = "0is0r49pbaxy8mgp5fdlx9hm7zdp64ij38hzgnjj9pzxxdrcw3qk";
       path = "Tests/images/ossfuzz-5730089102868480.sgi";
+    }
+    { # needed by 7.2.0-CVE-2021-25289.patch
+      commit = "3fee28eb9479bf7d59e0fa08068f9cc4a6e2f04c";
+      sha256 = "1lb1442x4yf013h4l37qi4p0zlrqb708d0ng69c76rdnzzfqs8yl";
+      path = "Tests/images/crash-0e16d3bfb83be87356d026d66919deaefca44dac.tif";
+    }
+    { # needed by 7.2.0-CVE-2021-25289.patch
+      commit = "3fee28eb9479bf7d59e0fa08068f9cc4a6e2f04c";
+      sha256 = "1ghxilrr5mash6cbladwrxa9sdqs93z0c3d24ixx0di5qmddhfwv";
+      path = "Tests/images/crash-1152ec2d1a1a71395b6f2ce6721c38924d025bf3.tif";
+    }
+    { # needed by CVE-2021-25290.patch
+      commit = "86f02f7c70862a0954bfe8133736d352db978eaa";
+      sha256 = "1d1zv60l90sik9niwqb07ww6nhvy14yl6p8cj6ksnmgm7qdf58vd";
+      path = "Tests/images/crash-0c7e0e8e11ce787078f00b5b0ca409a167f070e0.tif";
+    }
+    { # needed by CVE-2021-25290.patch
+      commit = "86f02f7c70862a0954bfe8133736d352db978eaa";
+      sha256 = "141yp5bwc0r07samc1vgjdv07kshr6hl9raxs47zhfvab0vpbfd4";
+      path = "Tests/images/crash-1185209cf7655b5aed8ae5e77784dfdd18ab59e9.tif";
+    }
+    { # needed by CVE-2021-25290.patch
+      commit = "86f02f7c70862a0954bfe8133736d352db978eaa";
+      sha256 = "0jnj5phyv3rlbqvlhk2cxkis1l44b45g7jxzf6fgy8xgpdyaxb2m";
+      path = "Tests/images/crash-338516dbd2f0e83caddb8ce256c22db3bd6dc40f.tif";
+    }
+    { # needed by CVE-2021-25290.patch
+      commit = "86f02f7c70862a0954bfe8133736d352db978eaa";
+      sha256 = "18m6x3y8ps5b6lqf94mwja5fpv22bdljpha2fggx2nsnrlkaxh4a";
+      path = "Tests/images/crash-4f085cc12ece8cde18758d42608bed6a2a2cfb1c.tif";
+    }
+    { # needed by CVE-2021-25290.patch
+      commit = "86f02f7c70862a0954bfe8133736d352db978eaa";
+      sha256 = "0fi8aqv3rxjvgkvfmqsg7kd0gb9nv7icwc6ng1ydy55da8gwb6f6";
+      path = "Tests/images/crash-86214e58da443d2b80820cff9677a38a33dcbbca.tif";
+    }
+    { # needed by CVE-2021-25290.patch
+      commit = "86f02f7c70862a0954bfe8133736d352db978eaa";
+      sha256 = "08c5rnqgmkasfqzmf7n1nqdcy5pacsyjpgc3ybysnwnac592kfsj";
+      path = "Tests/images/crash-f46f5b2f43c370fe65706c11449f567ecc345e74.tif";
+    }
+    { # needed by CVE-2021-25291.patch
+      commit = "cbdce6c5d054fccaf4af34b47f212355c64ace7a";
+      sha256 = "0x4apm0cg03kk88815b233c7yh80pvm8n7ryal793jxd9qw20583";
+      path = "Tests/images/crash-63b1dffefc8c075ddc606c0a2f5fdc15ece78863.tif";
+    }
+    { # needed by CVE-2021-25293.patch
+      commit = "4853e522bddbec66022c0915b9a56255d0188bf9";
+      sha256 = "1c7dg1nxcgald6yfy651pw0lbv7l17j90rxjahw8h3vrczbwxicc";
+      path = "Tests/images/crash-465703f71a0f0094873a3e0e82c9f798161171b8.sgi";
+    }
+    { # needed by CVE-2021-25293.patch
+      commit = "4853e522bddbec66022c0915b9a56255d0188bf9";
+      sha256 = "07mdcnq2x7za84ivxxmcxm5532vpk1z78bzq22ks0cv2gkpviflc";
+      path = "Tests/images/crash-64834657ee604b8797bf99eac6a194c124a9a8ba.sgi";
+    }
+    { # needed by CVE-2021-25293.patch
+      commit = "4853e522bddbec66022c0915b9a56255d0188bf9";
+      sha256 = "1ia32p8zmm83gqc3655rrzzqnq4b0zyfnqgfmf07nw7pvnv2nq39";
+      path = "Tests/images/crash-754d9c7ec485ffb76a90eeaab191ef69a2a3a3cd.sgi";
+    }
+    { # needed by CVE-2021-25293.patch
+      commit = "4853e522bddbec66022c0915b9a56255d0188bf9";
+      sha256 = "0m5b48cqss0jmnkw54h9jdxakbw3y6bxqgzmcl9wk77anq8czdff";
+      path = "Tests/images/crash-abcf1c97b8fe42a6c68f1fb0b978530c98d57ced.sgi";
+    }
+    { # needed by CVE-2021-25293.patch
+      commit = "4853e522bddbec66022c0915b9a56255d0188bf9";
+      sha256 = "0k145flxrxay4s5dqvy1avzzs4bdy33c1by9qbgbzcvj7nhpsynm";
+      path = "Tests/images/crash-b82e64d4f3f76d7465b6af535283029eda211259.sgi";
+    }
+    { # needed by CVE-2021-25293.patch
+      commit = "4853e522bddbec66022c0915b9a56255d0188bf9";
+      sha256 = "0ryv73b2mja4chxaszjlxb9r7h4jxmlc7lqvaxz83fhqisp32wll";
+      path = "Tests/images/crash-c1b2595b8b0b92cc5f38b6635e98e3a119ade807.sgi";
+    }
+    { # needed by CVE-2021-25293.patch
+      commit = "4853e522bddbec66022c0915b9a56255d0188bf9";
+      sha256 = "0c8qh3qyqw53wvkkkgpbhxcz72rjw2yxm8wb1s78mys78a7d83ai";
+      path = "Tests/images/crash-db8bfa78b19721225425530c5946217720d7df4e.sgi";
+    }
+    { # needed by CVE-2021-27921.CVE-2021-27922.CVE-2021-27923.patch
+      commit = "480f6819b592d7f07b9a9a52a7656c10bbe07442";
+      sha256 = "1y6317hfvmlcnkbf2qy6a7i8zxgydi9s8lagb21fn2a3k1igymha";
+      path = "Tests/images/oom-8ed3316a4109213ca96fb8a256a0bfefdece1461.icns";
     }
   ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-25289
https://nvd.nist.gov/vuln/detail/CVE-2021-25290
https://nvd.nist.gov/vuln/detail/CVE-2021-25291
https://nvd.nist.gov/vuln/detail/CVE-2021-25292
https://nvd.nist.gov/vuln/detail/CVE-2021-25293
https://nvd.nist.gov/vuln/detail/CVE-2021-27921
https://nvd.nist.gov/vuln/detail/CVE-2021-27922
https://nvd.nist.gov/vuln/detail/CVE-2021-27923

This is verging on the ridiculous. But I invite you to review the patches and apply your own judgement.

All I can say in favour of this:

 - It builds.
 - All existing tests pass.
 - The new included tests covering the addressed issues all pass.
 - Most changes are made to a single, seemingly quite self-contained file format module (none of which have had a lot of other work since 7.2.0)

Against this:

 - Is it all a patch too far? There's only so far I can realistically review this patch series for problems. The biggest risk I can imagine is there being changes to core data structures which these fixes expect. However the core structures don't look to have been touched much between 7.2.0 -> 8.1.2, the main work in this time appearing to be on the various drawing routines and dropping supported python versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
