### PR TITLE
glib: follow profile updates when searching apps

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation rec {
     ./quark_init_on_demand.patch
     ./gobject_init_on_demand.patch
   ] ++ [
+    ./glib-appinfo-watch.patch
     ./schema-override-variable.patch
 
     # GLib contains many binaries used for different purposes;

--- a/pkgs/development/libraries/glib/glib-appinfo-watch.patch
+++ b/pkgs/development/libraries/glib/glib-appinfo-watch.patch
@@ -1,0 +1,102 @@
+This patch lets GLib's GDesktopAppInfo API watch and notice changes
+to the Nix user and system profiles.  That way, the list of available
+applications shown by the desktop environment is immediately updated
+when the user installs or removes any
+(see <https://issues.guix.gnu.org/35594>).
+
+It does so by monitoring /nix/var/nix/profiles (for changes to the system
+profile) and /nix/var/nix/profiles/per-user/USER (for changes to the user
+profile) as well as /etc/profiles/per-user (for chanes to the user
+environment profile) and crawling their share/applications sub-directory when
+changes happen.
+
+diff --git a/gio/gdesktopappinfo.c b/gio/gdesktopappinfo.c
+index b779b30..31069f7 100644
+--- a/gio/gdesktopappinfo.c
++++ b/gio/gdesktopappinfo.c
+@@ -150,6 +150,7 @@ typedef struct
+   gchar                      *alternatively_watching;
+   gboolean                    is_config;
+   gboolean                    is_setup;
++  gchar                      *nix_profile_watch_dir;
+   GFileMonitor               *monitor;
+   GHashTable                 *app_names;
+   GHashTable                 *mime_tweaks;
+@@ -181,6 +182,7 @@ desktop_file_dir_unref (DesktopFileDir *dir)
+     {
+       desktop_file_dir_reset (dir);
+       g_free (dir->path);
++      g_free (dir->nix_profile_watch_dir);
+       g_free (dir);
+     }
+ }
+@@ -205,6 +207,14 @@ desktop_file_dir_get_alternative_dir (DesktopFileDir *dir)
+ {
+   gchar *parent;
+ 
++  /* If DIR is a profile, watch the specified directory--e.g.,
++   * /nix/var/nix/profiles/per-user/$USER/ for the user profile.  Do not watch
++   * ~/.nix-profile or /run/current-system/sw because GFileMonitor does
++   * not pass IN_DONT_FOLLOW and thus cannot notice any change.
++   * /etc/profiles/per-user is monitored directly for the same reason. */
++  if (dir->nix_profile_watch_dir != NULL)
++    return g_strdup (dir->nix_profile_watch_dir);
++
+   /* If the directory itself exists then we need no alternative. */
+   if (g_access (dir->path, R_OK | X_OK) == 0)
+     return NULL;
+@@ -250,11 +260,11 @@ desktop_file_dir_changed (GFileMonitor      *monitor,
+    *
+    * If this is a notification for a parent directory (because the
+    * desktop directory didn't exist) then we shouldn't fire the signal
+-   * unless something actually changed.
++   * unless something actually changed or it's part of a Nix profile.
+    */
+   g_mutex_lock (&desktop_file_dir_lock);
+ 
+-  if (dir->alternatively_watching)
++  if (dir->alternatively_watching && dir->nix_profile_watch_dir == NULL)
+     {
+       gchar *alternative_dir;
+ 
+@@ -1556,6 +1566,40 @@ desktop_file_dirs_lock (void)
+       for (i = 0; dirs[i]; i++)
+         g_ptr_array_add (desktop_file_dirs, desktop_file_dir_new (dirs[i]));
+ 
++      {
++        /* Monitor the system and user profile under /nix/var/nix/profiles and
++         * treat modifications to them as if they were modifications to their
++         * /share sub-directory.  */
++        const gchar *user;
++        DesktopFileDir *system_profile_dir, *user_profile_dir, *user_env_dir;
++
++        system_profile_dir =
++          desktop_file_dir_new ("/nix/var/nix/profiles/system/sw/share");
++        system_profile_dir->nix_profile_watch_dir = g_strdup ("/nix/var/nix/profiles");
++        g_ptr_array_add (desktop_file_dirs, desktop_file_dir_ref (system_profile_dir));
++
++        user = g_get_user_name ();
++        if (user != NULL)
++          {
++            gchar *profile_dir, *user_data_dir, *env_dir, *env_data_dir;
++
++            profile_dir = g_build_filename ("/nix/var/nix/profiles/per-user", user, NULL);
++            user_data_dir = g_build_filename (profile_dir, "profile", "share", NULL);
++            user_profile_dir = desktop_file_dir_new (user_data_dir);
++            user_profile_dir->nix_profile_watch_dir = profile_dir;
++            
++            env_dir = g_build_filename ("/etc/profiles/per-user", NULL);
++            env_data_dir = g_build_filename (env_dir, user, "share", NULL);
++            user_env_dir = desktop_file_dir_new (env_data_dir);
++            user_env_dir->nix_profile_watch_dir = env_dir;
++
++            g_ptr_array_add (desktop_file_dirs, desktop_file_dir_ref (user_profile_dir));
++            g_ptr_array_add (desktop_file_dirs, desktop_file_dir_ref (user_env_dir));
++            g_free (user_data_dir);
++            g_free (env_data_dir);
++          }
++      }
++
+       /* The list of directories will never change after this, unless
+        * g_get_user_config_dir() changes due to %G_TEST_OPTION_ISOLATE_DIRS. */
+       desktop_file_dirs_config_dir = user_config_dir;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

GNOME Shell monitors XDG_DATA_DIRS for changes using inotify for the
purpose of updating the list of applications displayed in the overview
as they are installed or removed. Because the relevant directories are
symlinks under NixOS and are swapped on change, Shell never notices it.
To remedy this, also monitor various profile directories to signal an
update whenever profiles are changed.

This uses a patch from Guix, slightly modified to also encompass user
environment profiles (/etc/profiles/per-user/$USER) in addition to the
system profile (/nix/var/nix/profiles/system) as well as regular user
profiles (/nix/var/nix/profiles/per-user/$USER/profile).

Fixes #12757

**Known limitation**: On installations to /etc/profiles/per-user, the list of applications gets updated, but Shell fails to find the icons for new applications. This is the case when installing them declaratively through home-manager's NixOS module. Other methods, such as ad-hoc via nix-env/nix profile install work fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
