### PR TITLE
haxe: add 4.1 and 4.0 compiler versions

### DIFF
--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -13,7 +13,8 @@ let
       sha
       dune_2
       luv
-      ocaml_extlib
+      (if lib.versionAtLeast version "4.2"
+      then ocaml_extlib else ocaml_extlib-1-7-7)
     ] else with ocaml-ng.ocamlPackages_4_05; [
       ocaml
       camlp4
@@ -124,6 +125,10 @@ in {
       ${defaultPatch}
       sed -i -re 's!(let +prefix_path += +).*( +in)!\1"'"$out/"'"\2!' src/main.ml
     '';
+  };
+  haxe_4_1 = generic {
+    version = "4.1.5";
+    sha256 = "0rns6d28qzkbai6yyws08yzbyvxfn848nj0fsji7chdi0y7pzzj0";
   };
   haxe_4_2 = generic {
     version = "4.2.1";

--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -126,6 +126,10 @@ in {
       sed -i -re 's!(let +prefix_path += +).*( +in)!\1"'"$out/"'"\2!' src/main.ml
     '';
   };
+  haxe_4_0 = generic {
+    version = "4.0.5";
+    sha256 = "0f534pchdx0m057ixnk07ab4s518ica958pvpd0vfjsrxg5yjkqa";
+  };
   haxe_4_1 = generic {
     version = "4.1.5";
     sha256 = "0rns6d28qzkbai6yyws08yzbyvxfn848nj0fsji7chdi0y7pzzj0";

--- a/pkgs/development/ocaml-modules/extlib/1.7.7.nix
+++ b/pkgs/development/ocaml-modules/extlib/1.7.7.nix
@@ -1,0 +1,11 @@
+# Older version of extlib for Haxe 4.0 and 4.1.
+# May be replaceable by the next extlib + extlib-base64 release.
+{ fetchurl, ocaml_extlib }:
+
+ocaml_extlib.overrideAttrs (_: rec {
+  version = "1.7.7";
+  src = fetchurl {
+    url = "https://github.com/ygrek/ocaml-extlib/releases/download/${version}/extlib-${version}.tar.gz";
+    sha256 = "1sxmzc1mx3kg62j8kbk0dxkx8mkf1rn70h542cjzrziflznap0s1";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10605,6 +10605,7 @@ in
 
   inherit (callPackage ../development/compilers/haxe { })
     haxe_4_2
+    haxe_4_1
     haxe_3_4
     haxe_3_2
     ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10606,6 +10606,7 @@ in
   inherit (callPackage ../development/compilers/haxe { })
     haxe_4_2
     haxe_4_1
+    haxe_4_0
     haxe_3_4
     haxe_3_2
     ;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1018,7 +1018,11 @@ let
 
     ocaml-protoc = callPackage ../development/ocaml-modules/ocaml-protoc { };
 
-    ocaml_extlib = callPackage ../development/ocaml-modules/extlib { };
+    ocaml_extlib = ocaml_extlib-1-7-8;
+
+    ocaml_extlib-1-7-8 = callPackage ../development/ocaml-modules/extlib { };
+
+    ocaml_extlib-1-7-7 = callPackage ../development/ocaml-modules/extlib/1.7.7.nix { };
 
     ocb-stubblr = callPackage ../development/ocaml-modules/ocb-stubblr { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #95638. cc @OPNA2608 

Arguably the extlib 1.7.7 override is not ideal, but I don't really want to be stuck with it in `ocamlPackages` as long as we don't need it for anything else. The compatibility patch from 4.2 unfortunately doesn't even apply on 4.1.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
