### PR TITLE
kuttl: init at version 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2339,6 +2339,12 @@
     githubId = 15774340;
     name = "Thomas Depierre";
   };
+  diegolelis = {
+    email = "diego.o.lelis@gmail.com";
+    github = "diegolelis";
+    githubId = 8404455;
+    name = "Diego Lelis";
+  };
   dipinhora = {
     email = "dipinhora+github@gmail.com";
     github = "dipinhora";

--- a/pkgs/applications/networking/cluster/kuttl/default.nix
+++ b/pkgs/applications/networking/cluster/kuttl/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub}:
+
+buildGoModule rec {
+  name = "kuttl";
+  pname = "kuttl";
+  version = "0.9.0";
+  cli = "kubectl-kuttl";
+
+  src = fetchFromGitHub {
+    owner  = "kudobuilder";
+    repo   = "kuttl";
+    rev    = "v${version}";
+    sha256 = "sha256:1cji0py2340mvcpplwq3licdkzjx7q5f27fdjjxvbhrgksnyw6hs";
+  };
+
+  vendorSha256 = "sha256:1shra42ifa2knxp58fj5hn074jg89f3nqdqk4rqbp3ybir84ahsd";
+
+  subPackages = [ "cmd/kubectl-kuttl" ];
+
+  buildFlagsArray = ''
+    -ldflags=-s -w
+    -X  github.com/kudobuilder/kuttl/pkg/version.gitVersion=${version}
+  '';
+
+  meta = with lib; {
+    description = "The KUbernetes Test TooL (KUTTL) provides a declarative approach to testing production-grade Kubernetes operators";
+    homepage = "https://github.com/kudobuilder/kuttl";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ diegolelis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23702,6 +23702,10 @@ in
 
   kubectl = callPackage ../applications/networking/cluster/kubectl { };
 
+  kuttl = callPackage ../applications/networking/cluster/kuttl {
+    buildGoModule = buildGo115Module;
+  };
+
   kubectl-doctor = callPackage ../applications/networking/cluster/kubectl-doctor { };
 
   kubectl-example = callPackage ../applications/networking/cluster/kubectl-example { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to test k8s clusters declaratively

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
