### PR TITLE
bcc: devendor libbpf

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl, fetchpatch
+{ lib, stdenv, fetchFromGitHub
 , makeWrapper, cmake, llvmPackages, kernel
 , flex, bison, elfutils, python, luajit, netperf, iperf, libelf
-, systemtap, bash
+, systemtap, bash, libbpf
 }:
 
 python.pkgs.buildPythonApplication rec {
@@ -10,9 +10,11 @@ python.pkgs.buildPythonApplication rec {
 
   disabled = !stdenv.isLinux;
 
-  src = fetchurl {
-    url = "https://github.com/iovisor/bcc/releases/download/v${version}/bcc-src-with-submodule.tar.gz";
-    sha256 = "sha256-TEH8Gmp+8ghLQ8UsGy5hBCMLqfMeApWEFr8THYSOdOQ=";
+  src = fetchFromGitHub {
+    owner = "iovisor";
+    repo = "bcc";
+    rev = "v${version}";
+    sha256 = "sha256:0k807vzznlb2icczw64ph6q28605kvghya2kd4h3c7jmap6gq1qg";
   };
   format = "other";
 
@@ -20,6 +22,7 @@ python.pkgs.buildPythonApplication rec {
     llvm clang-unwrapped kernel
     elfutils luajit netperf iperf
     systemtap.stapBuild flex bash
+    libbpf
   ];
 
   patches = [
@@ -38,6 +41,7 @@ python.pkgs.buildPythonApplication rec {
     "-DREVISION=${version}"
     "-DENABLE_USDT=ON"
     "-DENABLE_CPP_API=ON"
+    "-DCMAKE_USE_LIBBPF_PACKAGE=ON"
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Follow-up cleanup after discussion in #116588

###### /!\ Warning /!\

While this does build on linuxPackage_latest, this will be much pickier about building "against" older linux kernels than it used to be.
The rationale is that libbpf when vendored also in turn vendored linux headers appropriate for the libbpf version considered, but these are no longer available so we depend on every latest libbpf feature being present in the associated linux headers.

Linux is careful about ABI breakage so in practice using vendored libbpf headers was a good idea: it doesn't harm to have newer includes that define strictly more enum values and the code has runtime detection (well, trying to use newer features will just fail with ENOTSUP) -- it might actually make sense to have libbpf install its vendored linux uapi headers as well as its regular headers and have bcc/other bpf tools use these to avoid dependency hell...


TL;DR: with this patch, bcc will now only compile on linux kernels newer than bcc release date unless bcc is patched conditionally (e.g. to build with a 5.10 kernel removing a single line is enough: https://gitlab.alpinelinux.org/alpine/aports/-/raw/a55371125e8fd13800e8a394c80a4a4f930af64f/community/bcc/fix-newer-kernel-header-missing-enum.patch )

With that said it might be better to keep the current vendoring...

Cc @mic92 @ragnard @thoughtpolice (maintainers)


###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
