### PR TITLE
zlib-ng: init at 2.0.2

### DIFF
--- a/pkgs/development/libraries/zlib-ng/default.nix
+++ b/pkgs/development/libraries/zlib-ng/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub
+, cmake, pkg-config
+, withZlibCompat ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zlib-ng";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "zlib-ng";
+    repo = "zlib-ng";
+    rev = version;
+    sha256 = "1cl6asrav2512j7p02zcpibywjljws0m7aazvb3q2r9qiyvyswji";
+  };
+
+  outputs = [ "out" "dev" "bin" ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=/"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DINSTALL_UTILS=ON"
+  ] ++ lib.optionals withZlibCompat [ "-DZLIB_COMPAT=ON" ];
+
+  meta = with lib; {
+    description = "zlib data compression library for the next generation systems";
+    homepage    = "https://github.com/zlib-ng/zlib-ng";
+    license     = licenses.zlib;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ izorkin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17788,6 +17788,8 @@ in
 
   zlib = callPackage ../development/libraries/zlib { };
 
+  zlib-ng = callPackage ../development/libraries/zlib-ng { };
+
   libdynd = callPackage ../development/libraries/libdynd { };
 
   zlog = callPackage ../development/libraries/zlog { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add new library zlib-ng - zlib data compression library for the next generation systems.

cc @Mic92 @aanderse @flokli
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
