### PR TITLE
credslayer: init at 0.1.2

### DIFF
--- a/pkgs/tools/security/credslayer/default.nix
+++ b/pkgs/tools/security/credslayer/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, fetchFromGitHub
+, python3
+, wireshark-cli
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "credslayer";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "ShellCode33";
+    repo = "CredSLayer";
+    rev = "v${version}";
+    sha256 = "1rbfy0h9c2gra1r2b39kngj3m7g177nmzzs5xy9np8lxixrh17pc";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pyshark
+  ];
+
+  checkInputs = with python3.pkgs; [
+    wireshark-cli
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/tests.py" ];
+
+  disabledTests = [
+    # Requires a telnet setup
+    "test_telnet"
+  ];
+
+  pythonImportsCheck = [ "credslayer" ];
+
+  meta = with lib; {
+    description = "Extract credentials and other useful info from network captures";
+    homepage = "https://github.com/ShellCode33/CredSLayer";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -275,6 +275,8 @@ in
 
   creddump = callPackage ../tools/security/creddump {};
 
+  credslayer = callPackage ../tools/security/credslayer { };
+
   device-tree_rpi = callPackage ../os-specific/linux/device-tree/raspberrypi.nix {};
 
   devour = callPackage ../tools/X11/devour {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Extract credentials and other useful info from network captures

https://github.com/ShellCode33/CredSLayer

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
