### PR TITLE
sslscan: 1.11.13 -> 2.0.9

### DIFF
--- a/pkgs/tools/security/sslscan/default.nix
+++ b/pkgs/tools/security/sslscan/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rbsec";
     repo = "sslscan";
-    rev = "${version}";
+    rev = version;
     sha256 = "0594svwz4pya0syibar0ahmi5zdjbwd5kg6hrlhfpmmslrsyli6m";
   };
 

--- a/pkgs/tools/security/sslscan/default.nix
+++ b/pkgs/tools/security/sslscan/default.nix
@@ -1,14 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, openssl }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, openssl
+}:
 
 stdenv.mkDerivation rec {
   pname = "sslscan";
-  version = "1.11.13";
+  version = "2.0.9";
 
   src = fetchFromGitHub {
     owner = "rbsec";
     repo = "sslscan";
-    rev = "${version}-rbsec";
-    sha256 = "0sa8iw91wi3515lw761j84wagab1x9rxr0mn8m08qj300z2044yk";
+    rev = "${version}";
+    sha256 = "0594svwz4pya0syibar0ahmi5zdjbwd5kg6hrlhfpmmslrsyli6m";
   };
 
   buildInputs = [ openssl ];
@@ -18,8 +22,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Tests SSL/TLS services and discover supported cipher suites";
     homepage = "https://github.com/rbsec/sslscan";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ fpletz globin ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8347,12 +8347,7 @@ in
 
   sshpass = callPackage ../tools/networking/sshpass { };
 
-  sslscan = callPackage ../tools/security/sslscan {
-    openssl = openssl_1_0_2.override {
-      enableSSL2 = true;
-      enableSSL3 = true;
-    };
-  };
+  sslscan = callPackage ../tools/security/sslscan { };
 
   sslmate = callPackage ../development/tools/sslmate { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.9

Change log: https://github.com/rbsec/sslscan/releases

`sslscan` was decoupled from `openssl` with 2.x.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
