### PR TITLE
libtheora: Fix compilation when MACOSX_DEPLOYMENT_TARGET=11

### DIFF
--- a/pkgs/development/libraries/libtheora/default.nix
+++ b/pkgs/development/libraries/libtheora/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, libogg, libvorbis, pkg-config}:
+{lib, stdenv, fetchurl, libogg, libvorbis, pkg-config, autoreconfHook, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "libtheora-1.1.1";
@@ -7,18 +7,19 @@ stdenv.mkDerivation rec {
     url = "http://downloads.xiph.org/releases/theora/${name}.tar.gz";
     sha256 = "0swiaj8987n995rc7hw0asvpwhhzpjiws8kr3s6r44bqqib2k5a0";
   };
+  patches = [
+    # fix error in autoconf scripts
+    (fetchpatch {
+      url = "https://github.com/xiph/theora/commit/28cc6dbd9b2a141df94f60993256a5fca368fa54.diff";
+      sha256 = "16jqrq4h1b3krj609vbpzd5845cvkbh3mwmjrcdg35m490p19x9k";
+    })
+  ];
 
   outputs = [ "out" "dev" "devdoc" ];
   outputDoc = "devdoc";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
   propagatedBuildInputs = [ libogg libvorbis ];
-
-  # GCC's -fforce-addr flag is not supported by clang
-  # It's just an optimization, so it's safe to simply remove it
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace configure --replace "-fforce-addr" ""
-  '';
 
   meta = with lib; {
     homepage = "https://www.theora.org/";

--- a/pkgs/development/libraries/libtheora/default.nix
+++ b/pkgs/development/libraries/libtheora/default.nix
@@ -7,6 +7,7 @@ stdenv.mkDerivation rec {
     url = "http://downloads.xiph.org/releases/theora/${name}.tar.gz";
     sha256 = "0swiaj8987n995rc7hw0asvpwhhzpjiws8kr3s6r44bqqib2k5a0";
   };
+
   patches = [
     # fix error in autoconf scripts
     (fetchpatch {


### PR DESCRIPTION
MACOSX_DEPLOYMENT_TARGET will be 11.0 when built in arm64. libtheora's
libtool version doesn't handle this well, resulting in the linking phase
missing the "-Wl,-undefined -Wl,dynamic_lookup" args : 

```
libtheora> Undefined symbols for architecture arm64:
libtheora> "_th_comment_add", referenced from:
libtheora> _theora_comment_add in apiwrapper.o
libtheora> "_th_comment_add_tag", referenced from:
libtheora> _theora_comment_add_tag in apiwrapper.o
libtheora> "_th_comment_clear", referenced from:
libtheora> _theora_comment_clear in apiwrapper.o
libtheora> "_th_comment_init", referenced from:
libtheora> _theora_comment_init in apiwrapper.o
libtheora> "_th_comment_query", referenced from:
libtheora> _theora_comment_query in apiwrapper.o
libtheora> "_th_comment_query_count", referenced from:
libtheora> _theora_comment_query_count in apiwrapper.o
libtheora> ld: symbol(s) not found for architecture arm64
libtheora> clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I've been building packages on an M1 mac using @thefloweringash's apple-silicon branch (https://github.com/NixOS/nixpkgs/pull/105026). With this change I can get libtheora & ffmpeg building on arm.

~By itself this fix doesn't really help anything, but rather than add to the amount of stuff to be reviewed in https://github.com/NixOS/nixpkgs/pull/105026 I thought it might be better to submit this separately?~

~Would it be preferable to only set preConfigure on darwin, or run it everywhere for consistency?~

Tested using, eg, `nix build -f . libtheora` on master, and `nix build -f . --argstr system aarch64-darwin libtheora` on https://github.com/thefloweringash/nixpkgs/tree/apple-silicon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
