### PR TITLE
vagrant: 2.2.14 -> 2.2.15

### DIFF
--- a/pkgs/development/tools/vagrant/0001-Revert-Merge-pull-request-12225-from-chrisroberts-re.patch
+++ b/pkgs/development/tools/vagrant/0001-Revert-Merge-pull-request-12225-from-chrisroberts-re.patch
@@ -1,0 +1,342 @@
+From dc7156d8951242231cfd9142b3d5628815dc6589 Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Wed, 31 Mar 2021 14:30:01 +0200
+Subject: [PATCH] Revert "Merge pull request #12225 from
+ chrisroberts/resolution-isolation"
+
+This reverts commit 8a69d0c4dae035a4b1aa789bc4ec3db69c210df2, reversing
+changes made to 5dd0a8c8acc36b654c13a5102e4327eedf1858f2.
+
+-----
+
+Rationale: NixOS-specific patch. The changes in here break our current
+implementation of declarative plugins (only `vagrant-libvirt` atm).
+---
+ bin/vagrant                       | 28 +--------------
+ lib/vagrant.rb                    |  2 +-
+ lib/vagrant/bundler.rb            | 17 +++------
+ lib/vagrant/errors.rb             | 12 -------
+ lib/vagrant/plugin/manager.rb     | 22 ++----------
+ templates/locales/en.yml          | 23 ++----------
+ test/unit/bin/vagrant_test.rb     |  1 -
+ test/unit/vagrant/bundler_test.rb | 58 ++++++++++++++-----------------
+ 8 files changed, 39 insertions(+), 124 deletions(-)
+
+diff --git a/bin/vagrant b/bin/vagrant
+index c019f30ff..ba7e40076 100755
+--- a/bin/vagrant
++++ b/bin/vagrant
+@@ -23,9 +23,9 @@ if idx = argv.index("--")
+   argv = argv.slice(0, idx)
+ end
+ 
+-require_relative "../lib/vagrant/version"
+ # Fast path the version of Vagrant
+ if argv.include?("-v") || argv.include?("--version")
++  require_relative "../lib/vagrant/version"
+   puts "Vagrant #{Vagrant::VERSION}"
+   exit 0
+ end
+@@ -82,29 +82,6 @@ end
+ $stdout.sync = true
+ $stderr.sync = true
+ 
+-# Before we start activate all our dependencies
+-# so we can provide correct resolutions later
+-builtin_specs = []
+-
+-vagrant_spec = Gem::Specification.find_all_by_name("vagrant").detect do |spec|
+-  spec.version == Gem::Version.new(Vagrant::VERSION)
+-end
+-
+-dep_activator = proc do |spec|
+-  spec.runtime_dependencies.each do |dep|
+-    gem(dep.name, *dep.requirement.as_list)
+-    dep_spec = Gem::Specification.find_all_by_name(dep.name).detect(&:activated?)
+-    if dep_spec
+-      builtin_specs << dep_spec
+-      dep_activator.call(dep_spec)
+-    end
+-  end
+-end
+-
+-if vagrant_spec
+-  dep_activator.call(vagrant_spec)
+-end
+-
+ env = nil
+ begin
+   require 'log4r'
+@@ -114,9 +91,6 @@ begin
+   require 'vagrant/util/platform'
+   require 'vagrant/util/experimental'
+ 
+-  # Set our list of builtin specs
+-  Vagrant::Bundler.instance.builtin_specs = builtin_specs
+-
+   # Schedule the cleanup of things
+   at_exit(&Vagrant::Bundler.instance.method(:deinit))
+ 
+diff --git a/lib/vagrant.rb b/lib/vagrant.rb
+index f3dcba0bc..d696bdff8 100644
+--- a/lib/vagrant.rb
++++ b/lib/vagrant.rb
+@@ -81,7 +81,7 @@ if ENV["VAGRANT_LOG"] && ENV["VAGRANT_LOG"] != ""
+     # See https://github.com/rest-client/rest-client/issues/34#issuecomment-290858
+     # for more information
+     class VagrantLogger < Log4r::Logger
+-      def << msg
++      def << (msg)
+         debug(msg.strip)
+       end
+     end
+diff --git a/lib/vagrant/bundler.rb b/lib/vagrant/bundler.rb
+index eb2caabb0..d75f54362 100644
+--- a/lib/vagrant/bundler.rb
++++ b/lib/vagrant/bundler.rb
+@@ -189,11 +189,8 @@ module Vagrant
+     attr_reader :env_plugin_gem_path
+     # @return [Pathname] Vagrant environment data path
+     attr_reader :environment_data_path
+-    # @return [Array<Gem::Specification>, nil] List of builtin specs
+-    attr_accessor :builtin_specs
+ 
+     def initialize
+-      @builtin_specs = []
+       @plugin_gem_path = Vagrant.user_data_path.join("gems", RUBY_VERSION).freeze
+       @logger = Log4r::Logger.new("vagrant::bundler")
+     end
+@@ -290,6 +287,7 @@ module Vagrant
+         # Never allow dependencies to be remotely satisfied during init
+         request_set.remote = false
+ 
++        repair_result = nil
+         begin
+           @logger.debug("resolving solution from available specification set")
+           # Resolve the request set to ensure proper activation order
+@@ -652,6 +650,7 @@ module Vagrant
+         self_spec.activate
+         @logger.info("Activated vagrant specification version - #{self_spec.version}")
+       end
++      self_spec.runtime_dependencies.each { |d| gem d.name, *d.requirement.as_list }
+       # discover all the gems we have available
+       list = {}
+       if Gem.respond_to?(:default_specifications_dir)
+@@ -660,16 +659,10 @@ module Vagrant
+         spec_dir = Gem::Specification.default_specifications_dir
+       end
+       directories = [spec_dir]
+-      if Vagrant.in_bundler?
+-        Gem::Specification.find_all{true}.each do |spec|
+-          list[spec.full_name] = spec
+-        end
+-      else
+-        builtin_specs.each do |spec|
+-          list[spec.full_name] = spec
+-        end
++      Gem::Specification.find_all{true}.each do |spec|
++        list[spec.full_name] = spec
+       end
+-      if Vagrant.in_installer?
++      if(!Object.const_defined?(:Bundler))
+         directories += Gem::Specification.dirs.find_all do |path|
+           !path.start_with?(Gem.user_dir)
+         end
+diff --git a/lib/vagrant/errors.rb b/lib/vagrant/errors.rb
+index 5cb861c06..782615bc4 100644
+--- a/lib/vagrant/errors.rb
++++ b/lib/vagrant/errors.rb
+@@ -636,18 +636,6 @@ module Vagrant
+       error_key(:provisioner_winrm_unsupported)
+     end
+ 
+-    class PluginNeedsDeveloperTools < VagrantError
+-      error_key(:plugin_needs_developer_tools)
+-    end
+-
+-    class PluginMissingLibrary < VagrantError
+-      error_key(:plugin_missing_library)
+-    end
+-
+-    class PluginMissingRubyDev < VagrantError
+-      error_key(:plugin_missing_ruby_dev)
+-    end
+-
+     class PluginGemNotFound < VagrantError
+       error_key(:plugin_gem_not_found)
+     end
+diff --git a/lib/vagrant/plugin/manager.rb b/lib/vagrant/plugin/manager.rb
+index b73f07f9c..9058e68b3 100644
+--- a/lib/vagrant/plugin/manager.rb
++++ b/lib/vagrant/plugin/manager.rb
+@@ -179,26 +179,8 @@ module Vagrant
+         result
+       rescue Gem::GemNotFoundException
+         raise Errors::PluginGemNotFound, name: name
+-      rescue Gem::Exception => err
+-        @logger.warn("Failed to install plugin: #{err}")
+-        @logger.debug("#{err.class}: #{err}\n#{err.backtrace.join("\n")}")
+-        # Try and determine a cause for the failure
+-        case err.message
+-        when /install development tools first/
+-          raise Errors::PluginNeedsDeveloperTools
+-        when /library not found in default locations/
+-          lib = err.message.match(/(\w+) library not found in default locations/)
+-          if lib.nil?
+-            raise Errors::BundlerError, message: err.message
+-          end
+-          raise Errors::PluginMissingLibrary,
+-            library: lib.captures.first,
+-            name: name
+-        when /find header files for ruby/
+-          raise Errors::PluginMissingRubyDev
+-        else
+-          raise Errors::BundlerError, message: err.message
+-        end
++      rescue Gem::Exception => e
++        raise Errors::BundlerError, message: e.to_s
+       end
+ 
+       # Uninstalls the plugin with the given name.
+diff --git a/templates/locales/en.yml b/templates/locales/en.yml
+index edae9b477..782904f49 100644
+--- a/templates/locales/en.yml
++++ b/templates/locales/en.yml
+@@ -794,9 +794,9 @@ en:
+         matching this provider. For example, if you're using VirtualBox,
+         the clone environment must also be using VirtualBox.
+       cloud_init_not_found: |-
+-        cloud-init is not found. Please ensure that cloud-init is installed and
++        cloud-init is not found. Please ensure that cloud-init is installed and 
+         available on path for guest '%{guest_name}'.
+-      cloud_init_command_failed: |-
++      cloud_init_command_failed: |- 
+         cloud init command '%{cmd}' failed on guest '%{guest_name}'.
+       command_deprecated: |-
+         The command 'vagrant %{name}' has been deprecated and is no longer functional
+@@ -1238,23 +1238,6 @@ en:
+         following command:
+ 
+           vagrant plugin install --local
+-      plugin_needs_developer_tools: |-
+-        Vagrant failed to install the requested plugin because development tools
+-        are required for installation but are not currently installed on this
+-        machine. Please install development tools and then try this command
+-        again.
+-      plugin_missing_library: |-
+-        Vagrant failed to install the requested plugin because it depends
+-        on a library which is not currently installed on this system. The
+-        following library is required by the '%{name}' plugin:
+-
+-          %{library}
+-
+-        Please install the library and then run the command again.
+-      plugin_missing_ruby_dev: |-
+-        Vagrant failed to install the requested plugin because the Ruby header
+-        files could not be found. Install the ruby development package for your
+-        system and then run this command again.
+       powershell_not_found: |-
+         Failed to locate the powershell executable on the available PATH. Please
+         ensure powershell is installed and available on the local PATH, then
+@@ -3015,7 +2998,7 @@ en:
+     pushes:
+       file:
+         no_destination: "File destination must be specified."
+-
++    
+     autocomplete:
+       installed: |-
+         Autocomplete installed at paths:
+diff --git a/test/unit/bin/vagrant_test.rb b/test/unit/bin/vagrant_test.rb
+index dbbd52112..bc11309aa 100644
+--- a/test/unit/bin/vagrant_test.rb
++++ b/test/unit/bin/vagrant_test.rb
+@@ -30,7 +30,6 @@ describe "vagrant bin" do
+     allow(Kernel).to receive(:exit)
+     allow(Vagrant::Environment).to receive(:new).and_return(env)
+     allow(Vagrant).to receive(:in_installer?).and_return(true)
+-    allow(self).to receive(:require_relative)
+   end
+ 
+   after { expect(run_vagrant).to eq(exit_code) }
+diff --git a/test/unit/vagrant/bundler_test.rb b/test/unit/vagrant/bundler_test.rb
+index 69f425c66..00cedc021 100644
+--- a/test/unit/vagrant/bundler_test.rb
++++ b/test/unit/vagrant/bundler_test.rb
+@@ -778,46 +778,42 @@ describe Vagrant::Bundler do
+       end
+     end
+ 
+-    context "when bundler is not defined" do
+-      before { expect(Vagrant).to receive(:in_bundler?).and_return(false) }
++    context "when run time dependencies are defined" do
++      let(:vagrant_dep_specs) { [double("spec", name: "vagrant-dep", requirement: double("spec-req", as_list: []))] }
+ 
+-      context "when running inside the installer" do
+-        before { expect(Vagrant).to receive(:in_installer?).and_return(true) }
++      it "should call #gem to activate the dependencies" do
++        expect(subject).to receive(:gem).with("vagrant-dep", any_args)
++        subject.send(:vagrant_internal_specs)
++      end
++    end
+ 
+-        it "should load gem specification directories" do
+-          expect(Gem::Specification).to receive(:dirs).and_return(spec_dirs)
+-          subject.send(:vagrant_internal_specs)
+-        end
++    context "when bundler is not defined" do
++      before { expect(Object).to receive(:const_defined?).with(:Bundler).and_return(false) }
+ 
+-        context "when checking paths" do
+-          let(:spec_dirs) { [double("spec-dir", start_with?: in_user_dir)] }
+-          let(:in_user_dir) { true }
+-          let(:user_dir) { double("user-dir") }
++      it "should load gem specification directories" do
++        expect(Gem::Specification).to receive(:dirs).and_return(spec_dirs)
++        subject.send(:vagrant_internal_specs)
++      end
+ 
+-          before { allow(Gem).to receive(:user_dir).and_return(user_dir) }
++      context "when checking paths" do
++        let(:spec_dirs) { [double("spec-dir", start_with?: in_user_dir)] }
++        let(:in_user_dir) { true }
++        let(:user_dir) { double("user-dir") }
+ 
+-          it "should check if path is within local user directory" do
+-            expect(spec_dirs.first).to receive(:start_with?).with(user_dir).and_return(false)
+-            subject.send(:vagrant_internal_specs)
+-          end
+-
+-          context "when path is not within user directory" do
+-            let(:in_user_dir) { false }
++        before { allow(Gem).to receive(:user_dir).and_return(user_dir) }
+ 
+-            it "should use path when loading specs" do
+-              expect(Gem::Specification).to receive(:each_spec) { |arg| expect(arg).to include(spec_dirs.first) }
+-              subject.send(:vagrant_internal_specs)
+-            end
+-          end
++        it "should check if path is within local user directory" do
++          expect(spec_dirs.first).to receive(:start_with?).with(user_dir).and_return(false)
++          subject.send(:vagrant_internal_specs)
+         end
+-      end
+ 
+-      context "when running outside the installer" do
+-        before { expect(Vagrant).to receive(:in_installer?).and_return(false) }
++        context "when path is not within user directory" do
++          let(:in_user_dir) { false }
+ 
+-        it "should not load gem specification directories" do
+-          expect(Gem::Specification).not_to receive(:dirs)
+-          subject.send(:vagrant_internal_specs)
++          it "should use path when loading specs" do
++            expect(Gem::Specification).to receive(:each_spec) { |arg| expect(arg).to include(spec_dirs.first) }
++            subject.send(:vagrant_internal_specs)
++          end
+         end
+       end
+     end
+-- 
+2.29.3
+

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -5,9 +5,9 @@
 let
   # NOTE: bumping the version and updating the hash is insufficient;
   # you must use bundix to generate a new gemset.nix in the Vagrant source.
-  version = "2.2.14";
+  version = "2.2.15";
   url = "https://github.com/hashicorp/vagrant/archive/v${version}.tar.gz";
-  sha256 = "sha256-vsb7RFjT9l4N6BzwIvVLcRtA4n/c8jk20B6RUMkyhJs=";
+  sha256 = "sha256-mMnHJtXLfkZ5O0UF89kHsqBnPg9uQ5l8IYoL5TMMyD8=";
 
   deps = bundlerEnv rec {
     name = "${pname}-${version}";
@@ -54,6 +54,7 @@ in buildRubyGem rec {
     ./unofficial-installation-nowarn.patch
     ./use-system-bundler-version.patch
     ./0004-Support-system-installed-plugins.patch
+    ./0001-Revert-Merge-pull-request-12225-from-chrisroberts-re.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/tools/vagrant/gemset.nix
+++ b/pkgs/development/tools/vagrant/gemset.nix
@@ -4,10 +4,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "02vssr285m7kpsr47jdmzbar1h1d0mnkmyrpr1zg828isfmwii35";
+      sha256 = "0ndamfaivnkhc6hy0yqyk2gkwr6f3bz6216lh74hsiiyk3axz445";
       type = "gem";
     };
-    version = "1.0.1";
+    version = "1.1.0";
   };
   builder = {
     groups = ["default"];
@@ -34,10 +34,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1vnxrbhi7cq3p4y2v9iwd10v1c7l15is4var14hwnb2jip4fyjzz";
+      sha256 = "0mr23wq0szj52xnj0zcn1k0c7j4v79wlwbijkpfcscqww3l6jlg3";
       type = "gem";
     };
-    version = "1.1.7";
+    version = "1.1.8";
   };
   ed25519 = {
     groups = ["default"];
@@ -64,20 +64,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1hi89v53pm2abfv9j8lgqdd7hgkr7fr0gwrczr940iwbb3xv7rrs";
+      sha256 = "1759s0rz6qgsw86dds1z4jzb3fvizqsk11j5q6z7lc5n404w6i23";
       type = "gem";
     };
-    version = "0.78.0";
+    version = "0.79.0";
   };
   ffi = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "12lpwaw82bb0rm9f52v1498bpba8aj2l2q359mkwbxsswhpga5af";
+      sha256 = "0nq1fb3vbfylccwba64zblxy96qznxbys5900wd7gm9bpplmf432";
       type = "gem";
     };
-    version = "1.13.1";
+    version = "1.15.0";
   };
   gssapi = {
     dependencies = ["ffi"];
@@ -85,10 +85,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "13l6pqbfrx3vv7cw26nq9p8rnyp9br31gaz85q32wx6hnzfcriwh";
+      sha256 = "1qdfhj12aq8v0y961v4xv96a1y2z80h3xhvzrs9vsfgf884g6765";
       type = "gem";
     };
-    version = "1.3.0";
+    version = "1.3.1";
   };
   gyoku = {
     dependencies = ["builder"];
@@ -127,10 +127,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "153sx77p16vawrs4qpkv7qlzf9v5fks4g7xqcj1dwk40i6g7rfzk";
+      sha256 = "0g2fnag935zn2ggm5cn6k4s4xvv53v2givj1j90szmvavlpya96a";
       type = "gem";
     };
-    version = "1.8.5";
+    version = "1.8.10";
   };
   listen = {
     dependencies = ["rb-fsevent" "rb-inotify"];
@@ -138,10 +138,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0028p1fss6pvw4mlpjqdmxfzsm8ww79irsadbibrr7f23qfn8ykr";
+      sha256 = "0h2v34xhi30w0d9gfzds2w6v89grq2gkpgvmdj9m8x1ld1845xnj";
       type = "gem";
     };
-    version = "3.3.1";
+    version = "3.5.1";
   };
   little-plugger = {
     groups = ["default"];
@@ -190,10 +190,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0ipjyfwn9nlvpcl8knq3jk4g5f12cflwdbaiqxcq1s7vwfwfxcag";
+      sha256 = "1phcq7z0zpipwd7y4fbqmlaqghv07fjjgrx99mwq3z3n0yvy7fmi";
       type = "gem";
     };
-    version = "3.2020.1104";
+    version = "3.2021.0225";
   };
   multi_json = {
     groups = ["default"];
@@ -232,10 +232,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1hlyp6z3ffwdcnzq9khrkz6waxggn4hnzsczbp3mz61lhx4qiri3";
+      sha256 = "0jp3jgcn8cij407xx9ldb5h9c6jv13jc4cf6kk2idclz43ww21c9";
       type = "gem";
     };
-    version = "6.2.0.rc1";
+    version = "6.1.0";
   };
   nori = {
     groups = ["default"];
@@ -279,25 +279,15 @@
     };
     version = "0.2.5";
   };
-  ruby_dep = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0v0qznxz999lx4vs76mr590r90i0cm5m76wwvgis7sq4y21l308l";
-      type = "gem";
-    };
-    version = "1.3.1";
-  };
   rubyntlm = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1p6bxsklkbcqni4bcq6jajc2n57g0w5rzn4r49c3lb04wz5xg0dy";
+      sha256 = "0b8hczk8hysv53ncsqzx4q6kma5gy5lqc7s5yx8h64x3vdb18cjv";
       type = "gem";
     };
-    version = "0.6.2";
+    version = "0.6.3";
   };
   rubyzip = {
     groups = ["default"];
@@ -315,10 +305,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0b3b9ybd6mskfz2vffb6li2y6njdc9xqhik9c4mvzq9dchxpbxlj";
+      sha256 = "1rwfw014fbvaxshf8abi87srfaiirb7cr93s61qm177jm8q86h57";
       type = "gem";
     };
-    version = "3.0.2";
+    version = "3.0.4";
   };
   wdm = {
     groups = ["default"];
@@ -336,10 +326,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0k9i86v805gpya3pyqahjykljbdwpjsrk7hsdqrl05j2rpidvk4v";
+      sha256 = "0nxf6a47d1xf1nvi7rbfbzjyyjhz0iakrnrsr2hj6y24a381sd8i";
       type = "gem";
     };
-    version = "2.3.5";
+    version = "2.3.6";
   };
   winrm-elevated = {
     dependencies = ["erubi" "winrm" "winrm-fs"];

--- a/pkgs/development/tools/vagrant/gemset_libvirt.nix
+++ b/pkgs/development/tools/vagrant/gemset_libvirt.nix
@@ -14,10 +14,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1hi89v53pm2abfv9j8lgqdd7hgkr7fr0gwrczr940iwbb3xv7rrs";
+      sha256 = "1759s0rz6qgsw86dds1z4jzb3fvizqsk11j5q6z7lc5n404w6i23";
       type = "gem";
     };
-    version = "0.78.0";
+    version = "0.79.0";
   };
   fog-core = {
     dependencies = ["builder" "excon" "formatador" "mime-types"];
@@ -47,10 +47,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0by97bx0szdz47kdy0fqvx6j2kzy5yhrwbvvsfbh27dm9c0vfwgr";
+      sha256 = "1s62ihwxlwgp84xw32wg6hwcx4422v20c7g7azd0xslb91y1ln1r";
       type = "gem";
     };
-    version = "0.7.0";
+    version = "0.8.0";
   };
   fog-xml = {
     dependencies = ["fog-core" "nokogiri"];
@@ -78,10 +78,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "158fawfwmv2sq4whqqaksfykkiad2xxrrj0nmpnc6vnlzi1bp7iz";
+      sha256 = "0lrirj0gw420kw71bjjlqkqhqbrplla61gbv1jzgsz6bv90qr3ci";
       type = "gem";
     };
-    version = "2.3.1";
+    version = "2.5.1";
   };
   mime-types = {
     dependencies = ["mime-types-data"];
@@ -99,20 +99,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0ipjyfwn9nlvpcl8knq3jk4g5f12cflwdbaiqxcq1s7vwfwfxcag";
+      sha256 = "1phcq7z0zpipwd7y4fbqmlaqghv07fjjgrx99mwq3z3n0yvy7fmi";
       type = "gem";
     };
-    version = "3.2020.1104";
+    version = "3.2021.0225";
   };
   mini_portile2 = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "15zplpfw3knqifj9bpf604rb3wc1vhq6363pd6lvhayng8wql5vy";
+      sha256 = "1hdbpmamx8js53yk3h8cqy12kgv6ca06k0c9n3pxh6b6cjfs19x7";
       type = "gem";
     };
-    version = "2.4.0";
+    version = "2.5.0";
   };
   multi_json = {
     groups = ["default"];
@@ -125,15 +125,25 @@
     version = "1.15.0";
   };
   nokogiri = {
-    dependencies = ["mini_portile2"];
+    dependencies = ["mini_portile2" "racc"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0xmf60nj5kg9vaj5bysy308687sgmkasgx06vbbnf94p52ih7si2";
+      sha256 = "0b51df8fwadak075cvi17w0nch6qz1r66564qp29qwfj67j9qp0p";
       type = "gem";
     };
-    version = "1.10.10";
+    version = "1.11.2";
+  };
+  racc = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "178k7r0xn689spviqzhvazzvxfq6fyjldxb3ywjbgipbfi4s8j1g";
+      type = "gem";
+    };
+    version = "1.5.2";
   };
   ruby-libvirt = {
     groups = ["default"];
@@ -151,9 +161,9 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1b1m8fg1rin6ps15ykqhwz6qm7isadb83r22b733dkw2gvvj91jv";
+      sha256 = "07j30w23syvzrhznad9dkh1ks4lzxzi7ak2966b7i7wr4kz8x1hp";
       type = "gem";
     };
-    version = "0.2.1";
+    version = "0.4.0";
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ChangeLog: https://github.com/hashicorp/vagrant/blob/v2.2.15/CHANGELOG.md#2215-march-30-2021

Also had to revert a change which improved plugin-errors a bit since it
changed the dependency resolution in a way that broke `vagrant-libvirt`
from `$out/vagrant-plugins/plugins.d`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
