### PR TITLE
xcat: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/xpath-expressions/default.nix
+++ b/pkgs/development/python-modules/xpath-expressions/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, lxml
+, poetry-core
+, pythonOlder
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "xpath-expressions";
+  version = "1.1.0";
+  disabled = pythonOlder "3.5";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "orf";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0l289iw2zmzxyfi3g2z7b917vmsaz47h5jp871zvykpmpigc632h";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  checkInputs = [
+    lxml
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # Was fixed upstream but not released
+    substituteInPlace pyproject.toml \
+      --replace "poetry.masonry.api" "poetry.core.masonry.api"
+  '';
+
+  pythonImportsCheck = [ "xpath" ];
+
+  meta = with lib; {
+    description = "Python module to handle XPath expressions";
+    homepage = "https://github.com/orf/xpath-expressions";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/xcat/default.nix
+++ b/pkgs/tools/security/xcat/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "xcat";
+  version = "1.2.0";
+  disabled = python3.pythonOlder "3.7";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "orf";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "01r5998gdvqjdrahpk0ci27lx9yghbddlanqcspr3qp5y5930i0s";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    aiodns
+    aiohttp
+    appdirs
+    cchardet
+    click
+    colorama
+    prompt_toolkit
+    xpath-expressions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "xcat" ];
+
+  meta = with lib; {
+    description = "XPath injection tool";
+    longDescription = ''
+      xcat is an advanced tool for exploiting XPath injection vulnerabilities,
+      featuring a comprehensive set of features to read the entire file being
+      queried as well as other files on the filesystem, environment variables
+      and directories.
+    '';
+    homepage = "https://github.com/orf/xcat";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26515,6 +26515,8 @@ in
 
   xcape = callPackage ../tools/X11/xcape { };
 
+  xcat = callPackage ../tools/security/xcat { };
+
   xchainkeys = callPackage ../tools/X11/xchainkeys { };
 
   xchm = callPackage ../applications/misc/xchm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8956,6 +8956,8 @@ in {
 
   xnd = callPackage ../development/python-modules/xnd { };
 
+  xpath-expressions = callPackage ../development/python-modules/xpath-expressions { };
+
   xpybutil = callPackage ../development/python-modules/xpybutil { };
 
   xstatic-bootbox = callPackage ../development/python-modules/xstatic-bootbox { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
xcat is an advanced tool for exploiting XPath injection vulnerabilities,
featuring a comprehensive set of features to read the entire file being
queried as well as other files on the filesystem, environment variables
and directories.

https://github.com/orf/xcat

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
