### PR TITLE
pass-import: fix plugin usage

### DIFF
--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -36,7 +36,8 @@ in stdenv.mkDerivation rec {
       --prefix PYTHONPATH : "$out/${pythonPackages.python.sitePackages}"
     wrapProgram $out/lib/password-store/extensions/import.bash \
       --prefix PATH : "${pythonEnv}/bin" \
-      --prefix PYTHONPATH : "$out/${pythonPackages.python.sitePackages}"
+      --prefix PYTHONPATH : "$out/${pythonPackages.python.sitePackages}" \
+      --run "export PREFIX"
   '';
 
   meta = with lib; {

--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -6,7 +6,7 @@ let
     p.setuptools
     p.pyaml
     p.pykeepass
-    p.filemagic
+    p.magic
     p.cryptography
     p.secretstorage
   ]);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

pass import needs magic to determine file types
the current python dependency used is
https://github.com/aliles/filemagic. This is very outdated and when
running the import plugin we get an error "AttributeError: module
'magic' has no attribute 'from_buffer'"
Pass import actually specifies this: https://github.com/file/file as the
required dependency. Using these python bindings fixes the error

pass-import relies on the PREFIX variable being set. Normally it is
available when the extension is called from pass because pass sources
the extension entry point script. Because of the way the extension gets
wrapped by nix we need to export PREFIX in the wrapper script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
