### PR TITLE
multimon-ng: drop qt4

### DIFF
--- a/pkgs/applications/radio/multimon-ng/default.nix
+++ b/pkgs/applications/radio/multimon-ng/default.nix
@@ -1,10 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, qt4, qmake4Hook, libpulseaudio }:
-let
-  version = "1.1.9";
-in
-stdenv.mkDerivation {
+{ lib, stdenv, fetchFromGitHub, cmake, libpulseaudio, libX11 }:
+
+stdenv.mkDerivation rec {
   pname = "multimon-ng";
-  inherit version;
+  version = "1.1.9";
 
   src = fetchFromGitHub {
     owner = "EliasOenal";
@@ -13,16 +11,9 @@ stdenv.mkDerivation {
     sha256 = "01716cfhxfzsab9zjply9giaa4nn4b7rm3p3vizrwi7n253yiwm2";
   };
 
-  buildInputs = [ qt4 libpulseaudio ];
+  buildInputs = [ libpulseaudio libX11 ];
 
-  nativeBuildInputs = [ qmake4Hook ];
-
-  qmakeFlags = [ "multimon-ng.pro" ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp multimon-ng $out/bin
-  '';
+  nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
     description = "Multimon is a digital baseband audio protocol decoder";
@@ -39,6 +30,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/EliasOenal/multimon-ng";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = [ maintainers.markuskowa ];
+    maintainers = with maintainers; [ markuskowa ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

It works with plain X11, so we can drop qt4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
