### PR TITLE
 ocamlPackages.mirage-crypto*: 0.8.10 -> 0.9.0 

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -1,14 +1,17 @@
-{ lib, fetchurl, buildDunePackage, ounit, cstruct, dune-configurator, eqaf, pkg-config }:
+{ lib, fetchurl, buildDunePackage, ounit, cstruct, dune-configurator, eqaf, pkg-config
+, withFreestanding ? false
+, ocaml-freestanding
+}:
 
 buildDunePackage rec {
   minimumOCamlVersion = "4.08";
 
   pname = "mirage-crypto";
-  version = "0.8.10";
+  version = "0.9.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-v${version}.tbz";
-    sha256 = "8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc";
+    sha256 = "716684f8a70031f16115e3c84d42141c75fb1e688b7a699bbd09166176ed5217";
   };
 
   useDune2 = true;
@@ -17,12 +20,20 @@ buildDunePackage rec {
   checkInputs = [ ounit ];
 
   nativeBuildInputs = [ dune-configurator pkg-config ];
-  propagatedBuildInputs = [ cstruct eqaf ];
+  propagatedBuildInputs = [
+    cstruct eqaf
+  ] ++ lib.optionals withFreestanding [
+    ocaml-freestanding
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/mirage/mirage-crypto";
     description = "Simple symmetric cryptography for the modern age";
-    license = licenses.isc;
+    license = [
+      licenses.isc  # default license
+      licenses.bsd2 # mirage-crypto-rng-mirage
+      licenses.mit  # mirage-crypto-ec
+    ];
     maintainers = with maintainers; [ sternenseemann ];
   };
 }

--- a/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildDunePackage
+, mirage-crypto
+, dune-configurator
+, pkg-config
+, cstruct
+, mirage-crypto-rng
+, mirage-crypto-pk
+, hex
+, alcotest
+, asn1-combinators
+, ppx_deriving_yojson
+, ppx_deriving
+, yojson
+, withFreestanding ? false
+, ocaml-freestanding
+}:
+
+buildDunePackage {
+  pname = "mirage-crypto-ec";
+
+  inherit (mirage-crypto)
+    minimumOCamlVersion
+    src
+    version
+    useDune2
+    ;
+
+  nativeBuildInputs = [
+    pkg-config
+    dune-configurator
+  ];
+  propagatedBuildInputs = [
+    cstruct
+    mirage-crypto
+    mirage-crypto-rng
+  ] ++ lib.optionals withFreestanding [
+    ocaml-freestanding
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    hex
+    alcotest
+    asn1-combinators
+    ppx_deriving_yojson
+    ppx_deriving
+    yojson
+    mirage-crypto-pk
+  ];
+
+  meta = mirage-crypto.meta // {
+    description = "Elliptic Curve Cryptography with primitives taken from Fiat";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -689,6 +689,8 @@ let
 
     mirage-crypto = callPackage ../development/ocaml-modules/mirage-crypto { };
 
+    mirage-crypto-ec = callPackage ../development/ocaml-modules/mirage-crypto/ec.nix { };
+
     mirage-crypto-pk = callPackage ../development/ocaml-modules/mirage-crypto/pk.nix { };
 
     mirage-crypto-rng = callPackage ../development/ocaml-modules/mirage-crypto/rng.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirage/mirage-crypto/releases/tag/v0.9.0>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
