### PR TITLE
nixos/pipewire: Use formats.json, stricter typing and break up extremely long lines.

### DIFF
--- a/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
@@ -4,6 +4,7 @@
 with lib;
 
 let
+  json = pkgs.formats.json {};
   cfg = config.services.pipewire.media-session;
   enable32BitAlsaPlugins = cfg.alsa.support32Bit
                            && pkgs.stdenv.isx86_64
@@ -17,24 +18,13 @@ let
     media-session = (builtins.fromJSON (builtins.readFile ./media-session.conf.json));
     v4l2-monitor = (builtins.fromJSON (builtins.readFile ./v4l2-monitor.conf.json));
   };
-  # Helpers for generating the pipewire JSON config file
-  mkSPAValueString = v:
-  if builtins.isList v then "[${lib.concatMapStringsSep " " mkSPAValueString v}]"
-  else if lib.types.attrs.check v then
-    "{${lib.concatStringsSep " " (mkSPAKeyValue v)}}"
-  else if builtins.isString v then "\"${lib.generators.mkValueStringDefault { } v}\""
-  else lib.generators.mkValueStringDefault { } v;
 
-  mkSPAKeyValue = attrs: map (def: def.content) (
-  lib.sortProperties
-    (
-      lib.mapAttrsToList
-        (k: v: lib.mkOrder (v._priority or 1000) "${lib.escape [ "=" ":" ] k} = ${mkSPAValueString (v._content or v)}")
-        attrs
-    )
-  );
-
-  toSPAJSON = attrs: lib.concatStringsSep "\n" (mkSPAKeyValue attrs);
+  configs = {
+    alsa-monitor = recursiveUpdate defaults.alsa-monitor cfg.config.alsa-monitor;
+    bluez-monitor = recursiveUpdate defaults.bluez-monitor cfg.config.bluez-monitor;
+    media-session = recursiveUpdate defaults.media-session cfg.config.media-session;
+    v4l2-monitor = recursiveUpdate defaults.v4l2-monitor cfg.config.v4l2-monitor;
+  };
 in {
 
   meta = {
@@ -62,7 +52,7 @@ in {
 
       config = {
         media-session = mkOption {
-          type = types.attrs;
+          type = json.type;
           description = ''
             Configuration for the media session core. For details see
             https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/${cfg.package.version}/src/daemon/media-session.d/media-session.conf
@@ -71,7 +61,7 @@ in {
         };
 
         alsa-monitor = mkOption {
-          type = types.attrs;
+          type = json.type;
           description = ''
             Configuration for the alsa monitor. For details see
             https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/${cfg.package.version}/src/daemon/media-session.d/alsa-monitor.conf
@@ -80,7 +70,7 @@ in {
         };
 
         bluez-monitor = mkOption {
-          type = types.attrs;
+          type = json.type;
           description = ''
             Configuration for the bluez5 monitor. For details see
             https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/${cfg.package.version}/src/daemon/media-session.d/bluez-monitor.conf
@@ -89,7 +79,7 @@ in {
         };
 
         v4l2-monitor = mkOption {
-          type = types.attrs;
+          type = json.type;
           description = ''
             Configuration for the V4L2 monitor. For details see
             https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/${cfg.package.version}/src/daemon/media-session.d/v4l2-monitor.conf
@@ -106,15 +96,34 @@ in {
     systemd.packages = [ cfg.package ];
     systemd.user.services.pipewire-media-session.wantedBy = [ "pipewire.service" ];
 
-    environment.etc."pipewire/media-session.d/media-session.conf" = { text = toSPAJSON (recursiveUpdate defaults.media-session cfg.config.media-session); };
-    environment.etc."pipewire/media-session.d/v4l2-monitor.conf" = { text = toSPAJSON (recursiveUpdate defaults.v4l2-monitor cfg.config.v4l2-monitor); };
+    environment.etc."pipewire/media-session.d/media-session.conf" = {
+      source = json.generate "media-session.conf" configs.media-session;
+    };
+    environment.etc."pipewire/media-session.d/v4l2-monitor.conf" = {
+      source = json.generate "v4l2-monitor.conf" configs.v4l2-monitor;
+    };
 
-    environment.etc."pipewire/media-session.d/with-alsa" = mkIf config.services.pipewire.alsa.enable { text = ""; };
-    environment.etc."pipewire/media-session.d/alsa-monitor.conf" = mkIf config.services.pipewire.alsa.enable { text = toSPAJSON (recursiveUpdate defaults.alsa-monitor cfg.config.alsa-monitor); };
+    environment.etc."pipewire/media-session.d/with-alsa" =
+      mkIf config.services.pipewire.alsa.enable {
+        text = "";
+      };
+    environment.etc."pipewire/media-session.d/alsa-monitor.conf" =
+      mkIf config.services.pipewire.alsa.enable {
+        source = json.generate "alsa-monitor.conf" configs.alsa-monitor;
+      };
 
-    environment.etc."pipewire/media-session.d/with-pulseaudio" = mkIf config.services.pipewire.pulse.enable { text = ""; };
-    environment.etc."pipewire/media-session.d/bluez-monitor.conf" = mkIf config.services.pipewire.pulse.enable { text = toSPAJSON (recursiveUpdate defaults.bluez-monitor cfg.config.bluez-monitor); };
+    environment.etc."pipewire/media-session.d/with-pulseaudio" =
+      mkIf config.services.pipewire.pulse.enable {
+        text = "";
+      };
+    environment.etc."pipewire/media-session.d/bluez-monitor.conf" =
+      mkIf config.services.pipewire.pulse.enable {
+        source = json.generate "bluez-monitor.conf" configs.bluez-monitor;
+      };
 
-    environment.etc."pipewire/media-session.d/with-jack" = mkIf config.services.pipewire.jack.enable { text = ""; };
+    environment.etc."pipewire/media-session.d/with-jack" =
+      mkIf config.services.pipewire.jack.enable {
+        text = "";
+      };
   };
 }

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -75,6 +75,11 @@ let
       ./0070-installed-tests-path.patch
       # Add flag to specify configuration directory (different from the installation directory).
       ./0080-pipewire-config-dir.patch
+      # Fix JSON parser.
+      (fetchpatch {
+        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/34800dc0191a4ee7a329eeb361a6f2ccf4a75176.diff";
+        sha256 = "0dzxzr408qqzf0252nwg14709p1lb2k826i3kdzg6djq8w98d5aj";
+      })
     ];
 
     nativeBuildInputs = [


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The upstream pipewire config is written in an almost, but not quite JSON format. The parser accepts standard JSON, though, so we don't need to write our file in the same nonstandard version.

The typing for all config options is changed from `types.attrs`, which behaves poorly when the option is set from multiple locations, to the `formats.json`-type.

Also, rewrite some very long one-liners for improved readability.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
