### PR TITLE
steam: fix paradox launcher

### DIFF
--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -106,6 +106,7 @@ in buildFHSUserEnv rec {
     gst_all_1.gst-plugins-ugly
     gst_all_1.gst-plugins-base
     libdrm
+    libxkbcommon # paradox launcher
     mono
     xorg.xkeyboardconfig
     xorg.libpciaccess
@@ -205,7 +206,6 @@ in buildFHSUserEnv rec {
     libidn
     tbb
     wayland
-    libxkbcommon
 
     # Other things from runtime
     flac


### PR DESCRIPTION
###### Motivation for this change
Noticed the launcher for games like CK3 and EU4 was having trouble launching because it couldn't find `libxkbcommon.so.0`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
