### PR TITLE
grafana-polystat-panel: 1.2.2 -> 1.2.3

### DIFF
--- a/pkgs/servers/monitoring/grafana/plugins/grafana-polystat-panel/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-polystat-panel/default.nix
@@ -2,8 +2,8 @@
 
 grafanaPlugin rec {
   pname = "grafana-polystat-panel";
-  version = "1.2.2";
-  zipHash = "sha256-HWQdhstnrDuXPithZ8kOG2ZtSeAT215MJ1ftMCt6/tc=";
+  version = "1.2.3";
+  zipHash = "sha256-Eu3dTPfJxAWwqqGT6l4El4MqviBbzERarU30OXU+eEM=";
   meta = with lib; {
     description = "Hexagonal multi-stat panel for Grafana";
     license = licenses.asl20;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

## grafana-polystat-panel
### [v1.2.3](https://grafana.com/grafana/plugins/grafana-polystat-panel/?tab=changelog)
* Fix for polygon click-through causing incorrect fill color
* Support global value mappings in Overrides
* Compute X and Y mouse positions in mouseover
* Increase polystat-panel-tooltip z-index
* Fix for composite threshold evalation using global thresholds
* Fix for default warning color not rendering corectly
* Feature: Tooltip can now be disabled (on by default)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
