### PR TITLE
ocamlPackages.bigstring: 0.2 → 0.3

### DIFF
--- a/pkgs/development/ocaml-modules/bigstring/default.nix
+++ b/pkgs/development/ocaml-modules/bigstring/default.nix
@@ -2,7 +2,9 @@
 
 buildDunePackage rec {
   pname = "bigstring";
-  version = "0.2";
+  version = "0.3";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.03";
 
@@ -10,10 +12,11 @@ buildDunePackage rec {
     owner = "c-cube";
     repo = "ocaml-bigstring";
     rev = version;
-    sha256 = "0ypdf29cmwmjm3djr5ygz8ls81dl41a4iz1xx5gbcdpbrdiapb77";
+    sha256 = "0bkxwdcswy80f6rmx5wjza92xzq4rdqsb4a9fm8aav8bdqx021n8";
   };
 
-  doCheck = true;
+  # Circular dependency with bigstring-unix
+  doCheck = false;
 
   meta = with lib; {
     homepage = "https://github.com/c-cube/ocaml-bigstring";

--- a/pkgs/development/ocaml-modules/hidapi/default.nix
+++ b/pkgs/development/ocaml-modules/hidapi/default.nix
@@ -1,10 +1,12 @@
-{ pkgs, lib, fetchurl, buildDunePackage, pkg-config
+{ pkgs, lib, fetchurl, buildDunePackage, pkg-config, dune-configurator
 , bigstring,
 }:
 
 buildDunePackage rec {
   pname = "hidapi";
   version = "1.1.1";
+
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/vbmithr/ocaml-hidapi/releases/download/${version}/${pname}-${version}.tbz";
@@ -13,7 +15,7 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.03";
 
-  buildInputs = [ pkgs.hidapi pkg-config ];
+  buildInputs = [ pkgs.hidapi pkg-config dune-configurator ];
   propagatedBuildInputs = [ bigstring ];
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Use dune 2 (compatibility with OCaml 4.12)

cc maintainer @alexfmpe

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
