### PR TITLE
svkbd: init at 0.3

### DIFF
--- a/pkgs/applications/accessibility/svkbd/default.nix
+++ b/pkgs/applications/accessibility/svkbd/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchurl
+, writeText
+, pkg-config
+, libX11
+, libXft
+, libXi
+, libXinerama
+, libXtst
+, layout ? null
+, conf ? null
+, patches ? [ ]
+}:
+
+stdenv.mkDerivation rec {
+  pname = "svkbd";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "https://dl.suckless.org/tools/svkbd-${version}.tar.gz";
+    sha256 = "108khx665d7dlzs04iy4g1nw3fyqpy6kd0afrwiapaibgv4xhfsk";
+  };
+
+  inherit patches;
+
+  postPatch = let
+    configFile = if lib.isDerivation conf || lib.isPath conf then
+      conf
+    else
+      writeText "config.def.h" conf;
+  in lib.optionalString (conf != null) ''
+    cp ${configFile} config.def.h
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libX11
+    libXft
+    libXi
+    libXinerama
+    libXtst
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ] ++ lib.optional (layout != null) "LAYOUT=${layout}";
+
+  meta = with lib; {
+    description = "Simple virtual keyboard";
+    homepage = "https://tools.suckless.org/x/svkbd/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25656,6 +25656,8 @@ in
 
   sunvox = callPackage ../applications/audio/sunvox { };
 
+  svkbd = callPackage ../applications/accessibility/svkbd { };
+
   swaglyrics = callPackage ../tools/misc/swaglyrics { };
 
   swh_lv2 = callPackage ../applications/audio/swh-lv2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I thought I'd package everything needed for https://sr.ht/~mil/Sxmo/ over the course of the next few weeks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
