### PR TITLE
python3Packages.aiodiscover: init at 1.3.2

### DIFF
--- a/pkgs/development/python-modules/aiodiscover/default.nix
+++ b/pkgs/development/python-modules/aiodiscover/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, async-dns
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, ifaddr
+, pyroute2
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "aiodiscover";
+  version = "1.3.2";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "bdraco";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0qg2wm6ddsfai788chylr5ynrvakwg91q3dszz7dxzbkfdcxixj3";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "remove-entry_point.patch";
+      url = "https://github.com/bdraco/aiodiscover/commit/4c497fb7d4c8685a78209c710e92e0bd17f46bb2.patch";
+      sha256 = "0py9alhg6qdncbn6a04mrnjhs4j19kg759dv69knpqzryikcfa63";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    async-dns
+    pyroute2
+    ifaddr
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace '"pytest-runner>=5.2",' ""
+  '';
+
+  # Tests require access to /etc/resolv.conf
+  # pythonImportsCheck doesn't work as async-dns wants to create its CONFIG_DIR
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python module to discover hosts via ARP and PTR lookup";
+    homepage = "https://github.com/bdraco/aiodiscover";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/async-dns/default.nix
+++ b/pkgs/development/python-modules/async-dns/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, python
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "async-dns";
+  version = "1.1.9";
+  disabled = pythonOlder "3.6";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "gera2ld";
+    repo = "async_dns";
+    rev = "v${version}";
+    sha256 = "1z8j0s3dwcyavarhx41q75k1cmfzmwiqdh4svv3v15np26cywyag";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/gera2ld/async_dns/pull/22
+    # Can be remove for async-dns>1.1.9
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/gera2ld/async_dns/commit/25fee497aae3bde0ddf9f8804d249a27edbe607e.patch";
+      sha256 = "0w4zlppnp1a2q1wasc95ymqx3djswl32y5nw6fvz3nn8jg4gc743";
+    })
+  ];
+
+  checkPhase = ''
+    export HOME=$TMPDIR
+    # Test needs network access
+    rm tests/test_resolver.py
+    ${python.interpreter} -m unittest
+  '';
+
+  pythonImportsCheck = [ "async_dns" ];
+
+  meta = with lib; {
+    description = "Python DNS library";
+    homepage = "https://github.com/gera2ld/async_dns";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-raises/default.nix
+++ b/pkgs/development/python-modules/pytest-raises/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-raises";
+  version = "0.11";
+
+  src = fetchFromGitHub {
+    owner = "Lemmons";
+    repo = pname;
+    rev = version;
+    sha256 = "0gbb4kml2qv7flp66i73mgb4qihdaybb6c96b5dw3mhydhymcsy2";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pytest_raises" ];
+
+  meta = with lib; {
+    description = "An implementation of pytest.raises as a pytest.mark fixture";
+    homepage = "https://github.com/Lemmons/pytest-raises";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -236,6 +236,8 @@ in {
 
   aiocontextvars = callPackage ../development/python-modules/aiocontextvars { };
 
+  aiodiscover = callPackage ../development/python-modules/aiodiscover { };
+
   aiodns = callPackage ../development/python-modules/aiodns { };
 
   aioeafm = callPackage ../development/python-modules/aioeafm { };
@@ -537,6 +539,8 @@ in {
   astunparse = callPackage ../development/python-modules/astunparse { };
 
   async_generator = callPackage ../development/python-modules/async_generator { };
+
+  async-dns = callPackage ../development/python-modules/async-dns { };
 
   asyncio-dgram = callPackage ../development/python-modules/asyncio-dgram { };
 
@@ -6566,6 +6570,8 @@ in {
 
   pytest-quickcheck = self.pytestquickcheck;
   pytestquickcheck = callPackage ../development/python-modules/pytest-quickcheck { };
+
+  pytest-raises = callPackage ../development/python-modules/pytest-raises { };
 
   pytest-raisesregexp = callPackage ../development/python-modules/pytest-raisesregexp { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to discover hosts via ARP and PTR lookup

https://github.com/bdraco/aiodiscover

This will become a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
