### PR TITLE
sphinx_rtd_theme: 0.4.3 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/sphinx_rtd_theme/default.nix
+++ b/pkgs/development/python-modules/sphinx_rtd_theme/default.nix
@@ -8,16 +8,17 @@
 
 buildPythonPackage rec {
   pname = "sphinx_rtd_theme";
-  version = "0.4.3";
+  version = "0.5.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a";
+    sha256 = "19c31qhfiqbm6y7mamglrc2mc7l6n4lasb8jry01lc67l3nqk9pd";
   };
 
   propagatedBuildInputs = [ sphinx ];
 
   checkInputs = [ readthedocs-sphinx-ext pytest ];
+  CI=1;
 
   checkPhase = ''
     py.test
@@ -25,8 +26,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "ReadTheDocs.org theme for Sphinx";
-    homepage = "https://github.com/snide/sphinx_rtd_theme/";
-    license = licenses.bsd3;
+    homepage = "https://github.com/readthedocs/sphinx_rtd_theme";
+    license = licenses.mit;
     platforms = platforms.unix;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to the new version. It uses the hack mentioned in https://github.com/readthedocs/sphinx_rtd_theme/issues/1014 of setting CI=1 to avoid running npm.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
