### PR TITLE
python3Packages.async-upnp-client: 0.14.15 -> 0.16.0, python3Packages.python-didl-lite: 1.2.5 -> 1.2.6

### DIFF
--- a/pkgs/development/python-modules/async-upnp-client/default.nix
+++ b/pkgs/development/python-modules/async-upnp-client/default.nix
@@ -1,17 +1,26 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
-, voluptuous, aiohttp, async-timeout, python-didl-lite, defusedxml
-, pytestCheckHook, pytest-asyncio }:
+{ lib
+, aiohttp
+, async-timeout
+, buildPythonPackage
+, defusedxml
+, fetchFromGitHub
+, pytest-asyncio
+, pytestCheckHook
+, python-didl-lite
+, pythonOlder
+, voluptuous
+}:
 
 buildPythonPackage rec {
   pname = "async-upnp-client";
-  version = "0.14.15";
+  version = "0.16.0";
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "StevenLooman";
     repo = "async_upnp_client";
     rev = version;
-    sha256 = "1mr65msdc51wq7326z3q41x79yi9dsmcjrmyzkgj9h9vgpxdk2nw";
+    sha256 = "sha256-vgy/zn1Xm7Fm7u/YMe/nJa3tyRNKx/WHz0AHfhFaVKo=";
   };
 
   propagatedBuildInputs = [
@@ -27,8 +36,10 @@ buildPythonPackage rec {
     pytest-asyncio
   ];
 
+  pythonImportsCheck = [ "async_upnp_client" ];
+
   meta = with lib; {
-    description = "Asyncio UPnP Client library for Python/asyncio.";
+    description = "Asyncio UPnP Client library for Python";
     homepage = "https://github.com/StevenLooman/async_upnp_client";
     license = licenses.asl20;
     maintainers = with maintainers; [ hexa ];

--- a/pkgs/development/python-modules/python-didl-lite/default.nix
+++ b/pkgs/development/python-modules/python-didl-lite/default.nix
@@ -1,17 +1,21 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
 , defusedxml
-, pytest }:
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "python-didl-lite";
-  version = "1.2.5";
+  version = "1.2.6";
   disabled = pythonOlder "3.5.3";
 
   src = fetchFromGitHub {
     owner = "StevenLooman";
     repo = pname;
     rev = version;
-    sha256 = "0wm831g8k9xahw20y0461cvy6lp45sxppicxah1rg9isdc3vy3nh";
+    sha256 = "sha256-1rr26dnV5As15HeFLWEDBDYPiRDHkGfYOYFhSJi7iyU=";
   };
 
   propagatedBuildInputs = [
@@ -19,12 +23,10 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    py.test
-  '';
+  pythonImportsCheck = [ "didl_lite" ];
 
   meta = with lib; {
     description = "DIDL-Lite (Digital Item Declaration Language) tools for Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.16.0

Change log: https://github.com/StevenLooman/async_upnp_client/blob/development/CHANGES.rst

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
