### PR TITLE
python3Packages.pylitterbot: 2021.2.5 -> 2021.3.1

### DIFF
--- a/pkgs/development/python-modules/pylitterbot/default.nix
+++ b/pkgs/development/python-modules/pylitterbot/default.nix
@@ -3,28 +3,35 @@
 , buildPythonPackage
 , fetchFromGitHub
 , httpx
+, pytest-asyncio
+, pytestCheckHook
 , pythonOlder
+, pytz
 }:
 
 buildPythonPackage rec {
   pname = "pylitterbot";
-  version = "2021.2.5";
+  version = "2021.3.1";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "natekspencer";
     repo = pname;
     rev = version;
-    sha256 = "0705bxm0rlpgwg8my7z5pp6y362bs2j53zy1yslha0ya6cgx37g8";
+    sha256 = "sha256-w2iyzCYoma8zQsXGIQnpgijDHNqmlvCnbeyF7PmLz9c=";
   };
 
   propagatedBuildInputs = [
     authlib
     httpx
+    pytz
   ];
 
-  # Project has no tests
-  doCheck = false;
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
   pythonImportsCheck = [ "pylitterbot" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2021.3.1

Change log: https://github.com/natekspencer/pylitterbot/releases/tag/2021.3.1

Tests are executed..

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
