### PR TITLE
num-utils: init at 0.5

### DIFF
--- a/pkgs/tools/text/num-utils/default.nix
+++ b/pkgs/tools/text/num-utils/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchurl, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "num-utils";
+  version = "0.5";
+
+  src = fetchurl {
+    url = "https://suso.suso.org/programs/num-utils/downloads/num-utils-${version}.tar.gz";
+    sha256 = "0kn6yskjww2agcqvas5l2xp55mp4njdxqkdicchlji3qzih2fn83";
+  };
+
+  buildInputs = [ perl ];
+
+  patchPhase = ''
+    substituteInPlace Makefile --replace "-o 0 -g 0" "" --replace "\$(RPMDIR)" ""
+  '';
+  makeFlags = [
+    "TOPDIR=${placeholder "out"}"
+    "PERL=${perl}/bin/perl"
+  ];
+
+  meta = with lib; {
+    description = "Programs for dealing with numbers from the command line";
+    homepage = "https://suso.suso.org/xulu/Num-utils";
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+    maintainers = [ maintainers.catern ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2656,6 +2656,8 @@ in
 
   numworks-udev-rules = callPackage ../os-specific/linux/numworks-udev-rules { };
 
+  num-utils = callPackage ../tools/text/num-utils { };
+
   iio-sensor-proxy = callPackage ../os-specific/linux/iio-sensor-proxy { };
 
   ipvsadm = callPackage ../os-specific/linux/ipvsadm { };


### PR DESCRIPTION
###### Motivation for this change
num-utils is widely packaged in other distros

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
