### PR TITLE
hover: 0.46.2 -> 0.46.3

### DIFF
--- a/pkgs/development/tools/hover/default.nix
+++ b/pkgs/development/tools/hover/default.nix
@@ -18,7 +18,7 @@
 
 let
   pname = "hover";
-  version = "0.46.2";
+  version = "0.46.3";
 
   libs = with xorg; [
     libX11.dev
@@ -46,13 +46,13 @@ let
 
     subPackages = [ "." ];
 
-    vendorSha256 = "0hdh4vwzvwlarjzg6pv9dp665r9px9yplfjpgyyfjyy5b9sxl795";
+    vendorSha256 = "sha256-qTBGmONlcFJcN+9bMZbVY+6kOQ97JmJWWvgmNeDWBL0=";
 
     src = fetchFromGitHub {
       rev = "v${version}";
       owner = "go-flutter-desktop";
       repo = pname;
-      sha256 = "1gmsv7hmj7zzfwbz50az3kvgzqvj0jn8i2pv7sjyl9dx1bavi5g3";
+      sha256 = "sha256-0qzbRzpqoZcAt3k52+omqZ3Fq1KdS++wPpQkBkG1p6o=";
     };
 
     nativeBuildInputs = [ addOpenGLRunpath makeWrapper ];

--- a/pkgs/development/tools/hover/fix-assets-path.patch
+++ b/pkgs/development/tools/hover/fix-assets-path.patch
@@ -53,7 +53,7 @@ index cb75563..3822e80 100644
 -func ExecuteTemplateFromAssetsBox(boxed, to string, assetsBox *rice.Box, templateData interface{}) {
 -	templateString, err := assetsBox.String(boxed)
 +func ExecuteTemplateFromAssetsBox(boxed, to string, assetsBox string, templateData interface{}) {
-+	templateString, err := ioutil.ReadFile(boxed + "/" + boxed)
++	templateString, err := ioutil.ReadFile(assetsBox + "/" + boxed)
  	if err != nil {
  		log.Errorf("Failed to find template file: %v\n", err)
  		os.Exit(1)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/go-flutter-desktop/hover/releases/tag/v0.46.3

Also fix `hover init` command failing with the following error:

```
hover: Failed to find template file: open app/hover.yaml.tmpl/app/hover.yaml.tmpl: no such file or directory
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
