### PR TITLE
xorg.libXres: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1002,11 +1002,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   libXres = callPackage ({ stdenv, pkg-config, fetchurl, xorgproto, libX11, libXext }: stdenv.mkDerivation {
-    name = "libXres-1.2.0";
+    name = "libXres-1.2.1";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/lib/libXres-1.2.0.tar.bz2";
-      sha256 = "1m0jr0lbz9ixpp9ihk68349q0i7ry2379lnfzdy4mrl86ijc2xgz";
+      url = "mirror://xorg/individual/lib/libXres-1.2.1.tar.bz2";
+      sha256 = "049b7dk6hx47161hg47ryjrm6pwsp27r5pby05b0wqb1pcggprmn";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -198,7 +198,7 @@ mirror://xorg/individual/lib/libXpm-3.5.13.tar.bz2
 mirror://xorg/individual/lib/libXpresent-1.0.0.tar.bz2
 mirror://xorg/individual/lib/libXrandr-1.5.2.tar.bz2
 mirror://xorg/individual/lib/libXrender-0.9.10.tar.bz2
-mirror://xorg/individual/lib/libXres-1.2.0.tar.bz2
+mirror://xorg/individual/lib/libXres-1.2.1.tar.bz2
 mirror://xorg/individual/lib/libXScrnSaver-1.2.3.tar.bz2
 mirror://xorg/individual/lib/libxshmfence-1.3.tar.bz2
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-March/003078.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).