### PR TITLE
nixos/moodle-dl: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -710,6 +710,7 @@
   ./services/networking/miniupnpd.nix
   ./services/networking/mosquitto.nix
   ./services/networking/monero.nix
+  ./services/networking/moodle-dl.nix
   ./services/networking/morty.nix
   ./services/networking/miredo.nix
   ./services/networking/mstpd.nix

--- a/nixos/modules/services/networking/moodle-dl.nix
+++ b/nixos/modules/services/networking/moodle-dl.nix
@@ -19,6 +19,14 @@ in {
         '';
       };
 
+      notifyOnly = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Whether to notify about changes without downloading any files.
+        '';
+      };
+
       startAt = mkOption {
         type = with types; either str (listOf str);
         description = "When to run moodle-dl. See systemd.time(7) for the format.";
@@ -61,7 +69,7 @@ in {
           User = config.users.users.moodle-dl.name;
           Group = config.users.groups.moodle-dl.name;
           WorkingDirectory = cfg.directory;
-          ExecStart = "${cfg.package}/bin/moodle-dl";
+          ExecStart = "${cfg.package}/bin/moodle-dl ${lib.optionalString cfg.notifyOnly "--without-downloading-files"}";
           ExecStartPre = "${pkgs.coreutils}/bin/ln -sfn ${toString moodle-dl-json} ${cfg.directory}/config.json";
         }
         (mkIf (cfg.directory == stateDirectoryDefault) { StateDirectory = "moodle-dl"; })

--- a/nixos/modules/services/networking/moodle-dl.nix
+++ b/nixos/modules/services/networking/moodle-dl.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.moodle-dl;
+  json = pkgs.formats.json {};
+  moodle-dl-json = json.generate "moodle-dl.json" cfg.settings;
+  stateDirectoryDefault = "/var/lib/moodle-dl";
+in {
+  options = {
+    services.moodle-dl = {
+      enable = mkEnableOption "moodle-dl, a Moodle downloader";
+
+      settings = mkOption {
+        default = {};
+        type = json.type;
+        description = ''
+          Configuration for moodle-dl. For a full example, see
+          <link xlink:href="https://github.com/C0D3D3V/Moodle-Downloader-2/wiki/Config.json"/>.
+        '';
+      };
+
+      startAt = mkOption {
+        type = with types; either str (listOf str);
+        description = "When to run moodle-dl. See systemd.time(7) for the format.";
+      };
+
+      directory = mkOption {
+        default = stateDirectoryDefault;
+        type = types.path;
+        description = ''
+          The path moodle-dl should download course files to. If left
+          as the default value this directory will automatically be created before
+          moodle-dl runs, otherwise the sysadmin is responsible for ensuring
+          the directory exists with appropriate ownership and permissions.
+        '';
+      };
+
+      package = mkOption {
+        default = pkgs.moodle-dl;
+        type = types.package;
+        description = "The moodle-dl package to use.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    users.users.moodle-dl = {
+      isSystemUser = true;
+      home = cfg.directory;
+    };
+
+    users.groups.moodle-dl = {};
+
+    systemd.services.moodle-dl = {
+      description = "A Moodle downloader that downloads course content";
+      wants = [ "network-online.target" ];
+      serviceConfig = mkMerge [
+        {
+          Type = "oneshot";
+          User = config.users.users.moodle-dl.name;
+          Group = config.users.groups.moodle-dl.name;
+          WorkingDirectory = cfg.directory;
+          ExecStart = "${cfg.package}/bin/moodle-dl";
+          ExecStartPre = "${pkgs.coreutils}/bin/ln -sfn ${toString moodle-dl-json} ${cfg.directory}/config.json";
+        }
+        (mkIf (cfg.directory == stateDirectoryDefault) { StateDirectory = "moodle-dl"; })
+      ];
+      inherit (cfg) startAt;
+    };
+  };
+
+  meta.maintainers = [ maintainers.kmein ];
+}


### PR DESCRIPTION
###### Motivation for this change
This module was missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
