### PR TITLE
python3Packages.pymodbus: 2.4.0 -> 2.5.1

### DIFF
--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -1,12 +1,15 @@
 { lib
+, aiohttp
 , asynctest
 , buildPythonPackage
+, click
 , fetchFromGitHub
 , mock
+, prompt_toolkit
+, pygments
 , pyserial
 , pyserial-asyncio
 , pytestCheckHook
-, pythonOlder
 , redis
 , sqlalchemy
 , tornado
@@ -15,17 +18,21 @@
 
 buildPythonPackage rec {
   pname = "pymodbus";
-  version = "2.4.0";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
     owner = "riptideio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0x0dv02shcc2yxxm9kvcbhip111sna74dvcfssxdzzy967vnq76v";
+    sha256 = "sha256-b85jfBZfMZtqtmID+tGBgOe9o0BbmBH83UV71lYAI5c=";
   };
 
   # Twisted asynchronous version is not supported due to a missing dependency
   propagatedBuildInputs = [
+    aiohttp
+    click
+    prompt_toolkit
+    pygments
     pyserial
     pyserial-asyncio
     tornado
@@ -34,11 +41,9 @@ buildPythonPackage rec {
   checkInputs = [
     asynctest
     mock
-    pyserial-asyncio
     pytestCheckHook
     redis
     sqlalchemy
-    tornado
     twisted
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.5.1

CHange log: https://github.com/riptideio/pymodbus/releases/tag/v2.5.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
