### PR TITLE
python3Packages.accuweather: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/development/python-modules/accuweather/default.nix
+++ b/pkgs/development/python-modules/accuweather/default.nix
@@ -1,47 +1,48 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, pythonOlder
-, pytestrunner
 , aiohttp
 , aioresponses
-, pytestCheckHook
-, pytestcov
+, buildPythonPackage
+, fetchFromGitHub
 , pytest-asyncio
+, pytest-error-for-skips
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "accuweather";
-  version = "0.1.0";
-
+  version = "0.1.1";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = pname;
     rev = version;
-    sha256 = "0jp2x7fgg1shgr1fx296rni00lmjjmjgg141giljzizgd04dwgy3";
+    sha256 = "sha256-fjOwa13hxY8/gCM6TCAFWVmEY1oZyqKyc6o3OSsxHpY=";
   };
 
   postPatch = ''
-    # we don't have pytest-error-for-skips packaged
-    substituteInPlace pytest.ini --replace "--error-for-skips" ""
+    substituteInPlace setup.py \
+      --replace "pytest-runner" ""
+    substituteInPlace pytest.ini \
+      --replace "--cov --cov-report term-missing" ""
   '';
 
-  nativeBuildInputs = [ pytestrunner ];
-
-  propagatedBuildInputs = [ aiohttp ];
+  propagatedBuildInputs = [
+    aiohttp
+  ];
 
   checkInputs = [
     aioresponses
-    pytestCheckHook
-    pytestcov
     pytest-asyncio
+    pytest-error-for-skips
+    pytestCheckHook
   ];
 
+  pythonImportsCheck = [ "accuweather" ];
+
   meta = with lib; {
-    description =
-      "Python wrapper for getting weather data from AccuWeather servers.";
+    description = "Python wrapper for getting weather data from AccuWeather servers";
     homepage = "https://github.com/bieniu/accuweather";
     license = licenses.asl20;
     maintainers = with maintainers; [ jamiemagee ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -176,6 +176,7 @@ in with py.pkgs; buildPythonApplication rec {
   # services. Before adding new components to this list make sure we have all
   # its dependencies packaged and listed in ./component-packages.nix.
   componentTests = [
+    "accuweather"
     "alert"
     "api"
     "auth"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.1.1

Change log: https://github.com/bieniu/accuweather/releases/tag/0.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
