### PR TITLE
nixos/dhcpd: make hard-coded options configurable

### DIFF
--- a/nixos/modules/services/networking/dhcpd.nix
+++ b/nixos/modules/services/networking/dhcpd.nix
@@ -9,11 +9,11 @@ let
 
   writeConfig = cfg: pkgs.writeText "dhcpd.conf"
     ''
-      default-lease-time 600;
-      max-lease-time 7200;
+      default-lease-time ${toString cfg.defaultLeaseTime};
+      max-lease-time ${toString cfg.maxLeaseTime};
       ${optionalString (!cfg.authoritative) "not "}authoritative;
-      ddns-update-style interim;
-      log-facility local1; # see dhcpd.nix
+      ddns-update-style ${cfg.ddnsUpdateStyle};
+      log-facility ${cfg.logFacility}; # see dhcpd.nix
 
       ${cfg.extraConfig}
 
@@ -186,6 +186,67 @@ let
       '';
     };
 
+    ddnsUpdateStyle = mkOption {
+      type = types.enum [ "ad-hoc" "interim" "none" ];
+      default = "interim";
+      description = ''
+        The ddns-update-style statement is only meaningful in the outer scope
+        it is evaluated once after reading the dhcpd.conf file, rather than each
+        time a client is assigned an IP address, so there is no way to use
+        different DNS update styles for different clients.
+      '';
+    };
+
+    defaultLeaseTime = mkOption {
+      type = types.int;
+      default = 600;
+      description = ''
+        Time should be the length in seconds that will be assigned to a lease
+        if the client requesting the lease does not ask for a specific expiration time.
+      '';
+    };
+
+    maxLeaseTime = mkOption {
+      type = types.int;
+      default = 7200;
+      description = ''
+        Time should be the maximum length in seconds that will be assigned to a lease.
+      '';
+    };
+
+    logFacility = mkOption {
+      type = types.enum [
+        "auth"
+        "authpriv"
+        "cron"
+        "daemon"
+        "ftp"
+        "kern"
+        "lpr"
+        "mail"
+        "mark"
+        "news"
+        "ntp"
+        "security"
+        "syslog"
+        "user"
+        "uucp"
+        "lo‐cal0"
+        "local0"
+        "local1"
+        "local2"
+        "local3"
+        "local4"
+        "local5"
+        "local6"
+        "local7"
+      ];
+      default = "local1";
+      description = ''
+        This statement causes the DHCP server to do all of its logging on the
+        specified log facility once the dhcpd.conf file has been read.
+      '';
+    };
   };
 
 in

--- a/nixos/modules/services/networking/dhcpd.nix
+++ b/nixos/modules/services/networking/dhcpd.nix
@@ -7,8 +7,8 @@ let
   cfg4 = config.services.dhcpd4;
   cfg6 = config.services.dhcpd6;
 
-  writeConfig = cfg: pkgs.writeText "dhcpd.conf"
-    ''
+  writeConfig = cfg:
+    pkgs.writeText "dhcpd.conf" ''
       default-lease-time ${toString cfg.defaultLeaseTime};
       max-lease-time ${toString cfg.maxLeaseTime};
       ${optionalString (!cfg.authoritative) "not "}authoritative;
@@ -17,39 +17,45 @@ let
 
       ${cfg.extraConfig}
 
-      ${lib.concatMapStrings
-          (machine: ''
-            host ${machine.hostName} {
-              hardware ethernet ${machine.ethernetAddress};
-              fixed-address ${machine.ipAddress};
-            }
-          '')
-          cfg.machines
-      }
+      ${lib.concatMapStrings (machine: ''
+        host ${machine.hostName} {
+          hardware ethernet ${machine.ethernetAddress};
+          fixed-address ${machine.ipAddress};
+        }
+      '') cfg.machines}
     '';
 
-  dhcpdService = postfix: cfg: optionalAttrs cfg.enable {
-    "dhcpd${postfix}" = {
-      description = "DHCPv${postfix} server";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+  dhcpdService = postfix: cfg:
+    optionalAttrs cfg.enable {
+      "dhcpd${postfix}" = {
+        description = "DHCPv${postfix} server";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
 
-      preStart = ''
-        mkdir -m 755 -p ${cfg.stateDir}
-        chown dhcpd:nogroup ${cfg.stateDir}
-        touch ${cfg.stateDir}/dhcpd.leases
-      '';
+        preStart = ''
+          mkdir -m 755 -p ${cfg.stateDir}
+          chown dhcpd:nogroup ${cfg.stateDir}
+          touch ${cfg.stateDir}/dhcpd.leases
+        '';
 
-      serviceConfig =
-        let
-          configFile = if cfg.configFile != null then cfg.configFile else writeConfig cfg;
-          args = [ "@${pkgs.dhcp}/sbin/dhcpd" "dhcpd${postfix}" "-${postfix}"
-                   "-pf" "/run/dhcpd${postfix}/dhcpd.pid"
-                   "-cf" "${configFile}"
-                   "-lf" "${cfg.stateDir}/dhcpd.leases"
-                   "-user" "dhcpd" "-group" "nogroup"
-                 ] ++ cfg.extraFlags
-                   ++ cfg.interfaces;
+        serviceConfig = let
+          configFile =
+            if cfg.configFile != null then cfg.configFile else writeConfig cfg;
+          args = [
+            "@${pkgs.dhcp}/sbin/dhcpd"
+            "dhcpd${postfix}"
+            "-${postfix}"
+            "-pf"
+            "/run/dhcpd${postfix}/dhcpd.pid"
+            "-cf"
+            "${configFile}"
+            "-lf"
+            "${cfg.stateDir}/dhcpd.leases"
+            "-user"
+            "dhcpd"
+            "-group"
+            "nogroup"
+          ] ++ cfg.extraFlags ++ cfg.interfaces;
 
         in {
           ExecStart = concatMapStringsSep " " escapeShellArg args;
@@ -58,8 +64,8 @@ let
           RuntimeDirectory = [ "dhcpd${postfix}" ];
           PIDFile = "/run/dhcpd${postfix}/dhcpd.pid";
         };
+      };
     };
-  };
 
   machineOpts = { ... }: {
 
@@ -134,7 +140,7 @@ let
 
     extraFlags = mkOption {
       type = types.listOf types.str;
-      default = [];
+      default = [ ];
       description = ''
         Additional command line flags to be passed to the dhcpd daemon.
       '';
@@ -151,7 +157,7 @@ let
 
     interfaces = mkOption {
       type = types.listOf types.str;
-      default = ["eth0"];
+      default = [ "eth0" ];
       description = ''
         The interfaces on which the DHCP server should listen.
       '';
@@ -159,13 +165,15 @@ let
 
     machines = mkOption {
       type = with types; listOf (submodule machineOpts);
-      default = [];
+      default = [ ];
       example = [
-        { hostName = "foo";
+        {
+          hostName = "foo";
           ethernetAddress = "00:16:76:9a:32:1d";
           ipAddress = "192.168.1.10";
         }
-        { hostName = "bar";
+        {
+          hostName = "bar";
           ethernetAddress = "00:19:d1:1d:c4:9a";
           ipAddress = "192.168.1.11";
         }
@@ -249,13 +257,10 @@ let
     };
   };
 
-in
+in {
 
-{
-
-  imports = [
-    (mkRenamedOptionModule [ "services" "dhcpd" ] [ "services" "dhcpd4" ])
-  ];
+  imports =
+    [ (mkRenamedOptionModule [ "services" "dhcpd" ] [ "services" "dhcpd4" ]) ];
 
   ###### interface
 
@@ -265,7 +270,6 @@ in
     services.dhcpd6 = dhcpConfig "6";
 
   };
-
 
   ###### implementation
 


### PR DESCRIPTION
###### Motivation for this change

I need to change hard-coded dhcpd options default-lease-time, max-lease-time, ddns-update-style (without using configFile) and I think it can be useful for someone else. Also I ran nixfmt on dhcpd.nix and if it's a bad practice i'll revert these changes.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
