### PR TITLE
Vector: 0.12.1 -> 0.12.2

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -1,8 +1,17 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform, openssl, pkg-config, protobuf
-, Security, libiconv, rdkafka, tzdata, coreutils, CoreServices
-
-, features ?
-       ([ "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ]
+{ stdenv
+, lib
+, fetchFromGitHub
+, rustPlatform
+, openssl
+, pkg-config
+, protobuf
+, Security
+, libiconv
+, rdkafka
+, tzdata
+, coreutils
+, CoreServices
+, features ? ([ "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ]
     ++ (lib.optional stdenv.targetPlatform.isUnix "unix")
     ++ [ "sinks" "sources" "transforms" ])
 }:
@@ -12,20 +21,20 @@ rustPlatform.buildRustPackage rec {
   version = "0.12.1";
 
   src = fetchFromGitHub {
-    owner  = "timberio";
-    repo   = pname;
-    rev    = "v${version}";
+    owner = "timberio";
+    repo = pname;
+    rev = "v${version}";
     sha256 = "0sw05472znxmggckxjbrl3b8ky8nsw42xmrsb41p8z4q0aw115fd";
   };
 
   cargoSha256 = "0mfhrdqry6qrzfx5px1zqgfv5iqa186vl2yh290ibinkxy0x5fa9";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl protobuf rdkafka ]
-                ++ lib.optional stdenv.isDarwin [ Security libiconv coreutils CoreServices ];
+    ++ lib.optional stdenv.isDarwin [ Security libiconv coreutils CoreServices ];
 
   # needed for internal protobuf c wrapper library
-  PROTOC="${protobuf}/bin/protoc";
-  PROTOC_INCLUDE="${protobuf}/include";
+  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC_INCLUDE = "${protobuf}/include";
 
   cargoBuildFlags = [ "--no-default-features" "--features" (lib.concatStringsSep "," features) ];
   checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features} -- --test-threads 1";
@@ -54,8 +63,8 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "A high-performance logs, metrics, and events router";
-    homepage    = "https://github.com/timberio/vector";
-    license     = with licenses; [ asl20 ];
+    homepage = "https://github.com/timberio/vector";
+    license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ thoughtpolice happysalada ];
   };
 }

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "vector";
-  version = "0.12.1";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "timberio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0sw05472znxmggckxjbrl3b8ky8nsw42xmrsb41p8z4q0aw115fd";
+    sha256 = "sha256-LutCzpJo47wvEze7bAObRVraNhVuQFc9NQ79NzKA9CM=";
   };
 
-  cargoSha256 = "0mfhrdqry6qrzfx5px1zqgfv5iqa186vl2yh290ibinkxy0x5fa9";
+  cargoSha256 = "sha256-GU5p9DB5Bk8eQc1B/WA87grbVJVcT1ELJ0WzmRYgDzc=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl protobuf rdkafka ]
     ++ lib.optional stdenv.isDarwin [ Security libiconv coreutils CoreServices ];


### PR DESCRIPTION
###### Motivation for this change

just a version update.

I'm pleased to say that It built on my darwin hardware with no errors!

I ran the nixpkgs-fmt on the first commit, I hope that's not a problem

@thoughtpolice in case you have time

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
