### PR TITLE
packer: migrate to buildGoModule

### DIFF
--- a/pkgs/development/tools/packer/default.nix
+++ b/pkgs/development/tools/packer/default.nix
@@ -1,11 +1,8 @@
-{ lib, buildGoPackage, fetchFromGitHub, installShellFiles }:
-buildGoPackage rec {
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
   pname = "packer";
   version = "1.7.1";
-
-  goPackagePath = "github.com/hashicorp/packer";
-
-  subPackages = [ "." ];
 
   src = fetchFromGitHub {
     owner = "hashicorp";
@@ -14,12 +11,16 @@ buildGoPackage rec {
     sha256 = "sha256-PZwKvb43Xf8HaC148Xo076u3sP53nwC4fJ2X7HU0gDo=";
   };
 
+  vendorSha256 = null;
+
+  subPackages = [ "." ];
+
   buildFlagsArray = [ "-ldflags=-s -w" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
-    installShellCompletion --zsh go/src/${goPackagePath}/contrib/zsh-completion/_packer
+    installShellCompletion --zsh contrib/zsh-completion/_packer
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Maintaining upstream build compatibility - they moved to Go Modules a while back and there's no need to deviate.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
