### PR TITLE
python3Packages.zigpy: 0.32.0 -> 0.33.0

### DIFF
--- a/pkgs/development/python-modules/zigpy-deconz/default.nix
+++ b/pkgs/development/python-modules/zigpy-deconz/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "zigpy-deconz";
-  version = "0.11.1";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = pname;
     rev = version;
-    sha256 = "1p9mdsfc200iyszppcflazzfwqg4v8nqqwqsx114nip5km7a5s37";
+    sha256 = "sha256-d/yAk8owMu+J1BzlwR5mzF9HkXiE6Kc81AznvsAboy8=";
   };
 
   propagatedBuildInputs = [ pyserial pyserial-asyncio zigpy ];

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.32.0";
+  version = "0.33.0";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy";
     rev = version;
-    sha256 = "18grqx1fzh539ccar0865shgd2mnfni65rjj787cq5j5p5rn0yc7";
+    sha256 = "sha256-oEf4GnvbQ6LY4NaNFWRmnNz1TK2tMpIVUxskhU38g4w=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.33.0

Change log: https://github.com/zigpy/zigpy/releases/tag/0.33.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
