### PR TITLE
fvwm: add readline, fix man build, refactor fetch

### DIFF
--- a/pkgs/applications/window-managers/fvwm/default.nix
+++ b/pkgs/applications/window-managers/fvwm/default.nix
@@ -1,27 +1,37 @@
-{ gestures ? false
-, lib, stdenv, fetchurl, pkg-config
-, cairo, fontconfig, freetype, libXft, libXcursor, libXinerama
-, libXpm, libXt, librsvg, libpng, fribidi, perl
-, libstroke ? null
-}:
-
-assert gestures -> libstroke != null;
+{ autoreconfHook, enableGestures ? false, lib, stdenv, fetchFromGitHub
+, pkg-config, cairo, fontconfig, freetype, libXft, libXcursor, libXinerama
+, libXpm, libXt, librsvg, libpng, fribidi, perl, libstroke, readline, libxslt }:
 
 stdenv.mkDerivation rec {
   pname = "fvwm";
   version = "2.6.9";
 
-  src = fetchurl {
-    url = "https://github.com/fvwmorg/fvwm/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1bliqcnap7vb3m2rn8wvxyfhbf35h9x34s41fl4301yhrkrlrihv";
+  src = fetchFromGitHub {
+    owner = "fvwmorg";
+    repo = pname;
+    rev = version;
+    sha256 = "14jwckhikc9n4h93m00pzjs7xm2j0dcsyzv3q5vbcnknp6p4w5dh";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [
-    cairo fontconfig freetype
-    libXft libXcursor libXinerama libXpm libXt
-    librsvg libpng fribidi perl
-  ] ++ lib.optional gestures libstroke;
+    cairo
+    fontconfig
+    freetype
+    libXft
+    libXcursor
+    libXinerama
+    libXpm
+    libXt
+    librsvg
+    libpng
+    fribidi
+    perl
+    readline
+    libxslt
+  ] ++ lib.optional enableGestures libstroke;
+
+  configureFlags = [ "--enable-mandoc" "--disable-htmldoc" ];
 
   meta = {
     homepage = "http://fvwm.org";


### PR DESCRIPTION
###### Motivation for this change

The man page for fvwm (`fvwm.1`) was not present on the default build. After messing with the package, I was able to get it to install the proper man page, and fixed a few other things along the way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
