### PR TITLE
openttd: 1.10.3 -> 1.11.0

### DIFF
--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchzip, pkg-config, which, SDL2, libpng, zlib, xz, freetype, fontconfig, libxdg_basedir
+{ lib, stdenv, fetchurl, fetchzip, cmake, SDL2, libpng, zlib, xz, freetype, fontconfig, libxdg_basedir
 , withOpenGFX ? true, withOpenSFX ? true, withOpenMSX ? true
 , withFluidSynth ? true, audioDriver ? "alsa", fluidsynth, soundfont-fluid, procps
 , writeScriptBin, makeWrapper, runtimeShell
@@ -29,14 +29,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "openttd";
-  version = "1.10.3";
+  version = "1.11.0";
 
   src = fetchurl {
     url = "https://cdn.openttd.org/openttd-releases/${version}/${pname}-${version}-source.tar.xz";
-    sha256 = "0fxmfz1mm95a2x0rnzfff9wb8q57w0cvsdd0z7agdcbyakph25n1";
+    sha256 = "sha256-XmUYTgc2i6Gvpi27PjWrrubE2mcw/0vJ60RH1TNjx6g=";
   };
 
-  nativeBuildInputs = [ pkg-config which makeWrapper ];
+  nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ SDL2 libpng xz zlib freetype fontconfig libxdg_basedir ]
     ++ lib.optionals withFluidSynth [ fluidsynth soundfont-fluid ];
 
@@ -46,11 +46,7 @@ stdenv.mkDerivation rec {
     "--without-liblzo2"
   ];
 
-  makeFlags = [ "INSTALL_PERSONAL_DIR=" ];
-
   postInstall = ''
-    mv $out/games/ $out/bin
-
     ${lib.optionalString withOpenGFX ''
       cp ${opengfx}/* $out/share/games/openttd/baseset
     ''}

--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -6,18 +6,18 @@
 
 let
   opengfx = fetchzip {
-    url = "https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip";
-    sha256 = "1zg871j6kv7r0aqwca68d9kdf3smclgzan8hj76vj4fyfkykh173";
+    url = "https://cdn.openttd.org/opengfx-releases/0.6.1/opengfx-0.6.1-all.zip";
+    sha256 = "sha256-DeeIlLcmPeMZ0ju9DwXUInnQp2rWu60besDVto4+lDQ=";
   };
 
   opensfx = fetchzip {
-    url = "https://cdn.openttd.org/opensfx-releases/0.2.3/opensfx-0.2.3-all.zip";
-    sha256 = "1bb167kszdd6dqbcdjrxxwab6b7y7jilhzi3qijdhprpm5gf1lp3";
+    url = "https://cdn.openttd.org/opensfx-releases/1.0.1/opensfx-1.0.1-all.zip";
+    sha256 = "sha256-U1PIKbMZHRJ0Z9Cp2RqqCMhD1xRyudoNHAYIZyotxVk=";
   };
 
   openmsx = fetchzip {
-    url = "https://cdn.openttd.org/openmsx-releases/0.3.1/openmsx-0.3.1-all.zip";
-    sha256 = "0qnmfzz0v8vxrrvxnm7szphrlrlvhkwn3y92b4iy0b4b6yam0yd4";
+    url = "https://cdn.openttd.org/openmsx-releases/0.4.0/openmsx-0.4.0-all.zip";
+    sha256 = "sha256-Ok6W+iqi4SP7cD4HUQERrAysvVibnN7Q4/tkugffDgQ=";
   };
 
   playmidi = writeScriptBin "playmidi" ''
@@ -48,19 +48,19 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     ${lib.optionalString withOpenGFX ''
-      cp ${opengfx}/* $out/share/games/openttd/baseset
+      cp ${opengfx}/*.tar $out/share/games/openttd/baseset
     ''}
 
     mkdir -p $out/share/games/openttd/data
 
     ${lib.optionalString withOpenSFX ''
-      cp ${opensfx}/*.{obs,cat} $out/share/games/openttd/data
+      cp ${opensfx}/*.tar $out/share/games/openttd/data
     ''}
 
     mkdir $out/share/games/openttd/baseset/openmsx
 
     ${lib.optionalString withOpenMSX ''
-      cp ${openmsx}/*.{obm,mid} $out/share/games/openttd/baseset/openmsx
+      cp ${openmsx}/*.tar $out/share/games/openttd/baseset/openmsx
     ''}
 
     ${lib.optionalString withFluidSynth ''

--- a/pkgs/games/openttd/jgrpp.nix
+++ b/pkgs/games/openttd/jgrpp.nix
@@ -2,12 +2,12 @@
 
 openttd.overrideAttrs (oldAttrs: rec {
   pname = "openttd-jgrpp";
-  version = "0.34.4";
+  version = "0.40.5";
 
   src = fetchFromGitHub rec {
     owner = "JGRennison";
     repo = "OpenTTD-patches";
     rev = "jgrpp-${version}";
-    sha256 = "125mgia5hgcsn8314xyiip3z8y23rc3kdv7jczbncqlzsc75624v";
+    sha256 = "sha256-g1RmgVjefOrOVLTvFBiPEd19aLoFvB9yX/hMiKgGcGw=";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

New release, so version and hash update. Furthermore:
- The build system changed to cmake
- `INSTALL_PERSONAL_DIR` seems to have been removed a long time ago (upstream 323fb6a)
- Install now respects `CMAKE_INSTALL_BINDIR`, so don't need to move a dir anymore

I can get into a game and hear soothing train sounds.

@jcumming @fpletz 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
