### PR TITLE
sogo: 5.0.1 -> 5.1.0

### DIFF
--- a/pkgs/development/libraries/sope/default.nix
+++ b/pkgs/development/libraries/sope/default.nix
@@ -4,13 +4,13 @@ with lib;
 
 gnustep.stdenv.mkDerivation rec {
   pname = "sope";
-  version = "5.0.1";
+  version = "5.1.0";
 
   src = fetchFromGitHub {
     owner = "inverse-inc";
     repo = pname;
     rev = "SOPE-${version}";
-    sha256 = "031m8ydr4jhh29332mfbsw0i5d0cjfqfyfs55jm832dlmv4447gb";
+    sha256 = "0aw4qpl5wp3hrglyfqpm6bbl4015a5h3hv24dc0z010avdzszjmh";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/servers/web-apps/sogo/default.nix
+++ b/pkgs/servers/web-apps/sogo/default.nix
@@ -2,13 +2,13 @@
 , openssl_1_1, openldap, sope, libmemcached, curl, libsodium, libzip, pkg-config }:
 with lib; gnustep.stdenv.mkDerivation rec {
   pname = "SOGo";
-  version = "5.0.1";
+  version = "5.1.0";
 
   src = fetchFromGitHub {
     owner = "inverse-inc";
     repo = pname;
     rev = "SOGo-${version}";
-    sha256 = "145hdlwnqds5zmpxbh4yainsbv5vy99ji93d6pl7xkbqwncfi80i";
+    sha256 = "085fzbc1f8bbffahz1mxgb0ggxm6if5bz50waagnvf04nfwnw6wh";
   };
 
   nativeBuildInputs = [ gnustep.make makeWrapper python3 ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s): `sogo.nix`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).