### PR TITLE
chkrootkit: add missing binutils

### DIFF
--- a/pkgs/tools/security/chkrootkit/default.nix
+++ b/pkgs/tools/security/chkrootkit/default.nix
@@ -1,24 +1,30 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, makeWrapper, binutils-unwrapped }:
 
 stdenv.mkDerivation rec {
-  name = "chkrootkit-0.54";
+  pname = "chkrootkit";
+  version = "0.54";
 
   src = fetchurl {
-    url = "ftp://ftp.pangeia.com.br/pub/seg/pac/${name}.tar.gz";
-    sha256 = "sha256-FUySaSH1PbYHKKfLyXyohli2lMFLfSiO/jg+CEmRVgc=";
+    url = "ftp://ftp.pangeia.com.br/pub/seg/pac/${pname}-${version}.tar.gz";
+    sha256 = "01snj54hhgiqzs72hzabq6abcn46m1yckjx7503vcggm45lr4k0m";
   };
 
   # TODO: a lazy work-around for linux build failure ...
   makeFlags = [ "STATIC=" ];
 
-   postPatch = ''
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
     substituteInPlace chkrootkit \
       --replace " ./" " $out/bin/"
-   '';
+  '';
 
   installPhase = ''
     mkdir -p $out/sbin
     cp check_wtmpx chkdirs chklastlog chkproc chkrootkit chkutmp chkwtmp ifpromisc strings-static $out/sbin
+
+    wrapProgram $out/sbin/chkrootkit \
+      --prefix PATH : "${lib.makeBinPath [ binutils-unwrapped ]}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Wrappe with `binutils` so that package works. Fixes error message `chkrootkit: can't find 'strings'.`

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
