### PR TITLE
spotify-qt: init at v3.5

### DIFF
--- a/pkgs/applications/audio/spotify-qt/default.nix
+++ b/pkgs/applications/audio/spotify-qt/default.nix
@@ -31,6 +31,6 @@ mkDerivation rec {
     homepage = "https://github.com/kraxarn/spotify-qt";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ kiyengar ];
-    platforms = with platforms; unix;
+    platforms = platforms.unix;
    };
 }

--- a/pkgs/applications/audio/spotify-qt/default.nix
+++ b/pkgs/applications/audio/spotify-qt/default.nix
@@ -1,0 +1,36 @@
+{ fetchFromGitHub
+, lib
+, cmake
+, mkDerivation
+, libxcb
+, qtbase
+, qtsvg
+}:
+
+mkDerivation rec {
+   pname = "spotify-qt";
+   version = "3.5";
+
+   src = fetchFromGitHub {
+      owner = "kraxarn";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "1bgd0q4sbbww3lbrx2zwgaz0sl7qh195s4kvgsq16gv7ij82bskn";
+   };
+
+   buildInputs = [ libxcb qtbase qtsvg ];
+
+   nativeBuildInputs = [ cmake ];
+
+   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_INSTALL_PREFIX=" ];
+
+   installFlags = [ "DESTDIR=$(out)" ];
+
+   meta = with lib; {
+    description = "Lightweight unofficial Spotify client using Qt";
+    homepage = "https://github.com/kraxarn/spotify-qt";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ kiyengar ];
+    platforms = with platforms; unix;
+   };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25479,6 +25479,8 @@ in
 
   split2flac = callPackage ../applications/audio/split2flac { };
 
+  spotify-qt = libsForQt5.callPackage ../applications/audio/spotify-qt { };
+
   spotify-tui = callPackage ../applications/audio/spotify-tui {
     inherit (darwin.apple_sdk.frameworks) AppKit Security;
   };


### PR DESCRIPTION
Resolves #114785

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
