### PR TITLE
sc-im: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/applications/misc/sc-im/default.nix
+++ b/pkgs/applications/misc/sc-im/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , makeWrapper
 , pkg-config
 , which
@@ -15,30 +14,16 @@
 
 stdenv.mkDerivation rec {
   pname = "sc-im";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "andmarti1424";
     repo = "sc-im";
     rev = "v${version}";
-    sha256 = "sha256-/eG2BdkyfEGoSzPu6jT+Bn1RZTGT1D3etGj1tYchm1M=";
+    sha256 = "sha256-AIYa3d1ml1f5GNLKijeFPX+UabgEqzdXiP60BGvBPsQ=";
   };
 
   sourceRoot = "${src.name}/src";
-
-  # make default colors readable on dark background
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/andmarti1424/sc-im/commit/78d2fdaaf2c578691e68fb5bd773803cb967ddba.patch";
-      sha256 = "09716zsqa9qdsj2qpkji8wlzsmp9gl66ggvrg7lmrwwnvli2zn2w";
-    })
-    (fetchpatch {
-      url = "https://github.com/andmarti1424/sc-im/commit/f29d6605c8170febcec0dea7bda9613bee3b7011.patch";
-      sha256 = "1zs1sb23g0k6lig4d0qdzq1wdhcdzl424ch567zyjl191lyhsjyg";
-    })
-  ];
-
-  patchFlags = [ "-p2" ];
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
