### PR TITLE
dhcpcd: Fix patch url

### DIFF
--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://roy.marples.name/git/dhcpcd/patch/?id=114870290a8d3d696bc4049c32eef3eed03d6070";
-      sha256 = "0kzpwjh2gzvl5lvlnw6lis610p67nassk3apns68ga2pyxlky8qb";
+      sha256 = "sha256-h1gg1QDi0pL0Qj+ld8Rb2trbsFmBI3XPxfX+/T5d0nA=";
     })
   ];
 

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -24,8 +24,9 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://roy.marples.name/git/dhcpcd/patch/?id=114870290a8d3d696bc4049c32eef3eed03d6070";
-      sha256 = "sha256-h1gg1QDi0pL0Qj+ld8Rb2trbsFmBI3XPxfX+/T5d0nA=";
+      name = "?id=114870290a8d3d696bc4049c32eef3eed03d6070";
+      url = "https://roy.marples.name/git/dhcpcd/commitdiff_plain/114870290a8d3d696bc4049c32eef3eed03d6070";
+      sha256 = "0kzpwjh2gzvl5lvlnw6lis610p67nassk3apns68ga2pyxlky8qb";
     })
   ];
 

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://roy.marples.name/cgit/dhcpcd.git/patch/?id=114870290a8d3d696bc4049c32eef3eed03d6070";
+      url = "https://roy.marples.name/git/dhcpcd/patch/?id=114870290a8d3d696bc4049c32eef3eed03d6070";
       sha256 = "0kzpwjh2gzvl5lvlnw6lis610p67nassk3apns68ga2pyxlky8qb";
     })
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix #118253. Update a link to dhcpch patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
