### PR TITLE
pam-krb5: 4.9 -> 4.10

### DIFF
--- a/pkgs/os-specific/linux/pam_krb5/default.nix
+++ b/pkgs/os-specific/linux/pam_krb5/default.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl, pam, kerberos }:
 
 stdenv.mkDerivation rec {
-  name = "pam-krb5-4.9";
+  name = "pam-krb5-4.10";
 
   src = fetchurl {
     url = "https://archives.eyrie.org/software/kerberos/${name}.tar.gz";
-    sha256 = "0kzz6mjkzw571pkv684vyczhl874f6p7lih3dj7s764gxdxnv4y5";
+    sha256 = "09wzxd5zrj5bzqpb01qf148npj5k8hmd2bx2ij1qsy40hdxqyq79";
   };
 
   buildInputs = [ pam kerberos ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix #118254.

Change pam-krb5 version to 4.10 as
https://archives.eyrie.org/software/kerberos/pam-krb5-4.9.tar.gz
doesn't exists anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
