### PR TITLE
rastertosag-gdi (cups driver): init at 0.1

### DIFF
--- a/pkgs/misc/cups/drivers/cups-drv-rastertosag-gdi/default.nix
+++ b/pkgs/misc/cups/drivers/cups-drv-rastertosag-gdi/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, fetchzip
+, fetchpatch
+, cups
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "rastertosag-gdi";
+  version = "0.1";
+  src = fetchzip {
+    url = "https://www.openprinting.org/download/printing/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1ldplpv497j8vhw24sksg3fiw8c5pqr0wajajh7p5xpvb6zlcmvw";
+  };
+  patches = [
+    # port to python 3
+    ( fetchpatch {
+      url = "https://sources.debian.org/data/main/r/${pname}/0.1-7/debian/patches/0001-${pname}-python3.patch";
+      sha256 = "1l3xbrs67025595k9ba5794q3s74anizpbxwsshcfhmbrzd9h8hg";
+    })
+  ];
+  format = "other";
+  nativeBuildInputs = [ (lib.getBin cups) ];
+  # The source image also brings pre-built ppd files,
+  # be we prefer to generate from source where possible, so
+  # the following line generates ppd files from the drv file.
+  postBuild = ''
+    ppdc -v -d . -I "${cups}/share/cups/ppdc" rastertosag-gdi.drv
+  '';
+  installPhase = ''
+    runHook preInstall
+    install -vDm 0644 -t "${placeholder "out"}/share/cups/model/rastertosag-gdi/" *.ppd
+    install -vDm 0755 -t "${placeholder "out"}/bin/" rastertosag-gdi
+    install -vd "${placeholder "out"}/lib/cups/filter/"
+    ln -vst "${placeholder "out"}/lib/cups/filter/" "${placeholder "out"}/bin/rastertosag-gdi"
+    runHook postInstall
+  '';
+  meta = {
+    description = "CUPS driver for Ricoh Aficio SP 1000S and SP 1100S printers";
+    downloadPage = "https://www.openprinting.org/download/printing/rastertosag-gdi/";
+    homepage = "https://www.openprinting.org/driver/rastertosag-gdi/";
+    license = lib.licenses.free;  # just "GPL", according to README
+    maintainers = [ lib.maintainers.yarny ];
+    longDescription = ''
+      This package brings CUPS raster filter
+      for Ricoh Aficio SP 1000S and SP 1100S.
+      In contrast to other Ricoh laser printers,
+      they use the proprietary SAG-GDI raster format by
+      Sagem Communication and do not understand PCL or PostScript.
+      Therefore they do not work with Ricoh's PPD files.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29137,6 +29137,8 @@ in
 
   cups-brother-hll2340dw = pkgsi686Linux.callPackage  ../misc/cups/drivers/hll2340dw { };
 
+  cups-drv-rastertosag-gdi = callPackage ../misc/cups/drivers/cups-drv-rastertosag-gdi { };
+
   # this driver ships with pre-compiled 32-bit binary libraries
   cnijfilter_2_80 = pkgsi686Linux.callPackage ../misc/cups/drivers/cnijfilter_2_80 { };
 


### PR DESCRIPTION
###### Motivation for this change

Some Ricoh printers use the proprietary sag-gdi format and can't handle other, more common formats.  This commit brings a filter for cups that generates the sag-gdi format.

The latest version 0.1 is dated 2011.  So updates are unlikely.

The filter is written for Python 2.  To avoid new reverse dependencies on Python 2, the commit employs a patch from Debian that migrates the code to Python 3.

The README file just states "GPL" as license.  It is unclear whether that refers to the first version or to the "current version" in the year of the copyright (would be 3), and whether newer versions would be included.  The commit picks the nixpkgs `free` license as this seems to be the most general license covering all possible GPL combinations.  At least, `free` should permit Hydra to build the package.

The source tarball brings pdd files, but also a drv file that can be used to generate those ppd files.  Some discussions on Discource left me with the impression that building from source is generally preferable over using prebuilt files.  Hence the commit calls cups' `ppdc` to build ppd files from the drv file.

Here is a documentation of the sag-gdi format (with expired TLS cert, unfortunatelly): https://www.undocprint.org/formats/page_description_languages/sagem-gdi

There is no namespace for cups drivers (unlike the `xorg` attribute set, as far as I can tell), so I guess it's a good idea to prefix the package's attribute name with `cups-drv-`.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS: x86-64
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

More:

Tested successfully with a Philips 6050W 4-in-1 printer (connected via USB, with ppd file `rsp1000s.ppd`).  The printer identifes as `Sagem` in the USB device listing.  While the computer that is connected to the printer runs NixOS 20.09, for this test, the driver itself was build with the nixpkgs version the commit is based on (nixos-unstable commit ad47284f8b01f587e24a4f14e0f93126d8ebecda).  So the Python interpreter for the script and the `ppdc` binary that created the ppd files for this test all come from a recent nixos-unstable branch.