### PR TITLE
Support more FUSE packages on Darwin

### DIFF
--- a/doc/builders/packages/fuse.section.md
+++ b/doc/builders/packages/fuse.section.md
@@ -17,3 +17,29 @@ following, it's a likely sign that you need to have macFUSE installed.
     Referenced from: /nix/store/w8bi72bssv0bnxhwfw3xr1mvn7myf37x-sshfs-fuse-2.10/bin/sshfs
     Reason: image not found
     [1]    92299 abort      /nix/store/w8bi72bssv0bnxhwfw3xr1mvn7myf37x-sshfs-fuse-2.10/bin/sshfs
+
+Package maintainers may often encounter the following error when building FUSE
+packages on macOS:
+
+    checking for fuse.h... no
+    configure: error: No fuse.h found.
+
+This happens on autoconf based projects that uses `AC_CHECK_HEADERS` or
+`AC_CHECK_LIBS` to detect libfuse, and will occur even when the `fuse` package
+is included in `buildInputs`. It happens because libfuse headers throw an error
+on macOS if the `FUSE_USE_VERSION` macro is undefined. Many proejcts do define
+`FUSE_USE_VERSION`, but only inside C source files. This results in the above
+error at configure time because the configure script would attempt to compile
+sample FUSE programs without defining `FUSE_USE_VERSION`.
+
+There are two possible solutions for this problem in Nixpkgs:
+
+1. Pass `FUSE_USE_VERSION` to the configure script by adding
+   `CFLAGS=-DFUSE_USE_VERSION=25` in `configureFlags`. The actual value would
+   have to match the definition used in the upstream source code.
+2. Remove `AC_CHECK_HEADERS` / `AC_CHECK_LIBS` for libfuse.
+
+However, a better solution might be to fix the build script upstream to use
+`PKG_CHECK_MODULES` instead. This approach wouldn't suffer from the problem that
+`AC_CHECK_HEADERS`/`AC_CHECK_LIBS` has at the price of introducing a dependency
+on pkg-config.

--- a/pkgs/applications/networking/sync/acd_cli/default.nix
+++ b/pkgs/applications/networking/sync/acd_cli/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, buildPythonApplication, fuse
 , appdirs, colorama, dateutil, requests, requests_toolbelt
-, fusepy, sqlalchemy }:
+, fusepy, sqlalchemy, setuptools }:
 
 buildPythonApplication rec {
   pname = "acd_cli";
@@ -16,7 +16,7 @@ buildPythonApplication rec {
   };
 
   propagatedBuildInputs = [ appdirs colorama dateutil fusepy requests
-                            requests_toolbelt sqlalchemy ];
+                            requests_toolbelt setuptools sqlalchemy ];
 
   makeWrapperArgs = [ "--prefix LIBFUSE_PATH : ${fuse}/lib/libfuse.so" ];
 
@@ -34,7 +34,6 @@ buildPythonApplication rec {
     description = "A command line interface and FUSE filesystem for Amazon Cloud Drive";
     homepage = "https://github.com/yadayada/acd_cli";
     license = licenses.gpl2;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/development/libraries/afflib/default.nix
+++ b/pkgs/development/libraries/afflib/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, zlib, curl, expat, fuse, openssl
-, autoreconfHook, python3
+, autoreconfHook, python3, libiconv
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ zlib curl expat openssl python3 ]
-    ++ lib.optionals stdenv.isLinux [ fuse ];
+    ++ lib.optionals (with stdenv; isLinux || isDarwin) [ fuse ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   meta = {
     homepage = "http://afflib.sourceforge.net/";

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -31,7 +31,15 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://savannah.nongnu.org/projects/attr/";
     description = "Library and tools for manipulating extended attributes";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.gpl2Plus;
+
+    # The build failure on Darwin will likely be solved after upgrading the
+    # macOS SDK in nixpkgs. Check the current SDK version in
+    # ../../../../os-specific/darwin/apple-sdk/default.nix to see if it has
+    # been updated to 10.13 or later. Once the requirements are met, building
+    # it should be straightforward as Homebrew was able to build it without
+    # patching.
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/libraries/libspectrum/default.nix
+++ b/pkgs/development/libraries/libspectrum/default.nix
@@ -13,12 +13,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ audiofile bzip2 glib libgcrypt zlib ];
 
   enableParallelBuilding = true;
+  doCheck = true;
 
   meta = with lib; {
     homepage = "http://fuse-emulator.sourceforge.net/libspectrum.php";
     description = "ZX Spectrum input and output support library";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ orivej ];
   };
 }

--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -41,7 +41,6 @@ in stdenv.mkDerivation {
     description = "A C++ BitTorrent implementation focusing on efficiency and scalability";
     license = licenses.bsd3;
     maintainers = [ maintainers.phreedom ];
-    broken = stdenv.isDarwin;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/fusepy/default.nix
+++ b/pkgs/development/python-modules/fusepy/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , pkgs
@@ -18,7 +19,9 @@ buildPythonPackage rec {
   # No tests included
   doCheck = false;
 
-  patchPhase = ''
+  # On macOS, users are expected to install macFUSE. This means fusepy should
+  # be able to find libfuse in /usr/local/lib.
+  patchPhase = lib.optionalString (!stdenv.isDarwin) ''
     substituteInPlace fuse.py --replace \
       "find_library('fuse')" "'${pkgs.fuse}/lib/libfuse.so'"
   '';

--- a/pkgs/development/tools/build-managers/tup/default.nix
+++ b/pkgs/development/tools/build-managers/tup/default.nix
@@ -1,6 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, fuse3, pkg-config, pcre }:
+{ lib, stdenv, fetchFromGitHub, fuse3, macfuse-stubs, pkg-config, pcre }:
 
-stdenv.mkDerivation rec {
+let
+  fuse = if stdenv.isDarwin then macfuse-stubs else fuse3;
+in stdenv.mkDerivation rec {
   pname = "tup";
   version = "0.7.10";
   outputs = [ "bin" "man" "out" ];
@@ -13,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ fuse3 pcre ];
+  buildInputs = [ fuse pcre ];
 
   configurePhase = ''
     sed -i 's/`git describe`/v${version}/g' src/tup/link.sh
@@ -50,6 +52,13 @@ stdenv.mkDerivation rec {
     homepage = "http://gittup.org/tup/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ ehmry ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
+
+    # TODO: Remove once nixpkgs uses newer SDKs that supports '*at' functions.
+    # Probably MacOS SDK 10.13 or later. Check the current version in
+    # ../../../../os-specific/darwin/apple-sdk/default.nix
+    #
+    # https://github.com/gittup/tup/commit/3697c74
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/os-specific/linux/afuse/default.nix
+++ b/pkgs/os-specific/linux/afuse/default.nix
@@ -11,11 +11,18 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ fuse ];
 
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    # Fix the build on macOS with macFUSE installed
+    substituteInPlace configure.ac --replace \
+      'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH' \
+      ""
+  '';
+
   meta = {
     description = "Automounter in userspace";
     homepage = "https://github.com/pcarrier/afuse";
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.marcweber ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/os-specific/linux/btfs/default.nix
+++ b/pkgs/os-specific/linux/btfs/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/johang/btfs";
     license     = licenses.gpl3;
     maintainers = with maintainers; [ rnhmjoj ];
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/9pfs/default.nix
+++ b/pkgs/tools/filesystems/9pfs/default.nix
@@ -10,6 +10,10 @@ stdenv.mkDerivation {
     sha256 = "007s2idsn6bspmfxv1qabj39ggkgvn6gwdbhczwn04lb4c6gh3xc";
   };
 
+  # Upstream development has stopped and is no longer accepting patches
+  # https://github.com/mischief/9pfs/pull/3
+  patches = [ ./fix-darwin-build.patch ];
+
   preConfigure =
     ''
       substituteInPlace Makefile --replace '-g bin' ""
@@ -25,7 +29,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/mischief/9pfs";
     description = "FUSE-based client of the 9P network filesystem protocol";
     maintainers = [ lib.maintainers.eelco ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     license = with lib.licenses; [ lpl-102 bsd2 ];
   };
 }

--- a/pkgs/tools/filesystems/9pfs/fix-darwin-build.patch
+++ b/pkgs/tools/filesystems/9pfs/fix-darwin-build.patch
@@ -1,0 +1,47 @@
+From 6b7863b51c97f8ecd9a93fc4347f8938f9b5c05f Mon Sep 17 00:00:00 2001
+From: midchildan <git@midchildan.org>
+Date: Tue, 30 Mar 2021 22:21:51 +0900
+Subject: [PATCH] build: fix build for macOS
+
+---
+ 9pfs.c | 4 ++--
+ libc.h | 4 ++++
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/9pfs.c b/9pfs.c
+index 2c481bd..f5c487c 100644
+--- a/9pfs.c
++++ b/9pfs.c
+@@ -30,7 +30,7 @@
+ enum
+ {
+ 	CACHECTLSIZE = 8, /* sizeof("cleared\n") - 1 */
+-	MSIZE = 8192
++	MSIZE_9P = 8192
+ };
+ 
+ void	dir2stat(struct stat*, Dir*);
+@@ -505,7 +505,7 @@ main(int argc, char *argv[])
+ 		freeaddrinfo(ainfo);
+ 
+ 	init9p();
+-	msize = _9pversion(MSIZE);
++	msize = _9pversion(MSIZE_9P);
+ 	if(doauth){
+ 		authfid = _9pauth(AUTHFID, user, NULL);
+ 		ai = auth_proxy(authfid, auth_getkey, "proto=p9any role=client");
+diff --git a/libc.h b/libc.h
+index 099adba..aac03c5 100644
+--- a/libc.h
++++ b/libc.h
+@@ -61,6 +61,10 @@ typedef unsigned char uchar;
+ typedef unsigned long long uvlong;
+ typedef long long vlong;
+ 
++#ifndef __GLIBC__
++typedef unsigned long ulong;
++#endif
++
+ typedef
+ struct Qid
+ {

--- a/pkgs/tools/filesystems/aefs/default.nix
+++ b/pkgs/tools/filesystems/aefs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fuse }:
+{ lib, stdenv, fetchurl, fetchpatch, fuse }:
 
 stdenv.mkDerivation rec {
   name = "aefs-0.4pre259-8843b7c";
@@ -8,12 +8,29 @@ stdenv.mkDerivation rec {
     sha256 = "167hp58hmgdavg2mqn5dx1xgq24v08n8d6psf33jhbdabzx6a6zq";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/edolstra/aefs/commit/15d8df8b8d5dc1ee20d27a86c4d23163a67f3123.patch";
+      sha256 = "0k36hsyvf8a0ji2hpghgqff2fncj0pllxn8p0rs0aj4h7j2vp4iv";
+    })
+  ];
+
+  # autoconf's AC_CHECK_HEADERS and AC_CHECK_LIBS fail to detect libfuse on
+  # Darwin if FUSE_USE_VERSION isn't set at configure time.
+  #
+  # NOTE: Make sure the value of FUSE_USE_VERSION specified here matches the
+  # actual version used in the source code:
+  #
+  #     $ tar xf "$(nix-build -A aefs.src)"
+  #     $ grep -R FUSE_USE_VERSION
+  configureFlags = lib.optional stdenv.isDarwin "CPPFLAGS=-DFUSE_USE_VERSION=26";
+
   buildInputs = [ fuse ];
 
   meta = with lib; {
     homepage = "https://github.com/edolstra/aefs";
     description = "A cryptographic filesystem implemented in userspace using FUSE";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.eelco ];
     license = licenses.gpl2;
   };

--- a/pkgs/tools/filesystems/android-file-transfer/darwin-dont-vendor-dependencies.patch
+++ b/pkgs/tools/filesystems/android-file-transfer/darwin-dont-vendor-dependencies.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8b05ab0..81e31f5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -236,16 +236,6 @@ endif()
+
+ if (''${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+ 	set(MACOSX_BUNDLE_LIBS)
+-	if (OPENSSL_FOUND)
+-		list(APPEND MACOSX_BUNDLE_LIBS /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib)
+-	endif()
+-	if (TAGLIB_FOUND)
+-		list(APPEND MACOSX_BUNDLE_LIBS /usr/local/opt/taglib/lib/libtag.1.dylib)
+-	endif()
+-	if (FUSE_FOUND)
+-		list(APPEND MACOSX_BUNDLE_LIBS /usr/local/lib/libosxfuse.2.dylib)
+-	endif()
+-
+ 	set(MACOSX_BUNDLE_LIBS_INSTALL)
+ 	set(MACOSX_BUNDLE_ROOT_DIR "''${CMAKE_INSTALL_PREFIX}/''${CMAKE_PROJECT_NAME}.app")
+ 	message(STATUS "bundle root dir: ''${MACOSX_BUNDLE_ROOT_DIR}")

--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -1,4 +1,14 @@
-{ lib, mkDerivation, fetchFromGitHub, cmake, fuse, readline, pkg-config, qtbase, qttools }:
+{ lib
+, stdenv
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, fuse
+, readline
+, pkg-config
+, qtbase
+, qttools
+, wrapQtAppsHook }:
 
 mkDerivation rec {
   pname = "android-file-transfer";
@@ -11,14 +21,24 @@ mkDerivation rec {
     sha256 = "125rq8ji83nw6chfw43i0h9c38hjqh1qjibb0gnf9wrigar9zc8b";
   };
 
-  nativeBuildInputs = [ cmake readline pkg-config ];
+  patches = [ ./darwin-dont-vendor-dependencies.patch ];
+
+  nativeBuildInputs = [ cmake readline pkg-config wrapQtAppsHook ];
   buildInputs = [ fuse qtbase qttools ];
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    mkdir $out/Applications
+    mv $out/*.app $out/Applications
+    for f in $out/Applications/android-file-transfer.app/Contents/MacOS/*; do
+      wrapQtApp "$f"
+    done
+  '';
 
   meta = with lib; {
     description = "Reliable MTP client with minimalistic UI";
     homepage = "https://whoozle.github.io/android-file-transfer-linux/";
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.xaverdh ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/archivemount/default.nix
+++ b/pkgs/tools/filesystems/archivemount/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation {
   meta = {
     description = "Gateway between FUSE and libarchive: allows mounting of cpio, .tar.gz, .tar.bz2 archives";
     license = lib.licenses.gpl2;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/avfs/default.nix
+++ b/pkgs/tools/filesystems/avfs/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://avf.sourceforge.net/";
     description = "Virtual filesystem that allows browsing of compressed files";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     license = lib.licenses.gpl2;
   };
 }

--- a/pkgs/tools/filesystems/boxfs/default.nix
+++ b/pkgs/tools/filesystems/boxfs/default.nix
@@ -37,7 +37,10 @@ in stdenv.mkDerivation {
   buildInputs = [ curl fuse libxml2 ];
   nativeBuildInputs = [ pkg-config ];
 
-  buildFlags = [ "static" ];
+  buildFlags = [
+    "static"
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ] ++ lib.optional stdenv.isDarwin "CFLAGS=-D_BSD_SOURCE";
 
   installPhase = ''
     mkdir -p $out/bin
@@ -55,6 +58,6 @@ in stdenv.mkDerivation {
     '';
     homepage = "https://github.com/drotiro/boxfs2";
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/cryfs/default.nix
+++ b/pkgs/tools/filesystems/cryfs/default.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-fs/cryfs/files/cryfs-0.10.2-unbundle-libs.patch?id=192ac7421ddd4093125f4997898fb62e8a140a44";
       sha256 = "0hzss5rawcjrh8iqzc40w5yjhxdqya4gbg6dzap70180s50mahzs";
     })
+
+    # Backported from https://github.com/cryfs/cryfs/pull/378
+    ./use-macfuse.patch
   ];
 
   postPatch = ''
@@ -48,16 +51,18 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  buildInputs = [ boost cryptopp curl fuse openssl gtest ];
+  buildInputs = [ boost cryptopp curl fuse openssl ];
+
+  checkInputs = [ gtest ];
 
   cmakeFlags = [
     "-DCRYFS_UPDATE_CHECKS:BOOL=FALSE"
     "-DBoost_USE_STATIC_LIBS:BOOL=FALSE" # this option is case sensitive
     "-DUSE_SYSTEM_LIBS:BOOL=TRUE"
-    "-DBUILD_TESTING:BOOL=TRUE"
-  ];
+    "-DBUILD_TESTING:BOOL=${if doCheck then "TRUE" else "FALSE"}"
+  ] ++ lib.optional doCheck "-DCMAKE_PREFIX_PATH=${gtest.dev}/lib/cmake";
 
-  doCheck = (!stdenv.isDarwin); # Cryfs tests are broken on darwin
+  doCheck = true;
 
   checkPhase = ''
     # Skip CMakeFiles directory and tests depending on fuse (does not work well with sandboxing)
@@ -73,6 +78,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://www.cryfs.org";
     license     = licenses.lgpl3;
     maintainers = with maintainers; [ peterhoeg c0bw3b ];
-    platforms   = with platforms; linux;
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/cryfs/use-macfuse.patch
+++ b/pkgs/tools/filesystems/cryfs/use-macfuse.patch
@@ -1,0 +1,207 @@
+diff --git a/.travisci/install.sh b/.travisci/install.sh
+index 9057a75b..2929c360 100755
+--- a/.travisci/install.sh
++++ b/.travisci/install.sh
+@@ -6,12 +6,11 @@ set -e
+ if [ "${CXX}" == "g++" ]; then
+     # We need to uninstall oclint because it creates a /usr/local/include/c++ symlink that clashes with the gcc5 package
+     # see https://github.com/Homebrew/homebrew-core/issues/21172
+-    brew cask uninstall oclint
++    brew uninstall oclint
+     brew install gcc@7
+ fi
+ 
+-brew cask install osxfuse
+-brew install libomp
++brew install libomp pkg-config macfuse
+ 
+ # By default, travis only fetches the newest 50 commits. We need more in case we're further from the last version tag, so the build doesn't fail because it can't generate the version number.
+ git fetch --unshallow --tags
+diff --git a/README.md b/README.md
+index b0f4a684..7001119a 100644
+--- a/README.md
++++ b/README.md
+@@ -19,7 +19,7 @@ OSX
+ 
+ CryFS is distributed via Homebrew. Just do
+ 
+-    brew cask install osxfuse
++    brew install osxfuse
+     brew install cryfs
+     
+ Windows (experimental)
+@@ -45,6 +45,7 @@ Requirements
+   - Git (for getting the source code)
+   - GCC version >= 5.0 or Clang >= 4.0
+   - CMake version >= 3.0 
++  - pkg-config (on Unix)
+   - libcurl4 (including development headers)
+   - Boost libraries version >= 1.65.1 (including development headers)
+     - filesystem
+@@ -53,20 +54,20 @@ Requirements
+     - program_options
+     - thread
+   - SSL development libraries (including development headers, e.g. libssl-dev)
+-  - libFUSE version >= 2.8.6 (including development headers), on Mac OS X instead install osxfuse from https://osxfuse.github.io/
++  - libFUSE version >= 2.8.6 (including development headers), on Mac OS X instead install macFUSE from https://osxfuse.github.io/
+   - Python >= 2.7
+   - OpenMP
+ 
+ You can use the following commands to install these requirements
+ 
+         # Ubuntu
+-        $ sudo apt install git g++ cmake make libcurl4-openssl-dev libboost-filesystem-dev libboost-system-dev libboost-chrono-dev libboost-program-options-dev libboost-thread-dev libssl-dev libfuse-dev python
++        $ sudo apt install git g++ cmake make pkg-config libcurl4-openssl-dev libboost-filesystem-dev libboost-system-dev libboost-chrono-dev libboost-program-options-dev libboost-thread-dev libssl-dev libfuse-dev python
+ 
+         # Fedora
+-        sudo dnf install git gcc-c++ cmake make libcurl-devel boost-devel boost-static openssl-devel fuse-devel python
++        sudo dnf install git gcc-c++ cmake make pkgconf libcurl-devel boost-devel boost-static openssl-devel fuse-devel python
+ 
+         # Macintosh
+-        brew install cmake boost openssl libomp
++        brew install cmake pkg-config boost openssl libomp
+ 
+ Build & Install
+ ---------------
+@@ -116,17 +117,17 @@ On most systems, CMake should find the libraries automatically. However, that do
+ 
+         cmake .. -DBoost_USE_STATIC_LIBS=off
+ 
+-2. **Fuse/Osxfuse library not found**
++2. **Fuse library not found**
+ 
+     Pass in the library path with
+ 
+-        cmake .. -DFUSE_LIB_PATH=/path/to/fuse/or/osxfuse
++        PKG_CONFIG_PATH=/path-to-fuse-or-macFUSE/lib/pkgconfig cmake ..
+ 
+-3. **Fuse/Osxfuse headers not found**
++3. **Fuse headers not found**
+ 
+     Pass in the include path with
+ 
+-        cmake .. -DCMAKE_CXX_FLAGS="-I/path/to/fuse/or/osxfuse/headers"
++        PKG_CONFIG_PATH=/path-to-fuse-or-macFUSE/lib/pkgconfig cmake ..
+ 
+ 4. **Openssl headers not found**
+ 
+diff --git a/cmake-utils/utils.cmake b/cmake-utils/utils.cmake
+index da4dff8c..66021c5c 100644
+--- a/cmake-utils/utils.cmake
++++ b/cmake-utils/utils.cmake
+@@ -157,33 +157,6 @@ function(require_clang_version VERSION)
+     endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+ endfunction(require_clang_version)
+ 
+-##################################################
+-# Find the location of a library and return its full path in OUTPUT_VARIABLE.
+-# If PATH_VARIABLE points to a defined variable, then the library will only be searched in this path.
+-# If PATH_VARIABLE points to a undefined variable, default system locations will be searched.
+-#
+-# Uses (the following will search for fuse in system locations by default, and if the user passes -DFUSE_LIB_PATH to cmake, it will only search in this path.
+-#  find_library_with_path(MYLIBRARY fuse FUSE_LIB_PATH)
+-#  target_link_library(target ${MYLIBRARY})
+-##################################################
+-function(find_library_with_path OUTPUT_VARIABLE LIBRARY_NAME PATH_VARIABLE)
+-    if(${PATH_VARIABLE})
+-        find_library(${OUTPUT_VARIABLE} ${LIBRARY_NAME} PATHS ${${PATH_VARIABLE}} NO_DEFAULT_PATH)
+-        if (${OUTPUT_VARIABLE} MATCHES NOTFOUND)
+-            message(FATAL_ERROR "Didn't find ${LIBRARY_NAME} in path specified by the ${PATH_VARIABLE} parameter (${${PATH_VARIABLE}}). Pass in the correct path or remove the parameter to try common system locations.")
+-        else(${OUTPUT_VARIABLE} MATCHES NOTFOUND)
+-            message(STATUS "Found ${LIBRARY_NAME} in user-defined path ${${PATH_VARIABLE}}")
+-        endif(${OUTPUT_VARIABLE} MATCHES NOTFOUND)
+-    else(${PATH_VARIABLE})
+-        find_library(${OUTPUT_VARIABLE} ${LIBRARY_NAME})
+-        if (${OUTPUT_VARIABLE} MATCHES NOTFOUND)
+-            message(FATAL_ERROR "Didn't find ${LIBRARY_NAME} library. If ${LIBRARY_NAME} is installed, try passing in the library location with -D${PATH_VARIABLE}=/path/to/${LIBRARY_NAME}/lib.")
+-        else(${OUTPUT_VARIABLE} MATCHES NOTFOUND)
+-            message(STATUS "Found ${LIBRARY_NAME} in system location")
+-        endif(${OUTPUT_VARIABLE} MATCHES NOTFOUND)
+-    endif(${PATH_VARIABLE})
+-endfunction(find_library_with_path)
+-
+ include(cmake-utils/TargetArch.cmake)
+ function(get_target_architecture output_var)
+ 	target_architecture(local_output_var)
+diff --git a/src/fspp/fuse/CMakeLists.txt b/src/fspp/fuse/CMakeLists.txt
+index b991bd72..8df3dbb7 100644
+--- a/src/fspp/fuse/CMakeLists.txt
++++ b/src/fspp/fuse/CMakeLists.txt
+@@ -35,12 +35,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+     DESTINATION "${CMAKE_INSTALL_BINDIR}"
+   )
+ 
+-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+-  set(CMAKE_FIND_FRAMEWORK LAST)
+-  find_library_with_path(FUSE "osxfuse" FUSE_LIB_PATH)
+-  target_link_libraries(${PROJECT_NAME} PUBLIC ${FUSE})
+-else() # Linux
+-  find_library_with_path(FUSE "fuse" FUSE_LIB_PATH)
+-  target_link_libraries(${PROJECT_NAME} PUBLIC ${FUSE})
++else() # Linux and macOS
++  find_package(PkgConfig REQUIRED)
++  pkg_check_modules(Fuse REQUIRED IMPORTED_TARGET fuse)
++  target_link_libraries(${PROJECT_NAME} PUBLIC PkgConfig::Fuse)
+ endif()
+ 
++if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
++  set(CMAKE_FIND_FRAMEWORK LAST)
++endif()
+diff --git a/src/fspp/fuse/Fuse.cpp b/src/fspp/fuse/Fuse.cpp
+index 52cd5644..df0b400d 100644
+--- a/src/fspp/fuse/Fuse.cpp
++++ b/src/fspp/fuse/Fuse.cpp
+@@ -295,7 +295,7 @@ vector<char *> Fuse::_build_argv(const bf::path &mountdir, const vector<string>
+   // Make volume name default to mountdir on macOS
+   _add_fuse_option_if_not_exists(&argv, "volname", mountdir.filename().string());
+ #endif
+-  // TODO Also set read/write size for osxfuse. The options there are called differently.
++  // TODO Also set read/write size for macFUSE. The options there are called differently.
+   // large_read not necessary because reads are large anyhow. This option is only important for 2.4.
+   //argv.push_back(_create_c_string("-o"));
+   //argv.push_back(_create_c_string("large_read"));
+diff --git a/src/fspp/fuse/params.h b/src/fspp/fuse/params.h
+index 4a45ef79..9903ac82 100644
+--- a/src/fspp/fuse/params.h
++++ b/src/fspp/fuse/params.h
+@@ -3,14 +3,6 @@
+ #define MESSMER_FSPP_FUSE_PARAMS_H_
+ 
+ #define FUSE_USE_VERSION 26
+-#if defined(__linux__) || defined(__FreeBSD__)
+ #include <fuse.h>
+-#elif __APPLE__
+-#include <osxfuse/fuse.h>
+-#elif defined(_MSC_VER)
+-#include <fuse.h> // Dokany fuse
+-#else
+-#error System not supported
+-#endif
+ 
+ #endif
+diff --git a/src/fspp/impl/FilesystemImpl.cpp b/src/fspp/impl/FilesystemImpl.cpp
+index bc0ffbd7..23b28601 100644
+--- a/src/fspp/impl/FilesystemImpl.cpp
++++ b/src/fspp/impl/FilesystemImpl.cpp
+@@ -321,7 +321,7 @@ void FilesystemImpl::statfs(struct ::statvfs *fsstat) {
+   fsstat->f_namemax = stat.max_filename_length;
+ 
+   //f_frsize, f_favail, f_fsid and f_flag are ignored in fuse, see http://fuse.sourcearchive.com/documentation/2.7.0/structfuse__operations_4e765e29122e7b6b533dc99849a52655.html#4e765e29122e7b6b533dc99849a52655
+-  fsstat->f_frsize = fsstat->f_bsize; // even though this is supposed to be ignored, osxfuse needs it.
++  fsstat->f_frsize = fsstat->f_bsize; // even though this is supposed to be ignored, macFUSE needs it.
+ }
+ 
+ void FilesystemImpl::createSymlink(const bf::path &to, const bf::path &from, ::uid_t uid, ::gid_t gid) {
+diff --git a/test/fspp/testutils/FuseThread.cpp b/test/fspp/testutils/FuseThread.cpp
+index 277a2dac..7f3638db 100644
+--- a/test/fspp/testutils/FuseThread.cpp
++++ b/test/fspp/testutils/FuseThread.cpp
+@@ -23,7 +23,7 @@ void FuseThread::start(const bf::path &mountDir, const vector<string> &fuseOptio
+   //Wait until it is running (busy waiting is simple and doesn't hurt much here)
+   while(!_fuse->running()) {}
+ #ifdef __APPLE__
+-  // On Mac OS X, _fuse->running() returns true too early, because osxfuse calls init() when it's not ready yet. Give it a bit time.
++  // On Mac OS X, _fuse->running() returns true too early, because macFUSE calls init() when it's not ready yet. Give it a bit time.
+   std::this_thread::sleep_for(std::chrono::milliseconds(200));
+ #endif
+ }

--- a/pkgs/tools/filesystems/curlftpfs/default.nix
+++ b/pkgs/tools/filesystems/curlftpfs/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, fuse, curl, pkg-config, glib, zlib}:
+{ lib, stdenv, fetchurl, autoreconfHook, fuse, curl, pkg-config, glib, zlib }:
 
 stdenv.mkDerivation {
   name = "curlftpfs-0.9.2";
@@ -6,8 +6,18 @@ stdenv.mkDerivation {
     url = "mirror://sourceforge/curlftpfs/curlftpfs-0.9.2.tar.gz";
     sha256 = "0n397hmv21jsr1j7zx3m21i7ryscdhkdsyqpvvns12q7qwwlgd2f";
   };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [fuse curl glib zlib];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ fuse curl glib zlib ];
+
+  CFLAGS = lib.optionalString stdenv.isDarwin "-D__off_t=off_t";
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    # Fix the build on macOS with macFUSE installed. Needs autoreconfHook for
+    # this change to effect
+    substituteInPlace configure.ac --replace \
+      'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH' \
+      ""
+  '';
 
   doCheck = false; # fails, doesn't work well too, btw
 
@@ -15,7 +25,6 @@ stdenv.mkDerivation {
     description = "Filesystem for accessing FTP hosts based on FUSE and libcurl";
     homepage = "http://curlftpfs.sourceforge.net";
     license = licenses.gpl2;
-    platforms = platforms.linux;
-
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/darling-dmg/default.nix
+++ b/pkgs/tools/filesystems/darling-dmg/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fuse, zlib, bzip2, openssl, libxml2, icu, lzfse }:
+{ lib, stdenv, fetchFromGitHub, cmake, fuse, zlib, bzip2, openssl, libxml2, icu, lzfse, libiconv }:
 
 stdenv.mkDerivation rec {
   pname = "darling-dmg";
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ fuse openssl zlib bzip2 libxml2 icu lzfse ];
+  buildInputs = [ fuse openssl zlib bzip2 libxml2 icu lzfse ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   CXXFLAGS = [
     "-DCOMPILE_WITH_LZFSE=1"
@@ -22,8 +23,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.darlinghq.org/";
     description = "Darling lets you open macOS dmgs on Linux";
-    platforms = platforms.linux;
-    license = licenses.gpl3;
+    platforms = platforms.unix;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ Luflosi ];
   };
 }

--- a/pkgs/tools/filesystems/dislocker/default.nix
+++ b/pkgs/tools/filesystems/dislocker/default.nix
@@ -1,6 +1,8 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
+, pkg-config
 , mbedtls
 , fuse
 }:
@@ -17,7 +19,20 @@ stdenv.mkDerivation rec {
     sha256 = "1ak68s1v5dwh8y2dy5zjybmrh0pnqralmyqzis67y21m87g47h2k";
   };
 
-  nativeBuildInputs = [ cmake ];
+  patches = [
+    # This patch
+    #   1. adds support for the latest FUSE on macOS
+    #   2. uses pkg-config to find libfuse instead of searching in predetermined
+    #      paths
+    #
+    # https://github.com/Aorimn/dislocker/pull/246
+    (fetchpatch {
+      url = "https://github.com/Aorimn/dislocker/commit/7744f87c75fcfeeb414d0957771042b10fb64e62.diff";
+      sha256 = "0bpyccbbfjsidsrd2q9qylb95nvi8g3glb3jss7xmhywj86bhzr5";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ fuse mbedtls ];
 
   meta = with lib; {
@@ -25,6 +40,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/aorimn/dislocker";
     license     = licenses.gpl2;
     maintainers = with maintainers; [ elitak ];
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/encfs/default.nix
+++ b/pkgs/tools/filesystems/encfs/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An encrypted filesystem in user-space via FUSE";
     homepage = "https://vgough.github.io/encfs";
-    license = with licenses; [ gpl3 lgpl3 ];
-    platforms = with platforms; linux;
+    license = with licenses; [ gpl3Plus lgpl3Plus ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/exfat/default.nix
+++ b/pkgs/tools/filesystems/exfat/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ dywedir ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/gitfs/default.nix
+++ b/pkgs/tools/filesystems/gitfs/default.nix
@@ -14,6 +14,12 @@ python3Packages.buildPythonApplication rec {
   patchPhase = ''
     # requirement checks are unnecessary at runtime
     echo > requirements.txt
+
+    # NOTE: As of gitfs 0.5.2, The pygit2 release that upstream uses is a major
+    # version behind the one packaged in nixpkgs.
+    substituteInPlace gitfs/mounter.py --replace \
+      'from pygit2.remote import RemoteCallbacks' \
+      'from pygit2 import RemoteCallbacks'
   '';
 
   checkInputs = with python3Packages; [ pytest pytestcov mock ];
@@ -31,7 +37,7 @@ python3Packages.buildPythonApplication rec {
     '';
     homepage = "https://github.com/PressLabs/gitfs";
     license = lib.licenses.asl20;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.robbinch ];
   };
 }

--- a/pkgs/tools/filesystems/httpfs/default.nix
+++ b/pkgs/tools/filesystems/httpfs/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
     license = lib.licenses.gpl2Plus;
 
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = [ ];
   };
 }

--- a/pkgs/tools/filesystems/hubicfuse/default.nix
+++ b/pkgs/tools/filesystems/hubicfuse/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, curl, openssl, fuse, libxml2, json_c, file }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, curl, openssl, fuse, libxml2, json_c, file }:
 
 stdenv.mkDerivation rec {
   pname = "hubicfuse";
@@ -11,6 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "1x988hfffxgvqxh083pv3lj5031fz03sbgiiwrjpaiywfbhm8ffr";
   };
 
+  patches = [
+    # Fix Darwin build
+    # https://github.com/TurboGit/hubicfuse/pull/159
+    (fetchpatch {
+      url = "https://github.com/TurboGit/hubicfuse/commit/b460f40d86bc281a21379158a7534dfb9f283786.patch";
+      sha256 = "0nqvcbrgbc5dms8fkz3brlj40yn48p36drabrnc26gvb3hydh5dl";
+    })
+  ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ curl openssl fuse libxml2 json_c file ];
   postInstall = ''
@@ -22,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/TurboGit/hubicfuse";
     description = "FUSE-based filesystem to access hubic cloud storage";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.mit;
     maintainers = [ maintainers.jpierre03 ];
   };

--- a/pkgs/tools/filesystems/ifuse/default.nix
+++ b/pkgs/tools/filesystems/ifuse/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       devices.
     '';
     license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/tools/filesystems/jmtpfs/default.nix
+++ b/pkgs/tools/filesystems/jmtpfs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, file, fuse, libmtp }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, file, fuse, libmtp }:
 
 let version = "0.5"; in
 stdenv.mkDerivation {
@@ -12,14 +12,22 @@ stdenv.mkDerivation {
     owner = "JasonFerrara";
   };
 
+  patches = [
+    # Fix Darwin build (https://github.com/JasonFerrara/jmtpfs/pull/12)
+    (fetchpatch {
+      url = "https://github.com/JasonFerrara/jmtpfs/commit/b89084303477d1bc4dc9a887ba9cdd75221f497d.patch";
+      sha256 = "0s7x3jfk8i86rd5bwhj7mb1lffcdlpj9bd7b41s1768ady91rb29";
+    })
+  ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ file fuse libmtp ];
 
   meta = with lib; {
     description = "A FUSE filesystem for MTP devices like Android phones";
     homepage = "https://github.com/JasonFerrara/jmtpfs";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
     maintainers = [ maintainers.coconnor ];
   };
 }

--- a/pkgs/tools/filesystems/moosefs/default.nix
+++ b/pkgs/tools/filesystems/moosefs/default.nix
@@ -24,14 +24,30 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ fuse libpcap zlib python ];
 
+  buildFlags = lib.optionals stdenv.isDarwin [ "CPPFLAGS=-UHAVE_STRUCT_STAT_ST_BIRTHTIME" ];
+
+  # Fix the build on macOS with macFUSE installed
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace configure --replace \
+      "/usr/local/lib/pkgconfig" "/nonexistent"
+  '';
+
+  preBuild = lib.optional stdenv.isDarwin ''
+    substituteInPlace config.h --replace \
+      "#define HAVE_STRUCT_STAT_ST_BIRTHTIME 1" \
+      "#undef HAVE_STRUCT_STAT_ST_BIRTHTIME"
+  '';
+
   postInstall = ''
     substituteInPlace $out/sbin/mfscgiserv --replace "datapath=\"$out" "datapath=\""
   '';
 
+  doCheck = true;
+
   meta = with lib; {
     homepage = "https://moosefs.com";
     description = "Open Source, Petabyte, Fault-Tolerant, Highly Performing, Scalable Network Distributed File System";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.gpl2;
     maintainers = [ maintainers.mfossen ];
   };

--- a/pkgs/tools/filesystems/mp3fs/default.nix
+++ b/pkgs/tools/filesystems/mp3fs/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://khenriks.github.io/mp3fs/";
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/romdirfs/default.nix
+++ b/pkgs/tools/filesystems/romdirfs/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "FUSE for access Playstation 2 IOP IOPRP images and BIOS dumps";
     homepage = "https://github.com/mlafeldt/romdirfs";
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/filesystems/s3backer/default.nix
+++ b/pkgs/tools/filesystems/s3backer/default.nix
@@ -16,6 +16,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ fuse curl expat ];
 
+  # AC_CHECK_DECLS doesn't work with clang
+  postPatch = lib.optionalString stdenv.cc.isClang ''
+    substituteInPlace configure.ac --replace \
+      'AC_CHECK_DECLS(fdatasync)' ""
+  '';
+
   autoreconfPhase = ''
     patchShebangs ./autogen.sh
     ./autogen.sh
@@ -25,6 +31,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/archiecobbs/s3backer";
     description = "FUSE-based single file backing store via Amazon S3";
     license = licenses.gpl2Plus;
-    platforms = with platforms; linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/securefs/add-macfuse-support.patch
+++ b/pkgs/tools/filesystems/securefs/add-macfuse-support.patch
@@ -1,0 +1,188 @@
+From 8c65c2219976c02a68e27c28156ec0c4c02857e0 Mon Sep 17 00:00:00 2001
+From: midchildan <git@midchildan.org>
+Date: Sun, 28 Mar 2021 23:39:59 +0900
+Subject: [PATCH] Support the latest FUSE on macOS
+
+This drops osxfuse support in favor of macFUSE. macFUSE is a newer
+version of osxfuse that supports the latest release of macOS, and is a
+rebranded version of the same project.
+---
+ CMakeLists.txt             |  8 ++----
+ LICENSE.md                 | 58 ++++++++++++++++++++------------------
+ README.md                  |  2 +-
+ sources/commands.cpp       |  6 ----
+ 4 files changed, 33 insertions(+), 41 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7b5e57d..c176554 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -18,12 +18,8 @@ git_describe(GIT_VERSION --tags)
+ configure_file(${CMAKE_SOURCE_DIR}/sources/git-version.cpp.in ${CMAKE_BINARY_DIR}/git-version.cpp)
+ 
+ if (UNIX)
+-    find_path(FUSE_INCLUDE_DIR fuse.h PATHS /usr/local/include PATH_SUFFIXES osxfuse)
+-    if (APPLE)
+-        find_library(FUSE_LIBRARIES osxfuse PATHS /usr/local/lib)
+-    else()
+-        find_library(FUSE_LIBRARIES fuse PATHS /usr/local/lib)
+-    endif()
++    find_path(FUSE_INCLUDE_DIR fuse.h PATHS /usr/local/include)
++    find_library(FUSE_LIBRARIES fuse PATHS /usr/local/lib)
+     include_directories(${FUSE_INCLUDE_DIR})
+     link_libraries(${FUSE_LIBRARIES})
+     add_compile_options(-Wall -Wextra -Wno-unknown-pragmas)
+diff --git a/LICENSE.md b/LICENSE.md
+index a8f920c..b134532 100644
+--- a/LICENSE.md
++++ b/LICENSE.md
+@@ -758,13 +758,11 @@ Public License instead of this License.
+ 
+ ------------------------------------------------------------------------------
+ 
+-# [osxfuse] (https://github.com/osxfuse/osxfuse)
++# [macFUSE] (https://github.com/osxfuse/osxfuse)
+ 
+-FUSE for macOS is a software developed by the osxfuse project and is covered
+-under the following BSD-style license:
++macFUSE is covered under the following license:
+ 
+-  Copyright (c) 2011-2016 Benjamin Fleischer
+-  Copyright (c) 2011-2012 Erik Larsson
++  Copyright (c) 2011-2021 Benjamin Fleischer
+   All rights reserved.
+ 
+   Redistribution  and  use  in  source  and  binary  forms,  with   or   without
+@@ -775,9 +773,13 @@ under the following BSD-style license:
+   2. Redistributions in binary form must reproduce the above  copyright  notice,
+      this list of conditions and the following disclaimer in  the  documentation
+      and/or other materials provided with the distribution.
+-  3. Neither the name of osxfuse nor the names of its contributors may  be  used
+-     to endorse or promote products derived from this software without  specific
+-     prior written permission.
++  3. Neither the name of the copyright holder nor the names of its  contributors
++     may be used to endorse or  promote  products  derived  from  this  software 
++     without specific prior written permission.
++  4. Redistributions in binary form, bundled with commercial software,  are  not
++     allowed without  specific  prior  written  permission.  This  includes  the
++     automated download or installation or  both  of  the  binary  form  in  the
++     context of commercial software.
+ 
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND  CONTRIBUTORS  "AS  IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT  NOT  LIMITED  TO,  THE
+@@ -791,9 +793,9 @@ under the following BSD-style license:
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN  IF  ADVISED  OF  THE
+   POSSIBILITY OF SUCH DAMAGE.
+ 
+-FUSE for macOS is a fork of MacFUSE. MacFUSE has been developed by Google Inc..
+-Additional information and the original source of MacFUSE are available on
+-http://code.google.com/p/macfuse/. MacFUSE is covered under the following
++macFUSE is a fork of the legacy Google MacFUSE software. Additional information
++and the original source code of Google MacFUSE are available on
++http://code.google.com/p/macfuse/. Google MacFUSE is covered under the following
+ BSD-style license:
+ 
+   Copyright (c) 2007—2009 Google Inc.
+@@ -830,9 +832,9 @@ BSD-style license:
+ Portions of this package were derived from code developed by other authors.
+ Please read further for specific details.
+ 
+-* Unless otherwise noted, parts of the FUSE for macOS kernel extension contain
+-  code derived from the FreeBSD version of FUSE, which is covered under the
+-  following BSD-style license:
++* Unless otherwise noted, parts of the macFUSE kernel extension contain code
++  derived from the FreeBSD version of FUSE, which is covered under the following
++  BSD-style license:
+ 
+     Copyright (C) 2005 Csaba Henk. All rights reserved.
+ 
+@@ -856,12 +858,13 @@ Please read further for specific details.
+     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF  THE  USE  OF
+     THIS  SOFTWARE,  EVEN  IF  ADVISED  OF  THE  POSSIBILITY  OF  SUCH   DAMAGE.
+ 
+-* Parts of the FUSE for macOS kernel extension contain code derived from Tuxera
+-  Inc.'s "rebel" branch. The original source of the "rebel" branch is available
+-  on https://github.com/tuxera. These modifications are covered under the
+-  following BSD-style license:
++* Parts of the macFUSE kernel extension contain code derived from Tuxera's
++  "rebel" branch. The original source code of the "rebel" branch is available on
++  https://github.com/tuxera. These modifications are covered under the following
++  BSD-style license:
+ 
+     Copyright (c) 2010 Tuxera Inc.
++    Copyright (c) 2011-2012 Erik Larsson
+     All rights reserved.
+ 
+     Redistribution  and  use  in  source  and  binary  forms,  with  or  without
+@@ -888,9 +891,9 @@ Please read further for specific details.
+     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  OF  THE
+     POSSIBILITY OF SUCH DAMAGE.
+ 
+-* Parts of FUSE for macOS contain code derived from Fuse4X. The original source
+-  of Fuse4X is available on https://github.com/fuse4x. Fuse4X is covered under
+-  the following BSD-style license:
++* Parts of macFUSE contain code derived from Fuse4X. The original source code of
++  Fuse4X is available on https://github.com/fuse4x. Fuse4X is covered under the
++  following BSD-style license:
+ 
+     Copyright (c) 2011 Anatol Pomozov
+     All rights reserved.
+@@ -916,21 +919,20 @@ Please read further for specific details.
+     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  OF  THE
+     POSSIBILITY OF SUCH DAMAGE.
+ 
+-* Parts of the mount_osxfuse command-line program are covered under the Apple
++* Parts of the mount_macfuse command-line program are covered under the Apple
+   Public Source License (APSL). You can read the APSL at:
+ 
+     http://www.opensource.apple.com/license/apsl/
+ 
+-* fuse_kernel.h is an unmodified copy of the interface header from the Linux
++* fuse_kernel.h is a modified copy of the interface header from the Linux
+   FUSE distribution (https://github.com/libfuse/libfuse). fuse_kernel.h can be
+   redistributed either under the GPL or under the BSD license. It is being
+   redistributed here under the BSD license.
+ 
+-* fuse_nodehash.c is a slightly modified version of HashNode.c from an
+-  Apple Developer Technical Support (DTS) sample code example. The original
+-  source, which is available on
+-  http://developer.apple.com/library/mac/#samplecode/MFSLives/, has the
+-  following disclaimer:
++* fuse_nodehash.c is a modified version of HashNode.c from an Apple Developer
++  Technical Support (DTS) sample code example. The original source, which is
++  available on http://developer.apple.com/library/mac/#samplecode/MFSLives/,
++  has the following disclaimer:
+ 
+     Disclaimer: IMPORTANT: This Apple software  is  supplied  to  you  by  Apple
+     Computer, Inc.  Apple") in consideration of your agreement to the  following
+diff --git a/README.md b/README.md
+index 9085e96..6fe3592 100644
+--- a/README.md
++++ b/README.md
+@@ -28,7 +28,7 @@ There are already many encrypting filesystem in widespread use. Some notable one
+ 
+ ### macOS
+ 
+-Install with [Homebrew](https://brew.sh). [osxfuse](https://osxfuse.github.io) has to be installed beforehand.
++Install with [Homebrew](https://brew.sh). [macFUSE](https://osxfuse.github.io) has to be installed beforehand.
+ ```
+ brew install securefs
+ ```
+diff --git a/sources/commands.cpp b/sources/commands.cpp
+index a371212..862602b 100644
+--- a/sources/commands.cpp
++++ b/sources/commands.cpp
+@@ -1252,12 +1252,6 @@ class VersionCommand : public CommandBase
+                 printf("WinFsp %u.%u\n", vn >> 16, vn & 0xFFFFu);
+             }
+         }
+-#elif defined(__APPLE__)
+-        typedef const char* version_function(void);
+-        auto osx_version_func
+-            = reinterpret_cast<version_function*>(::dlsym(RTLD_DEFAULT, "osxfuse_version"));
+-        if (osx_version_func)
+-            printf("osxfuse %s\n", osx_version_func());
+ #else
+         typedef int version_function(void);
+         auto fuse_version_func
+

--- a/pkgs/tools/filesystems/securefs/default.nix
+++ b/pkgs/tools/filesystems/securefs/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Make it build with macFUSE
+    # Backported from https://github.com/netheril96/securefs/pull/114
+    ./add-macfuse-support.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ fuse ];
 
@@ -31,6 +37,6 @@ stdenv.mkDerivation rec {
       contents.
     '';
     license = with licenses; [ bsd2 mit ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/squashfs-tools-ng/default.nix
+++ b/pkgs/tools/filesystems/squashfs-tools-ng/default.nix
@@ -19,6 +19,17 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ qyliss ];
     platforms = platforms.unix;
+
+    # TODO: Remove once nixpkgs uses newer SDKs that supports '*at' functions.
+    # Probably macOS SDK 10.13 or later. Check the current version in
+    # ../../../../os-specific/darwin/apple-sdk/default.nix
+    #
+    # From the build logs:
+    #
+    # > Undefined symbols for architecture x86_64:
+    # >   "_utimensat", referenced from:
+    # >       _set_attribs in rdsquashfs-restore_fstree.o
+    # > ld: symbol(s) not found for architecture x86_64
     broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -8,10 +8,6 @@ stdenv.mkDerivation rec {
   pname = "squashfuse";
   version = "0.1.103";
 
-  # platforms.darwin should be supported : see PLATFORMS file in src.
-  # we could use a nix fuseProvider, and let the derivation choose the OS
-  # specific implementation.
-
   src = fetchFromGitHub {
     owner = "vasi";
     repo  = pname;
@@ -26,7 +22,7 @@ stdenv.mkDerivation rec {
     description = "FUSE filesystem to mount squashfs archives";
     homepage = "https://github.com/vasi/squashfuse";
     maintainers = [  ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = "BSD-2-Clause";
   };
 }

--- a/pkgs/tools/filesystems/svnfs/default.nix
+++ b/pkgs/tools/filesystems/svnfs/default.nix
@@ -1,14 +1,26 @@
-{ lib, stdenv, fetchurl, automake, autoconf, subversion, fuse, apr, perl }:
+{ lib, stdenv, fetchurl, autoreconfHook, subversion, fuse, apr, perl }:
 
-stdenv.mkDerivation {
-  name = "svnfs-0.4";
+stdenv.mkDerivation rec {
+  pname = "svnfs";
+  version = "0.4";
 
   src = fetchurl {
-    url = "http://www.jmadden.eu/wp-content/uploads/svnfs/svnfs-0.4.tgz";
+    url = "http://www.jmadden.eu/wp-content/uploads/svnfs/svnfs-${version}.tgz";
     sha256 = "1lrzjr0812lrnkkwk60bws9k1hq2iibphm0nhqyv26axdsygkfky";
   };
 
-  buildInputs = [automake autoconf subversion fuse apr perl];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ subversion fuse apr perl ];
+
+  # autoconf's AC_CHECK_HEADERS and AC_CHECK_LIBS fail to detect libfuse on
+  # Darwin if FUSE_USE_VERSION isn't set at configure time.
+  #
+  # NOTE: Make sure the value of FUSE_USE_VERSION specified here matches the
+  # actual version used in the source code:
+  #
+  #     $ tar xf "$(nix-build -A svnfs.src)"
+  #     $ grep -R FUSE_USE_VERSION
+  configureFlags = lib.optionals stdenv.isDarwin [ "CFLAGS=-DFUSE_USE_VERSION=25" ];
 
   # why is this required?
   preConfigure=''
@@ -21,8 +33,8 @@ stdenv.mkDerivation {
   meta = {
     description = "FUSE filesystem for accessing Subversion repositories";
     homepage = "http://www.jmadden.eu/index.php/svnfs/";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Only;
     maintainers = [lib.maintainers.marcweber];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/tmsu/default.nix
+++ b/pkgs/tools/filesystems/tmsu/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub, fuse, installShellFiles }:
+{ lib, buildGoPackage, fetchFromGitHub, installShellFiles }:
 
 buildGoPackage rec {
   pname = "tmsu";
@@ -14,7 +14,6 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  buildInputs = [ fuse ];
   nativeBuildInputs = [ installShellFiles ];
 
   preBuild = ''
@@ -24,7 +23,10 @@ buildGoPackage rec {
   '';
 
   postInstall = ''
-    mv $out/bin/{TMSU,tmsu}
+    # can't do "mv TMSU tmsu" on case-insensitive filesystems
+    mv $out/bin/{TMSU,tmsu.tmp}
+    mv $out/bin/{tmsu.tmp,tmsu}
+
     cp src/misc/bin/* $out/bin/
     installManPage src/misc/man/tmsu.1
     installShellCompletion --zsh src/misc/zsh/_tmsu
@@ -34,7 +36,7 @@ buildGoPackage rec {
     homepage    = "http://www.tmsu.org";
     description = "A tool for tagging your files using a virtual filesystem";
     maintainers = with maintainers; [ pSub ];
-    license     = licenses.gpl3;
-    platforms   = platforms.linux;
+    license     = licenses.gpl3Plus;
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/tmsu/deps.nix
+++ b/pkgs/tools/filesystems/tmsu/deps.nix
@@ -5,8 +5,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/hanwen/go-fuse";
-      rev = "730713460d4fc41afdc2533bd37ff60c94c0c586";
-      sha256 = "1y44d08fxyis99s6jxdr6dbbw5kv3wb8lkhq3xmr886i4w41lz03";
+      rev = "0f728ba15b38579efefc3dc47821882ca18ffea7";
+      sha256 = "05ymw2pp58avf19wvi0cgdzqf3d88k1jdf6ldj4hmhbkm3waqf7l";
     };
   }
   {

--- a/pkgs/tools/filesystems/wdfs/default.nix
+++ b/pkgs/tools/filesystems/wdfs/default.nix
@@ -1,18 +1,27 @@
-{lib, stdenv, fetchurl, glib, neon, fuse, pkg-config}:
+{lib, stdenv, fetchurl, glib, neon, fuse, autoreconfHook, pkg-config}:
 
-stdenv.mkDerivation {
-  name = "wdfs-fuse-1.4.2";
+stdenv.mkDerivation rec {
+  pname = "wdfs-fuse";
+  version = "1.4.2";
+
   src = fetchurl {
-    url = "http://noedler.de/projekte/wdfs/wdfs-1.4.2.tar.gz";
+    url = "http://noedler.de/projekte/wdfs/wdfs-${version}.tar.gz";
     sha256 = "fcf2e1584568b07c7f3683a983a9be26fae6534b8109e09167e5dff9114ba2e5";
   };
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [fuse glib neon];
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    # Fix the build on macOS with macFUSE installed. Needs autoreconfHook to
+    # take effect.
+    substituteInPlace configure.ac --replace \
+      'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH' ""
+  '';
 
   meta = with lib; {
     homepage = "http://noedler.de/projekte/wdfs/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     description = "User-space filesystem that allows to mount a webdav share";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21573,7 +21573,7 @@ in
   acd-cli = callPackage ../applications/networking/sync/acd_cli {
     inherit (python3Packages)
       buildPythonApplication appdirs colorama dateutil
-      requests requests_toolbelt sqlalchemy fusepy;
+      requests requests_toolbelt setuptools sqlalchemy fusepy;
   };
 
   adobe-reader = pkgsi686Linux.callPackage ../applications/misc/adobe-reader { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29848,7 +29848,9 @@ in
 
   rmount = callPackage ../tools/filesystems/rmount {};
 
-  romdirfs = callPackage ../tools/filesystems/romdirfs {};
+  romdirfs = callPackage ../tools/filesystems/romdirfs {
+    stdenv = gccStdenv;
+  };
 
   rss-glx = callPackage ../misc/screensavers/rss-glx { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add more FUSE packages on Darwin.

##### FUSE packages [formerly maintained by Homebrew](https://grep.app/search?q=%22requires%20fuse%22&filter[repo][0]=Homebrew/homebrew-core), ordered by [popularity](https://formulae.brew.sh/analytics/install-on-request/365d/)
- [x] ntfs-3g: Merged in #117132
- [x] sshfs: PR in #117217
- [ ] ex4fuse
- [x] ifuse: insufficient testing, need an idevice (perhaps unreliable with newer versions of iOS?)
- [x] s3fs: Merged in #116958
- [ ] ext2fuse
- [x] bindfs: Merged in #116958
- [x] gitfs
- [x] gcsfuse: Already builds on nixpkgs
- [x] encfs
- [x] dislocker: Some patching needed, upstream PR in Aorimn/dislocker#246
- [ ] goofys
- [x] gocryptfs: Already builds on nixpkgs
- [ ] simple-mtpfs
- [ ] xmount
- [ ] tup
- [x] curlftpfs
- [x] cryfs: Some patching needed, upstream PR in cryfs/cryfs#378
- [ ] fuse-zip
- [x] archivemount
- [x] btfs
- [x] squashfuse
- [x] securefs
- [x] avfs
- [ ] s3ql: Only supports libfuse 3.x
- [x] afuse
- [x] s3backer
- [x] mp3fs
- [x] wdfs
- [ ] rofs-filtered

##### Others
- [x] acd-cli: Insufficient testing, need an online account
- [x] afflib
- [ ] libnbd: Currently not compatible with Darwin
- [ ] seafile-shared
- [ ] catfs
- [ ] erofs: Depends on libuuid (util-linux), [which actually builds](https://github.com/Homebrew/homebrew-core/blob/2b5155470ccc9bcb7813104476b6dbcad85799ab/Formula/util-linux.rb) on Darwin. Working on a PR.
- [ ] rewritefs
- [ ] cromfs
- [ ] hpe-ltfs: Also depends on libuuid
- [x] 9pfs
- [x] aefs: needs patching, PR opened in edolstra/aefs#1
- [ ] afpfs-ng: depends on the `attr` package, which doesn't build with the current macOS SDK version on Nixpkgs
- [x] android-file-transfer: was also missing wrapQtApps
- [ ] apfs-fuse
- [ ] blobfuse: depends on libuuid
- [x] boxfs: insufficient testing, need online account
- [ ] chunkfs: not portable
- [ ] ciopfs: depends on the `attr` package
- [x] darling-dmg
- [ ] disorderfs: depends on the `attr` package
- [ ] djmount
- [x] exfat
- [ ] fuse-7z-ng
- [ ] fuseiso: not portable
- [x] httpfs2
- [x] hubicfuse
- [x] jmtpfs: insufficient testing, need Android device
- [ ] lizardfs: currently marked as broken
- [ ] mergerfs: depends on the `attr` package
- [x] moosefs: insufficient testing, need non-trivial configuration
- [ ] rar2fs
- [x] romdirfs: insufficient testing, need PlayStation2 images
- [ ] smbnetfs: need to fix samba first
- [x] svnfs
- [x] tmsu: removed libfuse dependency because it relies on go-fuse instead
- [ ] vmfs-tools: depends on libuuid
- [ ] wiimms-iso-tools: need gcc4, which is broken on darwin
- [ ] xtreemfs: depends on the `attr` package
- [ ] zkfuse
- [ ] cryptometer
- [ ] lkl
- [ ] veracrypt
- [ ] ocamlfuse
- [ ] google-drivce-ocalfuse
- [ ] orifs: currently marked as broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
