### PR TITLE
wayland: fix build on non-Linux 

### DIFF
--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wayland.freedesktop.org/";
     license = licenses.mit; # Expat version
     platforms = if withLibraries then platforms.linux else platforms.unix;
-    maintainers = with maintainers; [ primeos codyopel ];
+    maintainers = with maintainers; [ primeos codyopel qyliss ];
   };
 
   passthru.version = version;

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -10,7 +10,8 @@
 , libxml2
 , wayland
 , expat ? null # Build wayland-scanner (currently cannot be disabled as of 1.7.0)
-, withDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform
+, withLibraries ? stdenv.isLinux
+, withDocumentation ? withLibraries && stdenv.hostPlatform == stdenv.buildPlatform
 , graphviz-nox
 , doxygen
 , libxslt
@@ -20,6 +21,9 @@
 , docbook_xml_dtd_45
 , docbook_xml_dtd_42
 }:
+
+# Documentation is only built when building libraries.
+assert withDocumentation -> withLibraries;
 
 # Require the optional to be enabled until upstream fixes or removes the configure flag
 assert expat != null;
@@ -45,7 +49,10 @@ stdenv.mkDerivation rec {
   outputs = [ "out" ] ++ lib.optionals withDocumentation [ "doc" "man" ];
   separateDebugInfo = true;
 
-  mesonFlags = [ "-Ddocumentation=${lib.boolToString withDocumentation}" ];
+  mesonFlags = [
+    "-Dlibraries=${lib.boolToString withLibraries}"
+    "-Ddocumentation=${lib.boolToString withDocumentation}"
+  ];
 
   postPatch = lib.optionalString withDocumentation ''
     patchShebangs doc/doxygen/gen-doxygen.py
@@ -71,16 +78,17 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    libffi
     expat
     libxml2
+  ] ++ lib.optionals withLibraries [
+    libffi
   ] ++ lib.optionals withDocumentation [
     docbook_xsl
     docbook_xml_dtd_45
     docbook_xml_dtd_42
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Core Wayland window system code and protocol";
     longDescription = ''
       Wayland is a project to define a protocol for a compositor to talk to its
@@ -91,9 +99,9 @@ stdenv.mkDerivation rec {
       rendering).
     '';
     homepage = "https://wayland.freedesktop.org/";
-    license = lib.licenses.mit; # Expat version
-    platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ primeos codyopel ];
+    license = licenses.mit; # Expat version
+    platforms = if withLibraries then platforms.linux else platforms.unix;
+    maintainers = with maintainers; [ primeos codyopel ];
   };
 
   passthru.version = version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The Wayland libraries themselves only build on Linux, but other
platforms need wayland-scanner for cross-compiling to Linux.  So for
them, disable the libraries so only wayland-scanner is built.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
