### PR TITLE
python3Packages.airly: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/airly/default.nix
+++ b/pkgs/development/python-modules/airly/default.nix
@@ -1,29 +1,40 @@
 { lib
+, aiohttp
+, aioresponses
+, aiounittest
 , buildPythonPackage
 , fetchFromGitHub
-, aiohttp
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "airly";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "ak-ambi";
     repo = "python-airly";
     rev = "v${version}";
-    sha256 = "0an6nbl0i5pahxm6x4z03s9apzgqrw9zf7srjcs0r3y1ppicb4s6";
+    sha256 = "sha256-weliT/FYnRX+pzVAyRWFly7lfj2z7P+hpq5SIhyIgmI=";
   };
 
   propagatedBuildInputs = [ aiohttp ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    aioresponses
+    aiounittest
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    cd tests
+  '';
 
   disabledTests = [
     "InstallationsLoaderTestCase"
     "MeasurementsSessionTestCase"
   ];
+
   pythonImportsCheck = [ "airly" ];
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -177,6 +177,7 @@ in with py.pkgs; buildPythonApplication rec {
   # its dependencies packaged and listed in ./component-packages.nix.
   componentTests = [
     "accuweather"
+    "airly"
     "alert"
     "api"
     "auth"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.1.0

Change log: https://github.com/ak-ambi/python-airly/releases/tag/v1.1.0

Enable the `airly` test of Home Assistant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
