### PR TITLE
ocamlPackages.gettext-camomile: init at 0.4.2

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
@@ -1,0 +1,16 @@
+{ buildDunePackage, ocaml_gettext, camomile, ounit, fileutils }:
+
+buildDunePackage {
+  pname = "gettext-camomile";
+  inherit (ocaml_gettext) src version useDune2;
+
+  propagatedBuildInputs = [ camomile ocaml_gettext ];
+
+  doCheck = true;
+  checkInputs = [ ounit fileutils ];
+
+  meta = ocaml_gettext.meta // {
+    description = "Internationalization library using camomile (i18n)";
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -796,6 +796,8 @@ let
 
     ocaml_gettext = callPackage ../development/ocaml-modules/ocaml-gettext { };
 
+    gettext-camomile = callPackage ../development/ocaml-modules/ocaml-gettext/camomile.nix { };
+
     gettext-stub = callPackage ../development/ocaml-modules/ocaml-gettext/stub.nix { };
 
     ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };


### PR DESCRIPTION
###### Motivation for this change

This library is missing in `nixpkgs`…

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
