### PR TITLE
lisgd: init at 0.3.0

### DIFF
--- a/pkgs/tools/inputmethods/lisgd/default.nix
+++ b/pkgs/tools/inputmethods/lisgd/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, writeText
+, libinput
+, libX11
+, conf ? null
+, patches ? [ ]
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lisgd";
+  version = "0.3.0";
+
+  src = fetchFromSourcehut {
+    owner = "~mil";
+    repo = "lisgd";
+    rev = version;
+    sha256 = "0g2pwff2c6ipxz83l26kx4rs3vah9qlm4h0n4x1k80mzqzf15hb6";
+  };
+
+  inherit patches;
+
+  postPatch = let
+    configFile = if lib.isDerivation conf || lib.isPath conf then
+      conf
+    else
+      writeText "config.def.h" conf;
+  in lib.optionalString (conf != null) ''
+    cp ${configFile} config.def.h
+  '';
+
+  buildInputs = [
+    libinput
+    libX11
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    description = "Bind gestures via libinput touch events";
+    homepage = "https://git.sr.ht/~mil/lisgd";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2658,6 +2658,8 @@ in
 
   linuxptp = callPackage ../os-specific/linux/linuxptp { };
 
+  lisgd = callPackage ../tools/inputmethods/lisgd { };
+
   lite = callPackage ../applications/editors/lite { };
 
   loadwatch = callPackage ../tools/system/loadwatch { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
for https://sr.ht/~mil/Sxmo/
test with
```
./result/bin/lisgd -d /dev/input/some-device -g "1,LR,*,*,R,notify-send swiped lr"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
