### PR TITLE
defaultGemConfig.pg_query: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -211,12 +211,12 @@ in
     '';
   };
 
-  pg_query = attrs: lib.optionalAttrs (attrs.version == "2.0.1") {
+  pg_query = attrs: lib.optionalAttrs (attrs.version == "2.0.2") {
     dontBuild = false;
     postPatch = ''
       sed -i "s;'https://codeload.github.com.*';'${fetchurl {
-        url = "https://codeload.github.com/lfittl/libpg_query/tar.gz/13-2.0.0";
-        sha256 = "0ghk0dlmrn634p3zjr41fy4ipgw8i44f67a4l8cspqg0395m3rp5";
+        url = "https://codeload.github.com/lfittl/libpg_query/tar.gz/13-2.0.2";
+        sha256 = "0ms2s6hmy8qyzv4g1hj4i2p5fws1v8lrj73b2knwbp2ipd45yj7y";
       }}';" ext/pg_query/extconf.rb
     '';
   } // lib.optionalAttrs (attrs.version == "1.3.0") {

--- a/pkgs/development/tools/sqlint/Gemfile.lock
+++ b/pkgs/development/tools/sqlint/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     google-protobuf (3.15.6)
-    pg_query (2.0.1)
+    pg_query (2.0.2)
       google-protobuf (~> 3.15.5)
     sqlint (0.2.0)
       pg_query (~> 2)

--- a/pkgs/development/tools/sqlint/default.nix
+++ b/pkgs/development/tools/sqlint/default.nix
@@ -13,6 +13,6 @@ bundlerApp {
     homepage    = "https://github.com/purcell/sqlint";
     license     = licenses.mit;
     maintainers = with maintainers; [ ariutta nicknovitski purcell ];
-    platforms   = with platforms; [ "x86_64-linux" "x86_64-darwin" ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/sqlint/gemset.nix
+++ b/pkgs/development/tools/sqlint/gemset.nix
@@ -15,10 +15,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01a8asbgkr7f1gp50ikzr1zzmvwv50da389943hrrqzxwd202268";
+      sha256 = "0bvn0swyzzhl9x8hlgaz7m7s1jqmpdi2c4klarix0hiyapy2il9y";
       type = "gem";
     };
-    version = "2.0.1";
+    version = "2.0.2";
   };
   sqlint = {
     dependencies = ["pg_query"];


### PR DESCRIPTION
Follow-up to #116785, to apply a further small version bump for upstream fixes, including that pg_query 2.0.2 apparently should now build on ARM.

This change also re-locks my package `sqlint` to use the newer version, and generalises the platform spec to avoid excluding ARM.

As before, other packages which refer to pg_query (gitlab, gitlab-ee, gitaly) are unaffected, because they pin an older version of pg_query which is handled separately in the gem-config expressions.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
