### PR TITLE
liblinphone: 4.4.35 -> 4.5.1

### DIFF
--- a/pkgs/development/libraries/bctoolbox/default.nix
+++ b/pkgs/development/libraries/bctoolbox/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "bctoolbox";
-  version = "4.4.34";
+  version = "4.5.1";
 
   nativeBuildInputs = [ cmake bcunit ];
   buildInputs = [ mbedtls ];
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "0bfswwvvdshaahg4jd2j10f0sci8809s4khajd0m6b059zwc7y25";
+    sha256 = "1mm3v01jz2mp8vajsl45s23gw90zafbgg3br5n5yz03aan08f395";
   };
 
   # Do not build static libraries

--- a/pkgs/development/libraries/belcard/default.nix
+++ b/pkgs/development/libraries/belcard/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "belcard";
-  version = "4.4.34";
+  version = "4.5.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "16x2xp8d0a115132zhy1kpxkyj86ia7vrsnpjdg78fnbvmvysc8m";
+    sha256 = "14hkgwr2a9zw44v1s8xscqxa2mwin06jsxpwb3hflh9mp16ymfzv";
   };
 
   buildInputs = [ bctoolbox belr ];

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   pname = "belle-sip";
-  version = "4.4.34";
+  version = "4.5.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "1kknnlczq7dpqaj1dwxvy092dzrqjy11ndkv90rqwmdryigkjk6z";
+    sha256 = "0d1wf0jv9lb0s6r49i9gz5nrx8jzpkx558hywll7idma9d0mr61p";
   };
 
   nativeBuildInputs = [ antlr3_4 cmake ];

--- a/pkgs/development/libraries/belr/default.nix
+++ b/pkgs/development/libraries/belr/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "belr";
-  version = "4.4.34";
+  version = "4.5.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "0w2canwwm0qb99whnangvaybvjzq8xg6vksqxykgr8fbx7clw03h";
+    sha256 = "0m0s7g8d25nbnafbl76w9v3x7q4jhsypxmz1gg80pj7j34xc2dsd";
   };
 
   buildInputs = [ bctoolbox ];

--- a/pkgs/development/libraries/bzrtp/default.nix
+++ b/pkgs/development/libraries/bzrtp/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "bzrtp";
-  version = "4.4.34";
+  version = "4.5.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "1yjmsbqmymzl4r7sba6w4a2yld8m6hzafr6jf7sj0syhwpnc3zv6";
+    sha256 = "1a500ncgznwha0j3c27ak3p4jh5jm6fnnb531k7c0a4i91745agj";
   };
 
   buildInputs = [ bctoolbox sqlite ];

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -10,10 +10,8 @@
 , cyrus_sasl
 , doxygen
 , fetchFromGitLab
-, fetchurl
 , ffmpeg_3
 , gdk-pixbuf
-, git
 , glib
 , graphviz
 , gtk2
@@ -30,7 +28,6 @@
 , makeWrapper
 , mbedtls
 , mediastreamer
-, mediastreamer-openh264
 , openldap
 , ortp
 , pango

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -35,7 +35,7 @@
 , ortp
 , pango
 , pkg-config
-, python
+, python3
 , readline
 , soci
 , speex
@@ -49,7 +49,7 @@
 
 stdenv.mkDerivation rec {
   pname = "liblinphone";
-  version = "4.4.35";
+  version = "4.5.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "1sysr8wnf1kvq87h2ymr5qk9qcjapayvlmcmzcx3zxk8vhqp83d8";
+    sha256 = "05ybbxq2yqzy3f3vzq8c3szs3qr0zl64la53icpqnmfakwnps5gs";
   };
 
   # Do not build static libraries
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
   # defined when liblinphone and linphone-desktop weren't separated yet, so some
   # of them might not be needed for liblinphone alone.
   buildInputs = [
-    (python.withPackages (ps: [ ps.pystache ps.six ]))
+    (python3.withPackages (ps: [ ps.pystache ps.six ]))
     bcg729
     bctoolbox
     belcard

--- a/pkgs/development/libraries/lime/default.nix
+++ b/pkgs/development/libraries/lime/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lime";
-  version = "4.4.34";
+  version = "4.5.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "14jg1zisjbzflw3scfqdbwy48wq3cp93l867vigb8l40lkc6n26z";
+    sha256 = "1fsldk7gxagxkbkzksz6dz8a8dmix1lxfy8nvvp0m355pzgqj6lb";
   };
 
   buildInputs = [ bctoolbox soci belle-sip sqlite ];

--- a/pkgs/development/libraries/lime/default.nix
+++ b/pkgs/development/libraries/lime/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "End-to-end encryption library for instant messaging";
     homepage = "http://www.linphone.org/technical-corner/lime";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];
   };

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -24,7 +24,7 @@
 , libvpx
 , ortp
 , pkg-config
-, python
+, python3
 , SDL
 , speex
 , srtp
@@ -33,7 +33,7 @@
 
 stdenv.mkDerivation rec {
   pname = "mediastreamer2";
-  version = "4.4.35";
+  version = "4.5.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "18qmg678m087k7qsaxwfcv2p875z2kpy91pqryiv955km40drl0g";
+    sha256 = "0aqma9834lzy1593qb9qwmzvzn50y6fzhmmg493jznf8977b0gsw";
   };
 
   patches = [
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     doxygen
     intltool
     pkg-config
-    python
+    python3
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -4,11 +4,11 @@
 , cmake
 , doxygen
 , fetchFromGitLab
-, fetchpatch
 , ffmpeg_3
 , glew
 , gsm
 , intltool
+, lib
 , libGL
 , libGLU
 , libX11
@@ -28,7 +28,7 @@
 , SDL
 , speex
 , srtp
-, lib, stdenv
+, stdenv
 }:
 
 stdenv.mkDerivation rec {
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A powerful and lightweight streaming engine specialized for voice/video telephony applications";
     homepage = "http://www.linphone.org/technical-corner/mediastreamer2";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jluttine ];
   };

--- a/pkgs/development/libraries/ortp/default.nix
+++ b/pkgs/development/libraries/ortp/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "ortp";
-  version = "4.4.34";
+  version = "4.5.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "1r1kvjzyfvkf66in4p51wi87balzg3sw3aq6r4xr609mz86spi5m";
+    sha256 = "1lc1j7wvkyp5lhcflq3h5y7n8aiwgwj84ffm81ggbsmavamgwkk7";
   };
 
   # Do not build static libraries


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update liblinphone and its dependencies. The updating of liblinphone and its dependencies must typically be synced so that all the packages are updated at the same time, otherwise it's very likely that some packages will fail to build.

I tested running `linphone` executable from `linphone` package. I didn't test all the small executables in all the dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
