### PR TITLE
python3Packages.aioasuswrt: 1.3.2 -> 1.3.3

### DIFF
--- a/pkgs/development/python-modules/aioasuswrt/default.nix
+++ b/pkgs/development/python-modules/aioasuswrt/default.nix
@@ -2,7 +2,6 @@
 , asyncssh
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pytest-asyncio
 , pytest-mock
 , pytestCheckHook
@@ -10,24 +9,18 @@
 
 buildPythonPackage rec {
   pname = "aioasuswrt";
-  version = "1.3.2";
+  version = "1.3.3";
 
   src = fetchFromGitHub {
     owner = "kennedyshead";
     repo = pname;
     rev = "V${version}";
-    sha256 = "0bzl11224vny4p9vhi1n5s9p04kfavdzs9xkq5qimbisz9sg4ysj";
+    sha256 = "1h1qwc7szgrcwiz4q6x4mlf26is20lj1ds5rcb9i611j26656v6d";
   };
 
-  patches = [
-    (fetchpatch {
-      # Remove pytest-runner, https://github.com/kennedyshead/aioasuswrt/pull/63
-      url = "https://github.com/kennedyshead/aioasuswrt/pull/63/commits/e7923927648d5d8daccac1716db86db2a45fcb34.patch";
-      sha256 = "09xzs3hjr3133li6b7lr58n090r00kaxi9hx1fms2zn0ai4xwp9d";
-    })
-  ];
-
   postPatch = ''
+    substituteInPlace setup.py \
+      --replace "cryptography==3.3.2" "cryptography"
     substituteInPlace setup.cfg \
       --replace "--cov-report html" "" \
       --replace "--cov-report term-missing" ""


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.3.3

Change log: https://github.com/kennedyshead/aioasuswrt/releases/tag/V1.3.3

HOme Assistant tests for `asuswrt` don't pass (Config flow issue).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
