### PR TITLE
python3Packages.privacyIDEA: 3.5.1 -> 3.5.2

### DIFF
--- a/pkgs/development/python-modules/privacyidea/default.nix
+++ b/pkgs/development/python-modules/privacyidea/default.nix
@@ -11,15 +11,21 @@
 
 buildPythonPackage rec {
   pname = "privacyIDEA";
-  version = "3.5.1";
+  version = "3.5.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-XJnrrpU0x2Axu7W4G3oDTjSJuqEyh3C/0Aga5D0gw9k=";
+    sha256 = "sha256-k2om2LjkFRCT53ECPAJEztCiMdz4fF5eoipVUvSoyGo=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # Subset of https://github.com/privacyidea/privacyidea/commit/359db6dd10212b8a210e0a83536e92e9e796a1f8,
+    # fixes app context errors in tests. Can be removed on the next bump.
+    ./fix-tests.patch
+  ];
 
   propagatedBuildInputs = [
     cryptography pyrad pymysql python-dateutil flask-versioned flask_script
@@ -36,6 +42,7 @@ buildPythonPackage rec {
     "AESHardwareSecurityModuleTestCase"
     "test_01_cert_request"
     "test_01_loading_scripts"
+    "test_02_api_push_poll"
     "test_02_cert_enrolled"
     "test_02_enroll_rights"
     "test_02_get_resolvers"

--- a/pkgs/development/python-modules/privacyidea/fix-tests.patch
+++ b/pkgs/development/python-modules/privacyidea/fix-tests.patch
@@ -1,0 +1,28 @@
+diff --git a/privacyidea/lib/resolvers/LDAPIdResolver.py b/privacyidea/lib/resolvers/LDAPIdResolver.py
+index ae9d87764..cfc609931 100644
+--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
++++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
+@@ -97,11 +97,6 @@
+ SERVERPOOL_ROUNDS = 2
+ # The number of seconds a non-responding server is removed from the server pool
+ SERVERPOOL_SKIP = 30
+-# The number of seconds that ldap3 waits if no server is left in the pool, before
+-# starting the next round
+-pooling_loop_timeout = get_app_config_value("PI_LDAP_POOLING_LOOP_TIMEOUT", 10)
+-log.info("Setting system wide POOLING_LOOP_TIMEOUT to {0!s}.".format(pooling_loop_timeout))
+-ldap3.set_config_parameter("POOLING_LOOP_TIMEOUT", pooling_loop_timeout)
+ 
+ # 1 sec == 10^9 nano secs == 10^7 * (100 nano secs)
+ MS_AD_MULTIPLYER = 10 ** 7
+@@ -314,6 +309,11 @@ def __init__(self):
+         self.serverpool_rounds = SERVERPOOL_ROUNDS
+         self.serverpool_skip = SERVERPOOL_SKIP
+         self.serverpool = None
++        # The number of seconds that ldap3 waits if no server is left in the pool, before
++        # starting the next round
++        pooling_loop_timeout = get_app_config_value("PI_LDAP_POOLING_LOOP_TIMEOUT", 10)
++        log.info("Setting system wide POOLING_LOOP_TIMEOUT to {0!s}.".format(pooling_loop_timeout))
++        ldap3.set_config_parameter("POOLING_LOOP_TIMEOUT", pooling_loop_timeout)
+ 
+     def checkPass(self, uid, password):
+         """


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ChangeLog: https://github.com/privacyidea/privacyidea/blob/v3.5.2/Changelog#L1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
