### PR TITLE
python3Packages.yamllint: 1.25.0 -> 1.26.0

### DIFF
--- a/pkgs/development/python-modules/yamllint/default.nix
+++ b/pkgs/development/python-modules/yamllint/default.nix
@@ -5,16 +5,17 @@
 , pytestCheckHook
 , pythonOlder
 , pyyaml
+, stdenv
 }:
 
 buildPythonPackage rec {
   pname = "yamllint";
-  version = "1.25.0";
+  version = "1.26.0";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b1549cbe5b47b6ba67bdeea31720f5c51431a4d0c076c1557952d841f7223519";
+    sha256 = "11qhs1jk9pwvyk5k3q5blh9sq42dh1ywdf1f3i2zixf7hncwir5h";
   };
 
   propagatedBuildInputs = [
@@ -27,8 +28,13 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # Test failure could be related to https://github.com/adrienverge/yamllint/issues/334
+    # test failure reported upstream: https://github.com/adrienverge/yamllint/issues/373
     "test_find_files_recursively"
+  ] ++ lib.optional stdenv.isDarwin [
+    # locale tests are broken on BSDs; see https://github.com/adrienverge/yamllint/issues/307
+    "test_locale_accents"
+    "test_locale_case"
+    "test_run_with_locale"
   ];
 
   pythonImportsCheck = [ "yamllint" ];


### PR DESCRIPTION
python3Packages.yamllint: 1.25.0 -> 1.26.0

Fix Darwin build: disable broken tests on BSDs;
see https://github.com/adrienverge/yamllint/issues/307.

Report failure of test_find_files_recursively upstream;
see https://github.com/adrienverge/yamllint/issues/373.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>
Co-authored-by: Robert Schütz <dev@schuetz-co.de>
