### PR TITLE
gnomeExtensions.topicons-plus: 22 -> 27

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-topicons-plus";
-  version = "22";
+  version = "27";
 
   src = fetchFromGitHub {
     owner = "phocean";
     repo = "TopIcons-plus";
-    rev = "v${version}";
-    sha256 = "196s1gdir52gbc444pzrb5l7gn5xr5vqk5ajqaiqryqlmp3i8vil";
+    rev = version;
+    sha256 = "1p3jlvs4zgnrvy8am7myivv4rnnshjp49kg87rd22qqyvcz51ykr";
   };
 
   buildInputs = [ glib ];
@@ -24,7 +24,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ eperuffo ];
     homepage = "https://github.com/phocean/TopIcons-plus";
-    # Unmaintained and no longer working with GNOME Shell 3.34+
-    broken = lib.versionAtLeast gnome3.gnome-shell.version "3.32";
   };
 }

--- a/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, glib, gnome3, gettext }:
+{ lib, stdenv, fetchFromGitHub, glib, gettext }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-topicons-plus";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Brings all icons back to the top panel, so that it's easier to keep track of apps running in the backround";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ eperuffo ];
     homepage = "https://github.com/phocean/TopIcons-plus";
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Unmark as broken because it is compatible with the current version of GNOME.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
