### PR TITLE
gnomeExtension.disable-unredirect: init at unstable-2021-01-17

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/disable-unredirect/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/disable-unredirect/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-disable-unredirect";
+  version = "unstable-2021-01-17";
+
+  src = fetchFromGitHub {
+    owner = "kazysmaster";
+    repo = "gnome-shell-extension-disable-unredirect";
+    rev = "2ecb2f489ea3316b77d04f03a0c885f322c67e79";
+    sha256 = "1rjyrg8qya0asndxr7189a9npww0rcxk02wkxrxjy7fdp5m89p7y";
+  };
+
+  uuid = "unredirect@vaina.lt";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -R ${uuid} $out/share/gnome-shell/extensions/${uuid}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Disables unredirect fullscreen windows in gnome-shell to avoid tearing";
+    license = licenses.gpl3Only;
+    homepage = "https://github.com/kazysmaster/gnome-shell-extension-disable-unredirect";
+    maintainers = with maintainers; [ eduardosm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28099,6 +28099,7 @@ in
     clock-override = callPackage ../desktops/gnome-3/extensions/clock-override { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
+    disable-unredirect = callPackage ../desktops/gnome-3/extensions/disable-unredirect { };
     draw-on-your-screen = callPackage ../desktops/gnome-3/extensions/draw-on-your-screen { };
     drop-down-terminal = callPackage ../desktops/gnome-3/extensions/drop-down-terminal { };
     dynamic-panel-transparency = callPackage ../desktops/gnome-3/extensions/dynamic-panel-transparency { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
