### PR TITLE
pkgsStatic: apply stdenvAdapters to all llvm stdenvs

### DIFF
--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -83,15 +83,29 @@ self: super: let
       });
     };
 
+  llvmStaticAdapter = llvmPackages:
+    llvmPackages // {
+      stdenv = foldl (flip id) llvmPackages.stdenv staticAdapters;
+      libcxxStdenv = foldl (flip id) llvmPackages.libcxxStdenv staticAdapters;
+    };
+
 in {
   stdenv = foldl (flip id) super.stdenv staticAdapters;
+
   gcc49Stdenv = foldl (flip id) super.gcc49Stdenv staticAdapters;
   gcc6Stdenv = foldl (flip id) super.gcc6Stdenv staticAdapters;
   gcc7Stdenv = foldl (flip id) super.gcc7Stdenv staticAdapters;
   gcc8Stdenv = foldl (flip id) super.gcc8Stdenv staticAdapters;
   gcc9Stdenv = foldl (flip id) super.gcc9Stdenv staticAdapters;
-  clangStdenv = foldl (flip id) super.clangStdenv staticAdapters;
-  libcxxStdenv = foldl (flip id) super.libcxxStdenv staticAdapters;
+
+  llvmPackages_5 = llvmStaticAdapter super.llvmPackages_5;
+  llvmPackages_6 = llvmStaticAdapter super.llvmPackages_6;
+  llvmPackages_7 = llvmStaticAdapter super.llvmPackages_7;
+  llvmPackages_8 = llvmStaticAdapter super.llvmPackages_8;
+  llvmPackages_9 = llvmStaticAdapter super.llvmPackages_9;
+  llvmPackages_10 = llvmStaticAdapter super.llvmPackages_10;
+  llvmPackages_11 = llvmStaticAdapter super.llvmPackages_11;
+  llvmPackages_12 = llvmStaticAdapter super.llvmPackages_12;
 
   boost = super.boost.override {
     # Don’t use new stdenv for boost because it doesn’t like the


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Note that I haven't really been able to test this change yet, any hints on good starting points would be appreciated.
This has probably little impact on nixpkgs itself as the llvm stdenvs are rarely used, but may be useful for downstream
users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
