### PR TITLE
code-server: 3.8.0 -> 3.9.0

### DIFF
--- a/pkgs/servers/code-server/default.nix
+++ b/pkgs/servers/code-server/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cdr";
     repo = "code-server";
-    rev = commit;
+    rev = "v${version}";
     sha256 = "0jgmf8d7hki1iv6yy1z0s5qjyxchxnwj8kv53jrwkllim08swbi3";
   };
 

--- a/pkgs/servers/code-server/default.nix
+++ b/pkgs/servers/code-server/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cdr";
     repo = "code-server";
-    rev = "${commit}";
+    rev = commit;
     sha256 = "0jgmf8d7hki1iv6yy1z0s5qjyxchxnwj8kv53jrwkllim08swbi3";
   };
 

--- a/pkgs/servers/code-server/default.nix
+++ b/pkgs/servers/code-server/default.nix
@@ -1,26 +1,26 @@
 { lib, stdenv, fetchFromGitHub, buildGoModule, makeWrapper, runCommand
-, moreutils, jq, git, zip, rsync, pkg-config, yarn, python2
-, nodejs-12_x, libsecret, xorg, ripgrep
+, moreutils, jq, git, zip, rsync, pkg-config, yarn, python3
+, nodejs-14_x, libsecret, xorg, ripgrep
 , AppKit, Cocoa, Security, cctools }:
 
 let
   system = stdenv.hostPlatform.system;
 
-  nodejs = nodejs-12_x;
-  python = python2;
+  nodejs = nodejs-14_x;
+  python = python3;
   yarn' = yarn.override { inherit nodejs; };
   defaultYarnOpts = [ "frozen-lockfile" "non-interactive" "no-progress"];
 
 in stdenv.mkDerivation rec {
   pname = "code-server";
-  version = "3.8.0";
-  commit = "c4610f7829701aadb045d450013b84491c30580d";
+  version = "3.9.0";
+  commit = "fc6d123da59a4e5a675ac8e080f66e032ba01a1b";
 
   src = fetchFromGitHub {
     owner = "cdr";
     repo = "code-server";
-    rev = "v${version}";
-    sha256 = "1snc7dbqfz53337h6av2zhkrn54ypanxljs5by4jqczq96c2v6yk";
+    rev = "${commit}";
+    sha256 = "0jgmf8d7hki1iv6yy1z0s5qjyxchxnwj8kv53jrwkllim08swbi3";
   };
 
   cloudAgent = buildGoModule rec {
@@ -62,9 +62,9 @@ in stdenv.mkDerivation rec {
 
     # to get hash values use nix-build -A code-server.prefetchYarnCache
     outputHash = {
-      x86_64-linux = "0xc1yjz53ydg1mwyc2rp4hq20hg6i4aiirfwsnykjw1zm79qgrgb";
-      aarch64-linux = "0xc1yjz53ydg1mwyc2rp4hq20hg6i4aiirfwsnykjw1zm79qgrgb";
-      x86_64-darwin = "0xc1yjz53ydg1mwyc2rp4hq20hg6i4aiirfwsnykjw1zm79qgrgb";
+      x86_64-linux = "01nkqcfvx2qw9g60h8k9x221ibv3j58vdkjzcjnj7ph54a33ifih";
+      aarch64-linux = "01nkqcfvx2qw9g60h8k9x221ibv3j58vdkjzcjnj7ph54a33ifih";
+      x86_64-darwin = "01nkqcfvx2qw9g60h8k9x221ibv3j58vdkjzcjnj7ph54a33ifih";
     }.${system} or (throw "Unsupported system ${system}");
   };
 
@@ -210,7 +210,7 @@ in stdenv.mkDerivation rec {
     ln -s "${cloudAgent}/bin/cloud-agent" $out/libexec/code-server/lib/coder-cloud-agent
 
     # create wrapper
-    makeWrapper "${nodejs-12_x}/bin/node" "$out/bin/code-server" \
+    makeWrapper "${nodejs-14_x}/bin/node" "$out/bin/code-server" \
       --add-flags "$out/libexec/code-server/out/node/entry.js"
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates code-server to 3.9.0. There exist later minor versions but I can't get around `yarn` integrity check failures for those.

This also moves `node` major version to `14`, it's proven to work and later V8 versions should bring some performance improvement here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
