### PR TITLE
libreoffice-fresh: 7.1.1.2 -> 7.1.2.2

### DIFF
--- a/pkgs/applications/office/libreoffice/src-fresh/download.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/download.nix
@@ -742,11 +742,11 @@
     md5name = "12345c83b89aa29808568977f5200d6da00f88a035517f925293355432ffe61f-postgresql-13.1.tar.bz2";
   }
   {
-    name = "Python-3.8.4.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/Python-3.8.4.tar.xz";
-    sha256 = "5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37";
+    name = "Python-3.8.8rc1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/Python-3.8.8rc1.tar.xz";
+    sha256 = "bd746ed1ad9ccfa9b2a8d13736a5c452025c3600913d000078e6ed1df3d767b6";
     md5 = "";
-    md5name = "5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37-Python-3.8.4.tar.xz";
+    md5name = "bd746ed1ad9ccfa9b2a8d13736a5c452025c3600913d000078e6ed1df3d767b6-Python-3.8.8rc1.tar.xz";
   }
   {
     name = "QR-Code-generator-1.4.0.tar.gz";

--- a/pkgs/applications/office/libreoffice/src-fresh/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/primary.nix
@@ -8,7 +8,7 @@ rec {
 
   major = "7";
   minor = "1";
-  patch = "1";
+  patch = "2";
   tweak = "2";
 
   subdir = "${major}.${minor}.${patch}";
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "1vz028hzbc4n8jznigs419ygylz1vp426dprrkm62bzckv2p1rfn";
+    sha256 = "1y19p9701msf6jjzp9d5ighvmyjzj68qzhm2bk3l5p16ys8qk9bb";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    sha256 = "1vidv8077f394zn87b2ng1hsld0hgr1zb1p9lmjx0n9k7s7clavh";
+    sha256 = "1j5251lbc35d521d92w52lgps0v5pg8mhr8y3r6x2nl9p0gvw957";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    sha256 = "14wn0lvvplsj194jdqqv184xx0adb4mm8bjflddvcqsl7xsfqx27";
+    sha256 = "1bsrkmzhhpyrmi7akmdfvz4zb543fc093az9965k14rp8l6rhnvf";
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).