### PR TITLE
opensnitch: 1.3.6 -> 1.4.0

### DIFF
--- a/pkgs/tools/networking/opensnitch/daemon.nix
+++ b/pkgs/tools/networking/opensnitch/daemon.nix
@@ -1,6 +1,8 @@
 { buildGoModule
 , fetchFromGitHub
 , fetchpatch
+, protobuf
+, go-protobuf
 , pkg-config
 , libnetfilter_queue
 , libnfnetlink
@@ -9,36 +11,45 @@
 
 buildGoModule rec {
   pname = "opensnitch";
-  version = "1.3.6";
+  version = "1.4.0-rc.2";
 
   src = fetchFromGitHub {
     owner = "evilsocket";
     repo = "opensnitch";
     rev = "v${version}";
-    sha256 = "sha256-Cgo+bVQQeUZuYYhA1WSqlLyQQGAeXbbNno9LS7oNvhI=";
+    sha256 = "1kj32lc5pksh0r2j4x8ihasch1is8ahxhmd8q49dydm9z64f3nya";
   };
 
   patches = [
-    # https://github.com/evilsocket/opensnitch/pull/384 don't require
-    # a configuration file in /etc
+    # https://github.com/evilsocket/opensnitch/pull/417
+    (fetchpatch {
+      name = "add-gpbpf-to-go.mod";
+      url = "https://github.com/evilsocket/opensnitch/commit/356428b6c9f05447ed3c3ea19b5f507d16fba80a.patch";
+      sha256 = "sha256:0fc9qyj68rmdij2biq01bs7ky0k6hl21pk48gipk6w5l3cg2d085";
+    })
     (fetchpatch {
       name = "dont-require-config-in-etc.patch";
       url = "https://github.com/evilsocket/opensnitch/commit/8a3f63f36aa92658217bbbf46d39e6d20b2c0791.patch";
-      sha256 = "sha256-WkwjKTQZppR0nqvRO4xiQoKZ307NvuUwoRx+boIpuTg=";
+      sha256 = "sha256:0f5r5616wzhwl4qfbgnd9vgrk0j2ca63pldbkrs999hr6hlj6k2s";
     })
   ];
 
   modRoot = "daemon";
 
+  vendorSha256 = "sha256:13rwmk9asyz92937y7ggmisrmnzwvw6gylb2v5sigfsd5k0mqjxv";
+
+  nativeBuildInputs = [ pkg-config protobuf go-protobuf ];
+
+  preBuild = ''
+    make -C ../proto ../daemon/ui/protocol/ui.pb.go
+  '';
+
+  buildInputs = [ libnetfilter_queue libnfnetlink ];
+
   postBuild = ''
     mv $GOPATH/bin/daemon $GOPATH/bin/opensnitchd
   '';
 
-  vendorSha256 = "sha256-LMwQBFkHg1sWIUITLOX2FZi5QUfOivvrkcl9ELO3Trk=";
-
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ libnetfilter_queue libnfnetlink ];
 
   meta = with lib; {
     description = "An application firewall";

--- a/pkgs/tools/networking/opensnitch/ui.nix
+++ b/pkgs/tools/networking/opensnitch/ui.nix
@@ -6,16 +6,16 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "opensnitch-ui";
-  version = "1.3.6";
+  version = "1.4.0-rc.1";
 
   src = fetchFromGitHub {
     owner = "evilsocket";
     repo = "opensnitch";
     rev = "v${version}";
-    sha256 = "sha256-Cgo+bVQQeUZuYYhA1WSqlLyQQGAeXbbNno9LS7oNvhI=";
+    sha256 = "sha256-UJ46sGdL+YAeb3U9C07tzMpy6FOkLNRq2Z0koF1AL80=";
   };
 
-  nativeBuildInputs = [ wrapQtAppsHook ];
+  nativeBuildInputs = [ python3Packages.pyqt5 wrapQtAppsHook ];
 
   propagatedBuildInputs = with python3Packages; [
     grpcio-tools
@@ -27,6 +27,11 @@ python3Packages.buildPythonApplication rec {
 
   preConfigure = ''
     cd ui
+  '';
+
+  preBuild = ''
+    make -C ../proto ../ui/opensnitch/ui_pb2.py
+    pyrcc5 -o opensnitch/resources_rc.py opensnitch/res/resources.qrc
   '';
 
   preCheck = ''


### PR DESCRIPTION
###### Motivation for this change

New upstream release.

Note that starting this release, `opensnitchd` will apply the default action (which by default is `allow`) even while still waiting for your decision on a new connection. You might want to switch the default in the daemon configuration to `deny` (or wait for further improvements in this area, see https://github.com/evilsocket/opensnitch/issues/392#issuecomment-812565300) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
