### PR TITLE
duplicity: add setuptools_scm dependency

### DIFF
--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv
-, fetchpatch
 , fetchurl
 , pythonPackages
 , librsync
@@ -9,7 +8,6 @@
 , par2cmdline
 , util-linux
 , rsync
-, backblaze-b2
 , makeWrapper
 , gettext
 }:
@@ -34,13 +32,17 @@ pythonPackages.buildPythonApplication rec {
     # to make the testing code stop assuming it is run from the source directory.
     ./use-installed-scripts-in-test.patch
   ] ++ lib.optionals stdenv.isLinux [
+    # Broken on Linux in Nix' build environment
     ./linux-disable-timezone-test.patch
   ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     makeWrapper
     gettext
     pythonPackages.wrapPython
+    pythonPackages.setuptools-scm
   ];
   buildInputs = [
     librsync


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

duplicity fails to build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
