### PR TITLE
ruffle: nightly-2021-01-12 -> nightly-2021-04-02

### DIFF
--- a/pkgs/misc/emulators/ruffle/default.nix
+++ b/pkgs/misc/emulators/ruffle/default.nix
@@ -13,13 +13,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ruffle";
-  version = "nightly-2021-01-12";
+  version = "nightly-2021-04-02";
 
   src = fetchFromGitHub {
     owner = "ruffle-rs";
     repo = pname;
     rev = version;
-    sha256 = "1lywxn61w0b3pb8vjpavd9f3v58gq35ypwp41b7rjkc4rjxmf3cd";
+    sha256 = "1diz94y53hvii28894zz65aya12v8yw1864lqpkrdbj67yc6ykdj";
   };
 
   nativeBuildInputs = [
@@ -42,10 +42,13 @@ rustPlatform.buildRustPackage rec {
   ];
 
   postInstall = ''
+    # This name is too generic
+    mv $out/bin/exporter $out/bin/ruffle_exporter
+
     wrapProgram $out/bin/ruffle_desktop --prefix LD_LIBRARY_PATH ':' ${vulkan-loader}/lib
   '';
 
-  cargoSha256 = "113gh8nf2fs9shfvnzpwlc7zaq1l9l9jhlybcc4dq0wr4r8qpff5";
+  cargoSha256 = "0pnp5kmij4dwwvmgdv81mqcawcjcgg5gd6cpyf0xalyfjgj8i732";
 
   meta = with lib; {
     description = "An Adobe Flash Player emulator written in the Rust programming language.";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
