### PR TITLE
osmscout-server: 1.17.1 -> 2.0.1

### DIFF
--- a/pkgs/applications/misc/osmscout-server/default.nix
+++ b/pkgs/applications/misc/osmscout-server/default.nix
@@ -1,7 +1,7 @@
 { lib, mkDerivation, fetchFromGitHub, fetchpatch, pkg-config
 , qmake, qttools, kirigami2, qtquickcontrols2, qtlocation
 , libosmscout, mapnik, valhalla, libpostal, osrm-backend, protobuf
-, libmicrohttpd_0_9_70, sqlite, marisa, kyotocabinet, boost
+, libmicrohttpd, sqlite, marisa, kyotocabinet, boost
 }:
 
 let
@@ -14,43 +14,22 @@ let
 in
 mkDerivation rec {
   pname = "osmscout-server";
-  version = "1.17.1";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "rinigus";
     repo = "osmscout-server";
     rev = version;
-    sha256 = "0rpsi6nyhcz6bv0jab4vixkxhjmn84xi0q2xz15a097hn46cklx9";
+    sha256 = "01j1vwxyflfv6dhhgisv1a2v841xyx8ccas0q79g575s1lg6y765";
     fetchSubmodules = true;
   };
-
-  # Two patches required to work with valhalla 3.1
-  patches = [
-    # require C++14 to match latest Valhalla
-    (fetchpatch {
-      url = "https://github.com/rinigus/osmscout-server/commit/78b41b9b4c607fe9bfd6fbd61ae31cb7c8a725cd.patch";
-      sha256 = "0gk9mdwa75awl0bj30gm8waj454d8k2yixxwh05m0p550cbv3lg0";
-    })
-    # add Valhalla 3.1 config
-    (fetchpatch {
-      url = "https://github.com/rinigus/osmscout-server/commit/584de8bd47700053960fa139a2d7f8d3d184c876.patch";
-      sha256 = "0liz72n83q93bzzyyiqjkxa6hp9zjx7v9rgsmpwf88gc4caqm2dz";
-    })
-  ];
 
   nativeBuildInputs = [ qmake pkg-config qttools ];
   buildInputs = [
     kirigami2 qtquickcontrols2 qtlocation
-    mapnik valhalla libosmscout osrm-backend libmicrohttpd_0_9_70
+    mapnik valhalla libosmscout osrm-backend libmicrohttpd
     libpostal sqlite marisa kyotocabinet boost protobuf date
   ];
-
-  # OSMScout server currently defaults to an earlier version of valhalla,
-  # but valhalla 3.1 support has been added. (See patches above)
-  # Replace the default valhalla.json with the valhalla 3.1 version
-  postPatch = ''
-    mv data/valhalla.json-3.1 data/valhalla.json
-  '';
 
   # Choose to build the kirigami UI variant
   qmakeFlags = [ "SCOUT_FLAVOR=kirigami" ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Of the resultant binaries, `osmscout-server` works fine. The newly split-out `osmscout-server-gui` currently segfaults on startup on my machine (https://github.com/rinigus/osmscout-server/issues/377).