### PR TITLE
ocamlPackages.mimic: 0.0.1 -> 0.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/mimic/default.nix
+++ b/pkgs/development/ocaml-modules/mimic/default.nix
@@ -5,14 +5,14 @@
 
 buildDunePackage rec {
   pname = "mimic";
-  version = "0.0.1";
+  version = "0.0.2";
 
   minimumOCamlVersion = "4.08";
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${pname}-v${version}/${pname}-${pname}-v${version}.tbz";
-    sha256 = "0j4l99sgm5mdmv67vakkz2pw45l6i89bpza88xqkgmskfk50c5pk";
+    sha256 = "3ad5af3caa1120ecfdf022de41ba5be8edfbf50270fc99238b82d3d2d6e7c317";
   };
 
   # don't install changelogs for other packages
@@ -25,7 +25,6 @@ buildDunePackage rec {
     mirage-flow
     result
     rresult
-    cstruct
     logs
   ];
 
@@ -35,6 +34,7 @@ buildDunePackage rec {
     alcotest-lwt
     bigstringaf
     bigarray-compat
+    cstruct
     ke
   ];
 


### PR DESCRIPTION
https://github.com/mirage/ocaml-git/releases/tag/mimic-v0.0.2

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
