### PR TITLE
gnuradio3_8: 3.8.2.0 -> 3.8.3.0

### DIFF
--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -42,7 +42,7 @@
 , pname ? "gnuradio"
 , versionAttr ? {
   major = "3.8";
-  minor = "2";
+  minor = "3";
   patch = "0";
 }
 # We use our build of volk and not the one bundled with the release
@@ -50,7 +50,7 @@
 }:
 
 let
-  sourceSha256 =  "SFDjtyQRp0fXijZukpLYtISpx8imxedlYN9mRibv1eA=";
+  sourceSha256 = "0lwbj3slhc8bjjvfw7yz45if21hajydgy2vsjvj2barzmhfb37fd";
   featuresInfo = {
     # Needed always
     basic = {
@@ -241,12 +241,17 @@ stdenv.mkDerivation rec {
   };
   cmakeFlags = shared.cmakeFlags
     # From some reason, if these are not set, libcodec2 and gsm are not
-    # detected properly. NOTE: qradiolink needs libcodec2 to be detected in
+    # detected properly. The issue is reported upstream:
+    # https://github.com/gnuradio/gnuradio/issues/4278
+    #
+    # NOTE: qradiolink needs libcodec2 to be detected in
     # order to build, see https://github.com/qradiolink/qradiolink/issues/67
     ++ lib.optionals (hasFeature "gr-vocoder" features) [
+      "-DLIBCODEC2_FOUND=TRUE"
       "-DLIBCODEC2_LIBRARIES=${codec2}/lib/libcodec2.so"
       "-DLIBCODEC2_INCLUDE_DIRS=${codec2}/include"
       "-DLIBCODEC2_HAS_FREEDV_API=ON"
+      "-DLIBGSM_FOUND=TRUE"
       "-DLIBGSM_LIBRARIES=${gsm}/lib/libgsm.so"
       "-DLIBGSM_INCLUDE_DIRS=${gsm}/include/gsm"
     ]
@@ -262,23 +267,4 @@ stdenv.mkDerivation rec {
       ${removeReferencesTo}/bin/remove-references-to -t ${python} $out/lib/cmake/gnuradio/GnuradioConfig.cmake
     ''
   ;
-  patches = [
-    # Don't install python referencing files if python support is disabled.
-    # See: https://github.com/gnuradio/gnuradio/pull/3839
-    (fetchpatch {
-      url = "https://github.com/gnuradio/gnuradio/commit/4a4fd570b398b0b50fe875fcf0eb9c9db2ea5c6e.diff";
-      sha256 = "xz2E0ji6zfdOAhjfPecAcaVOIls1XP8JngLkBbBBW5Q=";
-    })
-    (fetchpatch {
-      url = "https://github.com/gnuradio/gnuradio/commit/dbc8ad7e7361fddc7b1dbc267c07a776a3f9664b.diff";
-      sha256 = "tQcCpcUbJv3yqAX8rSHN/pAuBq4ueEvoVo7sNzZGvf4=";
-    })
-    # Needed to use boost 1.7x, see:
-    # https://github.com/gnuradio/gnuradio/issues/3720
-    # https://github.com/gnuradio/gnuradio/pull/3967
-    (fetchpatch {
-      url = "https://github.com/gnuradio/gnuradio/commit/cbcb968358fad56f3646619b258f18b0e6693a07.diff";
-      sha256 = "1ajf4797f869lqv436xw61s29qdbn7f01i0970kfxv3yahd34p9v";
-    })
-  ];
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
