### PR TITLE
kotlin-language-server: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1969,6 +1969,12 @@
     githubId = 1222362;
     name = "Matías Lang";
   };
+  critbase = {
+    email = "12738442+critbase@users.noreply.github.com";
+    github = "critbase";
+    githubId = 12738442;
+    name = "critbase";
+  };
   CRTified = {
     email = "carl.schneider+nixos@rub.de";
     github = "CRTified";

--- a/pkgs/development/tools/kotlin-language-server/default.nix
+++ b/pkgs/development/tools/kotlin-language-server/default.nix
@@ -1,0 +1,78 @@
+{ lib, writeText, stdenv, fetchFromGitHub, jdk11, gradle, perl, kotlin, unzip
+, makeWrapper }:
+
+let
+  version = "1.1.1";
+  src = fetchFromGitHub {
+    owner = "fwcd";
+    repo = "kotlin-language-server";
+    rev = version;
+    sha256 = "4z6rpu3FYQRLNYeDo3NvTGTrV2/CMzUvQ+X3ZGNqszc=";
+  };
+  gradleCommand =
+    "gradle --no-daemon -Porg.gradle.java.installations.auto-download=false -Dorg.gradle.java.home=${jdk11.home}";
+  deps = stdenv.mkDerivation {
+    name = "kotlin-language-server-deps";
+    inherit src;
+    nativeBuildInputs = [ kotlin jdk11 gradle perl ];
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+      ${gradleCommand} jar
+    '';
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0skHvaLiU8Vj/9UHsgIBF16Wfx3vPSmE6hQ7bRbF78E=";
+  };
+
+  gradleInit = writeText "init.gradle" ''
+    logger.lifecycle 'Replacing Maven repositories with ${deps}...'
+
+    allprojects {
+      repositories {
+        maven { url "${deps}" }
+      }
+    }
+
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          maven { url "${deps}" }
+        }
+      }
+    }
+  '';
+in stdenv.mkDerivation rec {
+  pname = "kotlin-language-server";
+  inherit version;
+  inherit src;
+
+  nativeBuildInputs = [ jdk11 gradle kotlin unzip makeWrapper ];
+  buildInputs = [ jdk11 kotlin ];
+  buildPhase = ''
+    export GRADLE_USER_HOME=$(mktemp -d);
+    ${gradleCommand} --offline --init-script ${gradleInit} :server:distTar
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib,share}
+    tar -xvf server/build/distributions/server-${version}.tar
+
+    install  server-${version}/bin/* $out/bin
+    install  server-${version}/lib/* $out/lib
+    install  server-${version}/licenseReport.html $out/share
+  '';
+
+  meta = with lib; {
+    description =
+      "Intelligent Kotlin support for any editor/IDE using the Language Server Protocol";
+    homepage = "https://github.com/fwcd/kotlin-language-server";
+    license = licenses.mit;
+    maintainers = [ maintainers.critbase ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
