### PR TITLE
python3Packages.lark-parser: 0.8.8 -> 0.11.2

### DIFF
--- a/pkgs/development/python-modules/lark-parser/default.nix
+++ b/pkgs/development/python-modules/lark-parser/default.nix
@@ -1,28 +1,36 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, regex
+  # Test inputs
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "lark-parser";
-  version = "0.8.8";
+  version = "0.11.2";
 
   src = fetchFromGitHub {
     owner = "lark-parser";
     repo = "lark";
     rev = version;
-    sha256 = "1q2dvkkfx9dvag5v5ps0ki4avh7i003gn9sj30jy1rsv1bg4y2mb";
+    sha256 = "1v1piaxpz4780km2z5i6sr9ygi9wpn09yyh999b3f4y0dcz20pbd";
   };
 
-  # tests of Nearley support require js2py
-  preCheck = ''
-    rm -r tests/test_nearley
-  '';
+  propagatedBuildInputs = [ regex ];
 
-  meta = {
+  checkInputs = [ pytestCheckHook ];
+  disabledTestPaths = [
+    "tests/test_nearley" # requires Js2Py package (not in nixpkgs)
+  ];
+  disabledTests = [
+    "test_override_rule"  # has issue with file access paths
+  ];
+
+  meta = with lib; {
     description = "A modern parsing library for Python, implementing Earley & LALR(1) and an easy interface";
     homepage = "https://github.com/lark-parser/lark";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fridh ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ fridh drewrisinger ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest version. Most recent release notes: https://github.com/lark-parser/lark/releases/tag/0.11.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
