### PR TITLE
fava: modernize expression

### DIFF
--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -1,40 +1,43 @@
-{ lib, python3, beancount }:
+{ lib, python3 }:
 
-let
-  inherit (python3.pkgs) buildPythonApplication fetchPypi;
-in
-buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "fava";
   version = "1.18";
 
-  src = fetchPypi {
+  src = python3.pkgs.fetchPypi {
     inherit pname version;
     sha256 = "21336b695708497e6f00cab77135b174c51feb2713b657e0e208282960885bf5";
   };
 
-  checkInputs = [ python3.pkgs.pytest ];
   nativeBuildInputs = with python3.pkgs; [ setuptools-scm ];
-  propagatedBuildInputs = with python3.pkgs;
-    [
-      Babel
-      cheroot
-      flaskbabel
-      flask
-      jinja2
-      beancount
-      click
-      markdown2
-      ply
-      simplejson
-      werkzeug
-      jaraco_functools
-    ];
 
-  # CLI test expects fava on $PATH.  Not sure why static_url fails.
-  # the entry_slices and render_entries requires other files to pass
-  checkPhase = ''
-    py.test tests -k 'not cli and not static_url and not entry_slice and not render_entries'
+  propagatedBuildInputs = with python3.pkgs; [
+    Babel
+    cheroot
+    flaskbabel
+    flask
+    jinja2
+    beancount
+    click
+    markdown2
+    ply
+    simplejson
+    werkzeug
+    jaraco_functools
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$TEMPDIR
   '';
+
+  disabledTests = [
+    # runs fava in debug mode, which tries to interpret bash wrapper as Python
+    "test_cli"
+  ];
 
   meta = {
     homepage = "https://beancount.github.io/fava";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
use `pytestCheckHook`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The error that occurs in test_cli can also be reproduced by running `fava -d`. That's something the maintainers should look into.
cc @matthiasbeyer 