### PR TITLE
ddcutil: use nixos paths for kernel modules

### DIFF
--- a/pkgs/tools/misc/ddcutil/default.nix
+++ b/pkgs/tools/misc/ddcutil/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-F/tKW81bAyYtwpxhl5XC8YyMB+6S0XmqqigwJY2WFDU=";
   };
 
+  patches = [
+    # Look for kernel modules in /run/booted-system/kernel-modules/lib/modules/*
+    ./nixos-paths.diff
+  ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [
     i2c-tools udev libgudev

--- a/pkgs/tools/misc/ddcutil/nixos-paths.diff
+++ b/pkgs/tools/misc/ddcutil/nixos-paths.diff
@@ -1,0 +1,32 @@
+diff --git a/src/app_sysenv/query_sysenv_modules.c b/src/app_sysenv/query_sysenv_modules.c
+index 59df64f1..fb244dd0 100644
+--- a/src/app_sysenv/query_sysenv_modules.c
++++ b/src/app_sysenv/query_sysenv_modules.c
+@@ -50,7 +50,9 @@ bool is_module_loadable(char * module_name, int depth) {
+    g_snprintf(module_name_ko, 100, "%s.ko", module_name);
+ 
+    char dirname[PATH_MAX];
+-   g_snprintf(dirname, PATH_MAX, "/lib/modules/%s/kernel/drivers/i2c", utsbuf.release);
++   g_snprintf(dirname, PATH_MAX,
++      "/run/booted-system/kernel-modules/lib/modules/%s/kernel/drivers/i2c",
++      utsbuf.release);
+ 
+    struct dirent *dent;
+      DIR           *d;
+diff --git a/src/util/linux_util.c b/src/util/linux_util.c
+index 5eb8491c..3a129ccf 100644
+--- a/src/util/linux_util.c
++++ b/src/util/linux_util.c
+@@ -29,8 +29,10 @@ bool is_module_builtin(char * module_name)
+    int rc = uname(&utsbuf);
+    assert(rc == 0);
+ 
+-   char modules_builtin_fn[100];
+-   snprintf(modules_builtin_fn, 100, "/lib/modules/%s/modules.builtin", utsbuf.release);
++   char modules_builtin_fn[PATH_MAX];
++   snprintf(modules_builtin_fn, PATH_MAX,
++      "/run/booted-system/kernel-modules/lib/modules/%s/modules.builtin",
++      utsbuf.release);
+ 
+    char ko_name[40];
+    snprintf(ko_name, 40, "%s.ko", module_name);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ddcutil prints out a warning message on NixOS because it can't find the i2c kernel module:
```
# ddcutil -b 8 setvcp 0x10 15
Error opening file /lib/modules/5.11.9/modules.builtin: No such file or directory
Error reading file /lib/modules/5.11.9/modules.builtin: No such file or directory
Assuming module i2c-dev is not built in to kernel
```

This PR patches ddcutil to look for the kernel modules under /run/booted-system instead (which fixes the warning).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
