### PR TITLE
ydotool: 0.1.8 -> 2021-01-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4283,6 +4283,12 @@
     githubId = 2588851;
     name = "Jan Solanti";
   };
+  jappie = {
+    email = "jappieklooster@hotmail.com";
+    github = "jappeace";
+    githubId = 3874017;
+    name = "Jappie Klooster";
+  };
   javaguirre = {
     email = "contacto@javaguirre.net";
     github = "javaguirre";

--- a/pkgs/development/libraries/cxxopts/default.nix
+++ b/pkgs/development/libraries/cxxopts/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "cxxopts";
-  version = "2.2.1";
+  version = "unstable-2020-12-14";
 
   src = fetchFromGitHub {
     owner = "jarro2783";
     repo = name;
-    rev = "v${version}";
-    sha256 = "0d3y747lsh1wkalc39nxd088rbypxigm991lk3j91zpn56whrpha";
+    rev = "2d8e17c4f88efce80e274cb03eeb902e055a91d3";
+    sha256 = "0pwrac81zfqjs17g3hx8r3ds2xf04npb6mz111qjy4bx17314ib7";
   };
 
   buildInputs = lib.optional enableUnicodeHelp [ icu.dev ];

--- a/pkgs/development/libraries/iodash/0001-Add-cmake-install-directives.patch
+++ b/pkgs/development/libraries/iodash/0001-Add-cmake-install-directives.patch
@@ -1,0 +1,44 @@
+From 89c7c160f897f64e17fb74efffccfd1fc16f8b7d Mon Sep 17 00:00:00 2001
+From: Jappie Klooster <jappieklooster@hotmail.com>
+Date: Fri, 2 Apr 2021 14:22:02 -0400
+Subject: [PATCH] Add cmake install directives.
+
+To make nix builds work, it expect a `make install` command to
+be available.
+Adding these directives seems to fix the build.
+
+If it's no trouble to you, please add them.
+
+Maybe don't need endian
+---
+ CMakeLists.txt | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 06e416f..8d6f489 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,6 +6,8 @@ set(CMAKE_CXX_STANDARD 17)
+ add_library(IODash INTERFACE)
+ target_include_directories(IODash INTERFACE .)
+ 
++include(GNUInstallDirs)
++
+ add_executable(IODash_Test test.cpp)
+ target_link_libraries(IODash_Test IODash)
+ 
+@@ -20,3 +22,11 @@ if (DEFINED BUILD_BENCHMARKS AND (${BUILD_BENCHMARKS}))
+     target_link_libraries(boost_Benchmark_HTTP boost_system pthread)
+ endif()
+ 
++install(TARGETS IODash
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(FILES IODash.hpp
++        DESTINATION include/)
++
++install(FILES
++        IODash/Buffer.hpp IODash/SocketAddress.hpp IODash/File.hpp IODash/Socket.hpp IODash/EventLoop.hpp IODash/Serial.hpp IODash/Timer.hpp
++        DESTINATION include/IODash)
+-- 
+2.29.2
+

--- a/pkgs/development/libraries/iodash/default.nix
+++ b/pkgs/development/libraries/iodash/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "iodash";
+  version = "0.1.7";
+
+  src  = fetchFromGitHub {
+    owner  = "YukiWorkshop";
+    repo   = "IODash";
+    rev    = "9dcb26621a9c17dbab704b5bab0c3a5fc72624cb";
+    sha256 = "0db5y2206fwh3h1pzjm9hy3m76inm0xpm1c5gvrladz6hiqfp7bx";
+    fetchSubmodules = true;
+  };
+  # adds missing cmake install directives
+  # https://github.com/YukiWorkshop/IODash/pull/2
+  patches = [ ./0001-Add-cmake-install-directives.patch];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  meta = with lib; {
+    homepage = "https://github.com/YukiWorkshop/IODash";
+    description = "Lightweight C++ I/O library for POSIX operation systems";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jappie ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/libraries/libevdevplus/0001-Add-cmake-install-directives.patch
+++ b/pkgs/development/libraries/libevdevplus/0001-Add-cmake-install-directives.patch
@@ -1,0 +1,41 @@
+From 7f208aaf21aa468013fc41e67c32f6a6c8c08249 Mon Sep 17 00:00:00 2001
+From: Jappie Klooster <jappieklooster@hotmail.com>
+Date: Fri, 2 Apr 2021 16:01:05 -0400
+Subject: [PATCH] Add cmake install directives
+
+To make nix builds work, it expect a make install command to
+be available.
+Adding these directives seems to fix the build.
+
+If it's no trouble to you, please add them.
+---
+ CMakeLists.txt | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f9db618..425d391 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,10 +4,17 @@ project(libevdevPlus)
+ set(SOURCE_FILES
+         evdevPlus.cpp evdevPlus.hpp CommonIncludes.hpp InputEvent.hpp Resource.cpp)
+ 
++include(GNUInstallDirs)
++
+ add_library(evdevPlus ${SOURCE_FILES})
+ target_include_directories(evdevPlus PUBLIC .)
+ 
+ add_executable(evdevPlus_test test.cpp)
+ target_link_libraries(evdevPlus_test evdevPlus)
+ 
+-configure_file(evdevPlus.pc.in evdevPlus.pc @ONLY)
+\ No newline at end of file
++configure_file(evdevPlus.pc.in evdevPlus.pc @ONLY)
++
++install(TARGETS evdevPlus
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(FILES evdevPlus.hpp CommonIncludes.hpp InputEvent.hpp
++        DESTINATION include/)
+-- 
+2.29.2
+

--- a/pkgs/development/libraries/libevdevplus/default.nix
+++ b/pkgs/development/libraries/libevdevplus/default.nix
@@ -2,13 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "libevdevplus";
-  version = "unstable-2019-10-01";
+  version = "unstable-2021-04-02";
+
+  # adds missing cmake install directives
+  # https://github.com/YukiWorkshop/libevdevPlus/pull/10
+  patches = [ ./0001-Add-cmake-install-directives.patch];
 
   src  = fetchFromGitHub {
     owner  = "YukiWorkshop";
     repo   = "libevdevPlus";
-    rev    = "e863df2ade43e2c7d7748cc33ca27fb3eed325ca";
-    sha256 = "18z6pn4j7fhmwwh0q22ip5nn7sc1hfgwvkdzqhkja60i8cw2cvvj";
+    rev    = "b4d4b3143056424a3da9f0516ca02a47209ef757";
+    sha256 = "09y65s16gch0w7fy1s9yjk9gz3bjzxix36h5wmwww6lkj2i1z3rj";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/libraries/libuinputplus/0001-Add-cmake-install-directives.patch
+++ b/pkgs/development/libraries/libuinputplus/0001-Add-cmake-install-directives.patch
@@ -1,0 +1,40 @@
+From 265e406e254c8d84016b12b344d8df71d1765dd1 Mon Sep 17 00:00:00 2001
+From: Jappie Klooster <jappieklooster@hotmail.com>
+Date: Fri, 2 Apr 2021 16:33:18 -0400
+Subject: [PATCH] Add cmake install directives
+
+To make nix builds work, it expect a make install command to
+be available.
+Adding these directives seems to fix the build.
+
+If it's no trouble to you, please consider adding them.
+---
+ CMakeLists.txt | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cbfc9c1..948c432 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -7,6 +7,8 @@ set(SOURCE_FILES
+         uInput.cpp uInputSetup.cpp uInputResource.cpp
+         uInput.hpp CommonIncludes.hpp uInputSetup.hpp)
+ 
++include(GNUInstallDirs)
++
+ add_library(uInputPlus ${SOURCE_FILES})
+ target_include_directories(uInputPlus PUBLIC .)
+ 
+@@ -15,3 +17,9 @@ target_link_libraries(uInputPlus_test uInputPlus)
+ 
+ configure_file(uInputPlus.pc.in uInputPlus.pc @ONLY)
+ 
++
++install(TARGETS uInputPlus
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(FILES uInput.hpp CommonIncludes.hpp uInputSetup.hpp
++        DESTINATION include/)
++
+-- 
+2.29.2
+

--- a/pkgs/development/libraries/libuinputplus/default.nix
+++ b/pkgs/development/libraries/libuinputplus/default.nix
@@ -1,14 +1,17 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config }:
-
 stdenv.mkDerivation rec {
   pname = "libuinputplus";
-  version = "2019-10-01";
+  version = "2021-04-02";
+
+  # adds missing cmake install directives
+  # https://github.com/YukiWorkshop/libuInputPlus/pull/7
+  patches = [ ./0001-Add-cmake-install-directives.patch];
 
   src  = fetchFromGitHub {
     owner  = "YukiWorkshop";
     repo   = "libuInputPlus";
-    rev    = "962f180b4cc670e1f5cc73c2e4d5d196ae52d630";
-    sha256 = "0jy5i7bmjad7hw1qcyjl4swqribp2027s9g3609zwj7lj8z5x0bg";
+    rev    = "f7f18eb339bba61a43f2cad481a9b1a453a66957";
+    sha256 = "0sind2ghhy4h9kfkr5hsmhcq0di4ifwqyv4gac96rgj5mwvs33lp";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/tools/wayland/ydotool/default.nix
+++ b/pkgs/tools/wayland/ydotool/default.nix
@@ -1,26 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, boost, libevdevplus, libuinputplus }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, boost, libevdevplus, libuinputplus, iodash, cxxopts}:
 
 stdenv.mkDerivation rec {
   pname = "ydotool";
-  version = "0.1.8";
+  version = "unstable-2021-01-20";
 
   src = fetchFromGitHub {
     owner = "ReimuNotMoe";
     repo = "ydotool";
-    rev = "v${version}";
-    sha256 = "0mx3636p0f8pznmwm4rlbwq7wrmjb2ygkf8b3a6ps96a7j1fw39l";
+    rev = "b1d041f52f7bac364d6539b1251d29c3b77c0f37";
+    sha256 = "1gzdbx6fv0dbcyia3yyzhv93az2gf90aszb9kcj5cnxywfpv9w9g";
   };
 
-  # disable static linking
+  # upstream decided to use a cpp package manager called cpm.
+  # we need to disable that because it wants networking, furthermore,
+  # it does some system folder creating which also needs to be disabled.
+  # Both changes are to respect the sandbox.
+  patches = [ ./fixup-cmakelists.patch ];
+
+
+  # cxxopts is a header only library.
+  # See pull request: https://github.com/ReimuNotMoe/ydotool/pull/105
   postPatch = ''
     substituteInPlace CMakeLists.txt --replace \
-      "-static" \
-      ""
+      "PUBLIC cxxopts" \
+      "PUBLIC"
   '';
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
-    boost libevdevplus libuinputplus
+    boost libevdevplus libuinputplus iodash cxxopts
   ];
 
   meta = with lib; {

--- a/pkgs/tools/wayland/ydotool/fixup-cmakelists.patch
+++ b/pkgs/tools/wayland/ydotool/fixup-cmakelists.patch
@@ -1,0 +1,58 @@
+From bb8bc44d22060cd1215712117cf30eae09f4f6ba Mon Sep 17 00:00:00 2001
+From: Jappie Klooster <jappieklooster@hotmail.com>
+Date: Fri, 2 Apr 2021 14:04:14 -0400
+Subject: [PATCH] Fixup cmaklists
+
+We remove cpm, which is a package manager for c++,
+which requires networking, so it's better just deleted.
+
+Furthermore we delete the adddirectory statements.
+These want to modify directories outside of the sandbox.
+---
+ CMakeLists.txt | 26 --------------------------
+ 1 file changed, 26 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b5e8789..b797538 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,30 +13,6 @@ endif()
+ 
+ include(${CPM_DOWNLOAD_LOCATION})
+ 
+-CPMAddPackage(
+-        NAME IODash
+-        GITHUB_REPOSITORY YukiWorkshop/IODash
+-        VERSION 0.1.0
+-)
+-
+-CPMAddPackage(
+-        NAME libevdevPlus
+-        GITHUB_REPOSITORY YukiWorkshop/libevdevPlus
+-        VERSION 0.2.1
+-)
+-
+-CPMAddPackage(
+-        NAME libuInputPlus
+-        GITHUB_REPOSITORY YukiWorkshop/libuInputPlus
+-        VERSION 0.2.1
+-)
+-
+-CPMAddPackage(
+-        NAME cxxopts
+-        GITHUB_REPOSITORY jarro2783/cxxopts
+-        VERSION 3.0.0
+-        GIT_TAG 2d8e17c4f88efce80e274cb03eeb902e055a91d3
+-)
+ 
+ set(SOURCE_FILES_LIBRARY
+         CommonIncludes.hpp
+@@ -74,5 +50,3 @@ add_executable(ydotool ${SOURCE_FILES_CLIENT})
+ target_link_libraries(ydotool ydotool_library dl pthread uInputPlus evdevPlus)
+ install(TARGETS ydotool DESTINATION ${CMAKE_INSTALL_BINDIR})
+ 
+-add_subdirectory(Daemon)
+-add_subdirectory(manpage)
+-- 
+2.29.2
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6096,6 +6096,7 @@ in
 
   ispell = callPackage ../tools/text/ispell {};
 
+  iodash = callPackage ../development/libraries/iodash { };
   jumanpp = callPackage ../tools/text/jumanpp {};
 
   jump = callPackage ../tools/system/jump {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrading ydotool gives two big features:
1. support for sleep, making it easier to combine with sway
2. recording support. Allowing you to record macros!

This does however make the daemon a bit unstable, I had it crash
on my when trying to type.
However the daemon is optional, and there are several upstream issues about this [1] [2].
So I think it's a good change.

[1]: https://github.com/ReimuNotMoe/ydotool/issues/106
[2]: https://github.com/ReimuNotMoe/ydotool/issues/103

Furthermore several libraries had to be upgraded with this change as well,
or else ydotool got compile errors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` 
  I used ripgrep, I can't get this to work.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  ydotoolsd is more unstable, but that's an upstream problem I believe.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Another thing to note is that I made several pull requests that fix nix builds:
+ https://github.com/YukiWorkshop/libuInputPlus/pull/7
+ https://github.com/YukiWorkshop/libevdevPlus/pull/10
+ https://github.com/YukiWorkshop/IODash/pull/2
+ https://github.com/ReimuNotMoe/ydotool/pull/105
