### PR TITLE
uhexen2: init at 1.5.9

### DIFF
--- a/pkgs/games/uhexen2/default.nix
+++ b/pkgs/games/uhexen2/default.nix
@@ -1,0 +1,66 @@
+{ lib, fetchgit, SDL, stdenv, libogg, libvorbis, libmad, xdelta }:
+
+stdenv.mkDerivation rec {
+  name = "uhexen2";
+  version = "1.5.9";
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/uhexen2/uhexen2";
+    sha256 = "0crdihbnb92awkikn15mzdpkj1x9s34xixf1r7fxxf762m60niks";
+    rev = "4ef664bc41e3998b0d2a55ff1166dadf34c936be";
+  };
+
+  buildInputs = [ SDL libogg libvorbis libmad xdelta ];
+
+  preBuild = ''
+    makeFiles=(
+        "engine/hexen2 glh2"
+        "engine/hexen2 clean"
+        "engine/hexen2 h2"
+        "engine/hexen2/server"
+        "engine/hexenworld/client glhw"
+        "engine/hexenworld/client clean"
+        "engine/hexenworld/client hw"
+        "engine/hexenworld/server"
+        "h2patch"
+    )
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    for makefile in "''${makeFiles[@]}"; do
+          local flagsArray=(
+            -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES
+            SHELL=$SHELL
+            $makeFlags "''${makeFlagsArray[@]}"
+            $buildFlags "''${buildFlagsArray[@]}"
+          )
+          echoCmd 'build flags' ""''${flagsArray[@]}""
+          make  -C $makefile ""''${flagsArray[@]}""
+          unset flagsArray
+    done
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 engine/hexen2/{glhexen2,hexen2,server/h2ded} -t $out/bin
+    install -Dm755 engine/hexenworld/{client/glhwcl,client/hwcl,server/hwsv} -t $out/bin
+    install -Dm755 h2patch/h2patch -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A cross-platform port of Hexen II game";
+    longDescription = ''
+      Hammer of Thyrion (uHexen2) is a cross-platform port of Raven Software's Hexen II source.
+      It is based on an older linux port, Anvil of Thyrion.
+      HoT includes countless bug fixes, improved music, sound and video modes, opengl improvements,
+      support for many operating systems and architectures, and documentation among many others.
+    '';
+    homepage = "http://uhexen2.sourceforge.net/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ xdhampus ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27934,6 +27934,8 @@ in
 
   ufoai = callPackage ../games/ufoai { };
 
+  uhexen2 = callPackage ../games/uhexen2 { };
+
   ultimatestunts = callPackage ../games/ultimatestunts { };
 
   ultrastar-creator = libsForQt5.callPackage ../tools/misc/ultrastar-creator { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #110725

###### Things done

All executions appear to work on my system, not sure about `h2patch`.

I tested `glhexen2`, `hexen2` and `h2ded` using the game data published in [the compiled release of hexen2-1.5.9](https://sourceforge.net/projects/uhexen2/files/Hammer%20of%20Thyrion/1.5.9/Linux-x86_64/) found within the `data1` directory. This game data was then placed in my users `.hexen2` directory. They all worked without any glaring issues, had no issues connecting to the dedicated server locally.
Did the same for `glhwcl`, `hwcl` and `hwsv` using the release for hexenworld, found on the former site using the data from the `hw` directory, also no issues there.

Due to not having game data beyond the demo available I am unsure whether the binaries work properly.
In particular, the binary `h2patch`, did not provide a successful result, beyond launching and appropriately recognizing certain .pak files, as it did not support the demo files.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
