### PR TITLE
[20.09] bind: add patches for multiple CVEs

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -32,6 +32,11 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.isc.org/isc-projects/bind9/commit/6ed167ad0a647dff20c8cb08c944a7967df2d415.patch";
       sha256 = "1r191hvqabq8bpnik8hmx7qirghfv48fhrzzmiq8vbjmwkbvvjrj";
     })
+    (fetchpatch {
+      name = "CVE-2020-8624.patch";
+      url = "https://gitlab.isc.org/isc-projects/bind9/commit/7630a64141a997b5247d9ad4a7dfff6ac6d9a485.patch";
+      sha256 = "01xbi0nrl9zqv8yih92x2xman23dr8lbkxy4frrzsikfak41s1zd";
+    })
   ];
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation rec {
   patches = [
     ./dont-keep-configure-flags.patch
     ./remove-mkdir-var.patch
+    (fetchpatch {
+      name = "CVE-2020-8621.patch";
+      url = "https://gitlab.isc.org/isc-projects/bind9/commit/81514ff925dfc6e0c293745e0fc8320a8af95586.patch";
+      sha256 = "1h3p60xcxj1zd3ksqllhgr4z43li13n2famyvb8kyydycw0rhi4d";
+    })
   ];
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -37,6 +37,11 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.isc.org/isc-projects/bind9/commit/7630a64141a997b5247d9ad4a7dfff6ac6d9a485.patch";
       sha256 = "01xbi0nrl9zqv8yih92x2xman23dr8lbkxy4frrzsikfak41s1zd";
     })
+    (fetchpatch {
+      name = "CVE-2020-8625.patch";
+      url = "https://gitlab.isc.org/isc-projects/bind9/commit/b04cb88462863d762093760ffcfe1946200e30f5.patch";
+      sha256 = "14h57z1jpp4hbqp8wmdwnfwgz63v8zdcy1gzgjbwg8nbfy2h1gmk";
+    })
   ];
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.isc.org/isc-projects/bind9/commit/81514ff925dfc6e0c293745e0fc8320a8af95586.patch";
       sha256 = "1h3p60xcxj1zd3ksqllhgr4z43li13n2famyvb8kyydycw0rhi4d";
     })
+    (fetchpatch {
+      name = "CVE-2020-8622.patch";
+      url = "https://gitlab.isc.org/isc-projects/bind9/commit/6ed167ad0a647dff20c8cb08c944a7967df2d415.patch";
+      sha256 = "1r191hvqabq8bpnik8hmx7qirghfv48fhrzzmiq8vbjmwkbvvjrj";
+    })
   ];
 
   nativeBuildInputs = [ perl ];


### PR DESCRIPTION
###### Motivation for this change

 - https://nvd.nist.gov/vuln/detail/CVE-2020-8621
 - https://nvd.nist.gov/vuln/detail/CVE-2020-8622
 - https://nvd.nist.gov/vuln/detail/CVE-2020-8624
 - https://nvd.nist.gov/vuln/detail/CVE-2020-8625

Added as separate commits as I've included my justification for each patch's validity.

**Not** included fixes for:

 - https://nvd.nist.gov/vuln/detail/CVE-2020-8623 - it's a bit more substantial, and apparently only a problem if you build with `--enable-native-pkcs11`, and we use `--without-pkcs11`
 - https://nvd.nist.gov/vuln/detail/CVE-2020-8620 - only vulnerable from 9.15 onwards

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
