### PR TITLE
vmware-horizon-client: use pkgs.cairo instead of bundled version

### DIFF
--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -3,6 +3,7 @@
 , at-spi2-atk
 , atk
 , buildFHSUserEnv
+, cairo
 , dbus
 , fetchurl
 , fontconfig
@@ -67,6 +68,9 @@ let
       # This libjpeg library interferes with Chromium, so we will be using ours instead.
       rm $out/lib/vmware/libjpeg.*
 
+      # This library causes the program to core-dump occasionally. Use ours instead.
+      rm $out/lib/vmware/view/crtbora/libcairo.*
+
       # Force the default GTK theme (Adwaita) because Horizon is prone to
       # UI usability issues when using non-default themes, such as Adwaita-dark.
       makeWrapper "$out/bin/vmware-view" "$out/bin/vmware-view_wrapper" \
@@ -84,6 +88,7 @@ let
     targetPkgs = pkgs: [
       at-spi2-atk
       atk
+      cairo
       dbus
       fontconfig
       freetype


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The version of cairo bundled with the software causes some stability issues. Using the nixpkgs version of cairo gets rid of the issues.
https://github.com/NixOS/nixpkgs/issues/109312#issuecomment-779245896

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
