### PR TITLE
openzwave: use official version

### DIFF
--- a/pkgs/development/libraries/openzwave/default.nix
+++ b/pkgs/development/libraries/openzwave/default.nix
@@ -1,22 +1,32 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , doxygen, fontconfig, graphviz-nox, libxml2, pkg-config, which
 , systemd }:
 
-let
-  version = "2019-12-08";
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "openzwave";
-  inherit version;
+  version = "1.6";
 
-  # Use fork by Home Assistant because this package is mainly used for python.pkgs.homeassistant-pyozw.
-  # See https://github.com/OpenZWave/open-zwave/compare/master...home-assistant:hass for the difference.
   src = fetchFromGitHub {
-    owner = "home-assistant";
+    owner = "OpenZWave";
     repo = "open-zwave";
-    rev = "2cd2137025c529835e4893a7b87c3d56605b2681";
-    sha256 = "04g8fb4f4ihakvvsmzcnncgfdd2ikmki7s22i9c6layzdwavbwf1";
+    rev = "v${version}";
+    sha256 = "0xgs4mmr0480c269wx9xkk67ikjzxkh8xcssrdx0f5xcl1lyd333";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-strncat-build-failure.patch";
+      url = "https://github.com/OpenZWave/open-zwave/commit/601e5fb16232a7984885e67fdddaf5b9c9dd8105.patch";
+      sha256 = "1n1k5arwk1dyc12xz6xl4n8yw28vghzhv27j65z1nca4zqsxgza1";
+    })
+    (fetchpatch {
+      name = "fix-text-uninitialized.patch";
+      url = "https://github.com/OpenZWave/open-zwave/commit/3b029a467e83bc7f0054e4dbba1e77e6eac7bc7f.patch";
+      sha256 = "183mrzjh1zx2b2wzkj4jisiw8br7g7bbs167afls4li0fm01d638";
+    })
+  ];
+
+  outputs = [ "out" "doc" ];
 
   nativeBuildInputs = [ doxygen fontconfig graphviz-nox libxml2 pkg-config which ];
 
@@ -26,13 +36,9 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  installPhase = ''
-    runHook preInstall
-
-    DESTDIR=$out PREFIX= pkgconfigdir=lib/pkgconfig make install $installFlags
-
-    runHook postInstall
-  '';
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
 
   FONTCONFIG_FILE="${fontconfig.out}/etc/fonts/fonts.conf";
   FONTCONFIG_PATH="${fontconfig.out}/etc/fonts/";
@@ -40,15 +46,6 @@ in stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace cpp/src/Options.cpp \
       --replace /etc/openzwave $out/etc/openzwave
-  '';
-
-  fixupPhase = ''
-    substituteInPlace $out/lib/pkgconfig/libopenzwave.pc \
-      --replace prefix= prefix=$out \
-      --replace dir=    dir=$out
-
-    substituteInPlace $out/bin/ozw_config \
-      --replace pcfile=${pkg-config} pcfile=$out
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/homeassistant-pyozw/default.nix
+++ b/pkgs/development/python-modules/homeassistant-pyozw/default.nix
@@ -1,6 +1,19 @@
-{ python_openzwave, fetchPypi }:
+{ python_openzwave, fetchPypi, openzwave, fetchFromGitHub }:
 
-python_openzwave.overridePythonAttrs (oldAttrs: rec {
+(python_openzwave.override {
+  openzwave = openzwave.overrideAttrs (oldAttrs: {
+    version = "unstable-2020-03-24";
+
+    src = fetchFromGitHub {
+      owner = "home-assistant";
+      repo = "open-zwave";
+      rev = "94267fa298c1882f0dc73c0fd08f1f755ba83e83";
+      sha256 = "0p2869fwidz1wcqzfm52cwm9ab96pmwkna3d4yvvh21nh09cvmwk";
+    };
+
+    patches = [ ];
+  });
+}).overridePythonAttrs (oldAttrs: rec {
   pname = "homeassistant_pyozw";
   version = "0.1.10";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/86125

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

We should unvendor openzwave's dependencies as in https://github.com/archlinux/svntogit-community/blob/packages/openzwave/trunk/openzwave-system-libs.patch.