### PR TITLE
tellico: 3.3.3 -> 3.4

### DIFF
--- a/pkgs/applications/misc/tellico/default.nix
+++ b/pkgs/applications/misc/tellico/default.nix
@@ -1,29 +1,30 @@
 { lib
 , fetchurl
 , mkDerivation
-, libkcddb
-, kinit
-, kdelibs4support
-, solid
-, kxmlgui
-, karchive
-, kfilemetadata
-, khtml
-, knewstuff
-, libksane
 , cmake
 , exempi
 , extra-cmake-modules
-, libcdio
-, poppler
-, makeWrapper
+, karchive
 , kdoctools
+, kfilemetadata
+, khtml
+, kitemmodels
+, knewstuff
+, kxmlgui
+, libcdio
+, libkcddb
+, libksane
+, makeWrapper
+, poppler
+, qtcharts
+, qtwebengine
+, solid
 , taglib
 }:
 
 mkDerivation rec {
-  name = "tellico";
-  version = "3.3.3";
+  pname = "tellico";
+  version = "3.4";
 
   src = fetchurl {
     # version 3.3.0 just uses 3.3 in its name
@@ -31,7 +32,7 @@ mkDerivation rec {
       "https://tellico-project.org/files/tellico-${version}.tar.xz"
       "https://tellico-project.org/files/tellico-${lib.versions.majorMinor version}.tar.xz"
     ];
-    sha256 = "sha256-9cdbUTa2Mt3/yNylOSdGjgDETD74sR0dU4C58uW0Y6o=";
+    sha256 = "sha256-YXMJrAkfehe3ox4WZ19igyFbXwtjO5wxN3bmgP01jPs=";
   };
 
   nativeBuildInputs = [
@@ -43,17 +44,18 @@ mkDerivation rec {
 
   buildInputs = [
     exempi
-    extra-cmake-modules
     karchive
-    libkcddb
-    kdelibs4support
     kfilemetadata
     khtml
+    kitemmodels
     knewstuff
     kxmlgui
     libcdio
+    libkcddb
     libksane
     poppler
+    qtcharts
+    qtwebengine
     solid
     taglib
   ];


### PR DESCRIPTION
###### Motivation for this change

Upstream update. khtml -> qtwebengine

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
