### PR TITLE
pythonPackages.zopfli: 0.1.7 -> 0.1.8

### DIFF
--- a/pkgs/development/python-modules/zopfli/default.nix
+++ b/pkgs/development/python-modules/zopfli/default.nix
@@ -2,14 +2,15 @@
 
 buildPythonPackage rec {
   pname = "zopfli";
-  version = "0.1.7";
+  version = "0.1.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "512892714f0e3dcc9a77222cb509ed519f41ce2b92467e47a4b406a23b48561a";
+    sha256 = "8b977dc07e3797907ab59e08096583bcd0b7e6c739849fbbeec09263f6356623";
     extension = "zip";
   };
 
+  # doesn't work with pytestCheckHook
   checkInputs = [ pytest ];
 
   meta = with lib; {


### PR DESCRIPTION
https://github.com/obp/py-zopfli/releases/tag/v0.1.8

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
