### PR TITLE
python3Packages.axis: 43 -> 44

### DIFF
--- a/pkgs/development/python-modules/axis/default.nix
+++ b/pkgs/development/python-modules/axis/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "axis";
-  version = "43";
+  version = "44";
 
   src = fetchFromGitHub {
     owner = "Kane610";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1p9yfixsrkw7rxbvgybcb653rbqv0x18wzqkh620g193snm9sgm2";
+    sha256 = "sha256-GC8GiDP/QHU+8swe60VFPRx8kSMMHuXjIPEKCja8HPE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -182,6 +182,7 @@ in with py.pkgs; buildPythonApplication rec {
     "api"
     "auth"
     "automation"
+    "axis"
     "bayesian"
     "binary_sensor"
     "caldav"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 44

Change log: https://github.com/Kane610/axis/releases/tag/v44

Enable Home Assistant's tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
