### PR TITLE
grafana: add bigquery-grafana plugin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4868,6 +4868,12 @@
     email = "jwilberding@afiniate.com";
     name = "Jordan Wilberding";
   };
+  jwygoda = {
+    email = "jaroslaw@wygoda.me";
+    github = "jwygoda";
+    githubId = 20658981;
+    name = "Jarosław Wygoda";
+  };
   jyp = {
     email = "jeanphilippe.bernardy@gmail.com";
     github = "jyp";

--- a/pkgs/servers/monitoring/grafana/plugins/doitintl-bigquery-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/doitintl-bigquery-datasource/default.nix
@@ -1,0 +1,13 @@
+{ grafanaPlugin, lib }:
+
+grafanaPlugin rec {
+  pname = "doitintl-bigquery-datasource";
+  version = "2.0.1";
+  zipHash = "sha256-tZyvER/rxL+mo2tgxFvwSIAmjFm/AnZ0RgvmD1YAE2U=";
+  meta = with lib; {
+    description = "BigQuery DataSource for Grafana";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jwygoda ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -4,6 +4,7 @@
 
   grafanaPlugin = callPackage ./grafana-plugin.nix { };
 
+  doitintl-bigquery-datasource = callPackage ./doitintl-bigquery-datasource { };
   grafana-clock-panel = callPackage ./grafana-clock-panel { };
   grafana-piechart-panel = callPackage ./grafana-piechart-panel { };
   grafana-polystat-panel = callPackage ./grafana-polystat-panel { };


### PR DESCRIPTION
###### Motivation for this change

https://grafana.com/grafana/plugins/doitintl-bigquery-datasource/

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
