### PR TITLE
pythonPackages.pyturbojpeg: init at 1.4.1

### DIFF
--- a/pkgs/development/python-modules/pyturbojpeg/default.nix
+++ b/pkgs/development/python-modules/pyturbojpeg/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, python
+, buildPythonPackage
+, fetchPypi
+, substituteAll
+, libjpeg_turbo
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "pyturbojpeg";
+  version = "1.4.1";
+
+  src = fetchPypi {
+    pname = "PyTurboJPEG";
+    inherit version;
+    sha256 = "09688a93331281e566569b4d313e1d1a058ca32ccae1a2473847a10e4ca2f2a7";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./lib-path.patch;
+      libturbojpeg = "${libjpeg_turbo.out}/lib/libturbojpeg${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  # upstream has no tests, but we want to test whether the library is found
+  checkPhase = ''
+    ${python.interpreter} -c 'from turbojpeg import TurboJPEG; TurboJPEG()'
+  '';
+
+  pythonImportsCheck = [ "turbojpeg" ];
+
+  meta = with lib; {
+    description = "A Python wrapper of libjpeg-turbo for decoding and encoding JPEG image";
+    homepage = "https://github.com/lilohuang/PyTurboJPEG";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/pyturbojpeg/lib-path.patch
+++ b/pkgs/development/python-modules/pyturbojpeg/lib-path.patch
@@ -1,0 +1,28 @@
+diff --git a/turbojpeg.py b/turbojpeg.py
+index 73edb38..bfa8c67 100644
+--- a/turbojpeg.py
++++ b/turbojpeg.py
+@@ -408,22 +408,7 @@ class TurboJPEG(object):
+ 
+     def __find_turbojpeg(self):
+         """returns default turbojpeg library path if possible"""
+-        lib_path = find_library('turbojpeg')
+-        if lib_path is not None:
+-            return lib_path
+-        for lib_path in DEFAULT_LIB_PATHS[platform.system()]:
+-            if os.path.exists(lib_path):
+-                return lib_path
+-        if platform.system() == 'Linux' and 'LD_LIBRARY_PATH' in os.environ:
+-            ld_library_path = os.environ['LD_LIBRARY_PATH']
+-            for path in ld_library_path.split(':'):
+-                lib_path = os.path.join(path, 'libturbojpeg.so.0')
+-                if os.path.exists(lib_path):
+-                    return lib_path
+-        raise RuntimeError(
+-            'Unable to locate turbojpeg library automatically. '
+-            'You may specify the turbojpeg library path manually.\n'
+-            'e.g. jpeg = TurboJPEG(lib_path)')
++        return '@libturbojpeg@'
+ 
+     def __getaddr(self, nda):
+         """returns the memory address for a given ndarray"""

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -353,7 +353,7 @@
     "hlk_sw16" = ps: with ps; [ ]; # missing inputs: hlk-sw16
     "home_connect" = ps: with ps; [ aiohttp-cors ]; # missing inputs: homeconnect
     "homeassistant" = ps: with ps; [ ];
-    "homekit" = ps: with ps; [ HAP-python pyqrcode aiohttp-cors base36 fnvhash ha-ffmpeg zeroconf ]; # missing inputs: PyTurboJPEG
+    "homekit" = ps: with ps; [ HAP-python pyqrcode pyturbojpeg aiohttp-cors base36 fnvhash ha-ffmpeg zeroconf ];
     "homekit_controller" = ps: with ps; [ aiohomekit aiohttp-cors zeroconf ];
     "homematic" = ps: with ps; [ pyhomematic ];
     "homematicip_cloud" = ps: with ps; [ ]; # missing inputs: homematicip

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -227,6 +227,7 @@ in with py.pkgs; buildPythonApplication rec {
     "hddtemp"
     "history"
     "history_stats"
+    "homekit"
     "homekit_controller"
     "homeassistant"
     "homematic"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6915,6 +6915,8 @@ in {
 
   pytun = callPackage ../development/python-modules/pytun { };
 
+  pyturbojpeg = callPackage ../development/python-modules/pyturbojpeg { };
+
   pytz = callPackage ../development/python-modules/pytz { };
 
   pytzdata = callPackage ../development/python-modules/pytzdata { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/118234#discussion_r605800730

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

~I'm not done running Home Assistant's tests yet.~ Done