### PR TITLE
virtualisation/containers: move to settings model for containersConf

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -4,15 +4,7 @@ let
 
   inherit (lib) mkOption types;
 
-  # Once https://github.com/NixOS/nixpkgs/pull/75584 is merged we can use the TOML generator
-  toTOML = name: value: pkgs.runCommandNoCC name {
-    nativeBuildInputs = [ pkgs.remarshal ];
-    value = builtins.toJSON value;
-    passAsFile = [ "value" ];
-  } ''
-    json2toml "$valuePath" "$out"
-  '';
-
+  toml = pkgs.formats.toml { };
 in
 {
   meta = {
@@ -25,6 +17,11 @@ in
       lib.mkRemovedOptionModule
       [ "virtualisation" "containers" "users" ]
       "All users with `isNormalUser = true` set now get appropriate subuid/subgid mappings."
+    )
+    (
+      lib.mkRemovedOptionModule
+      [ "virtualisation" "containers" "containersConf" "extraConfig" ]
+      "Use virtualisation.containers.containersConf.settings instead."
     )
   ];
 
@@ -45,23 +42,10 @@ in
       description = "Enable the OCI seccomp BPF hook";
     };
 
-    containersConf = mkOption {
-      default = {};
+    containersConf.settings = mkOption {
+      type = toml.type;
+      default = { };
       description = "containers.conf configuration";
-      type = types.submodule {
-        options = {
-
-          extraConfig = mkOption {
-            type = types.lines;
-            default = "";
-            description = ''
-              Extra configuration that should be put in the containers.conf
-              configuration file
-            '';
-
-          };
-        };
-      };
     };
 
     registries = {
@@ -113,21 +97,19 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    virtualisation.containers.containersConf.settings = {
+      network.cni_plugin_dirs = [ "${pkgs.cni-plugins}/bin/" ];
+      engine = {
+        init_path = "${pkgs.catatonit}/bin/catatonit";
+      } // lib.optionalAttrs cfg.ociSeccompBpfHook.enable {
+        hooks_dir = [ config.boot.kernelPackages.oci-seccomp-bpf-hook ];
+      };
+    };
 
-    environment.etc."containers/containers.conf".text = ''
-      [network]
-      cni_plugin_dirs = ["${pkgs.cni-plugins}/bin/"]
+    environment.etc."containers/containers.conf".source =
+      toml.generate "containers.conf" cfg.containersConf.settings;
 
-      [engine]
-      init_path = "${pkgs.catatonit}/bin/catatonit"
-      ${lib.optionalString (cfg.ociSeccompBpfHook.enable) ''
-      hooks_dir = [
-        "${config.boot.kernelPackages.oci-seccomp-bpf-hook}",
-      ]
-      ''}
-    '' + cfg.containersConf.extraConfig;
-
-    environment.etc."containers/registries.conf".source = toTOML "registries.conf" {
+    environment.etc."containers/registries.conf".source = toml.generate "registries.conf" {
       registries = lib.mapAttrs (n: v: { registries = v; }) cfg.registries;
     };
 

--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -96,13 +96,12 @@ in
 
       virtualisation.containers = {
         enable = true; # Enable common /etc/containers configuration
-        containersConf.extraConfig = lib.optionalString cfg.enableNvidia
-          (builtins.readFile (toml.generate "podman.nvidia.containers.conf" {
-            engine = {
-              conmon_env_vars = [ "PATH=${lib.makeBinPath [ pkgs.nvidia-podman ]}" ];
-              runtimes.nvidia = [ "${pkgs.nvidia-podman}/bin/nvidia-container-runtime" ];
-            };
-          }));
+        containersConf.settings = lib.optionalAttrs cfg.enableNvidia {
+          engine = {
+            conmon_env_vars = [ "PATH=${lib.makeBinPath [ pkgs.nvidia-podman ]}" ];
+            runtimes.nvidia = [ "${pkgs.nvidia-podman}/bin/nvidia-container-runtime" ];
+          };
+        };
       };
 
       systemd.packages = [ cfg.package ];


### PR DESCRIPTION
- virtualisation/containers: move extraConfig to settings model
- virtualisation/podman: move nvidia settings to new containersConf settings model

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Using the nvidia Docker runtime with podman requires some additional settings
in `containers.conf`. After the additiion of `catatonit` using the nvidia docker
runtime with podman stopped working due to the way TOML works: repeated top level keys are not allowed.

Since we need to override the settings in the podman module, and since
we need to override the `[engine]` key, we *could* simply tack on the
settings necessary, since the last key specified in the creation of `containers.conf`
happens to be engine.

This is really bad idea, because it's very fragile: if any changes to the `virtualisation/containers.nix`
module move the `containers.conf` settings around in basically any way, using
the nvidia docker runtime with podman will again break.

This PR moves to the new `settings` model, allowing dependents of `containers.conf`
to add or change settings without having to worry about fragile configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Closes #118680