### PR TITLE
cpufetch: init at 0.94

### DIFF
--- a/pkgs/tools/misc/cpufetch/default.nix
+++ b/pkgs/tools/misc/cpufetch/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchFromGitHub, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "cpufetch";
+  version = "0.94";
+
+  src = fetchFromGitHub {
+    owner  = "Dr-Noob";
+    repo   = "cpufetch";
+    rev    = "v${version}";
+    sha256 = "1gncgkhqd8bnz254qa30yyl10qm28dwx6aif0dwrj38z5ql40ck9";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    install -Dm755 cpufetch   $out/bin/cpufetch
+    install -Dm644 LICENSE    $out/share/licenses/cpufetch/LICENSE
+    installManPage cpufetch.8
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Simplistic yet fancy CPU architecture fetching tool";
+    license = licenses.mit;
+    homepage = "https://github.com/Dr-Noob/cpufetch";
+    changelog = "https://github.com/Dr-Noob/cpufetch/releases/tag/v${version}";
+    maintainers = with maintainers; [ devhell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3577,6 +3577,8 @@ in
 
   cpio = callPackage ../tools/archivers/cpio { };
 
+  cpufetch = callPackage ../tools/misc/cpufetch { };
+
   crackxls = callPackage ../tools/security/crackxls { };
 
   create-cycle-app = nodePackages.create-cycle-app;


### PR DESCRIPTION
A "[s]implistic yet fancy CPU architecture fetching tool", similar to
neofetch, screenfetch, etc.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Thought this is a nifty little information tool others might also enjoy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
