### PR TITLE
ispc: 1.13.0 -> unstable-2021-04-02

### DIFF
--- a/pkgs/development/compilers/ispc/default.nix
+++ b/pkgs/development/compilers/ispc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , cmake, which, m4, python3, bison, flex, llvmPackages
 
   # the default test target is sse4, but that is not supported by all Hydra agents
@@ -7,14 +7,26 @@
 
 stdenv.mkDerivation rec {
   pname   = "ispc";
-  version = "1.13.0";
+  version = "unstable-2021-04-02";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
-    rev    = "v${version}";
-    sha256 = "1l74xkpwwxc38k2ngg7mpvswziiy91yxslgfad6688hh1n5jvayd";
+    # ISPC release 1.15.0 doesn't build against LLVM 11.1, only against 11.0. So we
+    # use latest ISPC main branch for now, until they support an LLVM version we have.
+    # https://github.com/ispc/ispc/issues/2027#issuecomment-784470530
+    rev    = "3e8313568265d2adfbf95bd6b6e1a4c70ef59bed";
+    sha256 = "sha256-gvr+VpoacmwQlP5gT4MnfmKdACZWJduVMIpR0YRzseg=";
   };
+
+  patches = [
+    # Fix cmake error: `Failed to find clang++`
+    # https://github.com/ispc/ispc/pull/2055
+    (fetchpatch {
+      url = "https://github.com/erictapen/ispc/commit/338119b2f4e11fcf0b0852de296c320928e572a2.patch";
+      sha256 = "sha256-+RqDq1LMWomu/K4SgK0Nip47b1RwyM6W0cTSNGD4+m4=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake which m4 bison flex python3 ];
   buildInputs = with llvmPackages; [
@@ -55,6 +67,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DCLANG_EXECUTABLE=${llvmPackages.clang}/bin/clang"
+    "-DCLANGPP_EXECUTABLE=${llvmPackages.clang}/bin/clang++"
     "-DISPC_INCLUDE_EXAMPLES=OFF"
     "-DISPC_INCLUDE_UTILS=OFF"
     "-DARM_ENABLED=FALSE"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14881,8 +14881,8 @@ in
   iso-flags = callPackage ../data/icons/iso-flags { };
 
   ispc = callPackage ../development/compilers/ispc {
-    stdenv = llvmPackages_10.stdenv;
-    llvmPackages = llvmPackages_10;
+    stdenv = llvmPackages_11.stdenv;
+    llvmPackages = llvmPackages_11;
   };
 
   isso = callPackage ../servers/isso { };


### PR DESCRIPTION

###### Motivation for this change


###### Things done

Using LLVM 11 brings a problem: 11.1 broke the build for ISPC so we could use latest ISPC main branch for now, or wait until the new ISPC release?

Also had to patch a cmake script. Opened a PR upstream: https://github.com/ispc/ispc/pull/2055

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
