### PR TITLE
exa: unstable-2021-01-14 -> 0.10.0

### DIFF
--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -4,15 +4,15 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "exa";
-  version = "unstable-2021-01-14";
+  version = "0.10.0";
 
-  cargoSha256 = "1lmjh0grpnx20y6raxnxgjkr92h395r6jk8mm2ypc4cxpxczdqvl";
+  cargoSha256 = "sha256-hslQZkmZ023gKxBbfgwqazBPUk0qWyy51uRJtr3QvWE=";
 
   src = fetchFromGitHub {
     owner = "ogham";
     repo = pname;
-    rev = "13b91cced4cab012413b25c9d3e30c63548639d0";
-    sha256 = "18y4v1s102lh3gvgjwdd66qlsr75wpwpcj8zsk5y5r95a405dkfm";
+    rev = "v${version}";
+    sha256 = "sha256-xolanu4zhAwsbSPdGKgY2/uHtP30DSpr/7Vv1z4jEnQ=";
   };
 
   nativeBuildInputs = [ cmake pkg-config installShellFiles pandoc ];
@@ -46,6 +46,6 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://the.exa.website";
     license = licenses.mit;
-    maintainers = with maintainers; [ ehegnes lilyball globin ];
+    maintainers = with maintainers; [ ehegnes lilyball globin fortuneteller2k ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
update to stable release [0.10.0](https://github.com/ogham/exa/releases/tag/v0.10.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
