### PR TITLE
python3Packages.aqualogic: 2.5 -> 2.6

### DIFF
--- a/pkgs/development/python-modules/aqualogic/default.nix
+++ b/pkgs/development/python-modules/aqualogic/default.nix
@@ -1,20 +1,29 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , pyserial
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "aqualogic";
-  version = "2.5";
+  version = "2.6";
 
   src = fetchFromGitHub {
     owner = "swilson";
     repo = pname;
     rev = version;
-    sha256 = "sha256-yxd+A5dsB9gBwVlPNjz+IgDHKTktNky84bWZMhA/xa4=";
+    sha256 = "sha256-dAC/0OjvrC8J/5pu5vcOKV/WqgkAlz0LuFl0up6FQRM=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "allow-iobase-objects.patch";
+      url = "https://github.com/swilson/aqualogic/commit/185fe25a86c82c497a55c78914b55ed39f5ca339.patch";
+      sha256 = "072jrrsqv86bn3skibjc57111jlpm8pq2503997fl3h4v6ziwdxg";
+    })
+  ];
 
   propagatedBuildInputs = [ pyserial ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.6

Change log: https://github.com/swilson/aqualogic/releases/tag/2.6

The Home Assistant's tests don't pass (`python-jose` issue).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
