### PR TITLE
python3Packages.plexwebsocket: 0.0.12 -> 0.0.13, python3Packages.plexapi: 4.5.0 -> 4.5.1

### DIFF
--- a/pkgs/development/python-modules/plexapi/default.nix
+++ b/pkgs/development/python-modules/plexapi/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "PlexAPI";
-  version = "4.5.0";
+  version = "4.5.1";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "pkkid";
     repo = "python-plexapi";
     rev = version;
-    sha256 = "sha256-MjV1JUHrIHTu3UHy4HnMtTEjSCx3U9kMgUkbCJOAZr0=";
+    sha256 = "sha256-WrjIN6+7ybprnjCv57BdKaQYoQ+HgGVr/XytXcbAmwg=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/plexwebsocket/default.nix
+++ b/pkgs/development/python-modules/plexwebsocket/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "plexwebsocket";
-  version = "0.0.12";
+  version = "0.0.13";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "jjlawren";
     repo = "python-plexwebsocket";
     rev = "v${version}";
-    sha256 = "1xdzb268c71yb25a5mk4g2jrbq4dv8bynfirs7p4n8a51p030dz6";
+    sha256 = "sha256-u9zO3d0d4Qg+u4ezVRGkNDpJqHkYIMrEMJzBK5WKk8Y=";
   };
 
   propagatedBuildInputs = [ aiohttp ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.0.13

Change log: https://github.com/jjlawren/python-plexwebsocket/releases/tag/v0.0.13

Update to latest upstream release 4.5.1 

Change log:https://github.com/pkkid/python-plexapi/releases/tag/4.5.1

Home Assistant's tests are not enabled as they don't pass.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
