### PR TITLE
Apache HTTPD module - structrured configuration

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -937,6 +937,7 @@
   ./services/web-apps/youtrack.nix
   ./services/web-apps/zabbix.nix
   ./services/web-servers/apache-httpd/default.nix
+  ./services/web-servers/apache-httpd2/default.nix
   ./services/web-servers/caddy.nix
   ./services/web-servers/darkhttpd.nix
   ./services/web-servers/fcgiwrap.nix

--- a/nixos/modules/services/web-servers/apache-httpd2/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd2/default.nix
@@ -1,0 +1,123 @@
+{ pkgs, config, lib, options, ... }:
+with lib;
+let
+  cfg = config.services.httpd2;
+  pkg = cfg.package.out;
+
+  # This stuff is included externally, because Magic_RB wanted to use those functions in his own projects without
+  # maintaining two separate copies. Please add anything which doesn't interact with the NixOS module system here,
+  # thanks! :)
+  inherit (import ./separate.nix { inherit lib; }) runtimeDir configParser;
+in
+{
+  options = {
+    services.httpd2 = {
+      enable = mkEnableOption "Enable Apache2 http server";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.apacheHttpd;
+        defaultText = "pkgs.apacheHttpd";
+        description = ''
+          Overridable attribute of the Apache HTTP Server package to use.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "wwwrun";
+        description = ''
+          User account under which httpd children processes run.
+          If you require the main httpd process to run as
+          <literal>root</literal> add the following configuration:
+          <programlisting>
+          systemd.services.httpd.serviceConfig.User = lib.mkForce "root";
+          </programlisting>
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "wwwrun";
+        description = ''
+          Group under which httpd children processes run.
+        '';
+      };
+
+      configuration = mkOption {
+        description = "Apache2 configuration";
+        type = with types;
+          let
+            self =
+              oneOf [
+                (attrsOf (oneOf [
+                  str
+                  int
+                  (listOf (oneOf [ str int (listOf (oneOf [ str int ])) ]))
+                  (attrsOf self)
+                ]))
+                (listOf (oneOf [ str self]))
+              ];
+          in
+            self // { description = "loop breaker"; };
+      };
+    };
+  };
+
+  config =
+    let
+      httpdConf = pkgs.writeText "apache.cfg" (configParser cfg.configuration);
+    in
+      (mkIf cfg.enable {
+        users.users = optionalAttrs (cfg.user == "wwwrun") {
+          wwwrun = {
+            group = cfg.group;
+            description = "Apache httpd user";
+            uid = config.ids.uids.wwwrun;
+          };
+        };
+
+        users.groups = optionalAttrs (cfg.group == "wwwrun") {
+          wwwrun.gid = config.ids.gids.wwwrun;
+        };
+
+        systemd.services.httpd2 = {
+          description = "Apache HTTPD";
+          wantedBy = [ "multi-user.target" ];
+          # wants = concatLists (map (certName: [ "acme-finished-${certName}.target" ]) dependentCertNames);
+          after = [ "network.target" ]; # ++ map (certName: "acme-selfsigned-${certName}.service") dependentCertNames;
+          # before = map (certName: "acme-${certName}.service") dependentCertNames;
+
+          path = [ pkg pkgs.coreutils pkgs.gnugrep ];
+
+          # environment =
+          #   optionalAttrs cfg.enablePHP { PHPRC = phpIni; }
+          #   // optionalAttrs cfg.enableMellon { LD_LIBRARY_PATH  = "${pkgs.xmlsec}/lib"; };
+
+          preStart =
+            ''
+                # Get rid of old semaphores.  These tend to accumulate across
+                # server restarts, eventually preventing it from restarting
+                # successfully.
+                for i in $(${pkgs.util-linux}/bin/ipcs -s | grep ' ${cfg.user} ' | cut -f2 -d ' '); do
+                  ${pkgs.util-linux}/bin/ipcrm -s $i
+                done
+            '';
+
+          serviceConfig = {
+            ExecStart = "${pkg}/bin/httpd -f ${httpdConf}";
+            ExecStop = "${pkg}/bin/httpd -f ${httpdConf} -k graceful-stop";
+            ExecReload = "${pkg}/bin/httpd -f ${httpdConf} -k graceful";
+            User = cfg.user;
+            Group = cfg.group;
+            Type = "forking";
+            PIDFile = "${runtimeDir}/httpd.pid";
+            Restart = "always";
+            RestartSec = "5s";
+            RuntimeDirectory = "httpd httpd/runtime";
+            RuntimeDirectoryMode = "0750";
+            AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+          };
+        };
+      });
+}

--- a/nixos/modules/services/web-servers/apache-httpd2/separate.nix
+++ b/nixos/modules/services/web-servers/apache-httpd2/separate.nix
@@ -1,0 +1,48 @@
+{ lib }:
+with lib;
+rec {
+  runtimeDir = "/run/httpd";
+
+  configParser = config:
+    if isAttrs config then
+      concatStringsSep "\n" (mapAttrsToList (name: value:
+        if isString value then
+          "${name} ${value}"
+        else if isInt value then
+          "${name} ${toString value}"
+        else if isStorePath value then
+          "${name} ${toString value}"
+        else if isList value then
+          if all (x: isString x) value then
+            "${name} ${concatStringsSep " " value}"
+          else if all (x: isInt x) value then
+            "${name} ${concatStringsSep " " (toString value)}"
+          else if all (x: isStorePath x) value then
+            "${name} ${concatStringsSep " " (toString value)}"
+          else if all (x: isList x) value then
+            concatStringsSep "\n"
+              (map (p: "${name} ${concatStringsSep " " p}") value)
+          else
+            abort "Unsupported type in ApacheHTTPD configuration attrset, the module system should have caught this!"
+        else if isAttrs value then
+          concatStringsSep "\n" (mapAttrsToList (an: av:
+            ''
+              <${name} ${an}>
+                ${configParser av}
+              </${name}>
+            '') value)
+        else
+          abort "Unsupported type in ApacheHTTPD configuration attrset, the module system should have caught this!"
+      ) config)
+    else if isList config then
+      concatMapStringsSep "\n" (x:
+        if isAttrs x then
+          configParser x
+        else if isString x then
+          x
+        else
+          abort "Unsupported type in ApacheHTTPD configuration attrset, the module system should have caught this!"
+      ) config
+    else
+      abort "Unsupported type in ApacheHTTPD configuration attrset, the module system should have caught this!";
+}


### PR DESCRIPTION
Signed-off-by: Magic_RB <magic_rb@redalder.org>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to create a more generic configuration system for Apache HTTPD, akin to the existing INI, YAML and JSON generators and this a draft of what that might look like. There are many things left to be done, I'd like to somehow port the old premade config system, (those opts that allow you to easily enable logging and such), but idk how it fits in with this new highly structured system, and I'm also for feedback before I start porting everything over. (I know about the commit, I'll be force pushing and squashing anyway)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
