### PR TITLE
kde: link frameworkintegration to kpackage

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
+++ b/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
@@ -2,8 +2,7 @@
   mkDerivation, lib,
   extra-cmake-modules,
   kbookmarks, kcompletion, kconfig, kconfigwidgets, ki18n, kiconthemes, kio,
-  knewstuff, knotifications, kpackage, kwidgetsaddons, libXcursor, qtx11extras,
-  kpackage
+  knewstuff, knotifications, kpackage, kwidgetsaddons, libXcursor, qtx11extras
 }:
 
 mkDerivation {

--- a/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
+++ b/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
@@ -2,7 +2,8 @@
   mkDerivation, lib,
   extra-cmake-modules,
   kbookmarks, kcompletion, kconfig, kconfigwidgets, ki18n, kiconthemes, kio,
-  knewstuff, knotifications, kpackage, kwidgetsaddons, libXcursor, qtx11extras
+  knewstuff, knotifications, kpackage, kwidgetsaddons, libXcursor, qtx11extras,
+  kpackage
 }:
 
 mkDerivation {
@@ -14,4 +15,7 @@ mkDerivation {
     kwidgetsaddons libXcursor qtx11extras
   ];
   propagatedBuildInputs = [ kconfigwidgets kiconthemes ];
+  postInstall=''
+    ln -s {${kpackage},$out}/libexec
+  '';
 }

--- a/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
+++ b/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
@@ -15,6 +15,6 @@ mkDerivation {
   ];
   propagatedBuildInputs = [ kconfigwidgets kiconthemes ];
   postInstall=''
-    ln -s {${kpackage},$out}/libexec
+    ln -s {${kpackage}/libexec $out/libexec
   '';
 }

--- a/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
+++ b/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
@@ -15,6 +15,6 @@ mkDerivation {
   ];
   propagatedBuildInputs = [ kconfigwidgets kiconthemes ];
   postInstall=''
-    ln -s {${kpackage}/libexec $out/libexec
+    ln -s ${kpackage}/libexec $out/libexec
   '';
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/76615 .
However, while it builds, I cannot have been able to find if it really fix the problem.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
