### PR TITLE
tracker: 3.0.4 -> 3.1.1

### DIFF
--- a/pkgs/development/libraries/tracker/default.nix
+++ b/pkgs/development/libraries/tracker/default.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tracker";
-  version = "3.0.3";
+  version = "3.1.1";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-b1yEqzvh7aUgUBsq7XIhYWoM8VKRDFN3V7U4vAXv/KM=";
+    sha256 = "sha256-Q3bi6YRUBm9E96JC5FuZs7/kwDtn+rGauw7Vhsp0iuc=";
   };
 
   patches = [
@@ -76,6 +76,7 @@ stdenv.mkDerivation rec {
 
   checkInputs = [
     python3.pkgs.pygobject3
+    python3.pkgs.tap
   ];
 
   mesonFlags = [
@@ -89,6 +90,7 @@ stdenv.mkDerivation rec {
     patchShebangs utils/data-generators/cc/generate
     patchShebangs tests/functional-tests/test-runner.sh.in
     patchShebangs tests/functional-tests/*.py
+    patchShebangs examples/python/*.py
   '';
 
   preCheck = ''

--- a/pkgs/development/python-modules/python-tap/default.nix
+++ b/pkgs/development/python-modules/python-tap/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "python-tap";
+  version = "3.0";
+
+  src = fetchFromGitHub {
+    owner = "python-tap";
+    repo = "tappy";
+    rev = "v${version}";
+    sha256 = "sha256-KKuIIG5IRsVIWxFv+amn/fo7CFMkQW3hbCA0ygJROyc=";
+  };
+
+  meta = with lib; {
+    description = "Pythonic API to Linux uinput kernel module";
+    homepage = "https://github.com/python-tap/tappy";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ avnik ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8128,6 +8128,8 @@ in {
 
   tahoma-api = callPackage ../development/python-modules/tahoma-api { };
 
+  tap = callPackage ../development/python-modules/python-tap { };
+
   tarman = callPackage ../development/python-modules/tarman { };
 
   tasklib = callPackage ../development/python-modules/tasklib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update tracker, which fails to pass tests.
I updated it to latest, but any release include https://gitlab.gnome.org/GNOME/tracker/-/issues/275 fix should works
Should fix #118155 (also breaks today's master snapshot build -- all depends on gtk3 was broken)

Would be nice, if someone who have faster build machine than my builder will test it (I can prove only that it unbreak build).

Also this PR include python-tap module, which needed by tracker 3.1.1 test suite

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
