### PR TITLE
ocamlPackages.printbox: 0.4 → 0.5

### DIFF
--- a/pkgs/development/ocaml-modules/printbox/default.nix
+++ b/pkgs/development/ocaml-modules/printbox/default.nix
@@ -1,21 +1,24 @@
-{ lib, fetchFromGitHub, buildDunePackage, uucp, uutf }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, uucp, uutf, mdx }:
 
 buildDunePackage rec {
   pname = "printbox";
-  version = "0.4";
+  version = "0.5";
 
-  minimumOCamlVersion = "4.05";
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.03";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = pname;
     rev = version;
-    sha256 = "0bq2v37v144i00h1zwyqhkfycxailr245n97yff0f7qnidxprix0";
+    sha256 = "099yxpp7d9bms6dwzp9im7dv1qb801hg5rx6awpx3rpfl4cvqfn2";
   };
 
-  checkInputs = lib.optionals doCheck [ uucp uutf ];
+  checkInputs = [ uucp uutf mdx.bin ];
 
-  doCheck = true;
+  # mdx is not available for OCaml < 4.07
+  doCheck = lib.versionAtLeast ocaml.version "4.07";
 
   meta = {
     homepage = "https://github.com/c-cube/printbox/";


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2 (support for OCaml 4.12).

cc maintainer @romildo.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
