### PR TITLE
python3Packages.openhomedevice: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/openhomedevice/default.nix
+++ b/pkgs/development/python-modules/openhomedevice/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, async-upnp-client
+, buildPythonPackage
+, fetchFromGitHub
+, lxml
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "openhomedevice";
+  version = "1.0.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "bazwilliams";
+    repo = pname;
+    rev = version;
+    sha256 = "04qdlyzc8xsk7qxyn9l59pbwnlw49zknw0r5lqwx402va12g4ra0";
+  };
+
+  propagatedBuildInputs = [
+    async-upnp-client
+    lxml
+  ];
+
+  # Tests are currently outdated
+  # https://github.com/bazwilliams/openhomedevice/issues/20
+  doCheck = false;
+  pythonImportsCheck = [ "openhomedevice" ];
+
+  meta = with lib; {
+    description = "Python module to access Linn Ds and Openhome devices";
+    homepage = "https://github.com/bazwilliams/openhomedevice";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -594,7 +594,7 @@
     "openexchangerates" = ps: with ps; [ ];
     "opengarage" = ps: with ps; [ ]; # missing inputs: open-garage
     "openhardwaremonitor" = ps: with ps; [ ];
-    "openhome" = ps: with ps; [ ]; # missing inputs: openhomedevice
+    "openhome" = ps: with ps; [ openhomedevice ];
     "opensensemap" = ps: with ps; [ opensensemap-api ];
     "opensky" = ps: with ps; [ ];
     "opentherm_gw" = ps: with ps; [ ]; # missing inputs: pyotgw

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4802,6 +4802,8 @@ in {
     pythonPackages = self;
   }));
 
+  openhomedevice = callPackage ../development/python-modules/openhomedevice { };
+
   openidc-client = callPackage ../development/python-modules/openidc-client { };
 
   openpyxl = if pythonAtLeast "3.6" then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to access Linn Ds and Openhome devices

https://github.com/bazwilliams/openhomedevice

This is a Home Assistant dependency. The Home Assistant's tests don't pass (python-jose issue).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
