### PR TITLE
hdf5: make possible to use the v1.10 API

### DIFF
--- a/pkgs/tools/misc/hdf5/1.10.nix
+++ b/pkgs/tools/misc/hdf5/1.10.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv
+, fetchurl
+, removeReferencesTo
+, zlib ? null
+, enableShared ? !stdenv.hostPlatform.isStatic
+}:
+
+let inherit (lib) optional optionals; in
+
+stdenv.mkDerivation rec {
+  version = "1.10.7";
+  pname = "hdf5";
+  src = fetchurl {
+    url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${lib.versions.majorMinor version}/${pname}-${version}/src/${pname}-${version}.tar.bz2";
+    sha256 = "0pm5xxry55i0h7wmvc7svzdaa90rnk7h78rrjmnlkz2ygsn8y082";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ removeReferencesTo ];
+
+  propagatedBuildInputs = optional (zlib != null) zlib;
+
+  configureFlags = optional enableShared "--enable-shared";
+
+  patches = [
+    ./bin-mv.patch
+  ];
+
+  postInstall = ''
+    find "$out" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
+    moveToOutput 'bin/h5cc' "''${!outputDev}"
+    moveToOutput 'bin/h5c++' "''${!outputDev}"
+    moveToOutput 'bin/h5fc' "''${!outputDev}"
+    moveToOutput 'bin/h5pcc' "''${!outputDev}"
+  '';
+
+  meta = {
+    description = "Data model, library, and file format for storing and managing data";
+    longDescription = ''
+      HDF5 supports an unlimited variety of datatypes, and is designed for flexible and efficient
+      I/O and for high volume and complex data. HDF5 is portable and is extensible, allowing
+      applications to evolve in their use of HDF5. The HDF5 Technology suite includes tools and
+      applications for managing, manipulating, viewing, and analyzing data in the HDF5 format.
+    '';
+    license = lib.licenses.bsd3; # Lawrence Berkeley National Labs BSD 3-Clause variant
+    homepage = "https://www.hdfgroup.org/HDF5/";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -10,6 +10,7 @@
 , enableShared ? !stdenv.hostPlatform.isStatic
 , javaSupport ? false
 , jdk
+, usev110Api ? false
 }:
 
 # cpp and mpi options are mutually exclusive
@@ -50,7 +51,8 @@ stdenv.mkDerivation rec {
     ++ optional (szip != null) "--with-szlib=${szip}"
     ++ optionals mpiSupport ["--enable-parallel" "CC=${mpi}/bin/mpicc"]
     ++ optional enableShared "--enable-shared"
-    ++ optional javaSupport "--enable-java";
+    ++ optional javaSupport "--enable-java"
+    ++ optional usev110Api "--with-default-api-version=v110";
 
   patches = [
     ./bin-mv.patch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17623,7 +17623,9 @@ in
     inherit (llvmPackages) openmp;
   };
 
-  vigra = callPackage ../development/libraries/vigra { };
+  vigra = callPackage ../development/libraries/vigra {
+    hdf5 = hdf5.override { usev110Api = true; };
+  };
 
   vlock = callPackage ../misc/screensavers/vlock { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5314,6 +5314,8 @@ in
     szip = null;
   };
 
+  hdf5_1_10 = callPackage ../tools/misc/hdf5/1.10.nix { };
+
   hdf5-mpi = appendToName "mpi" (hdf5.override {
     szip = null;
     mpiSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8128,9 +8128,13 @@ in {
   tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
 
   tables = if isPy3k then
-    callPackage ../development/python-modules/tables { }
+    callPackage ../development/python-modules/tables {
+      hdf5 = pkgs.hdf5_1_10;
+    }
   else
-    callPackage ../development/python-modules/tables/3.5.nix { };
+    callPackage ../development/python-modules/tables/3.5.nix {
+      hdf5 = pkgs.hdf5_1_10;
+    };
 
   tablib = callPackage ../development/python-modules/tablib { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

hdf5 v1.12 has introduced [breaking changes to the API](https://github.com/HDFGroup/hdf5/issues/2) and [some dependent packages are not yet compatible with it](https://github.com/NixOS/nixpkgs/pull/118312#issuecomment-813000589). This contribution adds a way to build the hdf5 library with the v1.10 API.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
