### PR TITLE
supertag: init at 0.1.4

### DIFF
--- a/pkgs/tools/filesystems/supertag/default.nix
+++ b/pkgs/tools/filesystems/supertag/default.nix
@@ -1,0 +1,41 @@
+{ lib, rustPlatform, fetchFromGitHub
+, clang, llvmPackages, pkg-config
+, dbus, fuse, sqlite
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "supertag";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "amoffat";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0jzm7pn38hlr96n0z8gqfsfdbw48y0nnbsgjdq7hpgwmcgvgqdam";
+  };
+
+  cargoSha256 = "1mzmp1jcxgn2swp52r9y7k09fk0z67i1qafzkkzlfxxd10vfr70v";
+
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+
+  nativeBuildInputs = [ clang pkg-config ];
+  buildInputs = [ dbus fuse sqlite ];
+
+  # The test are requiring extended permissions.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A tag-based filesystem";
+    longDescription = ''
+      Supertag is a tag-based filesystem, written in Rust, for Linux and MacOS.
+      It provides a tag-based view of your files by removing the hierarchy
+      constraints typically imposed on files and folders. In other words, it
+      allows you to think about your files not as objects stored in folders, but
+      as objects that can be filtered by folders.
+    '';
+    homepage = "https://github.com/amoffat/supertag";
+    license = licenses.agpl3Plus;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8408,6 +8408,8 @@ in
 
   super = callPackage ../tools/security/super { };
 
+  supertag = callPackage ../tools/filesystems/supertag { };
+
   supertux-editor = callPackage ../applications/editors/supertux-editor { };
 
   svgbob = callPackage ../tools/graphics/svgbob { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Supertag is a tag-based filesystem, written in Rust, for Linux and MacOS. Merging will close #116279.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
