### PR TITLE
libzip: install man-pages and add optionas for three optional dependencies

### DIFF
--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -5,6 +5,10 @@
 , perl
 , zlib
 , groff
+, withBzip2 ? false
+, bzip2
+, withLZMA ? false
+, xz
 }:
 
 stdenv.mkDerivation rec {
@@ -28,6 +32,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake perl groff ];
   propagatedBuildInputs = [ zlib ];
+  buildInputs = (lib.optional withLZMA xz) ++ (lib.optional withBzip2 bzip2);
 
   preCheck = ''
     # regress/runtest is a generated file

--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -9,6 +9,8 @@
 , bzip2
 , withLZMA ? false
 , xz
+, withOpenssl ? false
+, openssl
 }:
 
 stdenv.mkDerivation rec {
@@ -32,7 +34,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake perl groff ];
   propagatedBuildInputs = [ zlib ];
-  buildInputs = (lib.optional withLZMA xz) ++ (lib.optional withBzip2 bzip2);
+  buildInputs = (lib.optional withLZMA xz)
+    ++ (lib.optional withBzip2 bzip2)
+    ++ (lib.optional withOpenssl openssl );
 
   preCheck = ''
     # regress/runtest is a generated file

--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "1.7.3";
 
   src = fetchurl {
-    url = "https://www.nih.at/libzip/${pname}-${version}.tar.gz";
+    url = "https://libzip.org/download/${pname}-${version}.tar.gz";
     sha256 = "1k5rihiz7m1ahhjzcbq759hb9crzqkgw78pkxga118y5a32pc8hf";
   };
 
@@ -40,9 +40,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://www.nih.at/libzip";
+    homepage = "https://libzip.org/";
     description = "A C library for reading, creating and modifying zip archives";
     license = licenses.bsd3;
     platforms = platforms.unix;
+    changelog = "https://github.com/nih-at/libzip/blob/v${version}/NEWS.md";
   };
 }

--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -34,9 +34,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake perl groff ];
   propagatedBuildInputs = [ zlib ];
-  buildInputs = (lib.optional withLZMA xz)
-    ++ (lib.optional withBzip2 bzip2)
-    ++ (lib.optional withOpenssl openssl );
+  buildInputs = lib.optionals withLZMA [ xz ]
+    ++ lib.optionals withBzip2 [ bzip2 ]
+    ++ lib.optionals withOpenssl [ openssl ];
 
   preCheck = ''
     # regress/runtest is a generated file

--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -4,6 +4,7 @@
 , fetchurl
 , perl
 , zlib
+, groff
 }:
 
 stdenv.mkDerivation rec {
@@ -23,9 +24,9 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "man" ];
 
-  nativeBuildInputs = [ cmake perl ];
+  nativeBuildInputs = [ cmake perl groff ];
   propagatedBuildInputs = [ zlib ];
 
   preCheck = ''


### PR DESCRIPTION
###### Motivation for this change
This builds man-pages for `libzip` and adds three optional build arguments. Without this, some html manpages are installed, but I think it is better to install the regular man-pages instead.

The cmake files do not allow for both (man-pages and html-pages) to be installed without them being patched.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
