### PR TITLE
python3Packages.discordpy: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "discord.py";
-  version = "1.6.0";
+  version = "1.7.0";
   disabled = pythonOlder "3.5.3";
 
   # only distributes wheels on pypi now
@@ -17,13 +17,12 @@ buildPythonPackage rec {
     owner = "Rapptz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "036prc4iw91qx31zz48hy3b30kn2qnlg68lgrvv2mcvsjxf2gd1l";
+    sha256 = "1i5k2qb894rjksn21pk9shash1y7v4138rkk8mqr1a1yvgnr5ibg";
   };
 
   propagatedBuildInputs = [ aiohttp websockets ];
   patchPhase = ''
     substituteInPlace "requirements.txt" \
-      --replace "aiohttp>=3.6.0,<3.7.0" "aiohttp" \
       --replace "websockets>=6.0,!=7.0,!=8.0,!=8.0.1,<9.0" "websockets"
   '' + lib.optionalString withVoice ''
     substituteInPlace "discord/opus.py" \


### PR DESCRIPTION

###### Motivation for this change
Noticed an update was pushed upstream, so i decided to update the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
