### PR TITLE
free42: add desktop item

### DIFF
--- a/pkgs/applications/misc/free42/default.nix
+++ b/pkgs/applications/misc/free42/default.nix
@@ -1,6 +1,8 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
 , pkg-config
 , gtk3
 , alsaLib
@@ -17,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Htk2NHgYVL622URx67BUtounAUopLTahaSqfAqd3+ZI=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ copyDesktopItems pkg-config ];
   buildInputs = [ gtk3 alsaLib ];
 
   postPatch = ''
@@ -54,6 +56,29 @@ stdenv.mkDerivation rec {
     install -m644 skins/* $out/share/${pname}/skins
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "com.thomasokken.free42bin";
+      desktopName = "Free42Bin";
+      genericName = "Calculator";
+      exec = "free42bin";
+      type = "Application";
+      comment = meta.description;
+      categories = "Utility;Calculator;";
+      terminal = "false";
+    })
+    (makeDesktopItem {
+      name = "com.thomasokken.free42dec";
+      desktopName = "Free42Dec";
+      genericName = "Calculator";
+      exec = "free42dec";
+      type = "Application";
+      comment = meta.description;
+      categories = "Utility;Calculator;";
+      terminal = "false";
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/thomasokken/free42";


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a desktop item for the `free42dec` variant of Free42. It's unclear to me whether another one should be made for `free42bin`. Maybe it would be preferable to add a package option to select between the two?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
