### PR TITLE
[20.09] curl: add patches for CVE-2021-22876, CVE-2021-22890

### DIFF
--- a/pkgs/tools/networking/curl/7.74.0-CVE-2021-22876.patch
+++ b/pkgs/tools/networking/curl/7.74.0-CVE-2021-22876.patch
@@ -1,0 +1,139 @@
+Based on upstream 7214288898f5625a6cc196e22a74232eada7861c, adapted by ris to
+compensate for lack of 95cbcec8f986492766c4be3922af1e7644e1e7c5
+
+---
+ lib/transfer.c          | 25 ++++++++++++++--
+ tests/data/Makefile.inc |  2 +-
+ tests/data/test2081     | 66 +++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 90 insertions(+), 3 deletions(-)
+ create mode 100644 tests/data/test2081
+
+diff --git a/lib/transfer.c b/lib/transfer.c
+index 1976bc0338bc..a68c021c84d6 100644
+--- a/lib/transfer.c
++++ b/lib/transfer.c
+@@ -1581,6 +1581,9 @@ CURLcode Curl_follow(struct Curl_easy *data,
+       data->set.followlocation++; /* count location-followers */
+ 
+       if(data->set.http_auto_referer) {
++        CURLU *u;
++        char *referer;
++
+         /* We are asked to automatically set the previous URL as the referer
+            when we get the next URL. We pick the ->url field, which may or may
+            not be 100% correct */
+@@ -1590,9 +1593,27 @@ CURLcode Curl_follow(struct Curl_easy *data,
+           data->change.referer_alloc = FALSE;
+         }
+ 
+-        data->change.referer = strdup(data->change.url);
+-        if(!data->change.referer)
++        /* Make a copy of the URL without crenditals and fragment */
++        u = curl_url();
++        if(!u)
++          return CURLE_OUT_OF_MEMORY;
++
++        uc = curl_url_set(u, CURLUPART_URL, data->change.url, 0);
++        if(!uc)
++          uc = curl_url_set(u, CURLUPART_FRAGMENT, NULL, 0);
++        if(!uc)
++          uc = curl_url_set(u, CURLUPART_USER, NULL, 0);
++        if(!uc)
++          uc = curl_url_set(u, CURLUPART_PASSWORD, NULL, 0);
++        if(!uc)
++          uc = curl_url_get(u, CURLUPART_URL, &referer, 0);
++
++        curl_url_cleanup(u);
++
++        if(uc || referer == NULL)
+           return CURLE_OUT_OF_MEMORY;
++
++        data->change.referer = referer;
+         data->change.referer_alloc = TRUE; /* yes, free this later */
+       }
+     }
+diff --git a/tests/data/Makefile.inc b/tests/data/Makefile.inc
+index 2c7a0ca89fd8..ea52683d2254 100644
+--- a/tests/data/Makefile.inc
++++ b/tests/data/Makefile.inc
+@@ -225,7 +225,7 @@ test2064 test2065 test2066 test2067 test2068 test2069 \
+ test2064 test2065 test2066 test2067 test2068 test2069 test2070 \
+          test2071 test2072 test2073 test2074 test2075 test2076 test2077 \
+ test2078 \
+-test2080 \
++test2080 test2081 \
+ test2100 \
+ \
+ test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
+diff --git a/tests/data/test2081 b/tests/data/test2081
+new file mode 100644
+index 000000000000..a6733e737beb
+--- /dev/null
++++ b/tests/data/test2081
+@@ -0,0 +1,66 @@
++<testcase>
++<info>
++<keywords>
++HTTP
++HTTP GET
++referer
++followlocation
++--write-out
++</keywords>
++</info>
++
++# Server-side
++<reply>
++<data nocheck="yes">
++HTTP/1.1 301 This is a weirdo text message swsclose
++Location: data/%TESTNUMBER0002.txt?coolsite=yes
++Content-Length: 62
++Connection: close
++
++This server reply is for testing a simple Location: following
++</data>
++</reply>
++
++# Client-side
++<client>
++<server>
++http
++</server>
++ <name>
++Automatic referrer credential and anchor stripping check
++ </name>
++ <command>
++http://user:pass@%HOSTIP:%HTTPPORT/we/want/our/%TESTNUMBER#anchor --location --referer ';auto' --write-out '%{referer}\n'
++</command>
++</client>
++
++# Verify data after the test has been "shot"
++<verify>
++<errorcode>
++52
++</errorcode>
++<protocol>
++GET /we/want/our/%TESTNUMBER HTTP/1.1
++Host: %HOSTIP:%HTTPPORT
++Authorization: Basic dXNlcjpwYXNz
++User-Agent: curl/%VERSION
++Accept: */*
++
++GET /we/want/our/data/%TESTNUMBER0002.txt?coolsite=yes HTTP/1.1
++Host: %HOSTIP:%HTTPPORT
++Authorization: Basic dXNlcjpwYXNz
++User-Agent: curl/%VERSION
++Accept: */*
++Referer: http://%HOSTIP:%HTTPPORT/we/want/our/%TESTNUMBER
++
++</protocol>
++<stdout>
++HTTP/1.1 301 This is a weirdo text message swsclose
++Location: data/%TESTNUMBER0002.txt?coolsite=yes
++Content-Length: 62
++Connection: close
++
++http://%HOSTIP:%HTTPPORT/we/want/our/%TESTNUMBER
++</stdout>
++</verify>
++</testcase>

--- a/pkgs/tools/networking/curl/7.74.0-CVE-2021-22890.patch
+++ b/pkgs/tools/networking/curl/7.74.0-CVE-2021-22890.patch
@@ -1,0 +1,473 @@
+Based on upstream b09c8ee15771c614c4bf3ddac893cdb12187c844, adapted by ris mostly to
+compensate for lack of bbe3aa9f881fa27fe828e3c9a36d6831f254a3ee
+
+diff --git a/lib/vtls/bearssl.c b/lib/vtls/bearssl.c
+index 36c32d8d55be..39fc1a29209c 100644
+--- a/lib/vtls/bearssl.c
++++ b/lib/vtls/bearssl.c
+@@ -375,7 +375,8 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
+     void *session;
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    if(!Curl_ssl_getsessionid(conn, &session, NULL, sockindex)) {
++    if(!Curl_ssl_getsessionid(conn, SSL_IS_PROXY() ? TRUE : FALSE,
++                              &session, NULL, sockindex)) {
+       br_ssl_engine_set_session_parameters(&backend->ctx.eng, session);
+       infof(data, "BearSSL: re-using session ID\n");
+     }
+@@ -571,9 +572,13 @@ static CURLcode bearssl_connect_step3(struct Curl_easy *data,
+     br_ssl_engine_get_session_parameters(&backend->ctx.eng, session);
+     Curl_ssl_sessionid_lock(conn);
+-    incache = !(Curl_ssl_getsessionid(conn, &oldsession, NULL, sockindex));
++    incache = !(Curl_ssl_getsessionid(conn,
++                                      SSL_IS_PROXY() ? TRUE : FALSE,
++                                      &oldsession, NULL, sockindex));
+     if(incache)
+       Curl_ssl_delsessionid(conn, oldsession);
+-    ret = Curl_ssl_addsessionid(conn, session, 0, sockindex);
++    ret = Curl_ssl_addsessionid(conn,
++                                SSL_IS_PROXY() ? TRUE : FALSE,
++                                session, 0, sockindex);
+     Curl_ssl_sessionid_unlock(conn);
+     if(ret) {
+       free(session);
+diff --git a/lib/vtls/gtls.c b/lib/vtls/gtls.c
+index a75937b4646c..3b0d940a60e1 100644
+--- a/lib/vtls/gtls.c
++++ b/lib/vtls/gtls.c
+@@ -727,5 +727,7 @@ gtls_connect_step1(struct Curl_easy *data,
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    if(!Curl_ssl_getsessionid(conn, &ssl_sessionid, &ssl_idsize, sockindex)) {
++    if(!Curl_ssl_getsessionid(conn,
++                              SSL_IS_PROXY() ? TRUE : FALSE,
++                              &ssl_sessionid, &ssl_idsize, sockindex)) {
+       /* we got a session id, use it! */
+       gnutls_session_set_data(session, ssl_sessionid, ssl_idsize);
+@@ -1286,8 +1287,9 @@ gtls_connect_step3(struct Curl_easy *data,
+       gnutls_session_get_data(session, connect_sessionid, &connect_idsize);
+ 
+       Curl_ssl_sessionid_lock(conn);
+-      incache = !(Curl_ssl_getsessionid(conn, &ssl_sessionid, NULL,
+-                                        sockindex));
++      incache = !(Curl_ssl_getsessionid(conn,
++                                        SSL_IS_PROXY() ? TRUE : FALSE,
++                                        &ssl_sessionid, NULL, sockindex));
+       if(incache) {
+         /* there was one before in the cache, so instead of risking that the
+            previous one was rejected, we just kill that and store the new */
+@@ -1295,8 +1297,10 @@ gtls_connect_step3(struct Curl_easy *data,
+       }
+ 
+       /* store this session id */
+-      result = Curl_ssl_addsessionid(conn, connect_sessionid, connect_idsize,
+-                                     sockindex);
++      result = Curl_ssl_addsessionid(conn,
++                                     SSL_IS_PROXY() ? TRUE : FALSE,
++                                     connect_sessionid, connect_idsize,
++                                     sockindex);
+       Curl_ssl_sessionid_unlock(conn);
+       if(result) {
+         free(connect_sessionid);
+diff --git a/lib/vtls/mbedtls.c b/lib/vtls/mbedtls.c
+index 95cd4d99b665..93a7ac1fd87d 100644
+--- a/lib/vtls/mbedtls.c
++++ b/lib/vtls/mbedtls.c
+@@ -463,7 +463,9 @@ mbed_connect_step1(struct Curl_easy *data, struct connectdata *conn,
+     void *old_session = NULL;
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    if(!Curl_ssl_getsessionid(conn, &old_session, NULL, sockindex)) {
++    if(!Curl_ssl_getsessionid(conn,
++                              SSL_IS_PROXY() ? TRUE : FALSE,
++                              &old_session, NULL, sockindex)) {
+       ret = mbedtls_ssl_set_session(&backend->ssl, old_session);
+       if(ret) {
+         Curl_ssl_sessionid_unlock(conn);
+@@ -724,6 +726,7 @@ mbed_connect_step3(struct Curl_easy *data, struct connectdata *conn,
+     int ret;
+     mbedtls_ssl_session *our_ssl_sessionid;
+     void *old_ssl_sessionid = NULL;
++    bool isproxy = SSL_IS_PROXY() ? TRUE : FALSE;
+ 
+     our_ssl_sessionid = malloc(sizeof(mbedtls_ssl_session));
+     if(!our_ssl_sessionid)
+@@ -742,10 +745,12 @@ mbed_connect_step3(struct Curl_easy *data, struct connectdata *conn,
+ 
+     /* If there's already a matching session in the cache, delete it */
+     Curl_ssl_sessionid_lock(conn);
+-    if(!Curl_ssl_getsessionid(conn, &old_ssl_sessionid, NULL, sockindex))
++    if(!Curl_ssl_getsessionid(conn, isproxy, &old_ssl_sessionid, NULL,
++                              sockindex))
+       Curl_ssl_delsessionid(conn, old_ssl_sessionid);
+ 
+-    retcode = Curl_ssl_addsessionid(conn, our_ssl_sessionid, 0, sockindex);
++    retcode = Curl_ssl_addsessionid(conn, isproxy, our_ssl_sessionid,
++                                    0, sockindex);
+     Curl_ssl_sessionid_unlock(conn);
+     if(retcode) {
+       mbedtls_ssl_session_free(our_ssl_sessionid);
+diff --git a/lib/vtls/mesalink.c b/lib/vtls/mesalink.c
+index 4f1ab8627f49..5d6a1495d790 100644
+--- a/lib/vtls/mesalink.c
++++ b/lib/vtls/mesalink.c
+@@ -261,7 +261,9 @@ mesalink_connect_step1(struct Curl_easy *data,
+     void *ssl_sessionid = NULL;
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    if(!Curl_ssl_getsessionid(conn, &ssl_sessionid, NULL, sockindex)) {
++    if(!Curl_ssl_getsessionid(conn,
++                              SSL_IS_PROXY() ? TRUE : FALSE,
++                              &ssl_sessionid, NULL, sockindex)) {
+       /* we got a session id, use it! */
+       if(!SSL_set_session(BACKEND->handle, ssl_sessionid)) {
+         Curl_ssl_sessionid_unlock(conn);
+@@ -345,12 +347,14 @@ mesalink_connect_step3(struct connectdata *conn, int sockindex)
+     bool incache;
+     SSL_SESSION *our_ssl_sessionid;
+     void *old_ssl_sessionid = NULL;
++    bool isproxy = SSL_IS_PROXY() ? TRUE : FALSE;
+ 
+     our_ssl_sessionid = SSL_get_session(BACKEND->handle);
+ 
+     Curl_ssl_sessionid_lock(conn);
+     incache =
+-      !(Curl_ssl_getsessionid(conn, &old_ssl_sessionid, NULL, sockindex));
++      !(Curl_ssl_getsessionid(conn, isproxy, &old_ssl_sessionid, NULL,
++                              sockindex));
+     if(incache) {
+       if(old_ssl_sessionid != our_ssl_sessionid) {
+         infof(data, "old SSL session ID is stale, removing\n");
+@@ -361,8 +364,9 @@ mesalink_connect_step3(struct connectdata *conn, int sockindex)
+     }
+ 
+     if(!incache) {
+-      result = Curl_ssl_addsessionid(
+-        conn, our_ssl_sessionid, 0 /* unknown size */, sockindex);
++      result =
++        Curl_ssl_addsessionid(conn, isproxy, our_ssl_sessionid, 0,
++                              sockindex);
+       if(result) {
+         Curl_ssl_sessionid_unlock(conn);
+         failf(data, "failed to store ssl session");
+diff --git a/lib/vtls/openssl.c b/lib/vtls/openssl.c
+index 498f8b9d1d08..68b98984b460 100644
+--- a/lib/vtls/openssl.c
++++ b/lib/vtls/openssl.c
+@@ -393,12 +393,23 @@ static int ossl_get_ssl_conn_index(void)
+  */
+ static int ossl_get_ssl_sockindex_index(void)
+ {
+-  static int ssl_ex_data_sockindex_index = -1;
+-  if(ssl_ex_data_sockindex_index < 0) {
+-    ssl_ex_data_sockindex_index = SSL_get_ex_new_index(0, NULL, NULL, NULL,
+-        NULL);
++  static int sockindex_index = -1;
++  if(sockindex_index < 0) {
++    sockindex_index = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+   }
+-  return ssl_ex_data_sockindex_index;
++  return sockindex_index;
++}
++
++/* Return an extra data index for proxy boolean.
++ * This index can be used with SSL_get_ex_data() and SSL_set_ex_data().
++ */
++static int ossl_get_proxy_index(void)
++{
++  static int proxy_index = -1;
++  if(proxy_index < 0) {
++    proxy_index = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
++  }
++  return proxy_index;
+ }
+ 
+ static int passwd_callback(char *buf, int num, int encrypting,
+@@ -1174,6 +1185,7 @@ static int ossl_init(void)
+ 
+   /* Initialize the extra data indexes */
+-  if(ossl_get_ssl_conn_index() < 0 || ossl_get_ssl_sockindex_index() < 0)
++  if(ossl_get_ssl_conn_index() < 0 ||
++     ossl_get_ssl_sockindex_index() < 0 || ossl_get_proxy_index() < 0)
+     return 0;
+ 
+   return 1;
+@@ -2432,8 +2443,10 @@ static int ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
+   curl_socket_t *sockindex_ptr;
+   int connectdata_idx = ossl_get_ssl_conn_index();
+   int sockindex_idx = ossl_get_ssl_sockindex_index();
++  int proxy_idx = ossl_get_proxy_index();
++  bool isproxy;
+ 
+-  if(connectdata_idx < 0 || sockindex_idx < 0)
++  if(connectdata_idx < 0 || sockindex_idx < 0 || proxy_idx < 0)
+     return 0;
+ 
+   conn = (struct connectdata*) SSL_get_ex_data(ssl, connectdata_idx);
+@@ -2446,13 +2459,18 @@ static int ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
+   sockindex_ptr = (curl_socket_t*) SSL_get_ex_data(ssl, sockindex_idx);
+   sockindex = (int)(sockindex_ptr - conn->sock);
+ 
++  isproxy = SSL_get_ex_data(ssl, proxy_idx) ? TRUE : FALSE;
++
+   if(SSL_SET_OPTION(primary.sessionid)) {
+     bool incache;
+     void *old_ssl_sessionid = NULL;
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    incache = !(Curl_ssl_getsessionid(conn, &old_ssl_sessionid, NULL,
+-                                      sockindex));
++    if(isproxy)
++      incache = FALSE;
++    else
++      incache = !(Curl_ssl_getsessionid(conn, isproxy,
++                                        &old_ssl_sessionid, NULL, sockindex));
+     if(incache) {
+       if(old_ssl_sessionid != ssl_sessionid) {
+         infof(data, "old SSL session ID is stale, removing\n");
+@@ -2462,8 +2480,8 @@ static int ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
+     }
+ 
+     if(!incache) {
+-      if(!Curl_ssl_addsessionid(conn, ssl_sessionid,
+-                                      0 /* unknown size */, sockindex)) {
++      if(!Curl_ssl_addsessionid(conn, isproxy, ssl_sessionid,
++                                0 /* unknown size */, sockindex)) {
+         /* the session has been put into the session cache */
+         res = 1;
+       }
+@@ -3193,16 +3211,26 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
+     void *ssl_sessionid = NULL;
+     int connectdata_idx = ossl_get_ssl_conn_index();
+     int sockindex_idx = ossl_get_ssl_sockindex_index();
++    int proxy_idx = ossl_get_proxy_index();
+ 
+-    if(connectdata_idx >= 0 && sockindex_idx >= 0) {
++    if(connectdata_idx >= 0 && sockindex_idx >= 0 &&
++       proxy_idx >= 0) {
+       /* Store the data needed for the "new session" callback.
+        * The sockindex is stored as a pointer to an array element. */
+       SSL_set_ex_data(backend->handle, connectdata_idx, conn);
+       SSL_set_ex_data(backend->handle, sockindex_idx, conn->sock + sockindex);
++#ifndef CURL_DISABLE_PROXY
++      SSL_set_ex_data(backend->handle, proxy_idx, SSL_IS_PROXY() ? (void *) 1:
++                      NULL);
++#else
++      SSL_set_ex_data(backend->handle, proxy_idx, NULL);
++#endif
++
+     }
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    if(!Curl_ssl_getsessionid(conn, &ssl_sessionid, NULL, sockindex)) {
++    if(!Curl_ssl_getsessionid(conn, SSL_IS_PROXY() ? TRUE : FALSE,
++                              &ssl_sessionid, NULL, sockindex)) {
+       /* we got a session id, use it! */
+       if(!SSL_set_session(backend->handle, ssl_sessionid)) {
+         Curl_ssl_sessionid_unlock(conn);
+diff --git a/lib/vtls/schannel.c b/lib/vtls/schannel.c
+index d7b89d43f892..931bd853eb8e 100644
+--- a/lib/vtls/schannel.c
++++ b/lib/vtls/schannel.c
+@@ -496,5 +496,7 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
+   if(SSL_SET_OPTION(primary.sessionid)) {
+     Curl_ssl_sessionid_lock(conn);
+-    if(!Curl_ssl_getsessionid(conn, (void **)&old_cred, NULL, sockindex)) {
++    if(!Curl_ssl_getsessionid(conn,
++                              SSL_IS_PROXY() ? TRUE : FALSE,
++                              (void **)&old_cred, NULL, sockindex)) {
+       BACKEND->cred = old_cred;
+       DEBUGF(infof(data, "schannel: re-using existing credential handle\n"));
+@@ -1337,8 +1338,9 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
+   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+   SECURITY_STATUS sspi_status = SEC_E_OK;
+   CERT_CONTEXT *ccert_context = NULL;
++  bool isproxy = SSL_IS_PROXY();
+ #ifdef DEBUGBUILD
+-  const char * const hostname = SSL_IS_PROXY() ? conn->http_proxy.host.name :
++  const char * const hostname = isproxy ? conn->http_proxy.host.name :
+     conn->host.name;
+ #endif
+ #ifdef HAS_ALPN
+@@ -1414,8 +1416,8 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
+     struct Curl_schannel_cred *old_cred = NULL;
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    incache = !(Curl_ssl_getsessionid(conn, (void **)&old_cred, NULL,
+-                                      sockindex));
++    incache = !(Curl_ssl_getsessionid(conn, isproxy, (void **)&old_cred,
++                                      NULL, sockindex));
+     if(incache) {
+       if(old_cred != BACKEND->cred) {
+         DEBUGF(infof(data,
+@@ -1426,7 +1428,7 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
+       }
+     }
+     if(!incache) {
+-      result = Curl_ssl_addsessionid(conn, (void *)BACKEND->cred,
++      result = Curl_ssl_addsessionid(conn, isproxy, BACKEND->cred,
+                                      sizeof(struct Curl_schannel_cred),
+                                      sockindex);
+       if(result) {
+diff --git a/lib/vtls/sectransp.c b/lib/vtls/sectransp.c
+index 05b57dfaad91..e69b99b72cd6 100644
+--- a/lib/vtls/sectransp.c
++++ b/lib/vtls/sectransp.c
+@@ -1400,10 +1400,12 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
+   char * const ssl_cert = SSL_SET_OPTION(primary.clientcert);
+   const struct curl_blob *ssl_cert_blob = SSL_SET_OPTION(primary.cert_blob);
+ #ifndef CURL_DISABLE_PROXY
+-  const char * const hostname = SSL_IS_PROXY() ? conn->http_proxy.host.name :
++  bool isproxy = SSL_IS_PROXY();
++  const char * const hostname = isproxy ? conn->http_proxy.host.name :
+     conn->host.name;
+   const long int port = SSL_IS_PROXY() ? conn->port : conn->remote_port;
+ #else
++  const isproxy = FALSE;
+   const char * const hostname = conn->host.name;
+   const long int port = conn->remote_port;
+ #endif
+@@ -1613,7 +1615,7 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
+ #ifdef USE_NGHTTP2
+       if(data->state.httpversion >= CURL_HTTP_VERSION_2
+ #ifndef CURL_DISABLE_PROXY
+-         && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
++         && (!isproxy || !conn->bits.tunnel_proxy)
+ #endif
+         ) {
+         CFArrayAppendValue(alpnArr, CFSTR(NGHTTP2_PROTO_VERSION_ID));
+@@ -1953,7 +1955,7 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
+     size_t ssl_sessionid_len;
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    if(!Curl_ssl_getsessionid(conn, (void **)&ssl_sessionid,
++    if(!Curl_ssl_getsessionid(conn, isproxy, (void **)&ssl_sessionid,
+                               &ssl_sessionid_len, sockindex)) {
+       /* we got a session id, use it! */
+       err = SSLSetPeerID(backend->ssl_ctx, ssl_sessionid, ssl_sessionid_len);
+@@ -1981,7 +1983,7 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
+         return CURLE_SSL_CONNECT_ERROR;
+       }
+ 
+-      result = Curl_ssl_addsessionid(conn, ssl_sessionid, ssl_sessionid_len,
++      result = Curl_ssl_addsessionid(conn, isproxy, ssl_sessionid, ssl_sessionid_len,
+                                      sockindex);
+       Curl_ssl_sessionid_unlock(conn);
+       if(result) {
+diff --git a/lib/vtls/vtls.c b/lib/vtls/vtls.c
+index 6a0069237fdb..95fd6356285f 100644
+--- a/lib/vtls/vtls.c
++++ b/lib/vtls/vtls.c
+@@ -367,5 +367,6 @@ void Curl_ssl_sessionid_unlock(struct Curl_easy *data)
+  */
+ bool Curl_ssl_getsessionid(struct connectdata *conn,
++                           const bool isProxy,
+                            void **ssl_sessionid,
+                            size_t *idsize, /* set 0 if unknown */
+                            int sockindex)
+@@ -377,7 +378,6 @@ bool Curl_ssl_getsessionid(struct Curl_easy *data,
+   bool no_match = TRUE;
+ 
+ #ifndef CURL_DISABLE_PROXY
+-  const bool isProxy = CONNECT_PROXY_SSL();
+   struct ssl_primary_config * const ssl_config = isProxy ?
+     &conn->proxy_ssl_config :
+     &conn->ssl_config;
+@@ -389,10 +389,15 @@ bool Curl_ssl_getsessionid(struct Curl_easy *data,
+   struct ssl_primary_config * const ssl_config = &conn->ssl_config;
+   const char * const name = conn->host.name;
+   int port = conn->remote_port;
+-  (void)sockindex;
+ #endif
++  (void)sockindex;
+   *ssl_sessionid = NULL;
+ 
++#ifdef CURL_DISABLE_PROXY
++  if(isProxy)
++    return TRUE;
++#endif
++
+   DEBUGASSERT(SSL_SET_OPTION(primary.sessionid));
+ 
+   if(!SSL_SET_OPTION(primary.sessionid))
+@@ -480,5 +485,6 @@ void Curl_ssl_delsessionid(struct Curl_easy *data, void *ssl_sessionid)
+  */
+ CURLcode Curl_ssl_addsessionid(struct connectdata *conn,
++                               bool isProxy,
+                                void *ssl_sessionid,
+                                size_t idsize,
+                                int sockindex)
+@@ -492,7 +498,6 @@ CURLcode Curl_ssl_addsessionid(struct Curl_easy *data,
+   int conn_to_port;
+   long *general_age;
+ #ifndef CURL_DISABLE_PROXY
+-  const bool isProxy = CONNECT_PROXY_SSL();
+   struct ssl_primary_config * const ssl_config = isProxy ?
+     &conn->proxy_ssl_config :
+     &conn->ssl_config;
+@@ -505,6 +510,7 @@ CURLcode Curl_ssl_addsessionid(struct Curl_easy *data,
+   const char *hostname = conn->host.name;
+   (void)sockindex;
+ #endif
++  (void)sockindex;
+   DEBUGASSERT(SSL_SET_OPTION(primary.sessionid));
+ 
+   clone_host = strdup(hostname);
+diff --git a/lib/vtls/vtls.h b/lib/vtls/vtls.h
+index 273184f1894a..2b43e7744b19 100644
+--- a/lib/vtls/vtls.h
++++ b/lib/vtls/vtls.h
+@@ -235,5 +235,6 @@ void Curl_ssl_sessionid_unlock(struct Curl_easy *data);
+  */
+ bool Curl_ssl_getsessionid(struct connectdata *conn,
++                           const bool isproxy,
+                            void **ssl_sessionid,
+                            size_t *idsize, /* set 0 if unknown */
+                            int sockindex);
+@@ -245,5 +246,6 @@ bool Curl_ssl_getsessionid(struct Curl_easy *data,
+  */
+ CURLcode Curl_ssl_addsessionid(struct connectdata *conn,
++                               const bool isProxy,
+                                void *ssl_sessionid,
+                                size_t idsize,
+                                int sockindex);
+diff --git a/lib/vtls/wolfssl.c b/lib/vtls/wolfssl.c
+index 7159ac9d5e64..8fb2ea7acf31 100644
+--- a/lib/vtls/wolfssl.c
++++ b/lib/vtls/wolfssl.c
+@@ -516,7 +516,9 @@ wolfssl_connect_step1(struct Curl_easy *data, struct connectdata *conn,
+     void *ssl_sessionid = NULL;
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    if(!Curl_ssl_getsessionid(conn, &ssl_sessionid, NULL, sockindex)) {
++    if(!Curl_ssl_getsessionid(conn,
++                              SSL_IS_PROXY() ? TRUE : FALSE,
++                              &ssl_sessionid, NULL, sockindex)) {
+       /* we got a session id, use it! */
+       if(!SSL_set_session(backend->handle, ssl_sessionid)) {
+         char error_buffer[WOLFSSL_MAX_ERROR_SZ];
+@@ -772,10 +774,11 @@ wolfssl_connect_step3(struct Curl_easy *data, struct connectdata *conn,
+     void *old_ssl_sessionid = NULL;
+ 
+     our_ssl_sessionid = SSL_get_session(backend->handle);
++    bool isproxy = SSL_IS_PROXY() ? TRUE : FALSE;
+ 
+     Curl_ssl_sessionid_lock(conn);
+-    incache = !(Curl_ssl_getsessionid(conn, &old_ssl_sessionid, NULL,
+-                                      sockindex));
++    incache = !(Curl_ssl_getsessionid(conn, isproxy,
++                                      &old_ssl_sessionid, NULL, sockindex));
+     if(incache) {
+       if(old_ssl_sessionid != our_ssl_sessionid) {
+         infof(data, "old SSL session ID is stale, removing\n");
+@@ -786,8 +789,8 @@ wolfssl_connect_step3(struct Curl_easy *data, struct connectdata *conn,
+     }
+ 
+     if(!incache) {
+-      result = Curl_ssl_addsessionid(conn, our_ssl_sessionid,
+-                                     0 /* unknown size */, sockindex);
++      result = Curl_ssl_addsessionid(conn, isproxy, our_ssl_sessionid,
++                                     0, sockindex);
+       if(result) {
+         Curl_ssl_sessionid_unlock(conn);
+         failf(data, "failed to store ssl session");

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -44,6 +44,11 @@ stdenv.mkDerivation rec {
     sha256 = "19bp3d91xq9vqwlbzq261j23mk9lz4lyka4gr2fm6dhnd3k66k8g";
   };
 
+  patches = [
+    ./7.74.0-CVE-2021-22876.patch
+    ./7.74.0-CVE-2021-22890.patch
+  ];
+
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
   separateDebugInfo = stdenv.isLinux;
 


### PR DESCRIPTION
Backport of #118343 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
