### PR TITLE
betterdiscord-installer: init at 1.0.0-beta

### DIFF
--- a/pkgs/tools/misc/betterdiscord-installer/default.nix
+++ b/pkgs/tools/misc/betterdiscord-installer/default.nix
@@ -1,0 +1,32 @@
+{ appimageTools, lib, fetchurl }:
+let
+  pname = "betterdiscord-installer";
+  version = "1.0.0-beta";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/BetterDiscord/Installer/releases/download/v${version}/Betterdiscord-Linux.AppImage";
+    sha256 = "103acb11qmvjmf6g9lgsfm5jyahfwfdqw0x9w6lmv1hzwbs26dsr";
+  };
+
+  appimageContents = appimageTools.extract { inherit name src; };
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+
+    install -m 444 -D ${appimageContents}/betterdiscord.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/betterdiscord.desktop \
+      --replace "Exec=AppRun" "Exec=$out/bin/${pname}"
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "Installer for BetterDiscord";
+    homepage = "https://betterdiscord.net";
+    license = licenses.mit;
+    maintainers = [ maintainers.ivar ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1102,6 +1102,8 @@ in
 
   betterdiscordctl = callPackage ../tools/misc/betterdiscordctl { };
 
+  betterdiscord-installer = callPackage ../tools/misc/betterdiscord-installer { };
+
   brakeman = callPackage ../development/tools/analysis/brakeman { };
 
   brewtarget = libsForQt514.callPackage ../applications/misc/brewtarget { } ;


### PR DESCRIPTION

###### Motivation for this change
Seems to be working out of the box for me.

cc @ObserverOfTime

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
