### PR TITLE
apple-music-electron: fix desktop file exec path

### DIFF
--- a/pkgs/applications/audio/apple-music-electron/default.nix
+++ b/pkgs/applications/audio/apple-music-electron/default.nix
@@ -18,7 +18,7 @@ in appimageTools.wrapType2 {
 
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace 'Exec=AppRun' 'Exec=$out/bin/apple-music-electron'
+      --replace "Exec=AppRun" "Exec=$out/bin/apple-music-electron"
     cp -r ${appimageContents}/usr/share/icons $out/share
   '';
 


### PR DESCRIPTION

###### Motivation for this change
Because of the `substituteInPlace` command using single quotes instead of doubles, it takes `$out` as a literal string instead of the variable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
