### PR TITLE
macchanger: apply patches from Debian

### DIFF
--- a/pkgs/os-specific/linux/macchanger/default.nix
+++ b/pkgs/os-specific/linux/macchanger/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, texinfo }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, texinfo }:
 
 stdenv.mkDerivation rec {
   pname = "macchanger";
@@ -11,15 +11,38 @@ stdenv.mkDerivation rec {
     sha256 = "1hypx6sxhd2b1nsxj314hpkhj7q4x9p2kfaaf20rjkkkig0nck9r";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/m/macchanger/1.7.0-5.3/debian/patches/02-fix_usage_message.patch";
+      sha256 = "0pxljmq0l0znylbhms09i19qwil74gm8gx3xx2ffx00dajaizj18";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/m/macchanger/1.7.0-5.3/debian/patches/06-update_OUI_list.patch";
+      sha256 = "04kbd784z9nwkjva5ckkvb0yb3pim9valb1viywn1yyh577d0y7w";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/m/macchanger/1.7.0-5.3/debian/patches/08-fix_random_MAC_choice.patch";
+      sha256 = "1vz3appxxsdf1imzrn57amazfwlbrvx6g78b6n88aqgwzy5dm34d";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/m/macchanger/1.7.0-5.3/debian/patches/check-random-device-read-errors.patch";
+      sha256 = "0pra6qnk39crjlidspg3l6hpaqiw43cypahx793l59mqn956cngc";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/m/macchanger/1.7.0-5.3/debian/patches/verify-changed-MAC.patch";
+      sha256 = "0vjhf2fnj1hlghjl821p6idrfc8hmd4lgps5lf1l68ylqvwjw0zj";
+    })
+  ];
+
   nativeBuildInputs = [ autoreconfHook texinfo ];
 
   outputs = [ "out" "info" ];
 
   meta = with lib; {
     description = "A utility for viewing/manipulating the MAC address of network interfaces";
-    maintainers = with maintainers; [ joachifm ma27 ];
+    maintainers = with maintainers; [ joachifm ma27 dotlambda ];
     license = licenses.gpl2Plus;
-    homepage = "https://www.gnu.org/software/macchanger";
+    homepage = "https://github.com/alobbs/macchanger";
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Gentoo does the same:
https://gitweb.gentoo.org/repo/gentoo.git/plain/net-analyzer/macchanger/macchanger-1.7.0_p5_p4.ebuild

This fixes e.g. https://github.com/alobbs/macchanger/issues/17.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
