### PR TITLE
emacs: 27.1 -> 27.2

### DIFF
--- a/pkgs/applications/editors/emacs/27.nix
+++ b/pkgs/applications/editors/emacs/27.nix
@@ -1,6 +1,6 @@
 import ./generic.nix (rec {
-  version = "27.1";
-  sha256 = "0h9f2wpmp6rb5rfwvqwv1ia1nw86h74p7hnz3vb3gjazj67i4k2a";
+  version = "27.2";
+  sha256 = "sha256-tKfMTnjmPzeGJOCRkhW5EK9bsqCvyBn60pgnLp9Awbk=";
   patches = [
     ./tramp-detect-wrapped-gvfsd.patch
   ];

--- a/pkgs/applications/editors/emacs/tramp-detect-wrapped-gvfsd.patch
+++ b/pkgs/applications/editors/emacs/tramp-detect-wrapped-gvfsd.patch
@@ -1,12 +1,11 @@
 diff --git a/lisp/net/tramp-gvfs.el b/lisp/net/tramp-gvfs.el
-index 34a234c..b5a471c 100644
+index 9e26c8fd6d..fa220e513c 100644
 --- a/lisp/net/tramp-gvfs.el
 +++ b/lisp/net/tramp-gvfs.el
-@@ -122,6 +122,7 @@
- 	 (tramp-compat-funcall 'dbus-get-unique-name :system)
- 	 (tramp-compat-funcall 'dbus-get-unique-name :session)
- 	 (or (tramp-compat-process-running-p "gvfs-fuse-daemon")
+@@ -125,5 +125,6 @@
+ 	     ;; for some processes.  Better we don't check.
+ 	     (<= emacs-major-version 25)
+ 	     (tramp-compat-process-running-p "gvfs-fuse-daemon")
 +	     (tramp-compat-process-running-p ".gvfsd-fuse-wrapped")
  	     (tramp-compat-process-running-p "gvfsd-fuse"))))
    "Non-nil when GVFS is available.")
- 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Maintenance update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
