### PR TITLE
mopidy: allow overriding in mopidyPackages scope

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -1,46 +1,39 @@
-{ newScope, python }:
+{ lib, newScope, python }:
 
 # Create a custom scope so we are consistent in which python version is used
+lib.makeScope newScope (self: with self; {
+  inherit python;
+  pythonPackages = python.pkgs;
 
-let
-  callPackage = newScope self;
+  mopidy = callPackage ./mopidy.nix { };
 
-  self = {
+  mopidy-iris = callPackage ./iris.nix { };
 
-    inherit python;
-    pythonPackages = python.pkgs;
+  mopidy-local = callPackage ./local.nix { };
 
-    mopidy = callPackage ./mopidy.nix { };
+  mopidy-moped = callPackage ./moped.nix { };
 
-    mopidy-iris = callPackage ./iris.nix { };
+  mopidy-mopify = callPackage ./mopify.nix { };
 
-    mopidy-local = callPackage ./local.nix { };
+  mopidy-mpd = callPackage ./mpd.nix { };
 
-    mopidy-moped = callPackage ./moped.nix { };
+  mopidy-mpris = callPackage ./mpris.nix { };
 
-    mopidy-mopify = callPackage ./mopify.nix { };
+  mopidy-musicbox-webclient = callPackage ./musicbox-webclient.nix { };
 
-    mopidy-mpd = callPackage ./mpd.nix { };
+  mopidy-scrobbler = callPackage ./scrobbler.nix { };
 
-    mopidy-mpris = callPackage ./mpris.nix { };
+  mopidy-somafm = callPackage ./somafm.nix { };
 
-    mopidy-musicbox-webclient = callPackage ./musicbox-webclient.nix { };
+  mopidy-soundcloud = callPackage ./soundcloud.nix { };
 
-    mopidy-scrobbler = callPackage ./scrobbler.nix { };
+  mopidy-spotify = callPackage ./spotify.nix { };
 
-    mopidy-somafm = callPackage ./somafm.nix { };
+  mopidy-spotify-tunigo = callPackage ./spotify-tunigo.nix { };
 
-    mopidy-soundcloud = callPackage ./soundcloud.nix { };
+  mopidy-tunein = callPackage ./tunein.nix { };
 
-    mopidy-spotify = callPackage ./spotify.nix { };
+  mopidy-youtube = callPackage ./youtube.nix { };
 
-    mopidy-spotify-tunigo = callPackage ./spotify-tunigo.nix { };
-
-    mopidy-tunein = callPackage ./tunein.nix { };
-
-    mopidy-youtube = callPackage ./youtube.nix { };
-
-    mopidy-subidy = callPackage ./subidy.nix { };
-  };
-
-in self
+  mopidy-subidy = callPackage ./subidy.nix { };
+})


### PR DESCRIPTION


###### Motivation for this change

In the previous implementation, overrideScope' etc. was not exposed in
mopidyPackages, which made it annoying to override the mopidy package,
as the other packages in the scope would not pick up the changes,
causing conflicts.

e.g. this overlay can be used to add an extra dependency:

```nix
(selfp: superp: {
  mopidyPackages = superp.mopidyPackages.overrideScope'
  (self: super: {
    mopidy = super.mopidy.overridePythonAttrs (old: {
      buildInputs = [ superp.gst_all_1.gst-libav ] ++ old.buildInputs;
    });
  });
})
```

I checked that this doesn't change any of the derivations in the mopidyPackages scope.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
