### PR TITLE
libGL: use headers from glvnd

### DIFF
--- a/pkgs/applications/editors/atom/env.nix
+++ b/pkgs/applications/editors/atom/env.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, zlib, glib, alsaLib, dbus, gtk3, atk, pango, freetype, fontconfig
 , libgnome-keyring3, gdk-pixbuf, cairo, cups, expat, libgpgerror, nspr
 , gconf, nss, xorg, libcap, systemd, libnotify, libsecret, libuuid, at-spi2-atk
-, at-spi2-core, libdbusmenu
+, at-spi2-core, libdbusmenu, mesa
 }:
 
 let
@@ -12,6 +12,7 @@ let
     xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
     xorg.libXcursor xorg.libxkbfile xorg.libXScrnSaver libcap systemd libnotify
     xorg.libxcb libsecret libuuid at-spi2-atk at-spi2-core libdbusmenu
+    mesa # required for libgbm
   ];
 
   libPathNative = lib.makeLibraryPath packages;

--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -4,7 +4,7 @@
 , alsaLib, atk, at-spi2-atk, at-spi2-core, cairo, dbus, cups, expat
 , gdk-pixbuf, glib, gtk3, libX11, libXScrnSaver, libXcomposite, libXcursor
 , libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst
-, libxcb, libuuid, libxshmfence, nspr, nss, pango
+, libxcb, libuuid, libxshmfence, nspr, nss, pango, mesa
 
 , systemd
 }:
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
     libXtst
     libxcb
     libuuid
+    mesa # for libgbm
     nspr
     nss
     pango

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -138,6 +138,7 @@ let
       bison gperf libkrb5
       glib gtk3 dbus-glib
       libXScrnSaver libXcursor libXtst libxshmfence libGLU libGL
+      mesa # required for libgbm
       pciutils protobuf speechd libXdamage at-spi2-core
       jre
       pipewire

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -6,7 +6,7 @@
 , libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
 , freetype, fontconfig, file, nspr, nss, nss_3_53
 , yasm, libGLU, libGL, sqlite, unzip, makeWrapper
-, hunspell, libXdamage, libevent, libstartup_notification
+, hunspell, libevent, libstartup_notification
 , libvpx_1_8
 , icu67, libpng, jemalloc, glib, pciutils
 , autoconf213, which, gnused, rustPackages, rustPackages_1_45
@@ -22,7 +22,7 @@
 , pulseaudioSupport ? stdenv.isLinux, libpulseaudio
 , ffmpegSupport ? true
 , gtk3Support ? true, gtk2, gtk3, wrapGAppsHook
-, waylandSupport ? true, libxkbcommon
+, waylandSupport ? true, libxkbcommon, libdrm
 , ltoSupport ? (stdenv.isLinux && stdenv.is64bit), overrideCC, buildPackages
 , gssSupport ? true, libkrb5
 , pipewireSupport ? waylandSupport && webrtcSupport, pipewire
@@ -161,6 +161,7 @@ buildStdenv.mkDerivation ({
     xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
     xorg.pixman yasm libGLU libGL
     xorg.xorgproto
+    xorg.libXdamage
     xorg.libXext makeWrapper
     libevent libstartup_notification /* cairo */
     libpng jemalloc glib
@@ -175,7 +176,7 @@ buildStdenv.mkDerivation ({
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
   ++ lib.optional  gtk3Support gtk3
   ++ lib.optional  gssSupport libkrb5
-  ++ lib.optional  waylandSupport libxkbcommon
+  ++ lib.optionals waylandSupport [ libxkbcommon libdrm ]
   ++ lib.optional  pipewireSupport pipewire
   ++ lib.optional  (lib.versionAtLeast ffversion "82") gnum4
   ++ lib.optionals buildStdenv.isDarwin [ CoreMedia ExceptionHandling Kerberos

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -2,7 +2,7 @@
 , gnome2, gtk3, atk, at-spi2-atk, cairo, pango, gdk-pixbuf, glib, freetype, fontconfig
 , dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr, libXcomposite
 , libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss, nspr, alsaLib
-, cups, expat, libuuid, at-spi2-core, libappindicator-gtk3
+, cups, expat, libuuid, at-spi2-core, libappindicator-gtk3, mesa
 # Runtime dependencies:
 , systemd, libnotify, libdbusmenu, libpulseaudio
 # Unfortunately this also overwrites the UI language (not just the spell
@@ -73,6 +73,7 @@ in stdenv.mkDerivation rec {
     libappindicator-gtk3
     libnotify
     libuuid
+    mesa # for libgbm
     nspr
     nss
     pango

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -61,7 +61,7 @@
 , alsaSupport ? stdenv.isLinux, alsaLib
 , pulseaudioSupport ? stdenv.isLinux, libpulseaudio
 , gtk3Support ? true, gtk2, gtk3, wrapGAppsHook
-, waylandSupport ? true
+, waylandSupport ? true, libdrm
 , libxkbcommon, calendarSupport ? true
 
 # Use official trademarked branding.  Permission obtained at:
@@ -137,12 +137,13 @@ stdenv.mkDerivation rec {
     xorg.libXt
     xorg.pixman
     xorg.xorgproto
+    xorg.libXdamage
     zip
     zlib
   ] ++ lib.optional alsaSupport alsaLib
     ++ lib.optional gtk3Support gtk3
     ++ lib.optional pulseaudioSupport libpulseaudio
-    ++ lib.optional waylandSupport libxkbcommon;
+    ++ lib.optionals waylandSupport [ libxkbcommon libdrm ];
 
   NIX_CFLAGS_COMPILE =[
     "-I${glib.dev}/include/gio-unix-2.0"

--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, dpkg
 , alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype
-, gdk-pixbuf, glib, gnome2, pango, nspr, nss, gtk3
+, gdk-pixbuf, glib, gnome2, pango, nspr, nss, gtk3, mesa
 , xorg, autoPatchelfHook, systemd, libnotify, libappindicator
 }:
 
@@ -20,6 +20,7 @@ let deps = [
     gtk3
     libappindicator
     libnotify
+    mesa
     xorg.libX11
     xorg.libXScrnSaver
     xorg.libXcomposite

--- a/pkgs/applications/office/onlyoffice-bin/default.nix
+++ b/pkgs/applications/office/onlyoffice-bin/default.nix
@@ -21,6 +21,7 @@
 , gtk3
 , libpulseaudio
 , libudev0-shim
+, libdrm
 , makeWrapper
 , nspr
 , nss
@@ -101,6 +102,7 @@ in stdenv.mkDerivation rec {
     gtk2
     gtk3
     libpulseaudio
+    libdrm
     nspr
     nss
     qt5.qtbase

--- a/pkgs/applications/video/byzanz/default.nix
+++ b/pkgs/applications/video/byzanz/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ which gnome3.gnome-common glib intltool libtool cairo gtk3 xorg.xwininfo ]
+  buildInputs = [ which gnome3.gnome-common glib intltool libtool cairo gtk3 xorg.xwininfo xorg.libXdamage ]
   ++ (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-bad gst-plugins-good gst-plugins-ugly gst-libav wrapGAppsHook ]);
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -127,6 +127,7 @@ in stdenv.mkDerivation {
       bluez giflib glib harfbuzz lcms2 libpthreadstubs
       ffmpeg flatbuffers fmt fstrcmp rapidjson
       lirc
+      mesa # for libEGL
     ]
     ++ lib.optional x11Support [
       libX11 xorgproto libXt libXmu libXext.dev libXdmcp

--- a/pkgs/applications/video/streamlink-twitch-gui/bin.nix
+++ b/pkgs/applications/video/streamlink-twitch-gui/bin.nix
@@ -19,6 +19,7 @@
 , gtk3-x11
 , libudev0-shim
 , libuuid
+, mesa
 , nss
 , nspr
 , xorg
@@ -63,6 +64,7 @@ stdenv.mkDerivation rec {
     glib
     pango
     gtk3-x11
+    mesa
     nss
     nspr
     libuuid

--- a/pkgs/applications/window-managers/cage/default.nix
+++ b/pkgs/applications/window-managers/cage/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub
 , meson, ninja, pkg-config, wayland, scdoc, makeWrapper
 , wlroots, wayland-protocols, pixman, libxkbcommon
-, systemd, libGL, libX11
+, systemd, libGL, libX11, mesa
 , xwayland ? null
 , nixosTests
 }:
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     wlroots wayland wayland-protocols pixman libxkbcommon
+    mesa # for libEGL headers
     systemd libGL libX11
   ];
 

--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub
 , meson, ninja, pkg-config, wayland, scdoc, makeWrapper
 , wlroots, wayland-protocols, pixman, libxkbcommon
-, cairo , pango, fontconfig, pandoc, systemd
+, cairo , pango, fontconfig, pandoc, systemd, mesa
 , withXwayland ? true, xwayland
 , nixosTests
 }:
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     wlroots wayland wayland-protocols pixman libxkbcommon cairo
     pango fontconfig pandoc systemd
+    mesa # for libEGL headers
   ];
 
   outputs = [ "out" "contrib" ];

--- a/pkgs/applications/window-managers/hikari/default.nix
+++ b/pkgs/applications/window-managers/hikari/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchzip,
   pkg-config, bmake,
   cairo, glib, libevdev, libinput, libxkbcommon, linux-pam, pango, pixman,
-  libucl, wayland, wayland-protocols, wlroots,
+  libucl, wayland, wayland-protocols, wlroots, mesa,
   features ? {
     gammacontrol = true;
     layershell   = true;
@@ -35,6 +35,7 @@ stdenv.mkDerivation {
     pango
     pixman
     libucl
+    mesa # for libEGL
     wayland
     wayland-protocols
     wlroots

--- a/pkgs/applications/window-managers/waybox/default.nix
+++ b/pkgs/applications/window-managers/waybox/default.nix
@@ -11,6 +11,7 @@
 , pixman
 , udev
 , libGL
+, mesa
 }:
 
 stdenv.mkDerivation rec {
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
     pixman
     udev
     libGL
+    mesa # for libEGL
   ];
 
   meta = with lib; {

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, meson, ninja, pkg-config, git
 , cairo, libdrm, libexecinfo, libinput, libjpeg, libxkbcommon, wayland
-, wayland-protocols, wf-config, wlroots
+, wayland-protocols, wf-config, wlroots, mesa
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ meson ninja pkg-config wayland ];
   buildInputs = [
     cairo libdrm libexecinfo libinput libjpeg libxkbcommon wayland
-    wayland-protocols wf-config wlroots
+    wayland-protocols wf-config wlroots mesa
   ];
 
   mesonFlags = [ "--sysconfdir" "/etc" ];

--- a/pkgs/applications/window-managers/wio/default.nix
+++ b/pkgs/applications/window-managers/wio/default.nix
@@ -10,6 +10,7 @@
 , wayland
 , wayland-protocols
 , wlroots
+, mesa
 , xwayland
 , makeWrapper
 }:
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
     wayland
     wayland-protocols
     wlroots
+    mesa # for libEGL
     xwayland
   ];
 

--- a/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
@@ -13,6 +13,7 @@
 , granite
 , gettext
 , mutter
+, mesa
 , json-glib
 , python3
 , elementary-gtk-theme
@@ -55,6 +56,7 @@ stdenv.mkDerivation rec {
     json-glib
     libgee
     mutter
+    mesa # for libEGL
   ];
 
   patches = [

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -36,7 +36,7 @@
 , tracker
 , x11Support ? stdenv.isLinux
 , waylandSupport ? stdenv.isLinux
-, mesa
+, libGL
 , wayland
 , wayland-protocols
 , xineramaSupport ? stdenv.isLinux
@@ -143,7 +143,7 @@ stdenv.mkDerivation rec {
     # explicitly propagated, always needed
     Cocoa
   ] ++ lib.optionals waylandSupport [
-    mesa
+    libGL
     wayland
     wayland-protocols
   ] ++ lib.optionals xineramaSupport [

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -38,7 +38,7 @@
 , tracker
 , x11Support ? stdenv.isLinux
 , waylandSupport ? stdenv.isLinux
-, mesa
+, libGL
 , vulkan-loader
 , vulkan-headers
 , wayland
@@ -124,7 +124,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals trackerSupport [
     tracker
   ] ++ lib.optionals waylandSupport [
-    mesa
+    libGL
     wayland
     wayland-protocols
   ] ++ lib.optionals xineramaSupport [

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -34,9 +34,8 @@ let
   # Release frequency: https://www.mesa3d.org/releasing.html#schedule
   version = "21.0.2";
   branch  = versions.major version;
-in
 
-stdenv.mkDerivation {
+self = stdenv.mkDerivation {
   pname = "mesa";
   inherit version;
 
@@ -88,7 +87,9 @@ stdenv.mkDerivation {
       "find_program('${stdenv.cc.targetPrefix}nm')"
   '';
 
-  outputs = [ "out" "dev" "drivers" ] ++ lib.optional enableOSMesa "osmesa";
+  outputs = [ "out" "dev" "drivers" ]
+    ++ lib.optional enableOSMesa "osmesa"
+    ++ lib.optional stdenv.isLinux "driversdev";
 
   # TODO: Figure out how to enable opencl without having a runtime dependency on clang
   mesonFlags = [
@@ -181,20 +182,22 @@ stdenv.mkDerivation {
     mv -t $osmesa/lib/ $out/lib/libOSMesa*
   '';
 
-  # TODO:
-  #  check $out doesn't depend on llvm: builder failures are ignored
-  #  for some reason grep -qv '${llvmPackages.llvm}' -R "$out";
   postFixup = optionalString stdenv.isLinux ''
     # set the default search path for DRI drivers; used e.g. by X server
     substituteInPlace "$dev/lib/pkgconfig/dri.pc" --replace "$drivers" "${libglvnd.driverLink}"
+    substituteInPlace "$dev/lib/pkgconfig/d3d.pc" --replace "$drivers" "${libglvnd.driverLink}"
 
     # remove pkgconfig files for GL/EGL; they are provided by libGL.
     rm -f $dev/lib/pkgconfig/{gl,egl}.pc
 
-    # Update search path used by pkg-config
-    for pc in $dev/lib/pkgconfig/{d3d,dri,xatracker}.pc; do
-      if [ -f "$pc" ]; then
-        substituteInPlace "$pc" --replace $out $drivers
+    # Move development files for libraries in $drivers to $driversdev
+    mkdir -p $driversdev/include
+    mv $dev/include/xa_* $dev/include/d3d* $driversdev/include
+    mkdir -p $driversdev/lib/pkgconfig
+    for pc in lib/pkgconfig/{xatracker,d3d}.pc; do
+      if [ -f "$dev/$pc" ]; then
+        substituteInPlace "$dev/$pc" --replace $out $drivers
+        mv $dev/$pc $driversdev/$pc
       fi
     done
 
@@ -212,6 +215,14 @@ stdenv.mkDerivation {
   passthru = {
     inherit libdrm;
     inherit (libglvnd) driverLink;
+
+    tests.devDoesNotDependOnLLVM = stdenv.mkDerivation {
+      name = "mesa-dev-does-not-depend-on-llvm";
+      buildCommand = ''
+        echo ${self.dev} >>$out
+      '';
+      disallowedRequisites = [ llvmPackages.llvm self.drivers ];
+    };
   };
 
   meta = {
@@ -231,4 +242,6 @@ stdenv.mkDerivation {
     platforms = platforms.mesaPlatforms;
     maintainers = with maintainers; [ primeos vcunat ]; # Help is welcome :)
   };
-}
+};
+
+in self

--- a/pkgs/development/libraries/mesa/stubs.nix
+++ b/pkgs/development/libraries/mesa/stubs.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
 
     mkdir -p $dev/{,lib/pkgconfig,nix-support}
     echo "$out ${libglvnd} ${libglvnd.dev}" > $dev/nix-support/propagated-build-inputs
-    ln -s ${mesa.dev}/include $dev/include
+    ln -s ${libglvnd.dev}/include $dev/include
 
     genPkgConfig() {
       local name="$1"
@@ -61,9 +61,9 @@ stdenv.mkDerivation {
       cat <<EOF >$dev/lib/pkgconfig/$name.pc
     Name: $name
     Description: $lib library
-    Version: ${mesa.version}
+    Version: ${libglvnd.version}
     Libs: -L${libglvnd.out}/lib -l$lib
-    Cflags: -I${mesa.dev}/include -I${libglvnd.dev}/include
+    Cflags: -I${libglvnd.dev}/include
     EOF
     }
 

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -118,6 +118,7 @@ let
       ./qtwebkit-darwin-no-qos-classes.patch
     ];
     qttools = [ ./qttools.patch ];
+    qtwayland = [ ./qtwayland-libdrm-build.patch ];
   };
 
   qtModule =

--- a/pkgs/development/libraries/qt-5/5.14/qtwayland-libdrm-build.patch
+++ b/pkgs/development/libraries/qt-5/5.14/qtwayland-libdrm-build.patch
@@ -1,0 +1,56 @@
+commit 7217ea9cf297e664be876eb82b66a1b4f157ca80
+Author: Peter Seiderer <ps.report@gmx.net>
+Date:   Fri Apr 3 21:52:30 2020 +0200
+
+    fix libdrm related configure test failure
+    
+    Fixes:
+    
+      Project ERROR: Test config.qtwayland_client.tests.dmabuf-server-buffer tries to use undeclared library 'drm'
+      Project ERROR: Test config.qtwayland_compositor.tests.dmabuf-server-buffer tries to use undeclared library 'drm'
+      Project ERROR: Test config.qtwayland_compositor.tests.dmabuf-client-buffer tries to use undeclared library 'drm'
+    
+    Task-number: QTBUG-83303
+    Change-Id: I3970f4e3855fcfa760493631a14adb6a16950aa9
+    Reviewed-by: Ville Voutilainen <ville.voutilainen@qt.io>
+    Reviewed-by: Heikki Halmet <heikki.halmet@qt.io>
+    Reviewed-by: Eskil Abrahamsen Blomfeldt <eskil.abrahamsen-blomfeldt@qt.io>
+    (cherry picked from commit ca63fe81df8ac910f43539719566ed6745700c2b)
+    (cherry picked from commit 1344ca6b5a8fbc1b28727feea6d856af8bf3bc93)
+
+diff --git a/src/client/configure.json b/src/client/configure.json
+index 06213968..27c73f89 100644
+--- a/src/client/configure.json
++++ b/src/client/configure.json
+@@ -74,7 +74,8 @@
+             "label": "Linux dma-buf Buffer Sharing",
+             "type": "compile",
+             "test": "dmabuf_server_buffer",
+-            "use": "egl drm"
++            "libs": "-ldrm",
++            "use": "egl"
+         },
+         "vulkan-server-buffer": {
+             "label": "Vulkan Buffer Sharing",
+diff --git a/src/compositor/configure.json b/src/compositor/configure.json
+index 0dbb3364..73e4c1a8 100644
+--- a/src/compositor/configure.json
++++ b/src/compositor/configure.json
+@@ -80,13 +80,15 @@
+             "label": "Linux dma-buf Buffer Sharing",
+             "type": "compile",
+             "test": "dmabuf_server_buffer",
+-            "use": "egl drm"
++            "libs": "-ldrm",
++            "use": "egl"
+         },
+         "dmabuf-client-buffer": {
+             "label": "Linux Client dma-buf Buffer Sharing",
+             "type": "compile",
+             "test": "dmabuf_client_buffer",
+-            "use": "egl drm"
++            "libs": "-ldrm",
++            "use": "egl"
+         },
+         "vulkan-server-buffer": {
+             "label": "Vulkan Buffer Sharing",

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -36,6 +36,7 @@
 , readline
 , libGL
 , libGLU
+, mesa
 , libintl
 , libmanette
 , openjpeg
@@ -113,6 +114,7 @@ stdenv.mkDerivation rec {
     harfbuzz
     libGL
     libGLU
+    mesa # for libEGL headers
     libgcrypt
     libidn
     libintl

--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip, autoPatchelfHook, xorg, gtk2, gnome2, gtk3, nss, alsaLib, udev, unzip, wrapGAppsHook }:
+{ stdenv, lib, fetchzip, autoPatchelfHook, xorg, gtk2, gnome2, gtk3, nss, alsaLib, udev, unzip, wrapGAppsHook, mesa }:
 
 stdenv.mkDerivation rec {
   pname = "cypress";
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     libXScrnSaver libXdamage libXtst
   ] ++ [
     nss gtk2 alsaLib gnome2.GConf gtk3 unzip
+    mesa # for libgbm
   ];
 
   runtimeDependencies = [ (lib.getLib udev) ];

--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, makeWrapper, fetchurl, dpkg, alsaLib, atk, cairo, cups, dbus, expat
-, fontconfig, freetype, gdk-pixbuf, glib, gnome2, pango, nspr, nss, gtk3, gtk2
+, fontconfig, freetype, gdk-pixbuf, glib, gnome2, pango, mesa, nspr, nss, gtk3, gtk2
 , at-spi2-atk, gsettings-desktop-schemas, gobject-introspection, wrapGAppsHook
 , libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
 , libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, nghttp2
@@ -56,6 +56,7 @@ in stdenv.mkDerivation rec {
     libXrender
     libXtst
     libxcb
+    mesa # for libgbm
     nspr
     nss
     stdenv.cc.cc

--- a/pkgs/misc/emulators/pcsxr/default.nix
+++ b/pkgs/misc/emulators/pcsxr/default.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook intltool pkg-config wrapGAppsHook ];
   buildInputs = [
     gtk3 SDL2 xorg.libXv xorg.libXtst libcdio nasm ffmpeg file
+    xorg.libXxf86vm
   ];
 
   dynarecTarget =

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -433,7 +433,7 @@ self: super:
   });
 
   xf86videovmware = super.xf86videovmware.overrideAttrs (attrs: {
-    buildInputs =  attrs.buildInputs ++ [ mesa llvm ]; # for libxatracker
+    buildInputs =  attrs.buildInputs ++ [ mesa mesa.driversdev llvm ]; # for libxatracker
     meta = attrs.meta // {
       platforms = ["i686-linux" "x86_64-linux"];
     };

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -1,5 +1,5 @@
 { lib, clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, fetchgit
-, python3Packages, mesa, ninja, pkg-config, protobuf, zinnia, qt5, fcitx5
+, python3Packages, ninja, pkg-config, protobuf, zinnia, qt5, fcitx5
 , jsoncpp, gtest, which, gtk2, unzip, abseil-cpp, breakpad }:
 let
   inherit (python3Packages) python gyp six;
@@ -31,7 +31,7 @@ in clangStdenv.mkDerivation rec {
     sha256 = "R+w0slVFpqtt7PIr1pyupJjRoQsABVZiMdZ9fKGKAqw=";
   };
 
-  nativeBuildInputs = [ gyp ninja mesa python pkg-config qt5.wrapQtAppsHook six which unzip ];
+  nativeBuildInputs = [ gyp ninja python pkg-config qt5.wrapQtAppsHook six which unzip ];
 
   buildInputs = [ protobuf zinnia qt5.qtbase fcitx5 abseil-cpp jsoncpp gtest gtk2 ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently, libGL depends on the dev output of mesa, which in turn depends on the mesa drivers.  This e.g. causes many programs to include all mesa drivers in their closure: #118410 

This PR changes the libGL stub to use the GL headers from libglvnd instead, thus removing the mesa build dependency.
See also #44831 and #100712 (this does not completely solve the mesa issue, since some packages still need to depend on mesa directly)

I've quickly built and tested a few packages and could not find any regressions: alacritty, blender, chromium (still references mesa though), mpv (also references mesa)
Suggestions for other packages to test are welcome (i.e., what do you expect to break).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
