### PR TITLE
python3Packages.minio: add certifi

### DIFF
--- a/pkgs/development/python-modules/minio/default.nix
+++ b/pkgs/development/python-modules/minio/default.nix
@@ -8,6 +8,7 @@
 , pytz
 , pytestCheckHook
 , urllib3
+, certifi
 }:
 
 buildPythonPackage rec {
@@ -26,6 +27,7 @@ buildPythonPackage rec {
     python-dateutil
     pytz
     urllib3
+    certifi
   ];
 
   checkInputs = [ faker mock nose pytestCheckHook ];


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/140474131

###### Things done
added certifi

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
