### PR TITLE
racket: patching out runtime variant detection, fix #114993

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -72,6 +72,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ fontconfig libffi libtool sqlite gsettings-desktop-schemas gtk3 ]
     ++ lib.optionals stdenv.isDarwin [ libiconv CoreFoundation ncurses ];
 
+  patches = [
+    # Hardcode variant detection because we wrap the Racket binary making it
+    # fail to detect its variant at runtime.
+    # See: https://github.com/NixOS/nixpkgs/issues/114993#issuecomment-812951247
+    ./force-cs-variant.patch
+  ];
+
   preConfigure = ''
     unset AR
     for f in src/lt/configure src/cs/c/configure src/bc/src/string.c src/ChezScheme/workarea; do
@@ -96,10 +103,6 @@ stdenv.mkDerivation rec {
   configureScript = "../configure";
 
   enableParallelBuilding = false;
-
-  postFixup = lib.optionalString stdenv.isDarwin ''
-    wrapProgram $out/bin/drracket --prefix DYLD_LIBRARY_PATH : ${xorg.libX11}/lib
-  '';
 
   meta = with lib; {
     description = "A programmable programming language";

--- a/pkgs/development/interpreters/racket/force-cs-variant.patch
+++ b/pkgs/development/interpreters/racket/force-cs-variant.patch
@@ -1,0 +1,18 @@
+Hardcode Racket variant to CS
+
+Hardcode variant detection because nixpkgs wraps the Racket binary making it
+fail to detect its variant at runtime.
+https://github.com/NixOS/nixpkgs/issues/114993#issuecomment-812951247
+
+--- old/collects/setup/variant.rkt
++++ new/collects/setup/variant.rkt
+@@ -7,7 +7,8 @@
+ (provide variant-suffix
+          script-variant?)
+ 
+-(define plain-variant
++(define plain-variant 'cs)
++#;(define plain-variant
+   (delay/sync
+    (cond
+      [(cross-installation?)


### PR DESCRIPTION
###### Motivation for this change

`raco exe some-racket-file.rkt` is not working since update to Racket 8.0, see #114993

It fails because Racket try to detect a runtime variant reading a string from it's own executable. Of course it fails to correctly detect runtime type using this method because racket executable is a wrapper script.

This pull request removes patching out a runtime detection mechanism, hardcoding `'cs` runtime variant (because this is a variant built by racket derivation).

I don't like this solution. But maybe someone who will see this pull request could suggest a better way to mitigate the problem?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
