### PR TITLE
dash: add libedit support, enable parallel building

### DIFF
--- a/pkgs/shells/dash/default.nix
+++ b/pkgs/shells/dash/default.nix
@@ -11,7 +11,6 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  # Temporary fix until a proper one is accepted upstream
   patches = [
     (fetchurl {
       # Dash executes code when noexec ("-n") is specified
@@ -19,7 +18,11 @@ stdenv.mkDerivation rec {
       url = "https://git.kernel.org/pub/scm/utils/dash/dash.git/patch/?id=29d6f2148f10213de4e904d515e792d2cf8c968e";
       sha256 = "08q90bx36ixwlcj331dh7420qyj8i0qh1cc1gljrhd83fhl9w0y5";
     })
-  ] ++ lib.optional stdenv.isDarwin ./0001-fix-dirent64-et-al-on-darwin.patch;
+  ] ++ lib.optionals stdenv.isDarwin [
+      # Temporary fix until a proper one is accepted upstream
+    ./0001-fix-dirent64-et-al-on-darwin.patch
+  ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = lib.optional stdenv.isDarwin autoreconfHook;
 

--- a/pkgs/shells/dash/default.nix
+++ b/pkgs/shells/dash/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPackages, autoreconfHook, fetchurl }:
+{ lib, stdenv, buildPackages, autoreconfHook, fetchurl, libedit }:
 
 stdenv.mkDerivation rec {
   pname = "dash";
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = lib.optional stdenv.isDarwin autoreconfHook;
+  buildInputs = [ libedit ];
+
+  configureFlags = [ "--with-libedit" ];
 
   meta = with lib; {
     homepage = "http://gondor.apana.org.au/~herbert/dash/";

--- a/pkgs/shells/dash/default.nix
+++ b/pkgs/shells/dash/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-libedit" ];
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     homepage = "http://gondor.apana.org.au/~herbert/dash/";
     description = "A POSIX-compliant implementation of /bin/sh that aims to be as small as possible";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This allows running `set -o emacs` to get line editing in dash, which is a major usability improvement.

<pre>
Closure size before: 31.6M
              after: 35.3M
</pre>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
