### PR TITLE
obs-multi-rtmp: init at 0.2.6

### DIFF
--- a/pkgs/applications/video/obs-studio/obs-multi-rtmp.nix
+++ b/pkgs/applications/video/obs-studio/obs-multi-rtmp.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchFromGitHub, obs-studio, cmake, qtbase }:
+
+stdenv.mkDerivation rec {
+  pname = "obs-multi-rtmp";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "sorayuki";
+    repo = "obs-multi-rtmp";
+    rev = version;
+    sha256 = "sha256-SMcVL54HwFIc7/wejEol2XiZhlZCMVCwHHtIKJ/CoYY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ obs-studio qtbase ];
+
+  cmakeFlags = [
+    "-DLIBOBS_INCLUDE_DIR=${obs-studio}/include/obs"
+  ];
+
+  dontWrapQtApps = true;
+
+  # obs-studio expects the shared object to be located in bin/32bit or bin/64bit
+  # https://github.com/obsproject/obs-studio/blob/d60c736cb0ec0491013293c8a483d3a6573165cb/libobs/obs-nix.c#L48
+  postInstall = let
+    pluginPath = {
+      i686-linux = "bin/32bit";
+      x86_64-linux = "bin/64bit";
+    }.${stdenv.targetPlatform.system} or (throw "Unsupported system: ${stdenv.targetPlatform.system}");
+  in ''
+    mkdir -p $out/share/obs/obs-plugins/obs-multi-rtmp/${pluginPath}
+    ln -s $out/lib/obs-plugins/obs-multi-rtmp.so $out/share/obs/obs-plugins/obs-multi-rtmp/${pluginPath}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/sorayuki/obs-multi-rtmp/";
+    changelog = "https://github.com/sorayuki/obs-multi-rtmp/releases/tag/${version}";
+    description = "Multi-site simultaneous broadcast plugin for OBS Studio";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ jk ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24766,6 +24766,8 @@ in
 
   obs-move-transition = callPackage ../applications/video/obs-studio/obs-move-transition.nix { };
 
+  obs-multi-rtmp = libsForQt5.callPackage ../applications/video/obs-studio/obs-multi-rtmp.nix { };
+
   obs-v4l2sink = libsForQt5.callPackage ../applications/video/obs-studio/v4l2sink.nix { };
 
   obs-ndi = libsForQt5.callPackage ../applications/video/obs-studio/obs-ndi.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package `obs-multi-rtmp` for nixpkgs

The UI shows up fine.
Draft until tested with YT and Twitch or something

To test:

* `nix-build -A obs-multi-rtmp`
* `mkdir -p ~/.config/obs-studio/plugins`
* `ln -s $PWD/result/share/obs/obs-plugins/obs-multi-rtmp ~/.config/obs-studio/plugins/obs-multi-rtmp`
* open obs-studio

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
