### PR TITLE
vector: service fix remove deprecated --no-topology

### DIFF
--- a/nixos/modules/services/logging/vector.nix
+++ b/nixos/modules/services/logging/vector.nix
@@ -44,7 +44,7 @@ in
           conf = format.generate "vector.toml" cfg.settings;
           validateConfig = file:
             pkgs.runCommand "validate-vector-conf" { } ''
-              ${pkgs.vector}/bin/vector validate --no-topology --no-environment "${file}"
+              ${pkgs.vector}/bin/vector validate --no-environment "${file}"
               ln -s "${file}" "$out"
             '';
         in

--- a/nixos/modules/services/logging/vector.nix
+++ b/nixos/modules/services/logging/vector.nix
@@ -3,7 +3,8 @@
 with lib;
 let cfg = config.services.vector;
 
-in {
+in
+{
   options.services.vector = {
     enable = mkEnableOption "Vector";
 
@@ -37,25 +38,27 @@ in {
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
       requires = [ "network-online.target" ];
-      serviceConfig = let
-        format = pkgs.formats.toml { };
-        conf = format.generate "vector.toml" cfg.settings;
-        validateConfig = file:
-          pkgs.runCommand "validate-vector-conf" { } ''
-            ${pkgs.vector}/bin/vector validate --no-topology --no-environment "${file}"
-            ln -s "${file}" "$out"
-          '';
-      in {
-        ExecStart = "${pkgs.vector}/bin/vector --config ${validateConfig conf}";
-        User = "vector";
-        Group = "vector";
-        Restart = "no";
-        StateDirectory = "vector";
-        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
-        # This group is required for accessing journald.
-        SupplementaryGroups = mkIf cfg.journaldAccess "systemd-journal";
-      };
+      serviceConfig =
+        let
+          format = pkgs.formats.toml { };
+          conf = format.generate "vector.toml" cfg.settings;
+          validateConfig = file:
+            pkgs.runCommand "validate-vector-conf" { } ''
+              ${pkgs.vector}/bin/vector validate --no-topology --no-environment "${file}"
+              ln -s "${file}" "$out"
+            '';
+        in
+        {
+          ExecStart = "${pkgs.vector}/bin/vector --config ${validateConfig conf}";
+          User = "vector";
+          Group = "vector";
+          Restart = "no";
+          StateDirectory = "vector";
+          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+          AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+          # This group is required for accessing journald.
+          SupplementaryGroups = mkIf cfg.journaldAccess "systemd-journal";
+        };
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

using vector service I am getting the following error
```
remote: building the system configuration...
remote: error: builder for '/nix/store/y60q8dcmxfp01qh9vyafnzzwsmk37a4v-validate-vector-conf.drv' failed with exit code 1;
remote:        last 6 log lines:
remote:        > error: Found argument '--no-topology' which wasn't expected, or isn't valid in this context
remote:        >
remote:        > USAGE:
remote:        >     vector validate [FLAGS] [OPTIONS] [--] [paths]...
remote:        >
remote:        > For more information try --help
remote:        For full logs, run 'nix log /nix/store/y60q8dcmxfp01qh9vyafnzzwsmk37a4v-validate-vector-conf.drv'.
remote: error: 1 dependencies of derivation '/nix/store/pdnw0xfxfx8fmf8j78rd9m9f5ih8baaq-unit-vector.service.drv' failed to build
remote: error: 1 dependencies of derivation '/nix/store/hhjkp9426z5ghvm46xg05116mw6x87ns-system-units.drv' failed to build
remote: error: 1 dependencies of derivation '/nix/store/2l25kxgrdss7gaajdxkbf7vkhfly3c42-etc.drv' failed to build
remote: error: 1 dependencies of derivation '/nix/store/h35brn9yqzyllb9ws2djy4m0k0gdqbr7-nixos-system-hetzner-AX41-UEFI-ZFS-NVME-21.05.20210402.54c1e44.drv' failed to build
```

Looking at the doc, it looks like the option was removed
https://vector.dev/docs/reference/cli/#validate

2 commits here, one formatting with nixpkgs-fmt

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
