### PR TITLE
mailman: 3.3.1 -> 3.3.4 and python3Packages.aiosmtpd: 1.2.1 -> 1.4.2

### DIFF
--- a/pkgs/development/python-modules/aiosmtpd/default.nix
+++ b/pkgs/development/python-modules/aiosmtpd/default.nix
@@ -1,9 +1,9 @@
 { lib, isPy3k, fetchFromGitHub, buildPythonPackage
-, atpublic }:
+, attrs, atpublic }:
 
 buildPythonPackage rec {
   pname = "aiosmtpd";
-  version = "1.2.1";
+  version = "1.4.2";
   disabled = !isPy3k;
 
   # Release not published to Pypi
@@ -11,11 +11,11 @@ buildPythonPackage rec {
     owner = "aio-libs";
     repo = pname;
     rev = version;
-    sha256 = "14c30dm6jzxiblnsah53fdv68vqhxwvb9x0aq9bc4vcdas747vr7";
+    sha256 = "0hbpyns1j1fpvpj7gyb8cz359j7l4hzfqbig74xp4xih59sih0wj";
   };
 
   propagatedBuildInputs = [
-    atpublic
+    atpublic attrs
   ];
 
   # Tests need network access

--- a/pkgs/servers/mail/mailman/default.nix
+++ b/pkgs/servers/mail/mailman/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "mailman";
-  version = "3.3.1";
+  version = "3.3.4";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0idfiv48jjgc0jq4731094ddhraqq8bxnwmjk6sg5ask0jss9kxq";
+    sha256 = "01rx322b8mzcdj9xh4bjwnl0zis6n2wxd31rrij4cw3a2j03xpas";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/mail/mailman/hyperkitty.nix
+++ b/pkgs/servers/mail/mailman/hyperkitty.nix
@@ -7,6 +7,8 @@
 
 buildPythonPackage rec {
   pname = "HyperKitty";
+  # Note: Mailman core must be on the latest version before upgrading HyperKitty.
+  # See: https://gitlab.com/mailman/postorius/-/issues/516#note_544571309
   version = "1.3.3";
   disabled = !isPy3k;
 

--- a/pkgs/servers/mail/mailman/postorius.nix
+++ b/pkgs/servers/mail/mailman/postorius.nix
@@ -4,6 +4,8 @@
 
 buildPythonPackage rec {
   pname = "postorius";
+  # Note: Mailman core must be on the latest version before upgrading Postorious.
+  # See: https://gitlab.com/mailman/postorius/-/issues/516#note_544571309
   version = "1.3.4";
 
   src = fetchPypi {


### PR DESCRIPTION
###### Motivation for this change

I encountered an issue with the Mailman management interface (Postorious) which [I contacted the Mailman team](https://gitlab.com/mailman/postorius/-/issues/516) about. They informed me that the Mailman core has to be updated to add new endpoints.

Compiled + deployed + tested the fix on nixos-unstable. Also had to update aiosmtpd to resolve unmet dependencies in the Mailman update

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
