### PR TITLE
python3Packages.pyaxmlparser: 0.3.24 -> 0.3.26

### DIFF
--- a/pkgs/development/python-modules/pyaxmlparser/default.nix
+++ b/pkgs/development/python-modules/pyaxmlparser/default.nix
@@ -1,29 +1,19 @@
-{ buildPythonPackage, lib, lxml, click, fetchFromGitHub, pytest, isPy3k }:
+{ buildPythonPackage, lib, lxml, click, fetchFromGitHub, pytestCheckHook, asn1crypto }:
 
 buildPythonPackage rec {
-  version = "0.3.24";
+  version = "0.3.26";
   pname = "pyaxmlparser";
 
-  # the PyPI tarball doesn't ship tests.
   src = fetchFromGitHub {
     owner = "appknox";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0fys26p7xhbnbdzp80zm6n3mragp38p08nyrsnilfgnlpi6rjpg0";
+    sha256 = "sha256-wD0rN00q4ipKnKubptrgrjNwkBpqsA+ix2xedOOr8Yg=";
   };
 
-  disabled = !isPy3k;
+  propagatedBuildInputs = [ asn1crypto click lxml ];
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "click==6.7" "click"
-  '';
-
-  propagatedBuildInputs = [ lxml click ];
-
-  checkInputs = [ pytest ];
-  checkPhase = ''
-    py.test tests/
-  '';
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Python3 Parser for Android XML file and get Application Name without using Androguard";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
