### PR TITLE
raspberrypi: update kernel, eeprom, firmware, libraspberrypi

### DIFF
--- a/pkgs/development/libraries/libraspberrypi/default.nix
+++ b/pkgs/development/libraries/libraspberrypi/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libraspberrypi";
-  version = "unstable-2021-01-11";
+  version = "unstable-2021-03-17";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "userland";
-    rev = "4a0a19b88b43e48c6b51b526b9378289fb712a4c";
-    sha256 = "0g3a1a7w717h0fwk39banzgjwphh62fx64k130w2s5885lsn5r5k";
+    rev = "3fd8527eefd8790b4e8393458efc5f94eb21a615";
+    sha256 = "099qxh4bjzwd431ffpdhzx0gzlrkdyf66wplgkwg2rrfrc9zlv5a";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -3,13 +3,13 @@
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi
   pname = "raspberrypi-firmware";
-  version = "1.20210201";
+  version = "1.20210303";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
     rev = version;
-    sha256 = "0frmsixzy9nd8nfg15jsz037522h4gq1hca666cyaf9zg2sa1i7i";
+    sha256 = "0pgiw93hq4gfph5dnwbi8w59g0f7yhmagwzam971k529mh5yl86m";
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -2,8 +2,8 @@
 
 let
   # NOTE: raspberrypifw & raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "5.10.11";
-  tag = "1.20210201";
+  modDirVersion = "5.10.17";
+  tag = "1.20210303";
 in
 lib.overrideDerivation (buildLinux (args // {
   version = "${modDirVersion}-${tag}";
@@ -13,7 +13,7 @@ lib.overrideDerivation (buildLinux (args // {
     owner = "raspberrypi";
     repo = "linux";
     rev = "raspberrypi-kernel_${tag}-1";
-    sha256 = "0n4zq47k9bmkgmarrhwvivp10v5ga8y2bphsx0il3kmcpf0c1m3q";
+    sha256 = "0ffsllayl18ka4mgp4rdy9h0da5gy1n6g0kfvinvzdzabb5wzvrx";
   };
 
   defconfig = {

--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -3,13 +3,13 @@
 }:
 stdenvNoCC.mkDerivation {
   pname = "raspberrypi-eeprom";
-  version = "2021-01-11";
+  version = "2021-03-18";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-eeprom";
-    rev = "54cadc816ba739afd08ead6d679e647de028a65c";
-    sha256 = "0zlacr4z6h40h0g47195xsbss29gaa7kf8r31h372sxsn8srlnjf";
+    rev = "ff27ccf69403b01e337fc4ee6e7ae75244028cce";
+    sha256 = "1q1vlld0xxh9zinf5g0qa6jw1dggq93br938mvrfx3nb2aviiwcj";
   };
 
   buildInputs = [ python3 ];
@@ -28,7 +28,6 @@ stdenvNoCC.mkDerivation {
 
     cp rpi-eeprom-config rpi-eeprom-update $out/bin
     cp -r firmware/{beta,critical,old,stable} $out/share/rpi-eeprom
-    cp -r firmware/vl805 $out/bin
   '';
 
   fixupPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates.

- kernel
  - I quickly checked for DRM_AST, but saw no changes, so left it disabled
- libraspberrypi 
  - added board revision codes for Pi400 and Compute Module in https://github.com/raspberrypi/userland/commit/3fd8527eefd8790b4e8393458efc5f94eb21a615
- raspberrypi-eeprom
  - removed vl805 from firmware directory in https://github.com/raspberrypi/rpi-eeprom/commit/3e03056215823c567a55bd1fa368e8e95a240127


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
