### PR TITLE
ruby: reproducible

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -217,8 +217,8 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
 
     # looks like useless files which break build repeatability and consume space
     pushd $out/${ruby.gemPath}
-    rm -fv doc/*/*/created.rid || true
-    rm -fv {gems/*/ext/*,extensions/*/*/*}/{Makefile,mkmf.log,gem_make.out} || true
+    find doc/ -iname created.rid -delete -print
+    find gems/*/ext/ extensions/ \( -iname Makefile -o -iname mkmf.log -o -iname gem_make.out \) -delete -print
     ${if keepGemCache then "" else "rm -fvr cache"}
     popd
 


### PR DESCRIPTION
###### Motivation for this change
https://r13y.com/diff/fdf835d046bf03f72960cb4abf95821e9178bae26817e15753eaf3f166df6ff7-36caf8c832e64c8534b4c619d716d117b0963183f83d969b617f8ca498930821.html

Prior art:
https://github.com/NixOS/nixpkgs/pull/101655
https://github.com/NixOS/nixpkgs/pull/101655/commits/c3357d2cd919ae6b0d055ad04738bef3a2309231

###### Things done
Generated Makefile's were nested deeper than the existing rm would be
able to remove.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
