### PR TITLE
Add OverlayFs Multiple lower layers support

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -354,8 +354,11 @@ mountFS() {
 
     # Filter out x- options, which busybox doesn't do yet.
     local optionsFiltered="$(IFS=,; for i in $options; do if [ "${i:0:2}" != "x-" ]; then echo -n $i,; fi; done)"
+
     # Prefix (lower|upper|work)dir with /mnt-root (overlayfs)
-    local optionsPrefixed="$( echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g' )"
+    if [ "$fsType" = overlay ]; then
+        local optionsPrefixed="$( echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g; s#:#:/mnt-root#g' )"
+    fi
 
     echo "$device /mnt-root$mountPoint $fsType $optionsPrefixed" >> /etc/fstab
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
OverlayFs  Multiple lower layers is incorrectly addressed by the prefixing (add /mnt-root) step in stage-1-init.sh:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

OverlayFs  Multiple lower layers is incorrectly addressed by the prefixing (add /mnt-root) step in stage-1-init.sh:

Example:
`optionsFiltered=lowerdir=/mnt1:/mnt2,upperdir=/mnt3,workdir=/mnt4`

Actual prefix command (in nixos/modules/system/boot/stage-1-init.sh:):
`echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g'`

Obtained WRONG prefix:
`lowerdir=/mnt-root/mnt1:/mnt2:/mnt3,upperdir=/mnt-root/mnt3,workdir=/mnt-root/mnt4`

Proposed prefix command:
`echo "$optionsFiltered" | sed -E 's#\<(lowerdir|upperdir|workdir)=#\1=/mnt-root#g; s#:#:/mnt-root#g'`

Correct and EXPECTED prefix
`lowerdir=/mnt-root/mnt1:/mnt-root/mnt2:/mnt-root/mnt3,upperdir=/mnt-root/mnt3,workdir=/mnt-root/mnt4`

Added `if [ "$fsType" = overlay ]` to guard this prefixing step

@FRidh I'll apprecitate your opinion/review

