### PR TITLE
curaPlugins.rawmouse: init at 1.0.13

### DIFF
--- a/pkgs/applications/misc/cura/plugins.nix
+++ b/pkgs/applications/misc/cura/plugins.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, python3Packages }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, python3Packages, libspnav }:
 
 let
 
@@ -28,6 +28,35 @@ let
         description = "Enables printing directly to OctoPrint and monitoring the process";
         homepage = "https://github.com/fieldOfView/Cura-OctoPrintPlugin";
         license = licenses.agpl3;
+        maintainers = with maintainers; [ gebner ];
+      };
+    };
+
+    rawmouse = stdenv.mkDerivation rec {
+      pname = "RawMouse";
+      version = "1.0.13";
+
+      src = fetchFromGitHub {
+        owner = "smartavionics";
+        repo = pname;
+        rev = version;
+        sha256 = "1cj40pgsfcwliz47mkiqjbslkwcm34qb1pajc2mcljgflcnickly";
+      };
+
+      buildPhase = ''
+        substituteInPlace RawMouse/config.json --replace \
+          /usr/local/lib/libspnav.so ${libspnav}/lib/libspnav.so
+      '';
+
+      installPhase = ''
+        mkdir -p $out/lib/cura/plugins/RawMouse
+        cp -rv . $out/lib/cura/plugins/RawMouse/
+      '';
+
+      meta = with lib; {
+        description = "Cura plugin for HID mice such as 3Dconnexion spacemouse";
+        homepage = "https://github.com/smartavionics/RawMouse";
+        license = licenses.agpl3Plus;
         maintainers = with maintainers; [ gebner ];
       };
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

spnav support for cura.  Tested and works out of the box.  If you want to try it (requires space mouse):
```
nix-build -E 'with import ./. {}; cura.override { plugins = [ curaPlugins.rawmouse ]; }'
```

The package is a bit awkward, because upstream puts the configuration file into the source directory so you can't configure the plugin. :-/  On the other hand, we need to modify the configuration file to include the full path to the libspnav.so library...

Longer term, it's probably best to submit a PR to the plugin to additionally read a configuration file from `~/.config/cura`, if that exists.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
