### PR TITLE
krankerl: init at 0.13.0

### DIFF
--- a/pkgs/development/tools/krankerl/default.nix
+++ b/pkgs/development/tools/krankerl/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchgit
+, rustPlatform
+, pkg-config
+, openssl
+, dbus
+, sqlite
+, file
+, gzip
+, makeWrapper
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "krankerl";
+  version = "v0.13.0";
+
+  src = fetchgit {
+    url = "https://github.com/ChristophWurst/krankerl.git";
+    rev = version;
+    sha256 = "1gp8b2m8kcz2f16zv9xwv4n1zki6imvz9z31kixh6amdj6fif3d1";
+  };
+
+  cargoSha256 = "sha256:00b634w9kwbqjhyifnb3py2mdqghhf6j82q4k555fffidy1pnzxx";
+
+  nativeBuildInputs = [
+    pkg-config
+    gzip
+    makeWrapper
+  ];
+
+  buildInputs = [
+    openssl
+    dbus
+    sqlite
+  ];
+
+  checkInputs = [
+    file
+  ];
+
+  meta = with lib; {
+    description = " A CLI helper to manage, package and publish Nextcloud apps ";
+    homepage = "https://github.com/ChristophWurst/krankerl";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/tools/krankerl/default.nix
+++ b/pkgs/development/tools/krankerl/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchgit
+, fetchFromGitHub
 , rustPlatform
 , pkg-config
 , openssl
@@ -12,15 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "krankerl";
-  version = "v0.13.0";
+  version = "0.13.0";
 
-  src = fetchgit {
-    url = "https://github.com/ChristophWurst/krankerl.git";
-    rev = version;
+  src = fetchFromGitHub {
+    owner = "ChristophWurst";
+    repo = "krankerl";
+    rev = "v${version}";
     sha256 = "1gp8b2m8kcz2f16zv9xwv4n1zki6imvz9z31kixh6amdj6fif3d1";
   };
 
-  cargoSha256 = "sha256:00b634w9kwbqjhyifnb3py2mdqghhf6j82q4k555fffidy1pnzxx";
+  cargoSha256 = "sha256:01hcxs14wwhhvr08x816wa3jcm4zvm6g7vais793cgijipyv00rc";
 
   nativeBuildInputs = [
     pkg-config
@@ -39,9 +40,9 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = with lib; {
-    description = " A CLI helper to manage, package and publish Nextcloud apps ";
+    description = "A CLI helper to manage, package and publish Nextcloud apps";
     homepage = "https://github.com/ChristophWurst/krankerl";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ onny ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12866,6 +12866,7 @@ in
 
   khronos-ocl-icd-loader = callPackage ../development/libraries/khronos-ocl-icd-loader {  };
 
+  krankerl = callPackage ../development/tools/krankerl { };
 
   krew = callPackage ../development/tools/krew { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Create a package for [krankerl](https://github.com/ChristophWurst/krankerl), a helper utility to develop [Nextcloud](https://nextcloud.com/) apps.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
