### PR TITLE
nixos/wireless: add options for better roaming

### DIFF
--- a/nixos/modules/services/networking/connman.nix
+++ b/nixos/modules/services/networking/connman.nix
@@ -150,6 +150,7 @@ in {
       useDHCP = false;
       wireless = {
         enable = mkIf (!enableIwd) true;
+        dbusControlled = true;
         iwd = mkIf enableIwd {
           enable = true;
         };

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -410,5 +410,5 @@ in {
     '';
   };
 
-  meta.maintainers = with lib.maintainers; [ globin ];
+  meta.maintainers = with lib.maintainers; [ globin rnhmjoj ];
 }


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/issues/105560#issuecomment-812991613

- Generate a prettier configuration file

- Add an option to automatically launch a scan when the
signal of the current network is low

- Enable 802.11r (fast access point transition) by default for all
protected networks

###### Things done

- [x] Tested 802.11r with two openwrt aps (hostapd says `WPA: FT authentication already completed - do not start 4-way handshake`)
- [x] Tested wpa_supplicant runs
- [x] Tested `userControlled.enable` works
- [x] Built manual
- [x] Tested multiple interfaces
- [x] Tested resuming from sleep with multiple interfaces
- [x] Built and booted iso_minimal    
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
