### PR TITLE
python3Packages.nats-python: init at 0.8.0, python3Packages.asyncio-nats-client: init at 0.11.4

### DIFF
--- a/pkgs/development/python-modules/asyncio-nats-client/default.nix
+++ b/pkgs/development/python-modules/asyncio-nats-client/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, ed25519
+, fetchFromGitHub
+, nats-server
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "asyncio-nats-client";
+  version = "0.11.4";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "nats-io";
+    repo = "nats.py";
+    rev = "v${version}";
+    sha256 = "1aj57xi2rj1xswq8air13xdsll1ybpi0nmz5f6jq01azm0zy9xyd";
+  };
+
+  propagatedBuildInputs = [
+    ed25519
+  ];
+
+  checkInputs = [
+    nats-server
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=nats --cov-report html" ""
+  '';
+
+  disabledTests = [
+    # RuntimeError: Event loop is closed
+    "test_subscribe_no_echo"
+    "test_reconnect_to_new_server_with_auth"
+  ];
+
+  pythonImportsCheck = [ "nats.aio" ];
+
+  meta = with lib; {
+    description = "Python client for NATS.io";
+    homepage = "https://github.com/nats-io/nats.py";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/nats-python/default.nix
+++ b/pkgs/development/python-modules/nats-python/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "nats-python";
+  version = "0.8.0";
+  disabled = pythonOlder "3.6";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "Gr1N";
+    repo = "nats-python";
+    rev = version;
+    sha256 = "1j7skyxldir3mphvnsyhjxmf3cimv4h7n5v58jl2gff4yd0hdw7g";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/Gr1N/nats-python/pull/19
+    (fetchpatch {
+      name = "use-poetry-core.patch";
+      url = "https://github.com/Gr1N/nats-python/commit/71b25b324212dccd7fc06ba3914491adba22e83f.patch";
+      sha256 = "1fip1qpzk2ka7qgkrdpdr6vnrnb1p8cwapa51xp0h26nm7yis1gl";
+    })
+  ];
+
+  # Tests require a running NATS server
+  doCheck = false;
+
+  pythonImportsCheck = [ "pynats" ];
+
+  meta = with lib; {
+    description = "Python client for NATS messaging system";
+    homepage = "https://github.com/Gr1N/nats-python";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -542,6 +542,8 @@ in {
 
   asyncio-mqtt = callPackage ../development/python-modules/asyncio_mqtt { };
 
+  asyncio-nats-client = callPackage ../development/python-modules/asyncio-nats-client { };
+
   asyncio-throttle = callPackage ../development/python-modules/asyncio-throttle { };
 
   asyncpg = callPackage ../development/python-modules/asyncpg { };
@@ -4511,6 +4513,8 @@ in {
   nanotime = callPackage ../development/python-modules/nanotime { };
 
   nassl = callPackage ../development/python-modules/nassl { };
+
+  nats-python = callPackage ../development/python-modules/nats-python { };
 
   natsort = callPackage ../development/python-modules/natsort { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add NATS client.

- asyncio-nats-client: https://github.com/nats-io/nats.py
- nats-python: Python client for NATS messaging system

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
