### PR TITLE
google-compute-engine: fix incorrect usage of buildPythonApplication

### DIFF
--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -1,6 +1,6 @@
 { lib
 , fetchFromGitHub
-, buildPythonApplication
+, buildPythonPackage
 , bash
 , bashInteractive
 , systemd
@@ -10,7 +10,7 @@
 , distro
 }:
 
-buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "google-compute-engine";
   version = "20190124";
   namePrefix = "";
@@ -24,7 +24,6 @@ buildPythonApplication rec {
 
   buildInputs = [ bash ];
   propagatedBuildInputs = [ boto setuptools distro ];
-
 
   postPatch = ''
     for file in $(find google_compute_engine -type f); do
@@ -53,7 +52,11 @@ buildPythonApplication rec {
     patchShebangs $out/bin/*
   '';
 
-  doCheck = false;
+  checkPhase = ''
+    # this package has its own test suite, but they assume the ability to
+    # access resources like /sys/class/net causing them to fail in the sandbox
+    python -c 'import google_compute_engine'
+  '';
 
   meta = with lib; {
     description = "Google Compute Engine tools and services";

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -13,7 +13,6 @@
 buildPythonPackage rec {
   pname = "google-compute-engine";
   version = "20190124";
-  namePrefix = "";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -51,11 +51,7 @@ buildPythonPackage rec {
     patchShebangs $out/bin/*
   '';
 
-  checkPhase = ''
-    # this package has its own test suite, but they assume the ability to
-    # access resources like /sys/class/net causing them to fail in the sandbox
-    python -c 'import google_compute_engine'
-  '';
+  pythonImportsCheck = [ "import google_compute_engine" ];
 
   meta = with lib; {
     description = "Google Compute Engine tools and services";

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -51,7 +51,8 @@ buildPythonPackage rec {
     patchShebangs $out/bin/*
   '';
 
-  pythonImportsCheck = [ "import google_compute_engine" ];
+  doCheck = false;
+  pythonImportsCheck = [ "google_compute_engine" ];
 
   meta = with lib; {
     description = "Google Compute Engine tools and services";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The `google-compute-engine` package is currently built
with `buildPythonApplication`, which prevents the output of any Python modules
that result from building `google-compute-engine`.

This is almost always fine, except in the case of running certain utilities
from a GCE instance, e.g., `gsutil`.

While the `google-cloud-sdk` package *does* support including `google-compute-engine`
in the Python environment it uses to run the `gsutil` executable, since `google-compute-engine`
is built with `buildPythonApplication`, its Python modules are never installed into that
environment and thus `gsutil` fails when trying to run on a GCE instance.

This PR address the problem by switching `google-compute-engine` over to
`buildPythonPackage`, and since the `all-packages.nix` expression is already
using `toPythonApplication` the existing conventions are followed as per this
documentation
(https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/python.section.md#topythonapplication-function).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
