### PR TITLE
 pythonPackages.pytest-randomly: 3.5.0 -> 3.6.0 

### DIFF
--- a/pkgs/development/python-modules/backports-entry-points-selectable/default.nix
+++ b/pkgs/development/python-modules/backports-entry-points-selectable/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, importlib-metadata
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "backports.entry-points-selectable";
+  version = "1.0.3";
+
+  src = fetchPypi {
+    inherit version;
+    # pypi project name and tarball name differ
+    pname = builtins.replaceStrings [ "-" ] [ "_" ] pname;
+    sha256 = "f30bcd19c5e2728ac93821d2b6ae0a325597e0ca12324fd91a39fa80e1cd0dd8";
+  };
+
+  format = "pyproject";
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Compatibility shim providing selectable entry points for older implementations";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://github.com/jaraco/backports.entry_points_selectable";
+  };
+}

--- a/pkgs/development/python-modules/pytest-randomly/default.nix
+++ b/pkgs/development/python-modules/pytest-randomly/default.nix
@@ -1,26 +1,35 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27
-, factory_boy, faker, numpy
-, pytest, pytest_xdist
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, factory_boy, faker, numpy, backports-entry-points-selectable
+, pytestCheckHook, pytest_xdist
 }:
 
 buildPythonPackage rec {
   pname = "pytest-randomly";
-  version = "3.5.0";
+  version = "3.6.0";
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "440cec143fd9b0adeb072006c71e0294402a2bc2ccd08079c2341087ba4cf2d1";
+  # fetch from GitHub as pypi tarball doesn't include tests
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "pytest-dev";
+    rev = version;
+    sha256 = "17s7gx8b7sl7mp77f5dxzwbb32qliz9awrp6xz58bhjqp7pcsa5h";
   };
 
-  propagatedBuildInputs = [ numpy factory_boy faker ];
+  propagatedBuildInputs = [
+    backports-entry-points-selectable
+  ];
 
-  checkInputs = [ pytest pytest_xdist ];
-
-  # test warnings are fixed on an unreleased version:
-  # https://github.com/pytest-dev/pytest-randomly/pull/281
-  checkPhase = "pytest -p no:randomly";
+  checkInputs = [
+    pytestCheckHook
+    pytest_xdist
+    numpy
+    factory_boy
+    faker
+  ];
+  # needs special invocation, copied from tox.ini
+  pytestFlagsArray = [ "-p" "no:randomly" ];
 
   meta = with lib; {
     description = "Pytest plugin to randomly order tests and control random.seed";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -896,6 +896,8 @@ in {
 
   backports-datetime-fromisoformat = callPackage ../development/python-modules/backports-datetime-fromisoformat { };
 
+  backports-entry-points-selectable = callPackage ../development/python-modules/backports-entry-points-selectable { };
+
   backports_functools_lru_cache = callPackage ../development/python-modules/backports_functools_lru_cache { };
 
   backports_lzma = callPackage ../development/python-modules/backports_lzma { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/pytest-dev/pytest-randomly/releases/tag/3.6.0>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
