### PR TITLE
ocamlPackages.pbkdf: init at 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/pbkdf/default.nix
+++ b/pkgs/development/ocaml-modules/pbkdf/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, mirage-crypto
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "pbkdf";
+  version = "1.1.0";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/abeaumont/ocaml-pbkdf/releases/download/${version}/pbkdf-${version}.tbz";
+    sha256 = "e53ed1bd9abf490c858a341c10fb548bc9ad50d4479acdf95a9358a73d042264";
+  };
+
+  propagatedBuildInputs = [ mirage-crypto ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
+
+  meta = {
+    description = "Password based key derivation functions (PBKDF) from PKCS#5";
+    maintainers = [ lib.maintainers.sternenseemann ];
+    license = lib.licenses.bsd2;
+    homepage = "https://github.com/abeaumont/ocaml-pbkdf";
+  };
+}
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -930,6 +930,8 @@ let
 
     parse-argv = callPackage ../development/ocaml-modules/parse-argv { };
 
+    pbkdf = callPackage ../development/ocaml-modules/pbkdf { };
+
     pcap-format = callPackage ../development/ocaml-modules/pcap-format { };
 
     pecu = callPackage ../development/ocaml-modules/pecu { };


### PR DESCRIPTION
Necessary for the upcoming x509 0.12.0 release.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
