### PR TITLE
NATS tools

### DIFF
--- a/pkgs/tools/system/nats-top/default.nix
+++ b/pkgs/tools/system/nats-top/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "nats-top";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "nats-io";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0b1hpnq8m1xfrn58ammmnx6lmhk319m8z4xjxgckz7wvy2fbzw0n";
+  };
+
+  vendorSha256 = "1a48p9gx5zdc340ma6cqakhi6f3lw9b0kz2597j1jcsk2qb7s581";
+
+  meta = with lib; {
+    description = "top-like tool for monitoring NATS servers";
+    homepage = "https://github.com/nats-io/nats-top";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/system/natscli/default.nix
+++ b/pkgs/tools/system/natscli/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "natscli";
+  version = "0.0.22";
+
+  src = fetchFromGitHub {
+    owner = "nats-io";
+    repo = pname;
+    rev = version;
+    sha256 = "1qc6lpgl878kc316z10x59px6jyfzdwsj7fdr8k4ayln0lplvbq3";
+  };
+
+  vendorSha256 = "1a9d7hqj43qdh0h7pc5wckqshi8lacf6m2107wymzzz62j1msy26";
+
+  meta = with lib; {
+    description = "NATS Command Line Interface";
+    homepage = "https://github.com/nats-io/natscli";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/system/nkeys/default.nix
+++ b/pkgs/tools/system/nkeys/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "nkeys";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "nats-io";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06wbmb3cxjrcfvgfbn6rdfzb4pfaaw11bnvl1r4kig4ag22qcz7b";
+  };
+
+  vendorSha256 = "0kiqlw2411x5c1pamq3mn5wcm8mdn91avwg8xh2a7sy3kqw5d26d";
+
+  meta = with lib; {
+    description = "Public-key signature system for NATS";
+    homepage = "https://github.com/nats-io/nkeys";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6047,6 +6047,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  nats-top = callPackage ../tools/system/nats-top { };
+
   natscli = callPackage ../tools/system/natscli { };
 
   nbench = callPackage ../tools/misc/nbench { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6068,6 +6068,8 @@ in
 
   netsniff-ng = callPackage ../tools/networking/netsniff-ng { };
 
+  nkeys = callPackage ../tools/system/nkeys { };
+
   nyxt = callPackage ../applications/networking/browsers/nyxt { };
 
   nfpm = callPackage ../tools/package-management/nfpm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6047,6 +6047,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  natscli = callPackage ../tools/system/natscli { };
+
   nbench = callPackage ../tools/misc/nbench { };
 
   ncrack = callPackage ../tools/security/ncrack { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add helper for NATS

- nats-top: https://github.com/nats-io/nats-top
- natscli: https://github.com/nats-io/natscli
- nkeys: https://github.com/nats-io/nkeys

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
