### PR TITLE
coqPackages.stdpp: 1.4.0 → 1.5.0; coqPackages.iris: 3.3.0 → 3.4.0

### DIFF
--- a/pkgs/development/coq-modules/iris/default.nix
+++ b/pkgs/development/coq-modules/iris/default.nix
@@ -5,7 +5,11 @@ with lib; mkCoqDerivation rec {
   domain = "gitlab.mpi-sws.org";
   owner = "iris";
   inherit version;
-  defaultVersion = if versions.range "8.9" "8.12" coq.coq-version then "3.3.0" else null;
+  defaultVersion = with versions; switch coq.coq-version [
+    { case = isGe "8.11";        out = "3.4.0"; }
+    { case = range "8.9" "8.11"; out = "3.3.0"; }
+  ] null;
+  release."3.4.0".sha256 = "0vdc2mdqn5jjd6yz028c0c6blzrvpl0c7apx6xas7ll60136slrb";
   release."3.3.0".sha256 = "0az4gkp5m8sq0p73dlh0r7ckkzhk7zkg5bndw01bdsy5ywj0vilp";
   releaseRev = v: "iris-${v}";
 

--- a/pkgs/development/coq-modules/stdpp/default.nix
+++ b/pkgs/development/coq-modules/stdpp/default.nix
@@ -5,7 +5,11 @@ with lib; mkCoqDerivation rec {
   inherit version;
   domain = "gitlab.mpi-sws.org";
   owner = "iris";
-  defaultVersion = if versions.range "8.8" "8.12" coq.coq-version then "1.4.0" else null;
+  defaultVersion = with versions; switch coq.coq-version [
+    { case = isGe "8.11";        out = "1.5.0"; }
+    { case = range "8.8" "8.11"; out = "1.4.0"; }
+  ] null;
+  release."1.5.0".sha256 = "1ym0fy620imah89p8b6rii8clx2vmnwcrbwxl3630h24k42092nf";
   release."1.4.0".sha256 = "1m6c7ibwc99jd4cv14v3r327spnfvdf3x2mnq51f9rz99rffk68r";
   releaseRev = v: "coq-stdpp-${v}";
 


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.13

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
