### PR TITLE
bonzomatic: 2018-03-29 -> 2021-03-07

### DIFF
--- a/pkgs/applications/editors/bonzomatic/default.nix
+++ b/pkgs/applications/editors/bonzomatic/default.nix
@@ -1,29 +1,33 @@
-{ lib, stdenv, makeWrapper, fetchFromGitHub, cmake, alsaLib, mesa_glu, libXcursor, libXinerama, libXrandr, xorgserver }:
+{ lib, stdenv, fetchFromGitHub
+, cmake, makeWrapper
+, alsaLib, fontconfig, mesa_glu, libXcursor, libXinerama, libXrandr, xorg
+}:
 
 stdenv.mkDerivation rec {
   pname = "bonzomatic";
-  version = "2018-03-29";
+  version = "2021-03-07";
 
   src = fetchFromGitHub {
     owner = "Gargaj";
     repo = pname;
     rev = version;
-    sha256 = "12mdfjvbhdqz1585772rj4cap8m4ijfci6ib62jysxjf747k41fg";
+    sha256 = "0gbh7kj7irq2hyvlzjgbs9fcns9kamz7g5p6msv12iw75z9yi330";
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];
-  buildInputs = [ alsaLib mesa_glu libXcursor libXinerama libXrandr xorgserver ];
+  buildInputs = [
+    alsaLib fontconfig mesa_glu
+    libXcursor libXinerama libXrandr xorg.xinput xorg.libXi xorg.libXext
+  ];
 
   postFixup = ''
-    wrapProgram $out/bin/Bonzomatic --prefix LD_LIBRARY_PATH : "${alsaLib}/lib"
+    wrapProgram $out/bin/bonzomatic --prefix LD_LIBRARY_PATH : "${alsaLib}/lib"
   '';
 
   meta = with lib; {
-    description = "A live-coding tool for writing 2D fragment/pixel shaders";
-    license = with licenses; [
-      unlicense
-      unfreeRedistributable # contains libbass.so in repository
-    ];
+    description = "Live shader coding tool and Shader Showdown workhorse";
+    homepage = "https://github.com/gargaj/bonzomatic";
+    license = licenses.unlicense;
     maintainers = [ maintainers.ilian ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update bonzomatic to its latest version, as this package was not touched for three years.

In the meantime, bass was removed. Thus, this package is now only
licensed under the unlicense.

The discussion for the insertion of bonzomatic, #39171, mentioned a
required config.json file. This commit wraps bonzomatic in a launcher
with a default config. By doing so, it should be way easier to verify
future package updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
