### PR TITLE
meme-suite: init at 5.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3689,6 +3689,12 @@
     githubId = 343415;
     name = "Greg Roodt";
   };
+  gschwartz = {
+    email = "gsch@pennmedicine.upenn.edu";
+    github = "GregorySchwartz";
+    githubId = 2490088;
+    name = "Gregory Schwartz";
+  };
   gtrunsec = {
     email = "gtrunsec@hardenedlinux.org";
     github = "GTrunSec";

--- a/pkgs/applications/science/biology/meme-suite/default.nix
+++ b/pkgs/applications/science/biology/meme-suite/default.nix
@@ -17,5 +17,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ gschwartz ];
     platforms = platforms.linux;
   };
-
 }

--- a/pkgs/applications/science/biology/meme-suite/default.nix
+++ b/pkgs/applications/science/biology/meme-suite/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "5.1.1";
 
   src = fetchurl {
-    url = "http://meme-suite.org/meme-software/${version}/meme-${version}.tar.gz";
+    url = "https://meme-suite.org/meme-software/${version}/meme-${version}.tar.gz";
     sha256 = "38d73d256d431ad4eb7da2c817ce56ff2b4e26c39387ff0d6ada088938b38eb5";
   };
 

--- a/pkgs/applications/science/biology/meme-suite/default.nix
+++ b/pkgs/applications/science/biology/meme-suite/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, python3, perl, glibc, zlib }:
+{ lib, stdenv, fetchurl, python3, perl, glibc, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "meme-suite";

--- a/pkgs/applications/science/biology/meme-suite/default.nix
+++ b/pkgs/applications/science/biology/meme-suite/default.nix
@@ -1,0 +1,21 @@
+{stdenv, fetchurl, python3, perl, glibc, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "meme-suite";
+  version = "5.1.1";
+
+  src = fetchurl {
+    url = "http://meme-suite.org/meme-software/5.1.1/meme-5.1.1.tar.gz";
+    sha256 = "38d73d256d431ad4eb7da2c817ce56ff2b4e26c39387ff0d6ada088938b38eb5";
+  };
+
+  nativeBuildInputs = [ perl python3 zlib ];
+
+  meta = with stdenv.lib; {
+    description = "Motif-based sequence analysis tools";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ gschwartz ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/applications/science/biology/meme-suite/default.nix
+++ b/pkgs/applications/science/biology/meme-suite/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl python3 zlib ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Motif-based sequence analysis tools";
     license = licenses.unfree;
     maintainers = with maintainers; [ gschwartz ];

--- a/pkgs/applications/science/biology/meme-suite/default.nix
+++ b/pkgs/applications/science/biology/meme-suite/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "38d73d256d431ad4eb7da2c817ce56ff2b4e26c39387ff0d6ada088938b38eb5";
   };
 
-  nativeBuildInputs = [ perl python3 zlib ];
+  buildInputs = [ zlib ];
+  nativeBuildInputs = [ perl python3 ];
 
   meta = with lib; {
     description = "Motif-based sequence analysis tools";

--- a/pkgs/applications/science/biology/meme-suite/default.nix
+++ b/pkgs/applications/science/biology/meme-suite/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "5.1.1";
 
   src = fetchurl {
-    url = "http://meme-suite.org/meme-software/5.1.1/meme-5.1.1.tar.gz";
+    url = "http://meme-suite.org/meme-software/${version}/meme-${version}.tar.gz";
     sha256 = "38d73d256d431ad4eb7da2c817ce56ff2b4e26c39387ff0d6ada088938b38eb5";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24180,6 +24180,8 @@ in
 
   meme = callPackage ../applications/graphics/meme { };
 
+  meme-suite = callPackage ../applications/science/biology/meme-suite { };
+
   # Needs qtwebkit which is broken on qt5.15
   mendeley = libsForQt514.callPackage ../applications/office/mendeley {
     gconf = pkgs.gnome2.GConf;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The MEME suite is a commonly used tool for motif discovery and detection in sequences.

###### Things done

This is a basic build for the MEME suite of tools with no alterations at all. Tested in Arch Linux. Tested binaries, but some python scripts may be missing files (`dreme` and `alphabet_py3`) but that is not an issue with the derivation.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
