### PR TITLE
dapr: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/development/tools/dapr/cli/default.nix
+++ b/pkgs/development/tools/dapr/cli/default.nix
@@ -2,12 +2,12 @@
 
 buildGoModule rec {
   pname = "dapr";
-  version = "1.0.1";
+  version = "1.1.0";
 
-  vendorSha256 = "13fb6fdjqrsl74569nh2l7x9w7w61bcvkksj410s2f85bicc29rf";
+  vendorSha256 = "0fng5a1pvpbwil79xapdalzgkgc9dwsdxs6bznjfwnkyd1vvw6fm";
 
   src = fetchFromGitHub {
-    sha256 = "15zz212sm83l6l7npislixxn23fg190b44bfxnrjrlyjbz370kch";
+    sha256 = "0x2mvlzlmcik6ys6xp722px9l4lj9ssyxb06bzxd7yj7m1wwcwp9";
 
     owner = "dapr";
     repo = "cli";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Apologies, seems I didn't notice that a new version had been published already when I created the PR for 1.0.1 ( https://github.com/NixOS/nixpkgs/pull/118325 ) :confused: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
