### PR TITLE
pwncat: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/tools/security/pwncat/default.nix
+++ b/pkgs/tools/security/pwncat/default.nix
@@ -5,18 +5,18 @@
 
 buildPythonApplication rec {
   pname = "pwncat";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0sfdqphs0v3lj3vffda4w05r6sqir7qafa8lmlh0wr921wyiqwag";
+    sha256 = "62e625e9061f037cfca7b7455a4f7db4213c1d1302e73d4c475c63f924f1805f";
   };
 
   # Tests requires to start containers
   doCheck = false;
 
   meta = with lib; {
-    description = " TCP/UDP communication suite";
+    description = "TCP/UDP communication suite";
     homepage = "https://pwncat.org/";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];


### PR DESCRIPTION
# pwncat v0.1.1

Updated pwncat from version 0.1.0 to version 0.1.1 via `python-package-init pwncat`

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
