### PR TITLE
pythonPackages.hetzner: 0.8.2 -> 0.8.3

### DIFF
--- a/pkgs/development/python-modules/hetzner/default.nix
+++ b/pkgs/development/python-modules/hetzner/default.nix
@@ -5,13 +5,13 @@
 
 buildPythonPackage rec {
   pname = "hetzner";
-  version = "0.8.2";
+  version = "0.8.3";
 
   src = fetchFromGitHub {
     repo = "hetzner";
     owner = "aszlig";
     rev = "v${version}";
-    sha256 = "152fklxff08s71v0b78yp5ajwpqyszm3sd7j0qsrwa2x9ik4968h";
+    sha256 = "0nhm7j2y4rgmrl0c1rklg982qllp7fky34dchqwd4czbsdnv9j7a";
   };
 
   meta = with lib; {


### PR DESCRIPTION
Recent changes in the Hetzner Robot API have removed a few obsolete fields which version 0.8.2 was still referencing and which is now fixed in version 0.8.3.

Due to a misunderstanding on my side I haven't updated to version 0.8.3 in nixpkgs yet, which resulted in this delay.

This fixes the NixOps Hetzner backend.