### PR TITLE
macs2: init at 2.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3689,6 +3689,12 @@
     githubId = 343415;
     name = "Greg Roodt";
   };
+  gschwartz = {
+    email = "gsch@pennmedicine.upenn.edu";
+    github = "GregorySchwartz";
+    githubId = 2490088;
+    name = "Gregory Schwartz";
+  };
   gtrunsec = {
     email = "gtrunsec@hardenedlinux.org";
     github = "GTrunSec";

--- a/pkgs/applications/science/biology/MACS2/default.nix
+++ b/pkgs/applications/science/biology/MACS2/default.nix
@@ -1,0 +1,25 @@
+{ lib, python3, fetchurl }:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "MACS2";
+  version = "2.2.7.1";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "1rcxj943kgzs746f5jrb72x1cp4v50rk3qmad0m99a02vndscb5d";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ numpy ];
+
+  # To prevent ERROR: diffpeak_cmd (unittest.loader._FailedTest) for obsolete
+  # function (ImportError: Failed to import test module: diffpeak_cmd)
+  doCheck = false;
+  pythonImportsCheck = [ "MACS2" ];
+
+  meta = with lib; {
+    description = "Model-based Analysis for ChIP-Seq";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ gschwartz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28370,6 +28370,8 @@ in
 
   macse = callPackage ../applications/science/biology/macse { };
 
+  MACS2 = callPackage ../applications/science/biology/MACS2 { };
+
   migrate = callPackage ../applications/science/biology/migrate { };
 
   minia = callPackage ../applications/science/biology/minia {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`MACS2` is a commonly used tool for peak finding in ChIP-seq data.

###### Things done

`MACS2` is a python application so I did the (what I interpret as) basic procedure to add the package. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Arch Linux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
