### PR TITLE
tracy: force-disable LTO for darwin

### DIFF
--- a/pkgs/development/tools/tracy/default.nix
+++ b/pkgs/development/tools/tracy/default.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, darwin, fetchFromGitHub, tbb, gtk3, glfw, pkg-config, freetype, Carbon, AppKit, capstone }:
 
-stdenv.mkDerivation rec {
+let
+  disableLTO = stdenv.cc.isClang && stdenv.isDarwin;  # workaround issue #19098
+in stdenv.mkDerivation rec {
   pname = "tracy";
   version = "0.7.7";
 
@@ -19,7 +21,10 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ ]
     ++ lib.optional stdenv.isLinux "-ltbb"
-    ++ lib.optional stdenv.cc.isClang "-faligned-allocation";
+    ++ lib.optional stdenv.cc.isClang "-faligned-allocation"
+    ++ lib.optional disableLTO "-fno-lto";
+
+  NIX_CFLAGS_LINK = lib.optional disableLTO "-fno-lto";
 
   buildPhase = ''
     make -j $NIX_BUILD_CORES -C profiler/build/unix release

--- a/pkgs/development/tools/tracy/default.nix
+++ b/pkgs/development/tools/tracy/default.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
     install -D ./update/build/unix/update-release $out/bin/update
   '';
 
-  fixupPhase = lib.optionalString stdenv.isDarwin ''
+  postFixup = lib.optionalString stdenv.isDarwin ''
     install_name_tool -change libcapstone.4.dylib ${capstone}/lib/libcapstone.4.dylib $out/bin/Tracy
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Appears to have been broken for a while, perhaps since upstream enabled LTO for macos builds. Anyway, just means we have to work around #19098

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
