### PR TITLE
vouch-proxy: init at 0.23.1

### DIFF
--- a/pkgs/servers/vouch-proxy/default.nix
+++ b/pkgs/servers/vouch-proxy/default.nix
@@ -1,0 +1,39 @@
+{ pkgs, ... }:
+
+pkgs.buildGoModule rec {
+  pname = "vouch-proxy";
+  version = "0.23.1";
+
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
+  src = pkgs.fetchFromGitHub {
+    owner = "vouch";
+    repo = "vouch-proxy";
+    rev = "v0.23.1";
+    sha256 = "00nraynyscaxns3c6lpwq7pscflhj87yzy6474biqbp04qyn3m36";
+  };
+
+  vendorSha256 = "1yiagqg0x6n8mail0zz4400bpjvz49kbncm5km2nhapx6znzvghm";
+
+  doCheck = false;
+
+  # Vouch-proxy expects these static files to be either in the same directory as
+  # the root or in the directory pointed to by `VOUCH_ROOT`.  We choose to put the
+  # static files in the immutable nix store and set the env var accordingly.
+  #
+  # Note that `VOUCH_ROOT` is also used as the base path for the JWT secret
+  # file, which vouch-proxy will try to autogenerate if it's not otherwise
+  # configured.  Now that we've made `VOUCH_ROOT` immutable that will fail.
+  #
+  # You must set `VOUCH_JWT_SECRET` or the equivalent YAML config to avoid
+  # trouble.
+  postInstall = ''
+    cp -r static/ templates/ $out
+    wrapProgram "$out/bin/vouch-proxy" --set VOUCH_ROOT "$out"
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Vouch-proxy is an SSO and OAuth / OIDC login solution for Nginx using the auth_request module";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27503,6 +27503,8 @@ in
     inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly;
   };
 
+  vouch-proxy = callPackage ../servers/vouch-proxy { };
+
   vttest = callPackage ../tools/misc/vttest { };
 
   wacomtablet = libsForQt514.callPackage ../tools/misc/wacomtablet { };


### PR DESCRIPTION
Initializes a package for vouch-proxy.  Its developers describe it as
"an SSO and OAuth / OIDC login solution for Nginx using the auth_request
module".

Upstream project is here: https://github.com/vouch/vouch-proxy.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/90728

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
