### PR TITLE
nixos/spacenavd: run as user service

### DIFF
--- a/nixos/modules/services/hardware/spacenavd.nix
+++ b/nixos/modules/services/hardware/spacenavd.nix
@@ -13,13 +13,12 @@ in {
   };
 
   config = mkIf cfg.enable {
-    systemd.services.spacenavd = {
+    systemd.user.services.spacenavd = {
       description = "Daemon for the Spacenavigator 6DOF mice by 3Dconnexion";
       after = [ "syslog.target" ];
       wantedBy = [ "graphical.target" ];
       serviceConfig = {
         ExecStart = "${pkgs.spacenavd}/bin/spacenavd -d -l syslog";
-        StandardError = "syslog";
       };
     };
   };

--- a/pkgs/applications/misc/spnavcfg/configure-cfgfile-path.patch
+++ b/pkgs/applications/misc/spnavcfg/configure-cfgfile-path.patch
@@ -1,0 +1,100 @@
+diff --git a/back.c b/back.c
+index c1810dc..75416fb 100644
+--- a/back.c
++++ b/back.c
+@@ -25,7 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include "cfgfile.h"
+ #include "cmd.h"
+ 
+-#define CFGFILE		"/etc/spnavrc"
+ 
+ int get_daemon_pid(void);
+ static int update_cfg(void);
+@@ -127,7 +126,7 @@ int get_daemon_pid(void)
+ 
+ static int update_cfg(void)
+ {
+-	if(write_cfg(CFGFILE, &cfg) == -1) {
++	if(write_cfg(cfg_path(), &cfg) == -1) {
+ 		fprintf(stderr, "failed to update config file\n");
+ 		return -1;
+ 	}
+diff --git a/cfgfile.c b/cfgfile.c
+index 5a9c502..2ea323d 100644
+--- a/cfgfile.c
++++ b/cfgfile.c
+@@ -22,12 +22,40 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include <ctype.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#include <unistd.h>
++#include <sys/types.h>
++#include <pwd.h>
+ #include "cfgfile.h"
+ 
+ enum {TX, TY, TZ, RX, RY, RZ};
+ 
+ static const int def_axmap[] = {0, 2, 1, 3, 5, 4};
+ static const int def_axinv[] = {0, 1, 1, 0, 1, 1};
++static char* config_path;
++
++char* cfg_path()
++{
++	char* buf;
++	if((buf = getenv("XDG_CONFIG_HOME"))) {
++		if(config_path == NULL) {
++			config_path = malloc(strlen(buf) + strlen("/spnavrc") + 1);
++			if ( config_path != NULL) {
++				sprintf(config_path, "%s/spnavrc", buf);
++			}
++		};
++		return config_path;
++	} else {
++		if (!(buf = getenv("HOME"))) {
++			struct passwd *pw = getpwuid(getuid());
++			buf = pw->pw_dir;
++		}
++		config_path = malloc(strlen(buf) + strlen("/.config/spnavrc") + 1);
++		if ( config_path != NULL) {
++			sprintf(config_path, "%s/.config/spnavrc", buf);
++		}
++		return config_path;
++	}
++}
+ 
+ void default_cfg(struct cfg *cfg)
+ {
+diff --git a/cfgfile.h b/cfgfile.h
+index dfed8c9..5bb1b2c 100644
+--- a/cfgfile.h
++++ b/cfgfile.h
+@@ -47,6 +47,7 @@ struct cfg {
+ 	int devid[MAX_CUSTOM][2];	/* custom USB vendor/product id list */
+ };
+ 
++char* cfg_path(void);
+ void default_cfg(struct cfg *cfg);
+ int read_cfg(const char *fname, struct cfg *cfg);
+ int write_cfg(const char *fname, struct cfg *cfg);
+diff --git a/front_gtk.c b/front_gtk.c
+index e4c2cd7..6a800a0 100644
+--- a/front_gtk.c
++++ b/front_gtk.c
+@@ -28,8 +28,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include "cmd.h"
+ #include "ui.h"
+ 
+-#define CFGFILE		"/etc/spnavrc"
+-
+ #define CHK_AXINV_TRANS_X			"axinv_trans_x"
+ #define CHK_AXINV_TRANS_Y			"axinv_trans_y"
+ #define CHK_AXINV_TRANS_Z			"axinv_trans_z"
+@@ -121,7 +119,7 @@ void frontend(int pfd)
+ 
+ 	gtk_init(&argc, 0);
+ 
+-	read_cfg(CFGFILE, &cfg);
++	read_cfg(cfg_path(), &cfg);
+ 
+ 	create_ui();
+ 

--- a/pkgs/applications/misc/spnavcfg/configure-pidfile-path.patch
+++ b/pkgs/applications/misc/spnavcfg/configure-pidfile-path.patch
@@ -1,0 +1,40 @@
+diff --git a/back.c b/back.c
+index f364e31..c1810dc 100644
+--- a/back.c
++++ b/back.c
+@@ -26,7 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include "cmd.h"
+ 
+ #define CFGFILE		"/etc/spnavrc"
+-#define PIDFILE		"/var/run/spnavd.pid"
+ 
+ int get_daemon_pid(void);
+ static int update_cfg(void);
+@@ -97,11 +96,26 @@ int get_daemon_pid(void)
+ {
+ 	FILE *fp;
+ 	char buf[64];
++	char* xdg_runtime_dir;
++	char* pidfile;
+ 
+-	if(!(fp = fopen(PIDFILE, "r"))) {
++	if(!(xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))){
++		fprintf(stderr, "XDG_RUNTIME_DIR not set, can't find spacenav pid file\n");
++		return -1;
++	}
++	pidfile = malloc(strlen(xdg_runtime_dir) + strlen("/spnavd.pid") + 1);
++	if (pidfile == NULL) {
++		fprintf(stderr, "failed to allocate memory\n");
++		return -1;
++	}
++	sprintf(pidfile, "%s/spnavd.pid", xdg_runtime_dir);
++
++	if(!(fp = fopen(pidfile, "r"))) {
+ 		fprintf(stderr, "no spacenav pid file, can't find daemon\n");
++		free(pidfile);
+ 		return -1;
+ 	}
++	free(pidfile);
+ 	if(!fgets(buf, sizeof buf, fp) || !isdigit(buf[0])) {
+ 		fprintf(stderr, "corrupted pidfile, can't find the daemon\n");
+ 		fclose(fp);

--- a/pkgs/applications/misc/spnavcfg/default.nix
+++ b/pkgs/applications/misc/spnavcfg/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "180mkdis15gxs79rr3f7hpwa1p6v81bybw37pzzdjnmqwqrc08a0";
   };
 
+  patches = [
+    # Changes the pidfile path from /run/spnavd.pid to $XDG_RUNTIME_DIR/spnavd.pid
+    # to allow for a user service
+    ./configure-pidfile-path.patch
+  ];
+
   postPatch = ''
     sed -i s/4775/775/ Makefile.in
   '';

--- a/pkgs/applications/misc/spnavcfg/default.nix
+++ b/pkgs/applications/misc/spnavcfg/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
     # Changes the pidfile path from /run/spnavd.pid to $XDG_RUNTIME_DIR/spnavd.pid
     # to allow for a user service
     ./configure-pidfile-path.patch
+    # Changes the config file path from /etc/spnavrc to $XDG_CONFIG_HOME/spnavrc or $HOME/.config/spnavrc
+    # to allow for a user service
+    ./configure-cfgfile-path.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/libspnav/configure-socket-path.patch
+++ b/pkgs/development/libraries/libspnav/configure-socket-path.patch
@@ -1,0 +1,47 @@
+diff --git a/spnav.c b/spnav.c
+index f9e10f8..27149f7 100644
+--- a/spnav.c
++++ b/spnav.c
+@@ -36,7 +36,7 @@ OF SUCH DAMAGE.
+ #include <sys/select.h>
+ #include "spnav.h"
+ 
+-#define SPNAV_SOCK_PATH "/var/run/spnav.sock"
++#define DEFAULT_SPNAV_SOCK_PATH "/run/spnav.sock"
+ 
+ #ifdef USE_X11
+ #include <X11/Xlib.h>
+@@ -70,6 +70,24 @@ static struct event_node *ev_queue, *ev_queue_tail;
+ /* AF_UNIX socket used for alternative communication with daemon */
+ static int sock = -1;
+ 
++static char *spath = NULL;
++
++static char *socket_path()
++{
++	char *xdg_runtime_dir;
++	if((xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))) {
++		if ( spath == NULL ) {
++			spath = malloc(strlen(xdg_runtime_dir) + strlen("/spnav.sock") + 1);
++			if ( spath != NULL ) {
++				sprintf(spath, "%s/spnav.sock", xdg_runtime_dir);
++			}
++		}
++		if(access(spath, F_OK) != -1){
++			return spath;
++		}
++	}
++	return DEFAULT_SPNAV_SOCK_PATH;
++}
+ 
+ int spnav_open(void)
+ {
+@@ -92,7 +110,7 @@ int spnav_open(void)
+ 
+ 	memset(&addr, 0, sizeof addr);
+ 	addr.sun_family = AF_UNIX;
+-	strncpy(addr.sun_path, SPNAV_SOCK_PATH, sizeof(addr.sun_path));
++	strncpy(addr.sun_path, socket_path(), sizeof(addr.sun_path));
+ 
+ 
+ 	if(connect(s, (struct sockaddr*)&addr, sizeof addr) == -1) {

--- a/pkgs/development/libraries/libspnav/default.nix
+++ b/pkgs/development/libraries/libspnav/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = lib.optional stdenv.isDarwin fixDarwinDylibNames;
   buildInputs = [ libX11 ];
 
+  patches = [
+    # Changes the socket path from /run/spnav.sock to $XDG_RUNTIME_DIR/spnav.sock
+    # to allow for a user service
+    ./configure-socket-path.patch
+  ];
+
   configureFlags = [ "--disable-debug"];
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 

--- a/pkgs/misc/drivers/spacenavd/configure-cfgfile-path.patch
+++ b/pkgs/misc/drivers/spacenavd/configure-cfgfile-path.patch
@@ -1,0 +1,63 @@
+diff --git a/src/spnavd.c b/src/spnavd.c
+index 2d4eca6..a5227ed 100644
+--- a/src/spnavd.c
++++ b/src/spnavd.c
+@@ -27,6 +27,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include <sys/select.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>
++#include <sys/types.h>
++#include <pwd.h>
+ #include "spnavd.h"
+ #include "logger.h"
+ #include "dev.h"
+@@ -47,13 +49,39 @@ static void handle_events(fd_set *rset);
+ static void sig_handler(int s);
+ static char *fix_path(char *str);
+ 
+-static char *cfgfile = DEF_CFGFILE;
++static char* config_path;
++char* cfg_path()
++{
++	char* buf;
++	if((buf = getenv("XDG_CONFIG_HOME"))) {
++		if(config_path == NULL) {
++			config_path = malloc(strlen(buf) + strlen("/spnavrc") + 1);
++			if ( config_path != NULL) {
++				sprintf(config_path, "%s/spnavrc", buf);
++			}
++		};
++		return config_path;
++	} else {
++		if (!(buf = getenv("HOME"))) {
++			struct passwd *pw = getpwuid(getuid());
++			buf = pw->pw_dir;
++		}
++		config_path = malloc(strlen(buf) + strlen("/.config/spnavrc") + 1);
++		if ( config_path != NULL) {
++			sprintf(config_path, "%s/.config/spnavrc", buf);
++		}
++		return config_path;
++	}
++}
++
++static char *cfgfile = NULL;
+ static char *logfile = DEF_LOGFILE;
+ static char *pidpath = NULL;
+ 
+ int main(int argc, char **argv)
+ {
+ 	int i, pid, ret, become_daemon = 1;
++	cfgfile = cfg_path();
+ 
+ 	for(i=1; i<argc; i++) {
+ 		if(argv[i][0] == '-') {
+@@ -247,7 +275,7 @@ static void print_usage(const char *argv0)
+ 	printf("usage: %s [options]\n", argv0);
+ 	printf("options:\n");
+ 	printf(" -d: do not daemonize\n");
+-	printf(" -c <file>: config file path (default: " DEF_CFGFILE ")\n");
++	printf(" -c <file>: config file path (default: %s)\n", cfg_path());
+ 	printf(" -l <file>|syslog: log file path or log to syslog (default: " DEF_LOGFILE ")\n");
+ 	printf(" -v: verbose output\n");
+ 	printf(" -V,-version: print version number and exit\n");

--- a/pkgs/misc/drivers/spacenavd/configure-pidfile-path.patch
+++ b/pkgs/misc/drivers/spacenavd/configure-pidfile-path.patch
@@ -1,0 +1,82 @@
+diff --git a/src/spnavd.c b/src/spnavd.c
+index 03080da..2d4eca6 100644
+--- a/src/spnavd.c
++++ b/src/spnavd.c
+@@ -42,12 +42,14 @@ static void cleanup(void);
+ static void daemonize(void);
+ static int write_pid_file(void);
+ static int find_running_daemon(void);
++static char *pidfile_path(void);
+ static void handle_events(fd_set *rset);
+ static void sig_handler(int s);
+ static char *fix_path(char *str);
+ 
+ static char *cfgfile = DEF_CFGFILE;
+ static char *logfile = DEF_LOGFILE;
++static char *pidpath = NULL;
+ 
+ int main(int argc, char **argv)
+ {
+@@ -270,7 +272,7 @@ static void cleanup(void)
+ 		remove_device(tmp);
+ 	}
+ 
+-	remove(PIDFILE);
++	remove(pidfile_path());
+ }
+ 
+ static void daemonize(void)
+@@ -314,7 +316,7 @@ static int write_pid_file(void)
+ 	FILE *fp;
+ 	int pid = getpid();
+ 
+-	if(!(fp = fopen(PIDFILE, "w"))) {
++	if(!(fp = fopen(pidfile_path(), "w"))) {
+ 		return -1;
+ 	}
+ 	fprintf(fp, "%d\n", pid);
+@@ -329,7 +331,7 @@ static int find_running_daemon(void)
+ 	struct sockaddr_un addr;
+ 
+ 	/* try to open the pid-file */
+-	if(!(fp = fopen(PIDFILE, "r"))) {
++	if(!(fp = fopen(pidfile_path(), "r"))) {
+ 		return -1;
+ 	}
+ 	if(fscanf(fp, "%d\n", &pid) != 1) {
+@@ -356,6 +358,22 @@ static int find_running_daemon(void)
+ 	return pid;
+ }
+ 
++char *pidfile_path(void)
++{
++	char *xdg_runtime_dir;
++	if((xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))) {
++		if ( pidpath == NULL ) {
++			pidpath = malloc(strlen(xdg_runtime_dir) + strlen("/spnavd.pid") + 1);
++			if ( pidpath != NULL ) {
++				sprintf(pidpath, "%s/spnavd.pid", xdg_runtime_dir);
++			}
++		};
++		return pidpath;
++	} else {
++		return DEFAULT_PIDFILE;
++	}
++}
++
+ static void handle_events(fd_set *rset)
+ {
+ 	int dev_fd, hotplug_fd;
+diff --git a/src/spnavd.h b/src/spnavd.h
+index 2d1c48b..17d22d3 100644
+--- a/src/spnavd.h
++++ b/src/spnavd.h
+@@ -26,7 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #define DEF_CFGFILE		"/etc/spnavrc"
+ #define DEF_LOGFILE		"/var/log/spnavd.log"
+ 
+-#define PIDFILE		"/var/run/spnavd.pid"
++#define DEFAULT_PIDFILE		"/run/spnavd.pid"
+ #define DEFAULT_SOCK_NAME	"/run/spnav.sock"
+ #define SYSLOG_ID	"spnavd"
+ 

--- a/pkgs/misc/drivers/spacenavd/configure-socket-path.patch
+++ b/pkgs/misc/drivers/spacenavd/configure-socket-path.patch
@@ -1,0 +1,118 @@
+diff --git a/src/proto_unix.c b/src/proto_unix.c
+index 998f234..d38452c 100644
+--- a/src/proto_unix.c
++++ b/src/proto_unix.c
+@@ -36,11 +36,14 @@ enum {
+ 
+ static int lsock = -1;
+ 
++static char *spath = NULL;
++
+ int init_unix(void)
+ {
+ 	int s;
+ 	mode_t prev_umask;
+ 	struct sockaddr_un addr;
++	char *sock_path;
+ 
+ 	if(lsock >= 0) return 0;
+ 
+@@ -49,16 +52,18 @@ int init_unix(void)
+ 		return -1;
+ 	}
+ 
+-	unlink(SOCK_NAME);	/* in case it already exists */
++	sock_path = socket_path();
++
++	unlink(sock_path);	/* in case it already exists */
+ 
+ 	memset(&addr, 0, sizeof addr);
+ 	addr.sun_family = AF_UNIX;
+-	strcpy(addr.sun_path, SOCK_NAME);
++	strcpy(addr.sun_path, sock_path);
+ 
+ 	prev_umask = umask(0);
+ 
+ 	if(bind(s, (struct sockaddr*)&addr, sizeof addr) == -1) {
+-		logmsg(LOG_ERR, "failed to bind unix socket: %s: %s\n", SOCK_NAME, strerror(errno));
++		logmsg(LOG_ERR, "failed to bind unix socket: %s: %s\n", sock_path, strerror(errno));
+ 		close(s);
+ 		return -1;
+ 	}
+@@ -68,7 +73,7 @@ int init_unix(void)
+ 	if(listen(s, 8) == -1) {
+ 		logmsg(LOG_ERR, "listen failed: %s\n", strerror(errno));
+ 		close(s);
+-		unlink(SOCK_NAME);
++		unlink(sock_path);
+ 		return -1;
+ 	}
+ 
+@@ -82,7 +87,7 @@ void close_unix(void)
+ 		close(lsock);
+ 		lsock = -1;
+ 
+-		unlink(SOCK_NAME);
++		unlink(socket_path());
+ 	}
+ }
+ 
+@@ -173,3 +178,19 @@ int handle_uevents(fd_set *rset)
+ 
+ 	return 0;
+ }
++
++char *socket_path(void)
++{
++	char *xdg_runtime_dir;
++	if((xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))) {
++		if ( spath == NULL ) {
++			spath = malloc(strlen(xdg_runtime_dir) + strlen("/spnav.sock") + 1);
++			if ( spath != NULL ) {
++				sprintf(spath, "%s/spnav.sock", xdg_runtime_dir);
++			}
++		};
++		return spath;
++	} else {
++		return DEFAULT_SOCK_NAME;
++	}
++}
+diff --git a/src/proto_unix.h b/src/proto_unix.h
+index 045b379..ec4509c 100644
+--- a/src/proto_unix.h
++++ b/src/proto_unix.h
+@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include "event.h"
+ #include "client.h"
+ 
++char *socket_path(void);
+ int init_unix(void);
+ void close_unix(void);
+ int get_unix_socket(void);
+diff --git a/src/spnavd.c b/src/spnavd.c
+index cbea191..03080da 100644
+--- a/src/spnavd.c
++++ b/src/spnavd.c
+@@ -344,7 +344,7 @@ static int find_running_daemon(void)
+ 	}
+ 	memset(&addr, 0, sizeof addr);
+ 	addr.sun_family = AF_UNIX;
+-	strncpy(addr.sun_path, SOCK_NAME, sizeof addr.sun_path);
++	strncpy(addr.sun_path, socket_path(), sizeof addr.sun_path);
+ 
+ 	if(connect(s, (struct sockaddr*)&addr, sizeof addr) == -1) {
+ 		close(s);
+diff --git a/src/spnavd.h b/src/spnavd.h
+index fa0a916..2d1c48b 100644
+--- a/src/spnavd.h
++++ b/src/spnavd.h
+@@ -26,8 +26,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #define DEF_CFGFILE		"/etc/spnavrc"
+ #define DEF_LOGFILE		"/var/log/spnavd.log"
+ 
+-#define SOCK_NAME	"/var/run/spnav.sock"
+ #define PIDFILE		"/var/run/spnavd.pid"
++#define DEFAULT_SOCK_NAME	"/run/spnav.sock"
+ #define SYSLOG_ID	"spnavd"
+ 
+ /* Multiple devices support */

--- a/pkgs/misc/drivers/spacenavd/default.nix
+++ b/pkgs/misc/drivers/spacenavd/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
     # Changes the socket path from /run/spnav.sock to $XDG_RUNTIME_DIR/spnav.sock
     # to allow for a user service
     ./configure-socket-path.patch
+    # Changes the pidfile path from /run/spnavd.pid to $XDG_RUNTIME_DIR/spnavd.pid
+    # to allow for a user service
+    ./configure-pidfile-path.patch
   ];
 
   buildInputs = [ libX11 ]

--- a/pkgs/misc/drivers/spacenavd/default.nix
+++ b/pkgs/misc/drivers/spacenavd/default.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation rec {
     # Changes the pidfile path from /run/spnavd.pid to $XDG_RUNTIME_DIR/spnavd.pid
     # to allow for a user service
     ./configure-pidfile-path.patch
+    # Changes the config file path from /etc/spnavrc to $XDG_CONFIG_HOME/spnavrc or $HOME/.config/spnavrc
+    # to allow for a user service
+    ./configure-cfgfile-path.patch
   ];
 
   buildInputs = [ libX11 ]

--- a/pkgs/misc/drivers/spacenavd/default.nix
+++ b/pkgs/misc/drivers/spacenavd/default.nix
@@ -17,6 +17,9 @@ stdenv.mkDerivation rec {
       url = "https://github.com/FreeSpacenav/spacenavd/commit/d6a25d5c3f49b9676d039775efc8bf854737c43c.patch";
       sha256 = "02pdgcvaqc20qf9hi3r73nb9ds7yk2ps9nnxaj0x9p50xjnhfg5c";
     })
+    # Changes the socket path from /run/spnav.sock to $XDG_RUNTIME_DIR/spnav.sock
+    # to allow for a user service
+    ./configure-socket-path.patch
   ];
 
   buildInputs = [ libX11 ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This fixes the patches to run spacenavd as a user service.
However, it does not adjust the location of the default config (`/etc/spnavrc`) and the pid file (`/var/run/spnavd.pid`).
The user service obviously cannot write to these locations, so it is a bit of a problem. For example spnavcfg (as introduced in https://github.com/NixOS/nixpkgs/pull/118327) requires these files in their default location. I could of course also patch spnavcfg accordingly. What do you think? @gebner @flokli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
