### PR TITLE
ocamlPackages.minisat: 0.2 → 0.3

### DIFF
--- a/pkgs/development/ocaml-modules/minisat/default.nix
+++ b/pkgs/development/ocaml-modules/minisat/default.nix
@@ -2,15 +2,17 @@
 
 buildDunePackage rec {
   pname = "minisat";
-  version = "0.2";
+  version = "0.3";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.05";
 
   src = fetchFromGitHub {
     owner  = "c-cube";
     repo   = "ocaml-minisat";
-    rev    = version;
-    sha256 = "1jibylmb1ww0x42n6wl8bdwicaysgxp0ag244x7w5m3jifq3xs6q";
+    rev    = "v${version}";
+    sha256 = "01wggbziqz5x6d7mwdl40sbf6qal7fd853b224zjf9n0kzzsnczh";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Fixes: https://github.com/c-cube/ocaml-minisat/blob/v0.3/CHANGELOG.md#03

Use Dune 2 (compatibility with OCaml 4.12).

cc maintainer @mgttlinger

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
