### PR TITLE
pythonPackages.greenlet: 0.4.17 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/greenlet/default.nix
+++ b/pkgs/development/python-modules/greenlet/default.nix
@@ -8,20 +8,15 @@
 
 buildPythonPackage rec {
   pname = "greenlet";
-  version = "0.4.17";
+  version = "1.0.0";
   disabled = isPyPy;  # builtin for pypy
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0swdhrcq13bdszv3yz5645gi4ijbzmmhxpb6whcfg3d7d5f87n21";
+    sha256 = "1y6wbg9yhm9dw6m768n4yslp56h85pnxkk3drz6icn15g6f1d7ki";
   };
 
   propagatedBuildInputs = [ six ];
-
-  # see https://github.com/python-greenlet/greenlet/issues/85
-  preCheck = ''
-    rm tests/test_leaks.py
-  '';
 
   meta = {
     homepage = "https://pypi.python.org/pypi/greenlet";

--- a/pkgs/development/python-modules/meinheld/default.nix
+++ b/pkgs/development/python-modules/meinheld/default.nix
@@ -9,6 +9,12 @@ buildPythonPackage rec {
     sha256 = "008c76937ac2117cc69e032dc69cea9f85fc605de9bac1417f447c41c16a56d6";
   };
 
+  patchPhase = ''
+    # Allow greenlet-1.0.0.
+    # See https://github.com/mopemope/meinheld/pull/123
+    substituteInPlace setup.py --replace "greenlet>=0.4.5,<0.5" "greenlet>=0.4.5,<2.0.0"
+  '';
+
   propagatedBuildInputs = [ greenlet ];
 
   # No tests


### PR DESCRIPTION
###### Motivation for this change

Update greenlet to 1.0.0.

meinheld declares a dependency to greenlet <0.5, but according to [1]
and [2], there are no API or ABI changes leading to greenlet-1.0.0, so
it seems reasonable to drop the strict requirement.  This commit
includes the patch in nixpkgs since no upstream commit has landed in the
main branch yet.

Morehover, quoting [2]:

    Prior to greenlet 1.0 there were no semantic meanings attached to
    greenlet versions — API and ABI regularly changed from 0.4.x
    to 0.4.x+1, so their current pin doesn't make much sense anyway.

nix-review reveals few broken packages that are also broken in master.

[1] https://github.com/mopemope/meinheld/pull/123
[2] https://github.com/benoitc/gunicorn/issues/2541#issuecomment-800353993

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
