### PR TITLE
nixos/btrbk: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -248,6 +248,7 @@
   ./services/backup/bacula.nix
   ./services/backup/borgbackup.nix
   ./services/backup/borgmatic.nix
+  ./services/backup/btrbk
   ./services/backup/duplicati.nix
   ./services/backup/duplicity.nix
   ./services/backup/mysql-backup.nix

--- a/nixos/modules/services/backup/btrbk/btrbk-options.nix
+++ b/nixos/modules/services/backup/btrbk/btrbk-options.nix
@@ -1,0 +1,245 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+with types;
+
+let
+  # functions which will be used for the apply attribute of mkOption
+  # all these functions will be reduced to (listOf str)
+  conversions = {
+    valueIdentityPair = keyName: value:
+      lists.optionals (value != null) [ (keyName + "  " + value) ];
+
+    intToBoolPair = keyName: value:
+      lists.optionals (value != null) [ (keyName + "  " + (toString value)) ];
+
+    customList = value: lists.optionals (value != null) (filter isString (builtins.split "\n" value));
+
+    boolPair = keyName: value:
+      lists.optionals (value != null) [ (keyName + "  " + (if value then "yes" else "no")) ];
+  };
+
+  # option type which will be used to validate
+  # something is a valid retention policy
+  retentionPolicy = strMatching "(((([0-9]+)|\\*)[hdwmy])[ \t\n\r]*)+";
+in
+{
+  # Generel options
+  snapshotDir = mkOption {
+    type = nullOr str;
+    default = null;
+    description = ''
+      Directory where snapshots of the filesystem will be stored. Must be given
+      relative to individual volume-directory.
+    '';
+    apply = conversions.valueIdentityPair "snapshot_dir";
+  };
+
+  timestampFormat = mkOption {
+    type = nullOr (enum [ "short" "long" "long-iso" ]);
+    default = null;
+    description = ''
+      Timestamp format used as a suffix for new snapshot modules. 'short' only keeps
+      track of the date, 'long' also tracks the time of day and 'long-iso' will also
+      prevent issues with backups made during a time shift.
+    '';
+    apply = conversions.valueIdentityPair "timestamp_format";
+  };
+
+  extraOptions = mkOption {
+    type = nullOr lines;
+    default = null;
+    description = ''
+      Extra options which influence how a backup is stored.
+      See $(man btrbk) under 'Options' for more information.
+    '';
+    apply = conversions.customList;
+  };
+
+  snapshotName = mkOption {
+    type = nullOr str;
+    default = null;
+    description = ''
+      Name of backup'ed subvolume inside the target. Only set if you want the backup
+      have another name than the original subvolume
+    '';
+    apply = conversions.valueIdentityPair "snapshot_name";
+  };
+
+  snapshotCreate = mkOption {
+    type = nullOr (enum [ "always" "onchange" "ondemand" "no" ]);
+    default = null;
+    description = ''
+      When should snapshots be created. 'Always' will allways create one,
+      'onchange' if the subvolume has changed, 'ondemand' if the target is available
+      and 'no' will never create a snapshot.
+    '';
+    apply = conversions.valueIdentityPair "snapshot_create";
+  };
+
+  incremental = mkOption {
+    type = nullOr (enum [ "yes" "no" "strict" ]);
+    default = null;
+    description = ''
+      Wether incremental backups will be created. No will only create full
+      backups, yes will only create initial backups non-incremental and strict
+      will only create incremental backups.
+    '';
+    apply = conversions.valueIdentityPair "incremental";
+  };
+
+  noauto = mkOption {
+     type = nullOr bool;
+     default = null;
+     description = ''
+       If set, the context is skipped by all btrbk actions unless explicitly enabled
+       by a matching btrbk [filter] command line argument (e.g. 'btrbk run myfilter').
+     '';
+     apply = conversions.boolPair "noauto";
+  };
+
+  # Retention Policy Options
+  preserveDayOfWeek = mkOption {
+    type = nullOr
+      (enum ["monday" "tuesday" "wednesday" "thursday" "friday" "saturday" "sunday" ] );
+    default = null;
+    description = ''
+      A snapshot done at this day will be considered as weekly. See 'Retention Policy'
+      in $(man btrbk.conf) for more information on what that means.
+    '';
+    apply = conversions.valueIdentityPair "preserve_day_of_week";
+  };
+
+  preserveHourOfDay = mkOption {
+    type = nullOr (ints.between 0 23);
+    default = null;
+    description = ''
+      Defines after what time (in full hours since midnight) a snapshot/backup is
+      considered to be a 'daily' backup. Daily, weekly, monthly and yearly backups
+      are preserved on this hour (see RETENTION POLICY in $(man btrbk.conf)). If
+      you set this option, make sure to also set timestamp_format to 'long' or
+      'long-iso' (backups and snapshots having no time information will ignore
+      this option). Defaults to '0'.
+    '';
+    apply = conversions.intToBoolPair "preserve_hour_of_day";
+  };
+
+  snapshotPreserve = mkOption {
+    type = nullOr (either (strMatching "no") retentionPolicy);
+    default = null;
+    description = ''
+      Set retention policy for snapshots (see RETENTION POLICY in $(man btrbk.conf)).
+      If set to 'no', preserve snapshots according to snapshotPreserveMin only.
+      Defaults to 'no'.
+    '';
+    example = "5d 4m *y";
+    apply = conversions.valueIdentityPair "snapshot_preserve";
+  };
+
+  snapshotPreserveMin = mkOption {
+    type = nullOr (either (enum [ "all" "latest" "no" ]) (strMatching "[0-9]+[hdwmy]"));
+    description = ''
+      Preserve all snapshots for a minimum amount of hours (h), days (d), weeks (w),
+      months (m) or years (y), regardless of how many there are. If set to 'all',
+      preserve all snapshots forever. If set to 'latest', preserve latest snapshot.
+      Defaults to 'all'.
+    '';
+    default = null;
+    example = "5w";
+    apply = conversions.valueIdentityPair "snapshot_preserve_min";
+  };
+
+  targetPreserveMin = mkOption {
+    type = nullOr (either (enum [ "all" "latest" "no" ]) (strMatching "[0-9]+[hdwmy]"));
+    description = ''
+      Preserve all backups for a minimum amount of hours (h), days (d), weeks (w),
+      months (m) or years (y), regardless of how many there are. If set to 'all',
+      preserve all backups forever. If set to “latest”, always preserve the latest
+      backup (useful in conjunction with 'targetPreserve = "no"', if you want to
+      keep the latest backup only). If set to 'no', only the backups following the
+      targetPreserve policy are created. Defaults to 'all'.
+    '';
+    default = null;
+    example = "5w";
+    apply = conversions.valueIdentityPair "target_preserve_min";
+  };
+
+  targetPreserve = mkOption {
+    type = nullOr (either (strMatching "no") retentionPolicy);
+    default = null;
+    description = ''
+      Set retention policy for backups (see RETENTION POLICY in $(man btrbk.conf)).
+      If set to 'no', preserve backups according to targetPreserve%in only.
+      Defaults to 'no'.
+    '';
+    example = "5d 4m *y";
+    apply = conversions.valueIdentityPair "target_preserve";
+  };
+
+  # SSH Options
+  sshIdentity = mkOption {
+    type = nullOr str;
+    default = null;
+    description = ''
+      Absolute path to a ssh private key to authentificate at the target machine.
+
+      Note that for security reasons, this path must point to a file
+      in the local filesystem, *not* to the nix store.
+    '';
+    apply = conversions.valueIdentityPair "ssh_identity";
+  };
+
+  sshUser = mkOption {
+    type = nullOr str;
+    default = null;
+    description = ''
+      User on the target machine. Defaults to 'root'.
+    '';
+    apply = conversions.valueIdentityPair "ssh_user";
+  };
+
+  sshCompression = mkOption {
+    type = nullOr bool;
+    default = null;
+    description = ''
+      Enables or disables the compression of ssh connections. Defaults to false. Note
+      that if streamCompress is enabled, ssh compression will always be disabled for
+      send/receive operations.
+    '';
+    apply = conversions.boolPair "ssh_compression";
+  };
+
+  sshCipherSpec = mkOption {
+    type = nullOr str;
+    default = null;
+    description = ''
+      Selects the cipher specification for encrypting the session (comma-separated
+      list of ciphers in order of preference). See the '-c cipher_spec' option in
+      ssh(1) for more information. Defaults to 'default' (the ciphers specified in
+      ssh_config).
+    '';
+    apply = conversions.valueIdentityPair "ssh_cipher_spec";
+  };
+
+  stream_compress = mkOption {
+    type = nullOr (enum ["no" "gzip" "pigz" "bzip2" "pbzip2" "xz" "lzo" "lz4"]);
+    default = null;
+    description = ''
+      Compress the btrfs send stream before transferring it from/to remote locations.
+      Defaults to “no”. If enabled, make sure that the compress command is available
+      on the source and target hosts.
+    '';
+    apply = conversions.valueIdentityPair "stream_compress";
+  };
+
+  stream_compress_level = mkOption {
+    type = nullOr (either (enum ["default"]) int);
+    default = null;
+    description = ''
+      Compression level for the specified . Refer to the related man-page for details
+      (usually [1..9], where 1 means fastest compression). Defaults to “default” (the
+      default compression level of your compression tool).
+    '';
+    apply = conversions.valueIdentityPair "stream_compress_level";
+  };
+}

--- a/nixos/modules/services/backup/btrbk/default.nix
+++ b/nixos/modules/services/backup/btrbk/default.nix
@@ -1,0 +1,186 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.btrbk;
+  btrbkOptions = import ./btrbk-options.nix {inherit config lib pkgs;};
+
+  # Different Sections in the config accept different options.
+  # Theese sets inherit the respective valid options.
+  # The names used here, are the same names as in $(man btrbk.conf)
+  optionSections = {
+    global = {
+      inherit (btrbkOptions)
+      snapshotDir extraOptions timestampFormat snapshotCreate incremental
+      noauto preserveDayOfWeek sshUser sshIdentity sshCompression sshCipherSpec
+      preserveHourOfDay snapshotPreserve snapshotPreserveMin targetPreserve
+      targetPreserveMin stream_compress stream_compress_level;
+    };
+
+    subvolume = {
+      inherit (btrbkOptions)
+      snapshotDir extraOptions timestampFormat snapshotName snapshotCreate
+      incremental noauto preserveDayOfWeek sshUser sshIdentity sshCompression
+      sshCipherSpec preserveHourOfDay snapshotPreserve snapshotPreserveMin
+      targetPreserve targetPreserveMin stream_compress stream_compress_level;
+    };
+
+    target = {
+      inherit (btrbkOptions)
+      extraOptions incremental noauto preserveDayOfWeek sshUser sshIdentity
+      sshCompression sshCipherSpec preserveHourOfDay targetPreserve
+      targetPreserveMin stream_compress stream_compress_level;
+    };
+
+    volume = {
+      inherit (btrbkOptions)
+      snapshotDir extraOptions timestampFormat snapshotCreate incremental
+      noauto preserveDayOfWeek sshUser sshIdentity sshCompression sshCipherSpec
+      preserveHourOfDay snapshotPreserve snapshotPreserveMin targetPreserve
+      targetPreserveMin stream_compress stream_compress_level;
+    };
+  };
+
+  helpers = {
+    # list2lines :: listOf str -> lines
+    list2lines =
+      inputList: (concatStringsSep "\n" inputList) + "\n";
+
+    # addPrefixes :: listOf str -> listOf str
+    addPrefixes =
+      lines: map (line: "  " + line) lines;
+  };
+
+  # This function will be used if a subsection is given as a set
+  # which you would like to do if this subsection should have
+  # special options differing from the default or global settings
+  #
+  # convertEntrys :: attrs -> enum ["subvolume" "target"] -> listOf str
+  convertEntrys =
+    subentry: subentryType:
+    builtins.concatLists
+      (map
+          (entry: [(subentryType + " " + entry)]
+            ++ (helpers.addPrefixes (renderOptions subentry."${entry}")))
+          (builtins.attrNames subentry)
+      );
+
+  # This function will be used if a subsection is given as list
+  # It will put the name of its corrosponding kind of subsection
+  # (which is either "subvolume" or "target") in front of the subsections path
+  # and return them as a list of strings
+  #
+  # convertLists :: listOf str -> enum ["subvolume" "target"] -> listOf str
+  convertLists =
+    subentry: subentryType: map (entry: subentryType + " " + entry) subentry;
+
+  renderVolumes = builtins.concatLists (
+    mapAttrsToList (name: value:
+      # volume head line
+      [ ("volume " + name) ]
+      # volume options
+      ++ (helpers.addPrefixes (renderOptions value))
+      # volume subvolumes which should be backed up
+      ++ (renderSubsection value "subvolume")
+      # volume backup targets
+      ++ (renderSubsection value "target"))
+    cfg.volumes);
+
+  # renderSubsection :: attrs -> emum["subvolume" "target"] -> listOf str
+  renderSubsection =
+    volumeEntry: subsectionType:
+      let
+        subsectionEntry = builtins.getAttr (subsectionType + "s") volumeEntry;
+        converter =
+          # differentiate whether a simple list is used,
+          # or if extra options are used for the subentry
+          if (builtins.isAttrs subsectionEntry)
+            then convertEntrys else convertLists;
+      in
+        (helpers.addPrefixes (converter subsectionEntry subsectionType));
+
+  # A subsection is either typed as a list of strings
+  # or in more advanced cases as a list of options which specificly and only
+  # applys to this subsection
+  #
+  # if the later is the case, the bound variable 'options' will be elliminated
+  # in favor of the kind of options which can be used with this type of subsection
+  subsectionDataType = options: with types; either (listOf str) (attrsOf (submodule
+    ({name, config, ...}:
+    {
+      inherit options;
+    }))
+  );
+
+  # individual options will be parsed
+  #
+  # renderOptions :: attrs -> listOf str
+  renderOptions = options:
+  with builtins; concatLists (attrValues
+    (filterAttrs (name: value: builtins.hasAttr name btrbkOptions) options)
+  );
+
+
+  # Each btrfs volume is configured as an option of type submodule
+  # The following set specifies this submodule
+  #
+  # For example
+  # services.btrbk."/home/user".subvolumes."Movies".snapshotDir = "/snapshots";
+  # will generate the following excerpt in the final config:
+  #
+  # volume /home/user
+  #   subvolume Movies
+  #     snapshot_dir = "/snapshots";
+  volumeSubmodule =
+    ({name, config, ... }:
+    {
+      options = {
+        subvolumes = mkOption {
+            type = subsectionDataType optionSections.subvolume;
+            default = [];
+            example = [ "/home/user/important_data" "/mount/even_more_important_data"];
+            description = "A list of subvolumes which should be backed up.";
+        };
+        targets = mkOption {
+          type = subsectionDataType optionSections.target;
+          default = [];
+          example = ''[ "/mount/backup_drive" ]'';
+          description = "A list of targets where backups of this volume should be stored.";
+        };
+      } // optionSections.volume;
+  });
+  in {
+
+    meta.maintainers = [ maintainers.voidless ];
+
+    options.services.btrbk = ({
+      enable = mkEnableOption
+        "Enable the btrbk backup utility for btrfs based file systems.";
+
+      volumes = mkOption {
+        type = with types; attrsOf (submodule volumeSubmodule);
+        default = { };
+        description =
+        "The configuration for a specific volume.
+        The key of each entry is a string, reflecting the path of that volume.";
+        example = {
+         "/mount/btrfs_volumes" =
+          {
+            subvolumes = [ "btrfs_volume/important_files" ];
+            targets = [ "/mount/backup_drive" ];
+          };
+        };
+      };
+    } // optionSections.global);
+
+    ###### implementation
+    config = mkIf cfg.enable {
+      environment.systemPackages = [ pkgs.btrbk ];
+      environment.etc."btrbk/btrbk.conf" = {
+        source = pkgs.writeText "btrbk.conf"
+          ( (helpers.list2lines (renderOptions cfg))
+            + (helpers.list2lines renderVolumes));
+      };
+    };
+  }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -43,6 +43,7 @@ in
   boot = handleTestOn ["x86_64-linux"] ./boot.nix {}; # syslinux is unsupported on aarch64
   boot-stage1 = handleTest ./boot-stage1.nix {};
   borgbackup = handleTest ./borgbackup.nix {};
+  btrbk = handleTest ./btrbk.nix {};
   buildbot = handleTest ./buildbot.nix {};
   buildkite-agents = handleTest ./buildkite-agents.nix {};
   caddy = handleTest ./caddy.nix {};

--- a/nixos/tests/btrbk.nix
+++ b/nixos/tests/btrbk.nix
@@ -1,0 +1,56 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+let
+  btrfsRoot = "/run/important_files";
+  testData = "testdata";
+in
+  {
+   machine =
+    { config, pkgs, ... }:
+    {
+
+      environment.systemPackages = with pkgs; [ btrfs-progs ];
+      services.btrbk = {
+        enable = true;
+          volumes."${btrfsRoot}" = {
+            subvolumes = { "data" = {
+                  snapshotDir = "snapshots";
+                  snapshotName = "all_my_data";
+                };
+              };
+            targets = { "${btrfsRoot}/backup" = {}; };
+            extraOptions = ''
+              # test_line 1
+              # test_line 2
+            '';
+          };
+      };
+    };
+
+    testScript =
+      ''
+        # eliminate time as an unwanted side effect
+        machine.succeed("timedatectl set-time '00:00:00'")
+
+        # create the btrfs pool
+        machine.succeed("dd if=/dev/zero of=/data_fs bs=120M count=1")
+        machine.succeed("mkfs.btrfs /data_fs")
+        machine.succeed("mkdir -p ${btrfsRoot}")
+        machine.succeed("mount /data_fs ${btrfsRoot}")
+        machine.succeed("btrfs subvolume create ${btrfsRoot}/snapshots")
+        machine.succeed("btrfs subvolume create ${btrfsRoot}/data")
+        machine.succeed("btrfs subvolume create ${btrfsRoot}/backup")
+
+        # print the config file
+        machine.succeed("cat /etc/btrbk/btrbk.conf 1>&2")
+
+        # run the backup
+        machine.succeed("echo ${testData} > ${btrfsRoot}/data/testfile")
+        machine.succeed("btrbk --Version")
+        machine.succeed("btrbk run 1>&2")
+
+        backup = "${btrfsRoot}/backup/*/testfile"
+        data = "${btrfsRoot}/data/testfile"
+        machine.succeed("diff " + backup + " " + data)
+      '';
+  })


### PR DESCRIPTION
Adding support for configuring the btrbk backup utility via
the configuration.nix. Atm this is more a less a direct mapping
from nix syntax into the configuration syntax of the tool.

The unit test requires a rather big testdisk (120M). This is
due to the fact, that btrfs images cant be smaller than that.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I am using btrbk for my backups and wanted a way do configure it via the normal nixos way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
