### PR TITLE
prometheus-lnd-exporter: unstable-2020-12-04 -> unstable-2021-03-26, fix test

### DIFF
--- a/pkgs/servers/monitoring/prometheus/lnd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/lnd-exporter.nix
@@ -2,23 +2,21 @@
 
 buildGoModule rec {
   pname = "lndmon";
-  version = "unstable-2020-12-04";
+  version = "unstable-2021-03-26";
 
   src = fetchFromGitHub {
     owner = "lightninglabs";
     repo = "lndmon";
-    sha256 = "0q72jbkhw1vpwxd0r80l1v4ab71sakc315plfqbijy7al9ywq5nl";
-    rev = "f07d574320dd1a6a428fecd47f3a5bb46a0fc4d1";
+    sha256 = "14lmmjq61p8yhc86swigs43risqi31vlmz7ri8j0n0fyp8lm2kxs";
+    rev = "3aa925aa4f633a6c4d132601922e78f173ae8ac1";
   };
 
   vendorSha256 = "06if387b9m02ciqgcissih1x06l33djp87vgspwzz589f77vczk8";
 
-  doCheck = false;
-
   passthru.tests = { inherit (nixosTests.prometheus-exporters) lnd; };
 
   meta = with lib; {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/lightninglabs/lndmon";
     description = "Prometheus exporter for lnd (Lightning Network Daemon)";
     license = licenses.mit;
     maintainers = with maintainers; [ mmilata ];


### PR DESCRIPTION
###### Motivation for this change

Bunch of new metrics have been added since the last version. Also test was broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
