### PR TITLE
mailcap: 2.1.48 -> 2.1.52

### DIFF
--- a/pkgs/data/misc/mailcap/default.nix
+++ b/pkgs/data/misc/mailcap/default.nix
@@ -1,23 +1,23 @@
 { lib, fetchzip }:
 
 let
-  version = "2.1.48";
+  version = "2.1.52";
 
 in fetchzip {
   name = "mailcap-${version}";
 
   url = "https://releases.pagure.org/mailcap/mailcap-${version}.tar.xz";
-  sha256 = "08d0avz8971hkggd60dk9yyd14izz24yag3prpfafbvm670jlmqg";
+  sha256 = "sha256-2GRNg3zoMPMaOk2zoAx5sVIzjbQhnYJuaO8nrzWujVc=";
 
   postFetch = ''
     tar -xavf $downloadedFile --strip-components=1
     substituteInPlace mailcap --replace "/usr/bin/" ""
-    gzip mailcap.4
+    gzip mailcap.5
     sh generate-nginx-mimetypes.sh < mime.types > nginx-mime.types
 
     install -D -m0644 nginx-mime.types $out/etc/nginx/mime.types
     install -D -m0644 -t $out/etc mailcap mime.types
-    install -D -m0644 -t $out/share/man/man4 mailcap.4.gz
+    install -D -m0644 -t $out/share/man/man5 mailcap.5.gz
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Replaced #112020

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
This is a semi-automatic executed nixpkgs-review with [nixpkgs-review-checks extension](https://github.com/SuperSandro2000/nixpkgs-review-checks). It is checked by a human on
 a best effort basis and does not build all packages (e.g. lumo, tensorflow or pytorch).
If you have any questions or problems please reach out to SuperSandro2000 on IRC.

Result of `nixpkgs-review pr 118631` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
<summary>
1 package built:
</summary>
<ul>
<li>wireguard-go</li>
</ul>
</details>