### PR TITLE
maintainers/team: add home-assistant team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -87,6 +87,16 @@ with lib.maintainers; {
     scope = "Maintain GNOME desktop environment and platform.";
   };
 
+  home-assistant = {
+    members = [
+      fab
+      globin
+      hexa
+      mic92
+    ];
+    scope = "Maintain the Home Assistant ecosystem";
+  };
+
   jitsi = {
     members = [
       mmilata

--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -63,7 +63,7 @@ let
   };
 
 in {
-  meta.maintainers = with maintainers; [ ];
+  meta.maintainers = teams.home-assistant.members;
 
   options.services.home-assistant = {
     enable = mkEnableOption "Home Assistant";

--- a/pkgs/servers/home-assistant/appdaemon.nix
+++ b/pkgs/servers/home-assistant/appdaemon.nix
@@ -82,6 +82,6 @@ in python.pkgs.buildPythonApplication rec {
     description = "Sandboxed Python execution environment for writing automation apps for Home Assistant";
     homepage = "https://github.com/AppDaemon/appdaemon";
     license = licenses.mit;
-    maintainers = with maintainers; [ peterhoeg ] ++ teams.home-assistant.members;
+    maintainers = teams.home-assistant.members;
   };
 }

--- a/pkgs/servers/home-assistant/appdaemon.nix
+++ b/pkgs/servers/home-assistant/appdaemon.nix
@@ -82,6 +82,6 @@ in python.pkgs.buildPythonApplication rec {
     description = "Sandboxed Python execution environment for writing automation apps for Home Assistant";
     homepage = "https://github.com/AppDaemon/appdaemon";
     license = licenses.mit;
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg ] ++ teams.home-assistant.members;
   };
 }

--- a/pkgs/servers/home-assistant/cli.nix
+++ b/pkgs/servers/home-assistant/cli.nix
@@ -36,6 +36,6 @@ python3.pkgs.buildPythonApplication rec {
     description = "Command-line tool for Home Assistant";
     homepage = "https://github.com/home-assistant/home-assistant-cli";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = teams.home-assistant.members;
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -396,7 +396,7 @@ in with py.pkgs; buildPythonApplication rec {
     homepage = "https://home-assistant.io/";
     description = "Open source home automation that puts local control and privacy first";
     license = licenses.asl20;
-    maintainers = with maintainers; [ globin mic92 hexa ];
+    maintainers = teams.home-assistant.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     description = "Polymer frontend for Home Assistant";
     homepage = "https://github.com/home-assistant/home-assistant-polymer";
     license = licenses.asl20;
-    maintainers = with maintainers; [ globin ];
+    maintainers = teams.home-assistant.members;
   };
 }


### PR DESCRIPTION
With #118503 alot of packages were left without maintainers. It is clear that an ecosystem like home-assistant should be maintained by multiple people, so a home-assistant team isn't too far fetched I hope.

This is purely opt-in, I haven't migrated anyone into the team yet, but I'd hope some of you might want to join me.

@globin 
@Mic92
@fabaff 

and possibly others I've missed.