### PR TITLE
grit: init at 0.2.0

### DIFF
--- a/pkgs/tools/misc/grit/default.nix
+++ b/pkgs/tools/misc/grit/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "grit";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "climech";
+    repo = "grit";
+    rev = "v${version}";
+    sha256 = "0v4i8xdf1pgkmwad5jb6n6s4rx48zk57wij0ppzg6zb725wy7r8a";
+  };
+
+  vendorSha256 = "0a1lqfn710fgvrvbimd92102fhjs1wa7r8i0l7s5m7jxks629hw8";
+
+  meta = with lib; {
+    description = "A multitree-based personal task manager";
+    homepage = "https://github.com/climech/grit";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2568,6 +2568,8 @@ in
 
   gringo = callPackage ../tools/misc/gringo { };
 
+  grit = callPackage ../tools/misc/grit { };
+
   grobi = callPackage ../tools/X11/grobi { };
 
   gscan2pdf = callPackage ../applications/graphics/gscan2pdf { };


### PR DESCRIPTION

###### Motivation for this change
[grit](https://github.com/climech/grit) is a interesting package for managing TODO lists.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
