### PR TITLE
antsimulator: init at 1.2

### DIFF
--- a/pkgs/games/antsimulator/default.nix
+++ b/pkgs/games/antsimulator/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, cmake, sfml }:
+
+stdenv.mkDerivation rec {
+  pname = "antsimulator";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "johnBuffer";
+    repo = "AntSimulator";
+    rev = "v${version}";
+    sha256 = "0wz80971rf86kb7mcnxwrq75vriwhmyir5s5n3wzml12rzfnj5f1";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ sfml ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -Dm755 ./AntSimulator $out/bin/antsimulator
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/johnBuffer/AntSimulator";
+    description = "Simple Ants simulator";
+    license = licenses.free;
+    maintainers = with maintainers; [ ivar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -154,6 +154,8 @@ in
 
   ankisyncd = callPackage ../servers/ankisyncd { };
 
+  antsimulator = callPackage ../games/antsimulator { };
+
   fiche = callPackage ../servers/fiche { };
 
   fishnet = callPackage ../servers/fishnet { };


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
