### PR TITLE
qqc2-breeze-style: init at 5.21.3

### DIFF
--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -138,6 +138,7 @@ let
       plasma-workspace-wallpapers = callPackage ./plasma-workspace-wallpapers.nix {};
       polkit-kde-agent = callPackage ./polkit-kde-agent.nix {};
       powerdevil = callPackage ./powerdevil.nix {};
+      qqc2-breeze-style = callPackage ./qqc2-breeze-style.nix {};
       sddm-kcm = callPackage ./sddm-kcm.nix {};
       systemsettings = callPackage ./systemsettings.nix {};
       xdg-desktop-portal-kde = callPackage ./xdg-desktop-portal-kde.nix {};

--- a/pkgs/desktops/plasma-5/qqc2-breeze-style.nix
+++ b/pkgs/desktops/plasma-5/qqc2-breeze-style.nix
@@ -1,0 +1,26 @@
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, kconfig
+, kconfigwidgets
+, kdoctools
+, kguiaddons
+, kiconthemes
+, kirigami2
+, qtquickcontrols2
+, qtx11extras
+}:
+
+mkDerivation {
+  name = "qqc2-breeze-style";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    kconfig
+    kconfigwidgets
+    kguiaddons
+    kiconthemes
+    kirigami2
+    qtquickcontrols2
+    qtx11extras
+  ];
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -975,6 +975,7 @@ mapAliases ({
     plasma-vault
     plasma-workspace plasma-workspace-wallpapers
     polkit-kde-agent powerdevil
+    qqc2-breeze-style
     sddm-kcm systemsettings
     xdg-desktop-portal-kde
   ;


### PR DESCRIPTION
###### Motivation for this change

For plasma mobile so I'm guessing @samueldr might be interested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
