### PR TITLE
yoda: 1.8.5 -> 1.9.0

### DIFF
--- a/pkgs/development/libraries/physics/yoda/default.nix
+++ b/pkgs/development/libraries/physics/yoda/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "yoda";
-  version = "1.8.5";
+  version = "1.9.0";
 
   src = fetchurl {
     url = "https://www.hepforge.org/archive/yoda/YODA-${version}.tar.bz2";
-    sha256 = "1z9jmabsaddhs003zzq73fpq2absd12rnc2sa5qn45zwf62nnbjc";
+    sha256 = "1x7xi6w7lb92x8202kbaxgqg1sly534wana4f38l3gpbzw9dwmcs";
   };
 
   nativeBuildInputs = with python.pkgs; [ cython makeWrapper ];
@@ -39,7 +39,5 @@ stdenv.mkDerivation rec {
     homepage    = "https://yoda.hepforge.org";
     platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ veprbl ];
-    # https://gitlab.com/hepcedar/yoda/-/issues/24
-    broken      = withRootSupport;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New release

* Add missing inline declarations to free IO functions.
* Add fillDim() methods to the Bin, Bin1D and Bin2D classes.
* Rename the Point getParentAO etc. to getParent, using the new
  Scatter base, and improve the accessor methods.
* Add Scatter base class to the Scatter classes, with rmPoints()
  implemented there.
* Add Binned and Fillable base classes, the former introducing the
  fillDim() method and rmBin(), and use them as ABCs for the
  counter, histo and profile types.
* Allow YODA's Python interface to read from StringIO and FileIO objects.
* Add rmPoint() and rmPoints() methods on all Scatter types.
* Change scaleDim() to scale() for points and scatters
* Remove ROOT5 compatibility, and handle 6.22 change in PyROOT.
* Fix out-of-source builds re. bash completions.
* Fixes to the Profile1D Python interface.
* Add <limits> header include to AnalysisObject.h to support GCC11
  (cf. http://gcc.gnu.org/gcc-11/porting_to.html)
* Restructure yodamerge to use pairwise merges, avoiding
  simultaneous loading of all the input files and greatly speeding
  up processing. Simultaneous simplification by replacement of
  yodamerge stacking functionality with yodastack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
