### PR TITLE
ocamlPackages.ocamlnet: 4.1.8 → 4.1.9

### DIFF
--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, pkg-config, ncurses, ocaml, findlib, ocaml_pcre, camlzip
+{ stdenv, lib, fetchurl, pkg-config, which, ncurses, ocaml, findlib, ocaml_pcre, camlzip
 , gnutls, nettle
 }:
 
@@ -8,14 +8,14 @@ else
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-ocamlnet-${version}";
-  version = "4.1.8";
+  version = "4.1.9";
 
   src = fetchurl {
     url = "http://download.camlcity.org/download/ocamlnet-${version}.tar.gz";
-    sha256 = "1x703mjqsv9nvffnkj5i36ij2s5zfvxxll2z1qj6a7p428b2yfnm";
+    sha256 = "1vlwxjxr946gdl61a1d7yk859cijq45f60dhn54ik3w4g6cx33pr";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config which ];
   buildInputs = [ ncurses ocaml findlib ocaml_pcre camlzip gnutls nettle ];
 
   createFindlibDestdir = true;


### PR DESCRIPTION
###### Motivation for this change

Fixes & support for OCaml 4.12: https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/blob/ocamlnet-4.1.9/code/ChangeLog

cc maintainer @maggesi

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
