### PR TITLE
nixos/networkmanager: add missing kernel module for wpa authentication

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -484,6 +484,8 @@ in {
       })
     ];
 
+    boot.kernelModules = [ "ctr" ];
+
     security.polkit.extraConfig = polkitConf;
 
     services.dbus.packages = cfg.packages


### PR DESCRIPTION
###### Motivation for this change

When using [hardened profile](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/hardened.nix) `security.lockKernelModules = mkDefault true` gets set. So now if you want to connect to a wifi with a passcode `wpa_supplicant` will always fail with the message `WPA: 4-Way Handshake failed - pre-shared key may be incorrect`. The reason for this is that it can't load the required kernel driver [ctr](https://cateee.net/lkddb/web-lkddb/CRYPTO_CTR.html).

After adding `boot.kernelModules = [ "ctr" ]` to my config it worked with no further issues.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
