### PR TITLE
python3Packages.holidays: 0.10.5.2 -> 0.11.1

### DIFF
--- a/pkgs/development/python-modules/holidays/default.nix
+++ b/pkgs/development/python-modules/holidays/default.nix
@@ -1,31 +1,24 @@
 { lib
 , buildPythonPackage
-, fetchPypi
 , convertdate
 , dateutil
+, fetchPypi
 , hijri-converter
 , korean-lunar-calendar
+, pytestCheckHook
+, pythonOlder
 , six
-, python
-, flake8
 }:
 
 buildPythonPackage rec {
   pname = "holidays";
-  version = "0.10.5.2";
+  version = "0.11.1";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0g4hqbb94cwxlcwsjzrzxzlann1ks2r4mgnfzqz74a2rg1nih5zd";
+    sha256 = "sha256-f6/YRvZ/Drfh+cGcOPSnlnvweu1d7S3XqKovk3sOoBs=";
   };
-
-  postPatch = ''
-    # ignore too long line issues
-    # https://github.com/dr-prodigy/python-holidays/issues/423
-    substituteInPlace tests.py \
-      --replace "flake8.get_style_guide(ignore=[" "flake8.get_style_guide(ignore=['E501', "
-  '';
-
 
   propagatedBuildInputs = [
     convertdate
@@ -36,12 +29,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    flake8
+    pytestCheckHook
   ];
-
-  checkPhase = ''
-    ${python.interpreter} -m unittest
-  '';
 
   pythonImportsCheck = [ "holidays" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.11.1

Change log: https://github.com/dr-prodigy/python-holidays/blob/master/CHANGES

The project migrated to `pytest` and dropped support for Python 2.x in an older release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
