### PR TITLE
Django: 2.2.19 -> 2.2.20; 3.1.7 -> 3.2; asgiref: 3.3.1 -> 3.3.2

### DIFF
--- a/pkgs/development/python-modules/asgiref/default.nix
+++ b/pkgs/development/python-modules/asgiref/default.nix
@@ -9,7 +9,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "3.3.1";
+  version = "3.3.4";
   pname = "asgiref";
 
   disabled = pythonOlder "3.5";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "django";
     repo = pname;
     rev = version;
-    sha256 = "00r4l9x425wkbac6b6c2ksm2yjinrvvdf0ajizrzq32h0jg82016";
+    sha256 = "1rr76252l6p12yxc0q4k9wigg1jz8nsqga9c0nixy9q77zhvh9n2";
   };
 
   propagatedBuildInputs = [ async-timeout ];

--- a/pkgs/development/python-modules/django/2.nix
+++ b/pkgs/development/python-modules/django/2.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "Django";
-  version = "2.2.19";
+  version = "2.2.20";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0hysjf8bz4g8xrn2cdx6pmawimpyr6ag2fg3jxsnc1byr3g3bhih";
+    sha256 = "0r3a6gbhwngxl172yy6n0sq5knibl2vxc0wbk1g8licfbzfgjs95";
   };
 
   patches = lib.optional withGdal

--- a/pkgs/development/python-modules/django/3.nix
+++ b/pkgs/development/python-modules/django/3.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "Django";
-  version = "3.1.7";
+  version = "3.2";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "32ce792ee9b6a0cbbec340123e229ac9f765dff8c2a4ae9247a14b2ba3a365a7";
+    sha256 = "179qdxa438fnycnnf1j5z6359h1kbp2q7djf01v5jrr26xjgkw11";
   };
 
   patches = lib.optional withGdal


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.djangoproject.com/weblog/2021/apr/06/security-releases/
https://www.djangoproject.com/weblog/2021/apr/06/django-32-released/

Django 3.2 required an asgiref update.
https://github.com/django/asgiref/blob/34d1602c90ff1f5f0ca70919bc9c6a268285f80a/CHANGELOG.txt#L1-L14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
