### PR TITLE
python3Packages.pytube: 10.6.1 -> 10.7.1

### DIFF
--- a/pkgs/development/python-modules/pytube/default.nix
+++ b/pkgs/development/python-modules/pytube/default.nix
@@ -2,13 +2,12 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, typing-extensions
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pytube";
-  version = "10.6.1";
+  version = "10.7.1";
 
   disabled = pythonOlder "3.6";
 
@@ -16,7 +15,7 @@ buildPythonPackage rec {
     owner = "pytube";
     repo = "pytube";
     rev = "v${version}";
-    sha256 = "sha256-b0tN4m3/+K243zQ7L4wW4crk9r69Tj64is6C4I5oFZU=";
+    sha256 = "sha256-a9MYEQFJXfPXYkWiuZkjt/PGs73Dm5614/Xvv6Nn8RA=";
   };
 
   checkInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
