### PR TITLE
[20.09] mpv: backport security fix

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -196,13 +196,17 @@ in stdenv.mkDerivation rec {
     python3 TOOLS/osxbundle.py -s build/mpv
   '';
 
-  patches = stdenv.lib.optionals stdenv.isDarwin [
+  patches = (stdenv.lib.optionals stdenv.isDarwin [
     # Fix cocoa backend. Remove with the next release
     (fetchpatch {
       url = "https://github.com/mpv-player/mpv/commit/188169854313b99d01da8f69fe129f0a487eb7c4.patch";
       sha256 = "062sz4666prb2wg1rn5q8brqkzlq6lxn8sxic78a8lb0125c01f7";
     })
-  ];
+  ]) ++ [
+    (fetchpatch {
+      url = "https://github.com/mpv-player/mpv/commit/d0c530919d8cd4d7a774e38ab064e0fabdae34e6.patch";
+      sha256 = "1cxfdvzxm963kaiign876ypbr1zs762vr5bcww0mc9spgdxzjcx2";
+    })];
 
   postInstall = ''
     # Use a standard font


### PR DESCRIPTION
Version 0.33.1 fixes a security vulnerability. See
https://github.com/mpv-player/mpv/releases/tag/v0.33.1 for more
information.

(cherry picked from commit ff4e2fa19d35e7d8b9311e6788411a04ed47d582)

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/118639

@cript0nauta we can do 0.33.1 or patch, i don't have a specific preference
(I saw your comment as I was writing this)

###### Things done
cherry-pick

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
