### PR TITLE
ruby_3_0: 3.0.0 -> 3.0.1

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -265,10 +265,10 @@ in {
   };
 
   ruby_3_0 = generic {
-    version = rubyVersion "3" "0" "0" "";
+    version = rubyVersion "3" "0" "1" "";
     sha256 = {
-      src = "0a4fmxafxvkg1m738g2lmkhipwnmd96kzqy1m9kvk3n1l50x2gm1";
-      git = "0fvnxv97m94nridlc5nvvrlg53pr5g042dkfc5ysd327s7xj4cjp";
+      src = "09vpnxxcxc46qv40xbxr9xkdpbgb0imdy25l2vpsxxlr47djb61n";
+      git = "0vricyhnnczcbsgvz65pdhi9yx1i34zarbjlc5y5mcmj01y9r7ar";
     };
   };
 }

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -11,7 +11,7 @@
     "${patchSet}/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch"
   ];
-  "3.0.0" = ops useRailsExpress [
+  "3.0.1" = ops useRailsExpress [
     "${patchSet}/patches/ruby/3.0/head/railsexpress/01-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/3.0/head/railsexpress/02-malloc-trim.patch"
   ];


### PR DESCRIPTION
###### Motivation for this change
https://www.ruby-lang.org/en/news/2021/04/05/ruby-3-0-1-released/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
