### PR TITLE
materialize: init at 0.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7563,6 +7563,12 @@
     githubId = 28323;
     name = "Peter Simons";
   };
+  petrosagg = {
+    email = "petrosagg@gmail.com";
+    github = "petrosagg";
+    githubId = 939420;
+    name = "Petros Angelatos";
+  };
   petterstorvik = {
     email = "petterstorvik@gmail.com";
     github = "storvik";

--- a/pkgs/servers/sql/materialize/default.nix
+++ b/pkgs/servers/sql/materialize/default.nix
@@ -1,0 +1,91 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchzip
+, rustPlatform
+, bootstrap_cmds
+, DiskArbitration
+, Foundation
+, cmake
+, libiconv
+, openssl
+, perl
+, pkg-config}:
+
+let
+  fetchNpmPackage = {name, version, hash, js_prod_file, js_dev_file, ...} @ args:
+  let
+    package = fetchzip {
+      url = "https://registry.npmjs.org/${name}/-/${baseNameOf name}-${version}.tgz";
+      inherit hash;
+    };
+
+    static = "./src/materialized/src/http/static";
+    cssVendor = "./src/materialized/src/http/static/css/vendor";
+    jsProdVendor = "./src/materialized/src/http/static/js/vendor";
+    jsDevVendor = "./src/materialized/src/http/static-dev/js/vendor";
+
+    files = with args; [
+      { src = js_prod_file; dst = "${jsProdVendor}/${name}.js"; }
+      { src = js_dev_file;  dst = "${jsDevVendor}/${name}.js"; }
+    ] ++ lib.optional (args ? css_file) { src = css_file; dst = "${cssVendor}/${name}.css"; }
+      ++ lib.optional (args ? extra_file) { src = extra_file.src; dst = "${static}/${extra_file.dst}"; };
+  in
+    lib.concatStringsSep "\n" (lib.forEach files ({src, dst}: ''
+      mkdir -p "${dirOf dst}"
+      cp "${package}/${src}" "${dst}"
+    ''));
+
+  npmPackages = import ./npm_deps.nix;
+in
+rustPlatform.buildRustPackage rec {
+  pname = "materialize";
+  version = "0.7.1";
+  rev = "f4bd159fa73d37d44f8ed3f1db13c0c2ff85566f";
+
+  src = fetchFromGitHub {
+    owner = "MaterializeInc";
+    repo = pname;
+    inherit rev;
+    hash = "sha256-8nonB/KRv4qOGvJhh0v3UwlBzAXfzb3afeCm/7/E0AU=";
+  };
+
+  cargoSha256 = "sha256-5slgICqLZFqxPymgHvq98BtcD70hfJMr36pvAoQKEJ4=";
+
+  nativeBuildInputs = [ cmake perl pkg-config ]
+    # Provides the mig command used by the krb5-src build script
+    ++ lib.optional stdenv.isDarwin bootstrap_cmds;
+
+  buildInputs = [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv DiskArbitration Foundation ];
+
+  # Skip tests that use the network
+  checkFlags = [
+    "--exact"
+    "--skip test_client"
+    "--skip test_client_errors"
+    "--skip test_no_block"
+  ];
+
+  postPatch = ''
+    ${lib.concatStringsSep "\n" (map fetchNpmPackage npmPackages)}
+    substituteInPlace ./misc/dist/materialized.service \
+      --replace /usr/bin $out/bin \
+      --replace _Materialize root
+  '';
+
+  MZ_DEV_BUILD_SHA = rev;
+  cargoBuildFlags = [ "--package materialized" ];
+
+  postInstall = ''
+    install --mode=444 -D ./misc/dist/materialized.service $out/etc/systemd/system/materialized.service
+  '';
+
+  meta = with lib; {
+    homepage    = "https://materialize.com";
+    description = "A streaming SQL materialized view engine for real-time applications";
+    license     = licenses.bsl11;
+    platforms   = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = [ maintainers.petrosagg ];
+  };
+}

--- a/pkgs/servers/sql/materialize/npm_deps.nix
+++ b/pkgs/servers/sql/materialize/npm_deps.nix
@@ -1,0 +1,62 @@
+# materialized doesn't use npm to pull in its few node dependencies but instead
+# manually pulls the tar archives for each package and pulls out a couple of
+# files.
+#
+# The list of modules can be found in this file
+# https://github.com/MaterializeInc/materialize/blob/master/src/materialized/build/npm.rs
+[
+  {
+    name = "@hpcc-js/wasm";
+    version = "0.3.14";
+    hash = "sha256-EsbuFk9qtlm9yWpG29RnqVAHrP0rk3xyibQLy8qgRT4=";
+    js_prod_file = "dist/index.min.js";
+    js_dev_file = "dist/index.js";
+    extra_file = {
+      src = "dist/graphvizlib.wasm";
+      dst = "js/vendor/@hpcc-js/graphvizlib.wasm";
+    };
+  }
+  {
+    name = "babel-standalone";
+    version = "6.26.0";
+    hash = "sha256-zdeTj4aOEzWvrnh90T80jL+RD8qg8PaeG0Ceua82Dz4=";
+    js_prod_file = "babel.min.js";
+    js_dev_file = "babel.js";
+  }
+  {
+    name = "d3";
+    version = "5.16.0";
+    hash = "sha256-aQQRhnJxV5/9C+cQslctP3v/AePGfbSw8L3chObJzK4=";
+    js_prod_file = "dist/d3.min.js";
+    js_dev_file = "dist/d3.js";
+  }
+  {
+    name = "d3-flame-graph";
+    version = "3.1.1";
+    hash = "sha256-Ls3MqALr6+/A+n8jqFw7frIB++6d1W3lAXKU0qFZ2ok=";
+    css_file = "dist/d3-flamegraph.css";
+    js_prod_file = "dist/d3-flamegraph.min.js";
+    js_dev_file = "dist/d3-flamegraph.js";
+  }
+  {
+    name = "pako";
+    version = "1.0.11";
+    hash = "sha256-St7nKpcYlJQl8qMmPkEHwmTufOHAeZK4lBZHo8VRXLA=";
+    js_prod_file = "dist/pako.min.js";
+    js_dev_file = "dist/pako.js";
+  }
+  {
+    name = "react";
+    version = "16.14.0";
+    hash = "sha256-X/8Bc4XvC8IqQWbW/PCRJQpmOBI/0AZT/hSFBf/uJU8=";
+    js_prod_file = "umd/react.production.min.js";
+    js_dev_file = "umd/react.development.js";
+  }
+  {
+    name = "react-dom";
+    version = "16.14.0";
+    hash = "sha256-2mYm9dwBFrWws6CB5bL6ghROTzX84RLM31hdnEbhG10=";
+    js_prod_file = "umd/react-dom.production.min.js";
+    js_dev_file = "umd/react-dom.development.js";
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18549,6 +18549,11 @@ in
     nodejs-slim = nodejs-slim-12_x;
   };
 
+  materialize = callPackage ../servers/sql/materialize {
+    inherit (buildPackages.darwin) bootstrap_cmds;
+    inherit (darwin.apple_sdk.frameworks) DiskArbitration Foundation;
+  };
+
   mattermost = callPackage ../servers/mattermost { };
   matterircd = callPackage ../servers/mattermost/matterircd.nix { };
   matterbridge = callPackage ../servers/matterbridge { };


### PR DESCRIPTION
###### Motivation for this change

Make materialize available though nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
