### PR TITLE
kubelogin-oidc: init at 1.23.0

### DIFF
--- a/pkgs/applications/networking/cluster/kubelogin-oidc/default.nix
+++ b/pkgs/applications/networking/cluster/kubelogin-oidc/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubelogin";
+  version = "1.23.0";
+
+  src = fetchFromGitHub {
+    owner = "int128";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0n94nx17c6ln2nd6d9yr93vc251y1xphq1wj2vzs4j2l8dqfyjpn";
+  };
+
+  subPackages = ["."];
+
+  vendorSha256 = "1dvrk6z6k66wawgb50n8hbgdd8fly399mlbgnvxi671vfi7lkz09";
+
+  # Rename the binary instead of symlinking to avoid conflict with the
+  # Azure version of kubelogin
+  postInstall = ''
+    mv $out/bin/kubelogin $out/bin/kubectl-oidc_login
+  '';
+
+  meta = with lib; {
+    description = "A Kubernetes credential plugin implementing OpenID Connect (OIDC) authentication";
+    inherit (src.meta) homepage;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ benley ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23832,6 +23832,8 @@ in
 
   kubelogin = callPackage ../applications/networking/cluster/kubelogin { };
 
+  kubelogin-oidc = callPackage ../applications/networking/cluster/kubelogin-oidc { };
+
   k9s = callPackage ../applications/networking/cluster/k9s { };
 
   pgo-client = callPackage ../applications/networking/cluster/pgo-client { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
