### PR TITLE
umoci: 0.4.6 -> 0.4.7

### DIFF
--- a/pkgs/applications/virtualization/umoci/default.nix
+++ b/pkgs/applications/virtualization/umoci/default.nix
@@ -3,17 +3,18 @@
 , buildGoModule
 , go-md2man
 , installShellFiles
+, bash
 }:
 
 buildGoModule rec {
   pname = "umoci";
-  version = "0.4.6";
+  version = "0.4.7";
 
   src = fetchFromGitHub {
     owner = "opencontainers";
     repo = "umoci";
     rev = "v${version}";
-    sha256 = "0jaar26l940yh77cs31c3zndiycp85m3fz4zivcibzi68g6n6yzg";
+    sha256 = "0in8kyi4jprvbm3zsl3risbjj8b0ma62yl3rq8rcvcgypx0mn7d4";
   };
 
   vendorSha256 = null;
@@ -25,7 +26,8 @@ buildGoModule rec {
   nativeBuildInputs = [ go-md2man installShellFiles ];
 
   postInstall = ''
-    sed -i '/SHELL =/d' Makefile
+    substituteInPlace Makefile --replace \
+      '$(shell which bash)' '${lib.getBin bash}/bin/bash'
     make docs
     installManPage doc/man/*.[1-9]
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.openwall.com/lists/oss-security/2021/04/06/2

Fixes: CVE-2021-29136

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
