### PR TITLE
pipewire: 0.3.24 -> 0.3.25

### DIFF
--- a/nixos/modules/services/desktops/pipewire/bluez-monitor.conf.json
+++ b/nixos/modules/services/desktops/pipewire/bluez-monitor.conf.json
@@ -8,7 +8,13 @@
         }
       ],
       "actions": {
-        "update-props": {}
+        "update-props": {
+          "bluez5.reconnect-profiles": [
+            "hfp_hf",
+            "hsp_hs",
+            "a2dp_sink"
+          ]
+        }
       }
     },
     {

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitLab
-, fetchpatch
 , removeReferencesTo
 , meson
 , ninja
@@ -43,7 +42,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.24";
+    version = "0.3.25";
 
     outputs = [
       "out"
@@ -61,7 +60,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      hash = "sha256:PcY20FTtUtJYAwCscEs+HfkdwDksYPFZIVTVORP1ooI=";
+      hash = "sha256:EbXWcf6QLtbvm6/eXBI+PF2sTw2opYfmc+H/SMDEH1U=";
     };
 
     patches = [
@@ -75,11 +74,6 @@ let
       ./0070-installed-tests-path.patch
       # Add flag to specify configuration directory (different from the installation directory).
       ./0080-pipewire-config-dir.patch
-      # Fix JSON parser.
-      (fetchpatch {
-        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/34800dc0191a4ee7a329eeb361a6f2ccf4a75176.diff";
-        sha256 = "0dzxzr408qqzf0252nwg14709p1lb2k826i3kdzg6djq8w98d5aj";
-      })
     ];
 
     nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.25


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
