### PR TITLE
home-assistant: error out if enabled component test does not exist

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -383,6 +383,14 @@ in with py.pkgs; buildPythonApplication rec {
   preCheck = ''
     # the tests require the existance of a media dir
     mkdir /build/media
+
+    # error out when component test directory is missing, otherwise hidden by xdist execution :(
+    for component in ${lib.concatStringsSep " " (map lib.escapeShellArg componentTests)}; do
+      test -d "tests/components/$component" || {
+        >2& echo "ERROR: Tests for component '$component' were enabled, but they do not exist!"
+        exit 1
+      }
+    done
   '';
 
   passthru = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Unfortunately enabling xdist hides the error away and the tests fail
abruptly with no clear indication of what went wrong.

Only after disabling xdist (`-n auto`, `--dist loadfile`) you would see

> ERROR: file or directory not found: tests/components/openhome

https://github.com/NixOS/nixpkgs/pull/118453#issuecomment-814491608

```
Executing pytestCheckPhase
ERROR: Tests for component 'openhome' were enabled, but they do not exist!
builder for '/nix/store/jk08ik37iyivwb7n4x6vxqndzsw38vwp-homeassistant-2021.3.4.drv' failed with exit code 1
error: build of '/nix/store/jk08ik37iyivwb7n4x6vxqndzsw38vwp-homeassistant-2021.3.4.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
