### PR TITLE
 rkdeveloptool: unstable-2019-07-01 -> unstable-2021-02-03, fix build

### DIFF
--- a/pkgs/misc/rkdeveloptool/default.nix
+++ b/pkgs/misc/rkdeveloptool/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "rkdeveloptool";
-  version = "unstable-2019-07-01";
+  version = "unstable-2021-02-03";
 
   src = fetchFromGitHub {
     owner = "rockchip-linux";
     repo = "rkdeveloptool";
-    rev = "6e92ebcf8b1812da02663494a68972f956e490d3";
-    sha256 = "0zwrkqfxd671iy69v3q0844gfdpm1yk51i9qh2rqc969bd8glxga";
+    rev = "e607a5d6ad3f6af66d3daf3f6370e6dc9763a20d";
+    sha256 = "08m0yfds5rpr5l0s75ynfarq3hrv94l3aadld17cz5gqapqcfs2n";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];

--- a/pkgs/misc/rkdeveloptool/default.nix
+++ b/pkgs/misc/rkdeveloptool/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ libusb1 ];
 
+  # main.cpp:1568:36: error: '%s' directive output may be truncated writing up to 557 bytes into a region of size 5
+  CPPFLAGS = "-Wno-error=format-truncation";
+
   meta = with lib; {
     homepage = "https://github.com/rockchip-linux/rkdeveloptool";
     description = "A tool from Rockchip to communicate with Rockusb devices";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update rkdeveloptool and pass `-Wno-error=format-truncation` to fix build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @stigtsp @execat