### PR TITLE
monitoring-plugins: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -1,86 +1,120 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, runCommand
-, coreutils, gnugrep, gnused, lm_sensors, net-snmp, openssh, openssl, perl
-, dnsutils, libdbi, libmysqlclient, zlib, openldap, procps
-, runtimeShell }:
-
-with lib;
+{ lib
+, stdenv
+, fetchFromGitHub
+, writeShellScript
+, autoreconfHook
+, pkg-config
+, runCommand
+, coreutils
+, gnugrep
+, gnused
+, lm_sensors
+, net-snmp
+, openssh
+, openssl
+, perl
+, dnsutils
+, libdbi
+, libmysqlclient
+, uriparser
+, zlib
+, openldap
+, procps
+, runtimeShell
+}:
 
 let
-  majorVersion = "2.2";
-  minorVersion = ".0";
-
-  binPath = makeBinPath [ coreutils gnugrep gnused lm_sensors net-snmp procps ];
-
-in stdenv.mkDerivation {
-  name = "monitoring-plugins-${majorVersion}${minorVersion}";
-
-  src = fetchFromGitHub {
-    owner  = "monitoring-plugins";
-    repo   = "monitoring-plugins";
-    rev    = "v${majorVersion}";
-    sha256 = "1pw7i6d2cnb5nxi2lbkwps2qzz04j9zd86fzpv9ka896b4aqrwv1";
-  };
-
-  patches = [
-    # https://github.com/monitoring-plugins/monitoring-plugins/issues/1508
-    (fetchpatch {
-      url = "https://github.com/monitoring-plugins/monitoring-plugins/commit/ac0437ff896ba9ce2549b2d2ec3de146a886f08a.patch";
-      sha256 = "0jf6fqkyzag66rid92m7asnr2dp8rr8kn4zjvhqg0mqvf8imppky";
-    })
+  binPath = lib.makeBinPath [
+    (placeholder "out")
+    "/run/wrappers"
+    coreutils
+    gnugrep
+    gnused
+    lm_sensors
+    net-snmp
+    procps
   ];
 
-  # !!! Awful hack. Grrr... this of course only works on NixOS.
+  mailq = runCommand "mailq-wrapper" { preferLocalBuild = true; } ''
+    mkdir -p $out/bin
+    ln -s /run/wrappers/bin/sendmail $out/bin/mailq
+  '';
+
+  # For unknown reasons the installer tries executing $out/share and fails so
+  # we create it and remove it again later.
+  share = writeShellScript "share" ''
+    exit 0
+  '';
+
+in
+stdenv.mkDerivation rec {
+  pname = "monitoring-plugins";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "monitoring-plugins";
+    repo = "monitoring-plugins";
+    rev = "v" + lib.versions.majorMinor version;
+    sha256 = "sha256-yLhHOSrPFRjW701aOL8LPe4OnuJxL6f+dTxNqm0evIg=";
+  };
+
+  # TODO: Awful hack. Grrr... this of course only works on NixOS.
   # Anyway the check that configure performs to figure out the ping
   # syntax is totally impure, because it runs an actual ping to
   # localhost (which won't work for ping6 if IPv6 support isn't
   # configured on the build machine).
-  preConfigure= ''
+  #
+  # --with-ping-command needs to be done here instead of in
+  # configureFlags due to the spaces in the argument
+  postPatch = ''
     substituteInPlace po/Makefile.in.in \
-      --replace /bin/sh ${stdenv.shell}
+      --replace /bin/sh ${runtimeShell}
 
     sed -i configure.ac \
-      -e 's|^DEFAULT_PATH=.*|DEFAULT_PATH=\"\$out/bin:/run/wrappers/bin:${binPath}\"|'
+      -e 's|^DEFAULT_PATH=.*|DEFAULT_PATH=\"${binPath}\"|'
 
-    configureFlagsArray=(
+    configureFlagsArray+=(
       --with-ping-command='/run/wrappers/bin/ping -4 -n -U -w %d -c %d %s'
       --with-ping6-command='/run/wrappers/bin/ping -6 -n -U -w %d -c %d %s'
-      --with-sudo-command='/run/wrappers/bin/sudo'
-      --with-mailq-command='${runCommand "mailq-wrapper" {preferLocalBuild=true;} ''
-        mkdir -p $out/bin
-        ln -s /run/wrappers/bin/sendmail $out/bin/mailq
-        ''}/bin/mailq'
     )
+
+    install -Dm555 ${share} $out/share
   '';
 
-  # !!! make openssh a runtime dependency only
-  buildInputs = [ dnsutils libdbi libmysqlclient net-snmp openldap openssh openssl perl procps zlib ];
+  configureFlags = [
+    "--libexecdir=${placeholder "out"}/bin"
+    "--with-mailq-command=${mailq}/bin/mailq"
+    "--with-sudo-command=/run/wrappers/bin/sudo"
+  ];
 
-  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [
+    dnsutils
+    libdbi
+    libmysqlclient
+    net-snmp
+    openldap
+    # TODO: make openssh a runtime dependency only
+    openssh
+    openssl
+    perl
+    procps
+    uriparser
+    zlib
+  ];
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   enableParallelBuilding = true;
 
-  # For unknown reasons the installer tries executing $out/share and fails if
-  # it doesn't succeed.
-  # So we create it and remove it again later.
-  preBuild = ''
-    mkdir -p $out
-    cat <<_EOF > $out/share
-#!${runtimeShell}
-exit 0
-_EOF
-    chmod 755 $out/share
-  '';
-
   postInstall = ''
     rm $out/share
-    ln -s libexec $out/bin
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Official monitoring plugins for Nagios/Icinga/Sensu and others";
-    homepage    = "https://www.monitoring-plugins.org";
-    license     = licenses.gpl2;
-    platforms   = platforms.linux;
+    homepage = "https://www.monitoring-plugins.org";
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ thoughtpolice relrod ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream update and cleanups.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I haven't tried everything in here yet - we will be doing a test deployment next week.