### PR TITLE
nixos/home-assistant: use override before overridePythonAttrs

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -50,9 +50,14 @@ let
   # List of components used in config
   extraComponents = filter useComponent availableComponents;
 
-  package = if (cfg.autoExtraComponents && cfg.config != null)
+  testedPackage = if (cfg.autoExtraComponents && cfg.config != null)
     then (cfg.package.override { inherit extraComponents; })
     else cfg.package;
+
+  # overridePythonAttrs has to be applied after override
+  package = testedPackage.overridePythonAttrs (oldAttrs: {
+    doCheck = false;
+  });
 
   # If you are changing this, please update the description in applyDefaultConfig
   defaultConfig = {
@@ -183,13 +188,9 @@ in {
     };
 
     package = mkOption {
-      default = pkgs.home-assistant.overridePythonAttrs (oldAttrs: {
-        doCheck = false;
-      });
+      default = pkgs.home-assistant;
       defaultText = literalExample ''
-        pkgs.home-assistant.overridePythonAttrs (oldAttrs: {
-          doCheck = false;
-        })
+        pkgs.home-assistant
       '';
       type = types.package;
       example = literalExample ''
@@ -198,10 +199,12 @@ in {
         }
       '';
       description = ''
-        Home Assistant package to use. By default the tests are disabled, as they take a considerable amout of time to complete.
+        Home Assistant package to use. Tests are automatically disabled, as they take a considerable amout of time to complete.
         Override <literal>extraPackages</literal> or <literal>extraComponents</literal> in order to add additional dependencies.
         If you specify <option>config</option> and do not set <option>autoExtraComponents</option>
         to <literal>false</literal>, overriding <literal>extraComponents</literal> will have no effect.
+        Avoid <literal>home-assistant.overridePythonAttrs</literal> if you use
+        <literal>autoExtraComponents</literal>.
       '';
     };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/commit/f9bd8b1b7bda019a823e93a0ecb719e15ac620cb#commitcomment-49202157
@sweber83 Can you check whether this fixes it?

I think you can't use `override` after using `overridePythonAttrs`. I had the same problem in https://github.com/NixOS/nixpkgs/pull/118391#issuecomment-812917419.
cc @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
