### PR TITLE
electron-cash: 4.2.0 -> 4.2.4 and fix build

### DIFF
--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -3,35 +3,45 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "electron-cash";
-  version = "4.2.0";
+  version = "4.2.4";
 
   src = fetchFromGitHub {
     owner = "Electron-Cash";
     repo = "Electron-Cash";
     rev = version;
-    sha256 = "0ixsx4224jilc5zis6wbsbxqxv10mm5sksrzq15xp30zz0bzb6md";
+    sha256 = "sha256-hiOS0cTaPqllb31p+6nU4GYvw/E1Hdn8yd3sppzGkqg=";
   };
 
   propagatedBuildInputs = with python3Packages; [
-    dnspython
-    ecdsa
-    jsonrpclib-pelix
-    matplotlib
-    pbkdf2
+    # requirements
     pyaes
-    pycrypto
-    pyqt5
-    pysocks
-    qrcode
+    ecdsa
     requests
-    tlslite-ng
+    qrcode
+    protobuf
+    jsonrpclib-pelix
+    pysocks
     qdarkstyle
+    python-dateutil
     stem
+    certifi
+    pathvalidate
+    dnspython
 
-    # plugins
-    keepkey
+    # requirements-binaries
+    pyqt5
+    psutil
+    pycryptodomex
+    cryptography
+
+    # requirements-hw
+    cython
     trezor
+    keepkey
     btchip
+    hidapi
+    pyscard
+    pysatochip
   ];
 
   nativeBuildInputs = [ wrapQtAppsHook ];
@@ -83,7 +93,7 @@ python3Packages.buildPythonApplication rec {
     '';
     homepage = "https://www.electroncash.org/";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ lassulus nyanloutre ];
+    maintainers = with maintainers; [ lassulus nyanloutre oxalica ];
     license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/pathvalidate/default.nix
+++ b/pkgs/development/python-modules/pathvalidate/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "pathvalidate";
+  version = "2.4.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-PJvZTH7CPpz7IR/741audfl51sCZosdF7pSQ9STzJGg=";
+  };
+
+  # Requires `pytest-md-report`, causing infinite recursion.
+  doCheck = false;
+
+  pythonImportsCheck = [ "pathvalidate" ];
+
+  meta = with lib; {
+    description = "A Python library to sanitize/validate a string such as filenames/file-paths/etc";
+    homepage = "https://github.com/thombashi/pathvalidate";
+    license = licenses.mit;
+    maintainers = with maintainers; [ oxalica ];
+  };
+}

--- a/pkgs/development/python-modules/pysatochip/default.nix
+++ b/pkgs/development/python-modules/pysatochip/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, pyscard, ecdsa, pyaes
+, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "pysatochip";
+  version = "0.11.4";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Jj/zZIS9aXmZ2xdi29Eun7iRIrIk9oBlrtN9+6opIMo=";
+  };
+
+  propagatedBuildInputs = [ pyscard ecdsa pyaes ];
+
+  pythonImportsCheck = [ "pysatochip" ];
+
+  meta = with lib; {
+    description = "Simple python library to communicate with a Satochip hardware wallet";
+    homepage = "https://github.com/Toporin/pysatochip";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ oxalica ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6255,6 +6255,8 @@ in {
     inherit (pkgs) xmlsec;
   };
 
+  pysatochip = callPackage ../development/python-modules/pysatochip { };
+
   pysc2 = callPackage ../development/python-modules/pysc2 { };
 
   pyscard = callPackage ../development/python-modules/pyscard {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4990,6 +4990,8 @@ in {
 
   pathtools = callPackage ../development/python-modules/pathtools { };
 
+  pathvalidate = callPackage ../development/python-modules/pathvalidate { };
+
   patiencediff = callPackage ../development/python-modules/patiencediff { };
 
   patool = callPackage ../development/python-modules/patool { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump.
Fix build failure on master. Fix #118692 

cc @Lassulus @nyanloutre for testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  3 packages built:
  electron-cash python38Packages.pathvalidate python39Packages.pathvalidate
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
