### PR TITLE
yubikey-manager: 3.1.2 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/aws-adfs/default.nix
+++ b/pkgs/development/python-modules/aws-adfs/default.nix
@@ -44,7 +44,9 @@ buildPythonPackage rec {
 
   # Relax version constraint
   postPatch = ''
-    sed -i 's/coverage < 4/coverage/' setup.py
+    substituteInPlace setup.py \
+      --replace 'coverage < 4' 'coverage' \
+      --replace 'fido2>=0.8.1,<0.9.0' 'fido2>=0.8.1,<1.0.0'
   '';
 
   # Test suite writes files to $HOME/.aws/, or /homeless-shelter if unset

--- a/pkgs/development/python-modules/fido2/default.nix
+++ b/pkgs/development/python-modules/fido2/default.nix
@@ -9,16 +9,26 @@
 
 buildPythonPackage rec {
   pname = "fido2";
-  version = "0.8.1";
+  version = "0.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1hzprnd407g2xh9kyv8j8pq949hwr1snmg3fp65pqfbghzv6i424";
+    hash = "sha256-hoDuJSOOIwdZbrOQCg+MDZzJEYkUbtgDlUTxo6ad/m4=";
   };
 
   propagatedBuildInputs = [ six cryptography ];
 
   checkInputs = [ mock pyfakefs ];
+
+  # Testing with `python setup.py test` doesn't work:
+  # https://github.com/Yubico/python-fido2/issues/108#issuecomment-763513576
+  checkPhase = ''
+    runHook preCheck
+
+    python -m unittest discover -v
+
+    runHook postCheck
+  '';
 
   pythonImportsCheck = [ "fido2" ];
 

--- a/pkgs/development/python-modules/makefun/default.nix
+++ b/pkgs/development/python-modules/makefun/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "makefun";
+  version = "1.11.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-2qNQpILtWLVyREPGUUMhkem5ewyDdDh50JExccaigIU=";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  # Disabling tests for now due to various (transitive) dependencies on modules
+  # from @smarie which are, as of yet, not part of nixpkgs. Also introduces
+  # a tricky dependency: makefun tests depend on pytest-cases, installing
+  # pytest-cases depends on makefun.
+  doCheck = false;
+
+  pythonImportsCheck = [ "makefun" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/smarie/python-makefun";
+    description = "Small library to dynamically create python functions";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/development/python-modules/solo-python/default.nix
+++ b/pkgs/development/python-modules/solo-python/default.nix
@@ -60,5 +60,8 @@
     homepage = "https://github.com/solokeys/solo-python";
     maintainers = with maintainers; [ wucke13 ];
     license = with licenses; [ asl20 mit ];
+    # solo-python v0.0.27 does not support fido2 >= v0.9
+    # https://github.com/solokeys/solo-python/issues/110
+    broken = true;
   };
 }

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -3,11 +3,11 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "yubikey-manager";
-  version = "3.1.2";
+  version = "4.0.1";
 
   srcs = fetchurl {
     url = "https://developers.yubico.com/${pname}/Releases/${pname}-${version}.tar.gz";
-    hash = "sha256-dwnIOuu0QyWRl6RSdyQw7dGsAZ4xpXpx6jOpCkp4efE=";
+    hash = "sha256-OxbKo5vwOBabU6/2hO4RMWiifo4IVIxz+DlcwP9xO/E=";
   };
 
   propagatedBuildInputs =

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -42,8 +42,7 @@ python3Packages.buildPythonPackage rec {
       --replace 'compdef _ykman_completion ykman;' '_ykman_completion "$@"'
   '';
 
-  # See https://github.com/NixOS/nixpkgs/issues/29169
-  doCheck = false;
+  checkInputs = with python3Packages; [ pytestCheckHook makefun ];
 
   meta = with lib; {
     homepage = "https://developers.yubico.com/yubikey-manager";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4107,6 +4107,8 @@ in {
 
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
+  makefun = callPackage ../development/python-modules/makefun { };
+
   Mako = callPackage ../development/python-modules/Mako { };
 
   managesieve = callPackage ../development/python-modules/managesieve { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update YubiKey Manager CLI to v4.0.1.

###### Things done

- Updated Python package `fido2` to v0.9.1.
- Adapt Python package `aws-adf` to the new `fido2` version.
- Pinned `fido2` to v0.8.1 for Python package `solo-python` as it [does not support >=0.9.0](https://github.com/solokeys/solo-python/issues/110).
- Updated `yubikey-manager` to `v4.0.1`.

I tested `yubikey-manager` on macOS 11.2.3 with a YubiKey 5C.

The import check for `solo.cli` for package `solo-python` fails on macOS. This seems, however, unrelated to the changes of this PR as a `nix build -L nixpkgs#python3Packages.solo-python --rebuild` results in the same error. NixOS on x86_64 works fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
