### PR TITLE
python3Packages.qiskit: 0.24.1 -> 0.25.0

### DIFF
--- a/pkgs/development/python-modules/pylatexenc/default.nix
+++ b/pkgs/development/python-modules/pylatexenc/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "pylatexenc";
-  version = "2.8";
+  version = "2.10";
 
   src = fetchFromGitHub {
     owner = "phfaist";
     repo = "pylatexenc";
     rev = "v${version}";
-    sha256 = "0m9vrbh1gmbgq6dqm7xzklar3accadw0pn896rqsdi5jbgd3w0mh";
+    hash = "sha256-3Ho04qrmCtmmrR+BUJNbtdCZcK7lXhUGJjm4yfCTUkM=";
   };
 
   pythonImportsCheck = [ "pylatexenc" ];

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aer";
-  version = "0.7.6";
+  version = "0.8.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aer";
     rev = version;
-    sha256 = "0595as4rxjrd5dqx54ywz3rjsjk0z7r41bq0z9r8y1h7zgvvlrmn";
+    hash = "sha256-CWF3ehLs0HBXnYH11r+2CQwIcxddAfQm3ulAf1agl/o=";
   };
 
   nativeBuildInputs = [
@@ -61,6 +61,7 @@ buildPythonPackage rec {
     pybind11
   ];
 
+  # tries to install pypi cmake package, not needed
   postPatch = ''
     substituteInPlace setup.py --replace "'cmake!=3.17,!=3.17.0'," ""
   '';
@@ -83,6 +84,17 @@ buildPythonPackage rec {
   disabledTests = [
     "test_paulis_1_and_2_qubits"
     "test_3d_oscillator"
+    "_057"
+    "_136"
+    "_137"
+    "_139"
+    "_138"
+    "_140"
+    "_141"
+    "_143"
+    "_144"
+    "test_sparse_output_probabilities"
+    "test_reset_2_qubit"
   ];
   checkInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/development/python-modules/qiskit-aqua/default.nix
@@ -34,7 +34,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aqua";
-  version = "0.8.2";
+  version = "0.9.0";
 
   disabled = pythonOlder "3.6";
 
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aqua";
     rev = version;
-    sha256 = "sha256-ybf8bXqsVk6quYi0vrfo/Mplk7Nr7tQS7cevXxI9khw=";
+    hash = "sha256-knue9uJih72UQHsvfXZ9AA94mol4ERa9Lo/GMcp+2hA=";
   };
 
   # Optional packages: pyscf (see below NOTE) & pytorch. Can install via pip/nix if needed.
@@ -74,7 +74,13 @@ buildPythonPackage rec {
   # We disable appropriate tests below to allow building without pyscf installed
 
   postPatch = ''
-    substituteInPlace setup.py --replace "docplex==2.15.194" "docplex"
+    # Because this is a legacy/final release, the maintainers restricted the maximum
+    # versions of all dependencies to the latest current version. That will not
+    # work with nixpkgs' rolling release/update system.
+    # Unlock all versions for compatibility
+    substituteInPlace setup.py --replace "<=" ">="
+    sed -i 's/\(\w\+-*\w*\).*/\1/' requirements.txt
+    substituteInPlace requirements.txt --replace "dataclasses" ""
 
     # Add ImportWarning when running qiskit.chemistry (pyscf is a chemistry package) that pyscf is not included
     echo -e "\nimport warnings\ntry: import pyscf;\nexcept ImportError:\n    " \

--- a/pkgs/development/python-modules/qiskit-ignis/default.nix
+++ b/pkgs/development/python-modules/qiskit-ignis/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-ignis";
-  version = "0.5.2";
+  version = "0.6.0";
 
   disabled = pythonOlder "3.6";
 
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-ignis";
     rev = version;
-    sha256 = "sha256-Kl3tnoamZrCxwoDdu8betG6Lf3CC3D8R2TYiq8Zl3Aw=";
+    hash = "sha256-L5fwCMsN03ojiDvKIyqsGfUnwej1P7bpyHlL6mu7nh0=";
   };
 
   # hacky, fix https://github.com/Qiskit/qiskit-ignis/issues/532.

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -29,8 +29,8 @@
 , withCrosstalkPass ? false
 , z3
   # Classical function -> Quantum Circuit compiler
-, withClassicalFunctionCompiler ? false
-, tweedledum ? null
+, withClassicalFunctionCompiler ? true
+, tweedledum
   # test requirements
 , ddt
 , hypothesis
@@ -56,7 +56,7 @@ in
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
-  version = "0.16.4";
+  version = "0.17.0";
 
   disabled = pythonOlder "3.6";
 
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "sha256-/rWlPfpAHoMedKG42jfUYt0Ezq7i+9dkyPllavkg4cc=";
+    hash = "sha256-LbNbaHAWAVG5YLc9juuwcOlrREBW6OjEl7VPtACfl3I=";
   };
 
   nativeBuildInputs = [ cython ];
@@ -100,15 +100,17 @@ buildPythonPackage rec {
     "qiskit.transpiler.passes.routing.cython.stochastic_swap.swap_trial"
   ];
 
-  pytestFlagsArray = [
-    "--ignore=test/randomized/test_transpiler_equivalence.py" # collection requires qiskit-aer, which would cause circular dependency
-  ] ++ lib.optionals (!withClassicalFunctionCompiler ) [
-    "--ignore=test/python/classical_function_compiler/"
+  disabledTestPaths = [
+    "test/randomized/test_transpiler_equivalence.py" # collection requires qiskit-aer, which would cause circular dependency
+  ] ++ lib.optionals (!withClassicalFunctionCompiler) [
+    "test/python/classical_function_compiler/"
   ];
   disabledTests = [
     # Flaky tests
     "test_cx_equivalence"
     "test_pulse_limits"
+  ] ++ lib.optionals (!withClassicalFunctionCompiler) [
+    "TestPhaseOracle"
   ]
   # Disabling slow tests for build constraints
   ++ [
@@ -130,6 +132,14 @@ buildPythonPackage rec {
     "test_block_collection_reduces_1q_gate"
     "test_multi_controlled_rotation_gate_matrices"
     "test_block_collection_runs_for_non_cx_bases"
+    "test_with_two_qubit_reduction"
+    "test_basic_aer_qasm"
+    "test_hhl"
+    "test_H2_hamiltonian"
+    "test_max_evals_grouped_2"
+    "test_qaoa_qc_mixer_4"
+    "test_abelian_grouper_random_2"
+    "test_pauli_two_design"
   ];
 
   # Moves tests to $PACKAGEDIR/test. They can't be run from /build because of finding

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -15,7 +15,7 @@
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "0.24.1";
+  version = "0.25.0";
 
   disabled = pythonOlder "3.6";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "qiskit";
     repo = "qiskit";
     rev = version;
-    sha256 = "0qfz69n8sl7sk4hzygni9qars9q1cyz0n3bv1lca00ia5qsc72d2";
+    hash = "sha256-pJM6d3AyFs9AexvQXG+8QQ4zwpFisJC16iBFR9gNSk0=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/quandl/default.nix
+++ b/pkgs/development/python-modules/quandl/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "quandl";
-  version = "3.5.0";
+  version = "3.6.1";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit version;
     pname = "Quandl";
-    sha256 = "0zpw0nwqr4g56l9z4my0fahfgpcmfx74acbmv6nfx1dmq5ggraf3";
+    sha256 = "0jr69fqxhzdmkfh3fxz0yp2kks2hkmixrscjjf59q2l7irglwhc4";
   };
 
   checkInputs = [
@@ -51,6 +51,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Quandl Python client library";
     homepage = "https://github.com/quandl/quandl-python";
+    changelog = "https://github.com/quandl/quandl-python/blob/master/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ ilya-kolpakov ];
   };

--- a/pkgs/development/python-modules/tweedledum/default.nix
+++ b/pkgs/development/python-modules/tweedledum/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, ninja
+, scikit-build
+}:
+
+buildPythonPackage rec {
+  pname = "tweedledum";
+  version = "1.0.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub{
+    owner = "boschmitt";
+    repo = "tweedledum";
+    rev = "v${version}";
+    hash = "sha256-59lJzdw9HLJ9ADxp/a3KW4v5aU/dYm27NSYoz9D49i4=";
+  };
+
+  nativeBuildInputs = [ cmake ninja scikit-build ];
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "tweedledum" ];
+
+  # TODO: use pytest, but had issues with finding the correct directories
+  checkPhase = ''
+    python -m unittest discover -s ./python/test -t .
+  '';
+
+  meta = with lib; {
+    description = "A library for synthesizing and manipulating quantum circuits";
+    homepage = "https://github.com/boschmitt/tweedledum";
+    license = licenses.mit ;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8565,6 +8565,8 @@ in {
 
   tvnamer = callPackage ../development/python-modules/tvnamer { };
 
+  tweedledum = callPackage ../development/python-modules/tweedledum { };
+
   tweepy = callPackage ../development/python-modules/tweepy { };
 
   twentemilieu = callPackage ../development/python-modules/twentemilieu { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/Qiskit/qiskit/releases/tag/0.25.0.

* Adds ``tweedledum``, an optional-ish dependency of ``qiskit-terra``
* Updates ``pylatexenc``

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
