### PR TITLE
virtualbox: add patch to enable building with linux kernel 5.11

### DIFF
--- a/pkgs/os-specific/linux/virtualbox/default.nix
+++ b/pkgs/os-specific/linux/virtualbox/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, virtualbox, kernel }:
+{ stdenv, virtualbox, kernel, lib }:
 
-stdenv.mkDerivation {
+let inherit (lib) optional versionAtLeast;
+
+in stdenv.mkDerivation {
   name = "virtualbox-modules-${virtualbox.version}-${kernel.version}";
   src = virtualbox.modsrc;
   hardeningDisable = [
@@ -13,6 +15,12 @@ stdenv.mkDerivation {
 
   makeFlags = [ "INSTALL_MOD_PATH=$(out)" ];
   installTargets = [ "install" ];
+
+  # VirtualBox 6.1.18 doesn't build with linux kernel 5.11.  This fix is based on
+  # the discussion at https://forums.virtualbox.org/viewtopic.php?f=7&t=101860
+  patches = optional (versionAtLeast kernel.version "5.11" && versionAtLeast "6.1.18" virtualbox.version) [
+    ./linux-kernel-5.11.patch
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/virtualbox/linux-kernel-5.11.patch
+++ b/pkgs/os-specific/linux/virtualbox/linux-kernel-5.11.patch
@@ -1,0 +1,14 @@
+diff --git a/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c b/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c
+index 8819b580a0..bf68eac2e7 100644
+--- a/vboxnetflt/linux/VBoxNetFlt-linux.c
++++ b/vboxnetflt/linux/VBoxNetFlt-linux.c
+@@ -48,6 +48,9 @@
+ #if RTLNX_VER_MIN(4,5,0)
+ #include <uapi/linux/pkt_cls.h>
+ #endif
++#if RTLNX_VER_MIN(5,11,0)
++#include <linux/ethtool.h>
++#endif
+ #include <net/ipv6.h>
+ #include <net/if_inet6.h>
+ #include <net/addrconf.h>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without this change, virtualbox's kernel module does not build on linux kernel 5.11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [NA] macOS
   - [NA] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [NA] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
