### PR TITLE
rnp: init at 0.15.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8589,6 +8589,12 @@
     githubId = 6047658;
     name = "Ryan Horiguchi";
   };
+  ribose-jeffreylau = {
+    name = "Jeffrey Lau";
+    email = "jeffrey.lau@ribose.com";
+    github = "ribose-jeffreylau";
+    githubId = 2649467;
+  };
   richardipsum = {
     email = "richardipsum@fastmail.co.uk";
     github = "richardipsum";

--- a/pkgs/tools/security/rnp/default.nix
+++ b/pkgs/tools/security/rnp/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, asciidoctor
+, botan2
+, bzip2
+, cmake
+, fetchFromGitHub
+, gnupg
+, gtest
+, json_c
+, pkg-config
+, python3
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rnp";
+  version = "0.15.1";
+
+  src = fetchFromGitHub {
+    owner = "rnpgp";
+    repo = "rnp";
+    rev = "v${version}";
+    sha256 = "1l7y99rcss5w24lil6nqwr0dzh2jvq0qxmdvq7j5yx3fdssd5xsv";
+  };
+
+  buildInputs = [ zlib bzip2 json_c botan2 ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DBUILD_SHARED_LIBS=on"
+    "-DBUILD_TESTING=on"
+    "-DDOWNLOAD_GTEST=off"
+    "-DDOWNLOAD_RUBYRNP=off"
+  ];
+
+  nativeBuildInputs = [ asciidoctor cmake gnupg gtest pkg-config python3 ];
+
+  # NOTE: check-only inputs should ideally be moved to checkInputs, but it
+  # would fail during buildPhase.
+  # checkInputs = [ gtest python3 ];
+
+  outputs = [ "out" "lib" "dev" ];
+
+  preConfigure = ''
+    echo "v${version}" > version.txt
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/rnpgp/rnp";
+    description = "High performance C++ OpenPGP library, fully compliant to RFC 4880";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ribose-jeffreylau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8314,6 +8314,8 @@ in
 
   rnnoise-plugin = callPackage ../development/libraries/rnnoise-plugin {};
 
+  rnp = callPackage ../tools/security/rnp { };
+
   rnv = callPackage ../tools/text/xml/rnv { };
 
   rosie = callPackage ../tools/text/rosie { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package [rnp](https://github.com/rnpgp/rnp), a high performance C++ OpenPGP library, fully compliant to RFC 4880.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
