### PR TITLE
bluez: 5.56 -> 5.58

### DIFF
--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , lib
-, fetchpatch
 , fetchurl
 , alsaLib
 , dbus
@@ -20,11 +19,11 @@
   ];
 in stdenv.mkDerivation rec {
   pname = "bluez";
-  version = "5.56";
+  version = "5.58";
 
   src = fetchurl {
     url = "mirror://kernel/linux/bluetooth/${pname}-${version}.tar.xz";
-    sha256 = "sha256-WcTbqfyKripqX48S8ZvBsMLcJzVcfKMSPu0/5r19C50=";
+    sha256 = "1wgiv8cqya6n1w5fz24cb8q401bhn5aa6s7g95l26rzblmsmw1n8";
   };
 
   buildInputs = [
@@ -44,15 +43,6 @@ in stdenv.mkDerivation rec {
   ];
 
   outputs = [ "out" "dev" ] ++ lib.optional doCheck "test";
-
-  patches = [
-    # Fixes https://github.com/NixOS/nixpkgs/issues/117663
-    (fetchpatch {
-      name = "disconnect-fix.patch";
-      url = "https://github.com/bluez/bluez/commit/28ddec8d6b829e002fa268c07b71e4c564ba9e16.patch";
-      sha256 = "sha256-vzMf1i44e4JrpL7cXbn9oDr+3B+Glf7dPW3QDstEnEM=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace tools/hid2hci.rules \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update `bluez` to incorpoarte fixes from the latest release.

###### Things done

`nixpkgs-review` was going to perform a massive rebuild, so submitting to staging. I wasn't able to identify any nixos tests to execute for this, but will run any if someone can let me know which are applicable.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
