### PR TITLE
home-assistant: 2021.3.4 -> 2021.4.0

### DIFF
--- a/pkgs/development/python-modules/aiodiscover/default.nix
+++ b/pkgs/development/python-modules/aiodiscover/default.nix
@@ -10,23 +10,15 @@
 
 buildPythonPackage rec {
   pname = "aiodiscover";
-  version = "1.3.2";
+  version = "1.3.3";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "bdraco";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0qg2wm6ddsfai788chylr5ynrvakwg91q3dszz7dxzbkfdcxixj3";
+    sha256 = "186agrjx818vn00d3pqlka5ir48rgpbfyn1cifkn9ylsxg9cz3ph";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "remove-entry_point.patch";
-      url = "https://github.com/bdraco/aiodiscover/commit/4c497fb7d4c8685a78209c710e92e0bd17f46bb2.patch";
-      sha256 = "0py9alhg6qdncbn6a04mrnjhs4j19kg759dv69knpqzryikcfa63";
-    })
-  ];
 
   propagatedBuildInputs = [
     async-dns

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.3.4";
+  version = "2021.4.0";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];
@@ -31,6 +31,7 @@
     "ambient_station" = ps: with ps; [ aioambient ];
     "amcrest" = ps: with ps; [ amcrest ha-ffmpeg ];
     "ampio" = ps: with ps; [ ]; # missing inputs: asmog
+    "analytics" = ps: with ps; [ aiohttp-cors ];
     "android_ip_webcam" = ps: with ps; [ ]; # missing inputs: pydroid-ipcam
     "androidtv" = ps: with ps; [ adb-shell androidtv pure-python-adb ];
     "anel_pwrctrl" = ps: with ps; [ ]; # missing inputs: anel_pwrctrl-homeassistant
@@ -57,7 +58,7 @@
     "atag" = ps: with ps; [ ]; # missing inputs: pyatag
     "aten_pe" = ps: with ps; [ atenpdu ];
     "atome" = ps: with ps; [ ]; # missing inputs: pyatome
-    "august" = ps: with ps; [ ]; # missing inputs: py-august
+    "august" = ps: with ps; [ yalexs ];
     "aurora" = ps: with ps; [ auroranoaa ];
     "aurora_abb_powerone" = ps: with ps; [ ]; # missing inputs: aurorapy
     "auth" = ps: with ps; [ aiohttp-cors ];
@@ -154,7 +155,7 @@
     "deconz" = ps: with ps; [ pydeconz ];
     "decora" = ps: with ps; [ bluepy ]; # missing inputs: decora
     "decora_wifi" = ps: with ps; [ ]; # missing inputs: decora_wifi
-    "default_config" = ps: with ps; [ pynacl aiohttp-cors async-upnp-client defusedxml distro emoji hass-nabucasa netdisco pillow scapy sqlalchemy zeroconf ];
+    "default_config" = ps: with ps; [ pynacl aiodiscover aiohttp-cors async-upnp-client defusedxml distro emoji hass-nabucasa netdisco pillow scapy sqlalchemy zeroconf ];
     "delijn" = ps: with ps; [ ]; # missing inputs: pydelijn
     "deluge" = ps: with ps; [ deluge-client ];
     "demo" = ps: with ps; [ aiohttp-cors ];
@@ -167,7 +168,7 @@
     "device_tracker" = ps: with ps; [ ];
     "devolo_home_control" = ps: with ps; [ aiohttp-cors devolo-home-control-api zeroconf ];
     "dexcom" = ps: with ps; [ pydexcom ];
-    "dhcp" = ps: with ps; [ scapy ];
+    "dhcp" = ps: with ps; [ aiodiscover scapy ];
     "dht" = ps: with ps; [ ]; # missing inputs: Adafruit-DHT
     "dialogflow" = ps: with ps; [ aiohttp-cors ];
     "digital_ocean" = ps: with ps; [ digital-ocean ];
@@ -277,7 +278,7 @@
     "foscam" = ps: with ps; [ ]; # missing inputs: libpyfoscam
     "foursquare" = ps: with ps; [ aiohttp-cors ];
     "free_mobile" = ps: with ps; [ ]; # missing inputs: freesms
-    "freebox" = ps: with ps; [ aiohttp-cors freebox-api netdisco zeroconf ];
+    "freebox" = ps: with ps; [ freebox-api ];
     "freedns" = ps: with ps; [ ];
     "fritz" = ps: with ps; [ fritzconnection ];
     "fritzbox" = ps: with ps; [ pyfritzhome ];
@@ -326,7 +327,6 @@
     "gree" = ps: with ps; [ ]; # missing inputs: greeclimate
     "greeneye_monitor" = ps: with ps; [ ]; # missing inputs: greeneye_monitor
     "greenwave" = ps: with ps; [ ]; # missing inputs: greenwavereality
-    "griddy" = ps: with ps; [ ]; # missing inputs: griddypower
     "group" = ps: with ps; [ ];
     "growatt_server" = ps: with ps; [ ]; # missing inputs: growattServer
     "gstreamer" = ps: with ps; [ ]; # missing inputs: gstreamer-player
@@ -352,6 +352,7 @@
     "hive" = ps: with ps; [ ]; # missing inputs: pyhiveapi
     "hlk_sw16" = ps: with ps; [ ]; # missing inputs: hlk-sw16
     "home_connect" = ps: with ps; [ aiohttp-cors ]; # missing inputs: homeconnect
+    "home_plus_control" = ps: with ps; [ aiohttp-cors homepluscontrol ];
     "homeassistant" = ps: with ps; [ ];
     "homekit" = ps: with ps; [ HAP-python pyqrcode pyturbojpeg aiohttp-cors base36 fnvhash ha-ffmpeg zeroconf ];
     "homekit_controller" = ps: with ps; [ aiohomekit aiohttp-cors zeroconf ];
@@ -448,7 +449,7 @@
     "linux_battery" = ps: with ps; [ batinfo ];
     "lirc" = ps: with ps; [ ]; # missing inputs: python-lirc
     "litejet" = ps: with ps; [ ]; # missing inputs: pylitejet
-    "litterrobot" = ps: with ps; [ ]; # missing inputs: pylitterbot
+    "litterrobot" = ps: with ps; [ pylitterbot ];
     "llamalab_automate" = ps: with ps; [ ];
     "local_file" = ps: with ps; [ ];
     "local_ip" = ps: with ps; [ ];
@@ -715,6 +716,7 @@
     "scene" = ps: with ps; [ ];
     "schluter" = ps: with ps; [ ]; # missing inputs: py-schluter
     "scrape" = ps: with ps; [ beautifulsoup4 jsonpath xmltodict ];
+    "screenlogic" = ps: with ps; [ screenlogicpy ];
     "script" = ps: with ps; [ ];
     "scsgate" = ps: with ps; [ ]; # missing inputs: scsgate
     "search" = ps: with ps; [ aiohttp-cors ];
@@ -864,6 +866,7 @@
     "tplink" = ps: with ps; [ pyhs100 ];
     "tplink_lte" = ps: with ps; [ ]; # missing inputs: tp-connected
     "traccar" = ps: with ps; [ aiohttp-cors stringcase ]; # missing inputs: pytraccar
+    "trace" = ps: with ps; [ ];
     "trackr" = ps: with ps; [ ]; # missing inputs: pytrackr
     "tradfri" = ps: with ps; [ ]; # missing inputs: pytradfri[async]
     "trafikverket_train" = ps: with ps; [ pytrafikverket ];
@@ -906,7 +909,7 @@
     "velux" = ps: with ps; [ pyvlx ];
     "venstar" = ps: with ps; [ venstarcolortouch ];
     "vera" = ps: with ps; [ pyvera ];
-    "verisure" = ps: with ps; [ jsonpath vsure ];
+    "verisure" = ps: with ps; [ vsure ];
     "versasense" = ps: with ps; [ ]; # missing inputs: pyversasense
     "version" = ps: with ps; [ pyhaversion ];
     "vesync" = ps: with ps; [ pyvesync ];
@@ -974,7 +977,7 @@
     "zeroconf" = ps: with ps; [ aiohttp-cors zeroconf ];
     "zerproc" = ps: with ps; [ pyzerproc ];
     "zestimate" = ps: with ps; [ xmltodict ];
-    "zha" = ps: with ps; [ bellows pyserial-asyncio pyserial zha-quirks zigpy-cc zigpy-deconz zigpy-xbee zigpy-zigate zigpy-znp zigpy ];
+    "zha" = ps: with ps; [ aiohttp-cors bellows pyserial-asyncio pyserial zeroconf zha-quirks zigpy-cc zigpy-deconz zigpy-xbee zigpy-zigate zigpy-znp zigpy ];
     "zhong_hong" = ps: with ps; [ ]; # missing inputs: zhong_hong_hvac
     "ziggo_mediabox_xl" = ps: with ps; [ ]; # missing inputs: ziggo-mediabox-xl
     "zodiac" = ps: with ps; [ ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , python3
 , nixosTests
 
@@ -81,7 +80,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.3.4";
+  hassVersion = "2021.4.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -100,32 +99,22 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "110pvin39lr40zd3lhb8zvh2wafl0k0dy3nbmc483yafy31xa4kw";
+    sha256 = "1gkbkyxqsw3isdyskzi0ib07fgqvirnr20jkhrz86vl0k9ix8hwf";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling
   patches = [
-    (fetchpatch {
-      # Fix I-frame interval in stream test video
-      # https://github.com/home-assistant/core/pull/47638
-      url = "https://github.com/home-assistant/core/commit/d9bf63103fde44ddd38fb6b9a510d82609802b36.patch";
-      sha256 = "1y34cmw9zqb2lxyzm0q7vxlm05wwz76mhysgnh1jn39484fn9f9m";
-    })
   ];
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "aiohttp==3.7.4" "aiohttp>=3.7.3" \
-      --replace "attrs==19.3.0" "attrs>=19.3.0" \
-      --replace "awesomeversion==21.2.3" "awesomeversion>=21.2.3" \
-      --replace "bcrypt==3.1.7" "bcrypt>=3.1.7" \
+      --replace "awesomeversion==21.2.3" "awesomeversion" \
+      --replace "bcrypt==3.1.7" "bcrypt" \
       --replace "cryptography==3.3.2" "cryptography" \
-      --replace "httpx==0.16.1" "httpx>=0.16.1" \
-      --replace "jinja2>=2.11.3" "jinja2>=2.11.2" \
       --replace "pip>=8.0.3,<20.3" "pip" \
-      --replace "pytz>=2021.1" "pytz>=2020.5" \
+      --replace "pytz>=2021.1" "pytz" \
       --replace "pyyaml==5.4.1" "pyyaml" \
-      --replace "ruamel.yaml==0.15.100" "ruamel.yaml>=0.15.100"
+      --replace "ruamel.yaml==0.15.100" "ruamel.yaml"
     substituteInPlace tests/test_config.py --replace '"/usr"' '"/build/media"'
   '';
 
@@ -179,6 +168,7 @@ in with py.pkgs; buildPythonApplication rec {
   componentTests = [
     "accuweather"
     "airly"
+    "analytics"
     "alert"
     "api"
     "auth"
@@ -231,6 +221,7 @@ in with py.pkgs; buildPythonApplication rec {
     "hddtemp"
     "history"
     "history_stats"
+    "home_plus_control"
     "homekit"
     "homekit_controller"
     "homeassistant"
@@ -253,6 +244,7 @@ in with py.pkgs; buildPythonApplication rec {
     "ipp"
     "kmtronic"
     "light"
+    "litterrobot"
     "local_file"
     "local_ip"
     "lock"
@@ -298,6 +290,7 @@ in with py.pkgs; buildPythonApplication rec {
     "rss_feed_template"
     "safe_mode"
     "scene"
+    "screenlogic"
     "script"
     "search"
     "shell_command"
@@ -328,6 +321,7 @@ in with py.pkgs; buildPythonApplication rec {
     "time_date"
     "timer"
     "tod"
+    "trace"
     "tts"
     "universal"
     "updater"
@@ -357,6 +351,8 @@ in with py.pkgs; buildPythonApplication rec {
     "--dist loadfile"
     # tests are located in tests/
     "tests"
+    # screenlogic/test_config_flow.py: Tries to send out UDP broadcasts
+    "--deselect tests/components/screenlogic/test_config_flow.py::test_form_cannot_connect"
     # dynamically add packages required for component tests
   ] ++ map (component: "tests/components/" + component) componentTests;
 
@@ -379,9 +375,13 @@ in with py.pkgs; buildPythonApplication rec {
     # generic/test_camera.py: AssertionError: 500 == 200
     "test_fetching_without_verify_ssl"
     "test_fetching_url_with_verify_ssl"
+    # util/test_package.py: AssertionError on package.is_installed('homeassistant>=999.999.999')
+    "test_check_package_version_does_not_match"
   ];
 
   preCheck = ''
+    export HOME="$TEMPDIR"
+
     # the tests require the existance of a media dir
     mkdir /build/media
 

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -42,6 +42,21 @@ let
       });
     })
 
+    # Pinned due to API changes in pylilterbot>=2021.3.0
+    (self: super: {
+      pylitterbot = super.pylitterbot.overridePythonAttrs (oldAttrs: rec {
+        version = "2021.2.8";
+        src = fetchFromGitHub {
+          owner = "natekspencer";
+          repo = "pylitterbot";
+          rev = version;
+          sha256 = "142lhijm51v11cd0lhcfdnjdd143jxi2hjsrqdq0rrbbnmj6mymp";
+        };
+        # had no tests before 2021.3.0
+        doCheck = false;
+      });
+    })
+
     # Pinned due to bug in ring-doorbell 0.7.0
     # https://github.com/tchellomello/python-ring-doorbell/issues/240
     (mkOverride "ring-doorbell" "0.6.2"

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20210302.6";
+  version = "20210407.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-h3jCqfAPg+z6vsdLm5Pdr+7PCEWW58GCG9viIz3Mi64=";
+    sha256 = "sha256-7kgL6Ixlc1OZ+3sUAuvJd7vgY6FBgPFEKi6xhq7fiBc=";
   };
 
   # there is nothing to strip in this package


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Waiting for #118176 @fabaff 

https://www.home-assistant.io/blog/2021/04/07/release-20214/

nixosTests.home-assistant probably still broken because of #110863. No idea what is wrong there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
       Outdated dependencies        
┏━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┓
┃ Package       ┃ Current ┃ Wanted ┃
┡━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━┩
│ numpy         │ 1.20.1  │ 1.20.2 │
│ pillow        │ 8.1.1   │ 8.1.2  │
│ plexapi       │ 4.5.0   │ 4.5.1  │
│ plexwebsocket │ 0.0.12  │ 0.0.13 │
└───────────────┴─────────┴────────┘
```