### PR TITLE
ocamlPackages.postgresql: 4.6.3 → 5.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/postgresql/default.nix
+++ b/pkgs/development/ocaml-modules/postgresql/default.nix
@@ -1,8 +1,10 @@
-{ lib, fetchFromGitHub, buildDunePackage, postgresql }:
+{ lib, fetchFromGitHub, buildDunePackage, dune-configurator, postgresql }:
 
 buildDunePackage rec {
   pname = "postgresql";
-  version = "4.6.3";
+  version = "5.0.0";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.08";
 
@@ -10,10 +12,10 @@ buildDunePackage rec {
     owner = "mmottl";
     repo = "postgresql-ocaml";
     rev = version;
-    sha256 = "0fd96qqwkwjhv6pawk4wivwncszkif0sq05f0g5gd28jzwrsvpqr";
+    sha256 = "1i4pnh2v00i0s7s9pcwz1x6s4xcd77d08gjjkvy0fmda6mqq6ghn";
   };
 
-  buildInputs = [ postgresql ];
+  buildInputs = [ dune-configurator postgresql ];
 
   meta = {
     description = "Bindings to the PostgreSQL library";


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2 (compatibility with OCaml 4.12)

cc maintainer @bcc32

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
