### PR TITLE
pythonPackages.*: fix some builds

### DIFF
--- a/pkgs/development/python-modules/gdown/default.nix
+++ b/pkgs/development/python-modules/gdown/default.nix
@@ -5,6 +5,7 @@
 , requests
 , tqdm
 , setuptools
+, six
 }:
 
 buildPythonApplication rec {
@@ -16,7 +17,7 @@ buildPythonApplication rec {
     sha256 = "4b3a1301e57bfd8dce939bf25ef8fbb4b23967fd0f878eede328bdcc41386bac";
   };
 
-  propagatedBuildInputs = [ filelock requests tqdm setuptools ];
+  propagatedBuildInputs = [ filelock requests tqdm setuptools six ];
 
   checkPhase = ''
     $out/bin/gdown --help > /dev/null

--- a/pkgs/development/python-modules/requests-aws4auth/default.nix
+++ b/pkgs/development/python-modules/requests-aws4auth/default.nix
@@ -1,4 +1,5 @@
-{ lib, buildPythonPackage, fetchPypi, python, requests }:
+{ lib, buildPythonPackage, fetchPypi, python, requests, six }:
+
 with lib;
 buildPythonPackage rec {
   pname = "requests-aws4auth";
@@ -9,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "9a4a5f4a61c49f098f5f669410308ac5b0ea2682fd511ee3a4f9ff73b5bb275a";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [ requests six ];
 
   # pypi package no longer contains tests
   doCheck = false;

--- a/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
+++ b/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, boto3 }:
+{ lib, buildPythonPackage, fetchPypi, boto3, cryptography }:
 
 buildPythonPackage rec {
   pname = "ec2instanceconnectcli";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "sha256-VaCyCnEhSx1I3bNo57p0IXf92+tO1tT7KSUXzO1IyIU=";
   };
 
-  propagatedBuildInputs = [ boto3 ];
+  propagatedBuildInputs = [ boto3 cryptography ];
 
   # has no tests
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
fixing broken builds in https://github.com/NixOS/nixpkgs/pull/118750

```
builder for '/nix/store/zs4dhh1h4vifjd84axv8d8cgjxrmsv8a-gdown-3.12.2.drv' failed with exit code 1; last 10 log lines:
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  installing
  Executing pipInstallPhase
  /build/gdown-3.12.2/dist /build/gdown-3.12.2
  Processing ./gdown-3.12.2-py3-none-any.whl
  Requirement already satisfied: filelock in /nix/store/2vfk7xd8b51a39hiyzjsxbsfzgsmjpjv-python3.8-filelock-3.0.12/lib/python3.8/site-packages (from gdown==3.12.2) (3.0.12)
  Requirement already satisfied: tqdm in /nix/store/i12z8mf7qn2dp2n1qfsm7m5q1bi7zygp-python3.8-tqdm-4.58.0/lib/python3.8/site-packages (from gdown==3.12.2) (4.58.0)
  ERROR: Could not find a version that satisfies the requirement six (from gdown)
  ERROR: No matching distribution found for six
builder for '/nix/store/dmxgjw7y1lcy1wcn8f3rn0dk6dv6wbw9-python3.8-requests-aws4auth-1.0.1.drv' failed with exit code 1; last 10 log lines:
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 783, in exec_module
    File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
    File "/nix/store/0b9y6kjfjsxf54lml28ax6xh1s0v3dk1-python3.8-requests-aws4auth-1.0.1/lib/python3.8/site-packages/requests_aws4auth/__init__.py", line 204, in <module>
      from .aws4auth import AWS4Auth, StrictAWS4Auth, PassiveAWS4Auth
    File "/nix/store/0b9y6kjfjsxf54lml28ax6xh1s0v3dk1-python3.8-requests-aws4auth-1.0.1/lib/python3.8/site-packages/requests_aws4auth/aws4auth.py", line 32, in <module>
      from six import PY2, text_type
  ModuleNotFoundError: No module named 'six'
cannot build derivation '/nix/store/daps8fybb2h7sshndd2wwqba45yzilbw-elasticsearch-curator-5.8.1.drv': 1 dependencies couldn't be built
builder for '/nix/store/jg5chpifjfmwrc9yy4kkm2ybkn4vlb64-python3.8-ec2instanceconnectcli-1.0.2.drv' failed with exit code 1; last 10 log lines:
  adding 'ec2instanceconnectcli-1.0.2.dist-info/RECORD'
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  installing
  Executing pipInstallPhase
  /build/ec2instanceconnectcli-1.0.2/dist /build/ec2instanceconnectcli-1.0.2
  Processing ./ec2instanceconnectcli-1.0.2-py2.py3-none-any.whl
  Requirement already satisfied: botocore>=1.12.179 in /nix/store/zr94scyy7kpxp7dvd27x172jqvszw1a2-python3.8-botocore-1.20.46/lib/python3.8/site-packages (from ec2instanceconnectcli==1.0.2) (1.20.46)
  ERROR: Could not find a version that satisfies the requirement cryptography>=1.9 (from ec2instanceconnectcli)
  ERROR: No matching distribution found for cryptography>=1.9
builder for '/nix/store/jlp10j5rh5y0dp3r77506k5pwihidwa8-python3.9-ec2instanceconnectcli-1.0.2.drv' failed with exit code 1; last 10 log lines:
  adding 'ec2instanceconnectcli-1.0.2.dist-info/RECORD'
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  installing
  Executing pipInstallPhase
  /build/ec2instanceconnectcli-1.0.2/dist /build/ec2instanceconnectcli-1.0.2
  Processing ./ec2instanceconnectcli-1.0.2-py2.py3-none-any.whl
  Requirement already satisfied: botocore>=1.12.179 in /nix/store/cvgydhph8gw26i6m3qh00vkpc5ahpqab-python3.9-botocore-1.20.46/lib/python3.9/site-packages (from ec2instanceconnectcli==1.0.2) (1.20.46)
  ERROR: Could not find a version that satisfies the requirement cryptography>=1.9 (from ec2instanceconnectcli)
  ERROR: No matching distribution found for cryptography>=1.9
  ```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
