### PR TITLE
python3Packages.wakeonlan: 1.1.6 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/wakeonlan/default.nix
+++ b/pkgs/development/python-modules/wakeonlan/default.nix
@@ -1,26 +1,45 @@
-{ lib, fetchPypi, buildPythonPackage, setuptools_scm, pytest, mock }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "wakeonlan";
-  version = "1.1.6";
+  version = "2.0.0";
+  disabled = pythonOlder "3.6";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "5e6013a17004809e676c150689abd94bcc0f12a37ad3fbce1f6270968f95ffa9";
+  src = fetchFromGitHub {
+    owner = "remcohaszing";
+    repo = "pywakeonlan";
+    rev = version;
+    sha256 = "0p9jyiv0adcymbnmbay72g9phlbhsr4kmrwxscbdjq81gcmxsi0y";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "setuptools-scm ~= 1.15.7" "setuptools-scm"
-  '';
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
-  checkInputs = [ pytest mock ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  nativeBuildInputs = [ setuptools_scm ];
+  patches = [
+    # Switch to poetry-core, https://github.com/remcohaszing/pywakeonlan/pull/19
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/remcohaszing/pywakeonlan/commit/6aa5050ed94ef718dfcd0b946546b6a738f47ee3.patch";
+      sha256 = "1xzj2464ziwm7bp05bzbjwjp9whmgp1py3isr41d92qvnil86vm6";
+    })
+  ];
 
-  checkPhase = ''
-    py.test
-  '';
+  pytestFlagsArray = [ "test_wakeonlan.py" ];
+
+  pythonImportsCheck = [ "wakeonlan" ];
 
   meta = with lib; {
     description = "A small python module for wake on lan";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.0

Change log: https://github.com/remcohaszing/pywakeonlan/releases/tag/2.0.0

`openwebifpy` is only available for Python > 3.6. Thus, `wakeonlan` as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
