### PR TITLE
python3Packages.yalexs: init at 1.1.10

### DIFF
--- a/pkgs/development/python-modules/pubnub/default.nix
+++ b/pkgs/development/python-modules/pubnub/default.nix
@@ -13,16 +13,17 @@
 
 buildPythonPackage rec {
   pname = "pubnub";
-  version = "4.8.0";
+  version = "5.1.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = "python";
     rev = "v${version}";
-    sha256 = "16wjal95042kh5fxhvji0rwmw892pacqcnyms520mw15wcwilqir";
+    sha256 = "sha256-ir8f8A6XuN1ZQIYQbArChLzTlYu4ZKpkoOXQtSLOvKg=";
   };
 
   propagatedBuildInputs = [
+    aiohttp
     cbor2
     pycryptodomex
     requests
@@ -30,19 +31,15 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    aiohttp
-    pycryptodomex
     pytest-asyncio
     pytestCheckHook
     pytest-vcr
-
   ];
 
-  # Some tests don't pass with recent releases of tornado/twisted
-  pytestFlagsArray = [
-    "--ignore tests/integrational"
-    "--ignore tests/manual/asyncio"
-    "--ignore tests/manual/tornado/test_reconnections.py"
+  # Some tests don't pass with recent releases of twisted
+  disabledTestPaths = [
+    "tests/integrational"
+    "tests/manual/asyncio"
   ];
 
   pythonImportsCheck = [ "pubnub" ];

--- a/pkgs/development/python-modules/yalexs/default.nix
+++ b/pkgs/development/python-modules/yalexs/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, aiofiles
+, aiohttp
+, aioresponses
+, aiounittest
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
+, pubnub
+, pytestCheckHook
+, python-dateutil
+, pythonOlder
+, requests
+, requests-mock
+}:
+
+buildPythonPackage rec {
+  pname = "yalexs";
+  version = "1.1.10";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "bdraco";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1qmxiafqmh51i3l30pajaqj5h0kziq4d37fn6hl58429bb85dpp9";
+  };
+
+  propagatedBuildInputs = [
+    aiofiles
+    aiohttp
+    pubnub
+    python-dateutil
+    requests
+  ];
+
+  checkInputs = [
+    aioresponses
+    aiounittest
+    asynctest
+    pytestCheckHook
+    requests-mock
+  ];
+
+  postPatch = ''
+    # Not used requirement
+    substituteInPlace setup.py --replace '"vol",' ""
+  '';
+
+  pythonImportsCheck = [ "yalexs" ];
+
+  meta = with lib; {
+    description = "Python API for Yale Access (formerly August) Smart Lock and Doorbell";
+    homepage = "https://github.com/bdraco/yalexs";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9025,6 +9025,8 @@ in {
 
   yalesmartalarmclient = callPackage ../development/python-modules/yalesmartalarmclient { };
 
+  yalexs = callPackage ../development/python-modules/yalexs { };
+
   yamale = callPackage ../development/python-modules/yamale { };
 
   yamllint = callPackage ../development/python-modules/yamllint { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
"Python API for Yale Access (formerly August) Smart Lock and Doorbell

https://github.com/bdraco/yalexs

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
