### PR TITLE
python3Packages.screenlogicpy: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/screenlogicpy/default.nix
+++ b/pkgs/development/python-modules/screenlogicpy/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "screenlogicpy";
+  version = "0.3.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gn2mf2n2g1ffdbijrydgb7dgd60lkvckblx6s86kxlkrp1wqgrq";
+  };
+
+  # Project doesn't publish tests
+  # https://github.com/dieselrabbit/screenlogicpy/issues/8
+  doCheck = false;
+  pythonImportsCheck = [ "screenlogicpy" ];
+
+  meta = with lib; {
+    description = "Python interface for Pentair Screenlogic devices";
+    homepage = "https://github.com/dieselrabbit/screenlogicpy";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7534,6 +7534,8 @@ in {
 
   screeninfo = callPackage ../development/python-modules/screeninfo { };
 
+  screenlogicpy = callPackage ../development/python-modules/screenlogicpy { };
+
   scripttest = callPackage ../development/python-modules/scripttest { };
 
   scs = callPackage ../development/python-modules/scs { scs = pkgs.scs; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python interface for Pentair Screenlogic devices

https://github.com/dieselrabbit/screenlogicpy

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
