### PR TITLE
python3Packages.homepluscontrol: init at 0.0.5

### DIFF
--- a/pkgs/development/python-modules/homepluscontrol/default.nix
+++ b/pkgs/development/python-modules/homepluscontrol/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, aiohttp
+, aioresponses
+, buildPythonPackage
+, fetchFromGitHub
+, pyjwt
+, pytestCheckHook
+, pythonOlder
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "homepluscontrol";
+  version = "0.0.5";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "chemaaa";
+    repo = pname;
+    rev = version;
+    sha256 = "1nd3a7nhh1xb70cdh2h2bimwbffvpc3457smyzr9fqkjwfbcrr93";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    pyjwt
+    yarl
+  ];
+
+  checkInputs = [
+    aioresponses
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "homepluscontrol" ];
+
+  meta = with lib; {
+    description = "Python API to interact with the Legrand Eliot Home and Control";
+    homepage = "https://github.com/chemaaa/homepluscontrol";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3112,6 +3112,8 @@ in {
 
   homeassistant-pyozw = callPackage ../development/python-modules/homeassistant-pyozw { };
 
+  homepluscontrol = callPackage ../development/python-modules/homepluscontrol { };
+
   hoomd-blue = toPythonModule (callPackage ../development/python-modules/hoomd-blue {
     inherit python;
   });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API to interact with the Legrand Eliot Home and Control

https://github.com/chemaaa/homepluscontrol

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
