### PR TITLE
foxitreader: init at 2.4.4.0911

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7517,6 +7517,12 @@
     githubId = 3438604;
     name = "Petter Storvik";
   };
+  p-h = {
+    email = "p@hurlimann.org";
+    github = "p-h";
+    githubId = 645664;
+    name = "Philippe Hürlimann";
+  };
   philandstuff = {
     email = "philip.g.potter@gmail.com";
     github = "philandstuff";

--- a/pkgs/applications/misc/foxitreader/default.nix
+++ b/pkgs/applications/misc/foxitreader/default.nix
@@ -1,0 +1,79 @@
+{ mkDerivation, lib, fetchzip, libarchive, autoPatchelfHook, libsecret, libGL, zlib, openssl, qtbase, qtwebkit, qtxmlpatterns }:
+
+mkDerivation rec {
+  pname = "foxitreader";
+  version = "2.4.4.0911";
+
+  src = fetchzip {
+    url = "https://cdn01.foxitsoftware.com/pub/foxit/reader/desktop/linux/${lib.versions.major version}.x/${lib.versions.majorMinor version}/en_us/FoxitReader.enu.setup.${version}.x64.run.tar.gz";
+    sha256 = "0ff4xs9ipc7sswq0czfhpsd7qw7niw0zsf9wgsqhbbgzcpbdhcb7";
+    stripRoot = false;
+  };
+
+  buildInputs = [ libGL libsecret openssl qtbase qtwebkit qtxmlpatterns zlib ];
+
+  nativeBuildInputs = [ autoPatchelfHook libarchive ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    input_file=$src/*.run
+    mkdir -p extracted
+    # Look for all 7z files and extract them
+    grep --only-matching --byte-offset --binary \
+      --text -P '7z\xBC\xAF\x27\x1C\x00\x03' $input_file | cut -d: -f1 |
+      while read position; do
+        tail -c +$(($position + 1)) $input_file > file.7z
+        bsdtar xf file.7z -C extracted
+      done
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cd extracted
+
+    cp -r  \
+      CollectStrategy.txt \
+      cpdf_settings \
+      fxplugins \
+      lang \
+      resource \
+      run \
+      stamps \
+      welcome \
+      Wrappers \
+      $out/lib/
+
+    patchelf $out/lib/fxplugins/librms.so \
+      --replace-needed libssl.so.10 libssl.so \
+      --replace-needed libcrypto.so.10 libcrypto.so
+
+    # FIXME: Doing this with one invocation is broken right now
+    patchelf $out/lib/fxplugins/librmscrypto.so \
+      --replace-needed libssl.so.10 libssl.so
+    patchelf $out/lib/fxplugins/librmscrypto.so \
+      --replace-needed libcrypto.so.10 libcrypto.so
+
+    install -D -m 755 FoxitReader -t $out/bin
+
+    # Install icon and desktop files
+    install -D -m 644 images/FoxitReader.png -t $out/share/pixmaps/
+    install -D -m 644 FoxitReader.desktop -t $out/share/applications/
+    echo Exec=FoxitReader %F >> $out/share/applications/FoxitReader.desktop
+
+    runHook postInstall
+  '';
+
+  qtWrapperArgs = [ "--set appname FoxitReader" "--set selfpath $out/lib" ];
+
+  meta = with lib; {
+    description = "A viewer for PDF documents";
+    homepage = "https://www.foxitsoftware.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ p-h rhoriguchi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21708,6 +21708,8 @@ in
 
   masterpdfeditor4 = libsForQt5.callPackage ../applications/misc/masterpdfeditor4 { };
 
+  foxitreader = libsForQt512.callPackage ../applications/misc/foxitreader { };
+
   aeolus = callPackage ../applications/audio/aeolus { };
 
   aewan = callPackage ../applications/editors/aewan { };


### PR DESCRIPTION
###### Motivation for this change
closes #110839

###### Things done
Based on https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=foxitreader


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
