### PR TITLE
python3Packages.awslambdaric: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/awslambdaric/default.nix
+++ b/pkgs/development/python-modules/awslambdaric/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27, pytestCheckHook, autoconf
+, automake, cmake, gcc, libtool, perl, simplejson }:
+
+buildPythonPackage rec {
+  pname = "awslambdaric";
+  version = "1.0.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "aws-lambda-python-runtime-interface-client";
+    rev = "v${version}";
+    sha256 = "13v1lsp3lxbqknvlb3gvljjf3wyrx5jg8sf9yfiaj1sm8pb8pmrf";
+  };
+
+  propagatedBuildInputs = [ simplejson ];
+
+  nativeBuildInputs = [ autoconf automake cmake libtool perl ];
+
+  buildInputs = [ gcc ];
+
+  dontUseCmakeConfigure = true;
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "awslambdaric" "runtime_client" ];
+
+  meta = with lib; {
+    description = "AWS Lambda Runtime Interface Client for Python";
+    homepage =
+      "https://github.com/aws/aws-lambda-python-runtime-interface-client";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ austinbutler ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/awslambdaric/default.nix
+++ b/pkgs/development/python-modules/awslambdaric/default.nix
@@ -27,8 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "AWS Lambda Runtime Interface Client for Python";
-    homepage =
-      "https://github.com/aws/aws-lambda-python-runtime-interface-client";
+    homepage = "https://github.com/aws/aws-lambda-python-runtime-interface-client";
     license = licenses.asl20;
     maintainers = with maintainers; [ austinbutler ];
     platforms = platforms.linux;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -648,6 +648,8 @@ in {
 
   awsiotpythonsdk = callPackage ../development/python-modules/awsiotpythonsdk { };
 
+  awslambdaric = callPackage ../development/python-modules/awslambdaric { };
+
   axis = callPackage ../development/python-modules/axis { };
 
   azure-appconfiguration = callPackage ../development/python-modules/azure-appconfiguration { };


### PR DESCRIPTION
###### Motivation for this change

Add the package. It depends on some C++ code and the dependencies are not well-documented (see https://github.com/aws/aws-lambda-python-runtime-interface-client/issues/24), so it is hard to get working in Nix with just `pip`.

I have this working successfully in a `nixos/nix` Docker image, I can send a test `POST` to my Lambda in the Docker image.

That said, this would probably be easier to use packaged not just as a Python package, but as an application, like `black`. I tried imitating [how `black` is added to `all-packages.nix`](https://github.com/NixOS/nixpkgs/blob/49cfaef0c34007ade99c7a23497bd5993b8152f0/pkgs/top-level/all-packages.nix#L12296), but there's no resulting `bin` folder. I think this is maybe just due to how AWS has packaged it, their docs recommend installing via `pip` then running `python -m awslambdaric`. So I'm wondering if it would be appropriate to just have a simple wrapper to make `awslambdaric` an actual command available on the `PATH` and such.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).