### PR TITLE
lcdproc: do not show the GPL on every start

### DIFF
--- a/pkgs/servers/monitoring/lcdproc/default.nix
+++ b/pkgs/servers/monitoring/lcdproc/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
       --replace server/drivers/ $out/lib/lcdproc/
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Client/server suite for controlling a wide variety of LCD devices";
     homepage = "http://lcdproc.org/";
     license = licenses.gpl2;

--- a/pkgs/servers/monitoring/lcdproc/default.nix
+++ b/pkgs/servers/monitoring/lcdproc/default.nix
@@ -1,20 +1,39 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, makeWrapper, pkg-config
-, doxygen, freetype, libX11, libftdi, libusb-compat-0_1, libusb1, ncurses, perl }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, makeWrapper
+, pkg-config
+, doxygen
+, freetype
+, libX11
+, libftdi
+, libusb-compat-0_1
+, libusb1
+, ncurses
+, perl
+}:
 
 stdenv.mkDerivation rec {
   pname = "lcdproc";
   version = "0.5.9";
 
   src = fetchFromGitHub {
-    owner  = "lcdproc";
-    repo   = "lcdproc";
-    rev    = "v${version}";
+    owner = "lcdproc";
+    repo = "lcdproc";
+    rev = "v${version}";
     sha256 = "1r885zv1gsh88j43x6fvzbdgfkh712a227d369h4fdcbnnfd0kpm";
   };
 
   patches = [
     ./hardcode_mtab.patch
   ];
+
+  # we don't need to see the GPL every time we launch lcdd in the foreground
+  postPatch = ''
+    substituteInPlace server/main.c \
+      --replace 'output_GPL_notice();' '// output_GPL_notice();'
+  '';
 
   configureFlags = [
     "--enable-lcdproc-menus"
@@ -23,6 +42,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ freetype libX11 libftdi libusb-compat-0_1 libusb1 ncurses ];
+
   nativeBuildInputs = [ autoreconfHook doxygen makeWrapper pkg-config ];
 
   # In 0.5.9: gcc: error: libbignum.a: No such file or directory
@@ -39,11 +59,11 @@ stdenv.mkDerivation rec {
       --replace server/drivers/ $out/lib/lcdproc/
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Client/server suite for controlling a wide variety of LCD devices";
-    homepage    = "http://lcdproc.org/";
-    license     = licenses.gpl2;
+    homepage = "http://lcdproc.org/";
+    license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

We don't need to see the GPL on every start. It's just noise and clogs up the logs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
