### PR TITLE
ocamlPackages.safepass: 3.0 → 3.1

### DIFF
--- a/pkgs/development/ocaml-modules/safepass/default.nix
+++ b/pkgs/development/ocaml-modules/safepass/default.nix
@@ -2,13 +2,15 @@
 
 buildDunePackage rec {
   pname = "safepass";
-  version = "3.0";
+  version = "3.1";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "darioteixeira";
     repo = "ocaml-safepass";
     rev = "v${version}";
-    sha256 = "0i127gs9x23wzwa1q3dxa2j6hby07hvxdg1c98fc3j09rg6vy2bs";
+    sha256 = "1cwslwdb1774lfmhcclj9kymvidbcpjx1vp16jnjirqdqgl4zs5q";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2: https://github.com/darioteixeira/ocaml-safepass/blob/v3.1/CHANGES.md#v31-2021-03-20

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
