### PR TITLE
cmake: Fix Darwin SDK module

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -4,10 +4,14 @@ addCMakeParams() {
 
 fixCmakeFiles() {
     # Replace occurences of /usr and /opt by /var/empty.
+    # However, avoid replacing when /usr appears in the middle of a path with
+    # _CMAKE_OSX_SYSROOT_PATH or sdk_path variables preceding it. Those cases
+    # happen in the files related to the Darwin platform, and they relate to
+    # the Xcode SDK. Replacing by /var/empty in those cases would be incorrect.
     echo "fixing cmake files..."
     find "$1" \( -type f -name "*.cmake" -o -name "*.cmake.in" -o -name CMakeLists.txt \) -print |
         while read fn; do
-            sed -e 's^/usr\([ /]\|$\)^/var/empty\1^g' -e 's^/opt\([ /]\|$\)^/var/empty\1^g' < "$fn" > "$fn.tmp"
+            sed -e '/\${\(_CMAKE_OSX_SYSROOT_PATH\|sdk_path\)}\/usr/! s^/usr\([ /]\|$\)^/var/empty\1^g' -e 's^/opt\([ /]\|$\)^/var/empty\1^g' < "$fn" > "$fn.tmp"
             mv "$fn.tmp" "$fn"
         done
 }


### PR DESCRIPTION
The preConfigure step applies a very broad replacement of /usr and /opt
to /var/empty. However, the replacement affects also paths where /usr
and /opt appear in the middle.

One of those cases was breaking the Darwin SDK CMake module. In that
module many of the paths are relative to the SDK root (which is hold in
CMake variables like `_CMAKE_OSX_SYSROOT_PATH`), which actually include
an /usr path, with headers and libraries inside. The replacement was
breaking those paths, and making very difficult to use CMake to target
macOS, or other Darwin platforms.

The changes modify the replacement to skip lines where the replacement
is preceded by the variables used in the CMake files.

###### Motivation for this change

Fixing the CMake installation and making it usable for targetting Darwin platforms with the resulting CMake package.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [#] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested this change by executing `cmake` against a private project that builds targeting Darwin platforms. Before this change, the project would not had finish building, failing to find headers and libraries because the search paths include `/var/empty`. With the changes the project builds just fine.