### PR TITLE
foxotron: init at 2021-03-12

### DIFF
--- a/pkgs/applications/graphics/foxotron/default.nix
+++ b/pkgs/applications/graphics/foxotron/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, nix-update-script
+, cmake
+, pkg-config
+, makeWrapper
+, zlib
+, libX11
+, libXrandr
+, libXinerama
+, libXcursor
+, libXi
+, libXext
+, libGLU
+, alsaLib
+, fontconfig
+, AVFoundation
+, Carbon
+, Cocoa
+, CoreAudio
+, Kernel
+, OpenGL
+}:
+
+stdenv.mkDerivation rec {
+  pname = "foxotron";
+  version = "2021-03-12";
+
+  src = fetchFromGitHub {
+    owner = "Gargaj";
+    repo = "Foxotron";
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "1finvbs3pbfyvm525blwgwl5jci2zjxb1923i0cm8rmf7wasaapb";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config makeWrapper ];
+
+  buildInputs = [ zlib ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ libX11 libXrandr libXinerama libXcursor libXi libXext alsaLib fontconfig libGLU ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ AVFoundation Carbon Cocoa CoreAudio Kernel OpenGL ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/foxotron}
+    cp -R ${lib.optionalString stdenv.hostPlatform.isDarwin "Foxotron.app/Contents/MacOS/"}Foxotron \
+      ../{config.json,Shaders,Skyboxes} $out/lib/foxotron/
+    wrapProgram $out/lib/foxotron/Foxotron \
+      --run "cd $out/lib/foxotron"
+    ln -s $out/{lib/foxotron,bin}/Foxotron
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with lib; {
+    description = "General purpose model viewer";
+    longDescription = ''
+      ASSIMP based general purpose model viewer ("turntable") created for the
+      Revision 2021 3D Graphics Competition.
+    '';
+    homepage = "https://github.com/Gargaj/Foxotron";
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22959,6 +22959,10 @@ in
     inherit buildPythonApplication;
   };
 
+  foxotron = callPackage ../applications/graphics/foxotron {
+    inherit (darwin.apple_sdk.frameworks) AVFoundation Carbon Cocoa CoreAudio Kernel OpenGL;
+  };
+
   foxtrotgps = callPackage ../applications/misc/foxtrotgps { };
 
   fractal = callPackage ../applications/networking/instant-messengers/fractal { };


### PR DESCRIPTION
###### Motivation for this change
Package [Foxotron](https://github.com/Gargaj/Foxotron), a Public Domain 3D model viewer created & used for Revision 2021's 3D Graphics Competition.

![grafik](https://user-images.githubusercontent.com/23431373/114024692-a5c96680-9874-11eb-991b-585964be3f70.png)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
