### PR TITLE
python3Packages.webexteamssdk: init at 1.6

### DIFF
--- a/pkgs/development/python-modules/webexteamssdk/default.nix
+++ b/pkgs/development/python-modules/webexteamssdk/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, future
+, pyjwt
+, requests
+, requests_toolbelt
+}:
+
+buildPythonPackage rec {
+  pname = "webexteamssdk";
+  version = "1.6";
+
+  src = fetchFromGitHub {
+    owner = "CiscoDevNet";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0bw28ag1iqyqlxz83m4qb3r94kipv5mpf3bsvc8zv5vh4dv52bp2";
+  };
+
+  propagatedBuildInputs = [
+    future
+    pyjwt
+    requests
+    requests_toolbelt
+  ];
+
+  # Tests require a Webex Teams test domain
+  doCheck = false;
+  pythonImportsCheck = [ "webexteamssdk" ];
+
+  meta = with lib; {
+    description = "Python module for Webex Teams APIs";
+    homepage = "https://github.com/CiscoDevNet/webexteamssdk";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -115,7 +115,7 @@
     "circuit" = ps: with ps; [ ]; # missing inputs: circuit-webhook
     "cisco_ios" = ps: with ps; [ pexpect ];
     "cisco_mobility_express" = ps: with ps; [ ciscomobilityexpress ];
-    "cisco_webex_teams" = ps: with ps; [ ]; # missing inputs: webexteamssdk
+    "cisco_webex_teams" = ps: with ps; [ webexteamssdk ];
     "citybikes" = ps: with ps; [ ];
     "clementine" = ps: with ps; [ ]; # missing inputs: python-clementine-remote
     "clickatell" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8834,6 +8834,8 @@ in {
 
   webencodings = callPackage ../development/python-modules/webencodings { };
 
+  webexteamssdk = callPackage ../development/python-modules/webexteamssdk { };
+
   webhelpers = callPackage ../development/python-modules/webhelpers { };
 
   webob = callPackage ../development/python-modules/webob { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for Webex Teams APIs

https://github.com/CiscoDevNet/webexteamssdk

This is a Home Assistant dependency.

There are no tests available (thanks @mweinelt for checking).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
