### PR TITLE
scheherazade-new: 3.000 → 3.100

### DIFF
--- a/pkgs/data/fonts/scheherazade/default.nix
+++ b/pkgs/data/fonts/scheherazade/default.nix
@@ -1,10 +1,10 @@
-{ lib, fetchzip, version ? "3.000" }:
+{ lib, fetchzip, version ? "3.100" }:
 
 let
   new = lib.versionAtLeast version "3.000";
   sha256 = {
     "2.100" = "1g5f5f9gzamkq3kqyf7vbzvl4rdj3wmjf6chdrbxksrm3rnb926z";
-    "3.000" = "12sd2mjqb80ijc73y7p0iw6j3wy9i60a3aar3ywrxz4khpya48jw";
+    "3.100" = "0svnc7l3z3vvm27zx6msyx56n2fpv6ywb5lm75bym48slkccypn7";
   }."${version}";
 
 in fetchzip rec {


### PR DESCRIPTION
###### Motivation for this change

Fixes & additions: https://software.sil.org/scheherazade/release-3-100/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
