### PR TITLE
pythonPackages.ipympl: fix build

### DIFF
--- a/pkgs/development/python-modules/ipympl/default.nix
+++ b/pkgs/development/python-modules/ipympl/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, ipywidgets, matplotlib }:
+{ lib, buildPythonPackage, fetchPypi, ipywidgets, jupyter-packaging, matplotlib }:
 
 buildPythonPackage rec {
   pname = "ipympl";
@@ -8,6 +8,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "f0f1f356d8cb9d4fb51bb86dbbf837c190145316cb72f66081872ebc4d6db0a1";
   };
+
+  buildInputs = [ jupyter-packaging ];
 
   propagatedBuildInputs = [ ipywidgets matplotlib ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

EDIT: The package had already been upgraded in staging but the build was broken. This PR fixes that.

This update fixes matplotlib widget compatibility issues with JupyterLab 3

To test, launch Jupyter Lab with matplotlib:

```sh
nix-shell -p "(python3.withPackages (ps: with ps; [ jupyterlab matplotlib ipykernel ipympl ]))" --run jupyter-lab
```

In the Jupyter Lab, open a Python notebook and execute the following cell:

```python
%matplotlib widget
import matplotlib.pyplot as plt
plt.plot([1,2,4,8,16])
```

Without this upgrade, the plot won't show up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
