### PR TITLE
pythonPackages.jupyterlab: fix yarn.lock permissions for labextension

### DIFF
--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -18,6 +18,11 @@ buildPythonPackage rec {
     sha256 = "929c60d7fb4aa704084c02d8ededc209b8b378e0b3adab46158b7fa6acc24230";
   };
 
+  patches = [
+    # Fix https://github.com/jupyterlab/jupyterlab/issues/7525
+    ./yarn-lock-permissions.patch
+  ];
+
   propagatedBuildInputs = [ jupyterlab_server notebook jupyter-packaging nbclassic ];
 
   makeWrapperArgs = [

--- a/pkgs/development/python-modules/jupyterlab/yarn-lock-permissions.patch
+++ b/pkgs/development/python-modules/jupyterlab/yarn-lock-permissions.patch
@@ -1,0 +1,13 @@
+diff --git a/jupyterlab/commands.py b/jupyterlab/commands.py
+index 154ceb307..d14485ea1 100644
+--- a/jupyterlab/commands.py
++++ b/jupyterlab/commands.py
+@@ -1248,6 +1248,8 @@ class _AppHandler(object):
+                 f.write(template)
+         elif not osp.exists(lock_path):
+             shutil.copy(lock_template, lock_path)
++            import stat
++            os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
+ 
+     def _get_package_template(self, silent=False):
+         """Get the template the for staging package.json file.


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This commit adds a patch which fixes the following issue that affects mainly nix users only:

https://github.com/jupyterlab/jupyterlab/issues/7525

To test, launch a nix-shell as follows:

```
$ nix-shell -p python3Packages.jupyterlab nodejs
```

In the nix shell, try installng some jupyter lab extension:

```
$ cd `mktemp -d`
$ jupyter-labextension install --app-dir=`pwd` jupyter-matplotlib
```

Without this PR, the installation fails.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
