### PR TITLE
pythonPackages.ipywidgets: 7.5.1 -> 7.6.3

### DIFF
--- a/pkgs/development/python-modules/ipywidgets/default.nix
+++ b/pkgs/development/python-modules/ipywidgets/default.nix
@@ -7,6 +7,7 @@
 , mock
 , ipython
 , ipykernel
+, jupyterlab-widgets
 , traitlets
 , notebook
 , widgetsnbextension
@@ -14,11 +15,11 @@
 
 buildPythonPackage rec {
   pname = "ipywidgets";
-  version = "7.5.1";
+  version = "7.6.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97";
+    sha256 = "1w217j8i53x14l7b05fk300k222zs9vkcjaa1rbrw3sk43k466lz";
   };
 
   # Tests are not distributed
@@ -28,6 +29,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     ipython
     ipykernel
+    jupyterlab-widgets
     traitlets
     notebook
     widgetsnbextension

--- a/pkgs/development/python-modules/jupyterlab-widgets/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-widgets/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, jupyter-packaging }:
+
+buildPythonPackage rec {
+  pname = "jupyterlab_widgets";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0y7vhhas3qndiypcpcfnhrj9n92v2w4hdc86nn620s9h9nl2j6jw";
+  };
+
+  buildInputs = [ jupyter-packaging ];
+
+  pythonImportsCheck = [ "jupyterlab_widgets" ];
+
+  meta = {
+    description = "Interactive Widgets for the Jupyter Notebook ";
+    homepage = "https://github.com/jupyter-widgets/ipywidgets";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/jupyterlab-widgets/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-widgets/default.nix
@@ -1,11 +1,12 @@
 { lib, buildPythonPackage, fetchPypi, jupyter-packaging }:
 
 buildPythonPackage rec {
-  pname = "jupyterlab_widgets";
+  pname = "jupyterlab-widgets";
   version = "1.0.0";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit version;
+    pname = "jupyterlab_widgets";
     sha256 = "0y7vhhas3qndiypcpcfnhrj9n92v2w4hdc86nn620s9h9nl2j6jw";
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3609,6 +3609,8 @@ in {
 
   jupyterlab_server = callPackage ../development/python-modules/jupyterlab_server { };
 
+  jupyterlab-widgets = callPackage ../development/python-modules/jupyterlab-widgets { };
+
   jupyter-packaging = callPackage ../development/python-modules/jupyter-packaging { };
 
   jupyter-repo2docker = callPackage ../development/python-modules/jupyter-repo2docker {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This upgrade fixes a compatibility issue between Jupyter Lab 3 and ipywidgets. One new package needed to be added too as that was a new dependency.

To test, launch Jupyter Lab:

```bash
nix-shell -p "python3.withPackages (ps: with ps; [ jupyterlab ipywidgets ])" --run "jupyter lab"
```

In Jupyter Lab, open a Python notebook and execute the following cell:

```python
import ipywidgets as widgets
widgets.IntSlider()
```

With this PR, a working slider appears. Without this PR, there's no slider widget.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
