### PR TITLE
rippled: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/servers/rippled/default.nix
+++ b/pkgs/servers/rippled/default.nix
@@ -31,8 +31,8 @@ let
 
   nudb = fetchgit rec {
     url = "https://github.com/CPPAlliance/NuDB.git";
-    rev = "2.0.3";
-    sha256 = "0imd9sh6knydwa3pxa5bbvjs3bmb8650dnsvj04qgns6bynwlqh1";
+    rev = "2.0.5";
+    sha256 = "02zbd07qvdjjsm4ivvhxah5n466bncvm6m03vmq0qdbbrlnp6s37";
     leaveDotGit = true;
     fetchSubmodules = true;
     postFetch = "cd $out && git tag ${rev}";
@@ -40,8 +40,8 @@ let
 
   rocksdb = fetchgit rec {
     url = "https://github.com/facebook/rocksdb.git";
-    rev = "v6.5.3";
-    sha256 = "11kbwqph1i3w6rbhr0kl2aq4jidhai24gw420y9qi9ab7zl0zcqg";
+    rev = "v6.7.3";
+    sha256 = "16qb636qs2yxqmz30hmvq8mllf038s80p37b0vyc0bazwlr93d9z";
     deepClone = true;
     fetchSubmodules = false;
     leaveDotGit = true;
@@ -116,12 +116,12 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "rippled";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchgit {
     url = "https://github.com/ripple/rippled.git";
     rev = version;
-    sha256 = "176i3dm98zp5jllslpzfhh52bd2lapq9i8r7m45v8sg9icvsmyz7";
+    sha256 = "1rr5kxks9hsxyxrz90dw259b6fs9lywdlqv0bj2g21a6f7g60v2v";
     leaveDotGit = true;
     fetchSubmodules = true;
   };


### PR DESCRIPTION
###### Motivation for this change

Updates rippled to 1.7.0

This does not include support for the recent postgres and cassandra archival settings.

Putting this up first as 1.6.0 no longer syncs with the network. I will make a separate PR for the export to postgres features in a few days.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
