### PR TITLE
steam.fhsenv: move gtk3 to targetPkgs

### DIFF
--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -86,6 +86,8 @@ in buildFHSUserEnv rec {
     steamPackages.steam
     # License agreement
     gnome3.zenity
+
+    gtk3 # 32 bit version of tracker does not like to build, see https://github.com/NixOS/nixpkgs/issues/118155
   ] ++ commonTargetPkgs pkgs;
 
   multiPkgs = pkgs: with pkgs; [
@@ -113,7 +115,6 @@ in buildFHSUserEnv rec {
     udev # shadow of the tomb raider
 
     ## screeps dependencies
-    gtk3
     dbus
     zlib
     glib


### PR DESCRIPTION
###### Motivation for this change
This is to restore the `steam` package for unstable users.

`tracker` packages does not build consistently, and
hydra only has the 64bit version in cache.

Moving it to targetPkgs allows for 64bit machines to
only include the 64 bit version of the package

partial remedy to: #118155 only fixes it for steam, but 32bit gtk3 is still broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
