### PR TITLE
coqtail-math: init at 20201124

### DIFF
--- a/pkgs/development/coq-modules/coqtail-math/default.nix
+++ b/pkgs/development/coq-modules/coqtail-math/default.nix
@@ -1,0 +1,19 @@
+{ lib, mkCoqDerivation, coq, version ? null }:
+
+with lib;
+
+mkCoqDerivation {
+  pname = "coqtail-math";
+  owner = "coq-community";
+  inherit version;
+  defaultVersion = if versions.range "8.11" "8.13" coq.coq-version then "20201124" else null;
+  release."20201124".rev    = "5c22c3d7dcd8cf4c47cf84a281780f5915488e9e";
+  release."20201124".sha256 = "sha256-wd+Lh7dpAD4zfpyKuztDmSFEZo5ZiFrR8ti2jUCVvoQ=";
+
+  buildInputs = with coq.ocamlPackages; [ ocaml findlib ];
+
+  meta = {
+    license = licenses.lgpl3Only;
+    maintainers = [ maintainers.siraben ];
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -27,6 +27,7 @@ let
       coqeal = callPackage ../development/coq-modules/coqeal {};
       coqhammer = callPackage ../development/coq-modules/coqhammer {};
       coqprime = callPackage ../development/coq-modules/coqprime {};
+      coqtail-math = callPackage ../development/coq-modules/coqtail-math {};
       coquelicot = callPackage ../development/coq-modules/coquelicot {};
       corn = callPackage ../development/coq-modules/corn {};
       dpdgraph = callPackage ../development/coq-modules/dpdgraph {};


### PR DESCRIPTION
##### Motivation for this change
Add https://github.com/coq-community/coqtail-math which I find to have useful theorems and lemmas missing from the Coq standard library especially regarding real analysis.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
