### PR TITLE
myxer: init at 1.2.0

### DIFF
--- a/pkgs/applications/audio/myxer/default.nix
+++ b/pkgs/applications/audio/myxer/default.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "myxer";
-  version = "1.1.3";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "Aurailus";
     repo = pname;
     rev = version;
-    sha256 = "1yszcqz5yc8gjxc8w3rdmihk9sbadp86jvn2jplljk9qw10jnylx";
+    sha256 = "10m5qkys96n4v6qiffdiy0w660yq7b5sa70ww2zskc8d0gbmxp6x";
   };
 
-  cargoSha256 = "0s8smqr2nn6kkm7l7j4kc1lr6xax57nsgwmsnhx5g76xwinl79c9";
+  cargoSha256 = "0nsscdjl5fh24sg87vdmijjmlihc0zk0p3vac701v60xlz55qipn";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/audio/myxer/default.nix
+++ b/pkgs/applications/audio/myxer/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, libpulseaudio
+, glib
+, pango
+, gtk3
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "myxer";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "Aurailus";
+    repo = pname;
+    rev = version;
+    sha256 = "1yszcqz5yc8gjxc8w3rdmihk9sbadp86jvn2jplljk9qw10jnylx";
+  };
+
+  cargoSha256 = "0s8smqr2nn6kkm7l7j4kc1lr6xax57nsgwmsnhx5g76xwinl79c9";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libpulseaudio glib pango gtk3 ];
+
+  # Currently no tests are implemented, so we avoid building the package twice
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A modern Volume Mixer for PulseAudio";
+    homepage = "https://github.com/Aurailus/Myxer";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ erin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24960,6 +24960,8 @@ in
 
   pamixer = callPackage ../applications/audio/pamixer { };
 
+  myxer = callPackage ../applications/audio/myxer { };
+
   ncpamixer = callPackage ../applications/audio/ncpamixer { };
 
   pan = callPackage ../applications/networking/newsreaders/pan { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Myxer (a good alternative to pavucontrol) was missing from nixpkgs. This PR contains 2 commits as Myxer was updated to 1.2.0 after this PR was made. The first commits inits at 1.1.3, the second updates to 1.2.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
