### PR TITLE
[20.09] place-cursor-at: init at 1.0.1

### DIFF
--- a/pkgs/applications/misc/place-cursor-at/default.nix
+++ b/pkgs/applications/misc/place-cursor-at/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, haskellPackages
+, libXinerama
+}:
+let inherit (haskellPackages) base base-unicode-symbols X11; in
+haskellPackages.mkDerivation rec {
+  pname = "place-cursor-at";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "unclechu";
+    repo = "place-cursor-at";
+    rev = "v${version}";
+    sha256 = "1kryqcjnj33v6dva8nfb46qjw7ar9x7lhrns1ncns53xy2mdl9f0";
+  };
+
+  isExecutable = true;
+  isLibrary = false;
+  enableSharedExecutables = false;
+  enableLibraryProfiling = false;
+  doHaddock = false;
+  postFixup = "rm -rf $out/lib $out/nix-support $out/share/doc";
+
+  executableHaskellDepends = [ base base-unicode-symbols X11 ];
+  executableSystemDepends = [ libXinerama ];
+  homepage = "https://github.com/unclechu/place-cursor-at#readme";
+  description = "A utility for X11 that moves the mouse cursor using the keyboard";
+  license = stdenv.lib.licenses.gpl3;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25135,6 +25135,8 @@ in
 
   pioneers = callPackage ../games/pioneers { };
 
+  place-cursor-at = callPackage ../applications/misc/place-cursor-at {};
+
   planetary_annihilation = callPackage ../games/planetaryannihilation { };
 
   pong3d = callPackage ../games/pong3d { };


### PR DESCRIPTION
###### Motivation for this change

In current `master` it was just picked from `haskellPackages` in top-level packages (see #118598). But in `release-20.09` this package wasn’t picked from Hackage yet (see failed attempt to backport #118626). So this MR just directly pins the version from the source repo. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
