### PR TITLE
ocamlPackages.{cairo2, lablgtk3}: use dune 2

### DIFF
--- a/pkgs/development/ocaml-modules/cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/cairo2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildDunePackage, ocaml
+{ stdenv, lib, fetchurl, buildDunePackage, ocaml, dune-configurator
 , pkg-config, cairo
 }:
 
@@ -6,13 +6,15 @@ buildDunePackage rec {
   pname = "cairo2";
   version = "0.6.1";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/Chris00/ocaml-cairo/releases/download/${version}/cairo2-${version}.tbz";
     sha256 = "1ik4qf4b9443sliq2z7x9acd40rmzvyzjh3bh98wvjklxbb84a9i";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ cairo ];
+  buildInputs = [ cairo dune-configurator ];
 
   doCheck = !(stdenv.isDarwin
   # https://github.com/Chris00/ocaml-cairo/issues/19

--- a/pkgs/development/ocaml-modules/lablgtk3/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/default.nix
@@ -1,8 +1,10 @@
-{ lib, fetchurl, pkg-config, buildDunePackage, gtk3, cairo2 }:
+{ lib, fetchurl, pkg-config, buildDunePackage, dune-configurator, gtk3, cairo2 }:
 
 buildDunePackage rec {
   version = "3.1.1";
   pname = "lablgtk3";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.05";
 
@@ -12,6 +14,7 @@ buildDunePackage rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ gtk3 cairo2 ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/lablgtk3/gtkspell3.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/gtkspell3.nix
@@ -4,5 +4,5 @@ buildDunePackage {
   pname = "lablgtk3-gtkspell3";
   buildInputs = [ gtkspell3 ] ++ lablgtk3.buildInputs;
   propagatedBuildInputs = [ lablgtk3 ];
-  inherit (lablgtk3) src version meta nativeBuildInputs;
+  inherit (lablgtk3) src version useDune2 meta nativeBuildInputs;
 }

--- a/pkgs/development/ocaml-modules/lablgtk3/sourceview3.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/sourceview3.nix
@@ -4,5 +4,5 @@ buildDunePackage {
   pname = "lablgtk3-sourceview3";
   buildInputs = lablgtk3.buildInputs ++ [ gtksourceview ];
   propagatedBuildInputs = [ lablgtk3 ];
-  inherit (lablgtk3) src version meta nativeBuildInputs;
+  inherit (lablgtk3) src version useDune2 meta nativeBuildInputs;
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.12.

cc maintainer @jirkamarsik (`cairo2`).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
