### PR TITLE
python3Packages.pyobjc: repackage 7.1

### DIFF
--- a/pkgs/development/python-modules/pyobjc/default.nix
+++ b/pkgs/development/python-modules/pyobjc/default.nix
@@ -1,22 +1,476 @@
-{ lib, fetchPypi, isPy3k, buildPythonPackage }:
+{ lib
+, python
+, fetchFromGitHub
+, stdenvNoCC
+, buildPythonPackage
+, libffi
+, libdispatch
+, libobjc
+, frameworks
+, setuptools
+, packaging
+}:
 
-buildPythonPackage rec {
-  pname = "pyobjc";
+let
   version = "7.1";
-
-  # Gives "No matching distribution found for
-  # pyobjc-framework-Collaboration==4.0b1 (from pyobjc==4.0b1)"
-  disabled = isPy3k;
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1dfce78545df1af25d1dcd710309dd243083d90c977a8c84c483f8254967417b";
-  };
+  macSdkVersion = "10.12";
 
   meta = with lib; {
     description = "A bridge between the Python and Objective-C programming languages";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ lukegb ];
     homepage = "https://pythonhosted.org/pyobjc/";
+    platforms = platforms.darwin;
+  };
+  src = stdenvNoCC.mkDerivation rec {
+    pname = "pyobjc-src";
+    inherit version meta;
+
+    src = fetchFromGitHub {
+      owner = "ronaldoussoren";
+      repo = "pyobjc";
+      rev = "af0349674b08126e52f2d055cc5c2d917afc3913";
+      sha256 = "1d58hrzwaalssdfg1018n2rg2k2270b30c7gb1w0nk6q3r3fccq2";
+    };
+
+    patches = [
+      # Read macOS SDK version from environment variable, rather than using system version.
+      ./macos-sdk-version.patch
+      ./pyobjc-setup-sdk-version.patch
+
+      # Fix LaunchServices/CoreServices.LaunchServices.
+      ./launch-services.patch
+
+      # We don't package the iTunesLibrary framework.
+      ./pyobjc-setup-drop-itunes.patch
+    ];
+
+    postPatch = ''
+      substituteInPlace pyobjc-core/Modules/objc/libffi_support.h \
+        --replace "ffi/ffi.h" "ffi.h"
+
+      for f in pyobjc-framework-*/pyobjc_setup.py; do
+        cp pyobjc-core/Tools/pyobjc_setup.py "$f"
+      done
+    '';
+
+    buildPhase = "true";
+    installPhase = ''
+      cp -R . $out
+    '';
+  };
+
+  subdir = name: attrs: let
+    frameworkInputs = lib.optionals (attrs ? frameworks) attrs.frameworks;
+    buildInputs = lib.optionals (attrs ? buildInputs) attrs.buildInputs;
+    deps = lib.optionals (attrs ? deps) attrs.deps;
+    skipCoreDep = if attrs ? skipCoreDep then attrs.skipCoreDep else false;
+    pythonModuleName = if name == "pyobjc-core" then "objc" else lib.removePrefix "pyobjc-framework-" name;
+  in buildPythonPackage {
+    pname = name;
+    inherit version src;
+
+    sourceRoot = "${src.name}/${name}";
+    propagatedBuildInputs = deps ++ lib.optional (!skipCoreDep) modules.pyobjc-core;
+    buildInputs = frameworkInputs ++ buildInputs ++ [ libobjc frameworks.Foundation ];
+
+    # Tests for -core don't run, and then the other tests don't work anyway.
+    doCheck = false;
+    pythonImportsCheck = [ pythonModuleName ];
+
+    NIX_MACOS_SDK_VERSION = macSdkVersion;
+
+    # Don't let them turn warnings into errors.
+    NIX_CFLAGS_COMPILE = "-Wno-error";
+
+    # Avoid `clang-7: error: argument unused during compilation: '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]` spam
+    hardeningDisable = ["strictoverflow"];
+
+    preCheck = ''
+      # Needed for PyObjCTest.test_bundleFunctions.TestBundleFunctions
+      export HOME=/var/empty
+    '';
+
+  };
+
+  moduleDeps = with frameworks; with modules; {
+    pyobjc-core = {
+      frameworks = [ Carbon Cocoa ];
+      buildInputs = [ libffi ];
+      deps = [ setuptools ];
+      skipCoreDep = true;
+    };
+
+    pyobjc-framework-AVFoundation = {
+      frameworks = [ AVFoundation ];
+      deps = [ pyobjc-framework-CoreMedia pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-AVKit = {
+      frameworks = [ AVKit AppKit ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-Accounts = {
+      frameworks = [ Accounts ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-AddressBook = {
+      frameworks = [ AddressBook ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-AppleScriptKit = {
+      frameworks = [ AppleScriptKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-AppleScriptObjC = {
+      frameworks = [ AppleScriptObjC ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-ApplicationServices = {
+      frameworks = [ ApplicationServices ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-Automator = {
+      frameworks = [ Automator ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CFNetwork = {
+      frameworks = [ CFNetwork ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CalendarStore = {
+      frameworks = [ CalendarStore ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CloudKit = {
+      frameworks = [ CloudKit ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-CoreLocation pyobjc-framework-CoreData pyobjc-framework-Accounts ];
+    };
+    pyobjc-framework-Cocoa = {
+      frameworks = [ Cocoa ];
+      deps = [  ];
+    };
+    pyobjc-framework-Collaboration = {
+      frameworks = [ Collaboration ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-Contacts = {
+      frameworks = [ Contacts ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-ContactsUI = {
+      frameworks = [ ContactsUI ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Contacts ];
+    };
+    pyobjc-framework-CoreAudio = {
+      frameworks = [ CoreAudio ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CoreAudioKit = {
+      frameworks = [ CoreAudioKit Cocoa ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-CoreAudio ];
+    };
+    pyobjc-framework-CoreBluetooth = {
+      frameworks = [ CoreBluetooth ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CoreData = {
+      frameworks = [ CoreData ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CoreLocation = {
+      frameworks = [ CoreLocation ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CoreMIDI = {
+      frameworks = [ CoreMIDI ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CoreMedia = {
+      frameworks = [ CoreMedia ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CoreMediaIO = {
+      frameworks = [ CoreMediaIO ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CoreServices = {
+      frameworks = [ CoreServices ];
+      deps = [ pyobjc-framework-FSEvents ];
+    };
+    pyobjc-framework-CoreText = {
+      frameworks = [ CoreText ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-CoreWLAN = {
+      frameworks = [ CoreWLAN ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-CryptoTokenKit = {
+      frameworks = [ CryptoTokenKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-DVDPlayback = {
+      frameworks = [ DVDPlayback ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-DictionaryServices = {
+      frameworks = [ CoreServices ];
+      deps = [ pyobjc-framework-CoreServices ];
+    };
+    pyobjc-framework-DiscRecording = {
+      frameworks = [ DiscRecording ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-DiscRecordingUI = {
+      frameworks = [ DiscRecordingUI ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-DiscRecording ];
+    };
+    pyobjc-framework-DiskArbitration = {
+      frameworks = [ DiskArbitration ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-EventKit = {
+      frameworks = [ EventKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-ExceptionHandling = {
+      frameworks = [ ExceptionHandling ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-FSEvents = {
+      frameworks = [ CoreServices ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-FinderSync = {
+      frameworks = [ FinderSync ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-GameCenter = {
+      frameworks = [ GameCenter GameKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-GameController = {
+      frameworks = [ GameController AppKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-GameKit = {
+      frameworks = [ GameKit AddressBook ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-GameplayKit = {
+      frameworks = [ GameplayKit MetalKit SpriteKit AppKit Cocoa ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-SpriteKit ];
+    };
+    pyobjc-framework-IMServicePlugIn = {
+      frameworks = [ IMServicePlugIn GameKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-IOSurface = {
+      frameworks = [ IOSurface ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-ImageCaptureCore = {
+      frameworks = [ ImageCaptureCore ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-InputMethodKit = {
+      frameworks = [ InputMethodKit Cocoa ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-InstallerPlugins = {
+      frameworks = [ InstallerPlugins ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-InstantMessage = {
+      frameworks = [ InstantMessage ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-Intents = {
+      frameworks = [ Intents CoreLocation ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-LatentSemanticMapping = {
+      frameworks = [ LatentSemanticMapping ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-LaunchServices = {
+      frameworks = [ CoreServices ];
+      deps = [ pyobjc-framework-CoreServices ];
+    };
+    pyobjc-framework-LocalAuthentication = {
+      frameworks = [ LocalAuthentication ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-MapKit = {
+      frameworks = [ MapKit CoreLocation AppKit ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-CoreLocation pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-MediaAccessibility = {
+      frameworks = [ MediaAccessibility ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-MediaLibrary = {
+      frameworks = [ MediaLibrary ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-MediaPlayer = {
+      frameworks = [ MediaPlayer ];
+      deps = [ pyobjc-framework-AVFoundation ];
+    };
+    pyobjc-framework-MediaToolbox = {
+      frameworks = [ MediaToolbox ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-Metal = {
+      frameworks = [ Metal ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-MetalKit = {
+      frameworks = [ MetalKit AppKit ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Metal ];
+    };
+    pyobjc-framework-ModelIO = {
+      frameworks = [ ModelIO MetalKit ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-MultipeerConnectivity = {
+      frameworks = [ MultipeerConnectivity ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-NetFS = {
+      frameworks = [ NetFS ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-NetworkExtension = {
+      frameworks = [ NetworkExtension AddressBook ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-NotificationCenter = {
+      frameworks = [ NotificationCenter AppKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-OSAKit = {
+      frameworks = [ OSAKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-OpenDirectory = {
+      frameworks = [ OpenDirectory ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-Photos = {
+      frameworks = [ Photos ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-PhotosUI = {
+      frameworks = [ PhotosUI ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-PreferencePanes = {
+      frameworks = [ PreferencePanes ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-PubSub = {
+      frameworks = [ PubSub ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-Quartz = {
+      frameworks = [ Quartz AppKit Cocoa ImageCaptureCore ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-SafariServices = {
+      frameworks = [ SafariServices AppKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-SceneKit = {
+      frameworks = [ SceneKit MetalKit QuartzCore AppKit ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-ScreenSaver = {
+      frameworks = [ ScreenSaver AppKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-ScriptingBridge = {
+      frameworks = [ ScriptingBridge ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-SearchKit = {
+      frameworks = [ CoreServices ];
+      deps = [ pyobjc-framework-CoreServices ];
+    };
+    pyobjc-framework-Security = {
+      frameworks = [ Security ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-SecurityFoundation = {
+      frameworks = [ SecurityFoundation ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Security ];
+    };
+    pyobjc-framework-SecurityInterface = {
+      frameworks = [ SecurityInterface Cocoa ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Security ];
+    };
+    pyobjc-framework-ServiceManagement = {
+      frameworks = [ ServiceManagement ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-Social = {
+      frameworks = [ Social ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-SpriteKit = {
+      frameworks = [ SpriteKit AppKit MetalKit Cocoa ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz ];
+    };
+    pyobjc-framework-StoreKit = {
+      frameworks = [ StoreKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-SyncServices = {
+      frameworks = [ SyncServices ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-CoreData ];
+    };
+    pyobjc-framework-SystemConfiguration = {
+      frameworks = [ SystemConfiguration ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-VideoToolbox = {
+      frameworks = [ VideoToolbox ];
+      deps = [ pyobjc-framework-Cocoa pyobjc-framework-Quartz pyobjc-framework-CoreMedia ];
+    };
+    pyobjc-framework-WebKit = {
+      frameworks = [ WebKit AppKit ];
+      deps = [ pyobjc-framework-Cocoa ];
+    };
+    pyobjc-framework-libdispatch = {
+      frameworks = [ libdispatch ];
+    };
+  };
+
+  modules = builtins.mapAttrs subdir moduleDeps;
+in
+buildPythonPackage {
+  # This package isn't really a package, but it conforms to most of the nixpkgs Python packaging guidelines.
+  # It exists to fulfil the purpose of being a "pyobjc" package that can be installed that provides all the expected frameworks.
+
+  pname = "pyobjc";
+  inherit version meta src;
+
+  sourceRoot = "${src.name}/pyobjc";
+  buildInputs = [ packaging ];
+  propagatedBuildInputs = builtins.attrValues modules;
+
+  doCheck = false;
+  patches = [
+  ];
+
+  NIX_MACOS_SDK_VERSION = macSdkVersion;
+
+  # Expose the subdirectories as their corresponding Python module names under .modules.
+  # pyobjc-framework-WebKit -> WebKit, for instance.
+  # pyobjc-core is an exception to the rule, and it's named just "objc".
+  passthru.modules = (
+    lib.mapAttrs' (name: value: lib.nameValuePair (lib.removePrefix "pyobjc-framework-" name) value) (lib.filterAttrs (name: value: lib.hasPrefix "pyobjc-framework-" name) modules)
+  ) // {
+    objc = modules.pyobjc-core;
   };
 }

--- a/pkgs/development/python-modules/pyobjc/launch-services.patch
+++ b/pkgs/development/python-modules/pyobjc/launch-services.patch
@@ -1,0 +1,26 @@
+diff --git a/pyobjc-framework-CoreServices/Lib/CoreServices/LaunchServices/__init__.py b/pyobjc-framework-CoreServices/Lib/CoreServices/LaunchServices/__init__.py
+index d63c4532c..fcd9119c6 100644
+--- a/pyobjc-framework-CoreServices/Lib/CoreServices/LaunchServices/__init__.py
++++ b/pyobjc-framework-CoreServices/Lib/CoreServices/LaunchServices/__init__.py
+@@ -14,7 +14,7 @@ sys.modules["CoreServices.LaunchServices"] = mod = objc.ObjCLazyModule(
+     "LaunchServices",
+     "com.apple.CoreServices",
+     objc.pathForFramework(
+-        "/System/Library/Frameworks/CoreServices.framework/CoreServices"
++        "/System/Library/Frameworks/CoreServices.framework"
+     ),
+     _metadata.__dict__,
+     None,
+diff --git a/pyobjc-framework-LaunchServices/Lib/LaunchServices/__init__.py b/pyobjc-framework-LaunchServices/Lib/LaunchServices/__init__.py
+index 2caaab5e6..0591c8b92 100644
+--- a/pyobjc-framework-LaunchServices/Lib/LaunchServices/__init__.py
++++ b/pyobjc-framework-LaunchServices/Lib/LaunchServices/__init__.py
+@@ -19,7 +19,7 @@ sys.modules["LaunchServices"] = mod = objc.ObjCLazyModule(
+     "LaunchServices",
+     "com.apple.CoreServices",
+     objc.pathForFramework(
+-        "/System/Library/Frameworks/CoreServices.framework/CoreServices"
++        "/System/Library/Frameworks/CoreServices.framework"
+     ),
+     {},
+     None,

--- a/pkgs/development/python-modules/pyobjc/macos-sdk-version.patch
+++ b/pkgs/development/python-modules/pyobjc/macos-sdk-version.patch
@@ -1,0 +1,124 @@
+diff --git a/pyobjc-core/Tools/pyobjc_setup.py b/pyobjc-core/Tools/pyobjc_setup.py
+index 669c77a79..dace5e3fd 100644
+--- a/pyobjc-core/Tools/pyobjc_setup.py
++++ b/pyobjc-core/Tools/pyobjc_setup.py
+@@ -204,46 +204,11 @@ def get_os_level():
+ 
+ 
+ def get_sdk():
+-    env_cflags = os.environ.get("CFLAGS", "")
+-    config_cflags = get_config_var("CFLAGS")
+-    sdk = None
+-    for cflags_str in [env_cflags, config_cflags]:
+-        cflags = shlex.split(cflags_str)
+-        for i, val in enumerate(cflags):
+-            if val == "-isysroot":
+-                sdk = cflags[i + 1]
+-                break
+-            elif val.find("-isysroot") == 0:
+-                sdk = val[len("-isysroot") :]
+-                break
+-        if sdk:
+-            break
+-
+-    return sdk
++    return None
+ 
+ 
+ def get_sdk_level():
+-    sdk = get_sdk()
+-
+-    if not sdk:
+-        return None
+-
+-    if sdk == "/":
+-        return get_os_level()
+-
+-    sdk = sdk.rstrip("/")
+-    sdkname = os.path.basename(sdk)
+-    assert sdkname.startswith("MacOSX")
+-    assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
+-        try:
+-            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
+-                pl = plistlib.load(fp)
+-            return pl["Version"]
+-        except Exception:
+-            raise SystemExit("Cannot determine SDK version")
+-    else:
+-        return sdkname[6:-4]
++    return os.environ["NIX_MACOS_SDK_VERSION"]
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+@@ -418,39 +383,9 @@ def Extension(*args, **kwds):
+     if "clang" in get_config_var("CC"):
+         cflags.append("-Wno-deprecated-declarations")
+ 
+-    sdk = get_sdk()
+-    if not sdk:  
+-        # We're likely on a system with the Xcode Command Line Tools.
+-        # Explicitly use the most recent SDK to avoid compile problems.
+-        data = subprocess.check_output(
+-            ["/usr/bin/xcrun", "-sdk", "macosx", "--show-sdk-path"],
+-            universal_newlines=True,
+-        ).strip()
+-            
+-        if data:
+-            sdk_settings_path = os.path.join(data, 'SDKSettings.plist')
+-            if os.path.exists(sdk_settings_path):
+-                 with open(sdk_settings_path, 'rb') as fp:
+-                     sdk_settings = plistlib.load(fp)
+-                 version = sdk_settings['Version']
+-            else:
+-                 version = os.path.basename(data)[6:-4]
+-
+-            cflags.append("-isysroot")
+-            cflags.append(data)
+-            cflags.append(
+-                "-DPyObjC_BUILD_RELEASE=%02d%02d"
+-                % (tuple(map(int, version.split("."))))
+-            )
+-        else:
+-            cflags.append(
+-                "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+-            )
+-
+-    else:
+-        cflags.append(
+-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+-        )
++    cflags.append(
++        "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
++    )
+ 
+     if os_level == "10.4":
+         cflags.append("-DNO_OBJC2_RUNTIME")
+diff --git a/pyobjc-core/setup.py b/pyobjc-core/setup.py
+index eb2ded7a4..48ef2dc59 100644
+--- a/pyobjc-core/setup.py
++++ b/pyobjc-core/setup.py
+@@ -42,22 +42,7 @@ def get_os_level():
+ 
+ 
+ def get_sdk_level(sdk):
+-    if sdk == "/":
+-        return get_os_level()
+-
+-    sdk = sdk.rstrip("/")
+-    sdkname = os.path.basename(sdk)
+-    assert sdkname.startswith("MacOSX")
+-    assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
+-        try:
+-            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
+-                pl = plistlib.load(fp)
+-            return pl["Version"]
+-        except Exception:
+-            raise SystemExit("Cannot determine SDK version")
+-    else:
+-        return sdkname[6:-4]
++    return os.environ["NIX_MACOS_SDK_VERSION"]
+ 
+ 
+ # CFLAGS for the objc._objc extension:

--- a/pkgs/development/python-modules/pyobjc/pyobjc-setup-drop-itunes.patch
+++ b/pkgs/development/python-modules/pyobjc/pyobjc-setup-drop-itunes.patch
@@ -1,0 +1,14 @@
+diff --git a/pyobjc/setup.py b/pyobjc/setup.py
+index f9b5c3cc4..0ed41bdee 100644
+--- a/pyobjc/setup.py
++++ b/pyobjc/setup.py
+@@ -154,9 +154,6 @@ FRAMEWORK_WRAPPERS = [
+     ("VideoToolbox", "10.8", None),
+     ("Virtualization", "10.16", None),
+     ("Vision", "10.13", None),
+-    # iTunes library is shipped with iTunes, not part of macOS 'core'
+-    # Requires iTunes 11 or later, which is not available on 10.5
+-    ("iTunesLibrary", "10.6", None),
+ ]
+ 
+ MACOS_TO_DARWIN = {

--- a/pkgs/development/python-modules/pyobjc/pyobjc-setup-sdk-version.patch
+++ b/pkgs/development/python-modules/pyobjc/pyobjc-setup-sdk-version.patch
@@ -1,0 +1,37 @@
+diff --git a/pyobjc/setup.py b/pyobjc/setup.py
+index df29c8316..f9b5c3cc4 100644
+--- a/pyobjc/setup.py
++++ b/pyobjc/setup.py
+@@ -9,6 +9,8 @@ import subprocess
+ import sys
+ import tarfile
+ 
++from packaging import version
++
+ from setuptools import setup, Command
+ from setuptools.command import egg_info
+ 
+@@ -190,13 +192,23 @@ def framework_requires():
+ 
+     result = []
+ 
++    sdk_version = version.parse(os.environ["NIX_MACOS_SDK_VERSION"])
++
+     for name, introduced, removed in FRAMEWORK_WRAPPERS:
+ 
+         marker = []
+         if introduced is not None:
++            introduced_version = version.parse(introduced)
++            if introduced_version > sdk_version:
++                # nixpkgs hack: just skip things which don't match up with our SDK
++                continue
+             marker.append('platform_release>="%s"' % (MACOS_TO_DARWIN[introduced],))
+ 
+         if removed is not None:
++            removed_version = version.parse(removed)
++            if removed_version < sdk_version:
++                # nixpkgs hack: just skip things which don't match up with our SDK
++                continue
+             marker.append('platform_release<"%s"' % (MACOS_TO_DARWIN[removed],))
+ 
+         if marker:

--- a/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
@@ -20,8 +20,11 @@ with frameworks; with libs; {
   Automator               = {};
   CFNetwork               = {};
   CalendarStore           = {};
+  CloudKit                = {};
   Cocoa                   = { inherit AppKit CoreData; };
   Collaboration           = {};
+  Contacts                = {};
+  ContactsUI              = { inherit AppKit; };
   # Impure version of CoreFoundation, this should not be used unless another
   # framework includes headers that are not available in the pure version.
   CoreFoundation          = {};
@@ -38,6 +41,7 @@ with frameworks; with libs; {
   CoreText                = { inherit CoreGraphics; };
   CoreVideo               = { inherit ApplicationServices CoreGraphics IOSurface OpenGL; };
   CoreWLAN                = { inherit SecurityFoundation; };
+  CryptoTokenKit          = { inherit Foundation Security; };
   DVDPlayback             = {};
   DirectoryService        = {};
   DiscRecording           = { inherit libobjc CoreServices IOKit; };
@@ -46,6 +50,7 @@ with frameworks; with libs; {
   EventKit                = {};
   ExceptionHandling       = {};
   FWAUserLib              = {};
+  FinderSync              = {};
   ForceFeedback           = { inherit IOKit; };
   Foundation              = { inherit libobjc CoreFoundation Security ApplicationServices SystemConfiguration; };
   GLKit                   = {};
@@ -58,6 +63,7 @@ with frameworks; with libs; {
   Hypervisor              = {};
   ICADevices              = { inherit libobjc Carbon IOBluetooth; };
   IMServicePlugIn         = {};
+  Intents                 = {};
   IOBluetoothUI           = { inherit IOBluetooth; };
   IOKit                   = {};
   IOSurface               = { inherit IOKit xpc; };
@@ -78,21 +84,28 @@ with frameworks; with libs; {
   MapKit                  = {};
   MediaAccessibility      = { inherit CoreGraphics CoreText QuartzCore; };
   MediaPlayer             = {};
+  MediaLibrary            = {};
   MediaToolbox            = { inherit AudioToolbox AudioUnit CoreMedia; };
   Metal                   = {};
   MetalKit                = { inherit ModelIO Metal; };
+  MultipeerConnectivity   = { inherit Cocoa Foundation; };
   ModelIO                 = {};
+  NetworkExtension        = { inherit Foundation Network Security; };
   NetFS                   = {};
+  NotificationCenter      = {};
   OSAKit                  = { inherit Carbon; };
   OpenAL                  = {};
   OpenCL                  = { inherit IOSurface OpenGL; };
   OpenGL                  = {};
   PCSC                    = { inherit CoreData; };
+  Photos                  = { inherit AVFoundation CoreGraphics CoreImage CoreLocation CoreMedia Foundation ImageIO; };
+  PhotosUI                = { inherit AppKit Foundation MapKit Photos; };
   PreferencePanes         = {};
   PubSub                  = {};
   QTKit                   = { inherit CoreMediaIO CoreMedia MediaToolbox QuickTime VideoToolbox; };
   QuickLook               = { inherit ApplicationServices; };
-  SceneKit                = {};
+  SafariServices          = { };
+  SceneKit                = { inherit GLKit; };
   ScreenSaver             = {};
   Scripting               = {};
   ScriptingBridge         = {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5626,6 +5626,11 @@ in {
 
   pynzb = callPackage ../development/python-modules/pynzb { };
 
+  pyobjc = callPackage ../development/python-modules/pyobjc {
+    inherit (pkgs.darwin.apple_sdk) frameworks;
+    inherit (pkgs.darwin) libdispatch libobjc;
+  };
+
   pyocr = callPackage ../development/python-modules/pyocr {
     tesseract = pkgs.tesseract4;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The primary motivation is... that pyobjc doesn't actually build at master.

(this is my third attempt at this PR, the first time was targeted as master, the second time I based on staging but accidentally PRed against master, and _this_ time everything will go swimmingly)

Below follows the commit message for python3Packages.pyobjc, but the individual commits have pretty lengthy commit messages that explain the rationale behind each of them.

    At the same time, this actually fixes the build so it works at all; previously
    it was both disabled on Python 3, and not working on Python 2.7.

    pyobjc actually consists of a bunch of sub-modules (one for each wrapped
    framework, give-or-take). For parallelising the build at maximum efficiency, as
    well as allowing subpackages to select only the pyobjc dependencies which they
    actually need, we package each of the submodules individually, rather than
    pyobjc as a single coherent unit.

    To make this easier, we use the GitHub src archive, and patch it once upfront,
    which means we only need to move a single src pointer as we update (rather than
    fetching from PyPI, which would entail having separate fetch directives for
    each submodule).

    Additional packaging notes:
    * A lot of the exposed APIs are SDK-version-dependent, and nixpkgs takes great
      pains to expose separate frameworks from the SDK separately. In order for
      this to work, we patch out all the SDK version checks to instead use an
      environment variable with the macOS version, which we fix at 10.12 (which is,
      as of writing, the SDK version used).
    * LaunchServices just appears to be broken, and this breaks importing the
      entire CoreServices module. That's patched too.
    * iTunesLibrary is not actually a core macOS framework, but is usually provided
      in pyobjc. I don't want to delve into figuring out how to expose it properly
      as a framework, so for the purposes of getting a basic package up for review
      I've just dropped it.
    * Given the large number of frameworks that are needed it's impractical to
      separately provide these as arguments to pyobjc, so the entire frameworks
      attrset is provided as an argument instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
