### PR TITLE
devilutionx: update sha256, fix build

### DIFF
--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, SDL2, SDL2_mixer, SDL2_ttf, libsodium, pkg-config }:
+
 stdenv.mkDerivation rec {
   pname = "devilutionx";
   version = "1.2.0";
@@ -7,8 +8,12 @@ stdenv.mkDerivation rec {
     owner = "diasurgical";
     repo = "devilutionX";
     rev = version;
-    sha256 = "03w3bgmzwsbycx3fzvn47fsmabl069gw77yn2fqg89wlgaw1yrr9";
+    sha256 = "034xkz0a7j2nba17mh44r0kamcblvykdwfsjvjwaz2mrcsmzkr9z";
   };
+
+  postPatch = ''
+    substituteInPlace Source/init.cpp --replace "/usr/share/diasurgical/devilutionx/" "${placeholder "out"}/share/diasurgical/devilutionx/"
+  '';
 
   NIX_CFLAGS_COMPILE = [
     "-I${SDL2_ttf}/include/SDL2"
@@ -17,6 +22,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBINARY_RELEASE=ON"
+    "-DVERSION_NUM=${version}"
   ];
 
   nativeBuildInputs = [ pkg-config cmake ];
@@ -31,6 +37,7 @@ stdenv.mkDerivation rec {
   '' else ''
     install -Dm755 -t $out/bin devilutionx
     install -Dt $out/share/fonts/truetype ../Packaging/resources/CharisSILB.ttf
+    install -Dt $out/share/diasurgical/devilutionx ../Packaging/resources/devilutionx.mpq
 
     # TODO: icons and .desktop (see Packages/{debian,fedora}/*)
   '') + ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/118794

This PR did not update the hash which means it probably only appeared to build because of cached nonsense. I'm too lazy to look, but I'm assuming `devilutionx` is broken in `master` currently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @karolchmist 