### PR TITLE
gitlab-shell: 13.15.1 -> 13.17.0

### DIFF
--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -122,7 +122,10 @@ stdenv.mkDerivation {
     rubyEnv rubyEnv.wrappedRuby rubyEnv.bundler tzdata git nettools
   ];
 
-  patches = [ ./remove-hardcoded-locations.patch ];
+  patches = [
+    # Change hardcoded paths to the NixOS equivalent
+    ./remove-hardcoded-locations.patch
+  ];
 
   postPatch = ''
     ${lib.optionalString (!gitlabEnterprise) ''

--- a/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
@@ -7,14 +7,14 @@ buildGoModule rec {
     owner = "gitlab-org";
     repo = "gitlab-shell";
     rev = "v${version}";
-    sha256 = "sha256-wDZLcCBbWjG6wIcEj02eqwWVfAYy1TuAo/xvJB8tt+0=";
+    sha256 = "sha256-j/80AIIJdRSisu2fNXcqazb4oIzAQP5CfxHX3l6yijY=";
   };
 
   buildInputs = [ ruby ];
 
   patches = [ ./remove-hardcoded-locations.patch ];
 
-  vendorSha256 = "16fa3bka0008x2yazahc6xxcv4fa6yqg74kk64v8lrp7snbvjf4d";
+  vendorSha256 = "sha256-/jJTMtS5fcbQroWuaPPfvYxy6znNS0FOXVN7IcE/spQ=";
 
   postInstall = ''
     cp -r "$NIX_BUILD_TOP/source"/bin/* $out/bin

--- a/pkgs/applications/version-management/gitlab/gitlab-shell/remove-hardcoded-locations.patch
+++ b/pkgs/applications/version-management/gitlab/gitlab-shell/remove-hardcoded-locations.patch
@@ -1,34 +1,25 @@
 diff --git a/internal/config/config.go b/internal/config/config.go
-index 79c2a36..12ba31e 100644
+index 36f8625..72ede08 100644
 --- a/internal/config/config.go
 +++ b/internal/config/config.go
-@@ -3,7 +3,6 @@ package config
- import (
- 	"io/ioutil"
- 	"net/url"
--	"os"
- 	"path"
- 	"path/filepath"
+@@ -12,7 +12,7 @@ import (
+ )
  
-@@ -59,16 +58,13 @@ func (c *Config) GetHttpClient() *client.HttpClient {
- }
+ const (
+-	configFile            = "config.yml"
++	configFile            = "shell-config.yml"
+ 	defaultSecretFileName = ".gitlab_shell_secret"
+ )
  
- func New() (*Config, error) {
--	dir, err := os.Getwd()
--	if err != nil {
--		return nil, err
--	}
-+	dir := "/run/gitlab"
- 
- 	return NewFromDir(dir)
- }
- 
- func NewFromDir(dir string) (*Config, error) {
--	return newFromFile(path.Join(dir, configFile))
-+	return newFromFile("/run/gitlab/shell-config.yml")
- }
- 
- func newFromFile(filename string) (*Config, error) {
+@@ -91,7 +91,7 @@ func (c *Config) GetHttpClient() *client.HttpClient {
+ // NewFromDirExternal returns a new config from a given root dir. It also applies defaults appropriate for
+ // gitlab-shell running in an external SSH server.
+ func NewFromDirExternal(dir string) (*Config, error) {
+-	cfg, err := newFromFile(filepath.Join(dir, configFile))
++	cfg, err := newFromFile(filepath.Join("/run/gitlab", configFile))
+ 	if err != nil {
+ 		return nil, err
+ 	}
 diff --git a/internal/keyline/key_line.go b/internal/keyline/key_line.go
 index c6f2422..fb0426b 100644
 --- a/internal/keyline/key_line.go
@@ -55,6 +46,3 @@ index 52ac5ee..d96baa3 100644
    end
  
    def auth_file
--- 
-2.28.0
-


### PR DESCRIPTION
###### Motivation for this change
In #116798, only the version number was updated, not the hashes and patches. This seems to happen when the update script fails because the patches don't apply, so it's something to look out for with future updates.

###### Things done

- Manually tested adding an ssh key, cloning and pushing
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
