### PR TITLE
clickhouse-cli: init at 0.3.7

### DIFF
--- a/pkgs/development/python-modules/clickhouse-cli/default.nix
+++ b/pkgs/development/python-modules/clickhouse-cli/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, click
+, prompt_toolkit
+, pygments
+, requests
+, sqlparse
+}:
+
+buildPythonPackage rec {
+  pname = "clickhouse-cli";
+  version = "0.3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-fDvUdL6LzgCv6LDmB0R0M7v6BbnbL68p9pHMebP58h8=";
+  };
+
+  propagatedBuildInputs = [
+    click
+    prompt_toolkit
+    pygments
+    requests
+    sqlparse
+  ];
+
+  pythonImportsCheck = [ "clickhouse_cli" ];
+
+  meta = with lib; {
+    description = "A third-party client for the Clickhouse DBMS server";
+    homepage = "https://github.com/hatarist/clickhouse-cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ivan-babrou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18277,6 +18277,8 @@ in
     inherit (llvmPackages_10) clang-unwrapped lld lldClang llvm;
   };
 
+  clickhouse-cli = with python3Packages; toPythonApplication clickhouse-cli;
+
   couchdb = callPackage ../servers/http/couchdb {
     sphinx = python27Packages.sphinx;
     erlang = erlangR19;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1396,6 +1396,8 @@ in {
 
   clickhouse-cityhash = callPackage ../development/python-modules/clickhouse-cityhash {};
 
+  clickhouse-cli = callPackage ../development/python-modules/clickhouse-cli { };
+
   clickhouse-driver = callPackage ../development/python-modules/clickhouse-driver {};
 
   cliff = callPackage ../development/python-modules/cliff { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
