### PR TITLE
usbsdmux: 0.1.8 -> 0.2.0

### DIFF
--- a/pkgs/development/tools/misc/usbsdmux/default.nix
+++ b/pkgs/development/tools/misc/usbsdmux/default.nix
@@ -2,12 +2,15 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "usbsdmux";
-  version = "0.1.8";
+  version = "0.2.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0m3d0rs9s5v5hnsjkfybmd8v54gn7rc1dbg5vc48rryhc969pr9f";
+    sha256 = "sha256-ydDUSqBTY62iOtWdgrFh2qrO9LMi+OCYIw5reh6uoIA=";
   };
+
+  # usbsdmux is not meant to be used as an importable module and has no tests
+  doCheck = false;
 
   meta = with lib; {
     description = "Control software for the LXA USB-SD-Mux";


### PR DESCRIPTION
###### Motivation for this change

New upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
