### PR TITLE
qutebrowser: don't crash on :version command

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, fetchzip, python3
+{ lib, fetchpatch, fetchurl, fetchzip, python3
 , mkDerivationWith, wrapQtAppsHook, wrapGAppsHook, qtbase, glib-networking
 , asciidoc, docbook_xml_dtd_45, docbook_xsl, libxml2
 , libxslt, gst_all_1 ? null
@@ -67,7 +67,15 @@ in mkDerivationWith python3Packages.buildPythonApplication rec {
     ++ lib.optional (pythonOlder "3.9") importlib-resources
   );
 
-  patches = [ ./fix-restart.patch ];
+  patches = [
+    ./fix-restart.patch
+    (fetchpatch {
+      name = "fix-version-parsing.patch";
+      url = "https://github.com/qutebrowser/qutebrowser/commit/c3d1b71c6f08607f47353f406aca0168bb3062a1.patch";
+      excludes = [ "doc/changelog.asciidoc" ];
+      sha256 = "1vm2yjvmrw4cyn8mpwfwvvcihn74f60ql3qh1rjj8n0wak8z1ir6";
+    })
+  ];
 
   dontWrapGApps = true;
   dontWrapQtApps = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/118784

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @wedens