### PR TITLE
sdrangel: 6.4.0 -> 6.8.0

### DIFF
--- a/pkgs/applications/radio/rtl-sdr/default.nix
+++ b/pkgs/applications/radio/rtl-sdr/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchgit, fetchpatch, cmake, pkg-config, libusb1 }:
+{ lib
+, stdenv
+, fetchgit
+, cmake
+, pkg-config
+, libusb1
+}:
 
 stdenv.mkDerivation rec {
   pname = "rtl-sdr";
@@ -10,34 +16,25 @@ stdenv.mkDerivation rec {
     sha256 = "0lmvsnb4xw4hmz6zs0z5ilsah5hjz29g1s0050n59fllskqr3b8k";
   };
 
-  patches = [ (fetchpatch {
-    name = "hardened-udev-rules.patch";
-    url = "https://osmocom.org/projects/rtl-sdr/repository/revisions/b2814731563be4d5a0a68554ece6454a2c63af12/diff?format=diff";
-    sha256 = "0ns740s2rys4glq4la4bh0sxfv1mn61yfjns2yllhx70rsb2fqrn";
-  }) ];
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '/etc/udev/rules.d' "$out/etc/udev/rules.d"
+
+    substituteInPlace rtl-sdr.rules \
+      --replace 'MODE:="0666"' 'ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev"'
+  '';
 
   nativeBuildInputs = [ pkg-config cmake ];
+
   buildInputs = [ libusb1 ];
 
-  # TODO: get these fixes upstream:
-  # * Building with -DINSTALL_UDEV_RULES=ON tries to install udev rules to
-  #   /etc/udev/rules.d/, and there is no option to install elsewhere. So install
-  #   rules manually.
-  # * Propagate libusb-1.0 dependency in pkg-config file.
-  postInstall = lib.optionalString stdenv.isLinux ''
-    mkdir -p "$out/etc/udev/rules.d/"
-    cp ../rtl-sdr.rules "$out/etc/udev/rules.d/99-rtl-sdr.rules"
-
-    pcfile="$out"/lib/pkgconfig/librtlsdr.pc
-    grep -q "Requires:" "$pcfile" && { echo "Upstream has added 'Requires:' in $(basename "$pcfile"); update nix expression."; exit 1; }
-    echo "Requires: libusb-1.0" >> "$pcfile"
-  '';
+  cmakeFlags = lib.optional stdenv.isLinux "-DINSTALL_UDEV_RULES=ON";
 
   meta = with lib; {
     description = "Turns your Realtek RTL2832 based DVB dongle into a SDR receiver";
-    homepage = "http://sdr.osmocom.org/trac/wiki/rtl-sdr";
+    homepage = "http://github.com/librtlsdr/librtlsdr";
     license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ bjornfor ];
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -1,54 +1,78 @@
-{
-airspy,
-boost,
-cm256cc,
-cmake,
-codec2,
-fetchFromGitHub,
-fftwFloat,
-glew,
-hackrf,
-lib,
-ffmpeg,
-libiio,
-libopus,
-libpulseaudio,
-libusb1,
-limesuite,
-libbladeRF,
-mkDerivation,
-ocl-icd,
-opencv3,
-pkg-config,
-qtbase,
-qtmultimedia,
-qtserialport,
-qtwebsockets,
-rtl-sdr,
-serialdv,
-soapysdr-with-plugins,
-uhd
+{ airspy
+, boost
+, cm256cc
+, cmake
+, codec2
+, fetchFromGitHub
+, fftwFloat
+, glew
+, hackrf
+, lib
+, ffmpeg
+, libiio
+, libopus
+, libpulseaudio
+, libusb1
+, limesuite
+, libbladeRF
+, mkDerivation
+, ocl-icd
+, opencv3
+, pkg-config
+, qtcharts
+, qtlocation
+, qtmultimedia
+, qtserialport
+, qtspeech
+, qtwebsockets
+, rtl-sdr
+, serialdv
+, soapysdr-with-plugins
+, uhd
 }:
 
 mkDerivation rec {
   pname = "sdrangel";
-  version = "6.4.0";
+  version = "6.8.0";
 
   src = fetchFromGitHub {
     owner = "f4exb";
     repo = "sdrangel";
     rev = "v${version}";
-    sha256 = "4iJoKs0BHmBR6JRFuTIqs0GW3SjhPRMPRlqdyTI38T4=";
+    sha256 = "sha256-dFWwEs2nvcaCWpM4tA3/w8PbmNXn/R7JvxP3XEHasSQ=";
     fetchSubmodules = false;
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
+
   buildInputs = [
-    glew opencv3 libusb1 boost libopus limesuite ffmpeg libiio libpulseaudio
-    qtbase qtwebsockets qtmultimedia rtl-sdr airspy hackrf
-    fftwFloat codec2 cm256cc serialdv qtserialport
-    libbladeRF uhd soapysdr-with-plugins
+    airspy
+    boost
+    cm256cc
+    codec2
+    ffmpeg
+    fftwFloat
+    glew
+    hackrf
+    libbladeRF
+    libiio
+    libopus
+    libpulseaudio
+    libusb1
+    limesuite
+    opencv3
+    qtcharts
+    qtlocation
+    qtmultimedia
+    qtserialport
+    qtspeech
+    qtwebsockets
+    rtl-sdr
+    serialdv
+    soapysdr-with-plugins
+    uhd
   ];
+
   cmakeFlags = [
     "-DLIBSERIALDV_INCLUDE_DIR:PATH=${serialdv}/include/serialdv"
     "-DLIMESUITE_INCLUDE_DIR:PATH=${limesuite}/include"
@@ -61,11 +85,11 @@ mkDerivation rec {
   meta = with lib; {
     description = "Software defined radio (SDR) software";
     longDescription = ''
-        SDRangel is an Open Source Qt5 / OpenGL 3.0+ SDR and signal analyzer frontend to various hardware.
+      SDRangel is an Open Source Qt5 / OpenGL 3.0+ SDR and signal analyzer frontend to various hardware.
     '';
     homepage = "https://github.com/f4exb/sdrangel";
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ alkeryn ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/librtlsdr/default.nix
+++ b/pkgs/development/libraries/librtlsdr/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "librtlsdr";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "librtlsdr";
+    repo = "librtlsdr";
+    rev = "v${version}";
+    sha256 = "sha256-s03h+3EfC5c7yRYBM6aCRWtmstwRJWuBywuyVt+k/bk=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '/etc/udev/rules.d' "$out/etc/udev/rules.d"
+
+    substituteInPlace rtl-sdr.rules \
+      --replace 'MODE:="0666"' 'ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev"'
+  '';
+
+  nativeBuildInputs = [ pkg-config cmake ];
+
+  buildInputs = [ libusb1 ];
+
+  meta = with lib; {
+    description = "Turns your Realtek RTL2832 based DVB dongle into a SDR receiver";
+    homepage = "http://github.com/librtlsdr/librtlsdr";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ bjornfor ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25493,7 +25493,9 @@ in
 
   rtl-ais = callPackage ../applications/radio/rtl-ais { };
 
+  # librtlsdr is a friendly fork with additional features
   rtl-sdr = callPackage ../applications/radio/rtl-sdr { };
+  librtlsdr = callPackage ../development/libraries/librtlsdr { };
 
   rtv = callPackage ../applications/misc/rtv { };
 


### PR DESCRIPTION
###### Motivation for this change

Also introduce the `librtlsdr` fork of `rtl-sdr`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
