### PR TITLE
wdisplays: 1.0 -> 2021-04-03

### DIFF
--- a/pkgs/tools/graphics/wdisplays/default.nix
+++ b/pkgs/tools/graphics/wdisplays/default.nix
@@ -1,36 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, gtk3, epoxy, wayland, wrapGAppsHook
-, fetchpatch
-}:
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, gtk3, epoxy, wayland, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "wdisplays";
-  version = "1.0";
+  version = "unstable-2021-04-03";
 
   nativeBuildInputs = [ meson ninja pkg-config wrapGAppsHook ];
 
   buildInputs = [ gtk3 epoxy wayland ];
 
   src = fetchFromGitHub {
-    owner = "cyclopsian";
+    owner = "luispabon";
     repo = "wdisplays";
-    rev = version;
-    sha256 = "1xhgrcihja2i7yg54ghbwr1v6kf8jnsfcp364yb97vkxskc4y21y";
+    rev = "7f2eac0d2aa81b5f495da7950fd5a94683f7868e";
+    sha256 = "sha256-cOF3+T34zPro58maWUouGG+vlLm2C5NfcH7PZhSvApE=";
   };
-
-  patches = [
-    # Fixes `Gdk-Message: 10:26:38.752: Error reading events from display: Success`
-    # https://github.com/cyclopsian/wdisplays/pull/20
-    (fetchpatch {
-      url = "https://github.com/cyclopsian/wdisplays/commit/5198a9c94b40ff157c284df413be5402f1b75118.patch";
-      sha256 = "1xwphyn0ksf8isy9dz3mfdhmsz4jv02870qz5615zs7aqqfcwn85";
-    })
-  ];
 
   meta = with lib; {
     description = "A graphical application for configuring displays in Wayland compositors";
-    homepage = "https://github.com/cyclopsian/wdisplays";
-    maintainers = with lib.maintainers; [ lheckemann ma27 ];
-    license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    homepage = "https://github.com/luispabon/wdisplays";
+    maintainers = with maintainers; [ lheckemann ma27 ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I just realized that the original repository disappeared, so I decided
switch to a fork[1] for now. Also, I changed the following things:

* The project got relicensed[2] to `gpl3Plus`. Unfortunately the tags are
  gone, but it seems as this has happened after the 1.0 release, so no
  problem for us.

* The patch for sway 1.5[3] got merged into the fork, so it doesn't have
  to be applied here.

* Decided to go for `master` here for now. First of all there are no
  tags anymore, also there are a few fixes on `master` now.

* Compared the new source with the old 1.0 tarball via `diff -r`. Even
  though most of the changes were written by the original author on top
  of 1.0, I did a diff against everything from 1.0 and didn't find any
  issues. Also, `luispabon` doesn't seem to be a throw-away account so
  I'd say that using this fork for now is fine.

[1] https://github.com/luispabon/wdisplays
[2] https://github.com/luispabon/wdisplays/commit/69564522bc12569c96a2192e2dd0d5d4bef8aa13
[3] https://github.com/luispabon/wdisplays/commit/5198a9c94b40ff157c284df413be5402f1b75118



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
