### PR TITLE
rustc: reenable aarch64-darwin for 1.51.0

### DIFF
--- a/pkgs/development/compilers/rust/1_51.nix
+++ b/pkgs/development/compilers/rust/1_51.nix
@@ -45,6 +45,7 @@ import ./default.nix {
     aarch64-unknown-linux-gnu = "1db7a4fbddc68cd29eb9bca9fa7d0d2d9e3d59ede7ddaad66222fb4336a6bacf";
     aarch64-unknown-linux-musl = "adcc6c76a8967bacb6687b565d3cf739e35fde066b03edb745b05b52fa8b5b36";
     x86_64-apple-darwin = "1bf5a7ecf6468ce1bf9fe49c8083b3f648b40c16fbfb7539d106fe28eb0e792e";
+    aarch64-apple-darwin = "1ed91a867e7b86cc4bc84c0838240f1c25acd007100ec9f7a14c4873e4b56561";
     powerpc64le-unknown-linux-gnu = "e0472589d3f9ba7ebf27f033af320e0d5cfb70222955bd8ed73ce2c9a70ae535";
   };
 

--- a/pkgs/development/compilers/rust/print-hashes.sh
+++ b/pkgs/development/compilers/rust/print-hashes.sh
@@ -16,6 +16,7 @@ PLATFORMS=(
   aarch64-unknown-linux-gnu
   aarch64-unknown-linux-musl
   x86_64-apple-darwin
+  aarch64-apple-darwin
   powerpc64le-unknown-linux-gnu
 )
 BASEURL=https://static.rust-lang.org/dist


### PR DESCRIPTION
###### Motivation for this change
This adds the checksum of the bootstrap rust for rustc on aarch64-darwin. This is not yet used, as we are waiting on https://github.com/nixos/nixpkgs/pull/105026. But this makes rebasing there easier, as now the checksum is included.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
