### PR TITLE
Fix qtPrepareTool function

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0003-qtbase-mkspecs.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0003-qtbase-mkspecs.patch
@@ -1,6 +1,6 @@
-From 8bdbddc2e5fef1553b1ba0297d3c03b38e9b947b Mon Sep 17 00:00:00 2001
-From: Thomas Tuegel <ttuegel@mailbox.org>
-Date: Wed, 18 Sep 2019 05:39:39 -0500
+From 9ffbcc5e362d17aea3e3d67e43cd3cd993e987eb Mon Sep 17 00:00:00 2001
+From: OPNA2608 <christoph.neidahl@gmail.com>
+Date: Mon, 12 Apr 2021 20:05:25 +0200
 Subject: [PATCH 03/12] qtbase-mkspecs
 
 ---
@@ -12,13 +12,13 @@ Subject: [PATCH 03/12] qtbase-mkspecs
  mkspecs/features/qt_build_paths.prf           |  4 +-
  mkspecs/features/qt_docs.prf                  | 10 +--
  mkspecs/features/qt_example_installs.prf      |  2 +-
- mkspecs/features/qt_functions.prf             |  2 +-
+ mkspecs/features/qt_functions.prf             | 27 ++++---
  mkspecs/features/qt_installs.prf              | 22 ++---
  mkspecs/features/qt_plugin.prf                |  2 +-
- 11 files changed, 39 insertions(+), 142 deletions(-)
+ 11 files changed, 53 insertions(+), 153 deletions(-)
 
 diff --git a/mkspecs/features/create_cmake.prf b/mkspecs/features/create_cmake.prf
-index 00da9bd33f..bd166fbfea 100644
+index 02e5775983..3782949d32 100644
 --- a/mkspecs/features/create_cmake.prf
 +++ b/mkspecs/features/create_cmake.prf
 @@ -21,7 +21,7 @@ load(cmake_functions)
@@ -96,7 +96,7 @@ index 00da9bd33f..bd166fbfea 100644
      INSTALLS += cmake_qt5_plugin_file
  
      return()
-@@ -333,7 +308,7 @@ exists($$cmake_macros_file.input) {
+@@ -334,7 +309,7 @@ exists($$cmake_macros_file.input) {
      cmake_qt5_module_files.files += $$cmake_macros_file.output
  }
  
@@ -370,18 +370,44 @@ index 43b58817fe..e635b8f67a 100644
  
  check_examples {
 diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
-index 1903e509c8..ae7b585989 100644
+index 1903e509c8..1dc117a388 100644
 --- a/mkspecs/features/qt_functions.prf
 +++ b/mkspecs/features/qt_functions.prf
-@@ -69,7 +69,7 @@ defineTest(qtHaveModule) {
+@@ -69,19 +69,22 @@ defineTest(qtHaveModule) {
  defineTest(qtPrepareTool) {
      cmd = $$eval(QT_TOOL.$${2}.binary)
      isEmpty(cmd) {
 -        cmd = $$[QT_HOST_BINS]/$$2
-+        cmd = $$system("command -v $$2")
-         exists($${cmd}.pl) {
-             $${1}_EXE = $${cmd}.pl
-             cmd = perl -w $$system_path($${cmd}.pl)
+-        exists($${cmd}.pl) {
+-            $${1}_EXE = $${cmd}.pl
+-            cmd = perl -w $$system_path($${cmd}.pl)
+-        } else: contains(QMAKE_HOST.os, Windows) {
+-            $${1}_EXE = $${cmd}.exe
+-            cmd = $$system_path($${cmd}.exe)
+-        } else:contains(QMAKE_HOST.os, Darwin) {
+-            BUNDLENAME = $${cmd}.app/Contents/MacOS/$$2
+-            exists($$BUNDLENAME) {
+-                cmd = $$BUNDLENAME
++        cmd = $$system("command -v $${2}")
++        isEmpty(cmd) {
++            cmd = $$system("command -v $${2}.pl")
++            !isEmpty(cmd) {
++                $${1}_EXE = $$cmd
++                cmd = perl -w $$system_path($${cmd})
++            } else: contains(QMAKE_HOST.os, Windows) {
++                cmd = $$system("command -v $${2}.exe")
++                $${1}_EXE = $$cmd
++            } else: contains(QMAKE_HOST.os, Darwin) {
++                cmd = $$system("command -v $${2}.app")
++                !isEmpty(cmd) {
++                    cmd = $${cmd}/Contents/MacOS/$${2}
++                    $${1}_EXE = $$cmd
++                }
+             }
+-            $${1}_EXE = $$cmd
+         } else {
+             $${1}_EXE = $$cmd
+         }
 diff --git a/mkspecs/features/qt_installs.prf b/mkspecs/features/qt_installs.prf
 index 1ebca17366..b784441da0 100644
 --- a/mkspecs/features/qt_installs.prf
@@ -461,5 +487,5 @@ index 40528a65e2..903f795284 100644
  
  TARGET = $$qt5LibraryTarget($$TARGET)
 -- 
-2.23.GIT
+2.29.3
 

--- a/pkgs/development/libraries/qt-5/5.14/qtbase.patch.d/0003-qtbase-mkspecs.patch
+++ b/pkgs/development/libraries/qt-5/5.14/qtbase.patch.d/0003-qtbase-mkspecs.patch
@@ -1,6 +1,6 @@
-From 1cb5581d7f20bf87ac8d67a7295447a78a1d9645 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Milan=20P=C3=A4ssler?= <me@pbb.lc>
-Date: Sat, 4 Apr 2020 00:25:52 +0200
+From 87c81a31d65862a2f32fdc575cfb47b7a46bfae7 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <christoph.neidahl@gmail.com>
+Date: Mon, 12 Apr 2021 20:05:25 +0200
 Subject: [PATCH 03/10] qtbase-mkspecs
 
 ---
@@ -12,10 +12,10 @@ Subject: [PATCH 03/10] qtbase-mkspecs
  mkspecs/features/qt_build_paths.prf           |  4 +-
  mkspecs/features/qt_docs.prf                  | 10 +--
  mkspecs/features/qt_example_installs.prf      |  2 +-
- mkspecs/features/qt_functions.prf             |  2 +-
+ mkspecs/features/qt_functions.prf             | 27 ++++---
  mkspecs/features/qt_installs.prf              | 22 ++---
  mkspecs/features/qt_plugin.prf                |  2 +-
- 11 files changed, 38 insertions(+), 141 deletions(-)
+ 11 files changed, 52 insertions(+), 152 deletions(-)
 
 diff --git a/mkspecs/features/create_cmake.prf b/mkspecs/features/create_cmake.prf
 index 0e71fd0015..ba071d9a70 100644
@@ -369,18 +369,44 @@ index 72b47bce27..d59e949e78 100644
  
  check_examples {
 diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
-index 7777e615bd..abeb03a663 100644
+index 7777e615bd..b0c6880a74 100644
 --- a/mkspecs/features/qt_functions.prf
 +++ b/mkspecs/features/qt_functions.prf
-@@ -87,7 +87,7 @@ defineTest(qtHaveModule) {
+@@ -87,19 +87,22 @@ defineTest(qtHaveModule) {
  defineTest(qtPrepareTool) {
      cmd = $$eval(QT_TOOL.$${2}.binary)
      isEmpty(cmd) {
 -        cmd = $$[QT_HOST_BINS]/$$2
-+        cmd = $$system("command -v $$2")
-         exists($${cmd}.pl) {
-             $${1}_EXE = $${cmd}.pl
-             cmd = perl -w $$system_path($${cmd}.pl)
+-        exists($${cmd}.pl) {
+-            $${1}_EXE = $${cmd}.pl
+-            cmd = perl -w $$system_path($${cmd}.pl)
+-        } else: contains(QMAKE_HOST.os, Windows) {
+-            $${1}_EXE = $${cmd}.exe
+-            cmd = $$system_path($${cmd}.exe)
+-        } else:contains(QMAKE_HOST.os, Darwin) {
+-            BUNDLENAME = $${cmd}.app/Contents/MacOS/$$2
+-            exists($$BUNDLENAME) {
+-                cmd = $$BUNDLENAME
++        cmd = $$system("command -v $${2}")
++        isEmpty(cmd) {
++            cmd = $$system("command -v $${2}.pl")
++            !isEmpty(cmd) {
++                $${1}_EXE = $$cmd
++                cmd = perl -w $$system_path($${cmd})
++            } else: contains(QMAKE_HOST.os, Windows) {
++                cmd = $$system("command -v $${2}.exe")
++                $${1}_EXE = $$cmd
++            } else: contains(QMAKE_HOST.os, Darwin) {
++                cmd = $$system("command -v $${2}.app")
++                !isEmpty(cmd) {
++                    cmd = $${cmd}/Contents/MacOS/$${2}
++                    $${1}_EXE = $$cmd
++                }
+             }
+-            $${1}_EXE = $$cmd
+         } else {
+             $${1}_EXE = $$cmd
+         }
 diff --git a/mkspecs/features/qt_installs.prf b/mkspecs/features/qt_installs.prf
 index 1ebca17366..a8f958eae8 100644
 --- a/mkspecs/features/qt_installs.prf
@@ -460,5 +486,5 @@ index 573d717eea..024c624cb6 100644
  
  qt_libinfix_plugins: TARGET = $$TARGET$$QT_LIBINFIX
 -- 
-2.25.1
+2.29.3
 

--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0003-qtbase-mkspecs.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0003-qtbase-mkspecs.patch
@@ -1,6 +1,6 @@
-From 82771c437957b3684ce296997d795432756aa8b1 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Milan=20P=C3=A4ssler?= <me@pbb.lc>
-Date: Sat, 4 Apr 2020 00:25:52 +0200
+From 03a5a7eab673d18d00c9b5eb8c7d5b790079e8ff Mon Sep 17 00:00:00 2001
+From: OPNA2608 <christoph.neidahl@gmail.com>
+Date: Mon, 12 Apr 2021 20:20:46 +0200
 Subject: [PATCH 03/11] qtbase-mkspecs
 
 ---
@@ -12,10 +12,10 @@ Subject: [PATCH 03/11] qtbase-mkspecs
  mkspecs/features/qt_build_paths.prf           |  4 +-
  mkspecs/features/qt_docs.prf                  | 10 +--
  mkspecs/features/qt_example_installs.prf      |  2 +-
- mkspecs/features/qt_functions.prf             |  2 +-
+ mkspecs/features/qt_functions.prf             | 27 ++++---
  mkspecs/features/qt_installs.prf              | 22 ++---
  mkspecs/features/qt_plugin.prf                |  2 +-
- 11 files changed, 38 insertions(+), 141 deletions(-)
+ 11 files changed, 52 insertions(+), 152 deletions(-)
 
 diff --git a/mkspecs/features/create_cmake.prf b/mkspecs/features/create_cmake.prf
 index 24ed125f12..f0666a1986 100644
@@ -105,7 +105,7 @@ index 24ed125f12..f0666a1986 100644
  # We are generating cmake files. Most developers of Qt are not aware of cmake,
  # so we require automatic tests to be available. The only module which should
 diff --git a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-index 309798a767..b6c3ab8609 100644
+index db18dbece6..8246f37931 100644
 --- a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 +++ b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 @@ -2,30 +2,6 @@ if (CMAKE_VERSION VERSION_LESS 3.1.0)
@@ -200,7 +200,7 @@ index 309798a767..b6c3ab8609 100644
  !!IF !isEmpty(CMAKE_ADD_SOURCE_INCLUDE_DIRS)
      include(\"${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake\" OPTIONAL)
  !!ENDIF
-@@ -499,25 +455,13 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+@@ -491,25 +447,13 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
  !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
  !!IF isEmpty(CMAKE_DEBUG_TYPE)
  !!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
@@ -226,7 +226,7 @@ index 309798a767..b6c3ab8609 100644
          _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" $${CMAKE_DEBUG_AND_RELEASE})
  !!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
      endif()
-@@ -536,25 +480,13 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+@@ -528,25 +472,13 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
  !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
  !!IF isEmpty(CMAKE_RELEASE_TYPE)
  !!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
@@ -252,7 +252,7 @@ index 309798a767..b6c3ab8609 100644
          _populate_$${CMAKE_MODULE_NAME}_target_properties(RELEASE \"$${CMAKE_LIB_FILE_LOCATION_RELEASE}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" $${CMAKE_DEBUG_AND_RELEASE})
  !!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
      endif()
-@@ -581,11 +513,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+@@ -573,11 +505,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
            IsDebugAndRelease)
          set_property(TARGET Qt5::${Plugin} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
  
@@ -265,7 +265,7 @@ index 309798a767..b6c3ab8609 100644
          set_target_properties(Qt5::${Plugin} PROPERTIES
              \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
 diff --git a/mkspecs/features/qml_module.prf b/mkspecs/features/qml_module.prf
-index c0b50416c9..cabe39b22e 100644
+index 3d6cd9b3db..ca8b0b2701 100644
 --- a/mkspecs/features/qml_module.prf
 +++ b/mkspecs/features/qml_module.prf
 @@ -51,7 +51,7 @@ builtin_resources {
@@ -369,18 +369,44 @@ index 15b373ba40..5c373fe1d5 100644
  
  check_examples {
 diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
-index 7777e615bd..abeb03a663 100644
+index 7777e615bd..b0c6880a74 100644
 --- a/mkspecs/features/qt_functions.prf
 +++ b/mkspecs/features/qt_functions.prf
-@@ -87,7 +87,7 @@ defineTest(qtHaveModule) {
+@@ -87,19 +87,22 @@ defineTest(qtHaveModule) {
  defineTest(qtPrepareTool) {
      cmd = $$eval(QT_TOOL.$${2}.binary)
      isEmpty(cmd) {
 -        cmd = $$[QT_HOST_BINS]/$$2
-+        cmd = $$system("command -v $$2")
-         exists($${cmd}.pl) {
-             $${1}_EXE = $${cmd}.pl
-             cmd = perl -w $$system_path($${cmd}.pl)
+-        exists($${cmd}.pl) {
+-            $${1}_EXE = $${cmd}.pl
+-            cmd = perl -w $$system_path($${cmd}.pl)
+-        } else: contains(QMAKE_HOST.os, Windows) {
+-            $${1}_EXE = $${cmd}.exe
+-            cmd = $$system_path($${cmd}.exe)
+-        } else:contains(QMAKE_HOST.os, Darwin) {
+-            BUNDLENAME = $${cmd}.app/Contents/MacOS/$$2
+-            exists($$BUNDLENAME) {
+-                cmd = $$BUNDLENAME
++        cmd = $$system("command -v $${2}")
++        isEmpty(cmd) {
++            cmd = $$system("command -v $${2}.pl")
++            !isEmpty(cmd) {
++                $${1}_EXE = $$cmd
++                cmd = perl -w $$system_path($${cmd})
++            } else: contains(QMAKE_HOST.os, Windows) {
++                cmd = $$system("command -v $${2}.exe")
++                $${1}_EXE = $$cmd
++            } else: contains(QMAKE_HOST.os, Darwin) {
++                cmd = $$system("command -v $${2}.app")
++                !isEmpty(cmd) {
++                    cmd = $${cmd}/Contents/MacOS/$${2}
++                    $${1}_EXE = $$cmd
++                }
+             }
+-            $${1}_EXE = $$cmd
+         } else {
+             $${1}_EXE = $$cmd
+         }
 diff --git a/mkspecs/features/qt_installs.prf b/mkspecs/features/qt_installs.prf
 index 1ebca17366..a8f958eae8 100644
 --- a/mkspecs/features/qt_installs.prf
@@ -460,5 +486,5 @@ index 573d717eea..024c624cb6 100644
  
  qt_libinfix_plugins: TARGET = $$TARGET$$QT_LIBINFIX
 -- 
-2.25.4
+2.29.3
 

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -28,14 +28,6 @@ qtModule {
   qtInputs = [ qtdeclarative qtquickcontrols qtlocation qtwebchannel ];
   nativeBuildInputs = [
     bison coreutils flex git gperf ninja pkg-config python2 which gn nodejs
-
-    # qmake looks for syncqt instead of syncqt.pl and fails with a cryptic
-    # error if it can't find it. syncqt.pl also has a /usr/bin/env shebang, so
-    # it can't be directly used in a sandboxed build environment.
-    (writeScriptBin "syncqt" ''
-      #!${stdenv.shell}
-      exec ${perl}/bin/perl ${qtbase.dev}/bin/syncqt.pl "$@"
-    '')
   ] ++ optional stdenv.isDarwin xcbuild;
   doCheck = true;
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change
Fixes #76080. Extracted from #108366.

<details>
  <summary>What this fixes / Why this is needed</summary>

Loading qtbase's `qt_module` qmake feature in a project with `git_build` set (either manually set or when `.git` is present) will use the `qtPrepareTool` function to find Qt's `syncqt.pl` tool. This function, in its upstream implementation, uses the `$$[QT_HOST_BINS]` variable to reference the `<qt-installation>/bin` directory with all of Qt's modules installed, appends the requested tool name to it (`$${2}`) and checks for some variations of this path (`.pl`, `.exe`, `.app/Contents/MacOS/$${2}`), falling back to just the initial concatenation.

The current patch only replaces this concatenation (`$$[QT_HOST_BINS]/$$2`) with a `command -v $${2}` invocation (because we don't keep all tool binaries/scripts in the same directory), leaving the following extension-handling code unchanged. This functions fine for binary tools without any further file extension or path variation (like `moc`), but fails on `syncqt.pl` (empty response from `command -v syncqt` + `.pl`) and falls back to an empty string. This is an unexpected result for the rest of the feature code, which appends arguments to the result and tries to invoke the tool. Hence you may get:

```
Project MESSAGE: -module QtWebEngineCore -version 6.0.0 -outdir /home/michael/src/tmp/qtwebengine -builddir /home/michael/src/tmp/qtwebengine /home/michael/src/tmp/qtwebengine
sh: -module: not found
Project ERROR: Failed to run: -module QtWebEngineCore -version 6.0.0 -outdir /home/michael/src/tmp/qtwebengine -builddir /home/michael/src/tmp/qtwebengine /home/michael/src/tmp/qtwebengine
```

instead of:

```
perl -w /nix/store/22ll16l5gmx5dgq98a1i5v5p3ss9sjzb-qtbase-5.15.2-dev/bin/syncqt.pl -module QtWebEngineCore -version 6.0.0 -outdir /home/michael/src/tmp/qtwebengine -builddir /home/michael/src/tmp/qtwebengine /home/michael/src/tmp/qtwebengine
```

Or sometimes you may get no indication of any missing tool invocation at all, followed by missing header errors because the tool that would've generated them wasn't executed.

This PR fixes the patch.

1. We check for a binary, extension-less tool first: `command -v $${2}`. If a match for the tool name is found, we exit the finding code with its full path as the command.
2. Next we check for a Perl tool via `command -v $${2}.pl`. If a match is found then `perl -w ${/path/to/tool.pl}` is used as the command.
3. Lastly we check some platform-specific extensions for binary tools (.exe on Windows, .app on Darwin). If these aren't found either then we give up and continue with an empty command name again.

(I'm unsure if it would make sense to insert a known-bad command if no match was found. Sometimes `qtPrepareTool` seems to get used to check if an optional tool like `qdoc` exists, which always fails and doesn't seem to cause any problems?)

</details>

To test, try building `qtsvg` (looks for `moc` binary tool, sanity check) and `qtwebengine` (looks for `syncqt` Perl tool, I've removed the workaround that was added in https://github.com/NixOS/nixpkgs/pull/116724)

With this fix:
```
make[2]: Entering directory '/build/source/src/core'
( test -e Makefile.core_headers || /nix/store/22ll16l5gmx5dgq98a1i5v5p3ss9sjzb-qtbase-5.15.2-dev/bin/qmake -o Makefile.core_headers /build/source/src/core/core_headers.pro PREFIX=/nix/store/nywpzvcln3x5bc40sjrabrw8065kmnqq-qtwebengine-5.15.3-a059e74 NIX_OUTPUT_OUT=/nix/store/nywpzvcln3x5bc40sjrabrw8065kmnqq-qtwebengine-5.15.3-a059e74 NIX_OUTPUT_DEV=/nix/store/hxsbskrarzwhm2p2vsipq97z8kwzbygl-qtwebengine-5.15.3-a059e74-dev NIX_OUTPUT_BIN=/nix/store/hy73pygc6p5j3k7kfsmdrf71n38jnibz-qtwebengine-5.15.3-a059e74-bin NIX_OUTPUT_DOC=/nix/store/hxsbskrarzwhm2p2vsipq97z8kwzbygl-qtwebengine-5.15.3-a059e74-dev/share/doc/qt-5.15.2 NIX_OUTPUT_QML=/nix/store/hy73pygc6p5j3k7kfsmdrf71n38jnibz-qtwebengine-5.15.3-a059e74-bin/lib/qt-5.15.2/qml NIX_OUTPUT_PLUGIN=/nix/store/hy73pygc6p5j3k7kfsmdrf71n38jnibz-qtwebengine-5.15.3-a059e74-bin/lib/qt-5.15.2/plugins CONFIG+=release ) && make -f Makefile.core_headers 
Project MESSAGE: perl -w /nix/store/22ll16l5gmx5dgq98a1i5v5p3ss9sjzb-qtbase-5.15.2-dev/bin/syncqt.pl -module QtWebEngineCore -version 5.15.3 -outdir /build/source -builddir /build/source /build/source
<srcbase> = /build/source 
<bldbase> = /build/source 
<outbase> = /build/source 
QtWebEngineCore: created fwd-include header(s) for <srcbase>/src/core/api/ { qtwebenginecoreglobal.h (1), qtwebenginecoreglobal_p.h (1), qwebenginecallback.h (2), qwebenginecallback_p.h (1), qwebengineclientcertificatestore.h (2), qwebenginecookiestore.h (2), qwebenginecookiestore_p.h (1), qwebenginefindtextresult.h (2), qwebenginehttprequest.h (2), qwebenginemessagepumpscheduler_p.h (1), qwebenginenotification.h (2), qwebenginequotarequest.h (2), qwebengineregisterprotocolhandlerrequest.h (2), qwebengineurlrequestinfo.h (2), qwebengineurlrequestinfo_p.h (1), qwebengineurlrequestinterceptor.h (2), qwebengineurlrequestjob.h (2), qwebengineurlscheme.h (2), qwebengineurlschemehandler.h (2) }
```

Without the fix and without the workaround script (copied from the linked PR, haven't had the time to fully compile qtwebengine yet):
```
make[2]: Entering directory '/build/qtwebengine-everywhere-src-5.15.2/src/core'
( test -e Makefile.core_headers || /nix/store/rbwz406jsdnjg7lglyvwdpwhni2fgjys-qtbase-5.15.2-dev/bin/qmake -o Makefile.core_headers /build/qtwebengine-everywhere-src-5.15.2/src/core/core_headers.pro PREFIX=/nix/store/mpk1sfy77yqwf5rffc18wwkzhs4vdx1d-qtwebengine-5.15.2 NIX_OUTPUT_OUT=/nix/store/mpk1sfy77yqwf5rffc18wwkzhs4vdx1d-qtwebengine-5.15.2 NIX_OUTPUT_DEV=/nix/store/q0vi1drd7mfvpkq44dv04b084sb9i41f-qtwebengine-5.15.2-dev NIX_OUTPUT_BIN=/nix/store/v8m26xlb5lc4nbm7irxdwwiiyp32r142-qtwebengine-5.15.2-bin NIX_OUTPUT_DOC=/nix/store/q0vi1drd7mfvpkq44dv04b084sb9i41f-qtwebengine-5.15.2-dev/share/doc/qt-5.15.2 NIX_OUTPUT_QML=/nix/store/v8m26xlb5lc4nbm7irxdwwiiyp32r142-qtwebengine-5.15.2-bin/lib/qt-5.15.2/qml NIX_OUTPUT_PLUGIN=/nix/store/v8m26xlb5lc4nbm7irxdwwiiyp32r142-qtwebengine-5.15.2-bin/lib/qt-5.15.2/plugins CONFIG+=release ) && make -f Makefile.core_headers 
make[3]: Entering directory '/build/qtwebengine-everywhere-src-5.15.2/src/core'
make[3]: Nothing to be done for 'first'.
make[3]: Leaving directory '/build/qtwebengine-everywhere-src-5.15.2/src/core'
…
/build/qtwebengine-a059e74/src/core/api/qtwebenginecoreglobal_p.h:54:10: fatal error: QtWebEngineCore/qtwebenginecoreglobal.h: No such file or directory
   54 | #include <QtWebEngineCore/qtwebenginecoreglobal.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
  (Only `qtbase`, some `qtModule`s and afew minutes of `qtwebengine`)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
