### PR TITLE
spago: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2774,7 +2774,6 @@ extra-packages:
   - Cabal == 3.2.*                      # required for cabal-install etc.
   - base16-bytestring < 1               # required for cabal-install etc.
   - dhall == 1.29.0                     # required for ats-pkg
-  - dhall == 1.37.1                     # required for spago 0.19.0.
   - Diff < 0.4                          # required by liquidhaskell-0.8.10.2: https://github.com/ucsd-progsys/liquidhaskell/issues/1729
   - ghc-tcplugins-extra ==0.3.2         # required for polysemy-plugin 0.2.5.0
   - haddock == 2.23.*                   # required on GHC < 8.10.x

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -659,9 +659,7 @@ self: super: builtins.intersectAttrs super {
     let
       # spago requires an older version of megaparsec, but it appears to work
       # fine with newer versions.
-      spagoWithOverrides = doJailbreak (super.spago.override {
-        dhall = self.dhall_1_37_1;
-      });
+      spagoWithOverrides = doJailbreak super.spago;
 
       # This defines the version of the purescript-docs-search release we are using.
       # This is defined in the src/Spago/Prelude.hs file in the spago source.

--- a/pkgs/development/tools/purescript/spago/default.nix
+++ b/pkgs/development/tools/purescript/spago/default.nix
@@ -3,6 +3,7 @@
 , lib
 
 # The following are only needed for the passthru.tests:
+, cacert
 , git
 , nodejs
 , purescript
@@ -35,6 +36,7 @@ spago.overrideAttrs (oldAttrs: {
         {
           __noChroot = true;
           nativeBuildInputs = [
+            cacert
             git
             nodejs
             purescript

--- a/pkgs/development/tools/purescript/spago/spago.nix
+++ b/pkgs/development/tools/purescript/spago/spago.nix
@@ -12,11 +12,11 @@
 }:
 mkDerivation {
   pname = "spago";
-  version = "0.19.0";
+  version = "0.20.0";
   src = fetchgit {
     url = "https://github.com/purescript/spago.git";
-    sha256 = "182a9pkv64rbyqrig470cmql4ingf5vpxh11xkxqq2baxym3vwip";
-    rev = "960a310d6efca3bb40009eb06d88382e4670ccef";
+    sha256 = "1n48p9ycry8bjnf9jlcfgyxsbgn5985l4vhbwlv46kbb41ddwi51";
+    rev = "7dfd2236aff92e5ae4f7a4dc336b50a7e14e4f44";
     fetchSubmodules = true;
   };
   isLibrary = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update spago to 0.20.0.

Changelog: https://github.com/purescript/spago/releases/tag/0.20.0

cc @f-f


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
