### PR TITLE
pista: init at v0.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6825,6 +6825,12 @@
     githubId = 628342;
     name = "Tim Steinbach";
   };
+  nerdypepper = {
+    email = "nerdy@peppe.rs";
+    github = "nerdypepper";
+    githubId = 23743547;
+    name = "Akshay Oppiliappan";
+  };
   netixx = {
     email = "dev.espinetfrancois@gmail.com";
     github = "netixx";

--- a/pkgs/tools/misc/pista/default.nix
+++ b/pkgs/tools/misc/pista/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, rustPlatform, fetchFromGitHub, openssl, pkg-config }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pista";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "NerdyPepper";
+    repo = "pista";
+    rev = "v${version}";
+    sha256 = "1nrqgl5r5ja95g5xhfvkvfz72g318pqc7yj4fwl6xnad19smvms0";
+  };
+
+  cargoSha256 = "1qjg4z4nfqmiawczs4p4rf4mq250aqb5brd3hd2jcjdhqajksr90";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  # does not have tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Simple {bash, zsh} prompt for programmers";
+    homepage = "https://github.com/NerdyPepper/pista";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nerdypepper ];
+  };
+}

--- a/pkgs/tools/misc/pista/default.nix
+++ b/pkgs/tools/misc/pista/default.nix
@@ -9,6 +9,7 @@ rustPlatform.buildRustPackage rec {
     repo = "pista";
     rev = "v${version}";
     sha256 = "1nrqgl5r5ja95g5xhfvkvfz72g318pqc7yj4fwl6xnad19smvms0";
+    fetchSubmodules = true;
   };
 
   cargoSha256 = "1qjg4z4nfqmiawczs4p4rf4mq250aqb5brd3hd2jcjdhqajksr90";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25012,6 +25012,8 @@ in
     gtksharp = gtk-sharp-2_0;
   };
 
+  pista = callPackage ../tools/misc/pista { };
+
   pistol = callPackage ../tools/misc/pistol { };
 
   piston-cli = callPackage ../tools/misc/piston-cli { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the `pista` prompt to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first contribution to `nixpkgs`, I hope everything is in order.
