### PR TITLE
python3Packages.omnilogic: init at 0.4.3

### DIFF
--- a/pkgs/development/python-modules/omnilogic/default.nix
+++ b/pkgs/development/python-modules/omnilogic/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, aiohttp
+, xmltodict
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "omnilogic";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "djtimca";
+    repo = "omnilogic-api";
+    rev = "v${version}";
+    sha256 = "19pmbykq0mckk23aj33xbhg3gjx557xy9a481mp6pkmihf2lsc8z";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    xmltodict
+  ];
+
+  postPatch = ''
+    # Is not used but still present in setup.py
+    substituteInPlace setup.py --replace "'config'," ""
+  '';
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "omnilogic" ];
+
+  meta = with lib; {
+    description = "Python interface for the Hayward Omnilogic pool control system";
+    homepage = "https://github.com/djtimca/omnilogic-api";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -581,7 +581,7 @@
     "oem" = ps: with ps; [ ]; # missing inputs: oemthermostat
     "ohmconnect" = ps: with ps; [ defusedxml ];
     "ombi" = ps: with ps; [ ]; # missing inputs: pyombi
-    "omnilogic" = ps: with ps; [ ]; # missing inputs: omnilogic
+    "omnilogic" = ps: with ps; [ omnilogic ];
     "onboarding" = ps: with ps; [ aiohttp-cors pillow ];
     "ondilo_ico" = ps: with ps; [ aiohttp-cors ]; # missing inputs: ondilo
     "onewire" = ps: with ps; [ ]; # missing inputs: pi1wire pyownet

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -286,6 +286,7 @@ in with py.pkgs; buildPythonApplication rec {
     "notify"
     "notion"
     "number"
+    "omnilogic"
     "ozw"
     "panel_custom"
     "panel_iframe"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4798,6 +4798,8 @@ in {
 
   omegaconf = callPackage ../development/python-modules/omegaconf { };
 
+  omnilogic = callPackage ../development/python-modules/omnilogic { };
+
   onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };
 
   onnx = callPackage ../development/python-modules/onnx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python interface for the Hayward Omnilogic pool control system

https://github.com/djtimca/omnilogic-api

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
