### PR TITLE
protoc-gen-twirp: 7.1.1 -> 7.2.0

### DIFF
--- a/pkgs/development/tools/protoc-gen-twirp/default.nix
+++ b/pkgs/development/tools/protoc-gen-twirp/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "protoc-gen-twirp";
-  version = "7.1.1";
+  version = "7.2.0";
 
   src = fetchFromGitHub {
     owner = "twitchtv";
     repo = "twirp";
     rev = "v${version}";
-    sha256 = "sha256-GN7akAp0zzS8wVhgXlT1ceFUFKH4Sz74XQ8ofIE8T/k=";
+    sha256 = "sha256-W7t36F1St0YLPowHaZSboVNnvX7E2Lg5tPWeyeUSabA=";
   };
 
   goPackagePath = "github.com/twitchtv/twirp";
@@ -17,6 +17,8 @@ buildGoPackage rec {
     "protoc-gen-twirp"
     "protoc-gen-twirp_python"
   ];
+
+  doCheck = true;
 
   meta = with lib; {
     description = "A simple RPC framework with protobuf service definitions";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release https://github.com/twitchtv/twirp/releases/tag/v7.2.0. Also enabled `doCheck` to run the tests of the two built sub-packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
