### PR TITLE
pkgs-lib/formats: support top level INI keys

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -410,8 +410,10 @@ runTests {
   };
 
   testToINIDuplicateKeys = {
-    expr = generators.toINI { listsAsDuplicateKeys = true; } { foo.bar = true; baz.qux = [ 1 false ]; };
+    expr = generators.toINI { listsAsDuplicateKeys = true; } { top = [ 3 5 ]; foo.bar = true; baz.qux = [ 1 false ]; };
     expected = ''
+      top=3
+      top=5
       [baz]
       qux=1
       qux=false
@@ -453,6 +455,18 @@ runTests {
       attribute1=5
       boolean=false
       x=Me-se JarJar Binx
+    '';
+  };
+
+  testToINIToplevelKeys = {
+    expr = generators.toINI {} {
+      "toplevel" = "bar";
+      "foo" = { "bar" = "baz"; };
+    };
+    expected = ''
+      toplevel=bar
+      [foo]
+      bar=baz
     '';
   };
 

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -77,7 +77,9 @@ rec {
         else
           singleIniAtom;
 
-    in attrsOf (attrsOf iniAtom);
+    in attrsOf (either iniAtom (attrsOf iniAtom)) // {
+      description = "attribute set of either top-level ${iniAtom.description} or attribute sets of ${iniAtom.description} (INI sections)";
+    };
 
     generate = name: value: pkgs.writeText name (lib.generators.toINI args value);
 


### PR DESCRIPTION
lib/generators: support top level keys in toINI

Many packages using INI as their configuration format allow top-level
keys that don't belong to a section before the first section, for
example gmnisrv and foot. However lib.generators.toINI and
pkgs.formats.ini don't support this currently. This commit introduces
support for this.

All keys in the attribute set passed are considered as top-level entries
if they are not attribute sets (that is don't represent a section).
Introducing a switch for turning this behavior on or off doesn't seem
necessary as there is no valid representation for such values in the
input attribute set for the use case without top-level attributes.

Now such things are possible:

```nix
lib.generators.toINI {} {
  foo = 13;
  bar = {
    baz = 12;
    hello = "world";
  };
} == ''
  foo=13
  [bar]
  baz=12
  hello=world
''
```

Thanks to Ben Sima for cleaning up and porting a snippet I had for
proper nixpkgs!


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
