### PR TITLE
nixos/binfmt: correctly handle argv0 when preserveArgvZero

### DIFF
--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -20,11 +20,13 @@ let
                  optionalString fixBinary "F";
   in ":${name}:${type}:${offset'}:${magicOrExtension}:${mask'}:${interpreter}:${flags}";
 
-  activationSnippet = name: { interpreter, ... }: ''
+  activationSnippet = name: { interpreter, preserveArgvZero, ... }: ''
     rm -f /run/binfmt/${name}
     cat > /run/binfmt/${name} << 'EOF'
     #!${pkgs.bash}/bin/sh
-    exec -- ${interpreter} "$@"
+    ${if preserveArgvZero && interpreter == getEmulator name
+    then ''exec -- ${interpreter} -0 "$2" "$1" "''${@:3}"'' # Correctly handle argv0 for the default QEMU emulator.
+    else ''exec -- ${interpreter} "$@"''}
     EOF
     chmod +x /run/binfmt/${name}
   '';

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -389,6 +389,7 @@ in
   systemd = handleTest ./systemd.nix {};
   systemd-analyze = handleTest ./systemd-analyze.nix {};
   systemd-binfmt = handleTestOn ["x86_64-linux"] ./systemd-binfmt.nix {};
+  systemd-binfmt-argv0 = handleTestOn ["x86_64-linux"] ./systemd-binfmt-argv0.nix {};
   systemd-boot = handleTest ./systemd-boot.nix {};
   systemd-confinement = handleTest ./systemd-confinement.nix {};
   systemd-journal = handleTest ./systemd-journal.nix {};

--- a/nixos/tests/systemd-binfmt-argv0.nix
+++ b/nixos/tests/systemd-binfmt-argv0.nix
@@ -1,0 +1,32 @@
+# Test the default interpreter script correctly handle argv0
+# when `preserveArgvZero` is enabled.
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "systemd-binfmt-argv0";
+  machine = {
+    boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+    boot.binfmt.registrations."aarch64-linux".preserveArgvZero = true;
+  };
+
+  testScript = let
+    echoArgs = pkgs.pkgsCross.aarch64-multiplatform.runCommandCC "echo-args" {} ''
+      cat >echo.c <<EOF
+      #include <stdio.h>
+      int main(int argc, char **argv) {
+        printf("<");
+        for (int i = 0; i < argc; ++i)
+          printf("%s-", argv[i]);
+        puts(">");
+        return 0;
+      }
+      EOF
+      mkdir -p $out/bin
+      $CC echo.c -o $out/bin/echo -O2
+    '';
+  in ''
+    machine.start()
+    ret = machine.succeed(
+        "exec -a hello ${echoArgs}/bin/echo world"
+    )
+    assert "<hello-world->" in ret, "Got: " + ret
+  '';
+})


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Currently when `preserveArgvZero` is enabled, the prepended argv0 is directly pass to QEMU as `exec -- ${interpreter} "$@"`, which makes it actually interpreted as argv1.
This PR fix the interpreter script to correctly pass argv0 to QEMU, only when the default QEMU `interpreter` is used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
