### PR TITLE
stdenv: add option to change make command

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -497,6 +497,10 @@ The build phase is responsible for actually building the package (e.g. compiling
 
 Set to true to skip the build phase.
 
+##### `make` {#var-stdenv-make}
+
+The make command to run (useful if the package requires an alternate Make implementation like BSD make).
+
 ##### `makefile` {#var-stdenv-makefile}
 
 The file name of the Makefile.

--- a/pkgs/applications/window-managers/hikari/default.nix
+++ b/pkgs/applications/window-managers/hikari/default.nix
@@ -43,27 +43,18 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  # Must replace GNU Make by bmake
-  buildPhase = with lib; concatStringsSep " " (
-    [ "bmake" "-j$NIX_BUILD_CORES" "PREFIX=$out" ]
+  make = "bmake";
+  makeFlags = with lib; [ "PREFIX=$(out)" ]
     ++ optional stdenv.isLinux "WITH_POSIX_C_SOURCE=YES"
     ++ mapAttrsToList (feat: enabled:
          optionalString enabled "WITH_${toUpper feat}=YES"
-       ) features
-  );
+       ) features;
 
   # Can't suid in nix store
   # Run hikari as root (it will drop privileges as early as possible), or create
   # a systemd unit to give it the necessary permissions/capabilities.
   patchPhase = ''
     substituteInPlace Makefile --replace '4555' '555'
-  '';
-
-  installPhase = ''
-    bmake \
-      PREFIX=$out \
-      install
-    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/libfsm/default.nix
+++ b/pkgs/development/libraries/libfsm/default.nix
@@ -22,11 +22,8 @@ stdenv.mkDerivation rec {
   # if we use stdenv vs clangStdenv, we don't know which, and CC=cc in all
   # cases.) it's unclear exactly what should be done if we want those flags,
   # but the defaults work fine.
-  buildPhase = "PREFIX=$out bmake -r -j$NIX_BUILD_CORES";
-  installPhase = ''
-    PREFIX=$out bmake -r install
-    runHook postInstall
-  '';
+  make = "bmake";
+  makeFlags = [ "-r" "PREFIX=$(out)" ];
 
   # fix up multi-output install. we also have to fix the pkg-config libdir
   # file; it uses prefix=$out; libdir=${prefix}/lib, which is wrong in

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1033,7 +1033,7 @@ buildPhase() {
         )
 
         echoCmd 'build flags' "${flagsArray[@]}"
-        make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        ${make:-make} ${makefile:+-f $makefile} "${flagsArray[@]}"
         unset flagsArray
     fi
 
@@ -1052,9 +1052,9 @@ checkPhase() {
 
     if [[ -z "${checkTarget:-}" ]]; then
         #TODO(@oxij): should flagsArray influence make -n?
-        if make -n ${makefile:+-f $makefile} check >/dev/null 2>&1; then
+        if ${make:-make} -n ${makefile:+-f $makefile} check >/dev/null 2>&1; then
             checkTarget=check
-        elif make -n ${makefile:+-f $makefile} test >/dev/null 2>&1; then
+        elif ${make:-make} -n ${makefile:+-f $makefile} test >/dev/null 2>&1; then
             checkTarget=test
         fi
     fi
@@ -1073,7 +1073,7 @@ checkPhase() {
         )
 
         echoCmd 'check flags' "${flagsArray[@]}"
-        make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        ${make:-make} ${makefile:+-f $makefile} "${flagsArray[@]}"
 
         unset flagsArray
     fi
@@ -1099,7 +1099,7 @@ installPhase() {
     )
 
     echoCmd 'install flags' "${flagsArray[@]}"
-    make ${makefile:+-f $makefile} "${flagsArray[@]}"
+    ${make:-make} ${makefile:+-f $makefile} "${flagsArray[@]}"
     unset flagsArray
 
     runHook postInstall
@@ -1193,7 +1193,7 @@ installCheckPhase() {
         echo "no Makefile or custom installCheckPhase, doing nothing"
     #TODO(@oxij): should flagsArray influence make -n?
     elif [[ -z "${installCheckTarget:-}" ]] \
-       && ! make -n ${makefile:+-f $makefile} ${installCheckTarget:-installcheck} >/dev/null 2>&1; then
+       && ! ${make:-make} -n ${makefile:+-f $makefile} ${installCheckTarget:-installcheck} >/dev/null 2>&1; then
         echo "no installcheck target in ${makefile:-Makefile}, doing nothing"
     else
         # Old bash empty array hack
@@ -1207,7 +1207,7 @@ installCheckPhase() {
         )
 
         echoCmd 'installcheck flags' "${flagsArray[@]}"
-        make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        ${make:-make} ${makefile:+-f $makefile} "${flagsArray[@]}"
         unset flagsArray
     fi
 
@@ -1225,7 +1225,7 @@ distPhase() {
     )
 
     echo 'dist flags: %q' "${flagsArray[@]}"
-    make ${makefile:+-f $makefile} "${flagsArray[@]}"
+    ${make:-make} ${makefile:+-f $makefile} "${flagsArray[@]}"
 
     if [ "${dontCopyDist:-0}" != 1 ]; then
         mkdir -p "$out/tarballs"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Otherwise, when a package requires e.g. bmake, all the helpful stuff
stdenv implements around make has to be copied (as required by the
package).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
