### PR TITLE
snd: 20.3 -> 21.1; broaden platforms; parallelize

### DIFF
--- a/pkgs/applications/audio/snd/default.nix
+++ b/pkgs/applications/audio/snd/default.nix
@@ -1,30 +1,30 @@
 { lib, stdenv, fetchurl, pkg-config
-, gtk2, alsaLib
-, fftw, gsl
+, alsaLib, fftw, gsl, motif, xorg
 }:
 
 stdenv.mkDerivation rec {
-  name = "snd-20.3";
+  pname = "snd";
+  version = "21.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/snd/${name}.tar.gz";
-    sha256 = "016slh34gb6qqb38m8k9yg48rbhc5p12084szcwvanhh5v7fc7mk";
+    url = "mirror://sourceforge/snd/snd-${version}.tar.gz";
+    sha256 = "1jxvpgx1vqa6bwdzlzyzrjn2swjf9nfhzi9r1r96ivi0870vvjk3";
   };
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [
-    gtk2 alsaLib
-    fftw gsl
-  ];
+  buildInputs = [ alsaLib fftw gsl motif ]
+    ++ (with xorg; [ libXext libXft libXpm libXt ]);
 
-  meta = {
+  configureFlags = [ "--with-motif" ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
     description = "Sound editor";
-    homepage = "http://ccrma.stanford.edu/software/snd";
-    platforms = lib.platforms.linux;
-    license = lib.licenses.free;
-    maintainers = with lib.maintainers; [ ];
+    homepage = "https://ccrma.stanford.edu/software/snd/";
+    platforms = platforms.unix;
+    license = licenses.free;
+    maintainers = with maintainers; [ ];
   };
-
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Also updated the homepage URL.

Upstream has removed GTK support in favour of motif (I know!).

snd's README mentions a bunch of supported Unix platforms, so
constraining this to just Linux is wrong.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
