### PR TITLE
home-assistant: 2021.4.1 -> 2021.4.2

### DIFF
--- a/pkgs/development/python-modules/jsonrpc-async/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-async/default.nix
@@ -1,20 +1,37 @@
-{ lib, buildPythonPackage, fetchPypi
-, aiohttp, jsonrpc-base }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, jsonrpc-base
+, pytest-aiohttp
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "jsonrpc-async";
-  version = "1.1.1";
+  version = "2.0.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "383f331e28cd8f6e3fa86f3e7052efa541b7ae8bf328a4e692aa045cfc0ecf25";
+  src = fetchFromGitHub {
+    owner = "emlove";
+    repo = pname;
+    rev = version;
+    sha256 = "1ff3523rwgira5llmf5iriwqag7b6ln9vmj0s70yyc6k98yg06rp";
   };
 
   propagatedBuildInputs = [ aiohttp jsonrpc-base ];
 
+  checkInputs = [
+    pytest-aiohttp
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "tests.py"
+  ];
+
   meta = with lib; {
     description = "A JSON-RPC client library for asyncio";
-    homepage = "https://github.com/armills/jsonrpc-async";
+    homepage = "https://github.com/emlove/jsonrpc-async";
     license = licenses.bsd3;
     maintainers = with maintainers; [ peterhoeg ];
   };

--- a/pkgs/development/python-modules/jsonrpc-base/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-base/default.nix
@@ -1,19 +1,31 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "jsonrpc-base";
-  version = "1.1.0";
+  version = "2.0.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "7f374c57bfa1cb16d1f340d270bc0d9f1f5608fb1ac6c9ea15768c0e6ece48b7";
+  src = fetchFromGitHub {
+    owner = "emlove";
+    repo = pname;
+    rev = version;
+    sha256 = "0xxhn0vb7mr8k1w9xbqhhyx9qkgkc318qkyflgfbvjc926n50680";
   };
 
-  propagatedBuildInputs = [ ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "tests.py"
+  ];
 
   meta = with lib; {
     description = "A JSON-RPC client library base interface";
-    homepage = "https://github.com/armills/jsonrpc-base";
+    homepage = "https://github.com/emlove/jsonrpc-base";
     license = licenses.bsd3;
     maintainers = with maintainers; [ peterhoeg ];
   };

--- a/pkgs/development/python-modules/jsonrpc-websocket/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-websocket/default.nix
@@ -1,28 +1,36 @@
-{ lib, buildPythonPackage, fetchPypi
-, aiohttp, jsonrpc-base, pep8
-, pytestCheckHook
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, jsonrpc-base
 , pytest-asyncio
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "jsonrpc-websocket";
-  version = "1.2.1";
+  version = "3.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c343d057b572791ed3107b771c17358bc710772a9a6156047a3cfafb409ed895";
+    sha256 = "0fmw8xjzlhi7r84swn4w3njy389qqll5ad5ljdq5n2wpg424k98h";
   };
 
-  nativeBuildInputs = [ pep8 ];
+  propagatedBuildInputs = [
+    aiohttp
+    jsonrpc-base
+  ];
 
-  propagatedBuildInputs = [ aiohttp jsonrpc-base ];
+  checkInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
 
-  checkInputs = [ pytestCheckHook pytest-asyncio ];
   pytestFlagsArray = [ "tests.py" ];
 
   meta = with lib; {
     description = "A JSON-RPC websocket client library for asyncio";
-    homepage = "https://github.com/armills/jsonrpc-websocket";
+    homepage = "https://github.com/emlove/jsonrpc-websocket";
     license = licenses.bsd3;
     maintainers = with maintainers; [ peterhoeg ];
   };

--- a/pkgs/development/python-modules/pykodi/default.nix
+++ b/pkgs/development/python-modules/pykodi/default.nix
@@ -1,15 +1,28 @@
-{ lib, buildPythonPackage, fetchPypi, aiohttp, jsonrpc-async, jsonrpc-websocket }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, jsonrpc-async
+, jsonrpc-websocket
+}:
 
 buildPythonPackage rec {
   pname = "pykodi";
-  version = "0.2.3";
+  version = "0.2.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "099xyn5aql5mdim6kh4hwx0fg1a3bx73qdvwr48nz23cljmmk1m8";
+    sha256 = "1al2q4jiqxjnz0j2xvs2hqzrz6fm3hmda5zjnkp8gdvgchd1cmn7";
   };
 
-  propagatedBuildInputs = [ aiohttp jsonrpc-async jsonrpc-websocket ];
+  propagatedBuildInputs = [
+    aiohttp
+    jsonrpc-async
+    jsonrpc-websocket
+  ];
+
+  # has no tests
+  doCheck = false;
 
   pythonImportsCheck = [ "pykodi" ];
 

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.55";
+  version = "0.0.56";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zha-device-handlers";
     rev = version;
-    sha256 = "sha256-mc7mOaxn2FCvwYv9yE0mIOSQ1F+xJJ+1LynOdEV07I8=";
+    sha256 = "1jss5pnxdjlp0kplqxgr09vv1zq9n7l9w08hsywy2vglqmd67a66";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.4.1";
+  version = "2021.4.2";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -258,6 +258,7 @@ in with py.pkgs; buildPythonApplication rec {
     "intent_script"
     "ipp"
     "kmtronic"
+    "kodi"
     "light"
     "litterrobot"
     "local_file"

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -95,7 +95,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.4.1";
+  hassVersion = "2021.4.2";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -114,7 +114,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "154bmbxhyfv1sxa6fk5vimqjmvci710bm5pj590blyzbr4nyci77";
+    sha256 = "0z6a5m1yflnz468njp8v7vd189gv5pc63kji14f4fx4nfzbxhqdk";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20210407.2";
+  version = "20210407.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-MxXeept0qwDIs9tFZCd1JfDY1Csl8gLWOhzW/Ihlbzw=";
+    sha256 = "sha256-ucewS193kbvlk4Q+5IEYT6sfJ/H006uy0iIi8UHOzPo=";
   };
 
   # there is nothing to strip in this package


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/2021.4.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
