### PR TITLE
python3Packages.homematicip: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/aiohttp-wsgi/default.nix
+++ b/pkgs/development/python-modules/aiohttp-wsgi/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "aiohttp-wsgi";
+  version = "0.8.2";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "etianen";
+    repo = pname;
+    rev = version;
+    sha256 = "0wirn3xqxxgkpy5spicd7p1bkdnsrch61x2kcpdwpixmx961pq7x";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "aiohttp_wsgi" ];
+
+  meta = with lib; {
+    description = "WSGI adapter for aiohttp";
+    homepage = "https://github.com/etianen/aiohttp-wsgi";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/homematicip/default.nix
+++ b/pkgs/development/python-modules/homematicip/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, aenum
+, aiohttp
+, aiohttp-wsgi
+, async-timeout
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, pytest-aiohttp
+, pytest-asyncio
+, requests
+, websocket_client
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "homematicip";
+  version = "1.0.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "coreGreenberet";
+    repo = "homematicip-rest-api";
+    rev = version;
+    sha256 = "0bgvrjcf10kiqqkbl56sxx3jydd722b08q2j9c8sxpk0qdrmrinv";
+  };
+
+  propagatedBuildInputs = [
+    aenum
+    aiohttp
+    async-timeout
+    requests
+    websocket_client
+    websockets
+  ];
+
+  checkInputs = [
+    aiohttp-wsgi
+    pytest-aiohttp
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Assert issues with datetime
+    "test_contact_interface_device"
+    "test_dimmer"
+    "test_heating_failure_alert_group"
+    "test_heating"
+    "test_humidity_warning_rule_group"
+    "test_meta_group"
+    "test_pluggable_switch_measuring"
+    "test_rotary_handle_sensor"
+    "test_security_group"
+    "test_shutter_device"
+    "test_smoke_detector"
+    "test_switching_group"
+    "test_temperature_humidity_sensor_outdoor"
+    "test_wall_mounted_thermostat_pro"
+    "test_weather_sensor"
+    # Random failures
+    "test_home_getSecurityJournal"
+    "test_home_unknown_types"
+    # Requires network access
+    "test_websocket"
+  ];
+
+  pythonImportsCheck = [ "homematicip" ];
+
+  meta = with lib; {
+    description = "Python module for the homematicIP REST API";
+    homepage = "https://github.com/coreGreenberet/homematicip-rest-api";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -357,7 +357,7 @@
     "homekit" = ps: with ps; [ HAP-python pyqrcode pyturbojpeg aiohttp-cors base36 fnvhash ha-ffmpeg zeroconf ];
     "homekit_controller" = ps: with ps; [ aiohomekit aiohttp-cors zeroconf ];
     "homematic" = ps: with ps; [ pyhomematic ];
-    "homematicip_cloud" = ps: with ps; [ ]; # missing inputs: homematicip
+    "homematicip_cloud" = ps: with ps; [ homematicip ];
     "homeworks" = ps: with ps; [ ]; # missing inputs: pyhomeworks
     "honeywell" = ps: with ps; [ ]; # missing inputs: somecomfort
     "horizon" = ps: with ps; [ ]; # missing inputs: horimote

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -241,6 +241,7 @@ in with py.pkgs; buildPythonApplication rec {
     "homekit_controller"
     "homeassistant"
     "homematic"
+    "homematicip_cloud"
     "html5"
     "http"
     "hue"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3126,6 +3126,8 @@ in {
 
   homeassistant-pyozw = callPackage ../development/python-modules/homeassistant-pyozw { };
 
+  homematicip = callPackage ../development/python-modules/homematicip { };
+
   homepluscontrol = callPackage ../development/python-modules/homepluscontrol { };
 
   hoomd-blue = toPythonModule (callPackage ../development/python-modules/hoomd-blue {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -276,6 +276,8 @@ in {
 
   aiohttp-swagger = callPackage ../development/python-modules/aiohttp-swagger { };
 
+  aiohttp-wsgi = callPackage ../development/python-modules/aiohttp-wsgi { };
+
   aioitertools = callPackage ../development/python-modules/aioitertools { };
 
   aiobotocore = callPackage ../development/python-modules/aiobotocore { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for the homematicIP REST API

https://github.com/coreGreenberet/homematicip-rest-api

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
