### PR TITLE
beam-packages: init elixir_ls 0.7.0

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -63,6 +63,8 @@ let
         debugInfo = true;
       };
 
+      elixir_ls = callPackage ./elixir_ls.nix { inherit elixir fetchMixDeps mixRelease; };
+
       # Remove old versions of elixir, when the supports fades out:
       # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 

--- a/pkgs/development/beam-modules/elixir_ls.nix
+++ b/pkgs/development/beam-modules/elixir_ls.nix
@@ -1,0 +1,71 @@
+{ lib, elixir, fetchFromGitHub, fetchMixDeps, mixRelease }:
+# Based on the work of Hauleth
+# None of this would have happened without him
+
+mixRelease rec {
+  pname = "elixir-ls";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "elixir-lsp";
+    repo = "elixir-ls";
+    rev = "v{version}";
+    sha256 = "0d0hqc35hfjkpm88vz21mnm2a9rxiqfrdi83whhhh6d2ba216b7s";
+    fetchSubmodules = true;
+  };
+
+  mixDeps = fetchMixDeps {
+    pname = "mix-deps-${pname}";
+    inherit src version;
+    sha256 = "0r9x223imq4j9pn9niskyaybvk7jmq8dxcyzk7kwfsi128qig1a1";
+  };
+
+  # elixir_ls is an umbrella app
+  # override configurePhase to not skip umbrella children
+  configurePhase = ''
+    runHook preConfigure
+    mix deps.compile --no-deps-check
+    runHook postConfigure
+  '';
+
+  # elixir_ls require a special step for release
+  # compile and release need to be performed together because
+  # of the no-deps-check requirement
+  buildPhase = ''
+    runHook preBuild
+    mix do compile --no-deps-check, elixir_ls.release
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -Rv release $out/lib
+    # Prepare the wrapper script
+    substitute release/language_server.sh $out/bin/elixir-ls \
+      --replace 'exec "''${dir}/launch.sh"' "exec $out/lib/launch.sh"
+    chmod +x $out/bin/elixir-ls
+    # prepare the launcher
+    substituteInPlace $out/lib/launch.sh \
+      --replace "ERL_LIBS=\"\$SCRIPTPATH:\$ERL_LIBS\"" \
+                "ERL_LIBS=$out/lib:\$ERL_LIBS" \
+      --replace "exec elixir" "exec ${elixir}/bin/elixir"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/elixir-lsp/elixir-ls";
+    description = ''
+      A frontend-independent IDE "smartness" server for Elixir.
+      Implements the "Language Server Protocol" standard and provides debugger support via the "Debug Adapter Protocol"
+    '';
+    longDescription = ''
+      The Elixir Language Server provides a server that runs in the background, providing IDEs, editors, and other tools with information about Elixir Mix projects.
+      It adheres to the Language Server Protocol, a standard for frontend-independent IDE support.
+      Debugger integration is accomplished through the similar VS Code Debug Protocol.
+    '';
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = teams.beam.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11586,7 +11586,8 @@ in
   inherit (beam.interpreters)
     erlang erlangR23 erlangR22 erlangR21 erlangR20 erlangR19 erlangR18
     erlang_odbc erlang_javac erlang_odbc_javac erlang_basho_R16B02
-    elixir elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7;
+    elixir elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7
+    elixir_ls;
 
   erlang_nox = beam_nox.interpreters.erlang;
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -111,7 +111,7 @@ rec {
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR23.elixir`.
     inherit (packages.erlang)
-      elixir elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7;
+      elixir elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_ls;
 
     inherit (packages.erlang) lfe lfe_1_2 lfe_1_3;
   };


### PR DESCRIPTION
###### Motivation for this change

add elixir_ls to nixpkgs

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

### additional context

This is pretty much copyPasta from https://github.com/hauleth/nix-elixir/blob/master/lib/elixir-ls.nix

@minijackson @hauleth @NobbZ @afontaine @balsoft @yurrriq @cw789  you might be interested in this