### PR TITLE
nixos/nix-daemon: assert system or systems for buildMachines.

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -533,6 +533,22 @@ in
             + "\n"
           ) cfg.buildMachines;
       };
+    assertions =
+      let badMachine = m: m.system == null && m.systems == [];
+      in [
+        {
+          assertion = !(builtins.any badMachine cfg.buildMachines);
+          message = ''
+            At least one system type (via <varname>system</varname> or
+              <varname>systems</varname>) must be set for every build machine.
+              Invalid machine specifications:
+          '' + "      " +
+          (builtins.concatStringsSep "\n      "
+            (builtins.map (m: m.hostName)
+              (builtins.filter (badMachine) cfg.buildMachines)));
+        }
+      ];
+
 
     systemd.packages = [ nix ];
 


### PR DESCRIPTION
Commit 5395397f removed the assertions from the buildMachines to
ensure that either system or systems is set for each buildmachine.

This patch re-implements those assertions.

###### Motivation for this change

The symptom is that if both system and systems are omitted, then the
/etc/machines file has the wrong number of columns and any attempt to
run a `nix` operation that has to perform a build will fail with a
`stoull` exception.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
