### PR TITLE
ocamlPackages.ezxmlm: 1.0.2 → 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/ezxmlm/default.nix
+++ b/pkgs/development/ocaml-modules/ezxmlm/default.nix
@@ -1,14 +1,14 @@
-{ lib, fetchFromGitHub, buildDunePackage, xmlm }:
+{ lib, fetchurl, buildDunePackage, xmlm }:
 
 buildDunePackage rec {
   pname = "ezxmlm";
-  version = "1.0.2";
+  version = "1.1.0";
 
-  src = fetchFromGitHub {
-    owner = "avsm";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "1dgr61f0hymywikn67inq908x5adrzl3fjx3v14l9k46x7kkacl9";
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ezxmlm/releases/download/v${version}/ezxmlm-v${version}.tbz";
+    sha256 = "123dn4h993mlng9gzf4nc6mw75ja7ndcxkbkwfs48j5jk1z05j6d";
   };
 
   propagatedBuildInputs = [ xmlm ];
@@ -27,7 +27,7 @@ buildDunePackage rec {
       just fine with it if you decide to switch over.
     '';
     maintainers = [ maintainers.carlosdagos ];
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/mirage/ezxmlm/";
     license = licenses.isc;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.12.

cc maintainer @carlosdagos

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
