### PR TITLE
gi-docgen: make DevHelp and index.json ordered

### DIFF
--- a/pkgs/development/tools/documentation/gi-docgen/default.nix
+++ b/pkgs/development/tools/documentation/gi-docgen/default.nix
@@ -61,6 +61,13 @@ python3.pkgs.buildPythonApplication rec {
       url = "https://gitlab.gnome.org/jtojnar/gi-docgen/commit/08dcc31f62be1a5af9bd9f8f702f321f4b5cffde.patch";
       sha256 = "vAT8s7zQ9zCoZWK+6PsxcD5/48ZAfIOl4RSNljRCGWQ=";
     })
+    # make DevHelp sections & index.json have stable ordering
+    # already merged upstream, so patch can removed when we update
+    # beyond 2021.2
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gi-docgen/-/commit/cc21241d4386d4f78dbcb087fd9a92899935cb5c.patch";
+      sha256 = "0wna8mzrlbsv7f3bc7ndqll9l105kp8kdmhbbjhbdhzzzyvh6vcw";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

So the result is bit-by-bit reproducible #118910

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).