### PR TITLE
blender: install with python3Packages.requests, fixes #97250

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -35,8 +35,7 @@ stdenv.mkDerivation rec {
 
   patches = lib.optional stdenv.isDarwin ./darwin.patch;
 
-  nativeBuildInputs =
-    [ cmake makeWrapper python3Packages.wrapPython ]
+  nativeBuildInputs = [ cmake makeWrapper python3Packages.wrapPython ]
     ++ optional cudaSupport addOpenGLRunpath;
   buildInputs =
     [ boost ffmpeg gettext glew ilmbase

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   patches = lib.optional stdenv.isDarwin ./darwin.patch;
 
   nativeBuildInputs = [ cmake makeWrapper python3Packages.wrapPython ]
-    ++ optional cudaSupport addOpenGLRunpath;
+    ++ optionals cudaSupport [ addOpenGLRunpath ];
   buildInputs =
     [ boost ffmpeg gettext glew ilmbase
       freetype libjpeg libpng libsamplerate libsndfile libtiff


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/97250.
Some popular add-ons need `python3Packages.requests` (eg. [BlenderBIM](https://blenderbim.org/)).
It could be provided with `nix-shell -p python3Packages.requests --run blender` because the wrapper only prepend to `PYTHONPATH` instead of setting it, but still it's a better user-experience to just have this dependency bundled by default.
There was also an attempt to wrap blender in a separate derivation in https://github.com/NixOS/nixpkgs/pull/97388 which could be resurrected.

###### Things done
`requests` can now be imported from the console and by add-ons, including its dependencies because `buildPythonPath` is now used.
I'm not setting `PYTHON_REQUESTS_PATH` because `WITH_PYTHON_INSTALL_REQUESTS=OFF`, and I guess setting `PYTHON_NUMPY_PATH` is useless as well but I'm not removing it, however `PYTHON_NUMPY_INCLUDE_DIRS` would likely still be needed because `WITH_PYTHON_NUMPY=ON`.

###### FIXME
When running the "Render presets thumbs" of the community module Archipack, the `No module named 'numpy'` error is still raised without my knowing why. That kind of error was previously mentioned here https://github.com/NixOS/nixpkgs/issues/82337 but believed to be fixed in https://github.com/NixOS/nixpkgs/pull/82341.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
