### PR TITLE
edk2/OVMF: add hooks for building for IA32 on 64bit stdenv

### DIFF
--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -16,24 +16,10 @@
 let
   pythonEnv = python3.withPackages (ps: [ps.tkinter]);
 
-targetArch = if stdenv.isi686 then
-  "IA32"
-else if stdenv.isx86_64 then
-  "X64"
-else if stdenv.isAarch64 then
-  "AARCH64"
-else
-  throw "Unsupported architecture";
-
 buildStdenv = if stdenv.isDarwin then
   overrideCC clangStdenv [ clang_9 llvmPackages_9.llvm llvmPackages_9.lld ]
 else
   stdenv;
-
-buildType = if stdenv.isDarwin then
-    "CLANGPDB"
-  else
-    "GCC5";
 
 edk2 = buildStdenv.mkDerivation {
   pname = "edk2";
@@ -71,7 +57,7 @@ edk2 = buildStdenv.mkDerivation {
   };
 
   passthru = {
-    mkDerivation = projectDscPath: attrs: buildStdenv.mkDerivation ({
+    mkDerivation = projectDscPath: targetArch: buildType: attrs: buildStdenv.mkDerivation ({
       inherit (edk2) src;
 
       buildInputs = [ bc pythonEnv ] ++ attrs.buildInputs or [];


### PR DESCRIPTION
Currently, building for IA32 via pkgsi686Linux stdenv is broken.
This nominally fixes #118985 by allowing you to specify crossIa32, which
overrides targetArch, projectDscPath, buildType.

`nix-build -E 'with import <nixpkgs> {}; pkgs.OVMF.override { crossIa32 = true; }'`

This also moves all the logic for targetArch, projectDscPath, and builtType
into OVMF since that is not used within edk2/default.nix itself

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

OVMF 32 bit does not build on 64bit nixos standard environment.s

###### Things done

hooked into my own system:

```
packageOverrides = pkgs: rec {
  edk2 = (pkgs.callPackage ./pkgs/edk2.nix {});
  OVMF = (pkgs.callPackage ./pkgs/OVMF.nix {
    util-linux = pkgs.utillinux;
  });
```

64 bit:

```
% nix-build -E 'with import <nixpkgs> {}; pkgs.OVMF'
/nix/store/ivc0c7xsqgv5sixcbslfn93gcpzxwrvw-OVMF-202011
~ talos % dir /nix/store/ivc0c7xsqgv5sixcbslfn93gcpzxwrvw-OVMF-202011
AutoGen  BuildOptions  FV  GlobalVar_5a9e7754-d81b-49ea-85ad-69eaa7b1539b_X64.bin  Ovmf.map  PcdTokenNumber  X64
```

64 bit stdenv on 32bit:

```
% nix-build -E 'with import <nixpkgs> {}; pkgs.OVMF.override { crossIa32 = true; }'
/nix/store/xcsjqddprha1ykk8v58sjbq80s1rwbwh-OVMF-202011
% dir /nix/store/xcsjqddprha1ykk8v58sjbq80s1rwbwh-OVMF-202011
AutoGen  BuildOptions  FV  GlobalVar_5a9e7754-d81b-49ea-85ad-69eaa7b1539b_IA32.bin  IA32  Ovmf.map  PcdTokenNumber
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
