### PR TITLE
nixos/manual: document how to install over a serial port

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -46,6 +46,12 @@
    to increase the font size.
   </para>
 
+  <para>
+    To install over a serial port connect with <literal>115200n8</literal>
+    (e.g. <command>picocom -b 115200 /dev/ttyUSB0</command>). When the
+    bootloader lists boot entries, select the serial console boot entry.
+  </para>
+
   <section xml:id="sec-installation-booting-networking">
    <title>Networking in the installer</title>
 


### PR DESCRIPTION
###### Motivation for this change
Document how to install over serial, now that its less fiddly (as of https://github.com/NixOS/nixpkgs/issues/58198 ).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
