### PR TITLE
octant: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/applications/networking/cluster/octant/default.nix
+++ b/pkgs/applications/networking/cluster/octant/default.nix
@@ -1,27 +1,27 @@
 { lib, stdenv, fetchzip }:
 
-let
-  inherit (stdenv.hostPlatform) system;
-  suffix = {
-    x86_64-linux = "Linux-64bit";
-    aarch64-linux = "Linux-arm64";
-    x86_64-darwin = "macOS-64bit";
-  }.${system} or (throw "Unsupported system: ${system}");
-  baseurl = "https://github.com/vmware-tanzu/octant/releases/download";
-  fetchsrc = version: sha256: fetchzip {
-      url = "${baseurl}/v${version}/octant_${version}_${suffix}.tar.gz";
-      sha256 = sha256."${system}";
-    };
-in
 stdenv.mkDerivation rec {
   pname = "octant";
-  version = "0.18.0";
+  version = "0.19.0";
 
-  src = fetchsrc version {
-    x86_64-linux = "sha256-D/pHOXR7XQoJCGqUep1lBAY4239HH35m+evFd21pcK0=";
-    aarch64-linux = "sha256-aL1axz3ebqrKQ3xK2UgDMQ+o6ZKgIvwy6Phici7WT2c=";
-    x86_64-darwin = "sha256-MFxOAAEnLur0LJJNU0SSlO+bH4f18zOfZNA49fKEQEw=";
-  };
+  src =
+    let
+      inherit (stdenv.hostPlatform) system;
+      suffix = {
+        x86_64-linux = "Linux-64bit";
+        aarch64-linux = "Linux-arm64";
+        x86_64-darwin = "macOS-64bit";
+      }.${system} or (throw "Unsupported system: ${system}");
+      fetchsrc = version: sha256: fetchzip {
+        url = "https://github.com/vmware-tanzu/octant/releases/download/v${version}/octant_${version}_${suffix}.tar.gz";
+        sha256 = sha256.${system};
+      };
+    in
+    fetchsrc version {
+      x86_64-linux = "sha256-TKvUBof4TLcHr9hg6AOLjVd1NcAX9HHVuuABdFKRNQA=";
+      aarch64-linux = "sha256-BJb7h6kJZ3QhdlEqNHkiFp91uYLXzYHvKftxEAhjY38=";
+      x86_64-darwin = "sha256-Ig98IqLmlN9D4iXrP9SXYwTrQOvbtQ/tQW+uEmntm+I=";
+    };
 
   dontConfigure = true;
   dontBuild = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump octant to `0.19.0`

Also format similar to boundary moving the fetchsrc function within the derivation


As a note please check out #117677 for octant-desktop 🙂

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
