### PR TITLE
tcpdump: 4.9.3 -> 4.99.0

### DIFF
--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -1,21 +1,13 @@
-{ lib, stdenv, fetchurl, libpcap, perl, fetchpatch }:
+{ lib, stdenv, fetchurl, libpcap, perl }:
 
 stdenv.mkDerivation rec {
   pname = "tcpdump";
-  version = "4.9.3";
+  version = "4.99.0";
 
   src = fetchurl {
     url = "http://www.tcpdump.org/release/${pname}-${version}.tar.gz";
-    sha256 = "0434vdcnbqaia672rggjzdn4bb8p8dchz559yiszzdk0sjrprm1c";
+    sha256 = "0hmqh2fx8rgs9v1mk3vpywj61xvkifz260q685xllxr8jmxg3wlc";
   };
-
-  patches = [
-    # Patch for CVE-2020-8037
-    (fetchpatch {
-      url = "https://github.com/the-tcpdump-group/tcpdump/commit/32027e199368dad9508965aae8cd8de5b6ab5231.patch";
-      sha256 = "sha256-bO3aV032ru9+M/9isBRjmH8jTZLKj9Zf9ha2rmOaZwc=";
-    })
-  ];
 
   postPatch = ''
     patchShebangs tests
@@ -29,11 +21,11 @@ stdenv.mkDerivation rec {
     (stdenv.hostPlatform != stdenv.buildPlatform)
     "ac_cv_linux_vers=2";
 
-  meta = {
+  meta = with lib; {
     description = "Network sniffer";
-    homepage = "http://www.tcpdump.org/";
-    license = "BSD-style";
-    maintainers = with lib.maintainers; [ globin ];
-    platforms = lib.platforms.unix;
+    homepage = "https://www.tcpdump.org/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ globin ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>8 packages built:</summary>
  <ul>
    <li>compactor</li>
    <li>evillimiter</li>
    <li>firehol</li>
    <li>home-assistant</li>
    <li>john</li>
    <li>python38Packages.scapy</li>
    <li>python39Packages.scapy</li>
    <li>tcpdump</li>
  </ul>
</details>