### PR TITLE
pikchr: init at unstable-2021-04-07

### DIFF
--- a/pkgs/tools/graphics/pikchr/default.nix
+++ b/pkgs/tools/graphics/pikchr/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation {
+  pname = "pikchr";
+  version = "unstable-2021-04-07";
+
+  src = fetchurl {
+    url = "https://pikchr.org/home/tarball/90b6d5b4a3834ff0/pikchr.tar.gz";
+    sha256 = "1cqpnljy12gl82rcbb7mwhgv9szcliwkbwwh67hzdv020h1scxym";
+  };
+
+  # can't open generated html files
+  postPatch = ''
+    substituteInPlace Makefile --replace open "test -f"
+  '';
+
+  installPhase = ''
+    install -Dm755 pikchr $out/bin/pikchr
+    install -Dm755 pikchr.out $out/lib/pikchr.o
+    install -Dm644 pikchr.h $out/include/pikchr.h
+  '';
+
+  doCheck = true;
+  checkTarget = "test";
+
+  meta = with lib; {
+    description = "A PIC-like markup language for diagrams in technical documentation";
+    homepage = "https://pikchr.org";
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -859,6 +859,8 @@ in
 
   nimmm = callPackage ../applications/terminal-emulators/nimmm { };
 
+  pikchr = callPackage ../tools/graphics/pikchr { };
+
   roxterm = callPackage ../applications/terminal-emulators/roxterm { };
 
   rxvt = callPackage ../applications/terminal-emulators/rxvt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
