### PR TITLE
python3Packages.pykwalify: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/development/python-modules/pykwalify/default.nix
+++ b/pkgs/development/python-modules/pykwalify/default.nix
@@ -1,32 +1,40 @@
-{ lib, buildPythonPackage, fetchPypi
-, dateutil, docopt, pyyaml
-, pytest, testfixtures
+{ lib
+, buildPythonPackage
+, dateutil
+, docopt
+, fetchPypi
+, pytestCheckHook
+, pyyaml
+, ruamel-yaml
+, testfixtures
 }:
 
 buildPythonPackage rec {
-  version = "1.7.0";
+  version = "1.8.0";
   pname = "pykwalify";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cnfzkg1b01f825ikpw2fhjclf9c8akxjfrbd1vc22x1lg2kk2vy";
+    sha256 = "sha256-eWsq0+1MuZuIMItTP7L1WcMPpu+0+p/aETR/SD0kWIQ=";
   };
 
   propagatedBuildInputs = [
     dateutil
     docopt
     pyyaml
+    ruamel-yaml
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
     testfixtures
   ];
 
-  checkPhase = ''
-    pytest \
-      -k 'not test_multi_file_support'
-  '';
+  disabledTests = [
+    "test_multi_file_support"
+  ];
+
+  pythonImportsCheck = [ "pykwalify" ];
 
   meta = with lib; {
     homepage = "https://github.com/Grokzen/pykwalify";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.8.0

Change log: https://github.com/Grokzen/pykwalify/releases/tag/1.8.0

Switch to `pytestCheckHook`. Update was triggered by the `SyntaxWarning` in #118951.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
