### PR TITLE
astc-encoder: init at 2.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2171,6 +2171,16 @@
     githubId = 4971975;
     name = "Janne Heß";
   };
+  dasisdormax = {
+    email = "dasisdormax@mailbox.org";
+    github = "dasisdormax";
+    githubId = 3714905;
+    keys = [{
+      longkeyid = "rsa4096/0x02BA0D4480CA6C44";
+      fingerprint = "E59B A198 61B0 A9ED C1FA  3FB2 02BA 0D44 80CA 6C44";
+    }];
+    name = "Maximilian Wende";
+  };
   dasj19 = {
     email = "daniel@serbanescu.dk";
     github = "dasj19";

--- a/pkgs/tools/graphics/astc-encoder/default.nix
+++ b/pkgs/tools/graphics/astc-encoder/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, gccStdenv
+, fetchFromGitHub
+, cmake
+, simdExtensions ? null
+}:
+
+with rec {
+  # SIMD instruction sets to compile for. If none are specified by the user,
+  # an appropriate one is selected based on the detected host system
+  isas = with gccStdenv.hostPlatform;
+    if simdExtensions != null then lib.toList simdExtensions
+    else if avx2Support then [ "AVX2" ]
+    else if sse4_1Support then [ "SSE41" ]
+    else if isx86_64 then [ "SSE2" ]
+    else if isAarch64 then [ "NEON" ]
+    else [ "NONE" ];
+
+  archFlags = lib.optionals gccStdenv.hostPlatform.isAarch64 [ "-DARCH=aarch64" ];
+
+  # CMake Build flags for the selected ISAs. For a list of flags, see
+  # https://github.com/ARM-software/astc-encoder/blob/main/Docs/Building.md
+  isaFlags = map ( isa: "-DISA_${isa}=ON" ) isas;
+
+  # The suffix of the binary to link as 'astcenc'
+  mainBinary = builtins.replaceStrings
+    [ "AVX2" "SSE41"  "SSE2" "NEON" "NONE" ]
+    [ "avx2" "sse4.1" "sse2" "neon" "none" ]
+    ( builtins.head isas );
+};
+
+gccStdenv.mkDerivation rec {
+  pname = "astc-encoder";
+  version = "2.5";
+
+  src = fetchFromGitHub {
+    owner = "ARM-software";
+    repo = "astc-encoder";
+    rev = version;
+    sha256 = "0ff5jh40w942dz7hmgvznmpa9yhr1j4i9qqj5wy6icm2jb9j4pak";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = isaFlags ++ archFlags ++ [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  # Link binaries into environment and provide 'astcenc' link
+  postInstall = ''
+    mv $out/astcenc $out/bin
+    ln -s $out/bin/astcenc-${mainBinary} $out/bin/astcenc
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ARM-software/astc-encoder";
+    description = "An encoder for the ASTC texture compression format";
+    longDescription = ''
+      The Adaptive Scalable Texture Compression (ASTC) format is
+      widely supported by mobile and desktop graphics hardware and
+      provides better quality at a given bitrate compared to ETC2.
+
+      This program supports both compression and decompression in LDR
+      and HDR mode and can read various image formats. Run `astcenc
+      -help` to see all the options.
+    '';
+    platforms = platforms.unix;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dasisdormax ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1035,6 +1035,8 @@ in
 
   asls = callPackage ../development/tools/misc/asls { };
 
+  astc-encoder = callPackage ../tools/graphics/astc-encoder { };
+
   asymptote = callPackage ../tools/graphics/asymptote {
     texLive = texlive.combine { inherit (texlive) scheme-small epsf cm-super texinfo; };
     gsl = gsl_1;


### PR DESCRIPTION
This builds the astc-encoder for the x86_64 architecture and sets
an astcenc symlink for the most compatible sse2 version.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I use the ASTC format for texture compression in a mobile game I develop with LibGDX, as it can encode alpha values and is supported by hardware on modern iOS and Android devices. This is a command line utility for converting regular images (optionally created by a texture packer) into the ASTC or KTX format.

Usage example:
- Encoding: `astcenc -cl input.png compressed.astc 6x6 -medium`
- Decoding: `astcenc -dl compressed.astc decompressed.png`

Original source on Github: https://github.com/ARM-software/astc-encoder

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
