### PR TITLE
nixos/nginx: make sslCertificate and sslCertificateKey nullable

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -289,11 +289,15 @@ let
             return 301 http${optionalString hasSSL "s"}://${vhost.globalRedirect}$request_uri;
           ''}
           ${optionalString hasSSL ''
-            ssl_certificate ${vhost.sslCertificate};
-            ssl_certificate_key ${vhost.sslCertificateKey};
-          ''}
-          ${optionalString (hasSSL && vhost.sslTrustedCertificate != null) ''
-            ssl_trusted_certificate ${vhost.sslTrustedCertificate};
+            ${optionalString (vhost.sslCertificate != null) ''
+              ssl_certificate ${vhost.sslCertificate};
+            ''}
+            ${optionalString (vhost.sslCertificateKey != null) ''
+              ssl_certificate_key ${vhost.sslCertificateKey};
+            ''}
+            ${optionalString (vhost.sslTrustedCertificate != null) ''
+              ssl_trusted_certificate ${vhost.sslTrustedCertificate};
+            ''}
           ''}
 
           ${mkBasicAuth vhostName vhost}

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -119,15 +119,23 @@ with lib;
     };
 
     sslCertificate = mkOption {
-      type = types.path;
+      type = types.nullOr types.path;
+      default = null;
       example = "/var/host.cert";
-      description = "Path to server SSL certificate.";
+      description = ''
+        Path to server SSL certificate. Can be left unset, for example if
+        <literal>ssl_reject_handshake</literal> is used.
+      '';
     };
 
     sslCertificateKey = mkOption {
-      type = types.path;
+      type = types.nullOr types.path;
+      default = null;
       example = "/var/host.key";
-      description = "Path to server SSL certificate key.";
+      description = ''
+        Path to server SSL certificate key. Can be left unset, for example if
+        <literal>ssl_reject_handshake</literal> is used.
+      '';
     };
 
     sslTrustedCertificate = mkOption {


### PR DESCRIPTION
###### Motivation for this change

It sometimes makes sense to have `addSSL = true` without defining `sslCertificate` or `sslCertificateKey`, for example if one wants to use the `ssl_reject_handshake` directive.

cc @globin @aanderse @Ma27 

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
