### PR TITLE
ranger: Add 'source ranger' support

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -40,6 +40,27 @@ python3Packages.buildPythonApplication rec {
       --replace "set preview_images false" "set preview_images true"
   '';
 
+  # Adds support for doing `source ranger` in bash
+  postFixup = ''
+    substituteInPlace $out/bin/ranger \
+      --replace 'exec' '#exec '
+    cat >> $out/bin/ranger << EOF
+      if [[ "\$(basename "\$0")" == "ranger" ]]
+      then
+        exec -a "\$0" "$out/bin/.ranger-wrapped" "\$@"
+      else
+        temp_file="\$(mktemp -t "ranger_cd.XXXXXXXXXX")"
+        "$out/bin/ranger" --choosedir="\$temp_file" "\$@"
+        return_value="\$?"
+        if chosen_dir="\$(cat -- "\$temp_file")" && [ -n "\$chosen_dir" ] && [ "\$chosen_dir" != "\$PWD" ]; then
+            cd -- "\$chosen_dir"
+        fi
+        rm -f -- "\$temp_file"
+        return "\$return_value"
+      fi
+    EOF
+  '';
+
   meta =  with lib; {
     description = "File manager with minimalistic curses interface";
     homepage = "https://ranger.github.io/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The current ranger derivation does not support the `source ranger` trick to easily use ranger as a `cd` replacement for the bash shell.
It might be confusing for people using nix that this behaviour is not supported when it is mentioned in the ranger manual, so this commit adds support for it.

###### Things done
Changed the wrapper to check if the script is being sourced from bash, and automatically uses the `--choosedir` flag to write the path to a temporary file (much as the original ranger file does).
I would have preferred to actually use the code from the `.ranger-wrapped` file that ranger ships with, but it seems rather involved because of the shebangs and mixed python code.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
