### PR TITLE
passerine: init at 0.9.2

### DIFF
--- a/pkgs/development/compilers/passerine/default.nix
+++ b/pkgs/development/compilers/passerine/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "passerine";
+  version = "0.9.2";
+
+  src = fetchFromGitHub {
+    owner = "vrtbl";
+    repo = "passerine";
+    rev = "dd8a6f5efc5dcb03d45b102f61cc8a50d46e8e98";
+    sha256 = "sha256-/QzqKLkxAVqvTY4Uft1qk7nJat6nozykB/4X1YGqu/I=";
+  };
+
+  cargoSha256 = "sha256-8WiiDLIJ/abXELF8S+4s+BPA/Lr/rpKmC1NWPCLzQWA=";
+
+  meta = with lib; {
+    description = "A small extensible programming language designed for concise expression with little code";
+    homepage = "https://github.com/vrtbl/passerine";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11584,6 +11584,8 @@ in
 
   open-watcom-bin = callPackage ../development/compilers/open-watcom-bin { };
 
+  passerine = callPackage ../development/compilers/passerine { };
+
   pforth = callPackage ../development/compilers/pforth {};
 
   picat = callPackage ../development/compilers/picat { };


### PR DESCRIPTION
###### Motivation for this change
Add passerine, though build fails because of some cargo error I don't understand.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
