### PR TITLE
obs-websocket: init at 4.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2927,6 +2927,16 @@
     githubId = 147284;
     name = "Jason Felice";
   };
+  erdnaxe = {
+    email = "erdnaxe@crans.org";
+    github = "erdnaxe";
+    githubId = 2663216;
+    name = "Alexandre Iooss";
+    keys = [{
+      longkeyid = "rsa4096/0x6C79278F3FCDCC02";
+      fingerprint = "2D37 1AD2 7E2B BC77 97E1  B759 6C79 278F 3FCD CC02";
+    }];
+  };
   ericbmerritt = {
     email = "eric@afiniate.com";
     github = "ericbmerritt";

--- a/pkgs/applications/video/obs-studio/plugins/obs-websocket.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-websocket.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, qtbase
+, obs-studio
+, asio_1_10
+, websocketpp
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-websocket";
+  version = "4.9.0";
+
+  src = fetchFromGitHub {
+    owner = "Palakis";
+    repo = "obs-websocket";
+    rev = version;
+    sha256 = "1dxih5czcfs1vczbq48784jvmgs8awbsrwk8mdfi4pg8n577cr1w";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qtbase obs-studio asio_1_10 websocketpp ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    "-DLIBOBS_INCLUDE_DIR=${obs-studio.src}/libobs"
+  ];
+
+  meta = with lib; {
+    description = "Remote-control OBS Studio through WebSockets";
+    homepage = "https://github.com/Palakis/obs-websocket";
+    maintainers = with maintainers; [ erdnaxe ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

OBS websocket plugin enables users to remote control their OBS-Studio instance over the network.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
