### PR TITLE
kime: init at 2.5.2

### DIFF
--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -29,7 +29,7 @@ in
   options.i18n = {
     inputMethod = {
       enabled = mkOption {
-        type    = types.nullOr (types.enum [ "ibus" "fcitx" "fcitx5" "nabi" "uim" "hime" ]);
+        type    = types.nullOr (types.enum [ "ibus" "fcitx" "fcitx5" "nabi" "uim" "hime" "kime" ]);
         default = null;
         example = "fcitx";
         description = ''
@@ -46,6 +46,7 @@ in
           <listitem><para>nabi: A Korean input method based on XIM. Nabi doesn't support Qt 5.</para></listitem>
           <listitem><para>uim: The universal input method, is a library with a XIM bridge. uim mainly support Chinese, Japanese and Korean.</para></listitem>
           <listitem><para>hime: An extremely easy-to-use input method framework.</para></listitem>
+          <listitem><para>kime: Koream IME.</para></listitem>
           </itemizedlist>
         '';
       };

--- a/nixos/modules/i18n/input-method/default.xml
+++ b/nixos/modules/i18n/input-method/default.xml
@@ -40,6 +40,11 @@
     Hime: An extremely easy-to-use input method framework.
    </para>
   </listitem>
+  <listitem>
+    <para>
+     Kime: Korean IME
+    </para>
+  </listitem>
  </itemizedlist>
  <section xml:id="module-services-input-methods-ibus">
   <title>IBus</title>
@@ -263,6 +268,23 @@ i18n.inputMethod = {
 <programlisting>
 i18n.inputMethod = {
   <link linkend="opt-i18n.inputMethod.enabled">enabled</link> = "hime";
+};
+</programlisting>
+ </section>
+ <section xml:id="module-services-input-methods-kime">
+  <title>Kime</title>
+
+  <para>
+   Kime is Korean IME. it's built with Rust language and let you get simple, safe, fast Korean typing
+  </para>
+
+  <para>
+   The following snippet can be used to configure Kime:
+  </para>
+
+<programlisting>
+i18n.inputMethod = {
+  <link linkend="opt-i18n.inputMethod.enabled">enabled</link> = "kime";
 };
 </programlisting>
  </section>

--- a/nixos/modules/i18n/input-method/kime.nix
+++ b/nixos/modules/i18n/input-method/kime.nix
@@ -1,0 +1,49 @@
+{ config, pkgs, lib, generators, ... }:
+with lib;
+let
+  cfg = config.i18n.inputMethod.kime;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  options = {
+    i18n.inputMethod.kime = {
+      config = mkOption {
+        type = yamlFormat.type;
+        default = { };
+        example = literalExample ''
+          {
+            daemon = {
+              modules = ["Xim" "Indicator"];
+            };
+
+            indicator = {
+              icon_color = "White";
+            };
+
+            engine = {
+              hangul = {
+                layout = "dubeolsik";
+              };
+            };
+          }
+          '';
+        description = ''
+          kime configuration. Refer to <link xlink:href="https://github.com/Riey/kime/blob/v${pkgs.kime.version}/docs/CONFIGURATION.md"/> for details on supported values.
+        '';
+      };
+    };
+  };
+
+  config = mkIf (config.i18n.inputMethod.enabled == "kime") {
+    i18n.inputMethod.package = pkgs.kime;
+
+    environment.variables = {
+      GTK_IM_MODULE = "kime";
+      QT_IM_MODULE  = "kime";
+      XMODIFIERS    = "@im=kime";
+    };
+
+    environment.etc."xdg/kime/config.yaml".text = replaceStrings [ "\\\\" ] [ "\\" ] (builtins.toJSON cfg.config);
+  };
+}
+

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -92,6 +92,7 @@
   ./i18n/input-method/ibus.nix
   ./i18n/input-method/nabi.nix
   ./i18n/input-method/uim.nix
+  ./i18n/input-method/kime.nix
   ./installer/tools/tools.nix
   ./misc/assertions.nix
   ./misc/crashdump.nix

--- a/pkgs/tools/inputmethods/kime/default.nix
+++ b/pkgs/tools/inputmethods/kime/default.nix
@@ -1,0 +1,113 @@
+{ lib, stdenv, rustPlatform, rustc, cargo, fetchFromGitHub, pkg-config, cmake, extra-cmake-modules, llvmPackages
+, withWayland ? true
+, withIndicator ? true, dbus, libdbusmenu
+, withXim ? true, xorg, cairo
+, withGtk2 ? true, gtk2
+, withGtk3 ? true, gtk3
+, withQt5 ? true, qt5
+}:
+
+let
+  cmake_args = lib.optionals withGtk2 ["-DENABLE_GTK2=ON"]
+  ++ lib.optionals withGtk3 ["-DENABLE_GTK3=ON"]
+  ++ lib.optionals withQt5 ["-DENABLE_QT5=ON"];
+
+  optFlag = w: (if w then "1" else "0");
+in
+stdenv.mkDerivation rec {
+  pname = "kime";
+  version = "2.5.2";
+
+  src = fetchFromGitHub {
+    owner = "Riey";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "10zd4yrqxzxf4nj3b5bsblcmlbqssxqq9pac0misa1g61jdbszj8";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    sha256 = "1bimi7020m7v287bh7via7zm9m7y13d13kqpd772xmpdbwrj8nrl";
+  };
+
+  # Replace autostart path
+  postPatch = ''
+    substituteInPlace res/kime.desktop --replace "/usr/bin/kime" "$out/bin/kime"
+  '';
+
+  dontUseCmakeConfigure = true;
+  dontWrapQtApps = true;
+  buildPhase = ''
+    runHook preBuild
+    export KIME_BUILD_CHECK=1
+    export KIME_BUILD_INDICATOR=${optFlag withIndicator}
+    export KIME_BUILD_XIM=${optFlag withXim}
+    export KIME_BUILD_WAYLAND=${optFlag withWayland}
+    export KIME_BUILD_KIME=1
+    export KIME_CARGO_ARGS="-j$NIX_BUILD_CORES --frozen"
+    export KIME_MAKE_ARGS="-j$NIX_BUILD_CORES"
+    export KIME_CMAKE_ARGS="${lib.concatStringsSep " " cmake_args}"
+    bash scripts/build.sh -r
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    cargo test --release --frozen
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    export KIME_BIN_DIR=bin
+    export KIME_INSTALL_HEADER=1
+    export KIME_INSTALL_DOC=1
+    export KIME_INCLUDE_DIR=include
+    export KIME_DOC_DIR=share/doc/kime
+    export KIME_ICON_DIR=share/icons
+    export KIME_LIB_DIR=lib
+    export KIME_QT5_DIR=lib/qt-${qt5.qtbase.version}
+    bash scripts/install.sh "$out"
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    # Don't pipe output to head directly it will cause broken pipe error https://github.com/rust-lang/rust/issues/46016
+    kimeVersion=$(echo "$($out/bin/kime --version)" | head -n1)
+    echo "'kime --version | head -n1' returns: $kimeVersion"
+    [[ "$kimeVersion" == "kime ${version}" ]]
+    runHook postInstallCheck
+  '';
+
+  buildInputs = lib.optionals withIndicator [ dbus libdbusmenu ]
+  ++ lib.optionals withXim [ xorg.libxcb cairo ]
+  ++ lib.optionals withGtk2 [ gtk2 ]
+  ++ lib.optionals withGtk3 [ gtk3 ]
+  ++ lib.optionals withQt5 [ qt5.qtbase ];
+
+  nativeBuildInputs = [
+    pkg-config
+    llvmPackages.clang
+    llvmPackages.libclang
+    llvmPackages.bintools
+    cmake
+    extra-cmake-modules
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
+  ];
+
+  RUST_BACKTRACE = 1;
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+
+  meta = with lib; {
+    homepage = "https://github.com/Riey/kime";
+    description = "Korean IME";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.riey ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3462,6 +3462,8 @@ in
 
   gebaar-libinput = callPackage ../tools/inputmethods/gebaar-libinput { };
 
+  kime = callPackage ../tools/inputmethods/kime { };
+
   libpinyin = callPackage ../development/libraries/libpinyin { };
 
   libskk = callPackage ../development/libraries/libskk {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`kime` is new IME for Korean users it support gtk, qt, xim, wayland(unstable-v2)

https://github.com/Riey/kime

I've tested working with gtk3, qt5, xim, wayland

------

However I'm not sure this line is correct

https://github.com/NixOS/nixpkgs/blob/76adb53a9252055ee093fa92e56840749207e5eb/nixos/modules/i18n/input-method/kime.nix#L48

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
