### PR TITLE
telepresence2: init at 2.2.1

### DIFF
--- a/pkgs/tools/networking/telepresence2/default.nix
+++ b/pkgs/tools/networking/telepresence2/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "telepresence2";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "telepresenceio";
+    repo = "telepresence";
+    rev = "v${version}";
+    sha256 = "0pr6vm68jr5ld7hy2b4dwmjziir59vg137c74rdn1wlhq3n8vr41";
+  };
+
+  vendorSha256 = "0d0p879zchhrzrf6f5zc3vdcd5zi1ind7ibvb46y6wx6lp0f1nrp";
+
+  buildFlagsArray = ''
+    -ldflags=-s -w -X=github.com/telepresenceio/telepresence/v2/pkg/version.Version=${src.rev}
+  '';
+
+  subPackages = [ "cmd/telepresence" ];
+
+  meta = with lib; {
+    description = "Local development against a remote Kubernetes or OpenShift cluster";
+    homepage = "https://www.getambassador.io/docs/telepresence/2.1/quick-start/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mausch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8855,6 +8855,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  telepresence2 = callPackage ../tools/networking/telepresence2 { };
+
   teler = callPackage ../tools/security/teler { };
 
   termius = callPackage ../applications/networking/termius { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There's already a `telepresence` package but that's version 0.x . 
[It has since been rewritten in Go and called version 2.x](https://blog.getambassador.io/whats-new-in-telepresence-2-dbdff62b82d5)
More importantly, this is a separate package because the interface for telepresence is completely different i.e. it's pretty much an entirely different program (with the same purpose of course).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
