### PR TITLE
cc-wrapper: match useGccForLibs conditional order

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -299,10 +299,11 @@ stdenv.mkDerivation {
     # vs libstdc++, etc.) since Darwin isn't `useLLVM` on all counts. (See
     # https://clang.llvm.org/docs/Toolchain.html for all the axes one might
     # break `useLLVM` into.)
-    + optionalString (isClang && gccForLibs != null
+    + optionalString (isClang
                       && targetPlatform.isLinux
                       && !(stdenv.targetPlatform.useAndroidPrebuilt or false)
-                      && !(stdenv.targetPlatform.useLLVM or false)) ''
+                      && !(stdenv.targetPlatform.useLLVM or false)
+                      && gccForLibs != null) ''
       echo "--gcc-toolchain=${gccForLibs}" >> $out/nix-support/cc-cflags
     ''
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #115348

By matching the short-circuiting conditional order of `useGccForLibs` earlier in the file, this fixes the following infinite recursion:
```
 :  nix-build --dry-run . --arg crossSystem '{ config = "arm-none-eabi"; useLLVM = true; }' -A stdenv --show-trace   
error: while evaluating the attribute 'defaultNativeBuildInputs' of the derivation 'stdenv-linux' at /nixpkgs/pkgs/stdenv/generic/default.nix:88:14:
while evaluating the attribute 'llvmPackages.lldClang' at /nixpkgs/pkgs/development/compilers/llvm/11/default.nix:95:5:
while evaluating 'wrapCCWith' at /nixpkgs/pkgs/top-level/all-packages.nix:11467:5, called from /nixpkgs/pkgs/development/compilers/llvm/11/default.nix:95:16:
while evaluating 'callPackageWith' at /nixpkgs/lib/customisation.nix:117:35, called from /nixpkgs/pkgs/top-level/all-packages.nix:11481:7:
while evaluating 'makeOverridable' at /nixpkgs/lib/customisation.nix:67:24, called from /nixpkgs/lib/customisation.nix:121:8:
while evaluating anonymous function at /nixpkgs/pkgs/build-support/cc-wrapper/default.nix:8:1, called from /nixpkgs/lib/customisation.nix:69:16:
while evaluating the attribute 'stdenv' of the derivation 'newlib-3.3.0-arm-none-eabi' at /nixpkgs/pkgs/stdenv/generic/make-derivation.nix:203:11:
while evaluating the attribute 'defaultNativeBuildInputs' of the derivation 'stdenv-linux' at /nixpkgs/pkgs/stdenv/generic/default.nix:88:14:
while evaluating the attribute 'depsTargetTargetPropagated' of the derivation 'arm-none-eabi-clang-wrapper-8.0.1' at /nixpkgs/pkgs/stdenv/generic/make-derivation.nix:197:11:
while evaluating the attribute 'stdenv' of the derivation 'compiler-rt-8.0.1-arm-none-eabi' at /nixpkgs/pkgs/stdenv/generic/make-derivation.nix:203:11:
while evaluating the attribute 'defaultNativeBuildInputs' of the derivation 'stdenv-linux' at /nixpkgs/pkgs/stdenv/generic/default.nix:88:14:
while evaluating the attribute 'postFixup' of the derivation 'arm-none-eabi-clang-wrapper-8.0.1' at /nixpkgs/pkgs/stdenv/generic/make-derivation.nix:197:11:
while evaluating 'optionalString' at /nixpkgs/lib/strings.nix:202:5, called from /nixpkgs/pkgs/build-support/cc-wrapper/default.nix:302:7:
while evaluating 'isDerivation' at /nixpkgs/lib/attrsets.nix:323:18, called from /nixpkgs/pkgs/top-level/splice.nix:72:12:
while evaluating the attribute 'gccForLibs' at /nixpkgs/pkgs/top-level/all-packages.nix:12534:3:
while evaluating 'addMetaAttrs' at /nixpkgs/lib/meta.nix:15:28, called from /nixpkgs/pkgs/top-level/all-packages.nix:10333:11:
while evaluating 'wrapCC' at /nixpkgs/pkgs/top-level/all-packages.nix:11493:12, called from /nixpkgs/pkgs/top-level/all-packages.nix:10333:20:
while evaluating 'wrapCCWith' at /nixpkgs/pkgs/top-level/all-packages.nix:11467:5, called from /nixpkgs/pkgs/top-level/all-packages.nix:11493:16:
while evaluating 'callPackageWith' at /nixpkgs/lib/customisation.nix:117:35, called from /nixpkgs/pkgs/top-level/all-packages.nix:11481:7:
while evaluating 'makeOverridable' at /nixpkgs/lib/customisation.nix:67:24, called from /nixpkgs/lib/customisation.nix:121:8:
while evaluating anonymous function at /nixpkgs/pkgs/build-support/cc-wrapper/default.nix:8:1, called from /nixpkgs/lib/customisation.nix:69:16:
infinite recursion encountered, at undefined position
```

because... `stdenv` depends on `buildPackages.{g,}cc` which depends on `buildPackages.gccForLibs` which depends on `buildPackages.cc` and so on... This logic around cc wrapping is very fragile :<


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
