### PR TITLE
python3Packages.aiosyncthing: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/aiosyncthing/default.nix
+++ b/pkgs/development/python-modules/aiosyncthing/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, aiohttp
+, aioresponses
+, buildPythonPackage
+, fetchFromGitHub
+, expects
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "aiosyncthing";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "zhulik";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0704qbg3jy80vaw3bcvhy988s1qs3fahpfwkja71fy70bh0vc860";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    yarl
+  ];
+
+  checkInputs = [
+    aioresponses
+    expects
+    pytestCheckHook
+    pytest-asyncio
+    pytest-mock
+  ];
+
+  pythonImportsCheck = [ "aiosyncthing" ];
+
+  meta = with lib; {
+    description = "Python client for the Syncthing REST API";
+    homepage = "https://github.com/zhulik/aiosyncthing";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/expects/default.nix
+++ b/pkgs/development/python-modules/expects/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "expects";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "jaimegildesagredo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0mk1mhh8n9ly820krkhazn1w96f10vmgh21y2wr44sn8vwr4ngyy";
+  };
+
+  # mamba is used as test runner. Not available and should not be used as
+  # it's just another unmaintained test runner.
+  doCheck = false;
+  pythonImportsCheck = [ "expects" ];
+
+  meta = with lib; {
+    description = "Expressive and extensible TDD/BDD assertion library for Python";
+    homepage = "https://expects.readthedocs.io/";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -334,6 +334,8 @@ in {
 
   aioswitcher = callPackage ../development/python-modules/aioswitcher { };
 
+  aiosyncthing = callPackage ../development/python-modules/aiosyncthing { };
+
   aiounifi = callPackage ../development/python-modules/aiounifi { };
 
   aiounittest = callPackage ../development/python-modules/aiounittest { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2254,6 +2254,8 @@ in {
 
   exifread = callPackage ../development/python-modules/exifread { };
 
+  expects = callPackage ../development/python-modules/expects { };
+
   expiringdict = callPackage ../development/python-modules/expiringdict { };
 
   exrex = callPackage ../development/python-modules/exrex { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for the Syncthing REST API

https://github.com/zhulik/aiosyncthing

This is a future Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
