### PR TITLE
python3Packages.aioemonitor: init at 1.0.5

### DIFF
--- a/pkgs/development/python-modules/aioemonitor/default.nix
+++ b/pkgs/development/python-modules/aioemonitor/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, aiohttp
+, aioresponses
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytest-raises
+, pytestCheckHook
+, pythonOlder
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "aioemonitor";
+  version = "1.0.5";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "bdraco";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0h8zqqy8v8r1fl9bp3m8icr2sy44p0mbfl1hbb0zni17r9r50dhn";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    xmltodict
+  ];
+
+  checkInputs = [
+    aioresponses
+    pytest-asyncio
+    pytest-raises
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace '"pytest-runner>=5.2",' ""
+  '';
+
+  pythonImportsCheck = [ "aioemonitor" ];
+
+  meta = with lib; {
+    description = "Python client for SiteSage Emonitor";
+    homepage = "https://github.com/bdraco/aioemonitor";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -242,6 +242,8 @@ in {
 
   aioeafm = callPackage ../development/python-modules/aioeafm { };
 
+  aioemonitor = callPackage ../development/python-modules/aioemonitor { };
+
   aioesphomeapi = callPackage ../development/python-modules/aioesphomeapi { };
 
   aioeventlet = callPackage ../development/python-modules/aioeventlet { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for SiteSage Emonitor

https://github.com/bdraco/aioemonitor

This is a future Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
