### PR TITLE
Infnoise: init at master

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9266,8 +9266,8 @@
     name = "Stian Lågstad";
   };
   StijnDW = {
-    email = "stekke@airmail.cc";
-    github = "StijnDW";
+    email = "nixdev@rinsa.eu";
+    github = "Stekke";
     githubId = 1751956;
     name = "Stijn DW";
   };

--- a/pkgs/misc/drivers/infnoise/default.nix
+++ b/pkgs/misc/drivers/infnoise/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchFromGitHub, libftdi }:
+
+stdenv.mkDerivation rec {
+  pname = "infnoise";
+  version = "unstable-2019-08-12";
+
+  src = fetchFromGitHub {
+    owner = "13-37-org";
+    repo = "infnoise";
+    rev = "132683d4b5ce0902468b666cba63baea36e97f0c";
+    sha256 = "1dzfzinyvhyy9zj32kqkl19fyhih6sy8r5sa3qahbbr4c30k7flp";
+  };
+
+  # Patch makefile so we can set defines from the command line instead of it depending on .git
+  patches = [ ./makefile.patch ];
+  GIT_COMMIT = src.rev;
+  GIT_VERSION = version;
+  GIT_DATE = "2019-08-12";
+
+  buildInputs = [ libftdi ];
+
+  sourceRoot = "source/software";
+  makefile = "Makefile.linux";
+  makeFlags = [ "PREFIX=$(out)" ];
+  postPatch = ''
+    substituteInPlace init_scripts/infnoise.service --replace "/usr/local" "$out"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/13-37-org/infnoise";
+    description = "Driver for the Infinite Noise TRNG";
+    longDescription = ''
+      The Infinite Noise TRNG is a USB key hardware true random number generator.
+      It can either provide rng for userland applications, or provide rng for the OS entropy.
+      Add the following to your system configuration for plug and play support, adding to the OS entropy:
+      systemd.packages = [ pkgs.infnoise ];
+      services.udev.packages = [ pkgs.infnoise ];
+    '';
+    license = licenses.cc0;
+    maintainers = with maintainers; [ StijnDW ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/misc/drivers/infnoise/makefile.patch
+++ b/pkgs/misc/drivers/infnoise/makefile.patch
@@ -1,0 +1,14 @@
+diff --git a/software/Makefile.linux b/software/Makefile.linux
+index db48aa5..df8b3d2 100644
+--- a/Makefile.linux
++++ b/Makefile.linux
+@@ -1,6 +1,6 @@
+-GIT_VERSION := $(shell git --no-pager describe --tags --always)
+-GIT_COMMIT  := $(shell git rev-parse --verify HEAD)
+-GIT_DATE    := $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
++GIT_VERSION ?= $(shell git --no-pager describe --tags --always)
++GIT_COMMIT  ?= $(shell git rev-parse --verify HEAD)
++GIT_DATE    ?= $(firstword $(shell git --no-pager show --date=iso-strict --format="%ad" --name-only))
+ 
+ PREFIX = $(DESTDIR)/usr/local
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29617,6 +29617,8 @@ in
 
   image_optim = callPackage ../applications/graphics/image_optim { inherit (nodePackages) svgo; };
 
+  infnoise = callPackage ../misc/drivers/infnoise { };
+
   # using the new configuration style proposal which is unstable
   jack1 = callPackage ../misc/jackaudio/jack1.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Init infnoise package, a driver for a USB random number generator.
At master because the latest release doesn't compile (problem finding the right headers).
The product: https://leetronics.de/en/shop/infinite-noise-trng/

Additionally update my maintainer info.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
