### PR TITLE
python3Packages.pyeconet: init at 0.1.13

### DIFF
--- a/pkgs/development/python-modules/pyeconet/default.nix
+++ b/pkgs/development/python-modules/pyeconet/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, paho-mqtt
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+}:
+
+buildPythonPackage rec {
+  pname = "pyeconet";
+  version = "0.1.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pxwsmxzbmrab6p6qr867pc43ky2yjv2snra534wrdrknpj40h4s";
+  };
+
+  propagatedBuildInputs = [
+    paho-mqtt
+    aiohttp
+  ];
+
+  # Tests require credentials
+  doCheck = false;
+  pythonImportsCheck = [ "pyeconet" ];
+
+  meta = with lib; {
+    description = "Python interface to the EcoNet API";
+    homepage = "https://github.com/w1ll1am23/pyeconet";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -202,7 +202,7 @@
     "ebusd" = ps: with ps; [ ]; # missing inputs: ebusdpy
     "ecoal_boiler" = ps: with ps; [ ]; # missing inputs: ecoaliface
     "ecobee" = ps: with ps; [ ]; # missing inputs: python-ecobee-api
-    "econet" = ps: with ps; [ ]; # missing inputs: pyeconet
+    "econet" = ps: with ps; [ pyeconet ];
     "ecovacs" = ps: with ps; [ ]; # missing inputs: sucks
     "eddystone_temperature" = ps: with ps; [ construct ]; # missing inputs: beacontools[scan]
     "edimax" = ps: with ps; [ pyedimax ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -213,6 +213,7 @@ in with py.pkgs; buildPythonApplication rec {
     "devolo_home_control"
     "dhcp"
     "discovery"
+    "econet"
     "emulated_hue"
     "esphome"
     "fan"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5690,6 +5690,8 @@ in {
 
   pyechonest = callPackage ../development/python-modules/pyechonest { };
 
+  pyeconet = callPackage ../development/python-modules/pyeconet { };
+
   pyedimax = callPackage ../development/python-modules/pyedimax { };
 
   pyee = callPackage ../development/python-modules/pyee { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python interface to the EcoNet API

https://github.com/w1ll1am23/pyeconet

This is a Home assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
