### PR TITLE
python3Packages.pyenvisalink: init at 4.1

### DIFF
--- a/pkgs/development/python-modules/pyenvisalink/default.nix
+++ b/pkgs/development/python-modules/pyenvisalink/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, async-timeout
+, buildPythonPackage
+, colorlog
+, fetchPypi
+, pyserial
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyenvisalink";
+  version = "4.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1h30gmmynihmjkd107skk2gpi210b6gfdahwqmydyj5isxrvzmq2";
+  };
+
+  propagatedBuildInputs = [
+    async-timeout
+    colorlog
+    pyserial
+  ];
+
+  # Tests require an Envisalink device
+  doCheck = false;
+  pythonImportsCheck = [ "pyenvisalink" ];
+
+  meta = with lib; {
+    description = "Python interface for Envisalink 2DS/3 Alarm API";
+    homepage = "https://github.com/Cinntax/pyenvisalink";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -227,7 +227,7 @@
     "entur_public_transport" = ps: with ps; [ ]; # missing inputs: enturclient
     "environment_canada" = ps: with ps; [ ]; # missing inputs: env_canada
     "envirophat" = ps: with ps; [ smbus-cffi ]; # missing inputs: envirophat
-    "envisalink" = ps: with ps; [ ]; # missing inputs: pyenvisalink
+    "envisalink" = ps: with ps; [ pyenvisalink ];
     "ephember" = ps: with ps; [ ]; # missing inputs: pyephember
     "epson" = ps: with ps; [ ]; # missing inputs: epson-projector
     "epsonworkforce" = ps: with ps; [ ]; # missing inputs: epsonprinter

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5704,6 +5704,8 @@ in {
     inherit (pkgs) enchant2;
   };
 
+  pyenvisalink = callPackage ../development/python-modules/pyenvisalink { };
+
   pyepsg = callPackage ../development/python-modules/pyepsg { };
 
   pyerfa = callPackage ../development/python-modules/pyerfa { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python interface for Envisalink 2DS/3 Alarm API

https://github.com/Cinntax/pyenvisalink

This is a Home Assistant dependency. There are no tests for the `envisalink` integration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
