### PR TITLE
egg2nix: update to latest chicken-5 commit

### DIFF
--- a/pkgs/development/compilers/chicken/5/egg2nix.nix
+++ b/pkgs/development/compilers/chicken/5/egg2nix.nix
@@ -10,8 +10,9 @@ eggDerivation {
   src = fetchFromGitHub {
     owner = "corngood";
     repo = "egg2nix";
-    rev = "chicken-5";
-    sha256 = "1vfnhbcnyakywgjafhs0k5kpsdnrinzvdjxpz3fkwas1jsvxq3d1";
+    # from the chicken-5 branch
+    rev = "26039936505a301ad3d467c6aa54300cc400993b";
+    sha256 = "0mykaj1c3hccilm2vkb2qss1d8xib5mcksam0wsmmq2c2pm4mvii";
   };
 
   name = "egg2nix-${version}";


### PR DESCRIPTION
###### Motivation for this change

Since the `rev` passed to `fetchFromGitHub` pointed to a branch, the
latest version wasn't picked up. This adds support for generating Nix
expressions directly from CHICKEN 5 .egg files.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
