### PR TITLE
hfinger: init at 0.2.0

### DIFF
--- a/pkgs/tools/security/hfinger/default.nix
+++ b/pkgs/tools/security/hfinger/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, python3
+, wireshark-cli
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "hfinger";
+  version = "0.2.0";
+  disabled = python3.pythonOlder "3.3";
+
+  src = fetchFromGitHub {
+    owner = "CERT-Polska";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1vz8mf572qyng684fvb9gdwaaiybk7mjmikbymvjvy24d10raak1";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    fnvhash
+    python_magic
+  ] ++ [
+    wireshark-cli
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "hfinger" ];
+
+  meta = with lib; {
+    description = "Fingerprinting tool for HTTP requests";
+    homepage = "https://github.com/CERT-Polska/hfinger";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14749,6 +14749,8 @@ in
 
   hdt = callPackage ../misc/hdt {};
 
+  hfinger = callPackage ../tools/security/hfinger { };
+
   herqq = libsForQt5.callPackage ../development/libraries/herqq { };
 
   hidapi = callPackage ../development/libraries/hidapi {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fingerprinting tool for HTTP requests

https://github.com/CERT-Polska/hfinger

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
