### PR TITLE
go_2-dev: 2020-12-08 -> 2021-03-22

### DIFF
--- a/pkgs/development/compilers/go/2-dev.nix
+++ b/pkgs/development/compilers/go/2-dev.nix
@@ -39,12 +39,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go2-unstable";
-  version = "2020-12-08";
+  version = "2021-03-22";
 
   src = fetchgit {
     url = https://go.googlesource.com/go;
-    rev = "abe4d3dce12252ed09216eaa67b7dab8c8922537";
-    sha256 = "sha256:1d46w8426148q81fvrifx9glgn402jvf29n44i8j8g1pvzkfckh6";
+    rev = "a4b4db4cdeefb7b4ea5adb09073dd123846b3588";
+    sha256 = "sha256:1wqqnywcrfazydi5wcg04s6zgsfh4m879vxfgacgrnigd23ynhvr";
   };
 
   # perl is used for testing go vet
@@ -154,7 +154,7 @@ stdenv.mkDerivation rec {
     ./creds-test.patch
     ./go-1.9-skip-flaky-19608.patch
     ./go-1.9-skip-flaky-20072.patch
-    ./skip-external-network-tests-1.15.patch
+    ./skip-external-network-tests-1.16.patch
     ./skip-nohup-tests.patch
     ./skip-cgo-tests-1.15.patch
   ] ++ [
@@ -188,7 +188,7 @@ stdenv.mkDerivation rec {
       null;
 
   GOARM = toString (lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
-  GO386 = 387; # from Arch: don't assume sse2 on i686
+  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
   CGO_ENABLED = 1;
   # Hopefully avoids test timeouts on Hydra
   GO_TEST_TIMEOUT_SCALE = 3;

--- a/pkgs/development/compilers/go/ssl-cert-file-2-dev.patch
+++ b/pkgs/development/compilers/go/ssl-cert-file-2-dev.patch
@@ -1,8 +1,8 @@
-diff --git a/src/crypto/x509/root_darwin_amd64.go b/src/crypto/x509/root_darwin_amd64.go
-index ce88de025e..258ecc45d1 100644
---- a/src/crypto/x509/root_darwin_amd64.go
-+++ b/src/crypto/x509/root_darwin_amd64.go
-@@ -10,6 +10,7 @@ import (
+diff --git a/src/crypto/x509/root_darwin.go b/src/crypto/x509/root_darwin.go
+index 05593bb105..a6a11eeec1 100644
+--- a/src/crypto/x509/root_darwin.go
++++ b/src/crypto/x509/root_darwin.go
+@@ -11,6 +11,7 @@ import (
  	"bytes"
  	macOS "crypto/x509/internal/macos"
  	"fmt"
@@ -10,9 +10,9 @@ index ce88de025e..258ecc45d1 100644
  	"os"
  	"strings"
  )
-@@ -25,6 +26,14 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
- var loadSystemRootsWithCgo func() (*CertPool, error)
-
+@@ -22,6 +23,14 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
+ }
+ 
  func loadSystemRoots() (*CertPool, error) {
 +	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
 +		data, err := ioutil.ReadFile(file)
@@ -24,13 +24,21 @@ index ce88de025e..258ecc45d1 100644
 +	}
  	var trustedRoots []*Certificate
  	untrustedRoots := make(map[string]bool)
-
+ 
 diff --git a/src/crypto/x509/root_unix.go b/src/crypto/x509/root_unix.go
-index b48e618a65..195c1ff25a 100644
+index dede825edd..ffb3caf4a4 100644
 --- a/src/crypto/x509/root_unix.go
 +++ b/src/crypto/x509/root_unix.go
-@@ -42,6 +42,13 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
-
+@@ -9,6 +9,7 @@ package x509
+ 
+ import (
+ 	"io/fs"
++	"io/ioutil"
+ 	"os"
+ 	"path/filepath"
+ 	"strings"
+@@ -32,6 +33,13 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
+ 
  func loadSystemRoots() (*CertPool, error) {
  	roots := NewCertPool()
 +	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
@@ -40,6 +48,7 @@ index b48e618a65..195c1ff25a 100644
 +			return roots, nil
 +		}
 +	}
-
+ 
  	files := certFiles
  	if f := os.Getenv(certFileEnv); f != "" {
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upstream update

Note, that `GO386=387` is not supported since https://github.com/golang/go/commit/04b8a9fea57e37589d82410281f22ebde0027808

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
