### PR TITLE
googleearth-pro: init at 7.3.3.7786

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3391,6 +3391,12 @@
     githubId = 2129135;
     name = "Frederik Rietdijk";
   };
+  friedelino = {
+    email = "friede.mann@posteo.de";
+    github = "friedelino";
+    githubId = 46672819;
+    name = "Frido Friedemann";
+  };
   frlan = {
     email = "frank@frank.uvena.de";
     github = "frlan";

--- a/pkgs/applications/misc/googleearth-pro/default.nix
+++ b/pkgs/applications/misc/googleearth-pro/default.nix
@@ -1,0 +1,111 @@
+{ lib, stdenv, fetchurl, glibc, libGLU, libGL, freetype, glib, libSM, libICE, libXi, libXv
+, libXrender, libXrandr, libXfixes, libXcursor, libXinerama, libXext, libX11, libXcomposite
+, libxcb, sqlite, zlib, fontconfig, dpkg, libproxy, libxml2, gst_all_1, dbus, makeWrapper }:
+
+let
+  arch =
+    if stdenv.hostPlatform.system == "x86_64-linux" then "amd64"
+    else throw "Unsupported system ${stdenv.hostPlatform.system} ";
+  fullPath = lib.makeLibraryPath [
+    glibc
+    glib
+    stdenv.cc.cc
+    libSM
+    libICE
+    libXi
+    libXv
+    libGLU libGL
+    libXrender
+    libXrandr
+    libXfixes
+    libXcursor
+    libXinerama
+    libXcomposite
+    freetype
+    libXext
+    libX11
+    libxcb
+    sqlite
+    zlib
+    fontconfig
+    libproxy
+    libxml2
+    dbus
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "googleearth-pro";
+  version = "7.3.3.7786";
+
+  src = fetchurl {
+    url = "https://dl.google.com/linux/earth/deb/pool/main/g/google-earth-pro-stable/google-earth-pro-stable_${version}-r0_${arch}.deb";
+    sha256 = "1s3cakwrgf702g33rh8qs657d8bl68wgg8k89rksgvswwpd2zbb3";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  doInstallCheck = true;
+
+  dontBuild = true;
+
+  dontPatchELF = true;
+
+  unpackPhase = ''
+    # deb file contains a setuid binary, so 'dpkg -x' doesn't work here
+    dpkg --fsys-tarfile ${src} | tar --extract
+  '';
+
+  installPhase =''
+    mkdir $out
+    mv usr/* $out/
+    rmdir usr
+    mv * $out/
+    rm $out/bin/google-earth-pro $out/opt/google/earth/pro/googleearth
+
+    # patch and link googleearth binary
+    ln -s $out/opt/google/earth/pro/googleearth-bin $out/bin/googleearth-pro
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${fullPath}:\$ORIGIN" \
+      $out/opt/google/earth/pro/googleearth-bin
+
+    # patch and link gpsbabel binary
+    ln -s $out/opt/google/earth/pro/gpsbabel $out/bin/gpsbabel
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${fullPath}:\$ORIGIN" \
+      $out/opt/google/earth/pro/gpsbabel
+
+    # patch libraries
+    for a in $out/opt/google/earth/pro/*.so* ; do
+      patchelf --set-rpath "${fullPath}:\$ORIGIN" $a
+    done
+
+    # Add desktop config file and icons
+    mkdir -p $out/share/{applications,icons/hicolor/{16x16,22x22,24x24,32x32,48x48,64x64,128x128,256x256}/apps,pixmaps}
+    ln -s $out/opt/google/earth/pro/google-earth-pro.desktop $out/share/applications/google-earth-pro.desktop
+    sed -i -e "s|Exec=.*|Exec=$out/bin/googleearth-pro|g" $out/opt/google/earth/pro/google-earth-pro.desktop
+    for size in 16 22 24 32 48 64 128 256; do
+      ln -s $out/opt/google/earth/pro/product_logo_"$size".png $out/share/icons/hicolor/"$size"x"$size"/apps/google-earth-pro.png
+    done
+    ln -s $out/opt/google/earth/pro/product_logo_256.png $out/share/pixmaps/google-earth-pro.png
+  '';
+
+  installCheckPhase = ''
+    $out/bin/gpsbabel -V > /dev/null
+  '';
+
+  # wayland is not supported by Qt included in binary package, so make sure it uses xcb
+  fixupPhase = ''
+    wrapProgram $out/bin/googleearth-pro --set QT_QPA_PLATFORM xcb
+  '';
+
+
+  meta = with lib; {
+    description = "A world sphere viewer";
+    homepage = "https://earth.google.com";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ friedelino ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23282,6 +23282,8 @@ in
 
   googleearth = callPackage ../applications/misc/googleearth { };
 
+  googleearth-pro = callPackage ../applications/misc/googleearth-pro { };
+
   google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
 
   google-chrome-beta = google-chrome.override { chromium = chromiumBeta; channel = "beta"; };


### PR DESCRIPTION
###### Motivation for this change

The old googleearth derivation maintained by @markus1189  was quite outdated and there have been some changes by google about how they distribute googleearth. The freely available version now is called "google-earth-pro" and there is no more i386 package avialable... as far as i did search. This is also the reason why i decided to make new package instead of updating the 'googleearth' package. This way the old version which is also available in i386 is still in nixpkgs but we can benefit from the most recent version of googleearth.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
