### PR TITLE
kooha: init at 1.1.1

### DIFF
--- a/pkgs/applications/video/kooha/default.nix
+++ b/pkgs/applications/video/kooha/default.nix
@@ -1,0 +1,58 @@
+{ lib, fetchFromGitHub, appstream-glib, desktop-file-utils, glib
+, gobject-introspection, gst_all_1, gtk3, libhandy, librsvg, meson, ninja
+, pkg-config, python3, wrapGAppsHook }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "kooha";
+  version = "1.1.1";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "SeaDve";
+    repo = "Kooha";
+    rev = "v${version}";
+    sha256 = "05515xccs6y3wy28a6lkyn2jgi0fli53548l8qs73li8mdbxzd4c";
+  };
+
+  buildInputs = [
+    glib
+    gobject-introspection
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gtk3
+    libhandy
+    librsvg
+  ];
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    meson
+    ninja
+    python3
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = [ python3.pkgs.pygobject3 ];
+
+  strictDeps = false;
+
+  buildPhase = ''
+    export GST_PLUGIN_SYSTEM_PATH_1_0="$out/lib/gstreamer-1.0/:$GST_PLUGIN_SYSTEM_PATH_1_0"
+  '';
+
+  # Fixes https://github.com/NixOS/nixpkgs/issues/31168
+  postPatch = ''
+    chmod +x build-aux/meson/postinstall.py
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  meta = with lib; {
+    description = "Simple screen recorder";
+    homepage = "https://github.com/SeaDve/Kooha";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23722,6 +23722,8 @@ in
 
   konversation = libsForQt5.callPackage ../applications/networking/irc/konversation { };
 
+  kooha = callPackage ../applications/video/kooha { };
+
   kotatogram-desktop = libsForQt514.callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop { };
 
   kpt = callPackage ../applications/networking/cluster/kpt { };


### PR DESCRIPTION
###### Motivation for this change

Needed a screen recorder that works with Wayland, and this application is really simple and well done.

Demo:

https://user-images.githubusercontent.com/354741/114295349-8b041700-9a59-11eb-8b4b-dd592f87dca3.mp4

I had a heck of a time getting this to work, though. What was really frustrating was that whether it worked on not differed based on whether I ran it from the Gnome Shell menu or via command-line (note that I imported my local git clone of `nixpkgs` into an overlay in my main `configuration.nix` for my system for testing). It would work fine when run via command line, but running it via the icon it seems it couldn't find gstreamer and/or the gstreamer plugin. Add to that the fact that I don't know of a way to get Gnome's icon for the app to refer to the new version of the desktop file without rebooting and my workflow became:

1. Change `default.nix` for this app
2. Rebuild my system
3. Reboot
4. Run `sudo journalctl -f`
5. Run the app by opening "Activities" and searching "Kooha"
6. Test recording
7. Check the journal to see if the gstreamer error is still there

If anyone knows a better way to quickly test a desktop application without rebooting please let me know.

Eventually I stumbled upon what seems to have been the solution: adding `export GST_PLUGIN_SYSTEM_PATH_1_0="$out/lib/gstreamer-1.0/:$GST_PLUGIN_SYSTEM_PATH_1_0"` to the `buildPhase`. From [what the manual says](https://github.com/NixOS/nixpkgs/blame/be8a3b8d9d56921d6abc8ffdd61137ee9dfeaaf8/doc/languages-frameworks/gnome.section.md#L91), I thought just using the `wrapGAppsHook` would do that automatically in a way that works.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).