### PR TITLE
clpm: build with sbcl 2.0.9 

### DIFF
--- a/pkgs/development/tools/clpm/default.nix
+++ b/pkgs/development/tools/clpm/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchgit
 , wrapLisp
-, sbcl
+, sbcl_2_0_9
 , openssl
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    (wrapLisp sbcl)
+    (wrapLisp sbcl_2_0_9)
     openssl
   ];
 


### PR DESCRIPTION
Use SBCL < 2.1.0 when building as SB-VM::MAKE-EA was removed in version 2.1.0. 

###### Motivation for this change
CLPM wasn't building correctly after SBCL was upgraded in nixpkgs. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
