### PR TITLE
python3Packages.discordpy: 1.7.0 -> 1.7.1

### DIFF
--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -1,35 +1,40 @@
 { lib
-, fetchFromGitHub
-, buildPythonPackage
-, pythonOlder
-, withVoice ? true, libopus
 , aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, libopus
+, pynacl
+, pythonOlder
 , websockets
+, withVoice ? true
 }:
 
 buildPythonPackage rec {
   pname = "discord.py";
-  version = "1.7.0";
-  disabled = pythonOlder "3.5.3";
+  version = "1.7.1";
+  disabled = pythonOlder "3.8";
 
-  # only distributes wheels on pypi now
   src = fetchFromGitHub {
     owner = "Rapptz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1i5k2qb894rjksn21pk9shash1y7v4138rkk8mqr1a1yvgnr5ibg";
+    sha256 = "sha256-dpASIqe6rJEyiWJyPbQhq9M54lX1ilfp4UuGnbJcFLo=";
   };
 
-  propagatedBuildInputs = [ aiohttp websockets ];
+  propagatedBuildInputs = [
+    aiohttp
+    websockets
+  ] ++ lib.optionalString withVoice [
+    libopus
+    pynacl
+  ];
+
   patchPhase = ''
-    substituteInPlace "requirements.txt" \
-      --replace "websockets>=6.0,!=7.0,!=8.0,!=8.0.1,<9.0" "websockets"
-  '' + lib.optionalString withVoice ''
     substituteInPlace "discord/opus.py" \
       --replace "ctypes.util.find_library('opus')" "'${libopus}/lib/libopus.so.0'"
   '';
 
-  # only have integration tests with discord
+  # Only have integration tests with discord
   doCheck = false;
 
   pythonImportsCheck = [
@@ -44,7 +49,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A python wrapper for the Discord API";
+    description = "Python wrapper for the Discord API";
     homepage = "https://discordpy.rtfd.org/";
     maintainers = [ maintainers.ivar ];
     license = licenses.mit;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.7.1

Change log: https://github.com/Rapptz/discord.py/blob/master/docs/whats_new.rst#v171

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
