### PR TITLE
python3Packages.pycomfoconnect: init at 0.4

### DIFF
--- a/pkgs/development/python-modules/pycomfoconnect/default.nix
+++ b/pkgs/development/python-modules/pycomfoconnect/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, protobuf
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pycomfoconnect";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "michaelarnauts";
+    repo = "comfoconnect";
+    rev = version;
+    sha256 = "0bipzv68yw056iz9m2g9h40hzrwd058a7crxp0xbq4rw2d8j0jn6";
+  };
+
+  propagatedBuildInputs = [
+    protobuf
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pycomfoconnect" ];
+
+  meta = with lib; {
+    description = "Python module to interact with ComfoAir Q350/450/600 units";
+    homepage = "https://github.com/michaelarnauts/comfoconnect";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -131,7 +131,7 @@
     "coinbase" = ps: with ps; [ ]; # missing inputs: coinbase
     "color_extractor" = ps: with ps; [ ]; # missing inputs: colorthief
     "comed_hourly_pricing" = ps: with ps; [ ];
-    "comfoconnect" = ps: with ps; [ ]; # missing inputs: pycomfoconnect
+    "comfoconnect" = ps: with ps; [ pycomfoconnect ];
     "command_line" = ps: with ps; [ ];
     "concord232" = ps: with ps; [ ]; # missing inputs: concord232
     "config" = ps: with ps; [ aiohttp-cors ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -197,6 +197,7 @@ in with py.pkgs; buildPythonApplication rec {
     "cast"
     "climate"
     "cloud"
+    "comfoconnect"
     "command_line"
     "config"
     "configurator"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5621,6 +5621,8 @@ in {
 
   pycollada = callPackage ../development/python-modules/pycollada { };
 
+  pycomfoconnect = callPackage ../development/python-modules/pycomfoconnect { };
+
   pycontracts = callPackage ../development/python-modules/pycontracts { };
 
   pycosat = callPackage ../development/python-modules/pycosat { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to interact with ComfoAir Q350/450/600 units

https://github.com/michaelarnauts/comfoconnect

This is Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
