### PR TITLE
python3Packages.pythonegardia: init at 1.0.40

### DIFF
--- a/pkgs/development/python-modules/pythonegardia/default.nix
+++ b/pkgs/development/python-modules/pythonegardia/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pythonegardia";
+  version = "1.0.40";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rv6m5zaflf3nanpl1xmfmfcpg8kzcnmniq1hhgrybsspkc7mvry";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  # Project has no tests, only two test file for manual interaction
+  doCheck = false;
+  pythonImportsCheck = [ "pythonegardia" ];
+
+  meta = with lib; {
+    description = "Python interface with Egardia/Woonveilig alarms";
+    homepage = "https://github.com/jeroenterheerdt/python-egardia";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -209,7 +209,7 @@
     "edl21" = ps: with ps; [ ]; # missing inputs: pysml
     "ee_brightbox" = ps: with ps; [ ]; # missing inputs: eebrightbox
     "efergy" = ps: with ps; [ ];
-    "egardia" = ps: with ps; [ ]; # missing inputs: pythonegardia
+    "egardia" = ps: with ps; [ pythonegardia ];
     "eight_sleep" = ps: with ps; [ pyeight ];
     "elgato" = ps: with ps; [ ]; # missing inputs: elgato
     "eliqonline" = ps: with ps; [ ]; # missing inputs: eliqonline

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6732,6 +6732,8 @@ in {
 
   pythonefl = callPackage ../development/python-modules/python-efl { };
 
+  pythonegardia = callPackage ../development/python-modules/pythonegardia { };
+
   python-engineio = callPackage ../development/python-modules/python-engineio { };
 
   python-engineio_3 = callPackage ../development/python-modules/python-engineio/3.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python interface with Egardia/Woonveilig alarms

https://github.com/jeroenterheerdt/python-egardia

This is a Home Assistant dependency. There are no tests for the `egardia` integration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
