### PR TITLE
mysql: fix building on Apple Silicon

### DIFF
--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -21,7 +21,8 @@ self = stdenv.mkDerivation rec {
     export PATH=$PATH:$TMPDIR
   '';
 
-  nativeBuildInputs = [ cmake bison pkg-config rpcsvc-proto ];
+  nativeBuildInputs = [ bison cmake pkg-config ]
+    ++ lib.optionals (!stdenv.isDarwin) [ rpcsvc-proto ];
 
   buildInputs = [ boost libedit libevent lz4 ncurses openssl protobuf readline zlib ]
      ++ lib.optionals stdenv.isDarwin [ perl cctools CoreServices developer_cmds ]

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -17,7 +17,8 @@ self = stdenv.mkDerivation rec {
     ./abi-check.patch
   ];
 
-  nativeBuildInputs = [ bison cmake pkg-config rpcsvc-proto ];
+  nativeBuildInputs = [ bison cmake pkg-config ]
+    ++ lib.optionals (!stdenv.isDarwin) [ rpcsvc-proto ];
 
   ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.
   postPatch = ''


### PR DESCRIPTION
mysql8 uses rpcsvc-proto as a builtInput, but that doesn't build on aarch64-darwin:

```
make[2]: Entering directory '/private/tmp/nix-build-rpcsvc-proto-1.4.2.drv-3/source/rpcgen'
clang -DHAVE_CONFIG_H -I. -I..     -g -O2 -c -o rpc_clntout.o rpc_clntout.c
clang -DHAVE_CONFIG_H -I. -I..     -g -O2 -c -o rpc_cout.o rpc_cout.c
clang -DHAVE_CONFIG_H -I. -I..     -g -O2 -c -o rpc_hout.o rpc_hout.c
clang -DHAVE_CONFIG_H -I. -I..     -g -O2 -c -o rpc_main.o rpc_main.c
rpc_main.c:334:17: error: variable has incomplete type 'struct stat64'
  struct stat64 buf;
                ^
rpc_main.c:334:10: note: forward declaration of 'struct stat64'
  struct stat64 buf;
         ^
rpc_main.c:336:7: warning: implicit declaration of function 'stat64' is invalid in C99 [-Wimplicit-function-declaration]
  if (stat64 (CPP, &buf) == 0)
      ^
rpc_main.c:1122:17: error: variable has incomplete type 'struct stat64'
  struct stat64 buf;
                ^
rpc_main.c:1122:10: note: forward declaration of 'struct stat64'
  struct stat64 buf;
         ^
rpc_main.c:1125:9: warning: implicit declaration of function 'stat64' is invalid in C99 [-Wimplicit-function-declaration]
    if (stat64 (infile, &buf) < 0)
        ^
2 warnings and 2 errors generated.
make[2]: *** [Makefile:442: rpc_main.o] Error 1
```

Fortunately, it isn't actually necessary on Darwin/clang.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Get mysql8 running on aarch64-darwin.

For symmetry I've also applied the same thing to mysql57, but that doesn't still doesn't build because it uses an older version of boost:

```shellsession
$ nix-build -I nixpkgs=. --argstr localSystem aarch64-darwin -A boost159
error: assertion (with lib; (((toolset == "clang") && (! ((versionOlder  (stdenv).cc.version)  "8.0.0"))) -> (! ((versionOlder  version)  "1.69")))) failed at /Users/jon/Developer/vendor/nixpkgs/pkgs/development/libraries/boost/generic.nix:34:1
```

I'm ambivalent whether to keep that fix or not - any opinions?



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
