### PR TITLE
mailman-web-unstable: 2019-09-29 -> 2021-04-10

### DIFF
--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -263,7 +263,8 @@ in {
       # settings_local.json is loaded.
       os.environ["SECRET_KEY"] = ""
 
-      from mailman_web.settings import *
+      from mailman_web.settings.base import *
+      from mailman_web.settings.mailman import *
 
       import json
 

--- a/pkgs/servers/mail/mailman/web.nix
+++ b/pkgs/servers/mail/mailman/web.nix
@@ -1,16 +1,16 @@
 { buildPythonPackage, lib, fetchgit, isPy3k
-, git, makeWrapper, sassc, hyperkitty, postorius, whoosh
+, git, makeWrapper, sassc, hyperkitty, postorius, whoosh, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "mailman-web-unstable";
-  version = "2019-09-29";
+  version = "2021-04-10";
   disabled = !isPy3k;
 
   src = fetchgit {
     url = "https://gitlab.com/mailman/mailman-web";
-    rev = "d17203b4d6bdc71c2b40891757f57a32f3de53d5";
-    sha256 = "124cxr4vfi1ibgxygk4l74q4fysx0a6pga1kk9p5wq2yvzwg9z3n";
+    rev = "19a7abe27dd3bc39c0250440de073f0adecd4da1";
+    sha256 = "0h25140n2jaisl0ri5x7gdmbypiys8vlq8dql1zmaxvq459ybxkn";
     leaveDotGit = true;
   };
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [ git makeWrapper ];
-  propagatedBuildInputs = [ hyperkitty postorius whoosh ];
+  propagatedBuildInputs = [ hyperkitty postorius whoosh setuptools-scm ];
 
   # Tries to check runtime configuration.
   doCheck = false;
@@ -39,6 +39,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Django project for Mailman 3 web interface";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ peti qyliss ];
+    maintainers = with maintainers; [ peti qyliss m1cr0man ];
   };
 }

--- a/pkgs/servers/mail/mailman/web.nix
+++ b/pkgs/servers/mail/mailman/web.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Django project for Mailman 3 web interface";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ peti qyliss m1cr0man ];
   };
 }

--- a/pkgs/servers/mail/mailman/web.nix
+++ b/pkgs/servers/mail/mailman/web.nix
@@ -3,8 +3,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "mailman-web-unstable";
-  version = "2021-04-10";
+  pname = "mailman-web";
+  version = "unstable-2021-04-10";
   disabled = !isPy3k;
 
   src = fetchgit {
@@ -25,8 +25,8 @@ buildPythonPackage rec {
     sed -i '/^  Django/d' setup.cfg
   '';
 
-  nativeBuildInputs = [ git makeWrapper ];
-  propagatedBuildInputs = [ hyperkitty postorius whoosh setuptools-scm ];
+  nativeBuildInputs = [ git setuptools-scm makeWrapper ];
+  propagatedBuildInputs = [ hyperkitty postorius whoosh ];
 
   # Tries to check runtime configuration.
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Failing to build since #118527 

setuptools-scm now required as a build input.

Upstream removed mailman_web.settings.base +
mailman_web.settings.mailman from mailman_web.settings.__init__.py
so now the imports in settings.py are explicit. Their
documentation on virtualenv installation specifies these too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
