### PR TITLE
python3Packages.aiolip: init at 1.1.4, python3Packages.pylutron-caseta: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/aiolip/default.nix
+++ b/pkgs/development/python-modules/aiolip/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "aiolip";
+  version = "1.1.4";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "bdraco";
+    repo = pname;
+    rev = version;
+    sha256 = "1f8mlvbnfcn3sigsmjdpdpgxmnbvcjhfr7lzch61i8sy25dgakji";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "'pytest-runner'," ""
+  '';
+
+  pythonImportsCheck = [ "aiolip" ];
+
+  meta = with lib; {
+    description = "Python module for the Lutron Integration Protocol";
+    homepage = "https://github.com/bdraco/aiolip";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pylutron-caseta/default.nix
+++ b/pkgs/development/python-modules/pylutron-caseta/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, pytest-asyncio
+, pytest-sugar
+, pytest-timeout
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pylutron-caseta";
+  version = "0.9.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "gurumitts";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "07mz4hn0455qmfqs4xcqlhbf3qvrnmifd0vzpcqlqaqcn009iahq";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-sugar
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pylutron_caseta" ];
+
+  meta = with lib; {
+    description = "Python module o control Lutron Caseta devices";
+    homepage = "https://github.com/gurumitts/pylutron-caseta";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -467,7 +467,7 @@
     "luftdaten" = ps: with ps; [ luftdaten ];
     "lupusec" = ps: with ps; [ ]; # missing inputs: lupupy
     "lutron" = ps: with ps; [ pylutron ];
-    "lutron_caseta" = ps: with ps; [ ]; # missing inputs: aiolip pylutron-caseta
+    "lutron_caseta" = ps: with ps; [ aiolip pylutron-caseta ];
     "lw12wifi" = ps: with ps; [ ]; # missing inputs: lw12
     "lyft" = ps: with ps; [ ]; # missing inputs: lyft_rides
     "lyric" = ps: with ps; [ aiohttp-cors aiolyric ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -269,6 +269,7 @@ in with py.pkgs; buildPythonApplication rec {
     "logentries"
     "logger"
     "lovelace"
+    "lutron_caseta"
     "manual"
     "manual_mqtt"
     "mazda"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -301,6 +301,8 @@ in {
 
   aiolifx-effects = callPackage ../development/python-modules/aiolifx-effects { };
 
+  aiolip = callPackage ../development/python-modules/aiolip { };
+
   aiolyric = callPackage ../development/python-modules/aiolyric { };
 
   aiomultiprocess = callPackage ../development/python-modules/aiomultiprocess { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5977,6 +5977,8 @@ in {
 
   pylutron = callPackage ../development/python-modules/pylutron { };
 
+  pylutron-caseta = callPackage ../development/python-modules/pylutron-caseta { };
+
   pylxd = callPackage ../development/python-modules/pylxd { };
 
   pymacaroons = callPackage ../development/python-modules/pymacaroons { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Support for Lutron Caséta devices.

Those are Home Assistant dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
