### PR TITLE
tf2pulumi: init at 0.10.0

### DIFF
--- a/pkgs/development/tools/tf2pulumi/default.nix
+++ b/pkgs/development/tools/tf2pulumi/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "tf2pulumi";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "tf2pulumi";
+    rev = "v${version}";
+    sha256 = "199c4hd236mfz9c44rpzpbr3w3fjj8pbw656jd9k3v2igzw942c7";
+  };
+
+  vendorSha256 = "1cwyag67q0361szfjv1cyi51cg1bbmkpy34y33hn53aa55pkm1fw";
+
+  buildFlagsArray = ''
+    -ldflags=-s -w -X=github.com/pulumi/tf2pulumi/version.Version=${src.rev}
+  '';
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Convert Terraform projects to Pulumi TypeScript programs";
+    homepage = "https://www.pulumi.com/tf2pulumi/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mausch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8663,6 +8663,8 @@ in
 
   tex-match = callPackage ../tools/typesetting/tex/tex-match { };
 
+  tf2pulumi = callPackage ../development/tools/tf2pulumi { };
+
   thc-hydra = callPackage ../tools/security/thc-hydra { };
 
   thc-ipv6 = callPackage ../tools/security/thc-ipv6 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
