### PR TITLE
[20.09] syncthing: add patch for CVE-2021-21404

### DIFF
--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, stdenv, lib, procps, fetchFromGitHub, nixosTests }:
+{ buildGoModule, stdenv, lib, procps, fetchFromGitHub, nixosTests, fetchpatch }:
 
 let
   common = { stname, target, postInstall ? "" }:
@@ -19,6 +19,11 @@ let
 
       patches = [
         ./add-stcli-target.patch
+        (fetchpatch {
+          name = "CVE-2021-21404.patch";
+          url = "https://github.com/syncthing/syncthing/commit/fb4fdaf4c0a79c22cad000c42ac1394e3ccb6a97.patch";
+          sha256 = "0xjh500fi50570dkf3xdaj2367ynn1cs95lypq6b0wi81kp7m540";
+        })
       ];
       BUILD_USER="nix";
       BUILD_HOST="nix";


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-21404

Fixed in `master` in #118647

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
