### PR TITLE
medfile: use HDF5 1.12

### DIFF
--- a/pkgs/development/libraries/medfile/default.nix
+++ b/pkgs/development/libraries/medfile/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1khzclkrd1yn9mz3g14ndgpsbj8j50v8dsjarcj6kkn9zgbbazc4";
   };
 
+  patches = [
+    ./hdf5-1.12.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ hdf5 ];
 

--- a/pkgs/development/libraries/medfile/hdf5-1.12.patch
+++ b/pkgs/development/libraries/medfile/hdf5-1.12.patch
@@ -1,0 +1,86 @@
+--- a/config/cmake_files/medMacros.cmake
++++ b/config/cmake_files/medMacros.cmake
+@@ -447,7 +447,7 @@ MACRO(MED_FIND_HDF5)
+     ##
+     ## Requires 1.10.x version
+     ##
+-    IF (NOT HDF_VERSION_MAJOR_REF EQUAL 1 OR NOT HDF_VERSION_MINOR_REF EQUAL 10 OR NOT HDF_VERSION_RELEASE_REF GREATER 1)
++    IF (HDF5_VERSION VERSION_LESS 1.10.2)
+         MESSAGE(FATAL_ERROR "HDF5 version is ${HDF_VERSION_REF}. Only versions >= 1.10.2 are supported.")
+     ENDIF()
+     ##
+--- a/src/ci/MEDfileCompatibility.c
++++ b/src/ci/MEDfileCompatibility.c
+@@ -71,7 +71,7 @@ MEDfileCompatibility(const char* const filename,
+   _hversionMMR=10000*_hmajeur+100*_hmineur+_hrelease;
+   /* ISCRUTE(_hversionMMR); */
+   /* ISCRUTE(HDF_VERSION_NUM_REF); */
+-  if ( (_hversionMMR >= HDF_VERSION_NUM_REF) && (_hmineur == HDF_VERSION_MINOR_REF) ) *hdfok = MED_TRUE;
++  if ( ((_hversionMMR >= HDF_VERSION_NUM_REF) && (_hmineur == HDF_VERSION_MINOR_REF)) || _hversionMMR > HDF_VERSION_NUM_REF ) *hdfok = MED_TRUE;
+ 
+   /* TODO : Vérifier si la version mineure HDF du fichier est supérieure
+      à la version mineure de la bibliothèque HDF utilisée :
+@@ -113,7 +113,7 @@ MEDfileCompatibility(const char* const filename,
+ #if MED_NUM_MAJEUR != 4
+ #error "Don't forget to update the test version here when you change the major version of the library !"
+ #endif
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to check the compatibility version of the library, depending on the internal hdf model choice !"
+ #error "Cf. _MEDfileCreate ..."
+ #endif
+--- a/src/hdfi/_MEDfileCreate.c
++++ b/src/hdfi/_MEDfileCreate.c
+@@ -159,7 +159,7 @@ med_idt _MEDfileCreate(const char * const filename, const med_access_mode access
+    * En HDF5-1.10.0p1 cela n'a aucun effet ! 
+    * Un test autoconf permet de fixer un intervalle de version HDF à MED.
+    */
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+    
+--- a/src/hdfi/_MEDfileOpen.c
++++ b/src/hdfi/_MEDfileOpen.c
+@@ -72,7 +72,7 @@ med_idt _MEDfileOpen(const char * const filename,const med_access_mode accessmod
+ 
+    •   The creation order tracking property, H5P_CRT_ORDER_TRACKED, has been set in the group creation property list (see H5Pset_link_creation_order). 
+   */
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+ /* L'avantage de bloquer le modèle interne HDF5 
+--- a/src/hdfi/_MEDmemFileOpen.c
++++ b/src/hdfi/_MEDmemFileOpen.c
+@@ -434,7 +434,7 @@ med_idt _MEDmemFileOpen(const char * const filename, med_memfile * const memfile
+     goto ERROR;
+   }
+ 
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+   if ( H5Pset_libver_bounds( _fapl, H5F_LIBVER_18, H5F_LIBVER_18) ) {
+--- a/src/hdfi/_MEDparFileCreate.c
++++ b/src/hdfi/_MEDparFileCreate.c
+@@ -64,7 +64,7 @@ med_idt _MEDparFileCreate(const char * const filename, const med_access_mode acc
+    * En HDF5-1.10.0p1 cela n'a aucun effet ! 
+    * Un test autoconf permet de fixer un intervalle de version HDF à MED.
+    */
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+    
+--- a/src/hdfi/_MEDparFileOpen.c
++++ b/src/hdfi/_MEDparFileOpen.c
+@@ -55,7 +55,7 @@ med_idt _MEDparFileOpen(const char * const filename,const med_access_mode access
+     MED_ERR_(_fid,MED_ERR_INIT,MED_ERR_PROPERTY,MED_ERR_PARALLEL_MSG);
+     goto ERROR;
+   }
+-#if H5_VERS_MINOR > 10
++#if H5_VERS_MINOR > 12
+ #error "Don't forget to change the compatibility version of the library !"
+ #endif
+   if ( H5Pset_libver_bounds( _fapl, H5F_LIBVER_18, H5F_LIBVER_18 ) ) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6032,7 +6032,7 @@ in
   };
 
   medfile = callPackage ../development/libraries/medfile {
-    hdf5 = hdf5_1_10;
+    hdf5 = hdf5.override { usev110Api = true; };
   };
 
   meilisearch = callPackage ../servers/search/meilisearch {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

HDF5 1.10 has known security issues (CVE-2020-10809, CVE-2020-10810, CVE-2020-10811 and CVE-2020-10812).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>freecad</li>
    <li>medfile</li>
  </ul>
</details>