### PR TITLE
ccache: 4.2 -> 4.2.1

### DIFF
--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -48,7 +48,7 @@ let ccache = stdenv.mkDerivation rec {
   checkPhase = ''
     export HOME=$(mktemp -d)
     ctest --output-on-failure ${lib.optionalString stdenv.isDarwin ''
-      -E '^(test.nocpp2|test.modules|test.basedir|test.multi_arch)$'
+      -E '^(test.nocpp2|test.basedir|test.multi_arch)$'
     ''}
   '';
 

--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -13,19 +13,29 @@
 
 let ccache = stdenv.mkDerivation rec {
   pname = "ccache";
-  version = "4.2";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "1lr9804xyzbs72f9jbbzy1fjqxwrwpb4rp431wqialvms4251d8f";
+    hash = "sha256-AmgJpW7AGCSggbHp1fLO5yhXS9LIm7O77nQdDERJYAA=";
   };
 
-  patches = lib.optional stdenv.isDarwin (substituteAll {
-    src = ./force-objdump-on-darwin.patch;
-    objdump = "${binutils.bintools}/bin/objdump";
-  });
+  patches = [
+    # test/run use compgen to get environment variable names, but
+    # compgen isn't available in non-interactive bash.
+    ./env-instead-of-compgen.patch
+
+    # When building for Darwin, test/run uses dwarfdump, whereas on
+    # Linux it uses objdump. We don't have dwarfdump packaged for
+    # Darwin, so this patch updates the test to also use objdump on
+    # Darwin.
+    (substituteAll {
+      src = ./force-objdump-on-darwin.patch;
+      objdump = "${binutils.bintools}/bin/objdump";
+    })
+  ];
 
   nativeBuildInputs = [ asciidoc cmake perl ];
 
@@ -38,7 +48,7 @@ let ccache = stdenv.mkDerivation rec {
   checkPhase = ''
     export HOME=$(mktemp -d)
     ctest --output-on-failure ${lib.optionalString stdenv.isDarwin ''
-      -E '^(test.nocpp2|test.modules)$'
+      -E '^(test.nocpp2|test.modules|test.basedir|test.multi_arch)$'
     ''}
   '';
 

--- a/pkgs/development/tools/misc/ccache/env-instead-of-compgen.patch
+++ b/pkgs/development/tools/misc/ccache/env-instead-of-compgen.patch
@@ -1,0 +1,18 @@
+diff --git a/test/run b/test/run
+index cbdd98f0..bc930200 100755
+--- a/test/run
++++ b/test/run
+@@ -346,11 +346,11 @@ expect_perm() {
+ }
+ 
+ reset_environment() {
+-    while IFS= read -r name; do
++    while IFS='=' read -r name value; do
+         if [[ $name =~ ^CCACHE_[A-Z0-9_]*$ ]]; then
+             unset $name
+         fi
+-    done < <(compgen -e)
++    done < <(env)
+ 
+     unset GCC_COLORS
+     unset TERM


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/ccache/ccache/releases/tag/v4.2.1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@r-burns @veprbl