### PR TITLE
wine{Unstable,Staging}: 6.5 -> 6.7

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,9 +44,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.6";
+    version = "6.7";
     url = "https://dl.winehq.org/wine/source/6.x/wine-${version}.tar.xz";
-    sha256 = "sha256-meUixtzArB1T0gG/MFSJH98RhkJXRzw+s0HjdnH9hK0=";
+    sha256 = "sha256-wwUUt3YdRhFRSuAhyx41QSjXfv9UooPxQB7nAid7vqQ=";
     inherit (stable) gecko32 gecko64;
 
     ## see http://wiki.winehq.org/Mono
@@ -65,7 +65,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-ur7ZD9F/V4TkR4YzxwsuhP/Dq/svH29T4hFkp/ZNtTQ=";
+    sha256 = "sha256-fWriizSk2+U7Mpn6w/Dlrevd4vc5MnlSWSGxQDf2p+M=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,10 +44,17 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.5";
+    version = "6.6";
     url = "https://dl.winehq.org/wine/source/6.x/wine-${version}.tar.xz";
-    sha256 = "sha256-BgD9IIwGkl1mNNKfVDu6CmQ2HDTpvXYJwvDiCWEK00c=";
-    inherit (stable) mono gecko32 gecko64;
+    sha256 = "sha256-meUixtzArB1T0gG/MFSJH98RhkJXRzw+s0HjdnH9hK0=";
+    inherit (stable) gecko32 gecko64;
+
+    ## see http://wiki.winehq.org/Mono
+    mono = fetchurl rec {
+      version = "6.1.1";
+      url = "https://dl.winehq.org/wine/wine-mono/${version}/wine-mono-${version}-x86.msi";
+      sha256 = "sha256-rDsUvq/eNLhIIofllwABE9wGqRXzLJ/QbHfrgZB544s=";
+    };
 
     patches = [
       # Also look for root certificates at $NIX_SSL_CERT_FILE
@@ -58,7 +65,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-u6wDavrFirN1e0fFra4ui3i4PnJF0gcENYoIyNwhIYc=";
+    sha256 = "sha256-ur7ZD9F/V4TkR4YzxwsuhP/Dq/svH29T4hFkp/ZNtTQ=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
###### Motivation for this change

Upstream update.
The 6.6 release also includes "Mono engine updated to version 6.1.1, with upstream updates." - I assume we don't want that for the stable version, so I changed the `inherit` into a fresh attribute.

@avnik Thoughts?

###### Things done

```
$ nixpkgs-review wip
[...]
11 packages updated:
lutris lutris lutris-original pipelight wineUnstable (6.5 → 6.6) winePackages.unstable (6.5 → 6.6) wineStaging (6.5-staging → 6.6-staging) wine-staging (6.5-staging → 6.6-staging) winePackages.staging (6.5-staging → 6.6-staging) wineWowPackages.unstable (6.5 → 6.6) wineWowPackages.staging (6.5-staging → 6.6-staging)
[...]
9 packages built:
lutris lutris-free lutris-unwrapped pipelight wineStaging winePackages.staging wineUnstable wineWowPackages.staging wineWowPackages.unstable
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
