### PR TITLE
update.py: allow to disable autocommit

### DIFF
--- a/maintainers/scripts/pluginupdate.py
+++ b/maintainers/scripts/pluginupdate.py
@@ -460,6 +460,11 @@ def parse_args(editor: Editor):
         default=30,
         help="Number of concurrent processes to spawn.",
     )
+    parser.add_argument(
+        "--no-commit", "-n", action="store_false", default=True,
+        dest="autocommit",
+        help="Wether to autocommit"
+    )
     return parser.parse_args()
 
 
@@ -504,24 +509,28 @@ def update_plugins(editor: Editor):
 
     redirects = update()
     rewrite_input(args.input_file, editor.deprecated, redirects)
-    commit(nixpkgs_repo, f"{editor.name}Plugins: update", [args.outfile])
+
+    if args.autocommit:
+        commit(nixpkgs_repo, f"{editor.name}Plugins: update", [args.outfile])
 
     if redirects:
         update()
-        commit(
-            nixpkgs_repo,
-            f"{editor.name}Plugins: resolve github repository redirects",
-            [args.outfile, args.input_file, editor.deprecated],
-        )
+        if args.autocommit:
+            commit(
+                nixpkgs_repo,
+                f"{editor.name}Plugins: resolve github repository redirects",
+                [args.outfile, args.input_file, editor.deprecated],
+            )
 
     for plugin_line in args.add_plugins:
         rewrite_input(args.input_file, editor.deprecated, append=(plugin_line + "\n",))
         update()
         plugin = fetch_plugin_from_pluginline(plugin_line)
-        commit(
-            nixpkgs_repo,
-            "{editor}Plugins.{name}: init at {version}".format(
-                editor=editor.name, name=plugin.normalized_name, version=plugin.version
-            ),
-            [args.outfile, args.input_file],
-        )
+        if args.autocommit:
+            commit(
+                nixpkgs_repo,
+                "{editor}Plugins.{name}: init at {version}".format(
+                    editor=editor.name, name=plugin.normalized_name, version=plugin.version
+                ),
+                [args.outfile, args.input_file],
+            )

--- a/maintainers/scripts/pluginupdate.py
+++ b/maintainers/scripts/pluginupdate.py
@@ -461,9 +461,8 @@ def parse_args(editor: Editor):
         help="Number of concurrent processes to spawn.",
     )
     parser.add_argument(
-        "--no-commit", "-n", action="store_false", default=True,
-        dest="autocommit",
-        help="Wether to autocommit"
+        "--no-commit", "-n", action="store_true", default=False,
+        help="Whether to autocommit changes"
     )
     return parser.parse_args()
 
@@ -510,12 +509,14 @@ def update_plugins(editor: Editor):
     redirects = update()
     rewrite_input(args.input_file, editor.deprecated, redirects)
 
-    if args.autocommit:
+    autocommit = not args.no_commit
+
+    if autocommit:
         commit(nixpkgs_repo, f"{editor.name}Plugins: update", [args.outfile])
 
     if redirects:
         update()
-        if args.autocommit:
+        if autocommit:
             commit(
                 nixpkgs_repo,
                 f"{editor.name}Plugins: resolve github repository redirects",
@@ -526,7 +527,7 @@ def update_plugins(editor: Editor):
         rewrite_input(args.input_file, editor.deprecated, append=(plugin_line + "\n",))
         update()
         plugin = fetch_plugin_from_pluginline(plugin_line)
-        if args.autocommit:
+        if autocommit:
             commit(
                 nixpkgs_repo,
                 "{editor}Plugins.{name}: init at {version}".format(


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I use the update.py script to maintain an out of tree list of vim-plugins. Updating this list fails when the script tries to commit the new plugins.
This is my makefile entry
```
vimPlugins:
	cd ~/nixpkgs \
		&& pkgs/misc/vim-plugins/update.py -i $(CURDIR)/nixpkgs/overlays/vim-plugins/vim-plugin-names -o $(CURDIR)/nixpkgs/overlays/vim-plugins/generated.nix --no-commit
```
(--no-commit is the new addition)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
