### PR TITLE
python2Packages.pycairo: init at 1.18.2

### DIFF
--- a/pkgs/development/python-modules/pycairo/1.18.nix
+++ b/pkgs/development/python-modules/pycairo/1.18.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitHub
+, meson
+, ninja
+, buildPythonPackage
+, pytestCheckHook
+, pkg-config
+, cairo
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "pycairo";
+  version = "1.18.2";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "pygobject";
+    repo = "pycairo";
+    rev = "v${version}";
+    sha256 = "142145a2whvlk92jijrbf3i2bqrzmspwpysj0bfypw0krzi0aa6j";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  mesonFlags = [
+    "-Dpython=${python.interpreter}"
+  ];
+
+  meta = with lib; {
+    description = "Python 2 bindings for cairo";
+    homepage = "https://pycairo.readthedocs.io/";
+    license = with licenses; [ lgpl21Only mpl11 ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}

--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -1,4 +1,5 @@
 { lib
+, pythonOlder
 , fetchFromGitHub
 , meson
 , ninja
@@ -6,12 +7,14 @@
 , pytestCheckHook
 , pkg-config
 , cairo
-, isPy3k
+, python
 }:
 
 buildPythonPackage rec {
   pname = "pycairo";
   version = "1.20.0";
+
+  disabled = pythonOlder "3.6";
 
   format = "other";
 
@@ -37,11 +40,11 @@ buildPythonPackage rec {
   ];
 
   mesonFlags = [
-    "-Dpython=${if isPy3k then "python3" else "python"}"
+    "-Dpython=${python.interpreter}"
   ];
 
   meta = with lib; {
-    description = "Python 2/3 bindings for cairo";
+    description = "Python 3 bindings for cairo";
     homepage = "https://pycairo.readthedocs.io/";
     license = with licenses; [ lgpl21Only mpl11 ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -391,6 +391,10 @@ with self; with super; {
 
   pyblosxom = callPackage ../development/python-modules/pyblosxom { };
 
+  pycairo = callPackage ../development/python-modules/pycairo/1.18.nix {
+    inherit (pkgs) meson;
+  };
+
   pycangjie = disabled pycangjie;
 
   pycarddav = callPackage ../development/python-modules/pycarddav { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/119174

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

We should also try building Gtk2 with Python 3.