### PR TITLE
nixos/nginx: add option rejectSSL exposing ssl_reject_handshake

### DIFF
--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -118,6 +118,18 @@ with lib;
       '';
     };
 
+    rejectSSL = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to listen for and reject all HTTPS connections to this vhost. Useful in
+        <link linkend="opt-services.nginx.virtualHosts._name_.default">default</link>
+        server blocks to avoid serving the certificate for another vhost. Uses the
+        <literal>ssl_reject_handshake</literal> directive available in nginx versions
+        1.19.4 and above.
+      '';
+    };
+
     sslCertificate = mkOption {
       type = types.path;
       example = "/var/host.cert";


### PR DESCRIPTION
###### Motivation for this change

Alternative to #119039 as suggested in [this comment](https://github.com/NixOS/nixpkgs/pull/119039#issuecomment-817146736).

Exposes nginx 1.19.4's [`ssl_reject_handshake`](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_reject_handshake) directive. This is useful in default server blocks, to avoid serving the certificate for another vhost. For example, assuming I have a wildcard DNS record for `*.example.com`:

```nix
{ pkgs, ... }: {
  services.nginx = {
    enable = true;
    package = pkgs.nginxMainline;
    recommendedTlsSettings = true;
    virtualHosts = {
      "foo.example.com" = {
	forceSSL = true;
	# ...
      };

      default = {
	default = true;
	rejectSSL = true;
	extraConfig = "return 444;";
      };
    };
  };
}

```

Now accessing `http://unknown.example.com` results in a connection reset, and `https://unknown.example.com` results in a TLS error.

See https://trac.nginx.org/nginx/ticket/195 for additional context.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested this on my own server
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
