### PR TITLE
aws-c-common: 0.5.2 -> 0.5.4

### DIFF
--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , cmake
 }:

--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -1,23 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
+{ lib, stdenv
+, fetchFromGitHub
+, cmake
+}:
 
 stdenv.mkDerivation rec {
   pname = "aws-c-common";
-  version = "0.5.2";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0rd2qzaa9mmn5f6f2bl1wgv54f17pqx3vwyy9f8ylh59qfnilpmg";
+    sha256 = "sha256-NH66WAOqAaMm/IIu8L5R7CUFhX56yTLH7mPY1Q4jDC4=";
   };
-
-  patches = [
-    # Remove once https://github.com/awslabs/aws-c-common/pull/764 is merged
-    (fetchpatch {
-      url = "https://github.com/awslabs/aws-c-common/commit/4f85fb3e398d4e4d320d3559235267b26cbc9531.patch";
-      sha256 = "1jg3mz507w4kwgmg57kvz419gvw47pd9rkjr6jhsmvardmyyskap";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
