### PR TITLE
courier-prime: init at unstable-2019-12-05

### DIFF
--- a/pkgs/data/fonts/courier-prime/default.nix
+++ b/pkgs/data/fonts/courier-prime/default.nix
@@ -5,7 +5,7 @@ let
   repo = "CourierPrime";
   rev = "7f6d46a766acd9391d899090de467c53fd9c9cb0";
 in fetchzip rec {
-  name = "courier-prime";
+  name = "courier-prime-${version}";
   url = "https://github.com/quoteunquoteapps/${repo}/archive/${rev}/${name}.zip";
   sha256 = "1xh4pkksm6zrafhb69q4lq093q6pl245zi9qhqw3x6c1ab718704";
 

--- a/pkgs/data/fonts/courier-prime/default.nix
+++ b/pkgs/data/fonts/courier-prime/default.nix
@@ -6,8 +6,7 @@ let
   rev = "7f6d46a766acd9391d899090de467c53fd9c9cb0";
 in fetchzip rec {
   name = "courier-prime";
-  url =
-    "https://github.com/quoteunquoteapps/${repo}/archive/${rev}/${name}.zip";
+  url = "https://github.com/quoteunquoteapps/${repo}/archive/${rev}/${name}.zip";
   sha256 = "1xh4pkksm6zrafhb69q4lq093q6pl245zi9qhqw3x6c1ab718704";
 
   postFetch = ''

--- a/pkgs/data/fonts/courier-prime/default.nix
+++ b/pkgs/data/fonts/courier-prime/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchzip }:
+
+let
+  version = "unstable-2019-12-05";
+  repo = "CourierPrime";
+  rev = "7f6d46a766acd9391d899090de467c53fd9c9cb0";
+in fetchzip rec {
+  name = "courier-prime";
+  url =
+    "https://github.com/quoteunquoteapps/${repo}/archive/${rev}/${name}.zip";
+  sha256 = "1xh4pkksm6zrafhb69q4lq093q6pl245zi9qhqw3x6c1ab718704";
+
+  postFetch = ''
+    unzip $downloadedFile
+    install -m444 -Dt $out/share/fonts/truetype ${repo}-${rev}/fonts/ttf/*.ttf
+  '';
+
+  meta = with lib; {
+    description = "Monospaced font designed specifically for screenplays";
+    homepage = "https://github.com/quoteunquoteapps/CourierPrime";
+    license = licenses.ofl;
+    maintainers = [ maintainers.austinbutler ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20563,6 +20563,8 @@ in
 
   corefonts = callPackage ../data/fonts/corefonts { };
 
+  courier-prime = callPackage ../data/fonts/courier-prime { };
+
   cozette = callPackage ../data/fonts/cozette { };
 
   culmus = callPackage ../data/fonts/culmus { };


### PR DESCRIPTION
###### Motivation for this change

I'm intending to add a tool called [`wrap`](https://github.com/Wraparound/wrap) that requires this font (or a similar one, but Courier Prime is considered the top font for screenplays). Aside from needing it as an input to that package, I figure it's useful to have available as a standalone font as well.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).