### PR TITLE
Revert "nixos/home-assistant: use override before overridePythonAttrs"

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -50,14 +50,9 @@ let
   # List of components used in config
   extraComponents = filter useComponent availableComponents;
 
-  testedPackage = if (cfg.autoExtraComponents && cfg.config != null)
+  package = if (cfg.autoExtraComponents && cfg.config != null)
     then (cfg.package.override { inherit extraComponents; })
     else cfg.package;
-
-  # overridePythonAttrs has to be applied after override
-  package = testedPackage.overridePythonAttrs (oldAttrs: {
-    doCheck = false;
-  });
 
   # If you are changing this, please update the description in applyDefaultConfig
   defaultConfig = {
@@ -188,9 +183,13 @@ in {
     };
 
     package = mkOption {
-      default = pkgs.home-assistant;
+      default = pkgs.home-assistant.overridePythonAttrs (oldAttrs: {
+        doCheck = false;
+      });
       defaultText = literalExample ''
-        pkgs.home-assistant
+        pkgs.home-assistant.overridePythonAttrs (oldAttrs: {
+          doCheck = false;
+        })
       '';
       type = types.package;
       example = literalExample ''
@@ -199,12 +198,10 @@ in {
         }
       '';
       description = ''
-        Home Assistant package to use. Tests are automatically disabled, as they take a considerable amout of time to complete.
+        Home Assistant package to use. By default the tests are disabled, as they take a considerable amout of time to complete.
         Override <literal>extraPackages</literal> or <literal>extraComponents</literal> in order to add additional dependencies.
         If you specify <option>config</option> and do not set <option>autoExtraComponents</option>
         to <literal>false</literal>, overriding <literal>extraComponents</literal> will have no effect.
-        Avoid <literal>home-assistant.overridePythonAttrs</literal> if you use
-        <literal>autoExtraComponents</literal>.
       '';
     };
 

--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -202,6 +202,7 @@ in {
         Override <literal>extraPackages</literal> or <literal>extraComponents</literal> in order to add additional dependencies.
         If you specify <option>config</option> and do not set <option>autoExtraComponents</option>
         to <literal>false</literal>, overriding <literal>extraComponents</literal> will have no effect.
+        Avoid <literal>home-assistant.overridePythonAttrs</literal> if you use <literal>autoExtraComponents</literal>.
       '';
     };
 

--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -183,12 +183,12 @@ in {
     };
 
     package = mkOption {
-      default = pkgs.home-assistant.overridePythonAttrs (oldAttrs: {
-        doCheck = false;
+      default = pkgs.home-assistant.overrideAttrs (oldAttrs: {
+        doInstallCheck = false;
       });
       defaultText = literalExample ''
-        pkgs.home-assistant.overridePythonAttrs (oldAttrs: {
-          doCheck = false;
+        pkgs.home-assistant.overrideAttrs (oldAttrs: {
+          doInstallCheck = false;
         })
       '';
       type = types.package;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#118719

This breaks patching the package, overriding is a mess.