### PR TITLE
opencv-4: 4.3.0 -> 4.5.2

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -1,54 +1,91 @@
-{ lib, stdenv
-, fetchurl, fetchFromGitHub, fetchpatch
-, cmake, pkg-config, unzip, zlib, pcre, hdf5
-, glog, boost, gflags, protobuf
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitHub
+, cmake
+, pkg-config
+, unzip
+, zlib
+, pcre
+, hdf5
+, boost
+, gflags
+, protobuf
 , config
 
-, enableJPEG      ? true, libjpeg
-, enablePNG       ? true, libpng
-, enableTIFF      ? true, libtiff
-, enableWebP      ? true, libwebp
-, enableEXR ?     !stdenv.isDarwin, openexr, ilmbase
-, enableEigen     ? true, eigen
-, enableOpenblas  ? true, openblas, blas, lapack
-, enableContrib   ? true
+, enableJPEG ? true
+, libjpeg
+, enablePNG ? true
+, libpng
+, enableTIFF ? true
+, libtiff
+, enableWebP ? true
+, libwebp
+, enableEXR ? !stdenv.isDarwin
+, openexr
+, ilmbase
+, enableEigen ? true
+, eigen
+, enableOpenblas ? true
+, openblas
+, enableContrib ? true
 
-, enableCuda      ? (config.cudaSupport or false) &&
-                    stdenv.hostPlatform.isx86_64, cudatoolkit, nvidia-optical-flow-sdk
+, enableCuda ? (config.cudaSupport or false) && stdenv.hostPlatform.isx86_64
+, cudatoolkit
+, nvidia-optical-flow-sdk
 
-, enableUnfree    ? false
-, enableIpp       ? false
-, enablePython    ? false, pythonPackages
-, enableGtk2      ? false, gtk2
-, enableGtk3      ? false, gtk3
-, enableVtk       ? false, vtk
-, enableFfmpeg    ? false, ffmpeg_3
-, enableGStreamer ? false, gst_all_1
-, enableTesseract ? false, tesseract, leptonica
-, enableTbb       ? false, tbb
-, enableOvis      ? false, ogre
-, enableGPhoto2   ? false, libgphoto2
-, enableDC1394    ? false, libdc1394
-, enableDocs      ? false, doxygen, graphviz-nox
+, enableUnfree ? false
+, enableIpp ? false
+, enablePython ? false
+, pythonPackages
+, enableGtk2 ? false
+, gtk2
+, enableGtk3 ? false
+, gtk3
+, enableVtk ? false
+, vtk
+, enableFfmpeg ? true
+, ffmpeg_3
+, enableGStreamer ? true
+, gst_all_1
+, enableTesseract ? false
+, tesseract
+, leptonica
+, enableTbb ? false
+, tbb
+, enableOvis ? false
+, ogre
+, enableGPhoto2 ? false
+, libgphoto2
+, enableDC1394 ? false
+, libdc1394
+, enableDocs ? false
+, doxygen
+, graphviz-nox
 
-, AVFoundation, Cocoa, VideoDecodeAcceleration, CoreMedia, MediaToolbox, bzip2
+, AVFoundation
+, Cocoa
+, VideoDecodeAcceleration
+, CoreMedia
+, MediaToolbox
+, bzip2
 }:
 
 let
-  version = "4.3.0";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
-    owner  = "opencv";
-    repo   = "opencv";
-    rev    = version;
-    sha256 = "1r9bq9p1x99g2y8jvj9428sgqvljz75dm5vrfsma7hh5wjhz9775";
+    owner = "opencv";
+    repo = "opencv";
+    rev = version;
+    sha256 = "sha256-pxi1VBF4txvRqspdqvCsAQ3XKzl633/o3wyOgD9wid4=";
   };
 
   contribSrc = fetchFromGitHub {
-    owner  = "opencv";
-    repo   = "opencv_contrib";
-    rev    = version;
-    sha256 = "068b4f95rlryab3mffxs2w6dnbmbhrnpsdgl007rxk4bwnz29y49";
+    owner = "opencv";
+    repo = "opencv_contrib";
+    rev = version;
+    sha256 = "sha256-iMenRTY+qeL7WRgnRuQbsHflYDakE7pWWSHeIjrg0Iw=";
   };
 
   # Contrib must be built in order to enable Tesseract support:
@@ -57,35 +94,35 @@ let
   # See opencv/3rdparty/ippicv/ippicv.cmake
   ippicv = {
     src = fetchFromGitHub {
-      owner  = "opencv";
-      repo   = "opencv_3rdparty";
-      rev    = "a56b6ac6f030c312b2dce17430eef13aed9af274";
+      owner = "opencv";
+      repo = "opencv_3rdparty";
+      rev = "a56b6ac6f030c312b2dce17430eef13aed9af274";
       sha256 = "1msbkc3zixx61rcg6a04i1bcfhw1phgsrh93glq1n80hgsk3nbjq";
     } + "/ippicv";
-    files = let name = platform : "ippicv_2019_${platform}_general_20180723.tgz"; in
+    files = let name = platform: "ippicv_2019_${platform}_general_20180723.tgz"; in
       if stdenv.hostPlatform.system == "x86_64-linux" then
-      { ${name "lnx_intel64"} = "c0bd78adb4156bbf552c1dfe90599607"; }
+        { ${name "lnx_intel64"} = "c0bd78adb4156bbf552c1dfe90599607"; }
       else if stdenv.hostPlatform.system == "i686-linux" then
-      { ${name "lnx_ia32"}    = "4f38432c30bfd6423164b7a24bbc98a0"; }
+        { ${name "lnx_ia32"} = "4f38432c30bfd6423164b7a24bbc98a0"; }
       else if stdenv.hostPlatform.system == "x86_64-darwin" then
-      { ${name "mac_intel64"} = "fe6b2bb75ae0e3f19ad3ae1a31dfa4a2"; }
+        { ${name "mac_intel64"} = "fe6b2bb75ae0e3f19ad3ae1a31dfa4a2"; }
       else
-      throw "ICV is not available for this platform (or not yet supported by this package)";
+        throw "ICV is not available for this platform (or not yet supported by this package)";
     dst = ".cache/ippicv";
   };
 
   # See opencv_contrib/modules/xfeatures2d/cmake/download_vgg.cmake
   vgg = {
     src = fetchFromGitHub {
-      owner  = "opencv";
-      repo   = "opencv_3rdparty";
-      rev    = "fccf7cd6a4b12079f73bbfb21745f9babcd4eb1d";
+      owner = "opencv";
+      repo = "opencv_3rdparty";
+      rev = "fccf7cd6a4b12079f73bbfb21745f9babcd4eb1d";
       sha256 = "0r9fam8dplyqqsd3qgpnnfgf9l7lj44di19rxwbm8mxiw0rlcdvy";
     };
     files = {
-      "vgg_generated_48.i"  = "e8d0dcd54d1bcfdc29203d011a797179";
-      "vgg_generated_64.i"  = "7126a5d9a8884ebca5aea5d63d677225";
-      "vgg_generated_80.i"  = "7cd47228edec52b6d82f46511af325c5";
+      "vgg_generated_48.i" = "e8d0dcd54d1bcfdc29203d011a797179";
+      "vgg_generated_64.i" = "7126a5d9a8884ebca5aea5d63d677225";
+      "vgg_generated_80.i" = "7cd47228edec52b6d82f46511af325c5";
       "vgg_generated_120.i" = "151805e03568c9f490a5e3a872777b75";
     };
     dst = ".cache/xfeatures2d/vgg";
@@ -94,19 +131,19 @@ let
   # See opencv_contrib/modules/xfeatures2d/cmake/download_boostdesc.cmake
   boostdesc = {
     src = fetchFromGitHub {
-      owner  = "opencv";
-      repo   = "opencv_3rdparty";
-      rev    = "34e4206aef44d50e6bbcd0ab06354b52e7466d26";
+      owner = "opencv";
+      repo = "opencv_3rdparty";
+      rev = "34e4206aef44d50e6bbcd0ab06354b52e7466d26";
       sha256 = "13yig1xhvgghvxspxmdidss5lqiikpjr0ddm83jsi0k85j92sn62";
     };
     files = {
-      "boostdesc_bgm.i"          = "0ea90e7a8f3f7876d450e4149c97c74f";
-      "boostdesc_bgm_bi.i"       = "232c966b13651bd0e46a1497b0852191";
-      "boostdesc_bgm_hd.i"       = "324426a24fa56ad9c5b8e3e0b3e5303e";
+      "boostdesc_bgm.i" = "0ea90e7a8f3f7876d450e4149c97c74f";
+      "boostdesc_bgm_bi.i" = "232c966b13651bd0e46a1497b0852191";
+      "boostdesc_bgm_hd.i" = "324426a24fa56ad9c5b8e3e0b3e5303e";
       "boostdesc_binboost_064.i" = "202e1b3e9fec871b04da31f7f016679f";
       "boostdesc_binboost_128.i" = "98ea99d399965c03d555cef3ea502a0b";
       "boostdesc_binboost_256.i" = "e6dcfa9f647779eb1ce446a8d759b6ea";
-      "boostdesc_lbgm.i"         = "0ae0675534aa318d9668f2a179c2a052";
+      "boostdesc_lbgm.i" = "0ae0675534aa318d9668f2a179c2a052";
     };
     dst = ".cache/xfeatures2d/boostdesc";
   };
@@ -114,9 +151,9 @@ let
   # See opencv_contrib/modules/face/CMakeLists.txt
   face = {
     src = fetchFromGitHub {
-      owner  = "opencv";
-      repo   = "opencv_3rdparty";
-      rev    = "8afa57abc8229d611c4937165d20e2a2d9fc5a12";
+      owner = "opencv";
+      repo = "opencv_3rdparty";
+      rev = "8afa57abc8229d611c4937165d20e2a2d9fc5a12";
       sha256 = "061lsvqdidq9xa2hwrcvwi9ixflr2c2lfpc8drr159g68zi8bp4v";
     };
     files = {
@@ -136,10 +173,27 @@ let
     dst = ".cache/ade";
   };
 
+  # See opencv/modules/wechat_qrcode/CMakeLists.txt
+  wechat_qrcode = {
+    src = fetchFromGitHub {
+      owner = "opencv";
+      repo = "opencv_3rdparty";
+      rev = "a8b69ccc738421293254aec5ddb38bd523503252";
+      sha256 = "sha256-/n6zHwf0Rdc4v9o4rmETzow/HTv+81DnHP+nL56XiTY=";
+    };
+    files = {
+      "detect.caffemodel" = "238e2b2d6f3c18d6c3a30de0c31e23cf";
+      "detect.prototxt" = "6fb4976b32695f9f5c6305c19f12537d";
+      "sr.caffemodel" = "cbfcd60361a73beb8c583eea7e8e6664";
+      "sr.prototxt" = "69db99927a70df953b471daaba03fbef";
+    };
+    dst = ".cache/wechat_qrcode";
+  };
+
   # See opencv/cmake/OpenCVDownload.cmake
-  installExtraFiles = extra : with lib; ''
+  installExtraFiles = extra: with lib; ''
     mkdir -p "${extra.dst}"
-  '' + concatStrings (flip mapAttrsToList extra.files (name : md5 : ''
+  '' + concatStrings (flip mapAttrsToList extra.files (name: md5: ''
     ln -s "${extra.src}/${name}" "${extra.dst}/${md5}-${name}"
   ''));
   installExtraFile = extra: ''
@@ -149,7 +203,7 @@ let
 
   opencvFlag = name: enabled: "-DWITH_${name}=${printEnabled enabled}";
 
-  printEnabled = enabled : if enabled then "ON" else "OFF";
+  printEnabled = enabled: if enabled then "ON" else "OFF";
 in
 
 stdenv.mkDerivation {
@@ -172,13 +226,15 @@ stdenv.mkDerivation {
   preConfigure =
     installExtraFile ade +
     lib.optionalString enableIpp (installExtraFiles ippicv) + (
-    lib.optionalString buildContrib ''
-      cmakeFlagsArray+=("-DOPENCV_EXTRA_MODULES_PATH=$NIX_BUILD_TOP/source/opencv_contrib")
+      lib.optionalString buildContrib ''
+        cmakeFlagsArray+=("-DOPENCV_EXTRA_MODULES_PATH=$NIX_BUILD_TOP/source/opencv_contrib")
 
-      ${installExtraFiles vgg}
-      ${installExtraFiles boostdesc}
-      ${installExtraFiles face}
-    '');
+        ${installExtraFiles vgg}
+        ${installExtraFiles boostdesc}
+        ${installExtraFiles face}
+        ${installExtraFiles wechat_qrcode}
+      ''
+    );
 
   postConfigure = ''
     [ -e modules/core/version_string.inc ]
@@ -186,7 +242,7 @@ stdenv.mkDerivation {
   '';
 
   buildInputs =
-       [ zlib pcre hdf5 glog boost gflags protobuf ]
+    [ zlib pcre hdf5 boost gflags protobuf ]
     ++ lib.optional enablePython pythonPackages.python
     ++ lib.optional enableGtk2 gtk2
     ++ lib.optional enableGtk3 gtk3
@@ -198,7 +254,7 @@ stdenv.mkDerivation {
     ++ lib.optionals enableEXR [ openexr ilmbase ]
     ++ lib.optional enableFfmpeg ffmpeg_3
     ++ lib.optionals (enableFfmpeg && stdenv.isDarwin)
-                     [ VideoDecodeAcceleration bzip2 ]
+      [ VideoDecodeAcceleration bzip2 ]
     ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base ])
     ++ lib.optional enableOvis ogre
     ++ lib.optional enableGPhoto2 libgphoto2
@@ -274,15 +330,13 @@ stdenv.mkDerivation {
       "$out/lib/pkgconfig/opencv4.pc"
   '';
 
-  hardeningDisable = [ "bindnow" "relro" ];
-
-  passthru = lib.optionalAttrs enablePython { pythonPath = []; };
+  passthru = lib.optionalAttrs enablePython { pythonPath = [ ]; };
 
   meta = with lib; {
     description = "Open Computer Vision Library with more than 500 algorithms";
     homepage = "https://opencv.org/";
     license = with licenses; if enableUnfree then unfree else bsd3;
-    maintainers = with maintainers; [mdaiter basvandijk];
+    maintainers = with maintainers; [ mdaiter basvandijk ];
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/libraries/opencv/cmake-don-t-use-OpenCVFindOpenEXR.patch
+++ b/pkgs/development/libraries/opencv/cmake-don-t-use-OpenCVFindOpenEXR.patch
@@ -1,40 +1,17 @@
-From 6d988c08e852379a163ecd20df8639196d84d014 Mon Sep 17 00:00:00 2001
-From: Bernardo Meurer <meurerbernardo@gmail.com>
-Date: Sun, 26 Apr 2020 14:50:25 -0700
-Subject: [PATCH] cmake: don't use OpenCVFindOpenEXR
-
-Use find_package for this.
----
- CMakeLists.txt                  |  2 ++
- cmake/OpenCVFindLibsGrfmt.cmake | 15 +++------------
- 2 files changed, 5 insertions(+), 12 deletions(-)
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4c0b3880fc..0360469350 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -14,6 +14,8 @@ FATAL: In-source builds are not allowed.
- ")
- endif()
- 
-+# the future!
-+include(FindPkgConfig)
- 
- include(cmake/OpenCVMinDepVersions.cmake)
- 
 diff --git a/cmake/OpenCVFindLibsGrfmt.cmake b/cmake/OpenCVFindLibsGrfmt.cmake
-index 0beaf19317..4c5e46e615 100644
+index 23a6ca6959..27e121943a 100644
 --- a/cmake/OpenCVFindLibsGrfmt.cmake
 +++ b/cmake/OpenCVFindLibsGrfmt.cmake
-@@ -227,20 +227,11 @@ endif()
+@@ -255,21 +255,12 @@ endif()
  # --- OpenEXR (optional) ---
  if(WITH_OPENEXR)
    ocv_clear_vars(HAVE_OPENEXR)
 -  if(NOT BUILD_OPENEXR)
+-    ocv_clear_internal_cache_vars(OPENEXR_INCLUDE_PATHS OPENEXR_LIBRARIES OPENEXR_ILMIMF_LIBRARY OPENEXR_VERSION)
 -    include("${OpenCV_SOURCE_DIR}/cmake/OpenCVFindOpenEXR.cmake")
 -  endif()
--
 +  pkg_check_modules(OPENEXR OpenEXR)
+ 
    if(OPENEXR_FOUND)
      set(HAVE_OPENEXR YES)
 -  else()
@@ -50,6 +27,3 @@ index 0beaf19317..4c5e46e615 100644
    endif()
  endif()
  
--- 
-2.26.1
-


### PR DESCRIPTION
- Updated to 4.5.2
- Removed glog from buildInputs because of this error on python-opencv:
```
python -c "import cv2"
/nix/store/slfzk1gk74nfx3ky2vpdf9nb7b8nvdf2-opencv-4.5.2/lib/libopencv_sfm.so.4.5: error: symbol lookup error: undefined symbol: _ZN6google21kLogSiteUninitializedE (fatal)
```
- Enabled ffmpeg and gstreamer to open more video formats
- nixpkg-fmt

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
