### PR TITLE
Fix python mpv module

### DIFF
--- a/pkgs/development/python-modules/mpv/default.nix
+++ b/pkgs/development/python-modules/mpv/default.nix
@@ -18,8 +18,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace mpv.py \
-      --replace "sofile = ctypes.util.find_library('mpv')" \
-                'sofile = "${mpv}/lib/libmpv${stdenv.targetPlatform.extensions.sharedLibrary}"'
+      --replace "ctypes.util.find_library('mpv')" \
+                '"${mpv}/lib/libmpv${stdenv.targetPlatform.extensions.sharedLibrary}"'
   '';
 
   # tests impure, will error if it can't load libmpv.so

--- a/pkgs/development/python-modules/mpv/default.nix
+++ b/pkgs/development/python-modules/mpv/default.nix
@@ -28,6 +28,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A python interface to the mpv media player";
     homepage = "https://github.com/jaseg/python-mpv";
+    maintainers = [ maintainers.sumnerevans ];
     license = licenses.agpl3Plus;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

When the `python3Packages.mpv` package is included in another package via `buildInputs` (for example, from Sublime Music: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/audio/sublime-music/default.nix#L39), the `postPatch` hook wasn't actually causing the necessary replacement to occur.

This PR fixes that by moving the substitution to the `patchPhase`. This PR also adds myself as the maintainer of the python-mpv module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
