### PR TITLE
fixup! gpaste: 3.38.5 → 3.40.1

### DIFF
--- a/pkgs/desktops/gnome-3/misc/gpaste/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gpaste/default.nix
@@ -17,14 +17,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.38.5";
+  version = "3.40.1";
   pname = "gpaste";
 
   src = fetchFromGitHub {
     owner = "Keruspe";
     repo = "GPaste";
     rev = "v${version}";
-    sha256 = "sha256-hUqFijqUQ1W8OThpbioqcxkOgYvScKUBmXN84MbMPGE=";
+    sha256 = "sha256-coMye/arH0JYgcjf/y3ZS8Bijuivs9m5Z7EiJQJzThk=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/misc/gpaste/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/misc/gpaste/fix-paths.patch
@@ -17,7 +17,7 @@
  
 +imports.gi.GIRepository.Repository.prepend_search_path('@typelibPath@');
 +
- const { GPaste } = imports.gi;
+ //const { GPaste } = imports.gi;
  
  const ExtensionUtils = imports.misc.extensionUtils;
 --- a/src/libgpaste/settings/gpaste-settings.c


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update [GPaste](https://github.com/Keruspe/GPaste) from 3.38.5 to 3.40.1.

This fixes `meson.build:40:2: ERROR: Dependency "mutter-clutter-7" not found, tried pkgconfig` error on GNOME 40 build (as instructed in the draft PR below). 

For #117081.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
