### PR TITLE
nixos/mattermost: add preferNixConfig option, plugin support, and tests

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -30,6 +30,14 @@
           PHP 8.1 is now available
         </para>
       </listitem>
+      <listitem>
+        <para>
+          Mattermost has been updated to version 6.2. Migrations may
+          take a while, see the
+          <link xlink:href="https://docs.mattermost.com/install/self-managed-changelog.html#release-v6.2-feature-release">upgrade
+          notes</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-new-services">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -13,6 +13,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - PHP 8.1 is now available
 
+- Mattermost has been updated to version 6.2. Migrations may take a while,
+  see the [upgrade notes](https://docs.mattermost.com/install/self-managed-changelog.html#release-v6.2-feature-release).
+
 ## New Services {#sec-release-22.05-new-services}
 
 - [aesmd](https://github.com/intel/linux-sgx#install-the-intelr-sgx-psw), the Intel SGX Architectural Enclave Service Manager. Available as [services.aesmd](#opt-services.aesmd.enable).

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -6,23 +6,18 @@ let
 
   cfg = config.services.mattermost;
 
-  defaultConfig = builtins.fromJSON (builtins.replaceStrings [ "\\u0026" ] [ "&" ]
-    (readFile "${pkgs.mattermost}/config/config.json")
-  );
-
   database = "postgres://${cfg.localDatabaseUser}:${cfg.localDatabasePassword}@localhost:5432/${cfg.localDatabaseName}?sslmode=disable&connect_timeout=10";
 
-  mattermostConf = foldl recursiveUpdate defaultConfig
-    [ { ServiceSettings.SiteURL = cfg.siteUrl;
-        ServiceSettings.ListenAddress = cfg.listenAddress;
-        TeamSettings.SiteName = cfg.siteName;
-        SqlSettings.DriverName = "postgres";
-        SqlSettings.DataSource = database;
-      }
-      cfg.extraConfig
-    ];
+  mattermostConf = recursiveUpdate
+    { ServiceSettings.SiteURL = cfg.siteUrl;
+      ServiceSettings.ListenAddress = cfg.listenAddress;
+      TeamSettings.SiteName = cfg.siteName;
+      SqlSettings.DriverName = "postgres";
+      SqlSettings.DataSource = database;
+    }
+    cfg.extraConfig;
 
-  mattermostConfJSON = pkgs.writeText "mattermost-config-raw.json" (builtins.toJSON mattermostConf);
+  mattermostConfJSON = pkgs.writeText "mattermost-config.json" (builtins.toJSON mattermostConf);
 
 in
 
@@ -74,6 +69,16 @@ in
           If this option is disabled, changes in the system console won't
           be possible (default). If an config.json is present, it will be
           overwritten!
+        '';
+      };
+
+      preferNixConfig = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If both mutableConfig and this option are set, the Nix configuration
+          will take precedence over any settings configured in the server
+          console.
         '';
       };
 
@@ -180,14 +185,19 @@ in
           ln -sf ${pkgs.mattermost}/{bin,fonts,i18n,templates,client} ${cfg.statePath}
         '' + lib.optionalString (!cfg.mutableConfig) ''
           rm -f ${cfg.statePath}/config/config.json
-          cp ${mattermostConfJSON} ${cfg.statePath}/config/config.json
+          ${pkgs.jq}/bin/jq -s '.[0] * .[1]' ${pkgs.mattermost}/config/config.json ${mattermostConfJSON} > ${cfg.statePath}/config/config.json
           ${pkgs.mattermost}/bin/mattermost config migrate ${cfg.statePath}/config/config.json ${database}
         '' + lib.optionalString cfg.mutableConfig ''
           if ! test -e "${cfg.statePath}/config/.initial-created"; then
             rm -f ${cfg.statePath}/config/config.json
-            cp ${mattermostConfJSON} ${cfg.statePath}/config/config.json
+            ${pkgs.jq}/bin/jq -s '.[0] * .[1]' ${pkgs.mattermost}/config/config.json ${mattermostConfJSON} > ${cfg.statePath}/config/config.json
             touch ${cfg.statePath}/config/.initial-created
           fi
+        '' + lib.optionalString (cfg.mutableConfig && cfg.preferNixConfig) ''
+          newConfig="$(${pkgs.jq}/bin/jq -s '.[0] * .[1]' ${cfg.statePath}/config/config.json ${mattermostConfJSON})"
+
+          rm -f ${cfg.statePath}/config/config.json
+          echo "$newConfig" > ${cfg.statePath}/config/config.json
         '' + lib.optionalString cfg.localDatabaseCreate ''
           if ! test -e "${cfg.statePath}/.db-created"; then
             ${pkgs.sudo}/bin/sudo -u ${config.services.postgresql.superUser} \

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -260,6 +260,7 @@ in
   matomo = handleTest ./matomo.nix {};
   matrix-appservice-irc = handleTest ./matrix-appservice-irc.nix {};
   matrix-synapse = handleTest ./matrix-synapse.nix {};
+  mattermost = handleTest ./mattermost.nix {};
   mediawiki = handleTest ./mediawiki.nix {};
   meilisearch = handleTest ./meilisearch.nix {};
   memcached = handleTest ./memcached.nix {};

--- a/nixos/tests/mattermost.nix
+++ b/nixos/tests/mattermost.nix
@@ -37,6 +37,14 @@ in
     mostlyMutable = makeMattermost {
       mutableConfig = true;
       preferNixConfig = true;
+      plugins = let
+        mattermostDemoPlugin = pkgs.fetchurl {
+          url = "https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.9.0/com.mattermost.demo-plugin-0.9.0.tar.gz";
+          sha256 = "1h4qi34gcxcx63z8wiqcf2aaywmvv8lys5g8gvsk13kkqhlmag25";
+        };
+      in [
+        mattermostDemoPlugin
+      ];
     };
     immutable = makeMattermost {
       mutableConfig = false;

--- a/nixos/tests/mattermost.nix
+++ b/nixos/tests/mattermost.nix
@@ -1,0 +1,116 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+let
+  host = "smoke.test";
+  port = "8065";
+  url = "http://${host}:${port}";
+  siteName = "NixOS Smoke Tests, Inc.";
+
+  makeMattermost = mattermostConfig:
+    { config, ... }: {
+      environment.systemPackages = [
+        pkgs.mattermost
+        pkgs.curl
+        pkgs.jq
+      ];
+      networking.hosts = {
+        "127.0.0.1" = [ host ];
+      };
+      services.mattermost = lib.recursiveUpdate {
+        enable = true;
+        inherit siteName;
+        listenAddress = "0.0.0.0:${port}";
+        siteUrl = url;
+        extraConfig = {
+          SupportSettings.AboutLink = "https://nixos.org";
+        };
+      } mattermostConfig;
+    };
+in
+{
+  name = "mattermost";
+
+  nodes = {
+    mutable = makeMattermost {
+      mutableConfig = true;
+      extraConfig.SupportSettings.HelpLink = "https://search.nixos.org";
+    };
+    mostlyMutable = makeMattermost {
+      mutableConfig = true;
+      preferNixConfig = true;
+    };
+    immutable = makeMattermost {
+      mutableConfig = false;
+      extraConfig.SupportSettings.HelpLink = "https://search.nixos.org";
+    };
+  };
+
+  testScript = let
+    expectConfig = jqExpression: pkgs.writeShellScript "expect-config" ''
+      set -euo pipefail
+      echo "Expecting config to match: "${lib.escapeShellArg jqExpression} >&2
+      curl ${lib.escapeShellArg url} >/dev/null
+      config="$(curl ${lib.escapeShellArg "${url}/api/v4/config/client?format=old"})"
+      echo "Config: $(echo "$config" | ${pkgs.jq}/bin/jq)" >&2
+      [[ "$(echo "$config" | ${pkgs.jq}/bin/jq -r ${lib.escapeShellArg ".SiteName == $siteName and .Version == ($mattermostName / $sep)[-1] and (${jqExpression})"} --arg siteName ${lib.escapeShellArg siteName} --arg mattermostName ${lib.escapeShellArg pkgs.mattermost.name} --arg sep '-')" = "true" ]]
+    '';
+
+    setConfig = jqExpression: pkgs.writeShellScript "set-config" ''
+      set -euo pipefail
+      mattermostConfig=/var/lib/mattermost/config/config.json
+      newConfig="$(${pkgs.jq}/bin/jq -r ${lib.escapeShellArg jqExpression} $mattermostConfig)"
+      rm -f $mattermostConfig
+      echo "$newConfig" > "$mattermostConfig"
+    '';
+  in
+  ''
+    start_all()
+
+    ## Mutable node tests ##
+    mutable.wait_for_unit("mattermost.service")
+    mutable.wait_for_open_port(8065)
+
+    # Get the initial config
+    mutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://search.nixos.org"''}")
+
+    # Edit the config
+    mutable.succeed("${setConfig ''.SupportSettings.AboutLink = "https://mattermost.com"''}")
+    mutable.succeed("${setConfig ''.SupportSettings.HelpLink = "https://nixos.org/nixos/manual"''}")
+    mutable.systemctl("restart mattermost.service")
+    mutable.wait_for_open_port(8065)
+
+    # AboutLink and HelpLink should be changed
+    mutable.succeed("${expectConfig ''.AboutLink == "https://mattermost.com" and .HelpLink == "https://nixos.org/nixos/manual"''}")
+
+    ## Mostly mutable node tests ##
+    mostlyMutable.wait_for_unit("mattermost.service")
+    mostlyMutable.wait_for_open_port(8065)
+
+    # Get the initial config
+    mostlyMutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org"''}")
+
+    # Edit the config
+    mostlyMutable.succeed("${setConfig ''.SupportSettings.AboutLink = "https://mattermost.com"''}")
+    mostlyMutable.succeed("${setConfig ''.SupportSettings.HelpLink = "https://nixos.org/nixos/manual"''}")
+    mostlyMutable.systemctl("restart mattermost.service")
+    mostlyMutable.wait_for_open_port(8065)
+
+    # AboutLink should be overridden by NixOS configuration; HelpLink should be what we set above
+    mostlyMutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://nixos.org/nixos/manual"''}")
+
+    ## Immutable node tests ##
+    immutable.wait_for_unit("mattermost.service")
+    immutable.wait_for_open_port(8065)
+
+    # Get the initial config
+    immutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://search.nixos.org"''}")
+
+    # Edit the config
+    immutable.succeed("${setConfig ''.SupportSettings.AboutLink = "https://mattermost.com"''}")
+    immutable.succeed("${setConfig ''.SupportSettings.HelpLink = "https://nixos.org/nixos/manual"''}")
+    immutable.systemctl("restart mattermost.service")
+    immutable.wait_for_open_port(8065)
+
+    # Our edits should be ignored on restart
+    immutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://search.nixos.org"''}")
+  '';
+})

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,27 +1,63 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, buildGoModule, buildEnv }:
+{ lib, stdenv, fetchurl, fetchFromGitHub, buildGo117Package, buildEnv
+
+# The suffix for the Mattermost version.
+, versionSuffix ? "nixpkgs"
+
+# The constant build date.
+, buildDate ? "1970-01-01"
+
+# Set to true to set the build hash to the Nix store path.
+, storePathAsBuildHash ? false }:
 
 let
-  version = "5.37.5";
+  version = "6.2.1";
 
-  mattermost-server = buildGoModule rec {
+  goPackagePath = "github.com/mattermost/mattermost-server";
+
+  mattermost-server-build = buildGo117Package rec {
     pname = "mattermost-server";
-    inherit version;
+    inherit version goPackagePath;
 
     src = fetchFromGitHub {
       owner = "mattermost";
-      repo = pname;
+      repo = "mattermost-server";
       rev = "v${version}";
-      sha256 = "sha256-ddK7gxWl1arCtW2vqmon28AAeyZQPYlbGj3QtOlqtiU=";
+      sha256 = "WjBsbW7aEI+MX2I1LrEJh8JgNQ4Do7PpeshXgaQAk1s=";
     };
 
-    vendorSha256 = null;
-    doCheck = false;
-
     ldflags = [
-      "-s" "-w" "-X github.com/mattermost/mattermost-server/v${lib.versions.major version}/model.BuildNumber=${version}"
+      "-s" "-w"
+      "-X ${goPackagePath}/model.BuildNumber=${version}${lib.optionalString (versionSuffix != null) "-${versionSuffix}"}"
+      "-X ${goPackagePath}/model.BuildDate=${buildDate}"
+      "-X ${goPackagePath}/model.BuildEnterpriseReady=false"
     ];
-
   };
+
+  mattermost-server = if storePathAsBuildHash then mattermost-server-build.overrideAttrs (orig: {
+    buildPhase = ''
+      origGo="$(type -p go)"
+
+      # Override the Go binary to set the build hash in -ldflags to $out.
+      # Technically this is more accurate than a Git hash!
+      # nixpkgs does not appear to support environment variables in ldflags
+      # for go packages, so we have to rewrite -ldflags before calling go.
+      go() {
+        local args=()
+        local ldflags="-X ${goPackagePath}/model.BuildHash=$out"
+        local found=0
+        for arg in "$@"; do
+          if [[ "$arg" == -ldflags=* ]] && [ $found -eq 0 ]; then
+            arg="-ldflags=''${ldflags} ''${arg#-ldflags=}"
+            found=1
+          fi
+          args+=("$arg")
+        done
+        "$origGo" "''${args[@]}"
+      }
+
+      ${orig.buildPhase}
+    '';
+  }) else mattermost-server-build;
 
   mattermost-webapp = stdenv.mkDerivation {
     pname = "mattermost-webapp";
@@ -29,7 +65,7 @@ let
 
     src = fetchurl {
       url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-      sha256 = "sha256-G6L8Ct6PtARg2LKxcoFyg9vrDJXIKGByxovquMc6p00=";
+      sha256 = "pV/MwMCK8vMzASXuM1+ePcarIgrcNAkFLEdmPya911E=";
     };
 
     installPhase = ''
@@ -52,7 +88,7 @@ in
       description = "Open-source, self-hosted Slack-alternative";
       homepage = "https://www.mattermost.org";
       license = with licenses; [ agpl3 asl20 ];
-      maintainers = with maintainers; [ fpletz ryantm ];
+      maintainers = with maintainers; [ fpletz ryantm numinit ];
       platforms = platforms.unix;
     };
   }


### PR DESCRIPTION
###### Motivation for this change

One use case for Mattermost configuration is doing a "mostly
mutable" configuration where NixOS module options take priority
over Mattermost's config JSON.

Add a `preferNixConfig` option that prefers configured Nix options
over what's configured in Mattermost config if mutableConfig is set.

Add a `plugins` option that should be a list of Nix store paths to
Mattermost .tar.gz plugin bundles. Take it into account when building
the Mattermost config.

Remove the reliance on readFile (it's flake incompatible) and use
jq instead.

Merge Mattermost configs together on Mattermost startup, depending
on configured module options.

Write tests for mutable, mostly mutable, and immutable configurations.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
