### PR TITLE
mutter: fix build

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -16,9 +16,11 @@
 , ninja
 , xkeyboard_config
 , libxkbfile
+, libXdamage
 , libxkbcommon
 , libXtst
 , libinput
+, libdrm
 , gsettings-desktop-schemas
 , glib
 , gtk3
@@ -27,6 +29,7 @@
 , libgudev
 , libwacom
 , xwayland
+, mesa
 , meson
 , gnome-settings-daemon
 , xorgserver
@@ -84,6 +87,7 @@ let self = stdenv.mkDerivation rec {
   nativeBuildInputs = [
     desktop-file-utils
     gettext
+    mesa # needed for gbm
     meson
     ninja
     pkg-config
@@ -102,12 +106,14 @@ let self = stdenv.mkDerivation rec {
     gsettings-desktop-schemas
     gtk3
     libcanberra
+    libdrm
     libgudev
     libinput
     libstartup_notification
     libwacom
     libxkbcommon
     libxkbfile
+    libXdamage
     pango
     pipewire
     sysprof


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/119202

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
