### PR TITLE
ocamlPackages.jsonrpc: 1.4.1 → 1.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -4,23 +4,36 @@
 , ocaml-syntax-shims
 , yojson
 , result
-, fetchzip
+, fetchurl
 , lib
+, ocaml
 }:
 
+let params =
+  if lib.versionAtLeast ocaml.version "4.12"
+  then {
+    version = "1.5.0";
+    sha256 = "0g82m3jrp4s0m3fn9xmm8khrb3acccq8ns9p62bqa09pjd4vgdk2";
+  } else {
+    version = "1.4.1";
+    sha256 = "1ssyazc0yrdng98cypwa9m3nzfisdzpp7hqnx684rqj8f0g3gs6f";
+  }
+; in
 
 buildDunePackage rec {
   pname = "jsonrpc";
-  version = "1.4.1";
-  src = fetchzip {
+  inherit (params) version;
+  src = fetchurl {
     url = "https://github.com/ocaml/ocaml-lsp/releases/download/${version}/jsonrpc-${version}.tbz";
-    sha256 = "0hzpw17qfhb0cxgwah1fv4k300r363dy1kv0977anl44dlanx1v5";
+    inherit (params) sha256;
   };
 
   useDune2 = true;
   minimumOCamlVersion = "4.06";
 
-  buildInputs = [ yojson stdlib-shims ocaml-syntax-shims ppx_yojson_conv_lib result ];
+  buildInputs = [ yojson stdlib-shims ocaml-syntax-shims ];
+
+  propagatedBuildInputs = [ ppx_yojson_conv_lib result ];
 
   meta = with lib; {
     description = "Jsonrpc protocol implementation in OCaml";


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.12.

cc maintainers @marsam @symphorien

Closes #116810

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
