### PR TITLE
pythonPackages.woob: init at 3.0

### DIFF
--- a/pkgs/development/python-modules/woob/default.nix
+++ b/pkgs/development/python-modules/woob/default.nix
@@ -1,0 +1,82 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, Babel
+, colorama
+, cssselect
+, dateutil
+, feedparser
+, futures
+, gdata
+, gnupg
+, google-api-python-client
+, html2text
+, libyaml
+, lxml
+, mechanize
+, nose
+, pdfminer
+, pillow
+, prettytable
+, pyqt5
+, pyyaml
+, requests
+, simplejson
+, termcolor
+, unidecode
+}:
+
+buildPythonPackage rec {
+  pname = "woob";
+  version = "3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09hpxy5zhn2b8li0xjf3zd7s46lawb0315p5mdcsci3bj3s4v1j7";
+  };
+
+  patches = [
+    # Disable doctests that require networking:
+    ./no-test-requiring-network.patch
+  ];
+
+  checkInputs = [ nose ];
+
+  nativeBuildInputs = [ pyqt5 ];
+
+  propagatedBuildInputs = [
+    Babel
+    colorama
+    cssselect
+    dateutil
+    feedparser
+    gdata
+    gnupg
+    google-api-python-client
+    html2text
+    libyaml
+    lxml
+    mechanize
+    pdfminer
+    pillow
+    prettytable
+    pyqt5
+    pyyaml
+    requests
+    simplejson
+    termcolor
+    unidecode
+  ] ++ lib.optionals isPy27 [ futures ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with lib; {
+    homepage = "https://woob.tech";
+    description = "Collection of applications and APIs to interact with websites without requiring the user to open a browser";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.DamienCassou ];
+ };
+}

--- a/pkgs/development/python-modules/woob/no-test-requiring-network.patch
+++ b/pkgs/development/python-modules/woob/no-test-requiring-network.patch
@@ -1,0 +1,54 @@
+--- a/woob/browser/browsers.py
++++ b/woob/browser/browsers.py
+@@ -930,23 +930,6 @@
+
+         :class:`NextPage` constructor can take an url or a Request object.
+
+-        >>> from .pages import HTMLPage
+-        >>> class Page(HTMLPage):
+-        ...     def iter_values(self):
+-        ...         for el in self.doc.xpath('//li'):
+-        ...             yield el.text
+-        ...         for next in self.doc.xpath('//a'):
+-        ...             raise NextPage(next.attrib['href'])
+-        ...
+-        >>> class Browser(PagesBrowser):
+-        ...     BASEURL = 'https://woob.tech'
+-        ...     list = URL('/tests/list-(?P<pagenum>\d+).html', Page)
+-        ...
+-        >>> b = Browser()
+-        >>> b.list.go(pagenum=1) # doctest: +ELLIPSIS
+-        <woob.browser.browsers.Page object at 0x...>
+-        >>> list(b.pagination(lambda: b.page.iter_values()))
+-        ['One', 'Two', 'Three', 'Four']
+         """
+         while True:
+             try:
+--- a/woob/browser/pages.py
++++ b/woob/browser/pages.py
+@@ -49,25 +49,6 @@
+
+     :class:`NextPage` constructor can take an url or a Request object.
+
+-    >>> class Page(HTMLPage):
+-    ...     @pagination
+-    ...     def iter_values(self):
+-    ...         for el in self.doc.xpath('//li'):
+-    ...             yield el.text
+-    ...         for next in self.doc.xpath('//a'):
+-    ...             raise NextPage(next.attrib['href'])
+-    ...
+-    >>> from .browsers import PagesBrowser
+-    >>> from .url import URL
+-    >>> class Browser(PagesBrowser):
+-    ...     BASEURL = 'https://woob.tech'
+-    ...     list = URL('/tests/list-(?P<pagenum>\d+).html', Page)
+-    ...
+-    >>> b = Browser()
+-    >>> b.list.go(pagenum=1) # doctest: +ELLIPSIS
+-    <woob.browser.pages.Page object at 0x...>
+-    >>> list(b.page.iter_values())
+-    ['One', 'Two', 'Three', 'Four']
+     """
+
+     @wraps(func)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8987,6 +8987,8 @@ in {
 
   wled = callPackage ../development/python-modules/wled { };
 
+  woob = callPackage ../development/python-modules/woob { };
+
   word2vec = callPackage ../development/python-modules/word2vec { };
 
   wordcloud = callPackage ../development/python-modules/wordcloud { };


### PR DESCRIPTION
###### Motivation for this change

Introduce [woob](https://woob.tech/). Woob is a rebranding of weboob which is already packaged in nixpkgs. After some time, I suggest making "weboob" an alias for "woob".

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
