### PR TITLE
panotools: 2.9.19 -> 2.9.20

### DIFF
--- a/pkgs/applications/graphics/panotools/default.nix
+++ b/pkgs/applications/graphics/panotools/default.nix
@@ -1,11 +1,12 @@
 { fetchurl, lib, stdenv, libjpeg, libpng, libtiff, perl }:
 
 stdenv.mkDerivation rec {
-  name = "libpano13-2.9.19";
+  pname = "libpano13";
+  version = "2.9.20";
 
   src = fetchurl {
-    url = "mirror://sourceforge/panotools/${name}.tar.gz";
-    sha256 = "1a4m3plmfcrrplqs9zfzhc5apibn10m5sajpizm1sd3q74w5fwq3";
+    url = "mirror://sourceforge/panotools/${pname}-${version}.tar.gz";
+    sha256 = "12cv4886l1czfjwy7k6ipgf3zjksgwhdjzr2s9fdg33vqcv2hlrv";
   };
 
   buildInputs = [ perl libjpeg libpng libtiff ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-20307.

Changelog:
https://sourceforge.net/projects/panotools/files/libpano13/libpano13-2.9.20/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>autopanosiftc</li>
    <li>digikam (digikam5)</li>
    <li>hugin</li>
    <li>panotools</li>
  </ul>
</details>
