### PR TITLE
python3Packages.cvxpy: 1.1.11 -> 1.1.12

### DIFF
--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -9,6 +9,7 @@
 , osqp
 , scipy
 , scs
+, useOpenmp ? true
   # Check inputs
 , pytestCheckHook
 }:
@@ -33,6 +34,12 @@ buildPythonPackage rec {
     scipy
     scs
   ];
+
+  # Required flags from https://github.com/cvxgrp/cvxpy/releases/tag/v1.1.11
+  preBuild = lib.optional useOpenmp ''
+    export CFLAGS="-fopenmp"
+    export LDFLAGS="-lgomp"
+  '';
 
   checkInputs = [ pytestCheckHook ];
   pytestFlagsArray = [ "./cvxpy" ];

--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , pythonOlder
 , buildPythonPackage
 , fetchPypi
@@ -14,13 +15,14 @@
 
 buildPythonPackage rec {
   pname = "cvxpy";
-  version = "1.1.11";
+  version = "1.1.12";
+  format = "pyproject";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-W4qly+g07Q1iYJ76/tGZNkBPa+oavhTDUYRQ3cZ+s1I=";
+    hash = "sha256-tJnr+uT8ZF6VI2IVc//LHFtoVKG1wM4dZqippFhgWAc=";
   };
 
   propagatedBuildInputs = [
@@ -38,6 +40,8 @@ buildPythonPackage rec {
   disabledTests = [
     "test_tv_inpainting"
     "test_diffcp_sdp_example"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    "test_ecos_bb_mi_lp_2" # https://github.com/cvxgrp/cvxpy/issues/1241#issuecomment-780912155
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/cvxgrp/cvxpy/compare/v1.1.11...v1.1.12

Add support for openmp multithreading when solving convex optimization expressions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
