### PR TITLE
htmldoc: 1.8.29 -> 1.9.11

### DIFF
--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0660829zjfdm6vzx14z7gvsfipsb7h0z74gbkyp2ncg3g2432s4n";
   };
   buildInputs = [ zlib libpng ]
-      ++ lib.optionals stdenv.isDarwin [ Foundation SystemConfiguration ];
+    ++ lib.optionals stdenv.isDarwin [ Foundation SystemConfiguration ];
 
   meta = with lib; {
     description = "Converts HTML files to PostScript and PDF";

--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, zlib, libpng, SystemConfiguration, Foundation }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.11";
   pname = "htmldoc";
+  version = "1.9.11";
   src = fetchFromGitHub {
     owner = "michaelrsweet";
     repo = "htmldoc";

--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -1,29 +1,23 @@
-{ lib, stdenv, fetchurl
-
-, SystemConfiguration ? null, Foundation ? null
-}:
-
-assert stdenv.isDarwin -> SystemConfiguration != null
-                       && Foundation != null;
+{ lib, stdenv, fetchFromGitHub, zlib, libpng, SystemConfiguration, Foundation }:
 
 stdenv.mkDerivation rec {
-  version = "1.8.29";
+  version = "1.9.11";
   pname = "htmldoc";
-  src = fetchurl {
-    url = "https://github.com/michaelrsweet/htmldoc/releases/download"
-      + "/release-${version}/htmldoc-${version}-source.tar.gz";
-    sha256 = "15x0xdf487j4i4gfap5yr83airxnbp2v4lxaz79a4s3iirrq39p0";
+  src = fetchFromGitHub {
+    owner = "michaelrsweet";
+    repo = "htmldoc";
+    rev = "v${version}";
+    sha256 = "0660829zjfdm6vzx14z7gvsfipsb7h0z74gbkyp2ncg3g2432s4n";
   };
-  buildInputs = with stdenv;
-       lib.optional isDarwin SystemConfiguration
-    ++ lib.optional isDarwin Foundation;
+  buildInputs = [ zlib libpng ]
+      ++ lib.optionals stdenv.isDarwin [ Foundation SystemConfiguration ];
 
   meta = with lib; {
     description = "Converts HTML files to PostScript and PDF";
     homepage    = "https://michaelrsweet.github.io/htmldoc";
-    license     = licenses.gpl2;
+    license     = licenses.gpl2Only;
     maintainers = with maintainers; [ shanemikel ];
-    platforms   = with platforms; linux ++ darwin;
+    platforms   = platforms.unix;
 
     longDescription = ''
       HTMLDOC is a program that reads HTML source files or web pages and


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-20308.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>htmldoc</li>
  </ul>
</details>
