### PR TITLE
home-assistant-cli: 0.9.1 -> 0.9.3; python3Packages.jsonpath-ng: fix build

### DIFF
--- a/pkgs/development/python-modules/jsonpath-ng/default.nix
+++ b/pkgs/development/python-modules/jsonpath-ng/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
 
-  disabledTestFiles = [
+  disabledTestPaths = [
     # Exclude tests that require oslotest
     "tests/test_jsonpath_rw_ext.py"
   ];

--- a/pkgs/servers/home-assistant/cli.nix
+++ b/pkgs/servers/home-assistant/cli.nix
@@ -1,12 +1,14 @@
-{ lib, python3 }:
+{ lib
+, python3
+}:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "homeassistant-cli";
-  version = "0.9.1";
+  version = "0.9.3";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "1a31ky2p5w8byf0bjgma6xi328jj690qqksm3dwbi3v8dpqvghgf";
+    sha256 = "18h6bc99skzb0a1pffb6lr2z04928srrcz1w2zy66bndasic5yfs";
   };
 
   postPatch = ''
@@ -15,7 +17,17 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = with python3.pkgs; [
-    requests netdisco click click-log tabulate jsonpath_rw jinja2 dateparser regex ruamel_yaml aiohttp
+    aiohttp
+    click
+    click-log
+    dateparser
+    jinja2
+    jsonpath-ng
+    netdisco
+    regex
+    requests
+    ruamel-yaml
+    tabulate
   ];
 
   postInstall = ''
@@ -25,16 +37,14 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   checkInputs = with python3.pkgs; [
-    pytest requests-mock
+    pytestCheckHook
+    requests-mock
   ];
-
-  checkPhase = ''
-    pytest
-  '';
 
   meta = with lib; {
     description = "Command-line tool for Home Assistant";
     homepage = "https://github.com/home-assistant/home-assistant-cli";
+    changelog = "https://github.com/home-assistant-ecosystem/home-assistant-cli/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = teams.home-assistant.members;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant-ecosystem/home-assistant-cli/releases/tag/0.9.3
https://github.com/home-assistant-ecosystem/home-assistant-cli/releases/tag/0.9.2

Noticed jsonpath-ng was still using disabledTestFiles, which broke the tests.

It would be awesome if we could test hass-cli in nixosTests.home-assistant, but I'm not sure how we would go about creating a long-lived token in there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
