### PR TITLE
Adding a step in the installation documentation for Legacy Boot.

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -171,7 +171,7 @@
     <note>
      <para>
       You can safely ignore <command>parted</command>'s informational message
-      about needing to update /etc/fstab.
+      about needing to update /etc/fstab and about partition alignment.
      </para>
     </note>
    </para>
@@ -189,6 +189,12 @@
        Add the <emphasis>root</emphasis> partition. This will fill the the disk
        except for the end part, where the swap will live.
 <screen language="commands"><prompt># </prompt>parted /dev/sda -- mkpart primary 1MiB -8GiB</screen>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       Set it bootable. NixOS won't be able to boot if you don't set this flag.
+       <screen language="command"><prompt># </prompt>parted /dev/sda -- set 1 boot on</screen>
       </para>
      </listitem>
      <listitem>


### PR DESCRIPTION
Adding an instruction for Legacy Boot partition making: setting the bootable flag. Also added comment about ignoring a warning that `parted` shows, but that is not problematic.


###### Motivation for this change

I have tried to install NixOS following the manual, and saw there was a step missing (without it my computer wouldn't boot).

###### Things done

This is only a change in the documentation, so no testing is really required...

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
