### PR TITLE
pythonPackages.cxxfilt: init at 0.2.2

### DIFF
--- a/pkgs/development/python-modules/cxxfilt/default.nix
+++ b/pkgs/development/python-modules/cxxfilt/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, libcxx }:
+
+buildPythonPackage rec {
+  pname = "cxxfilt";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0az9d4ncr38fb43wv6rzq072f7gxxvcf4wb3p48mrj8ndpki0s7g";
+  };
+
+  postPatch = ''
+    substituteInPlace ./cxxfilt/__init__.py \
+      --replace "find_any_library('stdc++', 'c++')" "\"${libcxx}/lib/libc++.so.1\""
+  '';
+
+  meta = with lib; {
+    description = "Demangling C++ symbols in Python / interface to abi::__cxa_demangle";
+    homepage = "https://github.com/afq984/python-cxxfilt";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.bsd2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1658,6 +1658,8 @@ in {
 
   cx_oracle = callPackage ../development/python-modules/cx_oracle { };
 
+  cxxfilt = callPackage ../development/python-modules/cxxfilt { };
+
   cycler = callPackage ../development/python-modules/cycler { };
 
   cymem = callPackage ../development/python-modules/cymem { };


### PR DESCRIPTION
Adds the cxxfilt Python package for demangling C++ symbols in
Python (interfacing to abi::__cxa_demangle).

It appears to work with both Python 2 and Python 3, although I could
only test it using Python 3.

The package uses its own mechanism on top of ctypes for discovering a
C++ standard library. With Nix this does not seem to work though, and
hence the absolute path of the shared object is specified
instead. This should also make Nix pick up this library as a runtime
dependency of the package. A simple substituteInPlace of the
respective Python method invocation seems fine here, as using a proper
patch would've required a substitution for the path anyways.

Signed-off-by: Leon Schuermann <leon@is.currently.online>
Reviewed-by: William Casarin <jb55@jb55.com>
Tested-by: William Casarin <jb55@jb55.com>
Reviewed-by: Matthias Beyer <mail@beyermatthias.de>
Link: https://lists.sr.ht/~andir/nixpkgs-dev/%3C20210410113406.349-1-leon@is.currently.online%3E
