### PR TITLE
nix-du: 0.3.3 -> 0.3.4

### DIFF
--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     boost
     nix
-  ] ++ lib.optional stdenv.isDarwin Security;
+  ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -1,17 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, nix, boost, graphviz, darwin }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform, nix, boost, graphviz, Security, pkg-config }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-du";
-  version = "0.3.3";
+  version = "0.3.4";
 
   src = fetchFromGitHub {
     owner = "symphorien";
     repo = "nix-du";
     rev = "v${version}";
-    sha256 = "0h8ya0nn65hbyi3ssmrjarfxadx2sa61sspjlrln8knk7ppxk3mq";
+    sha256 = "0iwlprjbphwsrxdhgsxa8ja73snsyh0rdxrpsf1ygid2ky5vc83f";
   };
 
-  cargoSha256 = "0d86bn6myr29bwrzw3ihnzg1yij673s80bm1l8srk2k2szyfwwh5";
+  cargoSha256 = "19fwkw9iswzkhqgfq7pmcabqmq5c7vvirwaxbfjshkwcgn47rgjl";
 
   doCheck = true;
   checkInputs = [ nix graphviz ];
@@ -19,12 +19,14 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     boost
     nix
-  ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+  ] ++ lib.optional stdenv.isDarwin Security;
+
+  nativeBuildInputs = [ pkg-config ];
 
   meta = with lib; {
     description = "A tool to determine which gc-roots take space in your nix store";
     homepage = "https://github.com/symphorien/nix-du";
-    license = licenses.lgpl3;
+    license = licenses.lgpl3Only;
     maintainers = [ maintainers.symphorien ];
     platforms = platforms.unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29861,7 +29861,9 @@ in
   nix-deploy = haskell.lib.justStaticExecutables haskellPackages.nix-deploy;
   nix-diff = haskell.lib.justStaticExecutables haskellPackages.nix-diff;
 
-  nix-du = callPackage ../tools/package-management/nix-du { };
+  nix-du = callPackage ../tools/package-management/nix-du {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   nix-info = callPackage ../tools/nix/info { };
   nix-info-tested = nix-info.override { doCheck = true; };


### PR DESCRIPTION
###### Motivation for this change

update (takes keep-output and keep-derivations into account)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
