### PR TITLE
agi: init at 1.1.0-dev-20210413

### DIFF
--- a/pkgs/tools/graphics/agi/default.nix
+++ b/pkgs/tools/graphics/agi/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, fetchzip
+, autoPatchelfHook
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+, wrapGAppsHook
+, gobject-introspection
+, gdk-pixbuf
+, jre
+, androidenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "agi";
+  version = "1.1.0-dev-20210413";
+
+  src = fetchzip {
+    url = "https://github.com/google/agi-dev-releases/releases/download/v${version}/agi-${version}-linux.zip";
+    sha256 = "13i6n95d0cjrhx68qsich6xzk5f9ga0y3m19k4z2d58s164rnh0v";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    wrapGAppsHook
+    gdk-pixbuf
+    gobject-introspection
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,lib}
+    cp ./{agi,gapis,gapir,gapit,device-info} $out/bin
+    cp lib/gapic.jar $out/lib
+    wrapProgram $out/bin/agi \
+      --add-flags "--vm ${jre}/bin/java" \
+      --add-flags "--jar $out/lib/gapic.jar" \
+      --add-flags "--adb ${androidenv.androidPkgs_9_0.platform-tools}/bin/adb"
+    for i in 16 32 48 64 96 128 256 512 1024; do
+      install -D ${src}/icon.png $out/share/icons/hicolor/''${i}x$i/apps/agi.png
+    done
+    runHook postInstall
+  '';
+
+  desktopItems = [(makeDesktopItem {
+    name = "agi";
+    desktopName = "Android GPU Inspector";
+    exec = "$out/bin/agi";
+    icon = "agi";
+    type = "Application";
+    categories = "Development;Debugger;Graphics;3DGraphics";
+    terminal = "false";
+  })];
+
+  meta = with lib; {
+    homepage = "https://github.com/google/agi/";
+    description = "Android GPU Inspector";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -749,6 +749,8 @@ in
 
   agda-pkg = callPackage ../development/tools/agda-pkg { };
 
+  agi = callPackage ../tools/graphics/agi { };
+
   agrep = callPackage ../tools/text/agrep { };
 
   aha = callPackage ../tools/text/aha { };


### PR DESCRIPTION
###### Motivation for this change
Building this has proven to be a bit of a pain, so for now I'm just patching the binary.

Testing is much appreciated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
