### PR TITLE
helm-secrets: 3.5.0 -> 3.6.1

### DIFF
--- a/pkgs/applications/networking/cluster/helm/plugins/helm-secrets.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-secrets.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "helm-secrets";
-  version = "3.5.0";
+  version = "3.6.1";
 
   src = fetchFromGitHub {
     owner = "jkroepke";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-EXCr0QjupsBBKTm6Opw5bcNwAD4FGGyOiqaa8L91/OI=";
+    hash = "sha256-RACETma0AaqaAfe0HWC541/i+knr+emMUauFWnkEuMI=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Upgrade to the [latest release](https://github.com/jkroepke/helm-secrets/blob/v3.6.1/CHANGELOG.md#361---2021-03-30).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
