### PR TITLE
python3Packages.tables: fix usage, add tests

### DIFF
--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -1,9 +1,26 @@
-{ lib, fetchPypi, python, buildPythonPackage, isPy38
-, cython, bzip2, lzo, numpy, numexpr, hdf5, six, c-blosc, mock }:
+{ lib
+, fetchPypi
+, fetchurl
+, fetchpatch
+, buildPythonPackage
+, pythonOlder
+, python
+, bzip2
+, c-blosc
+, cython
+, hdf5
+, lzo
+, numpy
+, numexpr
+, setuptools
+  # Test inputs
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
-  version = "3.6.1";
   pname = "tables";
+  version = "3.6.1";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
@@ -12,12 +29,33 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ cython ];
 
-  buildInputs = [ hdf5 bzip2 lzo c-blosc ];
-  propagatedBuildInputs = [ numpy numexpr six mock ];
+  buildInputs = [
+    bzip2
+    c-blosc
+    hdf5
+    lzo
+  ];
+  propagatedBuildInputs = [
+    numpy
+    numexpr
+    setuptools  # uses pkg_resources at runtime
+  ];
 
+  patches = [
+    (fetchpatch {
+      # Needed for numpy >= 1.20.0
+      name = "tables-pr-862-use-lowercase-numpy-dtypes.patch";
+      url = "https://github.com/PyTables/PyTables/commit/93a3272b8fe754095637628b4d312400e24ae654.patch";
+      sha256 = "00czgxnm1dxp9763va9xw1nc7dd7kxh9hjcg9klim52519hkbhi4";
+    })
+  ];
   # When doing `make distclean`, ignore docs
   postPatch = ''
     substituteInPlace Makefile --replace "src doc" "src"
+    # Force test suite to error when unittest runner fails
+    substituteInPlace tables/tests/test_suite.py \
+      --replace "return 0" "assert result.wasSuccessful(); return 0" \
+      --replace "return 1" "assert result.wasSuccessful(); return 1"
   '';
 
   # Regenerate C code with Cython
@@ -25,44 +63,29 @@ buildPythonPackage rec {
     make distclean
   '';
 
-  # The setup script complains about missing run-paths, but they are
-  # actually set.
   setupPyBuildFlags = [
     "--hdf5=${lib.getDev hdf5}"
     "--lzo=${lib.getDev lzo}"
     "--bzip2=${lib.getDev bzip2}"
     "--blosc=${lib.getDev c-blosc}"
   ];
-  # Run the test suite.
-  # It requires the build path to be in the python search path.
-  # These tests take quite some time.
-  # If the hdf5 library is built with zlib then there is only one
-  # test-failure. That is the same failure as described in the following
-  # github issue:
-  #     https://github.com/PyTables/PyTables/issues/269
-  checkPhase = ''
-    ${python.interpreter} <<EOF
-    import sysconfig
-    import sys
-    import os
-    f = "lib.{platform}-{version[0]}.{version[1]}"
-    lib = f.format(platform=sysconfig.get_platform(),
-                   version=sys.version_info)
-    build = os.path.join(os.getcwd(), 'build', lib)
-    sys.path.insert(0, build)
-    import tables
-    r = tables.test()
-    if not r.wasSuccessful():
-        sys.exit(1)
-    EOF
-  '';
 
-  # Disable tests until the failure described above is fixed.
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
+  preCheck = ''
+    cd ..
+  '';
+  # Runs the test suite as one single test via unittest. The whole "heavy" test suite supposedly takes ~5 hours to run.
+  pytestFlagsArray = [
+    "--pyargs"
+    "tables.tests.test_suite"
+  ];
+
+  pythonImportsCheck = [ "tables" ];
 
   meta = with lib; {
     description = "Hierarchical datasets for Python";
-    homepage = "http://www.pytables.org/";
+    homepage = "https://www.pytables.org/";
     license = licenses.bsd2;
+    maintainers = with maintainers; [ drewrisinger ];
   };
 }

--- a/pkgs/tools/misc/hdf5/1.10.nix
+++ b/pkgs/tools/misc/hdf5/1.10.nix
@@ -8,11 +8,12 @@
 let inherit (lib) optional optionals; in
 
 stdenv.mkDerivation rec {
-  version = "1.10.7";
+  # pinned to 1.10.6 for pythonPackages.tables v3.6.1. tables has test errors for hdf5 > 1.10.6. https://github.com/PyTables/PyTables/issues/845
+  version = "1.10.6";
   pname = "hdf5";
   src = fetchurl {
     url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${lib.versions.majorMinor version}/${pname}-${version}/src/${pname}-${version}.tar.bz2";
-    sha256 = "0pm5xxry55i0h7wmvc7svzdaa90rnk7h78rrjmnlkz2ygsn8y082";
+    sha256 = "1gf38x51128hn00744358w27xgzjk0ff4wra4yxh2lk804ck1mh9";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

While trying to open a HDF5 file via ``python3Packages.pandas``, realized that pandas' HDF5 functionality was broken b/c ``python3Packages.tables`` wasn't importing.

The main failure I was having was due to setuptools not being installed at runtime (couldn't import ``pkg_resources``), but also noticed that tests weren't being run.
Trying to run the tests found that ``tables`` wasn't compatible with ``hdf5 v1.10.7`` (https://github.com/PyTables/PyTables/issues/845). ``tables`` seems to be the only package using ``hdf5_1_10`` (https://github.com/NixOS/nixpkgs/blob/311ceed827f531f88f46222920cd1ebb2c101f73/pkgs/top-level/python-packages.nix#L8232-L8239), so maybe we just revert the version of ``hdf5_1_10`` to ``v1.10.5``?

**I know this probably needs a little bit of work/cleanup, just wanted to get some opinions on this.**

Things tried:
* [x] building tables with hdf v1.12.X (latest in master). Produces a segfault
* [x] building tables with hdf5 v1.10.7. See https://github.com/PyTables/PyTables/issues/845.
* [x] building tables with hdf5 v1.10.6. This didn't work, but I don't remember exact issue. _Edit: this does work when combined with the other test fixes_
* [x] building tables with hdf5 v1.10.5. This did work.

Improvements:
* Update website address to HTTPS
* Add ``pythonImportsCheck``
* Run tests (via ``pytestCheckHook``)
* Add myself as maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
