### PR TITLE
e16: init at 1.0.23

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -15,6 +15,7 @@ in
     ./cwm.nix
     ./clfswm.nix
     ./dwm.nix
+    ./e16.nix
     ./evilwm.nix
     ./exwm.nix
     ./fluxbox.nix

--- a/nixos/modules/services/x11/window-managers/e16.nix
+++ b/nixos/modules/services/x11/window-managers/e16.nix
@@ -1,0 +1,26 @@
+{ config , lib , pkgs , ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.e16;
+in
+{
+  ###### interface
+  options = {
+    services.xserver.windowManager.e16.enable = mkEnableOption "e16";
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "E16";
+      start = ''
+        ${pkgs.e16}/bin/e16 &
+        waitPID=$!
+      '';
+    };
+
+    environment.systemPackages = [ pkgs.e16 ];
+  };
+}

--- a/pkgs/applications/window-managers/e16/default.nix
+++ b/pkgs/applications/window-managers/e16/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, freetype
+, imlib2
+, libSM
+, libXcomposite
+, libXdamage
+, libXext
+, libXfixes
+, libXft
+, libXinerama
+, libXrandr
+, libpulseaudio
+, libsndfile
+, pango
+, perl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "e16";
+  version = "1.0.23";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/enlightenment/e16-${version}.tar.xz";
+    sha256 = "028rn1plggacsvdd035qnnph4xw8nya34mmjvvl7d4gqj9pj293f";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    freetype
+    imlib2
+    libSM
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXft
+    libXinerama
+    libXrandr
+    libpulseaudio
+    libsndfile
+    pango
+    perl
+  ];
+
+  postPatch = ''
+    substituteInPlace scripts/e_gen_menu --replace "/usr/local:" "/run/current-system/sw:/usr/local:"
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.enlightenment.org/e16";
+    description = "Enlightenment DR16 window manager";
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22475,6 +22475,8 @@ in
 
   dzen2 = callPackage ../applications/window-managers/dzen2 { };
 
+  e16 = callPackage ../applications/window-managers/e16 { };
+
   eaglemode = callPackage ../applications/misc/eaglemode { };
 
   ebumeter = callPackage ../applications/audio/ebumeter { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [E16](https://www.enlightenment.org/e16).

> ### About E16
> E16 is predecessor of the current E24 Enlightenment Window Manager, which is rather complete rewrite than incremental update of E16. Although most of the current development focus goes to E24, E16 is still under independent active development and some users prefer it to E24. In this sense E16 will keep its name while incrementing the versions from 1.0.0 unlike the mainstream Enlightenment manager, which is likely going to increment its E-suffix number.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
