### PR TITLE
[experiment] try using `settings` for peertube

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -924,6 +924,7 @@
   ./services/web-apps/moodle.nix
   ./services/web-apps/nextcloud.nix
   ./services/web-apps/nexus.nix
+  ./services/web-apps/peertube.nix
   ./services/web-apps/plantuml-server.nix
   ./services/web-apps/pgpkeyserver-lite.nix
   ./services/web-apps/matomo.nix

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -9,7 +9,7 @@ let
 
     webserver:
       https: ${toString (if cfg.enableWebHttps then "true" else "false")}
-      hostname: '${cfg.LocalDomain}'
+      hostname: '${cfg.localDomain}'
       port: ${toString cfg.listenWeb}
 
     database:
@@ -87,7 +87,7 @@ in {
 
     localDomain = lib.mkOption {
       type = lib.types.str;
-      default = "example.com";
+      example = "peertube.example.com";
       description = "The domain serving your PeerTube instance.";
     };
 

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -219,19 +219,19 @@ in {
 
     services.peertube.settings = {
       storage = {
-        tmp = "/var/lib/peertube/storage/tmp/";
-        avatars = "/var/lib/peertube/storage/avatars/";
-        videos = "/var/lib/peertube/storage/videos/";
-        streaming_playlists = "/var/lib/peertube/storage/streaming-playlists/";
-        redundancy = "/var/lib/peertube/storage/redundancy/";
-        logs = "/var/lib/peertube/storage/logs/";
-        previews = "/var/lib/peertube/storage/previews/";
-        thumbnails = "/var/lib/peertube/storage/thumbnails/";
-        torrents = "/var/lib/peertube/storage/torrents/";
-        captions = "/var/lib/peertube/storage/captions/";
-        cache = "/var/lib/peertube/storage/cache/";
-        plugins = "/var/lib/peertube/storage/plugins/";
-        client_overrides = "/var/lib/peertube/storage/client-overrides/";
+        tmp = lib.mkDefault "/var/lib/peertube/storage/tmp/";
+        avatars = lib.mkDefault "/var/lib/peertube/storage/avatars/";
+        videos = lib.mkDefault "/var/lib/peertube/storage/videos/";
+        streaming_playlists = lib.mkDefault "/var/lib/peertube/storage/streaming-playlists/";
+        redundancy = lib.mkDefault "/var/lib/peertube/storage/redundancy/";
+        logs = lib.mkDefault "/var/lib/peertube/storage/logs/";
+        previews = lib.mkDefault "/var/lib/peertube/storage/previews/";
+        thumbnails = lib.mkDefault "/var/lib/peertube/storage/thumbnails/";
+        torrents = lib.mkDefault "/var/lib/peertube/storage/torrents/";
+        captions = lib.mkDefault "/var/lib/peertube/storage/captions/";
+        cache = lib.mkDefault "/var/lib/peertube/storage/cache/";
+        plugins = lib.mkDefault "/var/lib/peertube/storage/plugins/";
+        client_overrides = lib.mkDefault "/var/lib/peertube/storage/client-overrides/";
       };
     };
 

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -1,0 +1,387 @@
+{ lib, pkgs, config, ... }:
+
+let
+  cfg = config.services.peertube;
+
+  configFile = pkgs.writeText  "production.yaml" ''
+    listen:
+      port: ${toString cfg.listenHttp}
+
+    webserver:
+      https: ${toString (if cfg.enableWebHttps then "true" else "false")}
+      hostname: '${cfg.LocalDomain}'
+      port: ${toString cfg.listenWeb}
+
+    database:
+      hostname: '${cfg.database.host}'
+      port: ${toString cfg.database.port}
+      name: '${cfg.database.name}'
+      username: '${cfg.database.user}'
+
+    redis:
+      hostname: ${toString cfg.redis.host}
+      port: ${toString cfg.redis.port}
+      ${lib.optionalString cfg.redis.enableUnixSocket "socket: '/run/redis/redis.sock'"}
+
+    storage:
+      tmp: '/var/lib/peertube/storage/tmp/'
+      avatars: '/var/lib/peertube/storage/avatars/'
+      videos: '/var/lib/peertube/storage/videos/'
+      streaming_playlists: '/var/lib/peertube/storage/streaming-playlists/'
+      redundancy: '/var/lib/peertube/storage/redundancy/'
+      logs: '/var/lib/peertube/storage/logs/'
+      previews: '/var/lib/peertube/storage/previews/'
+      thumbnails: '/var/lib/peertube/storage/thumbnails/'
+      torrents: '/var/lib/peertube/storage/torrents/'
+      captions: '/var/lib/peertube/storage/captions/'
+      cache: '/var/lib/peertube/storage/cache/'
+      plugins: '/var/lib/peertube/storage/plugins/'
+      client_overrides: '/var/lib/peertube/storage/client-overrides/'
+
+    ${cfg.extraConfig}
+  '';
+
+  cfgService = {
+    # Access write directories
+    UMask = "0027";
+    # Capabilities
+    CapabilityBoundingSet = "";
+    # Security
+    NoNewPrivileges = true;
+    # Sandboxing
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    PrivateUsers = true;
+    ProtectClock = true;
+    ProtectHostname = true;
+    ProtectKernelLogs = true;
+    ProtectKernelModules = true;
+    ProtectKernelTunables = true;
+    ProtectControlGroups = true;
+    RestrictNamespaces = true;
+    LockPersonality = true;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    PrivateMounts = true;
+    # System Call Filtering
+    SystemCallArchitectures = "native";
+  };
+
+in {
+  options.services.peertube = {
+    enable = lib.mkEnableOption "Enable Peertube’s service";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "peertube";
+      description = "User account under which Peertube runs";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "peertube";
+      description = "Group under which Peertube runs";
+    };
+
+    localDomain = lib.mkOption {
+      type = lib.types.str;
+      default = "example.com";
+      description = "The domain serving your PeerTube instance.";
+    };
+
+    listenHttp = lib.mkOption {
+      type = lib.types.int;
+      default = 9000;
+      description = "listen port for HTTP server";
+    };
+
+    listenWeb = lib.mkOption {
+      type = lib.types.int;
+      default = 443;
+      description = "listen port for WEB server";
+    };
+
+    enableWebHttps = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable or disable HTTPS protocol";
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = ''
+        listen:
+          hostname: '0.0.0.0'
+        trust_proxy:
+          - '192.168.10.21'
+        log:
+          level: 'debug'
+      '';
+      description = "Extra config options for peertube";
+    };
+
+    serviceEnvironmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/keys/peertube/password-init-root";
+      description = ''
+        Set environment variables for the service. Mainly useful for setting the initial root password.
+        For example write to file:
+        PT_INITIAL_ROOT_PASSWORD=changeme
+      '';
+    };
+
+    database = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Configure local PostgreSQL database server for PeerTube";
+      };
+
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = if cfg.database.createLocally then "/run/postgresql" else null;
+        example = "192.168.15.47";
+        description = "Database host address or unix socket";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.int;
+        default = 5432;
+        description = "Database host port";
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "peertube";
+        description = "Database name";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "peertube";
+        description = "Database user";
+      };
+
+      passwordFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/keys/peertube/password-posgressql-db";
+        description = "Password for PostgreSQL database";
+      };
+    };
+
+    redis = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Configure local Redis server for PeerTube";
+      };
+
+      host = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = if cfg.redis.createLocally && !cfg.redis.enableUnixSocket then "127.0.0.1" else null;
+        description = "Redis host";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.nullOr lib.types.port;
+        default = if cfg.redis.createLocally && cfg.redis.enableUnixSocket then null else 6379;
+        description = "Redis port";
+      };
+
+      passwordFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/keys/peertube/password-redis-db";
+        description = "Password for redis database";
+      };
+
+      enableUnixSocket = lib.mkOption {
+        type = lib.types.bool;
+        default = cfg.redis.createLocally;
+        description = "Use Unix socket";
+      };
+    };
+
+    smtp = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Configure local Postfix SMTP server for PeerTube";
+      };
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.peertube;
+      description = "Peertube package to use";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      { assertion = cfg.serviceEnvironmentFile == null || !lib.hasPrefix builtins.storeDir cfg.serviceEnvironmentFile;
+          message = ''
+            <option>services.peertube.serviceEnvironmentFile</option> points to
+            a file in the Nix store. You should use a quoted absolute path to
+            prevent this.
+          '';
+      }
+      { assertion = !(cfg.redis.enableUnixSocket && (cfg.redis.host != null || cfg.redis.port != null));
+          message = ''
+            <option>services.peertube.redis.createLocally</option> and redis network connection (<option>services.peertube.redis.host</option> or <option>services.peertube.redis.port</option>) enabled. Disable either of them.
+        '';
+      }
+      { assertion = cfg.redis.enableUnixSocket || (cfg.redis.host != null && cfg.redis.port != null);
+          message = ''
+            <option>services.peertube.redis.host</option> and <option>services.peertube.redis.port</option> needs to be set if <option>services.peertube.redis.enableUnixSocket</option> is not enabled.
+        '';
+      }
+      { assertion = cfg.redis.passwordFile == null || !lib.hasPrefix builtins.storeDir cfg.redis.passwordFile;
+          message = ''
+            <option>services.peertube.redis.passwordFile</option> points to
+            a file in the Nix store. You should use a quoted absolute path to
+            prevent this.
+          '';
+      }
+      { assertion = cfg.database.passwordFile == null || !lib.hasPrefix builtins.storeDir cfg.database.passwordFile;
+          message = ''
+            <option>services.peertube.database.passwordFile</option> points to
+            a file in the Nix store. You should use a quoted absolute path to
+            prevent this.
+          '';
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d '/var/lib/peertube/config' 0700 ${cfg.user} ${cfg.group} - -"
+      "z '/var/lib/peertube/config' 0700 ${cfg.user} ${cfg.group} - -"
+      "d '/var/lib/peertube/storage' 0750 ${cfg.user} ${cfg.group} - -"
+      "z '/var/lib/peertube/storage' 0750 ${cfg.user} ${cfg.group} - -"
+    ];
+
+    systemd.services.peertube-init-db = lib.mkIf cfg.database.createLocally {
+      description = "Initialization database for PeerTube daemon";
+      after = [ "network.target" "postgresql.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      script = let
+        psqlSetupCommands = pkgs.writeText "peertube-init.sql" ''
+          SELECT 'CREATE USER "${cfg.database.user}"' WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${cfg.database.user}')\gexec
+          SELECT 'CREATE DATABASE "${cfg.database.name}" OWNER "${cfg.database.user}" TEMPLATE template0 ENCODING UTF8' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${cfg.database.name}')\gexec
+          \c '${cfg.database.name}'
+          CREATE EXTENSION IF NOT EXISTS pg_trgm;
+          CREATE EXTENSION IF NOT EXISTS unaccent;
+        '';
+      in "${config.services.postgresql.package}/bin/psql -f ${psqlSetupCommands}";
+
+      serviceConfig = {
+        Type = "oneshot";
+        WorkingDirectory = cfg.package;
+        # User and group
+        User = "postgres";
+        Group = "postgres";
+        # Sandboxing
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        MemoryDenyWriteExecute = true;
+        # System Call Filtering
+        SystemCallFilter = "~@clock @cpu-emulation @debug @keyring @memlock @module @mount @obsolete @privileged @raw-io @reboot @resources @setuid @swap";
+      } // cfgService;
+    };
+
+    systemd.services.peertube = {
+      description = "PeerTube daemon";
+      after = [ "network.target" ]
+        ++ lib.optionals cfg.redis.createLocally [ "redis.service" ]
+        ++ lib.optionals cfg.database.createLocally [ "postgresql.service" "peertube-init-db.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment.NODE_CONFIG_DIR = "/var/lib/peertube/config";
+      environment.NODE_ENV = "production";
+      environment.NODE_EXTRA_CA_CERTS = "/etc/ssl/certs/ca-certificates.crt";
+      environment.HOME = cfg.package;
+
+      path = with pkgs; [ bashInteractive ffmpeg nodejs openssl yarn youtube-dl ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStartPre = let preStartScript = pkgs.writeScript "peertube-pre-start.sh" ''
+          #!/bin/sh
+          umask 077
+          cat > /var/lib/peertube/config/local.yaml <<EOF
+          ${lib.optionalString ((!cfg.database.createLocally) && (cfg.database.passwordFile != null)) ''
+          database:
+            password: '$(cat ${cfg.database.passwordFile})'
+          ''}
+          ${lib.optionalString (cfg.redis.passwordFile != null) ''
+          redis:
+            auth: '$(cat ${cfg.redis.passwordFile})'
+          ''}
+          EOF
+          ln -sf ${cfg.package}/config/default.yaml /var/lib/peertube/config/default.yaml
+          ln -sf ${configFile} /var/lib/peertube/config/production.yaml
+        '';
+        in "${preStartScript}";
+        ExecStart = let startScript = pkgs.writeScript "peertube-start.sh" ''
+          #!/bin/sh
+          exec npm start
+        '';
+        in "${startScript}";
+        Restart = "always";
+        RestartSec = 20;
+        TimeoutSec = 60;
+        WorkingDirectory = cfg.package;
+        # User and group
+        User = cfg.user;
+        Group = cfg.group;
+        # State directory and mode
+        StateDirectory = "peertube";
+        StateDirectoryMode = "0750";
+        # Environment
+        EnvironmentFile = cfg.serviceEnvironmentFile;
+        # Sandboxing
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+        MemoryDenyWriteExecute = false;
+        # System Call Filtering
+        SystemCallFilter = "~@clock @cpu-emulation @debug @keyring @memlock @module @mount @obsolete @privileged @raw-io @reboot @setuid @swap";
+      } // cfgService;
+    };
+
+    services.postgresql = lib.mkIf cfg.database.createLocally {
+      enable = true;
+    };
+
+    services.redis = lib.mkMerge [
+      (lib.mkIf cfg.redis.createLocally {
+        enable = true;
+      })
+      (lib.mkIf (cfg.redis.createLocally && cfg.redis.enableUnixSocket) {
+        unixSocket = "/run/redis/redis.sock";
+        unixSocketPerm = 770;
+      })
+    ];
+
+    services.postfix = lib.mkIf cfg.smtp.createLocally {
+      enable = true;
+      hostname = lib.mkDefault "${cfg.localDomain}";
+    };
+
+    users.users = lib.mkMerge [
+      (lib.mkIf (cfg.user == "peertube") {
+        peertube = {
+          isSystemUser = true;
+          group = cfg.group;
+        };
+      })
+      (lib.mkIf cfg.redis.enableUnixSocket {${config.services.peertube.user}.extraGroups = [ "redis" ];})
+    ];
+
+    users.groups = lib.optionalAttrs (cfg.group == "peertube") {
+      peertube = { };
+    };
+  };
+}

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -48,32 +48,36 @@ in {
       description = "Group under which Peertube runs";
     };
 
-    localDomain = lib.mkOption {
-      type = lib.types.str;
-      example = "peertube.example.com";
-      description = "The domain serving your PeerTube instance.";
-    };
-
-    listenHttp = lib.mkOption {
-      type = lib.types.int;
-      default = 9000;
-      description = "listen port for HTTP server";
-    };
-
-    listenWeb = lib.mkOption {
-      type = lib.types.int;
-      default = 443;
-      description = "listen port for WEB server";
-    };
-
-    enableWebHttps = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Enable or disable HTTPS protocol";
-    };
-
     settings = lib.mkOption {
-      type = settingsFormat.type;
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        options.listen = {
+          port = lib.mkOption {
+            type = lib.types.port;
+            default = 9000;
+            description = "listen port for HTTP server";
+          };
+        };
+
+        options.webserver = {
+          https = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Enable or disable HTTPS protocol";
+          };
+          hostname = lib.mkOption {
+            type = lib.types.str;
+            default = null;
+            description = "Server name of reverse proxy";
+          };
+          port = lib.mkOption {
+            type = lib.types.port;
+            default = 443;
+            description = "listen port for WEB server";
+          };
+        };
+      };
       default = {};
       description = ''
         <link xlink:href="https://example.com/docs/foo">Configuration for peertube</link>
@@ -215,14 +219,6 @@ in {
     ];
 
     services.peertube.settings = {
-      listen = {
-        port = cfg.listenHttp;
-      };
-      webserver = {
-        https = cfg.enableWebHttps;
-        hostname = cfg.hostname;
-        port = cfg.listenWeb;
-      };
       redis = {
         hostname = cfg.redis.host;
         port = cfg.redis.port;

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -291,7 +291,7 @@ in {
           #!/bin/sh
           umask 077
           cat > /var/lib/peertube/config/local.yaml <<EOF
-          ${lib.optionalString ((!cfg.database.createLocally) && (cfg.database.passwordFile != null)) ''
+          ${lib.optionalString (cfg.database.passwordFile != null) ''
           database:
             password: '$(cat ${cfg.database.passwordFile})'
           ''}
@@ -322,7 +322,7 @@ in {
         # Environment
         EnvironmentFile = cfg.serviceEnvironmentFile;
         # Sandboxing
-        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
         MemoryDenyWriteExecute = false;
         # System Call Filtering
         SystemCallFilter = "~@clock @cpu-emulation @debug @keyring @memlock @module @mount @obsolete @privileged @raw-io @reboot @setuid @swap";
@@ -338,7 +338,7 @@ in {
         enable = true;
       })
       (lib.mkIf (cfg.redis.createLocally && cfg.settings.redis.socket != null) {
-        unixSocket = "/run/redis/redis.sock";
+        unixSocket = cfg.settings.redis.socket;
         unixSocketPerm = 770;
       })
     ];

--- a/pkgs/servers/peertube/client.nix
+++ b/pkgs/servers/peertube/client.nix
@@ -1,0 +1,30 @@
+{ yarnModulesConfig, mkYarnModulesFixed, server, sources, version, nodejs, stdenv }:
+rec {
+  modules = mkYarnModulesFixed rec {
+    inherit version;
+    pname = "peertube-client-yarn-modules";
+    name = "${pname}-${version}";
+    packageJSON = "${sources}/client/package.json";
+    yarnLock = "${sources}/client/yarn.lock";
+    pkgConfig = yarnModulesConfig;
+  };
+  dist = stdenv.mkDerivation {
+    inherit version;
+    pname = "peertube-client";
+    src = sources;
+    buildPhase = ''
+      ln -s ${server.modules}/node_modules .
+      cp -a ${modules}/node_modules client/
+      chmod -R +w client/node_modules
+      patchShebangs .
+      npm run build:client
+    '';
+
+    installPhase = ''
+      mkdir $out
+      cp -a client/dist $out
+    '';
+
+    buildInputs = [ nodejs ];
+  };
+}

--- a/pkgs/servers/peertube/default.nix
+++ b/pkgs/servers/peertube/default.nix
@@ -1,0 +1,121 @@
+{ light ? null, pkgs, stdenv, lib, fetchurl, fetchFromGitHub, callPackage
+, nodejs ? pkgs.nodejs-12_x
+, jq, youtube-dl, nodePackages, yarn2nix-moretea }:
+
+let
+  version = "3.0.1";
+
+  source = fetchFromGitHub {
+    owner = "Chocobozzz";
+    repo = "PeerTube";
+    rev = "v${version}";
+    sha256 = "bIXt5bQiBBlNDFXYzcdQA8qp4nse5epUx/XQOguDOX8=";
+  };
+
+  patchedSource = stdenv.mkDerivation {
+    pname = "peertube";
+    inherit version;
+    src = source;
+    phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+    patches = [ ./fix_yarn_lock.patch ];
+    installPhase = ''
+      mkdir $out
+      cp -a . $out/
+    '';
+  };
+  yarnModulesConfig = {
+    bcrypt = {
+      buildInputs = [ nodePackages.node-pre-gyp ];
+
+      postInstall = let
+        bcrypt_version = "5.0.0";
+        bcrypt_lib = fetchurl {
+          url = "https://github.com/kelektiv/node.bcrypt.js/releases/download/v${bcrypt_version}/bcrypt_lib-v${bcrypt_version}-napi-v3-linux-x64-glibc.tar.gz";
+          sha256 = "0j3p2px1xb17sw3gpm8l4apljajxxfflal1yy552mhpzhi21wccn";
+        };
+      in ''
+        if [ "${bcrypt_version}" != "$(cat package.json | ${jq}/bin/jq -r .version)" ]; then
+          echo "Mismatching version please update bcrypt in derivation"
+          false
+        fi
+        mkdir -p lib/binding && tar -C lib/binding -xf ${bcrypt_lib}
+        patchShebangs ../node-pre-gyp
+        npm run install
+      '';
+    };
+
+    utf-8-validate = {
+      buildInputs = [ nodePackages.node-gyp-build ];
+    };
+
+    youtube-dl = {
+      postInstall = ''
+        mkdir bin
+        ln -s ${youtube-dl}/bin/youtube-dl bin/youtube-dl
+        cat > bin/details <<EOF
+        {"version":"${youtube-dl.version}","path":null,"exec":"youtube-dl"}
+        EOF
+      '';
+    };
+  };
+
+  mkYarnModulesFixed = args: (yarn2nix-moretea.mkYarnModules args).overrideAttrs(old: {
+    # This hack permits to workaround the fact that the yarn.lock
+    # file doesn't respect the semver requirements
+    buildPhase = builtins.replaceStrings [" ./package.json"] [" /dev/null; cp deps/*/package.json ."] old.buildPhase;
+  });
+
+  server = callPackage ./server.nix {
+    inherit version yarnModulesConfig mkYarnModulesFixed;
+    sources = patchedSource;
+  };
+
+  client = callPackage ./client.nix {
+    inherit server version yarnModulesConfig mkYarnModulesFixed;
+    sources = patchedSource;
+  };
+
+in stdenv.mkDerivation rec {
+  inherit version;
+  pname = "peertube";
+  src = patchedSource;
+
+  buildPhase = ''
+    ln -s ${server.modules}/node_modules .
+    rm -rf dist && cp -a ${server.dist}/dist dist
+    rm -rf client/dist && cp -a ${client.dist}/dist client/
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp -a * $out
+    ln -s /tmp $out/.cache
+  '';
+
+  meta = {
+    description = "A free software to take back control of your videos";
+
+    longDescription = ''
+      PeerTube aspires to be a decentralized and free/libre alternative to video
+      broadcasting services.
+      PeerTube is not meant to become a huge platform that would centralize
+      videos from all around the world. Rather, it is a network of
+      inter-connected small videos hosters.
+      Anyone with a modicum of technical skills can host a PeerTube server, aka
+      an instance. Each instance hosts its users and their videos. In this way,
+      every instance is created, moderated and maintained independently by
+      various administrators.
+      You can still watch from your account videos hosted by other instances
+      though if the administrator of your instance had previously connected it
+      with other instances.
+    '';
+
+    license = lib.licenses.agpl3Plus;
+
+    homepage = "https://joinpeertube.org/";
+    platforms = lib.platforms.unix;
+
+    maintainers = with lib.maintainers; [ immae stevenroose ];
+  };
+}
+

--- a/pkgs/servers/peertube/fix_yarn_lock.patch
+++ b/pkgs/servers/peertube/fix_yarn_lock.patch
@@ -1,0 +1,28 @@
+diff --git a/client/yarn.lock b/client/yarn.lock
+index d27cdaec8..26706a9fc 100644
+--- a/client/yarn.lock
++++ b/client/yarn.lock
+@@ -5703,7 +5703,8 @@ http-errors@~1.7.2:
+ 
+ "http-node@github:feross/http-node#webtorrent":
+   version "1.2.0"
+-  resolved "https://codeload.github.com/feross/http-node/tar.gz/342ef8624495343ffd050bd0808b3750cf0e3974"
++  resolved "https://codeload.github.com/feross/http-node/tar.gz/342ef8624495343ffd050bd0808b3750cf0e3974#33fa312d37f0000b17acdb1a5086565400419a13"
++  integrity sha1-M/oxLTfwAAsXrNsaUIZWVABBmhM=
+   dependencies:
+     chrome-net "^3.3.3"
+     freelist "^1.0.3"
+diff --git a/yarn.lock b/yarn.lock
+index 61a2ea05e..c742276c7 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -3873,7 +3873,8 @@ http-errors@~1.7.2:
+ 
+ "http-node@github:feross/http-node#webtorrent":
+   version "1.2.0"
+-  resolved "https://codeload.github.com/feross/http-node/tar.gz/342ef8624495343ffd050bd0808b3750cf0e3974"
++  resolved "https://codeload.github.com/feross/http-node/tar.gz/342ef8624495343ffd050bd0808b3750cf0e3974#33fa312d37f0000b17acdb1a5086565400419a13"
++  integrity sha1-M/oxLTfwAAsXrNsaUIZWVABBmhM=
+   dependencies:
+     chrome-net "^3.3.3"
+     freelist "^1.0.3"

--- a/pkgs/servers/peertube/server.nix
+++ b/pkgs/servers/peertube/server.nix
@@ -1,0 +1,28 @@
+{ yarnModulesConfig, mkYarnModulesFixed, sources, version, nodejs, stdenv }:
+rec {
+  modules = mkYarnModulesFixed rec {
+    inherit version;
+    pname = "peertube-server-yarn-modules";
+    name = "${pname}-${version}";
+    packageJSON = "${sources}/package.json";
+    yarnLock = "${sources}/yarn.lock";
+    pkgConfig = yarnModulesConfig;
+  };
+  dist = stdenv.mkDerivation {
+    inherit version;
+    pname = "peertube-server";
+    src = sources;
+    buildPhase = ''
+      ln -s ${modules}/node_modules .
+      patchShebangs scripts/build/server.sh
+      npm run build:server
+    '';
+
+    installPhase = ''
+      mkdir $out
+      cp -a dist $out
+    '';
+
+    buildInputs = [ nodejs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25054,6 +25054,10 @@ in
 
   peek = callPackage ../applications/video/peek { };
 
+  peertube = callPackage ../servers/peertube {
+    nodejs = pkgs.nodejs-12_x;
+  };
+
   pflask = callPackage ../os-specific/linux/pflask {};
 
   pfsshell = callPackage ../tools/misc/pfsshell { };


### PR DESCRIPTION
###### Motivation for this change

###### Things done
Alternative idea to https://github.com/NixOS/nixpkgs/pull/119110

@Izorkin This probably won't make it - I just want to get some feedback regarding some problems with this approach and if that can be somehow improved. It would get a mess in the other PR.

@aanderse Pinging you is evil :D but it was your idea and I need some help. (Others are also welcome to help of course)

The important file is the module.
1. The problem is that some additional options for e.g. redis are needed that are not in the official peertube configuration (`createLocally` and `passwordFile` in this case). Should I use a) the current approach of splitting these up into two places, b) putting the options into settings where they are *currently* ignored by peertube, c) put all options that are usually needed outside of `settings` like before (inconsistent) or do you have another idea?
2. any idea how I can incoporate the `settings.storage` options without a lot of option declarations?
3. Is the way the passwords are read in now fine (the future encrypted nix secrets provisioning may unify this whole approach AFAICT)?
3. Anything else that comes to your mind in regard to the `settings` implementation?


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
