### PR TITLE
pythonPackages.amiibo-py: init at unstable-2021-01-16

### DIFF
--- a/pkgs/development/python-modules/amiibo-py/default.nix
+++ b/pkgs/development/python-modules/amiibo-py/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, aiohttp
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "amiibo-py";
+  version = "unstable-2021-01-16";
+  disabled = pythonOlder "3.5.3"; # Older versions are not supported upstream
+
+  src = fetchFromGitHub {
+    owner = "XiehCanCode";
+    repo = "amiibo.py";
+    rev = "4766037530f41ad11368240e994888d196783b83";
+    sha256 = "0ln8ykaws8c5fvzlzccn60mpbdbvxlhkp3nsvs2xqdbsqp270yv2";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    requests
+  ];
+
+  doCheck = false; # No tests are available upstream
+  pythonImportsCheck = [ "amiibo" ];
+
+  meta = with lib; {
+    description = "API Wrapper for amiiboapi.com";
+    homepage = "https://github.com/XiehCanCode/amiibo.py";
+    license = licenses.mit;
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -379,6 +379,8 @@ in {
 
   amcrest = callPackage ../development/python-modules/amcrest { };
 
+  amiibo-py = callPackage ../development/python-modules/amiibo-py { };
+
   amply = callPackage ../development/python-modules/amply { };
 
   amqp = callPackage ../development/python-modules/amqp { };


### PR DESCRIPTION
###### Motivation for this change
Fairly interesting python module I'd love to have available in nixpkgs.

Note that I am fetching from Github instead of pypy because the build pushed onto there fails, as it cannot find `requirements.txt`. The latest commit on Github did not have this issue, so I just used that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
