### PR TITLE
unipicker: unstable-2018-07-10 -> 2.0.1

### DIFF
--- a/pkgs/applications/misc/unipicker/default.nix
+++ b/pkgs/applications/misc/unipicker/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
    pname = "unipicker";
-   version = "unstable-2018-07-10";
+   version = "2.0.1";
 
    src = fetchFromGitHub {
       owner = "jeremija";
       repo = pname;
-      rev = "767571c87cdb1e654408d19fc4db98e5e6725c04";
+      rev = "v${version}";
       sha256 = "1k4v53pm3xivwg9vq2kndpcmah0yn4679r5jzxvg38bbkfdk86c1";
    };
 


### PR DESCRIPTION
###### Motivation for this change
Package Update

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
