### PR TITLE
[20.09] mozjpeg: 3.3.1 -> 4.0.3

### DIFF
--- a/pkgs/applications/graphics/mozjpeg/default.nix
+++ b/pkgs/applications/graphics/mozjpeg/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libpng, nasm }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libpng, zlib, nasm }:
 
 stdenv.mkDerivation rec {
-  version = "3.3.1";
+  version = "4.0.3";
   pname = "mozjpeg";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "mozjpeg";
     rev = "v${version}";
-    sha256 = "1na68860asn8b82ny5ilwbhh4nyl9gvx2yxmm4wr2v1v95v51fky";
+    sha256 = "1wb2ys0yjy6hgpb9qvzjxs7sb2zzs44p6xf7n026mx5nx85hjbyv";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ libpng nasm ];
+  cmakeFlags = [ "-DENABLE_STATIC=NO" "-DPNG_SUPPORTED=TRUE" ]; # See https://github.com/mozilla/mozjpeg/issues/351
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libpng zlib nasm ];
 
   meta = {
     description = "Mozilla JPEG Encoder Project";


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2018-14498

Backport of #119117. Attempted patching but was foiled by yet another person running an auto-formatter :roll_eyes: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
