### PR TITLE
python3Packages.weasyprint: fix failing build

### DIFF
--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   cairosvg,
   pyphen,
   cffi,
@@ -7,7 +8,6 @@
   lxml,
   html5lib,
   tinycss,
-  pygobject2,
   glib,
   pango,
   fontconfig,
@@ -43,9 +43,15 @@ buildPythonPackage rec {
 
   FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
 
-  propagatedBuildInputs = [ cairosvg pyphen cffi cssselect lxml html5lib tinycss pygobject2 ];
+  propagatedBuildInputs = [ cairosvg pyphen cffi cssselect lxml html5lib tinycss ];
 
+  # 47043a1fd7e50a892b9836466f521df85d597c4.patch can be removed after next release of weasyprint, see:
+  # https://github.com/Kozea/WeasyPrint/issues/1333#issuecomment-818062970
   patches = [
+    (fetchpatch {
+      url = "https://github.com/Kozea/WeasyPrint/commit/47043a1fd7e50a892b9836466f521df85d597c44.patch";
+      sha256 = "0l9z0hrav3bcdajlg3vbzljq0lkw7hlj8ppzrq3v21hbj1il1nsb";
+    })
     (substituteAll {
       src = ./library-paths.patch;
       fontconfig = "${fontconfig.lib}/lib/libfontconfig${stdenv.hostPlatform.extensions.sharedLibrary}";


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/118625. Looks like it was probably broken by https://github.com/NixOS/nixpkgs/pull/116347.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).