### PR TITLE
bmake: add setupHook

### DIFF
--- a/pkgs/applications/window-managers/hikari/default.nix
+++ b/pkgs/applications/window-managers/hikari/default.nix
@@ -42,27 +42,17 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  # Must replace GNU Make by bmake
-  buildPhase = with lib; concatStringsSep " " (
-    [ "bmake" "-j$NIX_BUILD_CORES" "PREFIX=$out" ]
+  makeFlags = with lib; [ "PREFIX=$(out)" ]
     ++ optional stdenv.isLinux "WITH_POSIX_C_SOURCE=YES"
     ++ mapAttrsToList (feat: enabled:
          optionalString enabled "WITH_${toUpper feat}=YES"
-       ) features
-  );
+       ) features;
 
   # Can't suid in nix store
   # Run hikari as root (it will drop privileges as early as possible), or create
   # a systemd unit to give it the necessary permissions/capabilities.
   patchPhase = ''
     substituteInPlace Makefile --replace '4555' '555'
-  '';
-
-  installPhase = ''
-    bmake \
-      PREFIX=$out \
-      install
-    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/libfsm/default.nix
+++ b/pkgs/development/libraries/libfsm/default.nix
@@ -22,11 +22,7 @@ stdenv.mkDerivation rec {
   # if we use stdenv vs clangStdenv, we don't know which, and CC=cc in all
   # cases.) it's unclear exactly what should be done if we want those flags,
   # but the defaults work fine.
-  buildPhase = "PREFIX=$out bmake -r -j$NIX_BUILD_CORES";
-  installPhase = ''
-    PREFIX=$out bmake -r install
-    runHook postInstall
-  '';
+  makeFlags = [ "-r" "PREFIX=$(out)" ];
 
   # fix up multi-output install. we also have to fix the pkg-config libdir
   # file; it uses prefix=$out; libdir=${prefix}/lib, which is wrong in

--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     ./fix-unexport-env-test.patch
   ];
 
+  setupHook = ./setup-hook.sh;
+
   meta = with lib; {
     description = "Portable version of NetBSD 'make'";
     homepage    = "http://www.crufty.net/help/sjg/bmake.html";

--- a/pkgs/development/tools/build-managers/bmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/bmake/setup-hook.sh
@@ -1,0 +1,117 @@
+bmakeBuildPhase() {
+    runHook preBuild
+
+    local flagsArray=(
+        ${enableParallelBuilding:+-j${NIX_BUILD_CORES}}
+        SHELL=$SHELL
+        $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
+        $buildFlags ${buildFlagsArray+"${buildFlagsArray[@]}"}
+    )
+
+    echoCmd 'build flags' "${flagsArray[@]}"
+    bmake ${makefile:+-f $makefile} "${flagsArray[@]}"
+    unset flagsArray
+
+    runHook postBuild
+}
+
+if [ -z "${dontUseBmakeBuild-}" -a -z "${buildPhase-}" ]; then
+    buildPhase=bmakeBuildPhase
+fi
+
+bmakeCheckPhase() {
+    runHook preCheck
+
+    if [ -z "${checkTarget:-}" ]; then
+        #TODO(@oxij): should flagsArray influence make -n?
+        if bmake -n ${makefile:+-f $makefile} check >/dev/null 2>&1; then
+            checkTarget=check
+        elif bmake -n ${makefile:+-f $makefile} test >/dev/null 2>&1; then
+            checkTarget=test
+        fi
+    fi
+
+    if [ -z "${checkTarget:-}" ]; then
+        echo "no test target found in bmake, doing nothing"
+    else
+        # shellcheck disable=SC2086
+        local flagsArray=(
+            ${enableParallelChecking:+-j${NIX_BUILD_CORES}}
+            SHELL=$SHELL
+            # Old bash empty array hack
+            $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
+            ${checkFlags:-VERBOSE=y} ${checkFlagsArray+"${checkFlagsArray[@]}"}
+            ${checkTarget}
+        )
+
+        echoCmd 'check flags' "${flagsArray[@]}"
+        bmake ${makefile:+-f $makefile} "${flagsArray[@]}"
+
+        unset flagsArray
+    fi
+
+    runHook postCheck
+}
+
+if [ -z "${dontUseBmakeCheck-}" -a -z "${checkPhase-}" ]; then
+    checkPhase=bmakeCheckPhase
+fi
+
+bmakeInstallPhase() {
+    runHook preInstall
+
+    if [ -n "$prefix" ]; then
+        mkdir -p "$prefix"
+    fi
+
+    # shellcheck disable=SC2086
+    local flagsArray=(
+        SHELL=$SHELL
+        # Old bash empty array hack
+        $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
+        $installFlags ${installFlagsArray+"${installFlagsArray[@]}"}
+        ${installTargets:-install}
+    )
+
+    echoCmd 'install flags' "${flagsArray[@]}"
+    bmake ${makefile:+-f $makefile} "${flagsArray[@]}"
+    unset flagsArray
+
+    runHook postInstall
+}
+
+if [ -z "${dontUseBmakeInstall-}" -a -z "${installPhase-}" ]; then
+    installPhase=bmakeInstallPhase
+fi
+
+bmakeDistPhase() {
+    runHook preDist
+
+    if [ -n "$prefix" ]; then
+        mkdir -p "$prefix"
+    fi
+
+    # Old bash empty array hack
+    # shellcheck disable=SC2086
+    local flagsArray=(
+        $distFlags ${distFlagsArray+"${distFlagsArray[@]}"} ${distTarget:-dist}
+    )
+
+    echo 'dist flags: %q' "${flagsArray[@]}"
+    bmake ${makefile:+-f $makefile} "${flagsArray[@]}"
+
+    if [ "${dontCopyDist:-0}" != 1 ]; then
+        mkdir -p "$out/tarballs"
+
+        # Note: don't quote $tarballs, since we explicitly permit
+        # wildcards in there.
+        # shellcheck disable=SC2086
+        cp -pvd ${tarballs:-*.tar.gz} "$out/tarballs"
+    fi
+
+    runHook postDist
+}
+
+if [ -z "${dontUseBmakeDist-}" -a -z "${distPhase-}" ]; then
+    distPhase=bmakeDistPhase
+fi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

With this change,

    nativeBuildInputs = [ bmake ];

will cause bmake to be used instead of GNU make, but with the usual
stdenv API.  Packages using bmake will no longer need to implement
their own {build,check,dist}Phase.  The implementations of the phases
are mostly copied from stdenv, with the check in buildPhase for the
existence of a Makefile removed.

Supersedes #118932.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
