### PR TITLE
pinnwand: apply patch for pygment lexer weirdness

### DIFF
--- a/pkgs/servers/pinnwand/default.nix
+++ b/pkgs/servers/pinnwand/default.nix
@@ -1,18 +1,11 @@
-{ lib, python3, fetchFromGitHub, nixosTests }:
+{ lib
+, python3
+, fetchFromGitHub
+, fetchpatch
+, nixosTests
+}:
 
-let
-  python = python3.override {
-    packageOverrides = self: super: {
-      tornado = super.tornado.overridePythonAttrs (oldAttrs: rec {
-        version = "6.0.4";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "1p5n7sw4580pkybywg93p8ddqdj9lhhy72rzswfa801vlidx9qhg";
-        };
-      });
-    };
-  };
-in with python.pkgs; buildPythonApplication rec {
+with python3.pkgs; buildPythonApplication rec {
   pname = "pinnwand";
   version = "1.2.3";
   format = "pyproject";
@@ -24,6 +17,14 @@ in with python.pkgs; buildPythonApplication rec {
     sha256 = "1p6agvp136q6km7gjfv8dpjn6x4ap770lqa40ifblyhw13bsrqlh";
   };
 
+  patches = [
+    (fetchpatch {
+      # https://github.com/supakeen/pinnwand/issues/110
+      url = "https://github.com/supakeen/pinnwand/commit/b9e72abb7f25104f5e57248294ed9ae1dbc87240.patch";
+      sha256 = "098acif9ck165398bp7vwfr9g7sj9q3pcdc42z5y63m1nbf8naan";
+    })
+  ];
+
   nativeBuildInputs = [
     poetry-core
   ];
@@ -31,10 +32,11 @@ in with python.pkgs; buildPythonApplication rec {
   propagatedBuildInputs = [
     click
     docutils
-    tornado
+    pygments
     pygments-better-html
-    toml
     sqlalchemy
+    toml
+    tornado
   ];
 
   checkInputs = [ pytestCheckHook ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The pygments 2.7.3 upgrade broke some expectations pinnwand had on the get_all_lexers() return values. This was fixed, but not yet released.

https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.pinnwand.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
