### PR TITLE
fishPlugins.done: init at 1.16.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5938,6 +5938,12 @@
     githubId = 115218;
     name = "Felix Richter";
   };
+  malo = {
+    email = "mbourgon@gmail.com";
+    github = "malob";
+    githubId = 2914269;
+    name = "Malo Bourgon";
+  };
   malyn = {
     email = "malyn@strangeGizmo.com";
     github = "malyn";

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -6,6 +6,8 @@ lib.makeScope newScope (self: with self; {
 
   clownfish = callPackage ./clownfish.nix { };
 
+  done = callPackage ./done.nix { };
+
   # Fishtape 2.x and 3.x aren't compatible,
   # but both versions are used in the tests of different other plugins.
   fishtape = callPackage ./fishtape.nix { };

--- a/pkgs/shells/fish/plugins/done.nix
+++ b/pkgs/shells/fish/plugins/done.nix
@@ -1,0 +1,25 @@
+{ lib, buildFishPlugin, fetchFromGitHub, fishtape }:
+
+buildFishPlugin rec {
+  pname = "done";
+  version = "1.16.1";
+
+  src = fetchFromGitHub {
+    owner = "franciscolourenco";
+    repo = "done";
+    rev = version;
+    sha256 = "NFysKzRZgDXXZW/sUlZNu7ZpMCKwbjAhIfspSK3UqCY=";
+  };
+
+  checkPlugins = [ fishtape ];
+  checkPhase = ''
+    fishtape test/done.fish
+  '';
+
+  meta = {
+    description = "Automatically receive notifications when long processes finish";
+    homepage = "https://github.com/franciscolourenco/done";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ malo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

I use this plugin, and it's currently not in `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
