### PR TITLE
lbry: init at 0.50.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2731,6 +2731,12 @@
     githubId = 18535642;
     name = "Emily";
   };
+  enderger = {
+    email = "endergeryt@gmail.com";
+    github = "enderger";
+    githubId = 36283171;
+    name = "Daniel";
+  };
   endocrimes = {
     email = "dani@builds.terrible.systems";
     github = "endocrimes";

--- a/pkgs/applications/video/lbry/default.nix
+++ b/pkgs/applications/video/lbry/default.nix
@@ -1,0 +1,49 @@
+{ lib, fetchurl, appimageTools}:
+
+let
+  pname = "lbry-desktop";
+  version = "0.50.2";
+in appimageTools.wrapAppImage rec {
+  name = "${pname}-${version}";
+
+  # Fetch from GitHub Releases and extract
+  src = appimageTools.extract {
+    inherit name;
+    src = fetchurl {
+      url = "https://github.com/lbryio/lbry-desktop/releases/download/v${version}/LBRY_${version}.AppImage";
+      # Gotten from latest-linux.yml
+      sha512 = "br6HvVRz+ybmAhmQh3vOC5wgLmOCVrGHDn59ueWk6rFoKOCbm8WdmdadOZvHeN1ld2nlvPzEy+KXMOEfF1LeQg==";
+    };
+  };
+
+  # At runtime, Lbry likes to have access to Ffmpeg
+  extraPkgs = pkgs: with pkgs; [
+    ffmpeg
+  ];
+
+  # General fixup
+  extraInstallCommands = ''
+    # Firstly, rename the executable to lbry for convinence
+    mv $out/bin/${name} $out/bin/lbry
+
+    # Now, install assets such as the desktop file and icons
+    install -m 444 -D ${src}/lbry.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/lbry.desktop \
+      --replace 'AppRun' '$out/bin/lbry'
+    cp -r ${src}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "A browser and wallet for LBRY, the decentralized, user-controlled content marketplace";
+    longDescription = ''
+      The LBRY app is a graphical browser for the decentralized content marketplace provided by the LBRY protocol.
+      It is essentially the lbry daemon bundled with a UI using Electron.
+    '';
+    license = licenses.mit;
+    homepage = "https://lbry.com/";
+    downloadPage = "https://lbry.com/get/";
+    changelog = "https://github.com/lbryio/lbry-desktop/blob/master/CHANGELOG.md";
+    maintainers = with maintainers; [ enderger ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24044,6 +24044,8 @@ in
 
   lbdb = callPackage ../tools/misc/lbdb { abook = null; gnupg = null; goobook = null; khard = null; mu = null; };
 
+  lbry = callPackage ../applications/video/lbry { };
+
   lbzip2 = callPackage ../tools/compression/lbzip2 { };
 
   lci = callPackage ../applications/science/logic/lci {};


### PR DESCRIPTION
###### Motivation for this change
Closes #78766 and a YouTube comment conversation with DistroTube (one of the 2 packages he stated were missing from NixPkgs, the other being LibreWolf).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - × macOS (will not work due to ElectronJS using a completely different file structure on OSX, and I don't have any means to try to test a Mac builder. This would probably entail a separate PR)
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after) (not entirely sure what this means)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
