### PR TITLE
mautrix-signal: init at 0.1.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -1,0 +1,87 @@
+{ lib, stdenv, fetchurl, fetchgit, jre, coreutils, gradle_6, git, perl
+, makeWrapper }:
+
+let
+  pname = "signald";
+
+  version = "0.13.1";
+
+  # This package uses the .git directory
+  src = fetchgit {
+    url = "https://gitlab.com/signald/signald";
+    rev = version;
+    sha256 = "1ilmg0i1kw2yc7m3hxw1bqdpl3i9wwbj8623qmz9cxhhavbcd5i7";
+    leaveDotGit = true;
+  };
+
+  buildConfigJar = fetchurl {
+    url = "https://dl.bintray.com/mfuerstenau/maven/gradle/plugin/de/fuerstenau/BuildConfigPlugin/1.1.8/BuildConfigPlugin-1.1.8.jar";
+    sha256 = "0y1f42y7ilm3ykgnm6s3ks54d71n8lsy5649xgd9ahv28lj05x9f";
+  };
+
+  patches = [ ./git-describe-always.patch ./gradle-plugin.patch ];
+
+  postPatch = ''
+    patchShebangs gradlew
+    sed -i -e 's|BuildConfig.jar|${buildConfigJar}|' build.gradle
+  '';
+
+  # fake build to pre-download deps into fixed-output derivation
+  deps = stdenv.mkDerivation {
+    name = "${pname}-deps";
+    inherit src version postPatch patches;
+    nativeBuildInputs = [ gradle_6 perl ];
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+      gradle --no-daemon build
+    '';
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/''${\($5 =~ s/-jvm//r)}" #e' \
+        | sh
+    '';
+    # Don't move info to share/
+    forceShare = [ "dummy" ];
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0w8ixp1l0ch1jc2dqzxdx3ljlh17hpgns2ba7qvj43nr4prl71l7";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname src version postPatch patches;
+
+  buildPhase = ''
+    export GRADLE_USER_HOME=$(mktemp -d)
+
+    # Use the local packages from -deps
+    sed -i -e 's|mavenCentral()|mavenLocal(); maven { url uri("${deps}") }|' build.gradle
+
+    gradle --offline --no-daemon distTar
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    tar xvf ./build/distributions/signald.tar --strip-components=1 --directory $out/
+    wrapProgram $out/bin/signald \
+      --prefix PATH : ${lib.makeBinPath [ coreutils ]} \
+      --set JAVA_HOME "${jre}"
+  '';
+
+  nativeBuildInputs = [ git gradle_6 makeWrapper ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Unofficial daemon for interacting with Signal";
+    longDescription = ''
+      Signald is a daemon that facilitates communication over Signal.  It is
+      unofficial, unapproved, and not nearly as secure as the real Signal
+      clients.
+    '';
+    homepage = "https://signald.org";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ expipiplus1 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/signald/git-describe-always.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/git-describe-always.patch
@@ -1,0 +1,9 @@
+diff --git a/version.sh b/version.sh
+index 7aeeb3c..060cba3 100755
+--- a/version.sh
++++ b/version.sh
+@@ -1,3 +1,3 @@
+ #!/bin/sh
+-VERSION=$(git describe --exact-match 2> /dev/null) || VERSION=$(git describe --abbrev=0)+git$(date +%Y-%m-%d)r$(git rev-parse --short=8 HEAD).$(git rev-list $(git describe --abbrev=0)..HEAD --count)
++VERSION=$(git describe --exact-match 2> /dev/null) || VERSION=$(git describe --always --abbrev=0)+git$(date +%Y-%m-%d)r$(git rev-parse --short=8 HEAD).$(git rev-list $(git describe --always --abbrev=0)..HEAD --count)
+ echo $VERSION

--- a/pkgs/applications/networking/instant-messengers/signald/gradle-plugin.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/gradle-plugin.patch
@@ -1,0 +1,26 @@
+diff --git a/build.gradle b/build.gradle
+index 11d7a99..66805bb 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -3,9 +3,12 @@ import org.gradle.nativeplatform.platform.internal.OperatingSystemInternal
+ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+ import org.xml.sax.SAXParseException
+ 
+-plugins {
+-   id 'de.fuerstenau.buildconfig' version '1.1.8'
++buildscript {
++  dependencies {
++    classpath files ("BuildConfig.jar")
++  }
+ }
++apply plugin: 'de.fuerstenau.buildconfig'
+ 
+ apply plugin: 'java'
+ apply plugin: 'application'
+@@ -185,4 +188,4 @@ task integrationTest(type: Test) {
+     testClassesDirs = sourceSets.integrationTest.output.classesDirs
+     classpath = sourceSets.integrationTest.runtimeClasspath
+     outputs.upToDateWhen { false }
+-}
+\ No newline at end of file
++}

--- a/pkgs/servers/mautrix-signal/default.nix
+++ b/pkgs/servers/mautrix-signal/default.nix
@@ -1,0 +1,55 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "mautrix-signal";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "tulir";
+    repo = "mautrix-signal";
+    rev = "v${version}";
+    sha256 = "11snsl7i407855h39g1fgk26hinnq0inr8sjrgd319li0d3jwzxl";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    CommonMark
+    aiohttp
+    asyncpg
+    attrs
+    mautrix
+    phonenumbers
+    pillow
+    prometheus_client
+    pycryptodome
+    python-olm
+    python_magic
+    qrcode
+    ruamel_yaml
+    unpaddedbase64
+    yarl
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/bin
+
+    # Make a little wrapper for running mautrix-signal with its dependencies
+    echo "$mautrixSignalScript" > $out/bin/mautrix-signal
+    echo "#!/bin/sh
+      exec python -m mautrix_signal \"$@\"
+    " > $out/bin/mautrix-signal
+    chmod +x $out/bin/mautrix-signal
+    wrapProgram $out/bin/mautrix-signal \
+      --set PATH ${python3Packages.python}/bin \
+      --set PYTHONPATH "$PYTHONPATH"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/tulir/mautrix-signal";
+    description = "A Matrix-Signal puppeting bridge";
+    license = licenses.agpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ expipiplus1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6036,6 +6036,8 @@ in
 
   matrix-corporal = callPackage ../servers/matrix-corporal { };
 
+  mautrix-signal = recurseIntoAttrs (callPackage ../servers/mautrix-signal { });
+
   mautrix-telegram = recurseIntoAttrs (callPackage ../servers/mautrix-telegram { });
 
   mautrix-whatsapp = callPackage ../servers/mautrix-whatsapp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8236,6 +8236,8 @@ in
 
   sigil = libsForQt5.callPackage ../applications/editors/sigil { };
 
+  signald = callPackage ../applications/networking/instant-messengers/signald { };
+
   signal-cli = callPackage ../applications/networking/instant-messengers/signal-cli { };
 
   signal-desktop = callPackage ../applications/networking/instant-messengers/signal-desktop { };


### PR DESCRIPTION
The script wrapping python -m mautrix_signal was inspired by
the gunicorn script in powerdns-admin

@ma27 or @nyanloutre (maintaners of the mautrix-telegram package): would you like to be maintainers too?


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (doesn't crash immediately)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).