### PR TITLE
probe-run: init at 0.2.1

### DIFF
--- a/pkgs/development/tools/rust/probe-run/default.nix
+++ b/pkgs/development/tools/rust/probe-run/default.nix
@@ -1,0 +1,25 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, libusb1 }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "probe-run";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "knurling-rs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "QEUsigoSqVczrsSSDnOhTXm94JTXHgxeNY0tGsOaRyg=";
+  };
+
+  cargoSha256 = "Fr5XWIUHXyfesouHi0Uryf/ZgB/rDDJ4G1BYGHw0QeQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libusb1 ];
+
+  meta = with lib; {
+    description = "Run embedded programs just like native ones.";
+    homepage = "https://github.com/knurling-rs/probe-run";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ hoverbear ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -257,6 +257,8 @@ in
 
   html5validator = python3Packages.callPackage ../applications/misc/html5validator { };
 
+  probe-run = callPackage ../development/tools/rust/probe-run {};
+
   proto-contrib = callPackage ../development/tools/proto-contrib {};
 
   protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};


### PR DESCRIPTION
###### Motivation for this change

Introduce the [Knurling-rs](https://knurling.ferrous-systems.com/tools/) tool [`probe-run`](https://github.com/knurling-rs/probe-run).

You can read about `probe-run`'s use in the [announcement post](https://ferrous-systems.com/blog/probe-run/).

You can run this package and see the help with:

```sh
$ nix run .#probe-run
error: The following required arguments were not provided:
    <ELF>
    --chip <chip>

USAGE:
    probe-run [FLAGS] [OPTIONS] <ELF> --chip <chip> [REST]...

For more information try --help                                                                                                                                                                       
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
