### PR TITLE
nnn: 3.6 → 4.0

### DIFF
--- a/pkgs/applications/misc/nnn/default.nix
+++ b/pkgs/applications/misc/nnn/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, ncurses, readline
+{ lib, stdenv, fetchFromGitHub, pkg-config, makeWrapper, ncurses, readline
+, archivemount, atool, fzf, libarchive, rclone, sshfs, unzip, vlock
 , conf ? null, withIcons ? false, withNerdIcons ? false }:
 
 # Mutually exclusive options
@@ -7,19 +8,19 @@ assert withNerdIcons -> withIcons == false;
 
 stdenv.mkDerivation rec {
   pname = "nnn";
-  version = "3.6";
+  version = "4.0";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1hwv7ncp8pmzdir30877ni4qlmczmb3yjdkbfd1pssr08y1srsc7";
+    sha256 = "0cbxgss9j0bvsp3czjx1kpm9id7c5xxmjfnvjyk3pfd69ygif2kl";
   };
 
   configFile = lib.optionalString (conf != null) (builtins.toFile "nnn.h" conf);
   preBuild = lib.optionalString (conf != null) "cp ${configFile} src/nnn.h";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config makeWrapper ];
   buildInputs = [ readline ncurses ];
 
   makeFlags = [ "PREFIX=$(out)" ]
@@ -31,6 +32,9 @@ stdenv.mkDerivation rec {
     install -Dm555 misc/auto-completion/bash/nnn-completion.bash $out/share/bash-completion/completions/nnn.bash
     install -Dm555 misc/auto-completion/zsh/_nnn -t $out/share/zsh/site-functions
     install -Dm555 misc/auto-completion/fish/nnn.fish -t $out/share/fish/vendor_completions.d
+
+    wrapProgram $out/bin/nnn \
+      --prefix PATH : ${lib.makeBinPath [ archivemount atool fzf libarchive rclone sshfs unzip vlock ]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://github.com/jarun/nnn/blob/master/CHANGELOG)
* Add [utils](https://github.com/jarun/nnn/blob/fa990562c1670782e455ff8efa69c480231c482e/src/nnn.c#L483-L518) to PATH

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
