### PR TITLE
ocamlPackages.earlybird: 0.1.5 → 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/dap/default.nix
+++ b/pkgs/development/ocaml-modules/dap/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildDunePackage, fetchurl
+, angstrom-lwt-unix, lwt, logs, lwt_ppx, ppx_deriving_yojson, ppx_expect, ppx_here, react
+}:
+
+buildDunePackage rec {
+  pname = "dap";
+  version = "1.0.6";
+  useDune2 = true;
+  src = fetchurl {
+    url = "https://github.com/hackwaly/ocaml-dap/releases/download/${version}/dap-${version}.tbz";
+    sha256 = "1zq0f8429m38a4x3h9n3rv7n1vsfjbs72pfi5902a89qwyilkcp0";
+  };
+
+  minimumOCamlVersion = "4.08";
+
+  buildInputs = [
+    lwt_ppx
+  ];
+
+  propagatedBuildInputs = [
+    angstrom-lwt-unix
+    logs
+    lwt
+    ppx_deriving_yojson
+    ppx_expect
+    ppx_here
+    react
+  ];
+
+  meta = {
+    description = "Debug adapter protocol";
+    homepage = "https://github.com/hackwaly/ocaml-dap";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/ocaml-modules/earlybird/default.nix
+++ b/pkgs/development/ocaml-modules/earlybird/default.nix
@@ -1,25 +1,25 @@
-{ lib, fetchurl, ocaml, buildDunePackage, angstrom, angstrom-lwt-unix,
-  batteries, cmdliner, lwt_ppx, ocaml_lwt, ppx_deriving_yojson,
-  ppx_tools_versioned, yojson }:
+{ lib, fetchurl, ocaml, buildDunePackage
+, cmdliner, dap, fmt, iter, logs, lru, lwt_ppx, lwt_react, menhir, path_glob, ppx_deriving_yojson
+}:
 
-if lib.versionAtLeast ocaml.version "4.08"
+if lib.versionAtLeast ocaml.version "4.13"
 then throw "earlybird is not available for OCaml ${ocaml.version}"
 else
 
 buildDunePackage rec {
   pname = "earlybird";
-  version = "0.1.5";
+  version = "1.1.0";
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.04";
+  minimumOCamlVersion = "4.11";
 
   src = fetchurl {
     url = "https://github.com/hackwaly/ocamlearlybird/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "10yflmsicw4sdmm075zjpbmxpwm9fvibnl3sl18zjpwnm6l9sv7d";
+    sha256 = "1pwzhcr3pw24ra4j4d23vz71h0psz4xkyp7b12l2wl1slxzjbrxa";
   };
 
-  buildInputs = [ angstrom angstrom-lwt-unix batteries cmdliner lwt_ppx ocaml_lwt ppx_deriving_yojson ppx_tools_versioned yojson ];
+  buildInputs = [ cmdliner dap fmt iter logs lru lwt_ppx lwt_react menhir path_glob ppx_deriving_yojson ];
 
   meta = {
     homepage = "https://github.com/hackwaly/ocamlearlybird";

--- a/pkgs/development/ocaml-modules/path_glob/default.nix
+++ b/pkgs/development/ocaml-modules/path_glob/default.nix
@@ -1,0 +1,17 @@
+{ lib, buildDunePackage, fetchurl }:
+
+buildDunePackage rec {
+  pname = "path_glob";
+  version = "0.2";
+  useDune2 = true;
+  src = fetchurl {
+    url = "https://gasche.gitlab.io/path_glob/releases/path_glob-${version}.tbz";
+    sha256 = "01ra20bzjiihbgma74axsp70gqmid6x7jmiizg48mdkni0aa42ay";
+  };
+
+  meta = {
+    homepage = "https://gitlab.com/gasche/path_glob";
+    description = "Checking glob patterns on paths";
+    license = lib.licenses.lgpl2Only;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -932,6 +932,8 @@ let
 
     parse-argv = callPackage ../development/ocaml-modules/parse-argv { };
 
+    path_glob = callPackage ../development/ocaml-modules/path_glob { };
+
     pbkdf = callPackage ../development/ocaml-modules/pbkdf { };
 
     pcap-format = callPackage ../development/ocaml-modules/pcap-format { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -236,6 +236,8 @@ let
 
     ctypes = callPackage ../development/ocaml-modules/ctypes { };
 
+    dap =  callPackage ../development/ocaml-modules/dap { };
+
     decompress =  callPackage ../development/ocaml-modules/decompress { };
 
     diet =  callPackage ../development/ocaml-modules/diet { };


### PR DESCRIPTION
###### Motivation for this change

Support for recent versions of OCaml (4.11, 4.12).

cc maintainer @romildo

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
