### PR TITLE
jellyfin-media-player: init at 1.3.1

### DIFF
--- a/pkgs/applications/video/jellyfin-media-player/default.nix
+++ b/pkgs/applications/video/jellyfin-media-player/default.nix
@@ -1,0 +1,108 @@
+{ lib
+, fetchFromGitHub
+, fetchzip
+, mkDerivation
+, stdenv
+, Cocoa
+, CoreAudio
+, CoreFoundation
+, MediaPlayer
+, SDL2
+, cmake
+, libGL
+, libX11
+, libXrandr
+, libvdpau
+, mpv
+, ninja
+, pkg-config
+, python3
+, qtbase
+, qtwayland
+, qtwebchannel
+, qtwebengine
+, qtx11extras
+}:
+
+mkDerivation rec {
+  pname = "jellyfin-media-player";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "iwalton3";
+    repo = "jellyfin-media-player";
+    rev = "v${version}";
+    sha256 = "sha256-rXW6vC0Ow8xFblXjGYaDExAZM8RgqLkDHiX7R8vAWjI=";
+  };
+
+  jmpDist = fetchzip {
+    url = "https://github.com/iwalton3/jellyfin-web-jmp/releases/download/jwc-10.7.2/dist.zip";
+    sha256 = "sha256-EpNAN4nzINiwMrmg0e4x3uJRTy5ovx4ZkmP83Kbn4S0=";
+  };
+
+  patches = [
+    # the webclient-files are not copied in the regular build script. Copy them just like the linux build
+    ./fix-osx-resources.patch
+  ];
+
+  buildInputs = [
+    SDL2
+    libGL
+    libX11
+    libXrandr
+    libvdpau
+    mpv
+    qtbase
+    qtwebchannel
+    qtwebengine
+    qtx11extras
+  ] ++ lib.optionals stdenv.isLinux [
+    qtwayland
+  ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa
+    CoreAudio
+    CoreFoundation
+    MediaPlayer
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    python3
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DQTROOT=${qtbase}"
+    "-GNinja"
+  ];
+
+  preBuild = ''
+    # copy the webclient-files to the expected "dist" directory
+    mkdir -p dist
+    cp -a ${jmpDist}/* dist
+  '';
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/bin $out/Applications
+    mv "$out/Jellyfin Media Player.app" $out/Applications
+
+    # move web-client resources
+    mv $out/Resources/* "$out/Applications/Jellyfin Media Player.app/Contents/Resources/"
+    rmdir $out/Resources
+
+    # fix 'Could not find the Qt platform plugin "cocoa" in ""' error
+    wrapQtApp "$out/Applications/Jellyfin Media Player.app/Contents/MacOS/Jellyfin Media Player"
+
+    ln -s "$out/Applications/Jellyfin Media Player.app/Contents/MacOS/Jellyfin Media Player" $out/bin/jellyfinmediaplayer
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/iwalton3/jellyfin-media-player";
+    description = "Jellyfin Desktop Client based on Plex Media Player";
+    license = with licenses; [ gpl2Plus mit ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/applications/video/jellyfin-media-player/fix-osx-resources.patch
+++ b/pkgs/applications/video/jellyfin-media-player/fix-osx-resources.patch
@@ -1,0 +1,15 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 780c0d3..d9c2341 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -108,8 +108,8 @@ endif()
+ set(RESOURCE_ROOT .)
+ if(APPLE)
+   set(RESOURCE_ROOT Resources)
+-  add_resources(TARGET ${MAIN_TARGET} SOURCES ${CMAKE_CURRENT_BINARY_DIR}/../dist/ DEST ${RESOURCE_ROOT}/web-client/desktop)
+-  add_resources(TARGET ${MAIN_TARGET} SOURCES ${CMAKE_SOURCE_DIR}/native/ DEST ${RESOURCE_ROOT}/web-client/extension)
++  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../dist/ DESTINATION ${RESOURCE_ROOT}/web-client/desktop)
++  install(DIRECTORY ${CMAKE_SOURCE_DIR}/native/ DESTINATION ${RESOURCE_ROOT}/web-client/extension)
+ endif()
+ 
+ if(NOT APPLE)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2643,6 +2643,10 @@ in
 
   jellyfin_10_5 = callPackage ../servers/jellyfin/10.5.x.nix { };
 
+  jellyfin-media-player = libsForQt5.callPackage ../applications/video/jellyfin-media-player {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Cocoa CoreAudio MediaPlayer;
+  };
+
   jellyfin-mpv-shim = python3Packages.callPackage ../applications/video/jellyfin-mpv-shim { };
 
   jotta-cli = callPackage ../applications/misc/jotta-cli { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added the [new native jellyfin-media-player](https://github.com/iwalton3/jellyfin-media-player), which will possibly replace the desktop-mode of the existing jellyfin-mpv-shim in the future (https://old.reddit.com/r/jellyfin/comments/mm5f5v/jellyfin_media_player_more_progress/gtq4qtk/).

~~Currently pulling the latest commit + patch from an open PR to fix wayland compatiblity (or else the executable needs to be run with `QT_QPA_PLATFORM=xcb ...` under wayland). Will use the next tagged release - until then leaving this as a draft.~~

~~Will try to add an darwin build as well.~~ Added a darwin build. Because i only got a VM i wasn't able to play any files due to missing hardware acceleration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/4fizbywqgif5kixvjsdixm9znagr7xrs-jellyfin-media-player-unstable-2021-04-13	 852.1M
/nix/store/744nflsl58wav3dmj0pqh6fjv2531a9x-jellyfin-media-player-unstable-2021-04-13	 620.5M (macOS)
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
