### PR TITLE
python3Packages.aiodiscover: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/development/python-modules/aiodiscover/default.nix
+++ b/pkgs/development/python-modules/aiodiscover/default.nix
@@ -2,22 +2,23 @@
 , async-dns
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , ifaddr
 , pyroute2
+, pytest-asyncio
+, pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aiodiscover";
-  version = "1.3.3";
+  version = "1.3.4";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "bdraco";
     repo = pname;
     rev = "v${version}";
-    sha256 = "186agrjx818vn00d3pqlka5ir48rgpbfyn1cifkn9ylsxg9cz3ph";
+    sha256 = "sha256-TmWl5d5HwyqWPUjwtEvc5FzVfxV/K1pekljcMkGN0Ag=";
   };
 
   propagatedBuildInputs = [
@@ -30,9 +31,21 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace '"pytest-runner>=5.2",' ""
   '';
 
-  # Tests require access to /etc/resolv.conf
-  # pythonImportsCheck doesn't work as async-dns wants to create its CONFIG_DIR
-  doCheck = false;
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  disabledTests = [
+    # Tests require access to /etc/resolv.conf
+    "test_async_discover_hosts"
+  ];
+
+  pythonImportsCheck = ["aiodiscover"];
 
   meta = with lib; {
     description = "Python module to discover hosts via ARP and PTR lookup";

--- a/pkgs/development/python-modules/pyroute2/default.nix
+++ b/pkgs/development/python-modules/pyroute2/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pyroute2";
-  version = "0.5.14";
+  version = "0.5.18";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "774c5ecf05fe40f0f601a7ab33c19ca0b24f00bf4a094e58deaa5333b7ca49b5";
+    sha256 = "sha256-CKxAytUsC7Lg8gCHUgWZqpH8zgsiHdJukEIzBCiBC8U=";
   };
 
   # requires root priviledges

--- a/pkgs/development/python-modules/pyroute2/default.nix
+++ b/pkgs/development/python-modules/pyroute2/default.nix
@@ -1,4 +1,7 @@
-{lib, buildPythonPackage, fetchPypi}:
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
 
 buildPythonPackage rec {
   pname = "pyroute2";
@@ -9,14 +12,16 @@ buildPythonPackage rec {
     sha256 = "sha256-CKxAytUsC7Lg8gCHUgWZqpH8zgsiHdJukEIzBCiBC8U=";
   };
 
-  # requires root priviledges
+  # Requires root privileges, https://github.com/svinota/pyroute2/issues/778
   doCheck = false;
+
+  pythonImportsCheck = [ "pyroute2" ];
 
   meta = with lib; {
     description = "Python Netlink library";
     homepage = "https://github.com/svinota/pyroute2";
     license = licenses.asl20;
-    maintainers = [maintainers.mic92];
+    maintainers = with maintainers; [ mic92 ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.3.4

Change log: https://github.com/bdraco/aiodiscover/releases/tag/v1.3.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
