### PR TITLE
remind: 03.03.05 -> 03.03.06

### DIFF
--- a/pkgs/tools/misc/remind/default.nix
+++ b/pkgs/tools/misc/remind/default.nix
@@ -1,6 +1,11 @@
-{lib, stdenv, fetchurl, tk, tcllib, makeWrapper
+{ lib
+, stdenv
+, fetchurl
+, tk
+, tcllib
+, makeWrapper
 , tkremind ? true
-} :
+}:
 
 assert tkremind -> tk != null;
 assert tkremind -> tcllib != null;
@@ -14,13 +19,14 @@ let
   tkremindPatch = optionalString tkremind ''
     substituteInPlace scripts/tkremind --replace "exec wish" "exec ${tk}/bin/wish"
   '';
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "remind";
-  version = "03.03.05";
+  version = "03.03.06";
 
   src = fetchurl {
     url = "https://dianne.skoll.ca/projects/remind/download/remind-${version}.tar.gz";
-    sha256 = "sha256-Ye0X2Gvek/pyaNVxGKL773OWJvC4I6F5nEsRQgzWbsE=";
+    sha256 = "sha256-lpoMAXDJxwODY0/aoo25GRBYWFhE4uf11pR5/ITZX1s=";
   };
 
   nativeBuildInputs = optional tkremind makeWrapper;
@@ -39,11 +45,11 @@ in stdenv.mkDerivation rec {
     wrapProgram $out/bin/tkremind --set TCLLIBPATH "${tclLibPaths}"
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://dianne.skoll.ca/projects/remind/";
     description = "Sophisticated calendar and alarm program for the console";
-    license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [raskin kovirobi];
-    platforms = with lib.platforms; unix;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ raskin kovirobi ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Also apply nixpkgs-format.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to new package version, see announcement [here](https://dianne.skoll.ca/pipermail/remind-fans/2021/003826.html).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
