### PR TITLE
kupfer: 319 -> 321

### DIFF
--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -4,8 +4,11 @@
 , python3Packages
 , gobject-introspection
 , gtk3
+, itstool
 , libwnck3
 , keybinder3
+, desktop-file-utils
+, shared-mime-info
 , wrapGAppsHook
 , wafHook
 }:
@@ -14,19 +17,22 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "kupfer";
-  version = "319";
+  version = "321";
 
   format = "other";
 
   src = fetchurl {
-    url = "https://github.com/kupferlauncher/kupfer/releases/download/v${version}/kupfer-v${version}.tar.xz";
-    sha256 = "0c9xjx13r8ckfr4az116bhxsd3pk78v04c3lz6lqhraak0rp4d92";
+    url = "https://github.com/kupferlauncher/kupfer/releases/download/v${version}/kupfer-v${version}.tar.bz2";
+    sha256 = "0nagjp63gxkvsgzrpjk78cbqx9a7rbnjivj1avzb2fkhrlxa90c7";
   };
 
   nativeBuildInputs = [
     wrapGAppsHook intltool
     # For setup hook
     gobject-introspection wafHook
+    itstool            # for help pages
+    desktop-file-utils # for update-desktop-database
+    shared-mime-info   # for update-mime-info
   ];
   buildInputs = [ docutils libwnck3 keybinder3 ];
   propagatedBuildInputs = [ pygobject3 gtk3 pyxdg dbus-python pycairo ];


### PR DESCRIPTION
###### Motivation for this change

New upstream release: https://github.com/kupferlauncher/kupfer/releases/tag/v321

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
