### PR TITLE
nixStatic: set derivation name to "nix-static-${version}"

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29752,7 +29752,14 @@ in
     nixUnstable
     nixFlakes;
 
-  nixStatic = pkgsStatic.nix;
+  nixStatic = pkgsStatic.nix.overrideAttrs (attrs: rec {
+    # workaround: make sure that the derivation's name is
+    # not too similar to pkgs.nix, so nix-env -u doesn't
+    # interpret the host suffix of nixStatic as a newer
+    # version than 2.3.10 and “upgrade” nix to nixStatic,
+    # breaking users' setups in the process.
+    pname = "nix-static";
+  });
 
   nixops = callPackage ../tools/package-management/nixops { };
 


### PR DESCRIPTION
This is a workaround for the issue a lot of people have been having
where nix-env -u would think that nixStatic was a newer version of nix
and “upgrade” it to that package, breaking setups in the process.

Reference https://github.com/NixOS/nixpkgs/issues/118481

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
