### PR TITLE
megapixels: 0.15.0 -> 0.16.0

### DIFF
--- a/pkgs/applications/graphics/megapixels/default.nix
+++ b/pkgs/applications/graphics/megapixels/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchgit
+, fetchFromSourcehut
 , meson
 , ninja
 , pkg-config
@@ -26,12 +26,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "megapixels";
-  version = "0.15.0";
+  version = "0.16.0";
 
-  src = fetchgit {
-    url = "https://git.sr.ht/~martijnbraam/megapixels";
+  src = fetchFromSourcehut {
+    owner = "~martijnbraam";
+    repo = "megapixels";
     rev = version;
-    sha256 = "1y8irwi8lbjs948j90gpic96dx5wjmwacd41hb3d9vzhkyni2dvb";
+    sha256 = "0z7sx76x18yqf7carq6mg9lib0zbz0yrd1dsg9qd6hbf5niqis37";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config wrapGAppsHook ];
@@ -49,6 +50,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "GTK3 camera application using raw v4l2 and media-requests";
     homepage = "https://sr.ht/~martijnbraam/Megapixels";
+    changelog = "https://git.sr.ht/~martijnbraam/megapixels/refs/${version}";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
[New release](https://git.sr.ht/~martijnbraam/megapixels/refs/0.16.0).

###### Things done

Tested buildability, ~~will test functionality when I'm back home~~ runs fine on my phone.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
