### PR TITLE
python3Packages.swisshydrodata: 0.0.3 -> 0.1.0

### DIFF
--- a/pkgs/development/python-modules/swisshydrodata/default.nix
+++ b/pkgs/development/python-modules/swisshydrodata/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "swisshydrodata";
-  version = "0.0.3";
+  version = "0.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1adpy6k2bknffzl5rckqpvaqyrvc00d6a4a4541438dqasx61npl";
+    sha256 = "0z8divdpdrjllf6y19kdrv19m7aqkbyxz43ml3d7hgaa6mj91mg5";
   };
 
   propagatedBuildInputs = [ requests ];

--- a/pkgs/development/python-modules/swisshydrodata/default.nix
+++ b/pkgs/development/python-modules/swisshydrodata/default.nix
@@ -1,22 +1,31 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, pytestCheckHook
 , requests
+, requests-mock
 }:
 
 buildPythonPackage rec {
   pname = "swisshydrodata";
   version = "0.1.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0z8divdpdrjllf6y19kdrv19m7aqkbyxz43ml3d7hgaa6mj91mg5";
+  src = fetchFromGitHub {
+    owner = "Bouni";
+    repo = pname;
+    rev = version;
+    sha256 = "1rdgfc6zg5j3fvrpbqs9vc3n5m66r5yljawyl7nmrqd5lwq1lqak";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [
+    requests
+  ];
 
-  # Tests are not releases at the moment
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+    requests-mock
+  ];
+
   pythonImportsCheck = [ "swisshydrodata" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.1.0

Change log: https://github.com/Bouni/swisshydrodata/releases/tag/0.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
