### PR TITLE
bookstack: 0.31.7 -> 21.04.3 + nixos/bookstack: use umask before echoing & clear cache before starting

### DIFF
--- a/pkgs/servers/web-apps/bookstack/default.nix
+++ b/pkgs/servers/web-apps/bookstack/default.nix
@@ -15,13 +15,13 @@ let
 
 in package.override rec {
   name = "bookstack";
-  version = "0.31.7";
+  version = "21.04.3";
 
   src = fetchFromGitHub {
     owner = "bookstackapp";
     repo = name;
     rev = "v${version}";
-    sha256 = "1jak6g2q4zbr0gxqj0bqhks687whmmw8ylzwm4saws7ikcxkwna4";
+    sha256 = "1vkl0v3c5q0734xvvqinq4zikhy37wjys6nj1h9qdbbka0h39592";
   };
 
   meta = with lib; {

--- a/pkgs/servers/web-apps/bookstack/php-packages.nix
+++ b/pkgs/servers/web-apps/bookstack/php-packages.nix
@@ -5,20 +5,20 @@ let
     "aws/aws-sdk-php" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "aws-aws-sdk-php-3e6143f5c12986d727307d5d19d6aec21575d903";
+        name = "aws-aws-sdk-php-0aa83b522d5ffa794c02e7411af87a0e241a3082";
         src = fetchurl {
-          url = https://api.github.com/repos/aws/aws-sdk-php/zipball/3e6143f5c12986d727307d5d19d6aec21575d903;
-          sha256 = "16hbw8gqscbc3bcvnfdsll6x1653lq2s4dga3d5jbpczil3ws9yb";
+          url = https://api.github.com/repos/aws/aws-sdk-php/zipball/0aa83b522d5ffa794c02e7411af87a0e241a3082;
+          sha256 = "03qahdj01bz76aar21limham7xnv5r0d61gfk1fph8ljf2gbg33i";
         };
       };
     };
     "barryvdh/laravel-dompdf" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "barryvdh-laravel-dompdf-30310e0a675462bf2aa9d448c8dcbf57fbcc517d";
+        name = "barryvdh-laravel-dompdf-5b99e1f94157d74e450f4c97e8444fcaffa2144b";
         src = fetchurl {
-          url = https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/30310e0a675462bf2aa9d448c8dcbf57fbcc517d;
-          sha256 = "1fnan9b2g4xhqqvlfsn3alb4nx5jjlrapgiad2kca13b3gizv7zr";
+          url = https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/5b99e1f94157d74e450f4c97e8444fcaffa2144b;
+          sha256 = "1r82fzrnjrjy5jgpyc071miiw1rwhwys9ccj81gs3yydq9hi4crw";
         };
       };
     };
@@ -45,10 +45,20 @@ let
     "doctrine/dbal" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "doctrine-dbal-47433196b6390d14409a33885ee42b6208160643";
+        name = "doctrine-dbal-c800380457948e65bbd30ba92cc17cda108bf8c9";
         src = fetchurl {
-          url = https://api.github.com/repos/doctrine/dbal/zipball/47433196b6390d14409a33885ee42b6208160643;
-          sha256 = "0bcg9494hr31902zcmq5kk7ji78yxk074d5bd9chxn9q0xz4g2h8";
+          url = https://api.github.com/repos/doctrine/dbal/zipball/c800380457948e65bbd30ba92cc17cda108bf8c9;
+          sha256 = "1x6bij89yaj0d52ffx683rlpxrgxl0vx9q6a121mkz1zplnif647";
+        };
+      };
+    };
+    "doctrine/deprecations" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "doctrine-deprecations-9504165960a1f83cc1480e2be1dd0a0478561314";
+        src = fetchurl {
+          url = https://api.github.com/repos/doctrine/deprecations/zipball/9504165960a1f83cc1480e2be1dd0a0478561314;
+          sha256 = "04kpbzk5iw86imspkg7dgs54xx877k9b5q0dfg2h119mlfkvxil6";
         };
       };
     };
@@ -85,10 +95,10 @@ let
     "dompdf/dompdf" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "dompdf-dompdf-db91d81866c69a42dad1d2926f61515a1e3f42c5";
+        name = "dompdf-dompdf-8768448244967a46d6e67b891d30878e0e15d25c";
         src = fetchurl {
-          url = https://api.github.com/repos/dompdf/dompdf/zipball/db91d81866c69a42dad1d2926f61515a1e3f42c5;
-          sha256 = "10nsmaiqfk6wgv0l9wjsh7h8nigdfabygkhjk7wdbxdfvlvniddd";
+          url = https://api.github.com/repos/dompdf/dompdf/zipball/8768448244967a46d6e67b891d30878e0e15d25c;
+          sha256 = "0mgsry4mq5bx6b74h3akay1bp03rnsl8ppcjxjkfjlq4svq7m5yf";
         };
       };
     };
@@ -115,10 +125,10 @@ let
     "facade/flare-client-php" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "facade-flare-client-php-ef0f5bce23b30b32d98fd9bb49c6fa37b40eb546";
+        name = "facade-flare-client-php-6bf380035890cb0a09b9628c491ae3866b858522";
         src = fetchurl {
-          url = https://api.github.com/repos/facade/flare-client-php/zipball/ef0f5bce23b30b32d98fd9bb49c6fa37b40eb546;
-          sha256 = "1car7k8zzkgib9wpi9lzw1dj9qgjak8s9dmiimxaigvb7q4bc5vk";
+          url = https://api.github.com/repos/facade/flare-client-php/zipball/6bf380035890cb0a09b9628c491ae3866b858522;
+          sha256 = "1y0rjlpd71jkl0zzl3q4flv5s9gbk87947xgfi8w62sg5g7jjgl2";
         };
       };
     };
@@ -135,10 +145,10 @@ let
     "facade/ignition-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "facade-ignition-contracts-aeab1ce8b68b188a43e81758e750151ad7da796b";
+        name = "facade-ignition-contracts-3c921a1cdba35b68a7f0ccffc6dffc1995b18267";
         src = fetchurl {
-          url = https://api.github.com/repos/facade/ignition-contracts/zipball/aeab1ce8b68b188a43e81758e750151ad7da796b;
-          sha256 = "0b5hv56758fh2y6fqbygwn94qgqwjan8d2s1i10m242x80h9jjiw";
+          url = https://api.github.com/repos/facade/ignition-contracts/zipball/3c921a1cdba35b68a7f0ccffc6dffc1995b18267;
+          sha256 = "1nsjwd1k9q8qmfvh7m50rs42yxzxyq4f56r6dq205gwcmqsjb2j0";
         };
       };
     };
@@ -155,40 +165,40 @@ let
     "filp/whoops" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "filp-whoops-df7933820090489623ce0be5e85c7e693638e536";
+        name = "filp-whoops-d501fd2658d55491a2295ff600ae5978eaad7403";
         src = fetchurl {
-          url = https://api.github.com/repos/filp/whoops/zipball/df7933820090489623ce0be5e85c7e693638e536;
-          sha256 = "0azpv2r8hc9s5pbk9wh2qk52qzycsbvpijr8w68l311igpcj4f78";
+          url = https://api.github.com/repos/filp/whoops/zipball/d501fd2658d55491a2295ff600ae5978eaad7403;
+          sha256 = "1mpgkl7yzw9j4pxkw404fvykapr42347lyz7jgrl1ks61pk6s9v5";
         };
       };
     };
     "guzzlehttp/guzzle" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "guzzlehttp-guzzle-0aa74dfb41ae110835923ef10a9d803a22d50e79";
+        name = "guzzlehttp-guzzle-7008573787b430c1c1f650e3722d9bba59967628";
         src = fetchurl {
-          url = https://api.github.com/repos/guzzle/guzzle/zipball/0aa74dfb41ae110835923ef10a9d803a22d50e79;
-          sha256 = "0gba1711dpi147fzi2ab2pg0k1g6zfanm5w5hf4c7w0b3h4ya5gj";
+          url = https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628;
+          sha256 = "10fiv9ifhz5vg78z4xa41dkwic5ql4m6xf8bglyvpw3x7b76l81m";
         };
       };
     };
     "guzzlehttp/promises" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "guzzlehttp-promises-60d379c243457e073cff02bc323a2a86cb355631";
+        name = "guzzlehttp-promises-8e7d04f1f6450fef59366c399cfad4b9383aa30d";
         src = fetchurl {
-          url = https://api.github.com/repos/guzzle/promises/zipball/60d379c243457e073cff02bc323a2a86cb355631;
-          sha256 = "0lvcr64bx9sb90qggxk7g7fsplz403gm3i8lnlcaifyjrlmdj5wb";
+          url = https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d;
+          sha256 = "158wd8nmvvl386c24lkr4jkwdhqpdj0dxdbjwh8iv6a2rgccjr2q";
         };
       };
     };
     "guzzlehttp/psr7" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "guzzlehttp-psr7-53330f47520498c0ae1f61f7e2c90f55690c06a3";
+        name = "guzzlehttp-psr7-35ea11d335fd638b5882ff1725228b3d35496ab1";
         src = fetchurl {
-          url = https://api.github.com/repos/guzzle/psr7/zipball/53330f47520498c0ae1f61f7e2c90f55690c06a3;
-          sha256 = "0948mbbqn1xcz39diajhvlr9a7586vx3091kzx96m0z4ki3lhv7g";
+          url = https://api.github.com/repos/guzzle/psr7/zipball/35ea11d335fd638b5882ff1725228b3d35496ab1;
+          sha256 = "1nsd7sla2jpx9kzg0lzk4kvc66d30bnkf2yfzdp7gghb67wvajfa";
         };
       };
     };
@@ -215,30 +225,30 @@ let
     "laravel/framework" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "laravel-framework-d0e4731e92ca88f4a78fe9e0c2c426a3e8c063c8";
+        name = "laravel-framework-d94c07d72c14f07e7d2027458e7f0a76f9ceb0d9";
         src = fetchurl {
-          url = https://api.github.com/repos/laravel/framework/zipball/d0e4731e92ca88f4a78fe9e0c2c426a3e8c063c8;
-          sha256 = "15zjpq6lbxs019vd0mm2nbfi91yyw40wsf5fl0jbw3s1ffvaq898";
+          url = https://api.github.com/repos/laravel/framework/zipball/d94c07d72c14f07e7d2027458e7f0a76f9ceb0d9;
+          sha256 = "02cml6rg3qxnr8gynnd8iqwdyzflqwnyivxw034dzbm60xpg6w93";
         };
       };
     };
     "laravel/socialite" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "laravel-socialite-8d25d574b4f2005411c0b9cb527ef5e745c1b07d";
+        name = "laravel-socialite-1960802068f81e44b2ae9793932181cf1cb91b5c";
         src = fetchurl {
-          url = https://api.github.com/repos/laravel/socialite/zipball/8d25d574b4f2005411c0b9cb527ef5e745c1b07d;
-          sha256 = "0ash56za1flniq9nnk3siyb8l0m2cjwn2n25315qfhmdgbxxjz68";
+          url = https://api.github.com/repos/laravel/socialite/zipball/1960802068f81e44b2ae9793932181cf1cb91b5c;
+          sha256 = "1v68icdk7x1qbnhzsvpzv4nj0hwdw70s75g2bzbvmli6ah0kvvck";
         };
       };
     };
     "league/commonmark" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-commonmark-11df9b36fd4f1d2b727a73bf14931d81373b9a54";
+        name = "league-commonmark-08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf";
         src = fetchurl {
-          url = https://api.github.com/repos/thephpleague/commonmark/zipball/11df9b36fd4f1d2b727a73bf14931d81373b9a54;
-          sha256 = "15chm1sa65b58b47am00ik03s2agnx49i8yww3mhqlijvbrjvxc3";
+          url = https://api.github.com/repos/thephpleague/commonmark/zipball/08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf;
+          sha256 = "10bs8r0qiq9bybypnascvk7a7181699cnwl27yq4m108cj1i223h";
         };
       };
     };
@@ -305,10 +315,10 @@ let
     "nesbot/carbon" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "nesbot-carbon-528783b188bdb853eb21239b1722831e0f000a8d";
+        name = "nesbot-carbon-2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4";
         src = fetchurl {
-          url = https://api.github.com/repos/briannesbitt/Carbon/zipball/528783b188bdb853eb21239b1722831e0f000a8d;
-          sha256 = "18pvfwjvclfj0mrgqvycgrbyx5jfcp1hks4yljc6mp66yxr787x4";
+          url = https://api.github.com/repos/briannesbitt/Carbon/zipball/2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4;
+          sha256 = "0riizvfqxvvbkhhfadcqr8717s0q12p00qmffv26664h5kckl58r";
         };
       };
     };
@@ -325,20 +335,20 @@ let
     "onelogin/php-saml" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "onelogin-php-saml-a7328b11887660ad248ea10952dd67a5aa73ba3b";
+        name = "onelogin-php-saml-f30f5062f3653c4d2082892d207f4dc3e577d979";
         src = fetchurl {
-          url = https://api.github.com/repos/onelogin/php-saml/zipball/a7328b11887660ad248ea10952dd67a5aa73ba3b;
-          sha256 = "0ycj3n22k5i3h8p7gn0xff6a7smjypazl2k5qvyzg86fjr7s3vfv";
+          url = https://api.github.com/repos/onelogin/php-saml/zipball/f30f5062f3653c4d2082892d207f4dc3e577d979;
+          sha256 = "0nl431rx1gngc2g92w4hjf2y26vjvscgbrwhq0m6kzm9kq043qzh";
         };
       };
     };
     "opis/closure" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "opis-closure-943b5d70cc5ae7483f6aff6ff43d7e34592ca0f5";
+        name = "opis-closure-06e2ebd25f2869e54a306dda991f7db58066f7f6";
         src = fetchurl {
-          url = https://api.github.com/repos/opis/closure/zipball/943b5d70cc5ae7483f6aff6ff43d7e34592ca0f5;
-          sha256 = "0y47ldgzzv22c5dnsdzqmbrsicq6acjyba0119d3dc6wa3n7zqi6";
+          url = https://api.github.com/repos/opis/closure/zipball/06e2ebd25f2869e54a306dda991f7db58066f7f6;
+          sha256 = "0fpa1w0rmwywj67jgaldmw563p7gycahs8gpkpjvrra9zhhj4yyc";
         };
       };
     };
@@ -405,20 +415,20 @@ let
     "predis/predis" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "predis-predis-9930e933c67446962997b05201c69c2319bf26de";
+        name = "predis-predis-b240daa106d4e02f0c5b7079b41e31ddf66fddf8";
         src = fetchurl {
-          url = https://api.github.com/repos/predis/predis/zipball/9930e933c67446962997b05201c69c2319bf26de;
-          sha256 = "0qnpiyv96gs8yzy3b1ba918yw1pv8bgzw7skcf3k40ffpxsmkxv6";
+          url = https://api.github.com/repos/predis/predis/zipball/b240daa106d4e02f0c5b7079b41e31ddf66fddf8;
+          sha256 = "0wbsmq5c449vwfvsriyjwqaq5sjf9kw2chr4f2xlh3vqc4kw720j";
         };
       };
     };
     "psr/container" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "psr-container-b7ce3b176482dbbc1245ebf52b181af44c2cf55f";
+        name = "psr-container-8622567409010282b7aeebe4bb841fe98b58dcaf";
         src = fetchurl {
-          url = https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f;
-          sha256 = "0rkz64vgwb0gfi09klvgay4qnw993l1dc03vyip7d7m2zxi6cy4j";
+          url = https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf;
+          sha256 = "0qfvyfp3mli776kb9zda5cpc8cazj3prk0bg0gm254kwxyfkfrwn";
         };
       };
     };
@@ -565,10 +575,10 @@ let
     "socialiteproviders/slack" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "socialiteproviders-slack-8efb25c71d98bedf4010a829d1e41ff9fe449bcc";
+        name = "socialiteproviders-slack-2b781c95daf06ec87a8f3deba2ab613d6bea5e8d";
         src = fetchurl {
-          url = https://api.github.com/repos/SocialiteProviders/Slack/zipball/8efb25c71d98bedf4010a829d1e41ff9fe449bcc;
-          sha256 = "0ax3n4s1djidkhgvrcgv1qipv3k0fhfd0cvs273h6wh66bjniq66";
+          url = https://api.github.com/repos/SocialiteProviders/Slack/zipball/2b781c95daf06ec87a8f3deba2ab613d6bea5e8d;
+          sha256 = "1xilg7l1wc1vgwyakhfl8dpvgkjqx90g4khvzi411j9xa2wvpprh";
         };
       };
     };
@@ -595,20 +605,20 @@ let
     "swiftmailer/swiftmailer" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "swiftmailer-swiftmailer-698a6a9f54d7eb321274de3ad19863802c879fb7";
+        name = "swiftmailer-swiftmailer-15f7faf8508e04471f666633addacf54c0ab5933";
         src = fetchurl {
-          url = https://api.github.com/repos/swiftmailer/swiftmailer/zipball/698a6a9f54d7eb321274de3ad19863802c879fb7;
-          sha256 = "1zmyr6szxvbc77rs4q1cp7f3vzw1wfx9rbbj7x9s65gh37z9fd1w";
+          url = https://api.github.com/repos/swiftmailer/swiftmailer/zipball/15f7faf8508e04471f666633addacf54c0ab5933;
+          sha256 = "1xiisdaxlmkzi16szh7lm3ay9vr9pdz0q2ah7vqaqrm2b4mwd90g";
         };
       };
     };
     "symfony/console" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-console-24026c44fc37099fa145707fecd43672831b837a";
+        name = "symfony-console-1ba4560dbbb9fcf5ae28b61f71f49c678086cf23";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/console/zipball/24026c44fc37099fa145707fecd43672831b837a;
-          sha256 = "19c5yczwxk0965pdg7ka8sa8wsr569r6l725rj4y9sabfd6mg6jf";
+          url = https://api.github.com/repos/symfony/console/zipball/1ba4560dbbb9fcf5ae28b61f71f49c678086cf23;
+          sha256 = "1zsmv0p0xxdp44301yd3n1w9j79g631bvvfp04zniqk4h5q6kvg9";
         };
       };
     };
@@ -625,30 +635,30 @@ let
     "symfony/debug" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-debug-af4987aa4a5630e9615be9d9c3ed1b0f24ca449c";
+        name = "symfony-debug-157bbec4fd773bae53c5483c50951a5530a2cc16";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/debug/zipball/af4987aa4a5630e9615be9d9c3ed1b0f24ca449c;
-          sha256 = "15y1bgdrzq3859ql37ymx4fsvd28kyck69ncm6zyg84q3fhd8i19";
+          url = https://api.github.com/repos/symfony/debug/zipball/157bbec4fd773bae53c5483c50951a5530a2cc16;
+          sha256 = "0v7l7081fw2wr96xv472nhi1d0xzw6lnl8hnjgi9g3gnksfagwq8";
         };
       };
     };
     "symfony/deprecation-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-deprecation-contracts-5fa56b4074d1ae755beb55617ddafe6f5d78f665";
+        name = "symfony-deprecation-contracts-5f38c8804a9e97d23e0c8d63341088cd8a22d627";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665;
-          sha256 = "0ny59x0aaipqaj956wx7ak5f6d5rn90766swp5m18019v9cppg10";
+          url = https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627;
+          sha256 = "11k6a8v9b6p0j788fgykq6s55baba29lg37fwvmn4igxxkfwmbp3";
         };
       };
     };
     "symfony/error-handler" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-error-handler-d603654eaeb713503bba3e308b9e748e5a6d3f2e";
+        name = "symfony-error-handler-48e81a375525872e788c2418430f54150d935810";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/error-handler/zipball/d603654eaeb713503bba3e308b9e748e5a6d3f2e;
-          sha256 = "15xdk9bbyfdm8yf19jfb3zr1yaj0lprf9pmxgj630vbpbqkgsd8f";
+          url = https://api.github.com/repos/symfony/error-handler/zipball/48e81a375525872e788c2418430f54150d935810;
+          sha256 = "17hpwx8arv3h4cw4fwzkm7a39lsa92vwxsinyqmx723v1nr5z1d2";
         };
       };
     };
@@ -675,50 +685,50 @@ let
     "symfony/finder" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-finder-25d79cfccfc12e84e7a63a248c3f0720fdd92db6";
+        name = "symfony-finder-2543795ab1570df588b9bbd31e1a2bd7037b94f6";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/finder/zipball/25d79cfccfc12e84e7a63a248c3f0720fdd92db6;
-          sha256 = "04fwddn12sj6vzr5xr4xd25m86cn4l15079490h3q3igprzvrqk8";
+          url = https://api.github.com/repos/symfony/finder/zipball/2543795ab1570df588b9bbd31e1a2bd7037b94f6;
+          sha256 = "0scclnfc9aphjsric1xaj51vbqqz56kiz6l8l6ldqv6cvyg8zlyi";
         };
       };
     };
     "symfony/http-client-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-http-client-contracts-41db680a15018f9c1d4b23516059633ce280ca33";
+        name = "symfony-http-client-contracts-7e82f6084d7cae521a75ef2cb5c9457bbda785f4";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/http-client-contracts/zipball/41db680a15018f9c1d4b23516059633ce280ca33;
-          sha256 = "1iia9rpbri1whp2dw4qfhh90gmkdvxhgjwxi54q7wlnlhijgga81";
+          url = https://api.github.com/repos/symfony/http-client-contracts/zipball/7e82f6084d7cae521a75ef2cb5c9457bbda785f4;
+          sha256 = "04mszmb94y0xjs0cwqxzhpf65kfqhhqznldifbxvrrlxb9nn23qc";
         };
       };
     };
     "symfony/http-foundation" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-http-foundation-8888741b633f6c3d1e572b7735ad2cae3e03f9c5";
+        name = "symfony-http-foundation-02d968647fe61b2f419a8dc70c468a9d30a48d3a";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/http-foundation/zipball/8888741b633f6c3d1e572b7735ad2cae3e03f9c5;
-          sha256 = "0qs389nxxqc6nwx5x6b9kz8ykdlhdx7k8k6nd2apppxpqalvk6sw";
+          url = https://api.github.com/repos/symfony/http-foundation/zipball/02d968647fe61b2f419a8dc70c468a9d30a48d3a;
+          sha256 = "1bq4why2v8p7wy8801bdml43xh7kb5fli16cv74bvqpwlp4cdv9f";
         };
       };
     };
     "symfony/http-kernel" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-http-kernel-07ea794a327d7c8c5d76e3058fde9fec6a711cb4";
+        name = "symfony-http-kernel-0248214120d00c5f44f1cd5d9ad65f0b38459333";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/http-kernel/zipball/07ea794a327d7c8c5d76e3058fde9fec6a711cb4;
-          sha256 = "0mnay6nn299ljjgaqqbk8kcl431wrzvzsqybvl648pf513mp9vy9";
+          url = https://api.github.com/repos/symfony/http-kernel/zipball/0248214120d00c5f44f1cd5d9ad65f0b38459333;
+          sha256 = "032ljl732x0bs3my26wjfmxrxplz8vlxs0xzlqsxrh18lnyv6z3h";
         };
       };
     };
     "symfony/mime" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-mime-7dee6a43493f39b51ff6c5bb2bd576fe40a76c86";
+        name = "symfony-mime-1b2092244374cbe48ae733673f2ca0818b37197b";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/mime/zipball/7dee6a43493f39b51ff6c5bb2bd576fe40a76c86;
-          sha256 = "0931zsmnpx75b9b34a03l0sfp22mailaa2y5az3cgx9v0bkc0vka";
+          url = https://api.github.com/repos/symfony/mime/zipball/1b2092244374cbe48ae733673f2ca0818b37197b;
+          sha256 = "0d2vhmd25d7yvh9xzl2vazx2bfsb8qyvd2kgvl9cry1va4vrpkj3";
         };
       };
     };
@@ -815,50 +825,50 @@ let
     "symfony/routing" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-routing-87529f6e305c7acb162840d1ea57922038072425";
+        name = "symfony-routing-69919991c845b34626664ddc9b3aef9d09d2a5df";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/routing/zipball/87529f6e305c7acb162840d1ea57922038072425;
-          sha256 = "0qrgacividsp7c61y03qh8lb4vj30g0mvljnm5k60h4zzdmivlgc";
+          url = https://api.github.com/repos/symfony/routing/zipball/69919991c845b34626664ddc9b3aef9d09d2a5df;
+          sha256 = "0ghynrw6d9dpskhgyf3ljlz4pfmi68r3bzhr45lygadx21yacddw";
         };
       };
     };
     "symfony/service-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-service-contracts-d15da7ba4957ffb8f1747218be9e1a121fd298a1";
+        name = "symfony-service-contracts-f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1;
-          sha256 = "168iq1lp2r5qb5h8j0s17da09iaj2h5hrrdc9rw2p73hq8rvm1w2";
+          url = https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb;
+          sha256 = "1i573rmajc33a9nrgwgc4k3svg29yp9xv17gp133rd1i705hwv1y";
         };
       };
     };
     "symfony/translation" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-translation-e1d0c67167a553556d9f974b5fa79c2448df317a";
+        name = "symfony-translation-eb8f5428cc3b40d6dffe303b195b084f1c5fbd14";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/translation/zipball/e1d0c67167a553556d9f974b5fa79c2448df317a;
-          sha256 = "1b6fj278i1wdf4l7py9n86lmhrqmzvjy7kapjpfkz03adn2ps127";
+          url = https://api.github.com/repos/symfony/translation/zipball/eb8f5428cc3b40d6dffe303b195b084f1c5fbd14;
+          sha256 = "0x80ijdhpfv9is847pp09jlr0g0hwg9sil95jknil7dgx5pjsa5z";
         };
       };
     };
     "symfony/translation-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-translation-contracts-e2eaa60b558f26a4b0354e1bbb25636efaaad105";
+        name = "symfony-translation-contracts-95c812666f3e91db75385749fe219c5e494c7f95";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/translation-contracts/zipball/e2eaa60b558f26a4b0354e1bbb25636efaaad105;
-          sha256 = "1k26yvgk84rz6ja9ml6l6iwbbi68qsqnq2cpky044g9ymvlg8d5g";
+          url = https://api.github.com/repos/symfony/translation-contracts/zipball/95c812666f3e91db75385749fe219c5e494c7f95;
+          sha256 = "073l1pbmwbkaviwwjq9ypb1w7dk366nn2vn1vancbal0zqk0zx7b";
         };
       };
     };
     "symfony/var-dumper" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-var-dumper-a1eab2f69906dc83c5ddba4632180260d0ab4f7f";
+        name = "symfony-var-dumper-0da0e174f728996f5d5072d6a9f0a42259dbc806";
         src = fetchurl {
-          url = https://api.github.com/repos/symfony/var-dumper/zipball/a1eab2f69906dc83c5ddba4632180260d0ab4f7f;
-          sha256 = "1yw12jbx6gf5mvg7jrr1v57ah3b2s4hflz2p1m98nayi4qhdp20m";
+          url = https://api.github.com/repos/symfony/var-dumper/zipball/0da0e174f728996f5d5072d6a9f0a42259dbc806;
+          sha256 = "1qmv99bvq10siy8bbszqmn488cjcm70vip4xs8vxwm6x6x5cw1ia";
         };
       };
     };


### PR DESCRIPTION
###### Motivation for this change
Update BookStack package. Also now the service clears its cache before starting, as recommended by [BookStack's update guide](https://www.bookstackapp.com/docs/admin/updates/).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
