### PR TITLE
butane: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/development/tools/butane/default.nix
+++ b/pkgs/development/tools/butane/default.nix
@@ -3,14 +3,14 @@
 with lib;
 
 buildGoModule rec {
-  pname = "fcct";
-  version = "0.10.0";
+  pname = "butane";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "coreos";
-    repo = "fcct";
+    repo = "butane";
     rev = "v${version}";
-    sha256 = "0gxaj2fy889fl5vhb4s89rhih9a65aqjsz2yffhi5z4fa2im8szv";
+    sha256 = "1s4rkq7mj1lyi8h47jyfy3qygfxhrmpihdy8rcnn55gcy04lm0qc";
   };
 
   vendorSha256 = null;
@@ -20,17 +20,17 @@ buildGoModule rec {
   subPackages = [ "internal" ];
 
   buildFlagsArray = ''
-    -ldflags=-X github.com/coreos/fcct/internal/version.Raw=v${version}
+    -ldflags=-X github.com/coreos/butane/internal/version.Raw=v${version}
   '';
 
   postInstall = ''
-    mv $out/bin/{internal,fcct}
+    mv $out/bin/{internal,butane}
   '';
 
   meta = {
-    description = "Translates Fedora CoreOS configs into Ignition configs";
+    description = "Translates human-readable Butane configs into machine-readable Ignition configs";
     license = licenses.asl20;
-    homepage = "https://github.com/coreos/fcct";
+    homepage = "https://github.com/coreos/butane";
     maintainers = with maintainers; [ elijahcaine ruuda ];
     platforms = platforms.unix;
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -185,6 +185,7 @@ mapAliases ({
   exfat-utils = exfat;                  # 2015-09-11
   facette = throw "facette has been removed."; # added 2020-01-06
   fast-neural-doodle = throw "fast-neural-doodle has been removed, as the upstream project has been abandoned"; # added 2020-03-28
+  fedora-coreos-config-transpiler = throw "fedora-coreos-config-transpiler has been renamed to 'butane'."; # added 2021-04-13
   fetchFromGithub = throw "You meant fetchFromGitHub, with a capital H.";
   ffadoFull = ffado; # added 2018-05-01
   firefox-esr-68 = throw "Firefox 68 ESR reached end of life with its final release 68.12esr on 2020-08-25 and was therefore removed from nixpkgs";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1240,8 +1240,6 @@ in
 
   fedora-backgrounds = callPackage ../data/misc/fedora-backgrounds { };
 
-  fedora-coreos-config-transpiler = callPackage ../development/tools/fedora-coreos-config-transpiler { };
-
   ccextractor = callPackage ../applications/video/ccextractor { };
 
   cconv = callPackage ../tools/text/cconv { };
@@ -1747,6 +1745,8 @@ in
   bluemix-cli = callPackage ../tools/admin/bluemix-cli { };
 
   blur-effect = callPackage ../tools/graphics/blur-effect { };
+
+  butane = callPackage ../development/tools/butane { };
 
   charles = charles4;
   inherit (callPackage ../applications/networking/charles {})


### PR DESCRIPTION
###### Motivation for this change

* [Version 0.11.0 was released upstream](https://github.com/coreos/butane/releases/tag/v0.11.0).
* Version 0.11.0 renames the project from “Fedora CoreOS Config Transpiler” (fcct) to “Butane”, so I’ve renamed the package here as well. I added an error in the old package to point people who rely on the current `fedora-coreos-config-transpiler` in the right direction. Is this the right thing to do? Should it be recorded in release notes somewhere?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
