### PR TITLE
buildRustPackage: Provide overrideAttrs

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -17,132 +17,140 @@
 , windows
 }:
 
-{ name ? "${args.pname}-${args.version}"
-
-  # SRI hash
-, cargoHash ? ""
-
-  # Legacy hash
-, cargoSha256 ? ""
-
-  # Name for the vendored dependencies tarball
-, cargoDepsName ? name
-
-, src ? null
-, srcs ? null
-, unpackPhase ? null
-, cargoPatches ? []
-, patches ? []
-, sourceRoot ? null
-, logLevel ? ""
-, buildInputs ? []
-, nativeBuildInputs ? []
-, cargoUpdateHook ? ""
-, cargoDepsHook ? ""
-, buildType ? "release"
-, meta ? {}
-, cargoVendorDir ? null
-, checkType ? buildType
-, depsExtraArgs ? {}
-
-# Toggles whether a custom sysroot is created when the target is a .json file.
-, __internal_dontAddSysroot ? false
-
-# Needed to `pushd`/`popd` into a subdir of a tarball if this subdir
-# contains a Cargo.toml, but isn't part of a workspace (which is e.g. the
-# case for `rustfmt`/etc from the `rust-sources).
-# Otherwise, everything from the tarball would've been built/tested.
-, buildAndTestSubdir ? null
-, ... } @ args:
-
-assert cargoVendorDir == null -> !(cargoSha256 == "" && cargoHash == "");
-assert buildType == "release" || buildType == "debug";
-
 let
+  self =
+    { name ? "${args.pname}-${args.version}"
 
-  cargoDeps = if cargoVendorDir == null
-    then fetchCargoTarball ({
-        inherit src srcs sourceRoot unpackPhase cargoUpdateHook;
-        name = cargoDepsName;
-        hash = cargoHash;
-        patches = cargoPatches;
-        sha256 = cargoSha256;
-      } // depsExtraArgs)
-    else null;
+      # SRI hash
+    , cargoHash ? ""
 
-  # If we have a cargoSha256 fixed-output derivation, validate it at build time
-  # against the src fixed-output derivation to check consistency.
-  validateCargoDeps = !(cargoHash == "" && cargoSha256 == "");
+      # Legacy hash
+    , cargoSha256 ? ""
 
-  target = rust.toRustTargetSpec stdenv.hostPlatform;
-  targetIsJSON = lib.hasSuffix ".json" target;
-  useSysroot = targetIsJSON && !__internal_dontAddSysroot;
+      # Name for the vendored dependencies tarball
+    , cargoDepsName ? name
 
-  # see https://github.com/rust-lang/cargo/blob/964a16a28e234a3d397b2a7031d4ab4a428b1391/src/cargo/core/compiler/compile_kind.rs#L151-L168
-  # the "${}" is needed to transform the path into a /nix/store path before baseNameOf
-  shortTarget = if targetIsJSON then
-      (lib.removeSuffix ".json" (builtins.baseNameOf "${target}"))
-    else target;
+    , src ? null
+    , srcs ? null
+    , unpackPhase ? null
+    , cargoPatches ? []
+    , patches ? []
+    , sourceRoot ? null
+    , logLevel ? ""
+    , buildInputs ? []
+    , nativeBuildInputs ? []
+    , cargoUpdateHook ? ""
+    , cargoDepsHook ? ""
+    , buildType ? "release"
+    , meta ? {}
+    , cargoVendorDir ? null
+    , checkType ? buildType
+    , depsExtraArgs ? {}
 
-  sysroot = (callPackage ./sysroot {}) {
-    inherit target shortTarget;
-    RUSTFLAGS = args.RUSTFLAGS or "";
-    originalCargoToml = src + /Cargo.toml; # profile info is later extracted
-  };
+      # Toggles whether a custom sysroot is created when the target is a .json file.
+    , __internal_dontAddSysroot ? false
 
-in
+      # Needed to `pushd`/`popd` into a subdir of a tarball if this subdir
+      # contains a Cargo.toml, but isn't part of a workspace (which is e.g. the
+      # case for `rustfmt`/etc from the `rust-sources).
+      # Otherwise, everything from the tarball would've been built/tested.
+    , buildAndTestSubdir ? null
+    , ... } @ args:
 
-# Tests don't currently work for `no_std`, and all custom sysroots are currently built without `std`.
-# See https://os.phil-opp.com/testing/ for more information.
-assert useSysroot -> !(args.doCheck or true);
+    assert cargoVendorDir == null -> !(cargoSha256 == "" && cargoHash == "");
+    assert buildType == "release" || buildType == "debug";
 
-stdenv.mkDerivation ((removeAttrs args ["depsExtraArgs"]) // lib.optionalAttrs useSysroot {
-  RUSTFLAGS = "--sysroot ${sysroot} " + (args.RUSTFLAGS or "");
-} // {
-  inherit buildAndTestSubdir cargoDeps;
+    let
 
-  cargoBuildType = buildType;
+      cargoDeps = if cargoVendorDir == null
+                  then fetchCargoTarball ({
+                    inherit src srcs sourceRoot unpackPhase cargoUpdateHook;
+                    name = cargoDepsName;
+                    hash = cargoHash;
+                    patches = cargoPatches;
+                    sha256 = cargoSha256;
+                  } // depsExtraArgs)
+                  else null;
 
-  cargoCheckType = checkType;
+      # If we have a cargoSha256 fixed-output derivation, validate it at build time
+      # against the src fixed-output derivation to check consistency.
+      validateCargoDeps = !(cargoHash == "" && cargoSha256 == "");
 
-  patchRegistryDeps = ./patch-registry-deps;
+      target = rust.toRustTargetSpec stdenv.hostPlatform;
+      targetIsJSON = lib.hasSuffix ".json" target;
+      useSysroot = targetIsJSON && !__internal_dontAddSysroot;
 
-  nativeBuildInputs = nativeBuildInputs ++ [
-    cacert
-    git
-    cargoBuildHook
-    cargoCheckHook
-    cargoInstallHook
-    cargoSetupHook
-    rustc
-  ];
+      # see https://github.com/rust-lang/cargo/blob/964a16a28e234a3d397b2a7031d4ab4a428b1391/src/cargo/core/compiler/compile_kind.rs#L151-L168
+      # the "${}" is needed to transform the path into a /nix/store path before baseNameOf
+      shortTarget = if targetIsJSON then
+        (lib.removeSuffix ".json" (builtins.baseNameOf "${target}"))
+                    else target;
 
-  buildInputs = buildInputs ++ lib.optional stdenv.hostPlatform.isMinGW windows.pthreads;
+      sysroot = (callPackage ./sysroot {}) {
+        inherit target shortTarget;
+        RUSTFLAGS = args.RUSTFLAGS or "";
+        originalCargoToml = src + /Cargo.toml; # profile info is later extracted
+      };
 
-  patches = cargoPatches ++ patches;
+    in
 
-  PKG_CONFIG_ALLOW_CROSS =
-    if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
+      # Tests don't currently work for `no_std`, and all custom sysroots are currently built without `std`.
+      # See https://os.phil-opp.com/testing/ for more information.
+      assert useSysroot -> !(args.doCheck or true);
 
-  postUnpack = ''
-    eval "$cargoDepsHook"
+      lib.extendDerivation
+        true
+        {
+          overrideAttrs = f: self (args // (f args));
+        }
+        (stdenv.mkDerivation ((removeAttrs args ["depsExtraArgs"]) // lib.optionalAttrs useSysroot {
+          RUSTFLAGS = "--sysroot ${sysroot} " + (args.RUSTFLAGS or "");
+        } // {
+          inherit buildAndTestSubdir cargoDeps;
 
-    export RUST_LOG=${logLevel}
-  '' + (args.postUnpack or "");
+          cargoBuildType = buildType;
 
-  configurePhase = args.configurePhase or ''
-    runHook preConfigure
-    runHook postConfigure
-  '';
+          cargoCheckType = checkType;
 
-  doCheck = args.doCheck or true;
+          patchRegistryDeps = ./patch-registry-deps;
 
-  strictDeps = true;
+          nativeBuildInputs = nativeBuildInputs ++ [
+            cacert
+            git
+            cargoBuildHook
+            cargoCheckHook
+            cargoInstallHook
+            cargoSetupHook
+            rustc
+          ];
 
-  passthru = { inherit cargoDeps; } // (args.passthru or {});
+          buildInputs = buildInputs ++ lib.optional stdenv.hostPlatform.isMinGW windows.pthreads;
 
-  meta = {
-    # default to Rust's platforms
-    platforms = rustc.meta.platforms;
-  } // meta;
-})
+          patches = cargoPatches ++ patches;
+
+          PKG_CONFIG_ALLOW_CROSS =
+            if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
+
+          postUnpack = ''
+            eval "$cargoDepsHook"
+
+            export RUST_LOG=${logLevel}
+          '' + (args.postUnpack or "");
+
+          configurePhase = args.configurePhase or ''
+            runHook preConfigure
+            runHook postConfigure
+          '';
+
+          doCheck = args.doCheck or true;
+
+          strictDeps = true;
+
+          passthru = { inherit cargoDeps; } // (args.passthru or {});
+
+          meta = {
+            # default to Rust's platforms
+            platforms = rustc.meta.platforms;
+          } // meta;
+        }));
+in self


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Previously, calls to `overrideAttrs` applied to the wrapped `mkDerivation` call, and overriding calls to `buildRustPackage` thus wasn't possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
