### PR TITLE
todofi.sh: init at 1.0.0

### DIFF
--- a/pkgs/applications/office/todofi.sh/default.nix
+++ b/pkgs/applications/office/todofi.sh/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, coreutils
+, gawk
+, gnugrep
+, gnused
+, rofi
+, todo-txt-cli
+}:
+
+stdenv.mkDerivation rec {
+  pname = "todofi.sh";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "hugokernel";
+    repo = "todofi.sh";
+    rev = "v${version}";
+    sha256 = "1gmy5inlghycsxiwnyyjyv81jn2fmfk3s9x78kcgyf7khzb5kwvj";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -Dm 755 todofi.sh -t $out/bin
+  '';
+
+  wrapperPath = with lib; makeBinPath [
+    coreutils
+    gawk
+    gnugrep
+    gnused
+    rofi
+    todo-txt-cli
+  ];
+
+  fixupPhase = ''
+    patchShebangs $out/bin
+    wrapProgram $out/bin/todofi.sh --prefix PATH : "${wrapperPath}"
+  '';
+
+  meta = with lib; {
+    description = "Todo-txt + Rofi = Todofi.sh";
+    homepage = "https://github.com/hugokernel/todofi.sh";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ewok ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/office/todofi.sh/default.nix
+++ b/pkgs/applications/office/todofi.sh/default.nix
@@ -29,8 +29,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     patchShebangs $out/bin
-    wrapProgram $out/bin/todofi.sh --prefix PATH : "${lib.makeBinPath [ coreutils gawk gnugrep gnused rofi todo-txt-cli ];
-}"
+    wrapProgram $out/bin/todofi.sh --prefix PATH : "${lib.makeBinPath [ coreutils gawk gnugrep gnused rofi todo-txt-cli ]}"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/office/todofi.sh/default.nix
+++ b/pkgs/applications/office/todofi.sh/default.nix
@@ -27,18 +27,10 @@ stdenv.mkDerivation rec {
     install -Dm 755 todofi.sh -t $out/bin
   '';
 
-  wrapperPath = with lib; makeBinPath [
-    coreutils
-    gawk
-    gnugrep
-    gnused
-    rofi
-    todo-txt-cli
-  ];
-
-  fixupPhase = ''
+  postFixup = ''
     patchShebangs $out/bin
-    wrapProgram $out/bin/todofi.sh --prefix PATH : "${wrapperPath}"
+    wrapProgram $out/bin/todofi.sh --prefix PATH : "${lib.makeBinPath [ coreutils gawk gnugrep gnused rofi todo-txt-cli ];
+}"
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26113,6 +26113,8 @@ in
 
   todo-txt-cli = callPackage ../applications/office/todo.txt-cli { };
 
+  todofi-sh = callPackage ../applications/office/todofi.sh { };
+
   todoman = callPackage ../applications/office/todoman { };
 
   toggldesktop = libsForQt514.callPackage ../applications/misc/toggldesktop { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding rofi based UI for Todo-txt-cli. It's just released with v1.0.0. 
I have been using it on a daily bases for several month already. Looks nice and handy. 

![screenshot](https://user-images.githubusercontent.com/454695/114562011-c7608e80-9c76-11eb-8ff4-19c3ebebe47b.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
