### PR TITLE
elementary-planner: 2.5.7 -> 2.6.9

### DIFF
--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -12,22 +12,24 @@
 , libgee
 , json-glib
 , glib
+, glib-networking
 , sqlite
 , libsoup
 , gtk3
 , pantheon /* granite, icons, maintainers */
 , webkitgtk
+, libpeas
 }:
 
 stdenv.mkDerivation rec {
   pname = "elementary-planner";
-  version = "2.5.7";
+  version = "2.6.9";
 
   src = fetchFromGitHub {
     owner = "alainm23";
     repo = "planner";
     rev = version;
-    sha256 = "0s2f9q7i31c2splflfnaiqviwnxbsp2zvibr70xafhbhnkmzlrsk";
+    sha256 = "17ij017x2cplqhway8376k8mmrll4w1jfwhf7ixldq9g0q2inzd8";
   };
 
   nativeBuildInputs = [
@@ -43,10 +45,12 @@ stdenv.mkDerivation rec {
   buildInputs = [
     evolution-data-server
     glib
+    glib-networking
     gtk3
     json-glib
     libgee
     libical
+    libpeas
     libsoup
     pantheon.elementary-icon-theme
     pantheon.granite
@@ -64,6 +68,10 @@ stdenv.mkDerivation rec {
       # the theme is hardcoded
       --prefix XDG_DATA_DIRS : "${pantheon.elementary-gtk-theme}/share"
     )
+  '';
+
+  postFixup = ''
+    ln -s $out/bin/com.github.alainm23.planner $out/bin/planner
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Also add a symbolic link `planner -> com.github.alainm23.planner`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
