### PR TITLE
gradle: 7-rc-2 -> 7, bumping latest 6.8.3 -> 7

### DIFF
--- a/pkgs/applications/networking/p2p/frostwire/default.nix
+++ b/pkgs/applications/networking/p2p/frostwire/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, gradle, perl, jre, makeWrapper, makeDesktopItem, mplayer }:
+{ lib, stdenv, fetchFromGitHub, gradle_6, perl, jre, makeWrapper, makeDesktopItem, mplayer }:
 
 let
   version = "6.6.7-build-529";
@@ -25,7 +25,7 @@ let
   deps = stdenv.mkDerivation {
     name = "${name}-deps";
     inherit src;
-    buildInputs = [ gradle perl ];
+    buildInputs = [ gradle_6 perl ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
       ( cd desktop
@@ -47,7 +47,7 @@ in stdenv.mkDerivation {
   inherit name src;
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ gradle ];
+  buildInputs = [ gradle_6 ];
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -61,13 +61,12 @@ in rec {
     };
   };
 
-  # NOTE: Gradle 7 is a release candidate, so point to 6.8.
-  gradle_latest = gradle_6_8;
+  gradle_latest = gradle_7;
 
   gradle_7 = gradleGen (gradleSpec {
-    version = "7.0-rc-2";
+    version = "7.0";
     nativeVersion = "0.22-milestone-11";
-    sha256 = "0gzvigyvwwizx90vnzhdnbm5rdaki11inxna11s4y67xkn8hrnx5";
+    sha256 = "01f3bjn8pbpni8kmxvx1dpwpf4zz04vj7cpm6025n0k188c8k2zb";
   });
 
   gradle_6_8 = gradleGen (gradleSpec {

--- a/pkgs/development/tools/scenebuilder/default.nix
+++ b/pkgs/development/tools/scenebuilder/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, jdk, gradleGen, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell, makeWrapper, glib, wrapGAppsHook }:
 let
   # The default one still uses jdk8 (#89731)
-  gradle = (gradleGen.override (old: { java = jdk; })).gradle_latest;
+  gradle = (gradleGen.override (old: { java = jdk; })).gradle_6_8;
 
   pname = "scenebuilder";
   version = "15.0.1";

--- a/pkgs/games/shattered-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/default.nix
@@ -2,7 +2,7 @@
 , makeWrapper
 , fetchFromGitHub
 , nixosTests
-, gradle
+, gradle_6
 , perl
 , jre
 , libpulseaudio
@@ -33,7 +33,7 @@ let
   deps = stdenv.mkDerivation {
     pname = "${pname}-deps";
     inherit version src postPatch;
-    nativeBuildInputs = [ gradle perl ];
+    nativeBuildInputs = [ gradle_6 perl ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
       # https://github.com/gradle/gradle/issues/4426
@@ -54,7 +54,7 @@ let
 in stdenv.mkDerivation rec {
   inherit pname version src postPatch;
 
-  nativeBuildInputs = [ gradle perl makeWrapper ];
+  nativeBuildInputs = [ gradle_6 perl makeWrapper ];
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)

--- a/pkgs/servers/ma1sd/default.nix
+++ b/pkgs/servers/ma1sd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, jre, git, gradle, perl, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, jre, git, gradle_6, perl, makeWrapper }:
 
 let
   name = "ma1sd-${version}";
@@ -16,7 +16,7 @@ let
   deps = stdenv.mkDerivation {
     name = "${name}-deps";
     inherit src;
-    nativeBuildInputs = [ gradle perl git ];
+    nativeBuildInputs = [ gradle_6 perl git ];
 
     buildPhase = ''
       export MA1SD_BUILD_VERSION=${rev}
@@ -41,7 +41,7 @@ let
 in
 stdenv.mkDerivation {
   inherit name src version;
-  nativeBuildInputs = [ gradle perl makeWrapper ];
+  nativeBuildInputs = [ gradle_6 perl makeWrapper ];
   buildInputs = [ jre ];
 
   buildPhase = ''

--- a/pkgs/servers/mxisd/default.nix
+++ b/pkgs/servers/mxisd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, jre, git, gradle, perl, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, jre, git, gradle_6, perl, makeWrapper }:
 
 let
   name = "mxisd-${version}";
@@ -16,7 +16,7 @@ let
   deps = stdenv.mkDerivation {
     name = "${name}-deps";
     inherit src;
-    nativeBuildInputs = [ gradle perl git ];
+    nativeBuildInputs = [ gradle_6 perl git ];
 
     buildPhase = ''
       export MXISD_BUILD_VERSION=${rev}
@@ -41,7 +41,7 @@ let
 in
 stdenv.mkDerivation {
   inherit name src version;
-  nativeBuildInputs = [ gradle perl makeWrapper ];
+  nativeBuildInputs = [ gradle_6 perl makeWrapper ];
   buildInputs = [ jre ];
 
   patches = [ ./0001-gradle.patch ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Release of Gradle 7. See:

 - [Release Notes](https://docs.gradle.org/7.0/release-notes.html)
 - [Upgrade Guide](https://docs.gradle.org/7.0/userguide/upgrading_version_6.html#changes_7.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Please review, @SuperSandro2000 @mstrangfeld 