### PR TITLE
lunar-client: 2.4.0 -> 2.6.0

### DIFF
--- a/pkgs/games/lunar-client/default.nix
+++ b/pkgs/games/lunar-client/default.nix
@@ -1,13 +1,14 @@
 { appimageTools, lib, fetchurl, makeDesktopItem }:
+
 let
   name = "lunar-client";
-  version = "2.4.0";
+  version = "2.6.0";
 
   desktopItem = makeDesktopItem {
     name = "Lunar Client";
     exec = "lunar-client";
     icon = "lunarclient";
-    comment = "Optimized Minecraft Client for 1.7.10 and 1.8.9";
+    comment = "Minecraft 1.7, 1.8, 1.12, 1.15, and 1.16 Client";
     desktopName = "Lunar Client";
     genericName = "Minecraft Client";
     categories = "Game;";
@@ -20,7 +21,7 @@ let
   src = fetchurl {
     url = "https://launcherupdates.lunarclientcdn.com/Lunar%20Client-${version}.AppImage";
     name = "lunar-client.AppImage";
-    sha256 = "bb85a62127a9b3848cc60796c20ac75655794f1d3cd17cb6b5499bbf19d16019";
+    sha256 = "1pmblnnvs5jv5v7y5nnxr3liw9xfp5h6l44x7pln8kr9zg85dzma";
   };
 in appimageTools.wrapType1 rec {
   inherit name src;
@@ -31,8 +32,10 @@ in appimageTools.wrapType1 rec {
     cp -r ${appimageContents}/usr/share/icons/ $out/share/
   '';
 
+  extraPkgs = pkgs: [ pkgs.libpulseaudio ];
+
   meta = with lib; {
-    description = "Minecraft 1.7.10 & 1.8.9 PVP Client";
+    description = "Minecraft 1.7, 1.8, 1.12, 1.15, and 1.16 Client";
     homepage = "https://www.lunarclient.com/";
     license = with licenses; [ unfree ];
     maintainers = with maintainers; [ zyansheep Technical27 ];

--- a/pkgs/games/lunar-client/default.nix
+++ b/pkgs/games/lunar-client/default.nix
@@ -35,7 +35,7 @@ in appimageTools.wrapType1 rec {
     description = "Minecraft 1.7.10 & 1.8.9 PVP Client";
     homepage = "https://www.lunarclient.com/";
     license = with licenses; [ unfree ];
-    maintainers = with maintainers; [ zyansheep ];
+    maintainers = with maintainers; [ zyansheep Technical27 ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The auto updater in lunar client doesn't (and can't) work, and it refuses to run if the version is too old.

###### Things done
Add myself to maintainers.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
