### PR TITLE
fcitx5-m17n: init at 5.0.4

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-m17n.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-m17n.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , cmake
 , extra-cmake-modules

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-m17n.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-m17n.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, pkg-config
+, fcitx5
+, m17n_lib
+, m17n_db
+, gettext
+, fmt
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fcitx5-m17n";
+  version = "5.0.4";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-yI6Svr1KEdHqAX3qd7t7GvD0EcWg0A2vZpuJw1U9oKQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+    gettext
+  ];
+
+  buildInputs = [
+    fcitx5
+    m17n_db
+    m17n_lib
+    fmt
+  ];
+
+  meta = with lib; {
+    description = "m17n support for Fcitx5";
+    homepage = "https://github.com/fcitx/fcitx5-m17n";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ Technical27 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4356,6 +4356,8 @@ in
 
   fcitx5-lua = callPackage ../tools/inputmethods/fcitx5/fcitx5-lua.nix { };
 
+  fcitx5-m17n = callPackage ../tools/inputmethods/fcitx5/fcitx5-m17n.nix { };
+
   fcitx5-gtk = callPackage ../tools/inputmethods/fcitx5/fcitx5-gtk.nix { };
 
   fcitx5-rime = callPackage ../tools/inputmethods/fcitx5/fcitx5-rime.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
m17n is only packaged for fcitx4 and ibus.

###### Things done
Add fcitx5-m17n as a new package.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
