### PR TITLE
python3Packages.karton-yaramatcher: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/karton-yaramatcher/default.nix
+++ b/pkgs/development/python-modules/karton-yaramatcher/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, karton-core
+, python
+, yara-python
+}:
+
+buildPythonPackage rec {
+  pname = "karton-yaramatcher";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "CERT-Polska";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "093h5hbx2ss4ly523gvf10a5ky3vvin6wipigvhx13y1rdxl6c9n";
+  };
+
+  propagatedBuildInputs = [
+    karton-core
+    yara-python
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "karton-core==4.0.5" "karton-core" \
+      --replace "yara-python==4.0.2" "yara-python" \
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m unittest discover
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "karton.yaramatcher" ];
+
+  meta = with lib; {
+    description = "File and analysis artifacts yara matcher for the Karton framework";
+    homepage = "https://github.com/CERT-Polska/karton-yaramatcher";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3685,6 +3685,8 @@ in {
 
   karton-core = callPackage ../development/python-modules/karton-core { };
 
+  karton-yaramatcher = callPackage ../development/python-modules/karton-yaramatcher { };
+
   kazoo = callPackage ../development/python-modules/kazoo { };
 
   kconfiglib = callPackage ../development/python-modules/kconfiglib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
File and analysis artifacts yara matcher for the Karton framework

https://github.com/CERT-Polska/karton-yaramatcher

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @chivay