### PR TITLE
velero: 1.5.4 -> 1.6.0

### DIFF
--- a/pkgs/applications/networking/cluster/velero/default.nix
+++ b/pkgs/applications/networking/cluster/velero/default.nix
@@ -2,24 +2,27 @@
 
 buildGoModule rec {
   pname = "velero";
-  version = "1.5.4";
+  # When updating, change the commit underneath
+  version = "1.6.0";
+  commit = "5bd70fd8eef316d220317245e46dc6016c348dce";
+
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "vmware-tanzu";
     repo = "velero";
-    sha256 = "sha256-YHBqIM3NV2L13w9WCzldUWmdBMec7ZndzYgGHblS8Dg=";
+    sha256 = "sha256-2d4xsffh5DpxGahmzXpgUBRFAt5CsDnHCm8xU1ksqyQ=";
   };
 
   buildFlagsArray = ''
     -ldflags=
       -s -w
       -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${version}
-      -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=456eb19668f8da603756353d9179b59b5a7bfa04
+      -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=${commit}
       -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean
   '';
 
-  vendorSha256 = "sha256-m/zShJeclZ1k8Fr9faK2x1Mpwbwun674iMPJhMw/9Mc=";
+  vendorSha256 = "sha256-aQjtebIyV69nRwc/zvK/9v0mX3pAPKfOunSL/FpFZJU=";
 
   excludedPackages = [ "issue-template-gen" ];
 


### PR DESCRIPTION
###### Motivation for this change
Velero update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
