### PR TITLE
geoclue2: Use our own mozilla API key

### DIFF
--- a/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
@@ -65,17 +65,20 @@ index fde6fa3..39b7b0a 100644
  conf.set_quoted('LOCALEDIR', localedir)
 -conf.set_quoted('SYSCONFDIR', sysconfdir)
 +conf.set_quoted('SYSCONFDIR', get_option('sysconfdir'))
+ conf.set_quoted('MOZILLA_API_KEY', get_option('mozilla-api-key'))
  conf.set10('GCLUE_USE_3G_SOURCE', get_option('3g-source'))
  conf.set10('GCLUE_USE_CDMA_SOURCE', get_option('cdma-source'))
- conf.set10('GCLUE_USE_MODEM_GPS_SOURCE', get_option('modem-gps-source'))
 diff --git a/meson_options.txt b/meson_options.txt
 index 83bc60e..b726329 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -34,3 +34,6 @@ option('systemd-system-unit-dir',
+@@ -34,6 +34,9 @@ option('systemd-system-unit-dir',
  option('dbus-srv-user',
         type: 'string', value: 'root',
         description: 'The user (existing) as which the service will run')
 +option('sysconfdir_install',
 +       type: 'string', value: '',
 +       description: 'sysconfdir to use during installation')
+ option('mozilla-api-key',
+        type: 'string', value: 'geoclue',
+        description: 'Your API key for Mozilla Location Service')

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -1,13 +1,33 @@
-{ lib, stdenv, fetchFromGitLab, intltool, meson, ninja, pkg-config, gtk-doc, docbook_xsl, docbook_xml_dtd_412, glib, json-glib, libsoup, libnotify, gdk-pixbuf
-, modemmanager, avahi, glib-networking, python3, wrapGAppsHook, gobject-introspection, vala
+{ lib
+, stdenv
+, fetchFromGitLab
+, intltool
+, meson
+, ninja
+, pkg-config
+, gtk-doc
+, docbook-xsl-nons
+, docbook_xml_dtd_412
+, glib
+, json-glib
+, libsoup
+, libnotify
+, gdk-pixbuf
+, modemmanager
+, avahi
+, glib-networking
+, python3
+, wrapGAppsHook
+, gobject-introspection
+, vala
 , withDemoAgent ? false
 }:
-
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "geoclue";
   version = "2.5.6";
+
+  outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -21,30 +41,45 @@ stdenv.mkDerivation rec {
     ./add-option-for-installation-sysconfdir.patch
   ];
 
-  outputs = [ "out" "dev" "devdoc" ];
-
   nativeBuildInputs = [
-    pkg-config intltool meson ninja wrapGAppsHook python3 vala gobject-introspection
+    pkg-config
+    intltool
+    meson
+    ninja
+    wrapGAppsHook
+    python3
+    vala
+    gobject-introspection
     # devdoc
-    gtk-doc docbook_xsl docbook_xml_dtd_412
+    gtk-doc
+    docbook-xsl-nons
+    docbook_xml_dtd_412
   ];
 
   buildInputs = [
-    glib json-glib libsoup avahi
-  ] ++ optionals withDemoAgent [
+    glib
+    json-glib
+    libsoup
+    avahi
+  ] ++ lib.optionals withDemoAgent [
     libnotify gdk-pixbuf
-  ] ++ optionals (!stdenv.isDarwin) [ modemmanager ];
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    modemmanager
+  ];
 
-  propagatedBuildInputs = [ glib glib-networking ];
+  propagatedBuildInputs = [
+    glib
+    glib-networking
+  ];
 
   mesonFlags = [
     "-Dsystemd-system-unit-dir=${placeholder "out"}/etc/systemd/system"
-    "-Ddemo-agent=${boolToString withDemoAgent}"
+    "-Ddemo-agent=${lib.boolToString withDemoAgent}"
     "--sysconfdir=/etc"
     "-Dsysconfdir_install=${placeholder "out"}/etc"
     "-Ddbus-srv-user=geoclue"
     "-Ddbus-sys-dir=${placeholder "out"}/share/dbus-1/system.d"
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     "-D3g-source=false"
     "-Dcdma-source=false"
     "-Dmodem-gps-source=false"

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , intltool
 , meson
 , ninja
@@ -38,6 +39,17 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Make the Mozilla API key configurable
+    # https://gitlab.freedesktop.org/geoclue/geoclue/merge_requests/54 (only partially backported)
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/geoclue/geoclue/commit/95c9ad4dc176860c85a07d0db4cb4179929bdb54.patch";
+      sha256 = "/lq/dLBJl2vf16tt7emYoTtXY6iUw+4s2XcABUHp3Kc=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/geoclue/geoclue/commit/1a00809a0d89b0849a57647c878d192354247a33.patch";
+      sha256 = "6FuiukgFWg2cEKt8LlKP4E0rfSH/ZQgk6Ip1mGJpNFQ=";
+    })
+
     ./add-option-for-installation-sysconfdir.patch
   ];
 
@@ -77,6 +89,7 @@ stdenv.mkDerivation rec {
     "-Ddemo-agent=${lib.boolToString withDemoAgent}"
     "--sysconfdir=/etc"
     "-Dsysconfdir_install=${placeholder "out"}/etc"
+    "-Dmozilla-api-key=5c28d1f4-9511-47ff-b11a-2bef80fc177c"
     "-Ddbus-srv-user=geoclue"
     "-Ddbus-sys-dir=${placeholder "out"}/share/dbus-1/system.d"
   ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation rec {
   pname = "geoclue";
-  version = "2.5.6";
+  version = "2.5.7";
 
   outputs = [ "out" "dev" "devdoc" ];
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "13fk6n4j74lvcsrg3kwbw1mkxgcr3iy9dnysmy0pclfsym8z5m5m";
+    sha256 = "1mv1vs4q94bqkmgkj53jcsw1x31kczwydyy3r27a7fycgzmii1pj";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/110031, closes https://github.com/NixOS/nixpkgs/pull/111208

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
