### PR TITLE
mdbook-mermaid: init at 0.8.1

### DIFF
--- a/pkgs/tools/text/mdbook-mermaid/default.nix
+++ b/pkgs/tools/text/mdbook-mermaid/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, CoreServices }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-mermaid";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "badboy";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-UMYWRQeSQwWVJla/+RPlAXPMuFVnxqDtYDxLKmbMw4g=";
+  };
+
+  cargoSha256 = "sha256-nhJS2QZUyGeNRMS9D+P+QPMDHK2PqVK/H2AKaP7EECw=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
+
+  meta = with lib; {
+    description = "A preprocessor for mdbook to add mermaid.js support";
+    homepage = "https://github.com/badboy/mdbook-mermaid";
+    license = [ licenses.mpl20 ];
+    maintainers = with maintainers; [ xrelkd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6034,6 +6034,10 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  mdbook-mermaid = callPackage ../tools/text/mdbook-mermaid {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
+
   mdcat = callPackage ../tools/text/mdcat {
     inherit (darwin.apple_sdk.frameworks) Security;
     inherit (python3Packages) ansi2html;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`mdbook-mermaid` is a preprocessor for `mdbook` to add `mermaid.js` support.
- https://github.com/badboy/mdbook-mermaid

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
