### PR TITLE
river: init at unstable-2021-04-08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1364,6 +1364,12 @@
     githubId = 302429;
     name = "Marton Boros";
   };
+  branwright1 = {
+    email = "branwright@protonmail.com";
+    github = "branwright1";
+    githubId = 71175207;
+    name = "Brandon Wright";
+  };
   bramd = {
     email = "bram@bramd.nl";
     github = "bramd";

--- a/pkgs/applications/window-managers/river/default.nix
+++ b/pkgs/applications/window-managers/river/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv ,fetchFromGitHub
+, zig, pkg-config, scdoc
+, wayland ,xwayland, wayland-protocols, wlroots
+, libxkbcommon, pixman, libudev, libevdev, libX11, libGL
+}:
+
+stdenv.mkDerivation rec {
+  name = "river";
+
+  src = fetchFromGitHub {
+    owner = "ifreund";
+    repo = "river";
+    rev = "9e3e92050e04320949c6cd995273c30319ebd515";
+    sha256 = "1v8dpbadsb3c7bc84sai09dbqv5s5s5d77vs12kdkd45x0ppmk3j";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ wayland xwayland wayland-protocols wlroots pixman
+    libxkbcommon pixman libudev libevdev libX11 libGL
+  ];
+
+  preBuild = "export HOME=$TMPDIR;";
+  installPhase = "zig build -Drelease-safe -Dxwayland -Dman-pages --prefix $out install";
+
+  nativeBuildInputs = [ zig scdoc pkg-config ];
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with lib; {
+    description = "A dynamic tiling wayland compositor";
+    longDescription = ''
+    river is a dynamic tiling wayland compositor that takes inspiration from dwm and bspwm.
+    '';
+    homepage = "https://github.com/ifreund/river";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ branwright1 ];
+  };
+}

--- a/pkgs/applications/window-managers/river/default.nix
+++ b/pkgs/applications/window-managers/river/default.nix
@@ -1,11 +1,12 @@
 { lib, stdenv ,fetchFromGitHub
-, zig, pkg-config, scdoc
-, wayland ,xwayland, wayland-protocols, wlroots
-, libxkbcommon, pixman, libudev, libevdev, libX11, libGL
+, zig, wayland, pkg-config, scdoc
+, xwayland, wayland-protocols, wlroots
+, libxkbcommon, pixman, udev, libevdev, libX11, libGL
 }:
 
 stdenv.mkDerivation rec {
-  name = "river";
+  pname = "river";
+  version = "unstable-2021-04-08";
 
   src = fetchFromGitHub {
     owner = "ifreund";
@@ -15,21 +16,25 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ wayland xwayland wayland-protocols wlroots pixman
-    libxkbcommon pixman libudev libevdev libX11 libGL
+  buildInputs = [ xwayland wayland-protocols wlroots pixman
+    libxkbcommon pixman udev libevdev libX11 libGL
   ];
 
-  preBuild = "export HOME=$TMPDIR;";
-  installPhase = "zig build -Drelease-safe -Dxwayland -Dman-pages --prefix $out install";
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+  installPhase = ''
+    zig build -Drelease-safe -Dxwayland -Dman-pages --prefix $out install
+   '';
 
-  nativeBuildInputs = [ zig scdoc pkg-config ];
+  nativeBuildInputs = [ zig wayland scdoc pkg-config ];
 
   installFlags = [ "DESTDIR=$(out)" ];
 
   meta = with lib; {
     description = "A dynamic tiling wayland compositor";
     longDescription = ''
-    river is a dynamic tiling wayland compositor that takes inspiration from dwm and bspwm.
+      river is a dynamic tiling wayland compositor that takes inspiration from dwm and bspwm.
     '';
     homepage = "https://github.com/ifreund/river";
     license = licenses.gpl3Plus;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2912,6 +2912,8 @@ in
 
   psrecord = python3Packages.callPackage ../tools/misc/psrecord {};
 
+  river = callPackage ../applications/window-managers/river { };
+
   rmapi = callPackage ../applications/misc/remarkable/rmapi { };
 
   rmview = libsForQt5.callPackage ../applications/misc/remarkable/rmview { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Hi, I just wanted to add new Wayland Compositor into master branch, it's quite popular but just saw that a lot of people have problems with building/installing it on nixos. I have tested this derivation by building it through selhosted hydra, locally on nixos with nix-build and on non-nixos distribution locally and from own channel. I'm not sure about versioning in commit message since they doesn't provide any github releases yet.

Here is github page for this package https://github.com/ifreund/river

###### Things done 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
