### PR TITLE
ocamlPackages.labltk: fix ocamlbrowser by wrapping; remove legacy versions

### DIFF
--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -1,46 +1,24 @@
-{ stdenv, lib, fetchurl, fetchzip, ocaml, findlib, tcl, tk }:
+{ stdenv, lib, makeWrapper, fetchzip, ocaml, findlib, tcl, tk }:
 
-let OCamlVersionAtLeast = lib.versionAtLeast ocaml.version; in
-
-if !OCamlVersionAtLeast "4.04"
-then throw "labltk is not available for OCaml ${ocaml.version}"
-else
-
-let param =
-  let mkNewParam = { version, sha256 }: {
+let
+ params =
+  let mkNewParam = { version, sha256, rev ? version }: {
     inherit version;
     src = fetchzip {
-      url = "https://github.com/garrigue/labltk/archive/${version}.tar.gz";
+      url = "https://github.com/garrigue/labltk/archive/${rev}.tar.gz";
       inherit sha256;
     };
-  }; in
-  let mkOldParam = { version, key, sha256 }: {
-    src = fetchurl {
-      url = "https://forge.ocamlcore.org/frs/download.php/${key}/labltk-${version}.tar.gz";
-      inherit sha256;
-    };
-    inherit version;
   }; in
  rec {
-  "4.04" = mkOldParam {
-    version = "8.06.2";
-    key = "1628";
-    sha256 = "1p97j9s33axkb4yyl0byhmhlyczqarb886ajpyggizy2br3a0bmk";
-  };
-  "4.05" = mkOldParam {
-    version = "8.06.3";
-    key = "1701";
-    sha256 = "1rka9jpg3kxqn7dmgfsa7pmsdwm16x7cn4sh15ijyyrad9phgdxn";
-  };
-  "4.06" = mkOldParam {
+  "4.06" = mkNewParam {
     version = "8.06.4";
-    key = "1727";
-    sha256 = "0j3rz0zz4r993wa3ssnk5s416b1jhj58l6z2jk8238a86y7xqcii";
+    rev = "labltk-8.06.4";
+    sha256 = "03xwnnnahb2rf4siymzqyqy8zgrx3h26qxjgbp5dh1wdl7n02c7g";
   };
-  "4.07" = mkOldParam {
+  "4.07" = mkNewParam {
     version = "8.06.5";
-    key = "1764";
-    sha256 = "0wgx65y1wkgf22ihpqmspqfp95fqbj3pldhp1p3b1mi8rmc37zwj";
+    rev = "1b71e2c6f3ae6847d3d5e79bf099deb7330fb419";
+    sha256 = "02vchmrm3izrk7daldd22harhgrjhmbw6i1pqw6hmfmrmrypypg2";
   };
   _8_06_7 = mkNewParam {
     version = "8.06.7";
@@ -60,14 +38,16 @@ let param =
     version = "8.06.10";
     sha256 = "06cck7wijq4zdshzhxm6jyl8k3j0zglj2axsyfk6q1sq754zyf4a";
   };
-}.${builtins.substring 0 4 ocaml.version};
+ };
+ param = params . ${lib.versions.majorMinor ocaml.version}
+   or (throw "labltk is not available for OCaml ${ocaml.version}");
 in
 
 stdenv.mkDerivation rec {
   inherit (param) version src;
   name = "ocaml${ocaml.version}-labltk-${version}";
 
-  buildInputs = [ ocaml findlib tcl tk ];
+  buildInputs = [ ocaml findlib tcl tk makeWrapper ];
 
   configureFlags = [ "--use-findlib" "--installbindir" "$(out)/bin" ];
   dontAddPrefix = true;
@@ -79,6 +59,10 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $OCAMLFIND_DESTDIR/stublibs
     mv $OCAMLFIND_DESTDIR/labltk/dlllabltk.so $OCAMLFIND_DESTDIR/stublibs/
+    for p in $out/bin/*
+    do
+      wrapProgram $p --set CAML_LD_LIBRARY_PATH $OCAMLFIND_DESTDIR/stublibs
+    done
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Source tarballs for old versions are no longer available.
The `ocamlbrowser` binary won’t run:

> Fatal error: cannot load shared library dlllabltk
Reason: dlllabltk.so: cannot open shared object file: No such file or directory

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
