### PR TITLE
jellyfin-mpv-shim: 1.10.3 -> 1.10.4

### DIFF
--- a/pkgs/applications/video/jellyfin-mpv-shim/default.nix
+++ b/pkgs/applications/video/jellyfin-mpv-shim/default.nix
@@ -20,11 +20,11 @@
 
 buildPythonApplication rec {
   pname = "jellyfin-mpv-shim";
-  version = "1.10.3";
+  version = "1.10.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-Tl7P8SJ/ZuwIi8RxDWkhfd7LUd63xv5Ehg1UqaYHb1g=";
+    sha256 = "sha256-QMyb69S8Ln4X0oUuLpL6vtgxJwq8f+Q4ReNckrN4E+E=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upsteam release (https://github.com/jellyfin/jellyfin-desktop/releases/tag/v1.10.4).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/4pwcd58qrcam789bjirnji511z0kljqy-jellyfin-mpv-shim-1.10.3	 909.7M
/nix/store/cml1wzsi4xp1lsv521hjk9c13f93c5fw-jellyfin-mpv-shim-1.10.4	 909.7M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
