### PR TITLE
timg: init at v1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4045,6 +4045,12 @@
     githubId = 12491746;
     name = "Masato Yonekawa";
   };
+  hzeller = {
+    email = "h.zeller@acm.org";
+    github = "hzeller";
+    githubId = 140937;
+    name = "Henner Zeller";
+  };
   i077 = {
     email = "nixpkgs@imranhossa.in";
     github = "i077";

--- a/pkgs/tools/graphics/timg/default.nix
+++ b/pkgs/tools/graphics/timg/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, graphicsmagick, libjpeg
+, ffmpeg, zlib, libexif }:
+
+stdenv.mkDerivation rec {
+  pname = "timg";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "hzeller";
+    repo = "timg";
+    rev = "v${version}";
+    sha256 = "10qhjfkbazncmj07y0a6cpmi7ki0l10qzpvi2zh8369yycqqxr8y";
+  };
+
+  buildInputs = [ graphicsmagick ffmpeg libexif libjpeg zlib ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  cmakeFlags = [
+    "-DTIMG_VERSION_FROM_GIT=Off"
+    "-DWITH_VIDEO_DECODING=On"
+    "-DWITH_VIDEO_DEVICE=On"
+    "-DWITH_OPENSLIDE_SUPPORT=Off" # https://openslide.org/ lib not yet in nix
+  ];
+
+  meta = with lib; {
+    homepage = "https://timg.sh/";
+    description = "A terminal image and video viewer";
+    license = licenses.gpl2Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ hzeller ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26089,6 +26089,8 @@ in
 
   timewarrior = callPackage ../applications/misc/timewarrior { };
 
+  timg = callPackage ../tools/graphics/timg { };
+
   timidity = callPackage ../tools/misc/timidity { };
 
   tint2 = callPackage ../applications/misc/tint2 { };


### PR DESCRIPTION
Timg is an image and video viewer for the terminal,
useful to look at images without leaving the comfort
of the shell or if remotely logged in to a shell.

https://timg.sh/

I am the maintainer of timg.

###### Motivation for this change

I want to use Nix on my remote webserver and have to assess images on that server; for that the timg tool is the ideal tool as it allows to present images in the terminal (Also, I am maintainer of timg so feel responsible to provide the package in NixOS).

###### Things done

(Note, I am very new to Nix and this is my first contribution to packages)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions  (`nix-build -A timg`)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
