### PR TITLE
openapi-generator-cli: Use headless jre

### DIFF
--- a/pkgs/tools/networking/openapi-generator-cli/default.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, jre, makeWrapper }:
+{ callPackage, lib, stdenv, fetchurl, jre, makeWrapper }:
 
-stdenv.mkDerivation rec {
+let this = stdenv.mkDerivation rec {
   version = "5.1.0";
   pname = "openapi-generator-cli";
 
@@ -30,4 +30,9 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = [ maintainers.shou ];
   };
-}
+
+  passthru.tests.example = callPackage ./example.nix {
+    openapi-generator-cli = this;
+  };
+};
+in this

--- a/pkgs/tools/networking/openapi-generator-cli/default.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/default.nix
@@ -18,10 +18,14 @@ let this = stdenv.mkDerivation rec {
   phases = [ "installPhase" ];
 
   installPhase = ''
+    runHook preInstall
+
     install -D "$src" "$out/share/java/${jarfilename}"
 
     makeWrapper ${jre}/bin/java $out/bin/${pname} \
       --add-flags "-jar $out/share/java/${jarfilename}"
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/openapi-generator-cli/example.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/example.nix
@@ -1,0 +1,31 @@
+{ openapi-generator-cli, fetchurl, runCommand }:
+
+runCommand "openapi-generator-cli-test" {
+  nativeBuildInputs = [ openapi-generator-cli ];
+  petstore = fetchurl {
+    url = "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/14c0908becbccd78252be49bd92be8c53cd2b9e3/examples/v3.0/petstore.yaml";
+    sha256 = "sha256:1mgdbzv42alv0b1a18dqbabqyvyhrg3brynr5hqsrm3qljfzaq5b";
+  };
+  config = builtins.toJSON {
+    elmVersion = "0.19";
+    elmPrefixCustomTypeVariants = false;
+  };
+  passAsFile = [ "config" ];
+} ''
+  openapi-generator-cli generate \
+    --input-spec $petstore \
+    --enable-post-process-file \
+    --generator-name elm \
+    --config "$config" \
+    --additional-properties elmEnableCustomBasePaths=true \
+    --output "$out" \
+    ;
+  find $out
+  echo >&2 'Looking for some keywords'
+  set -x
+  grep 'module Api.Request.Pets' $out/src/Api/Request/Pets.elm
+  grep 'createPets' $out/src/Api/Request/Pets.elm
+  grep '"limit"' $out/src/Api/Request/Pets.elm
+  set +x
+  echo "Looks OK!"
+''

--- a/pkgs/tools/networking/openapi-generator-cli/unstable.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/unstable.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, jre, makeWrapper }:
+{ callPackage, lib, stdenv, fetchurl, jre, makeWrapper }:
 
-stdenv.mkDerivation rec {
+let this = stdenv.mkDerivation rec {
   version = "6.0.0-2021-01-18";  # Also update the fetchurl link
   pname = "openapi-generator-cli";
 
@@ -30,5 +30,9 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = [ maintainers.shou ];
   };
-}
 
+  passthru.tests.example = callPackage ./example.nix {
+    openapi-generator-cli = this;
+  };
+};
+in this

--- a/pkgs/tools/networking/openapi-generator-cli/unstable.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/unstable.nix
@@ -18,10 +18,14 @@ let this = stdenv.mkDerivation rec {
   phases = [ "installPhase" ];
 
   installPhase = ''
+    runHook preInstall
+
     install -D "$src" "$out/share/java/${jarfilename}"
 
     makeWrapper ${jre}/bin/java $out/bin/${pname} \
       --add-flags "-jar $out/share/java/${jarfilename}"
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7202,8 +7202,8 @@ in
 
   onlykey-cli = callPackage ../tools/security/onlykey-cli { };
 
-  openapi-generator-cli = callPackage ../tools/networking/openapi-generator-cli { };
-  openapi-generator-cli-unstable = callPackage ../tools/networking/openapi-generator-cli/unstable.nix { };
+  openapi-generator-cli = callPackage ../tools/networking/openapi-generator-cli { jre = pkgs.jre_headless; };
+  openapi-generator-cli-unstable = callPackage ../tools/networking/openapi-generator-cli/unstable.nix { jre = pkgs.jre_headless; };
 
   openbazaar = callPackage ../applications/networking/openbazaar { };
   openbazaar-client = callPackage ../applications/networking/openbazaar/client.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 - Remove unnecessary dependency on linux gui libs.
 - Add a test to ease maintenance


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more ~NixOS~ test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
