### PR TITLE
lib/attrsets: make toDerivation x always work when isStorePath x

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -667,7 +667,7 @@ rec {
        => false
   */
   isStorePath = x:
-    if isCoercibleToString x then
+    if !(isList x) && isCoercibleToString x then
       let str = toString x; in
       substring 0 1 str == "/"
       && dirOf str == storeDir

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -659,7 +659,7 @@ rec {
      Example:
        isStorePath "/nix/store/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11/bin/python"
        => false
-       isStorePath "/nix/store/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11/"
+       isStorePath "/nix/store/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11"
        => true
        isStorePath pkgs.python
        => true


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change



isStorePath may be true for anything which `isCoercibleToString`, however
there seems to be different coercion behavior within nix builtins: a
list of derivations can be coerced to a string with` toString`, but
`builtins.storePath` will throw:

```
nix-repl> builtins.storePath [ pkgs.hello ]
error: cannot coerce a list to a string, at (string):1:1

nix-repl> toString [ pkgs.hello ]
"/nix/store/0pisd259nldh8yfjvw663mspm60cn5v8-hello-2.10"
```

This means that `lib.strings.isStorePath [ pkgs.hello ] == true`, but
`lib.toDerivation [ pkgs.hello ]` will throw. This causes very hard to
debug evaluation errors when mistakenly putting a list in a place where
`types.package` was expected since it expects to be able to call
`toDerivation` on anything for that `isStorePath` returns true. The
evaluation errors for this issue are terrible as the only identifiable
location points to `toDerivation` and no offending values are printed
since `types.package` doesn't actually treat this situation as a type
error.

This is however fixed easily: Just call `toString` before passing the
value to `builtins.storePath`, so that builtin receives the same value
`isStorePath` does its checks on.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
