### PR TITLE
tensorflow-haskell: Unbreak / update to Tensorflow 2.4

### DIFF
--- a/pkgs/development/haskell-modules/configuration-tensorflow.nix
+++ b/pkgs/development/haskell-modules/configuration-tensorflow.nix
@@ -11,8 +11,8 @@ let
   tensorflow-haskell = pkgs.fetchFromGitHub {
     owner = "tensorflow";
     repo = "haskell";
-    rev = "568c9b6f03e5d66a25685a776386e2ff50b61aa9";
-    sha256 = "0v58zhqipa441hzdvp9pwgv6srir2fm7cp0bq2pb5jl1imwyd37h";
+    rev = "d088e30b80f1508281e400975bec9d14b431a22c";
+    sha256 = "0lshsvajy5b67dkz0aaja4aj61q2x4dl526jx3i4c3sqjyz2vb7r";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This just updates the Haskell Tensorflow bindings to Tensorflow 2.4, which has been the default version for a few months.

This supersedes

https://github.com/NixOS/nixpkgs/pull/111399

... which has stalled. As per the discussion there, I'm submitting a fresh pull request.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
