### PR TITLE
 oci-cli: init at 2.23.0 

### DIFF
--- a/pkgs/development/python-modules/oci/default.nix
+++ b/pkgs/development/python-modules/oci/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, certifi
+, configparser
+, cryptography
+, pyopenssl
+, dateutil
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "oci";
+  version = "2.36.0";
+
+  src = fetchFromGitHub {
+    owner = "oracle";
+    repo = "oci-python-sdk";
+    rev = "v${version}";
+    hash = "sha256-scG/ZhWeiCgXp7iD6arWIN8KZecSjKLsCW4oXeJvx6M=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "configparser==4.0.2" "configparser" \
+      --replace "cryptography==3.2.1" "cryptography" \
+      --replace "pyOpenSSL>=17.5.0,<=19.1.0" "pyOpenSSL"
+  '';
+
+  propagatedBuildInputs = [
+    certifi configparser cryptography pyopenssl dateutil pytz
+  ];
+
+  # Tests fail: https://github.com/oracle/oci-python-sdk/issues/164
+  doCheck = false;
+
+  pythonImportsCheck = [ "oci" ];
+
+  meta = with lib; {
+    description = "Oracle Cloud Infrastructure Python SDK";
+    homepage = "https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/index.html";
+    maintainers = with maintainers; [ ilian ];
+    license = with licenses; [ asl20 upl ];
+  };
+}

--- a/pkgs/tools/admin/oci-cli/default.nix
+++ b/pkgs/tools/admin/oci-cli/default.nix
@@ -1,0 +1,58 @@
+{ lib, fetchFromGitHub, python3Packages, locale }:
+
+let
+  # https://github.com/oracle/oci-cli/issues/189
+  pinned_click = python3Packages.click.overridePythonAttrs (old: rec {
+    pname = "click";
+    version = "6.7";
+    src = python3Packages.fetchPypi {
+      inherit pname version;
+      hash = "sha256-8VUW30eNWlYYD7+A5o8gYBDm0WD8OfpQi2XgNf11Ews=";
+    };
+
+    postPatch = ''
+      substituteInPlace click/_unicodefun.py \
+      --replace "'locale'" "'${locale}/bin/locale'"
+    '';
+
+    # Issue that wasn't resolved when this version was released:
+    # https://github.com/pallets/click/issues/823
+    doCheck = false;
+  });
+in
+
+python3Packages.buildPythonApplication rec {
+  pname = "oci-cli";
+  version = "2.23.0";
+
+  src = fetchFromGitHub {
+    owner = "oracle";
+    repo = "oci-cli";
+    rev = "v${version}";
+    hash = "sha256-XRkycJrUSOZQAGiSyQZGA/SnlxnFumYL82kOkYd7s2o=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    oci arrow certifi pinned_click configparser cryptography jmespath dateutil
+    pytz retrying six terminaltables pyopenssl pyyaml
+  ];
+
+  # https://github.com/oracle/oci-cli/issues/187
+  doCheck = false;
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "configparser==4.0.2" "configparser" \
+      --replace "cryptography==3.2.1" "cryptography" \
+      --replace "pyOpenSSL==19.1.0" "pyOpenSSL" \
+      --replace "PyYAML==5.3.1" "PyYAML" \
+      --replace "six==1.14.0" "six"
+  '';
+
+  meta = with lib; {
+    description = "Command Line Interface for Oracle Cloud Infrastructure";
+    homepage = "https://docs.cloud.oracle.com/iaas/Content/API/Concepts/cliconcepts.htm";
+    maintainers = with maintainers; [ ilian ];
+    license = with licenses; [ asl20 upl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2837,6 +2837,8 @@ in
 
   nyx = callPackage ../tools/networking/nyx { };
 
+  oci-cli = callPackage ../tools/admin/oci-cli { };
+
   ocrmypdf = callPackage ../tools/text/ocrmypdf { };
 
   ocrfeeder = callPackage ../applications/graphics/ocrfeeder { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4813,6 +4813,8 @@ in {
     graphvizPkgs = pkgs.graphviz;
   };
 
+  oci = callPackage ../development/python-modules/oci { };
+
   od = callPackage ../development/python-modules/od { };
 
   odfpy = callPackage ../development/python-modules/odfpy { };


### PR DESCRIPTION
###### Motivation for this change
Add the [official cli tool](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/cliconcepts.htm) to interact with the Oracle Cloud Infrastructure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
