### PR TITLE
[staging-next] python3Packages.woob: fix eval

### DIFF
--- a/pkgs/development/python-modules/woob/default.nix
+++ b/pkgs/development/python-modules/woob/default.nix
@@ -7,7 +7,6 @@
 , cssselect
 , dateutil
 , feedparser
-, futures
 , gdata
 , gnupg
 , google-api-python-client
@@ -30,6 +29,7 @@
 buildPythonPackage rec {
   pname = "woob";
   version = "3.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     simplejson
     termcolor
     unidecode
-  ] ++ lib.optionals isPy27 [ futures ];
+  ];
 
   checkPhase = ''
     nosetests


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Drops python2 support, the package was freshly inited in #119215, so I don't expect there to be a significant userbase.

https://github.com/NixOS/nixpkgs/pull/119215#issuecomment-819487375

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
