### PR TITLE
mailman-web: unstable-2019-09-29 -> unstable-2021-04-10

### DIFF
--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -263,7 +263,8 @@ in {
       # settings_local.json is loaded.
       os.environ["SECRET_KEY"] = ""
 
-      from mailman_web.settings import *
+      from mailman_web.settings.base import *
+      from mailman_web.settings.mailman import *
 
       import json
 

--- a/pkgs/servers/mail/mailman/web.nix
+++ b/pkgs/servers/mail/mailman/web.nix
@@ -3,26 +3,33 @@
 }:
 
 buildPythonPackage rec {
-  pname = "mailman-web-unstable";
-  version = "2019-09-29";
+  pname = "mailman-web";
+  version = "unstable-2021-04-10";
   disabled = !isPy3k;
 
   src = fetchgit {
     url = "https://gitlab.com/mailman/mailman-web";
-    rev = "d17203b4d6bdc71c2b40891757f57a32f3de53d5";
-    sha256 = "124cxr4vfi1ibgxygk4l74q4fysx0a6pga1kk9p5wq2yvzwg9z3n";
+    rev = "19a7abe27dd3bc39c0250440de073f0adecd4da1";
+    sha256 = "0h25140n2jaisl0ri5x7gdmbypiys8vlq8dql1zmaxvq459ybxkn";
     leaveDotGit = true;
   };
 
-  # This is just so people installing from pip also get uwsgi
-  # installed, AFAICT.
-
-  # Django is depended on transitively by hyperkitty and postorius,
-  # and mailman_web has overly restrictive version bounds on it, so
-  # let's remove it.
   postPatch = ''
+    # This is just so people installing from pip also get uwsgi
+    # installed, AFAICT.
     sed -i '/^  uwsgi$/d' setup.cfg
+
+    # Django is depended on transitively by hyperkitty and postorius,
+    # and mailman_web has overly restrictive version bounds on it, so
+    # let's remove it.
     sed -i '/^  Django/d' setup.cfg
+
+    # Upstream seems to mostly target installing on top of existing
+    # distributions, and uses a path appropriate for that, but we are
+    # a distribution, so use a state directory appropriate for a
+    # distro package.
+    substituteInPlace mailman_web/settings/base.py \
+        --replace /opt/mailman/web /var/lib/mailman-web
   '';
 
   nativeBuildInputs = [ git makeWrapper setuptools-scm ];
@@ -38,7 +45,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Django project for Mailman 3 web interface";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ peti qyliss ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ peti qyliss m1cr0man ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is #119135, but with the state directory set to /var/lib/mailman-web to avoid breaking the mailman NixOS module, and to use a path more appropriate to a service in Nixpkgs.

I've tested it on my server and it seems to work fine, although one thing I've noticed is that the Postorius URL has changed from /lists/postorius to /lists/mailman3, and the Hyperkitty URL has changed from /lists/hyperkitty to /lists/archives.  But that's an upstream behaviour change, so I don't think we have to do anything about that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
