### PR TITLE
tengine: Add modules to passthru

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -818,7 +818,7 @@ in
         ProtectControlGroups = true;
         RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
         LockPersonality = true;
-        MemoryDenyWriteExecute = !(builtins.any (mod: (mod.allowMemoryWriteExecute or false)) (optionals (cfg.package ? modules) cfg.package.modules));
+        MemoryDenyWriteExecute = !(builtins.any (mod: (mod.allowMemoryWriteExecute or false)) cfg.package.modules);
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         PrivateMounts = true;

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -142,7 +142,10 @@ stdenv.mkDerivation {
 
   passthru = {
     modules = modules;
-    tests.nginx = nixosTests.nginx;
+    tests = {
+      inherit (nixosTests) nginx nginx-auth nginx-etag nginx-pubhtml nginx-sandbox nginx-sso;
+      variants = lib.recurseIntoAttrs nixosTests.nginx-variants;
+    };
   };
 
   meta = if meta != null then meta else {

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -111,6 +111,10 @@ stdenv.mkDerivation rec {
     mv $out/sbin $out/bin
   '';
 
+  passthru = {
+    inherit modules;
+  };
+
   meta = {
     description = "A web server based on Nginx and has many advanced features, originated by Taobao";
     homepage    = "https://tengine.taobao.org";

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, openssl, zlib, pcre, libxml2, libxslt
-, substituteAll, gd, geoip, gperftools, jemalloc
+, substituteAll, gd, geoip, gperftools, jemalloc, nixosTests
 , withDebug ? false
 , withMail ? false
 , withStream ? false
@@ -113,6 +113,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit modules;
+    tests = nixosTests.nginx-variants.tengine;
   };
 
   meta = {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Follow the interface of the `nginx` package and expose the enabled modules. This is used in the `nginx` module to enable the
`additionalModules` option.

The `nginx-variants`-test broke with the addition of the `additionalModules` option in #116074. This fixes that.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
