### PR TITLE
maintainers: add hzeller

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4045,6 +4045,12 @@
     githubId = 12491746;
     name = "Masato Yonekawa";
   };
+  hzeller = {
+    email = "h.zeller@acm.org";
+    github = "hzeller";
+    githubId = 140937;
+    name = "Henner Zeller";
+  };
   i077 = {
     email = "nixpkgs@imranhossa.in";
     github = "i077";


### PR DESCRIPTION
My first time contribution. 

###### Motivation for this change

Was asked to separate this commit out in #119394

Signed-off-by: Henner Zeller <h.zeller@acm.org>

###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
