### PR TITLE
netbsd: take fetchcvs from buildPackages to fix eval

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, stdenvNoCC, fetchcvs, lib, groff, mandoc, zlib, bison, flex
+{ stdenv, stdenvNoCC, lib, groff, mandoc, zlib, bison, flex
 , writeText, buildPackages, splicePackages, symlinkJoin }:
 
 let
-  fetchNetBSD = path: version: sha256: fetchcvs {
+  fetchNetBSD = path: version: sha256: buildPackages.fetchcvs {
     cvsRoot = ":pserver:anoncvs@anoncvs.NetBSD.org:/cvsroot";
     module = "src/${path}";
     inherit sha256;


### PR DESCRIPTION
For some reason fetchcvs was taken from the cross package set when
cross compiling netbsd.* instead of from buildPackages. I suspect that
this was no issue previously because it just could be substituted as it
only ever produced fixed output derivations. However since
00a2084a409e65e9781e9792644bbf5b1b1bca5a the evaluation of fetchcvs
would depend on `stdenv.cc` (via its openssh dependency). Since
netbsd.libc is required to evaluate stdenv.cc this caused a infinite
recursion when staging the cross stdenv for pkgsCross.amd64-netbsd. The
fix for this is pretty easy: Just take fetchcvs from buildPackages
explicitly instead of hoping for mkDerivation to get it right.

Resolves #119323.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
