### PR TITLE
Add Firefox libs to beginning of LD_LIBRARY_PATH

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -257,7 +257,7 @@ let
 
         makeWrapper "$oldExe" \
           "$out${browser.execdir or "/bin"}/${browserName}${nameSuffix}" \
-            --suffix LD_LIBRARY_PATH ':' "$libs" \
+            --prefix LD_LIBRARY_PATH ':' "$libs" \
             --suffix-each GTK_PATH ':' "$gtk_modules" \
             --prefix PATH ':' "${xdg-utils}/bin" \
             --suffix PATH ':' "$out${browser.execdir or "/bin"}" \


### PR DESCRIPTION
When firefox is executed by programs that also make changes to
`LD_LIBRARY_PATH`, the paths can conflict causing firefox to look for
shared libraries in the wrong location. This is because the wrapper
script around firefox *appends* library paths to `LD_LIBRARY_PATH`
instead of prepending them, causing library paths that are already in
the environment to take precedence over the library paths that firefox
depends on.

As an example, Discord and firefox both depend on different versions of
libnss. When Discord launches firefox, which happens when clicking on
hyperlinks, the path in `LD_LIBRARY_PATH` to libnss set by Discord takes
precedence over then one set by the firefox wrapper script causing
firefox to load a different version of libnss than the one it was built
against. This causes a fatal error in firefox which prevents it from
starting.

This commit fixes this issue by switching the firefox wrapper script to
*prepend* its library paths to `LD_LIBRARY_PATH`.

Fixes #118432

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
