### PR TITLE
llvm_11: Correct path for TLI-musl patch

### DIFF
--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -70,7 +70,7 @@ in stdenv.mkDerivation (rec {
       --replace "Path.cpp" ""
     rm unittests/Support/Path.cpp
   '' + optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -i ${../TLI-musl.patch}
+    patch -p1 -i ${../../TLI-musl.patch}
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "add_subdirectory(DynamicLibrary)" ""
     rm unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp


### PR DESCRIPTION
###### Motivation for this change

The path for the the _TLI-musl.patch_ is incorrect in the llvm_11 derivation (it should be one more directory down like all the other llvm derivations)
```
~/nixpkgs (master)> nix build -f . pkgsMusl.llvm_11
error: getting attributes of path '/home/tyson/nixpkgs/pkgs/development/compilers/llvm/11/TLI-musl.patch': No such file or directory
~/nixpkgs (master)> 
```

After fix the patch path
```
~/nixpkgs (llvm_11-musl)> nix build -f . pkgsMusl.llvm_11
~/nixpkgs (llvm_11-musl)> ./result/bin/llc --version
LLVM (http://llvm.org/):
  LLVM version 11.1.0
...
```

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
