### PR TITLE
pythonPackages.surt: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/surt/default.nix
+++ b/pkgs/development/python-modules/surt/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, six
+, tldextract
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "surt";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "internetarchive";
+    repo = "surt";
+    rev = "6934c321b3e2f66af9c001d882475949f00570c5"; # Has no git tag
+    sha256 = "sha256-pSMNpFfq2V0ANWNFPcb1DwPHccbfddo9P4xZ+ghwbz4=";
+  };
+
+  propagatedBuildInputs = [
+    six
+    tldextract
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "surt" ];
+
+  meta = with lib; {
+    description = "Sort-friendly URI Reordering Transform (SURT) python module";
+    homepage = "https://github.com/internetarchive/surt";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8196,6 +8196,8 @@ in {
 
   surepy = callPackage ../development/python-modules/surepy { };
 
+  surt = callPackage ../development/python-modules/surt { };
+
   survey = callPackage ../development/python-modules/survey { };
 
   suseapi = callPackage ../development/python-modules/suseapi { };


### PR DESCRIPTION
###### Motivation for this change
This adds surt from https://github.com/internetarchive/surt.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).