### PR TITLE
gradle: Decouple from JDK 8 and support Java Toolchains

### DIFF
--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, writeText, gradleGen, pkg-config, perl, cmake
+{ stdenv, lib, fetchurl, writeText, gradle_4, pkg-config, perl, cmake
 , gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg, python2, ruby
 , openjdk11-bootstrap }:
 
@@ -7,9 +7,9 @@ let
   update = ".0.3";
   build = "1";
   repover = "${major}${update}+${build}";
-  gradle_ = (gradleGen.override {
+  gradle_ = (gradle_4.override {
     java = openjdk11-bootstrap;
-  }).gradle_4_10;
+  });
 
   makePackage = args: stdenv.mkDerivation ({
     version = "${major}${update}-${build}";

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradleGen
+{ stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradle_5
 , pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
 , ffmpeg, python3, ruby }:
 
@@ -7,9 +7,9 @@ let
   update = ".0.1";
   build = "+1";
   repover = "${major}${update}${build}";
-  gradle_ = (gradleGen.override {
+  gradle_ = (gradle_5.override {
     java = openjdk11_headless;
-  }).gradle_5_6;
+  });
 
   makePackage = args: stdenv.mkDerivation ({
     version = "${major}${update}${build}";

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -1,73 +1,119 @@
-{ lib, stdenv, fetchurl, unzip, jdk, java ? jdk, makeWrapper }:
+{ jdk8, jdk11, jdk17 }:
 
 rec {
-  gradleGen = { version, nativeVersion, sha256 }: stdenv.mkDerivation {
-    pname = "gradle";
-    inherit version;
+  gen =
 
-    src = fetchurl {
-      inherit sha256;
-      url = "https://services.gradle.org/distributions/gradle-${version}-bin.zip";
-    };
+    { version, nativeVersion, sha256, defaultJava ? jdk8 }:
 
-    dontBuild = true;
+    { lib, stdenv, fetchurl, makeWrapper, unzip, java ? defaultJava
+    , javaToolchains ? [ ] }:
 
-    nativeBuildInputs = [ makeWrapper unzip ];
-    buildInputs = [ java ];
+    stdenv.mkDerivation rec {
+      pname = "gradle";
+      inherit version;
 
-    installPhase = ''
-      mkdir -pv $out/lib/gradle/
-      cp -rv lib/ $out/lib/gradle/
+      src = fetchurl {
+        inherit sha256;
+        url =
+          "https://services.gradle.org/distributions/gradle-${version}-bin.zip";
+      };
 
-      gradle_launcher_jar=$(echo $out/lib/gradle/lib/gradle-launcher-*.jar)
-      test -f $gradle_launcher_jar
-      makeWrapper ${java}/bin/java $out/bin/gradle \
-        --set JAVA_HOME ${java} \
-        --add-flags "-classpath $gradle_launcher_jar org.gradle.launcher.GradleMain"
-    '';
+      dontBuild = true;
 
-    fixupPhase = if (!stdenv.isLinux) then ":" else
-    let arch = if stdenv.is64bit then "amd64" else "i386"; in
-    ''
-      mkdir patching
-      pushd patching
-      jar xf $out/lib/gradle/lib/native-platform-linux-${arch}-${nativeVersion}.jar
-      patchelf --set-rpath "${stdenv.cc.cc.lib}/lib:${stdenv.cc.cc.lib}/lib64" net/rubygrapefruit/platform/linux-${arch}/libnative-platform.so
-      jar cf native-platform-linux-${arch}-${nativeVersion}.jar .
-      mv native-platform-linux-${arch}-${nativeVersion}.jar $out/lib/gradle/lib/
-      popd
+      nativeBuildInputs = [ makeWrapper unzip ];
+      buildInputs = [ java ];
 
-      # The scanner doesn't pick up the runtime dependency in the jar.
-      # Manually add a reference where it will be found.
-      mkdir $out/nix-support
-      echo ${stdenv.cc.cc} > $out/nix-support/manual-runtime-dependencies
-    '';
+      # NOTE: For more information on toolchains,
+      # see https://docs.gradle.org/current/userguide/toolchains.html
+      installPhase = with builtins;
+        let
+          toolchain = rec {
+            var = x: "JAVA_TOOLCHAIN_NIX_${toString x}";
+            vars = (lib.imap0 (i: x: ("${var i} ${x}")) javaToolchains);
+            varNames = lib.imap0 (i: x: var i) javaToolchains;
+            property = " -Porg.gradle.java.installations.fromEnv='${
+                 concatStringsSep "," varNames
+               }'";
+          };
+          vars = concatStringsSep "\n" (map (x: "  --set ${x} \\")
+            ([ "JAVA_HOME ${java}" ] ++ toolchain.vars));
+        in ''
+          mkdir -pv $out/lib/gradle/
+          cp -rv lib/ $out/lib/gradle/
 
-    meta = with lib; {
-      description = "Enterprise-grade build system";
-      longDescription = ''
-        Gradle is a build system which offers you ease, power and freedom.
-        You can choose the balance for yourself. It has powerful multi-project
-        build support. It has a layer on top of Ivy that provides a
-        build-by-convention integration for Ivy. It gives you always the choice
-        between the flexibility of Ant and the convenience of a
-        build-by-convention behavior.
+          gradle_launcher_jar=$(echo $out/lib/gradle/lib/gradle-launcher-*.jar)
+          test -f $gradle_launcher_jar
+          makeWrapper ${java}/bin/java $out/bin/gradle \
+            ${vars}
+            --add-flags "-classpath $gradle_launcher_jar org.gradle.launcher.GradleMain${toolchain.property}"
+        '';
+
+      dontFixup = !stdenv.isLinux;
+
+      fixupPhase = let arch = if stdenv.is64bit then "amd64" else "i386";
+      in ''
+        mkdir patching
+        pushd patching
+        jar xf $out/lib/gradle/lib/native-platform-linux-${arch}-${nativeVersion}.jar
+        patchelf --set-rpath "${stdenv.cc.cc.lib}/lib:${stdenv.cc.cc.lib}/lib64" net/rubygrapefruit/platform/linux-${arch}/libnative-platform.so
+        jar cf native-platform-linux-${arch}-${nativeVersion}.jar .
+        mv native-platform-linux-${arch}-${nativeVersion}.jar $out/lib/gradle/lib/
+        popd
+
+        # The scanner doesn't pick up the runtime dependency in the jar.
+        # Manually add a reference where it will be found.
+        mkdir $out/nix-support
+        echo ${stdenv.cc.cc} > $out/nix-support/manual-runtime-dependencies
       '';
-      homepage = "https://www.gradle.org/";
-      changelog = "https://docs.gradle.org/${version}/release-notes.html";
-      downloadPage = "https://gradle.org/next-steps/?version=${version}";
-      license = licenses.asl20;
-      platforms = platforms.unix;
-      maintainers = with maintainers; [ lorenzleutgeb ];
+
+      meta = with lib; {
+        description = "Enterprise-grade build system";
+        longDescription = ''
+          Gradle is a build system which offers you ease, power and freedom.
+          You can choose the balance for yourself. It has powerful multi-project
+          build support. It has a layer on top of Ivy that provides a
+          build-by-convention integration for Ivy. It gives you always the choice
+          between the flexibility of Ant and the convenience of a
+          build-by-convention behavior.
+        '';
+        homepage = "https://www.gradle.org/";
+        changelog = "https://docs.gradle.org/${version}/release-notes.html";
+        downloadPage = "https://gradle.org/next-steps/?version=${version}";
+        license = licenses.asl20;
+        platforms = platforms.unix;
+        maintainers = with maintainers; [ lorenzleutgeb ];
+      };
     };
+
+  # NOTE: Default JDKs are LTS versions and according to
+  # https://docs.gradle.org/current/userguide/compatibility.html
+
+  gradle_7 = gen {
+    version = "7.3";
+    nativeVersion = "0.22-milestone-21";
+    sha256 = "04741q7avmn7rv9h5s6dqj4ibnvdylxrlhvj9wb5kixx96nm53yy";
+    defaultJava = jdk17;
   };
 
-  gradle_latest = gradle_7_3;
+  gradle_6 = gen {
+    version = "6.9.1";
+    nativeVersion = "0.22-milestone-20";
+    sha256 = "1zmjfwlh34b65rdx9izgavw3qwqqwm39h5siyj2bf0m55111a4lc";
+    defaultJava = jdk11;
+  };
 
-  gradle_7_3 = gradleGen (import ./gradle-7.3-spec.nix);
-  gradle_6_9 = gradleGen (import ./gradle-6.9.1-spec.nix);
+  # NOTE: No GitHub Release for the following versions. `update.sh` will not work.
+  gradle_5 = gen {
+    version = "5.6.4";
+    nativeVersion = "0.18";
+    sha256 = "03d86bbqd19h9xlanffcjcy3vg1k5905vzhf9mal9g21603nfc0z";
+    defaultJava = jdk11;
+  };
 
-  # NOTE: No GitHub Release for the following versions. Update.sh will not work.
-  gradle_5_6 = gradleGen (import ./gradle-5.6.4-spec.nix);
-  gradle_4_10 = gradleGen (import ./gradle-4.10.3-spec.nix);
+  gradle_4 = gen {
+    version = "4.10.3";
+    nativeVersion = "0.14";
+    sha256 = "0vhqxnk0yj3q9jam5w4kpia70i4h0q4pjxxqwynh3qml0vrcn9l6";
+    defaultJava = jdk8;
+  };
 }

--- a/pkgs/development/tools/build-managers/gradle/gradle-4.10.3-spec.nix
+++ b/pkgs/development/tools/build-managers/gradle/gradle-4.10.3-spec.nix
@@ -1,5 +1,0 @@
-{
-  version = "4.10.3";
-  nativeVersion = "0.14";
-  sha256 = "0vhqxnk0yj3q9jam5w4kpia70i4h0q4pjxxqwynh3qml0vrcn9l6";
-}

--- a/pkgs/development/tools/build-managers/gradle/gradle-5.6.4-spec.nix
+++ b/pkgs/development/tools/build-managers/gradle/gradle-5.6.4-spec.nix
@@ -1,5 +1,0 @@
-{
-  version = "5.6.4";
-  nativeVersion = "0.18";
-  sha256 = "03d86bbqd19h9xlanffcjcy3vg1k5905vzhf9mal9g21603nfc0z";
-}

--- a/pkgs/development/tools/build-managers/gradle/gradle-6.9.1-spec.nix
+++ b/pkgs/development/tools/build-managers/gradle/gradle-6.9.1-spec.nix
@@ -1,5 +1,0 @@
-{
-  version = "6.9.1";
-  nativeVersion = "0.22-milestone-20";
-  sha256 = "1zmjfwlh34b65rdx9izgavw3qwqqwm39h5siyj2bf0m55111a4lc";
-}

--- a/pkgs/development/tools/build-managers/gradle/gradle-7.2-spec.nix
+++ b/pkgs/development/tools/build-managers/gradle/gradle-7.2-spec.nix
@@ -1,5 +1,0 @@
-{
-  version = "7.2";
-  nativeVersion = "0.22-milestone-21";
-  sha256 = "1pg6w5czysywsgdvmll5bwd2p6y99cn5sn3gw69cps9mkjd710gm";
-}

--- a/pkgs/development/tools/build-managers/gradle/gradle-7.3-spec.nix
+++ b/pkgs/development/tools/build-managers/gradle/gradle-7.3-spec.nix
@@ -1,5 +1,0 @@
-{
-  version = "7.3";
-  nativeVersion = "0.22-milestone-21";
-  sha256 = "04741q7avmn7rv9h5s6dqj4ibnvdylxrlhvj9wb5kixx96nm53yy";
-}

--- a/pkgs/development/tools/scenebuilder/default.nix
+++ b/pkgs/development/tools/scenebuilder/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, jdk11, gradleGen, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell, makeWrapper, glib, wrapGAppsHook }:
+{ lib, stdenv, fetchFromGitHub, jdk11, gradle_6, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell, makeWrapper, glib, wrapGAppsHook }:
 let
-  gradle = (gradleGen.override (old: { java = jdk11; })).gradle_6_9;
+  gradle = gradle_6;
 
   pname = "scenebuilder";
   version = "15.0.1";

--- a/pkgs/development/tools/scenic-view/default.nix
+++ b/pkgs/development/tools/scenic-view/default.nix
@@ -1,8 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, jdk, gradleGen, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, jdk, gradle, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell, makeWrapper }:
 let
-  # The default one still uses jdk8 (#89731)
-  gradle = (gradleGen.override (old: { java = jdk; })).gradle_latest;
-
   pname = "scenic-view";
   version = "11.0.2";
 

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -3,8 +3,8 @@
 , makeDesktopItem
 , copyDesktopItems
 , fetchFromGitHub
-, gradleGen
-, jdk
+, gradle_6
+, jdk11
 , perl
 
 # for arc
@@ -87,8 +87,8 @@ let
     popd
   '';
 
-  # The default one still uses jdk8 (#89731)
-  gradle_6 = (gradleGen.override (old: { java = jdk; })).gradle_6_9;
+  jdk = jdk11;
+  gradle = (gradle_6.override (old: { java = jdk11; }));
 
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {
@@ -96,7 +96,7 @@ let
     inherit version unpackPhase patches;
     postPatch = cleanupMindustrySrc;
 
-    nativeBuildInputs = [ gradle_6 perl ];
+    nativeBuildInputs = [ gradle perl ];
     # Here we download dependencies for both the server and the client so
     # we only have to specify one hash for 'deps'. Deps can be garbage
     # collected after the build, so this is not really an issue.
@@ -136,7 +136,7 @@ stdenv.mkDerivation rec {
   ];
   nativeBuildInputs = [
     pkg-config
-    gradle_6
+    gradle
     makeWrapper
     jdk
   ] ++ lib.optionals enableClient [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14598,14 +14598,15 @@ with pkgs;
 
   gpuvis = callPackage ../development/tools/misc/gpuvis { };
 
-  gradleGen = callPackage ../development/tools/build-managers/gradle {
-    java = jdk8; # TODO: upgrade https://github.com/NixOS/nixpkgs/pull/89731
+  gradle-packages = import ../development/tools/build-managers/gradle {
+    inherit jdk8 jdk11 jdk17;
   };
-  gradle = res.gradleGen.gradle_latest;
-  gradle_4 = res.gradleGen.gradle_4_10;
-  gradle_5 = res.gradleGen.gradle_5_6;
-  gradle_6 = res.gradleGen.gradle_6_9;
-  gradle_7 = res.gradleGen.gradle_7_3;
+  gradleGen = gradle-packages.gen;
+  gradle_4 = callPackage gradle-packages.gradle_4 { };
+  gradle_5 = callPackage gradle-packages.gradle_5 { };
+  gradle_6 = callPackage gradle-packages.gradle_6 { };
+  gradle_7 = callPackage gradle-packages.gradle_7 { };
+  gradle = gradle_7;
 
   gperf = callPackage ../development/tools/misc/gperf { };
   # 3.1 changed some parameters from int to size_t, leading to mismatches.


### PR DESCRIPTION
This sets a default Java installation per Gradle version, and allows to specify [Java Toolchains](https://docs.gradle.org/current/userguide/toolchains.html).

Gradle Version | Attribute | Default Java Version | `defaultJava`
---------------|-----------|----------------------|--------------
7.3 | `gradle_7` | 17 | `jdk8`
6.9.1 | `gradle_6` | 11 | `jdk11`
5.6.4 | `gradle_5` | 11 | `jdk11`
4.10.3 | `gradle_4` | 8 | `jdk8`

(see also Gradle's [Compatibility Matrix](https://docs.gradle.org/current/userguide/compatibility.html))

E.g. with `gradle_7.override { javaToolchains = [ jdk8 jdk11 ]; }` I get

```
$ gradle -q javaToolchains

 + Options
     | Auto-detection:     Enabled
     | Auto-download:      Enabled

 + N/A JDK 17.0.1+12-nixos
     | Location:           /nix/store/1vi5p9gliab13jc3v56kz7z78x5bq0da-openjdk-17.0.1+12/lib/openjdk
     | Language Version:   17
     | Vendor:             N/A
     | Is JDK:             true
     | Detected by:        Current JVM

 + OpenJDK 1.8.0_272-b10
     | Location:           /nix/store/4f0d8c9lmj174hz3qvn1qhc70n22bai4-openjdk-8u272-b10
     | Language Version:   8
     | Vendor:             Oracle
     | Is JDK:             true
     | Detected by:        environment variable 'JAVA_TOOLCHAIN_NIX_0'

 + OpenJDK 11.0.12+0-adhoc..source
     | Location:           /nix/store/7r5b2r4kjsbflgxs8sy7i86c1wy773is-openjdk-11.0.12+7
     | Language Version:   11
     | Vendor:             Oracle
     | Is JDK:             true
     | Detected by:        environment variable 'JAVA_TOOLCHAIN_NIX_1'
```