### PR TITLE
inotify-tools: 3.20.2.2 -> 3.20.11.0

### DIFF
--- a/pkgs/development/tools/misc/inotify-tools/default.nix
+++ b/pkgs/development/tools/misc/inotify-tools/default.nix
@@ -1,29 +1,22 @@
-{ lib, stdenv, autoreconfHook, fetchFromGitHub, fetchpatch }:
+{ lib, stdenv, autoreconfHook, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "inotify-tools";
-  version = "3.20.2.2";
+  version = "3.20.11.0";
 
   src = fetchFromGitHub {
     repo = "inotify-tools";
     owner = "rvoicilas";
     rev = version;
-    sha256 = "1r12bglkb0bkqff6kgxjm81hk6z20nrxq3m7iv15d4nrqf9pm7s0";
+    sha256 = "1m8avqccrhm38krlhp88a7v949f3hrzx060bbrr5dp5qw2nmw9j2";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/inotify-tools/inotify-tools/commit/7ddf45158af0c1e93b02181a45c5b65a0e5bed25.patch";
-      sha256 = "08imqancx8l0bg9q7xaiql1xlalmbfnpjfjshp495sjais0r6gy7";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = with lib; {
     homepage = "https://github.com/rvoicilas/inotify-tools/wiki";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ marcweber pSub ];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ marcweber pSub shamilton ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Needed the -P flag

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
