### PR TITLE
zoxide: remove imports

### DIFF
--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -3,15 +3,7 @@
 , fetchFromGitHub
 , rustPlatform
 , withFzf ? true
-, fzf
 , libiconv
-  # checkInputs
-, fish
-, powershell
-, shellcheck
-, shfmt
-, xonsh
-, zsh
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -27,22 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 
-  # tests are broken on darwin
-  doCheck = !stdenv.isDarwin;
-
-  # fish needs a writable HOME for whatever reason
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
-
-  checkInputs = [
-    fish
-    powershell
-    shellcheck
-    shfmt
-    xonsh
-    zsh
-  ];
+  doCheck = true;
 
   postPatch = lib.optionalString withFzf ''
     substituteInPlace src/fzf.rs \

--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -20,8 +20,6 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 
-  doCheck = true;
-
   postPatch = lib.optionalString withFzf ''
     substituteInPlace src/fzf.rs \
       --replace '"fzf"' '"${fzf}/bin/fzf"'

--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , rustPlatform
 , withFzf ? true
+, fzf
 , libiconv
 }:
 


### PR DESCRIPTION
###### Motivation for this change
zoxide no longer requires external programs in tests by default, so I've removed the extra imports.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
