### PR TITLE
corosync: 2.4.5 -> 3.1.2; kronosnet: init at 1.20

### DIFF
--- a/pkgs/development/libraries/kronosnet/default.nix
+++ b/pkgs/development/libraries/kronosnet/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub
+, autoreconfHook, pkg-config
+, libqb, libxml2, libnl, lksctp-tools
+, nss, openssl, bzip2, lzo, lz4, xz, zlib, zstd
+, doxygen
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kronosnet";
+  version = "1.20";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-lP5W+4b9McU2Uqibh2SucIu2y4KluO3B1RpAJKgYq/M=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config doxygen ];
+
+  buildInputs = [
+    libqb libxml2 libnl lksctp-tools
+    nss openssl
+    bzip2 lzo lz4 xz zlib zstd
+  ];
+
+  meta = with lib; {
+    description = "VPN on steroids";
+    homepage = "https://kronosnet.org/";
+    license = with licenses; [ lgpl21Plus gpl2Plus ];
+    maintainers = with maintainers; [ ryantm ];
+  };
+}

--- a/pkgs/servers/corosync/default.nix
+++ b/pkgs/servers/corosync/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, pkg-config, nss, nspr, libqb
+{ lib, stdenv, fetchurl, makeWrapper, pkg-config, kronosnet, nss, nspr, libqb
 , dbus, rdma-core, libstatgrab, net-snmp
 , enableDbus ? false
 , enableInfiniBandRdma ? false
@@ -10,17 +10,17 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "corosync";
-  version = "2.4.5";
+  version = "3.1.2";
 
   src = fetchurl {
     url = "http://build.clusterlabs.org/corosync/releases/${pname}-${version}.tar.gz";
-    sha256 = "0pxs18vci9kq3qnqsg5i1h35jrxxiccwbm0mzja3g8j3izdsyvmb";
+    sha256 = "sha256-eAypUbDeGa3GKF/wJ602dyTW5FlkvjWeCRXT6h0d4zw=";
   };
 
   nativeBuildInputs = [ makeWrapper pkg-config ];
 
   buildInputs = [
-    nss nspr libqb
+    kronosnet nss nspr libqb
   ] ++ optional enableDbus dbus
     ++ optional enableInfiniBandRdma rdma-core
     ++ optional enableMonitoring libstatgrab
@@ -45,6 +45,8 @@ stdenv.mkDerivation rec {
     "LOGROTATEDIR=$(out)/etc/logrotate.d"
   ];
 
+  enableParallelBuilding = true;
+
   preConfigure = optionalString enableInfiniBandRdma ''
     # configure looks for the pkg-config files
     # of librdmacm and libibverbs
@@ -61,13 +63,11 @@ stdenv.mkDerivation rec {
       --prefix PATH ":" "$out/sbin:${libqb}/sbin"
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     homepage = "http://corosync.org/";
     description = "A Group Communication System with features for implementing high availability within applications";
     license = licenses.bsd3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ montag451 ];
+    maintainers = with maintainers; [ montag451 ryantm ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15050,6 +15050,8 @@ in
   krb5Full = krb5;
   libkrb5 = krb5.override { type = "lib"; };
 
+  kronosnet = callPackage ../development/libraries/kronosnet { };
+
   l-smash = callPackage ../development/libraries/l-smash {
     stdenv = gccStdenv;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Trying to use corosync with pacemaker and want to have a recent version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

closes #56804