### PR TITLE
python3Packages.karton-config-extractor: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/karton-config-extractor/default.nix
+++ b/pkgs/development/python-modules/karton-config-extractor/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, karton-core
+, malduck
+}:
+
+buildPythonPackage rec {
+  pname = "karton-config-extractor";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "CERT-Polska";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1v0zqa81yjz6hm17x9hp0iwkllymqzn84dd6r2yrhillbwnjg9bb";
+  };
+
+  propagatedBuildInputs = [
+    karton-core
+    malduck
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "karton.core==4.0.5" "karton-core"
+  '';
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "karton.config_extractor" ];
+
+  meta = with lib; {
+    description = "Static configuration extractor for the Karton framework";
+    homepage = "https://github.com/CERT-Polska/karton-config-extractor";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/malduck/default.nix
+++ b/pkgs/development/python-modules/malduck/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, capstone
+, click
+, cryptography
+, fetchFromGitHub
+, pefile
+, pycryptodomex
+, pyelftools
+, pythonOlder
+, typing-extensions
+, yara-python
+}:
+
+buildPythonPackage rec {
+  pname = "malduck";
+  version = "4.1.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "CERT-Polska";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04d8bhzax9ynbl83hif9i8gcs29zrvcay2r6n7mcxiixlxcqciak";
+  };
+
+  propagatedBuildInputs = [
+    capstone
+    click
+    cryptography
+    pefile
+    pycryptodomex
+    pyelftools
+    typing-extensions
+    yara-python
+  ];
+
+  # Project has no tests. They will come with the next release
+  doCheck = false;
+  pythonImportsCheck = [ "malduck" ];
+
+  meta = with lib; {
+    description = "Helper for malware analysis";
+    homepage = "https://github.com/CERT-Polska/malduck";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3683,6 +3683,8 @@ in {
 
   karton-classifier = callPackage ../development/python-modules/karton-classifier { };
 
+  karton-config-extractor = callPackage ../development/python-modules/karton-config-extractor { };
+
   karton-core = callPackage ../development/python-modules/karton-core { };
 
   kazoo = callPackage ../development/python-modules/kazoo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4154,6 +4154,8 @@ in {
 
   Mako = callPackage ../development/python-modules/Mako { };
 
+  malduck= callPackage ../development/python-modules/malduck { };
+
   managesieve = callPackage ../development/python-modules/managesieve { };
 
   manhole = callPackage ../development/python-modules/manhole { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/CERT-Polska/karton-config-extractor

incl. malduck (https://github.com/CERT-Polska/malduck)

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @chivay