### PR TITLE
sysbench: avoid using flags specific to the build machine

### DIFF
--- a/pkgs/development/tools/misc/sysbench/default.nix
+++ b/pkgs/development/tools/misc/sysbench/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1sanvl2a52ff4shj62nw395zzgdgywplqvwip74ky8q7s6qjf5qy";
   };
 
-  configureFlags = [ "--with-gcc-arch=unknown" ];
+  configureFlags = [ "--without-gcc-arch" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/misc/sysbench/default.nix
+++ b/pkgs/development/tools/misc/sysbench/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     sha256 = "1sanvl2a52ff4shj62nw395zzgdgywplqvwip74ky8q7s6qjf5qy";
   };
 
+  configureFlags = [ "--with-gcc-arch=unknown" ];
+
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
Fixes #119446.
