### PR TITLE
koka: take C compiler from targetPackages

### DIFF
--- a/pkgs/development/compilers/koka/default.nix
+++ b/pkgs/development/compilers/koka/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, cmake, gnumake, makeWrapper, mkDerivation, fetchFromGitHub
+{ stdenv, pkgsHostTarget, cmake, makeWrapper, mkDerivation, fetchFromGitHub
 , alex, array, base, bytestring, cond, containers, directory, extra
 , filepath, haskeline, hpack, hspec, hspec-core, json, lib, mtl
 , parsec, process, regex-compat, text, time }:
@@ -18,11 +18,12 @@ let
     src = "${src}/kklib";
     nativeBuildInputs = [ cmake ];
   };
+  inherit (pkgsHostTarget.targetPackages.stdenv) cc;
   runtimeDeps = [
-    buildPackages.stdenv.cc
-    buildPackages.stdenv.cc.bintools.bintools
-    gnumake
-    cmake
+    cc
+    cc.bintools.bintools
+    pkgsHostTarget.gnumake
+    pkgsHostTarget.cmake
   ];
 in
 mkDerivation rec {
@@ -42,7 +43,7 @@ mkDerivation rec {
     cp -a contrib $out/share/koka/v${version}
     cp -a kklib $out/share/koka/v${version}
     wrapProgram "$out/bin/koka" \
-      --set CC "${lib.getBin buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc" \
+      --set CC "${lib.getBin cc}/bin/${cc.targetPrefix}cc" \
       --prefix PATH : "${lib.makeSearchPath "bin" runtimeDeps}"
   '';
   doCheck = false;


### PR DESCRIPTION
buildPackages.stdenv.cc.cc is a C compiler that runs on the build
platform and produces binaries for the host platform. This is not
what we want. Also pkgsHostTarget.stdenv.cc is not the compiler we
want as stdenv always runs on the previous stage so to say (the stdenv
is used to build the package set, in the case of cross compiling
this is not done natively). Thus stdenv.targetPackages.stdenv.cc is what
we want (note that I haven't really spent any thought on cross compiling
a koka cross compiler, but it'll be a while until someone needs to do
this).

Testing would be appreciated.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
