### PR TITLE
llvmPackages_7.libcxxabi: make libunwind an optional dependency again

### DIFF
--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -181,6 +181,12 @@ let
         libunwind = libraries.libunwind;
       }));
 
+    libunwind = callPackage ./libunwind ({
+      inherit (buildLlvmTools) llvm;
+    } // lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
+      stdenv = overrideCC stdenv buildLlvmTools.lldClangNoLibcxx;
+    });
+
     openmp = callPackage ./openmp.nix {};
   });
 

--- a/pkgs/development/compilers/llvm/7/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++abi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, cmake, fetch, libcxx, llvm, version
+{ lib, stdenv, cmake, fetch, libcxx, libunwind, llvm, version
 , standalone ? false
   # on musl the shared objects don't build
 , enableShared ? !stdenv.hostPlatform.isStatic
@@ -11,6 +11,7 @@ stdenv.mkDerivation {
   src = fetch "libcxxabi" "1zcqxsdjhawgz1cvpk07y3jl6fg9p3ay4nl69zsirqb2ghgyhhb2";
 
   nativeBuildInputs = [ cmake ];
+  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;
 
   postUnpack = ''
     unpackFile ${libcxx.src}

--- a/pkgs/development/compilers/llvm/7/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/7/libunwind/default.nix
@@ -1,0 +1,15 @@
+{ lib, stdenv, version, fetch, cmake, llvm
+, enableShared ? !stdenv.hostPlatform.isStatic
+}:
+
+stdenv.mkDerivation {
+  pname = "libunwind";
+  inherit version;
+
+  src = fetch "libunwind" "035dsxs10nyiqd00q07yycvmkjl01yz4jdlrjvmch8klxg4pyjhp";
+
+  nativeBuildInputs = [ cmake llvm ];
+
+  cmakeFlags = lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF"
+    ++ [ "-DLIBUNWIND_STANDALONE_BUILD=ON" ];
+}


### PR DESCRIPTION
76b54c75b3bc7a17ffaa20a862246f1d7fe89b58 removed the dependency on
libunwind for some unknown reason in llvmPackages_7 (the only
llvmPackages set where libc++abi does not depend on libunwind). This is
not properly reflected in the conditional override for libcxxabi leading
to an evaluation error if stdenv.hostPlatform.useLLVM is true.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
