### PR TITLE
phpExtensions.ds: init at 1.3.0

### DIFF
--- a/pkgs/development/php-packages/ds/default.nix
+++ b/pkgs/development/php-packages/ds/default.nix
@@ -1,0 +1,28 @@
+{ buildPecl, fetchFromGitHub, php, lib, pcre2 }:
+let
+  pname = "ds";
+  version = "1.3.0";
+in php.buildPecl rec {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "php-ds";
+    repo = "ext-ds";
+    rev = "v${version}";
+    sha256 = "08fqn5q0p0d6qny08xkr2nnlkgmrr2chvda21ch231xnwd12s52p";
+  };
+
+  buildInputs = [
+    pcre2
+  ];
+
+  internalDeps = with php.extensions; [
+    json
+  ];
+
+  meta = with lib; {
+    description = "An extension providing efficient data structures for PHP 7";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ajs124 das_j ] ++ teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -64,6 +64,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     couchbase = callPackage ../development/php-packages/couchbase { };
 
+    ds = callPackage ../development/php-packages/ds { };
+
     event = callPackage ../development/php-packages/event { };
 
     igbinary = callPackage ../development/php-packages/igbinary { };


### PR DESCRIPTION
###### Motivation for this change
I might be deploying some software that needs this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
