### PR TITLE
nx2elf: init at unstable-2020-05-26

### DIFF
--- a/pkgs/tools/compression/nx2elf/default.nix
+++ b/pkgs/tools/compression/nx2elf/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, lz4 }:
+
+stdenv.mkDerivation rec {
+  pname = "nx2elf";
+  version = "unstable-2020-05-26";
+
+  src = fetchFromGitHub {
+    owner = "shuffle2";
+    repo = "nx2elf";
+    rev = "7212e82a77b84fcc18ef2d050970350dbf63649b";
+    sha256 = "1j4k5s86c6ixa3wdqh4cfm31fxabwn6jcjc6pippx8mii98ac806";
+  };
+
+  buildInputs = [ lz4 ];
+
+  postPatch = ''
+    # This project does not comply with C++14 standards, and compilation on that fails.
+    # This does however succesfully compile with the gnu++20 standard.
+    substituteInPlace Makefile --replace "c++14" "gnu++20"
+
+    # pkg-config is not supported, so we'll manually use a non-ancient version of lz4
+    cp ${lz4.src}/lib/lz4.{h,c} .
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D nx2elf $out/bin/nx2elf
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/shuffle2/nx2elf";
+    description = "Convert Nintendo Switch executable files to ELFs";
+    license = licenses.unfree; # No license specified upstream
+    platforms = [ "x86_64-linux " ]; # Should work on Darwin as well, but this is untested. aarch64-linux fails.
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/tools/compression/nx2elf/default.nix
+++ b/pkgs/tools/compression/nx2elf/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/shuffle2/nx2elf";
     description = "Convert Nintendo Switch executable files to ELFs";
     license = licenses.unfree; # No license specified upstream
-    platforms = [ "x86_64-linux " ]; # Should work on Darwin as well, but this is untested. aarch64-linux fails.
+    platforms = [ "x86_64-linux" ]; # Should work on Darwin as well, but this is untested. aarch64-linux fails.
     maintainers = [ maintainers.ivar ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2843,6 +2843,8 @@ in
 
   nwipe = callPackage ../tools/security/nwipe { };
 
+  nx2elf = callPackage ../tools/compression/nx2elf { };
+
   nx-libs = callPackage ../tools/X11/nx-libs { };
 
   nyx = callPackage ../tools/networking/nyx { };


### PR DESCRIPTION
###### Motivation for this change
Due to security concerns, I've updated the (4 year old) local version of `lz4` with the one from nixpkgs, which incidentally fixes a warning.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
