### PR TITLE
terraform_0_15: init at 0.15.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -164,6 +164,14 @@ in rec {
     passthru = { inherit plugins; };
   });
 
+  terraform_0_15 = pluggable (generic {
+    version = "0.15.0";
+    sha256 = "0d7hai57x6qczacdnzzvs3766180n6grmq0a7rlw5jp3zgzp8bmr";
+    vendorSha256 = "1l67kkrk8jw7v1rqpwj6n0l7lvmfgf1ir430j1n96459s1dzf0cn";
+    patches = [ ./provider-path-0_15.patch ];
+    passthru = { inherit plugins; };
+  });
+
   # Tests that the plugins are being used. Terraform looks at the specific
   # file pattern and if the plugin is not found it will try to download it
   # from the Internet. With sandboxing enable this test will fail if that is

--- a/pkgs/applications/networking/cluster/terraform/provider-path-0_15.patch
+++ b/pkgs/applications/networking/cluster/terraform/provider-path-0_15.patch
@@ -1,0 +1,23 @@
+diff -Naur terraform.old/command/init.go terraform.new/command/init.go
+--- terraform.old/command/init.go
++++ terraform.new/command/init.go
+@@ -3,6 +3,7 @@
+ import (
+ 	"context"
+ 	"fmt"
++	"os"
+ 	"log"
+ 	"strings"
+ 
+@@ -55,6 +56,11 @@
+ 
+ 	var diags tfdiags.Diagnostics
+ 
++	val, ok := os.LookupEnv("NIX_TERRAFORM_PLUGIN_DIR")
++	if ok {
++		flagPluginPath = append(flagPluginPath, val)
++	}
++
+ 	if len(flagPluginPath) > 0 {
+ 		c.pluginPath = flagPluginPath
+ 	}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30327,6 +30327,7 @@ in
     terraform_0_12
     terraform_0_13
     terraform_0_14
+    terraform_0_15
     terraform_plugins_test
     ;
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/hashicorp/terraform/releases/tag/v0.15.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
