### PR TITLE
tts: 0.0.9 -> 0.0.11

### DIFF
--- a/pkgs/development/python-modules/pypinyin/default.nix
+++ b/pkgs/development/python-modules/pypinyin/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pypinyin";
+  version = "0.41.0";
+
+  src = fetchFromGitHub {
+    owner = "mozillazg";
+    repo = "python-pinyin";
+    rev = "v${version}";
+    sha256 = "1s01dd5n6cgjg24dmji0abxkyvr1yi18lx4rpm9z54v0q3wkccg9";
+  };
+
+  postPatch = ''
+    substituteInPlace pytest.ini --replace \
+      "--cov-report term-missing" ""
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "tests"
+  ];
+
+  meta = with lib; {
+    description = "Chinese Characters to Pinyin - 汉字转拼音";
+    homepage = "https://github.com/mozillazg/python-pinyin";
+    changelog = "https://github.com/mozillazg/python-pinyin/blob/master/CHANGELOG.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa mic92 ];
+  };
+}

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -12,19 +12,18 @@
 # For now, for deployment check the systemd unit in the pull request:
 #   https://github.com/NixOS/nixpkgs/pull/103851#issue-521121136
 #
+# Check the latest release for compatible models:
+#   https://github.com/coqui-ai/TTS/releases/tag/v0.0.11
 
 python3Packages.buildPythonApplication rec {
   pname = "tts";
-  # until https://github.com/mozilla/TTS/issues/424 is resolved
-  # we treat released models as released versions:
-  # https://github.com/mozilla/TTS/wiki/Released-Models
-  version = "0.0.9";
+  version = "0.0.11";
 
   src = fetchFromGitHub {
-    owner = "mozilla";
+    owner = "coqui-ai";
     repo = "TTS";
-    rev = "df5899daf4ba4ec89544edf94f9c2e105c544461";
-    sha256 = "sha256-lklG8DqG04LKJY93z2axeYhW8gtpbRG41o9ow2gJjuA=";
+    rev = "v${version}";
+    sha256 = "0kk9bgiw2x5ybwz0v3zrfaxajl3lnccc9xmrwc295n2rfkmwxsis";
   };
 
   preBuild = ''
@@ -37,6 +36,8 @@ python3Packages.buildPythonApplication rec {
     sed -i -e 's!unidecode==[^"]*!unidecode!' requirements.txt setup.py
     sed -i -e 's!bokeh==[^"]*!bokeh!' requirements.txt setup.py
     sed -i -e 's!numba==[^"]*!numba!' requirements.txt setup.py
+    sed -i -e 's!numpy==[^"]*!numpy!' requirements.txt setup.py
+    sed -i -e 's!umap-learn==[^"]*!umap-learn!' requirements.txt setup.py
     # Not required for building/installation but for their development/ci workflow
     sed -i -e '/pylint/d' requirements.txt
     sed -i -e '/cardboardlint/d' requirements.txt setup.py
@@ -45,24 +46,25 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [ python3Packages.cython ];
 
   propagatedBuildInputs = with python3Packages; [
-    matplotlib
-    scipy
-    pytorch
-    flask
     attrdict
     bokeh
-    soundfile
-    tqdm
-    librosa
-    unidecode
-    umap-learn
-    phonemizer
-    tensorboardx
+    flask
     fuzzywuzzy
-    inflect
     gdown
+    inflect
+    jieba
+    librosa
+    matplotlib
+    phonemizer
+    pypinyin
     pysbd
-    pyworld
+    pytorch
+    scipy
+    soundfile
+    tensorboardx
+    tqdm
+    umap-learn
+    unidecode
   ];
 
   postInstall = ''
@@ -92,16 +94,17 @@ python3Packages.buildPythonApplication rec {
     mv TTS{,.old}
   '';
 
-  pytestFlagsArray = [
+  disabledTestPaths = [
     # requires tensorflow
-    "--ignore=tests/test_tacotron2_tf_model.py"
-    "--ignore=tests/test_vocoder_tf_melgan_generator.py"
-    "--ignore=tests/test_vocoder_tf_pqmf.py"
+    "tests/test_tacotron2_tf_model.py"
+    "tests/test_vocoder_tf_melgan_generator.py"
+    "tests/test_vocoder_tf_pqmf.py"
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/mozilla/TTS";
-    description = "Deep learning for Text to Speech";
+    homepage = "https://github.com/coqui-ai/TTS";
+    changelog = "https://github.com/coqui-ai/TTS/releases/tag/v${version}";
+    description = "Deep learning toolkit for Text-to-Speech, battle-tested in research and production";
     license = licenses.mpl20;
     maintainers = with maintainers; [ hexa mic92 ];
   };

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -2,6 +2,7 @@
 , python3Packages
 , fetchFromGitHub
 , python3
+, fetchpatch
 }:
 
 # USAGE:
@@ -9,22 +10,31 @@
 # # pick your favorite vocoder/tts model
 # $ tts-server --model_name tts_models/en/ljspeech/glow-tts --vocoder_name vocoder_models/universal/libri-tts/fullband-melgan
 #
+# If you upgrade from an old version you may have to delete old models from ~/.local/share/tts
+# Also note that your tts version might not support all available models so check:
+#   https://github.com/coqui-ai/TTS/releases/tag/v0.0.12
+#
 # For now, for deployment check the systemd unit in the pull request:
 #   https://github.com/NixOS/nixpkgs/pull/103851#issue-521121136
-#
-# Check the latest release for compatible models:
-#   https://github.com/coqui-ai/TTS/releases/tag/v0.0.11
 
 python3Packages.buildPythonApplication rec {
   pname = "tts";
-  version = "0.0.11";
+  version = "0.0.12";
 
   src = fetchFromGitHub {
     owner = "coqui-ai";
     repo = "TTS";
     rev = "v${version}";
-    sha256 = "0kk9bgiw2x5ybwz0v3zrfaxajl3lnccc9xmrwc295n2rfkmwxsis";
+    sha256 = "sha256-0M9wcdBmuTK+NvEGsXEdoYiVFjw8G2MRUwmi1PJgmzI=";
   };
+
+  patches = [
+    # https://github.com/coqui-ai/TTS/pull/435
+    (fetchpatch {
+      url = "https://github.com/coqui-ai/TTS/commit/97f98e4c4584ef14ed2f4885aa02c162d9364a00.patch";
+      sha256 = "sha256-DAZYOOAe+6TYBF5ukFq5HRwm49askEvNEivuwb/oCWM=";
+    })
+  ];
 
   preBuild = ''
     # numba jit tries to write to its cache directory
@@ -39,6 +49,8 @@ python3Packages.buildPythonApplication rec {
     sed -i -e 's!numpy==[^"]*!numpy!' requirements.txt setup.py
     sed -i -e 's!umap-learn==[^"]*!umap-learn!' requirements.txt setup.py
     # Not required for building/installation but for their development/ci workflow
+    sed -i -e '/black/d' requirements.txt
+    sed -i -e '/isor/d' requirements.txt
     sed -i -e '/pylint/d' requirements.txt
     sed -i -e '/cardboardlint/d' requirements.txt setup.py
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6210,6 +6210,8 @@ in {
 
   pypillowfight = callPackage ../development/python-modules/pypillowfight { };
 
+  pypinyin = callPackage ../development/python-modules/pypinyin { };
+
   pyplaato  = callPackage ../development/python-modules/pyplaato { };
 
   pyplatec = callPackage ../development/python-modules/pyplatec { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/119496
https://github.com/coqui-ai/TTS/releases/tag/v0.0.10
https://github.com/coqui-ai/TTS/releases/tag/v0.0.11

requirements.txt diff

```diff
8a9,10
> pypinyin
> jieba
17c19
< pyworld
---
> # pyworld
23c25
< umap-learn
---
> umap-learn==0.4.6
```

- We have umap-learn==0.5.0, not sure if that causes issues
- We don't have `pypinyin` <s>nor `jieba`</s> packaged, it is used in the chinese/mandarin phonemizer: https://github.com/coqui-ai/TTS/search?q=pypinyin

**Untested**
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
