### PR TITLE
netbsd.statHook: init

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, stdenvNoCC, fetchcvs, lib, groff, mandoc, zlib, bison, flex
-, writeText, buildPackages, splicePackages, symlinkJoin }:
+, makeSetupHook, writeText, buildPackages, splicePackages, symlinkJoin }:
 
 let
   fetchNetBSD = path: version: sha256: fetchcvs {
@@ -30,7 +30,7 @@ let
 
     extraPaths = [ ];
 
-    nativeBuildInputs = [ makeMinimal install tsort lorder mandoc groff stat ];
+    nativeBuildInputs = [ makeMinimal install tsort lorder mandoc groff statHook ];
     buildInputs = [ compat ];
     # depsBuildBuild = [ buildPackages.stdenv.cc ];
 
@@ -243,12 +243,24 @@ let
     ];
   };
 
+  # Don't add this to nativeBuildInputs directly.  Use statHook instead.
   stat = mkDerivation {
     path = "usr.bin/stat";
     version = "8.0";
     sha256 = "0z4r96id2r4cfy443rw2s1n52n186xm0lqvs8s3qjf4314z7r7yh";
     nativeBuildInputs = [ makeMinimal install mandoc groff ];
   };
+
+  # stat isn't in POSIX, and NetBSD stat supports a completely
+  # different range of flags than GNU stat, so including it in PATH
+  # breaks stdenv.  Work around that with a hook that will point
+  # NetBSD's build system and NetBSD stat without including it in
+  # PATH.
+  statHook = makeSetupHook {
+    name = "netbsd-stat-hook";
+  } (writeText "netbsd-stat-hook-impl" ''
+    makeFlagsArray+=(TOOL_STAT=${netbsd.stat}/bin/stat)
+  '');
 
   tsort = mkDerivation {
     path = "usr.bin/tsort";
@@ -563,7 +575,7 @@ let
     sha256 = "0630lbvz6v4ic13bfg8ccwfhqkgcv76bfdw9f36rfsnwfgpxqsmq";
     meta.platforms = lib.platforms.netbsd;
     nativeBuildInputs = [ makeMinimal install mandoc groff flex
-                          bison genassym gencat lorder tsort stat ];
+                          bison genassym gencat lorder tsort statHook ];
     extraPaths = [ sys.src ld_elf_so.src ];
   };
 
@@ -587,7 +599,7 @@ let
                    librpcsvc.src libutil.src librt.src libcrypt.src ];
     buildInputs = [ buildPackages.netbsd.headers csu ];
     nativeBuildInputs = [ makeMinimal install mandoc groff flex
-                          bison genassym gencat lorder tsort stat ];
+                          bison genassym gencat lorder tsort statHook ];
     NIX_CFLAGS_COMPILE = "-B${csu}/lib";
     meta.platforms = lib.platforms.netbsd;
     SHLIBINSTALLDIR = "$(out)/lib";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes the build of various NetBSD programs on Linux,
e.g. netbsd.genassym.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
