### PR TITLE
netbsd: fix cross-compilation to NetBSD

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -599,7 +599,7 @@ let
                    librpcsvc.src libutil.src librt.src libcrypt.src ];
     buildInputs = [ buildPackages.netbsd.headers csu ];
     nativeBuildInputs = [ makeMinimal install mandoc groff flex
-                          byacc genassym gencat lorder tsort statHook ];
+                          byacc genassym gencat lorder tsort statHook rpcgen ];
     NIX_CFLAGS_COMPILE = "-B${csu}/lib";
     meta.platforms = lib.platforms.netbsd;
     SHLIBINSTALLDIR = "$(out)/lib";
@@ -629,8 +629,8 @@ let
       make -C $NETBSDSRCDIR/lib/libresolv $makeFlags
       make -C $NETBSDSRCDIR/lib/libresolv $makeFlags install
 
-      make -C $NETBSDSRCDIR/lib/librpcsv $makeFlags
-      make -C $NETBSDSRCDIR/lib/librpcsv $makeFlags install
+      make -C $NETBSDSRCDIR/lib/librpcsvc $makeFlags
+      make -C $NETBSDSRCDIR/lib/librpcsvc $makeFlags install
 
       make -C $NETBSDSRCDIR/lib/i18n_module $makeFlags
       make -C $NETBSDSRCDIR/lib/i18n_module $makeFlags install
@@ -645,8 +645,8 @@ let
       make -C $NETBSDSRCDIR/lib/libcrypt $makeFlags install
     '';
     postPatch = ''
-      substituteInPlace sys/Makefile.inc \
-        --replace /usr/include/sys/syscall.h ${buildPackages.netbsd.headers}/include/sys/syscall.h
+      sed -i 's,/usr\(/include/sys/syscall.h\),${buildPackages.netbsd.headers}\1,g' \
+        sys/Makefile.inc ../librt/sys/Makefile.inc
     '';
   };
   #

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, stdenvNoCC, fetchcvs, lib, groff, mandoc, zlib, bison, flex
+{ stdenv, stdenvNoCC, fetchcvs, lib, groff, mandoc, zlib, byacc, flex
 , makeSetupHook, writeText, buildPackages, splicePackages, symlinkJoin }:
 
 let
@@ -575,7 +575,7 @@ let
     sha256 = "0630lbvz6v4ic13bfg8ccwfhqkgcv76bfdw9f36rfsnwfgpxqsmq";
     meta.platforms = lib.platforms.netbsd;
     nativeBuildInputs = [ makeMinimal install mandoc groff flex
-                          bison genassym gencat lorder tsort statHook ];
+                          byacc genassym gencat lorder tsort statHook ];
     extraPaths = [ sys.src ld_elf_so.src ];
   };
 
@@ -599,7 +599,7 @@ let
                    librpcsvc.src libutil.src librt.src libcrypt.src ];
     buildInputs = [ buildPackages.netbsd.headers csu ];
     nativeBuildInputs = [ makeMinimal install mandoc groff flex
-                          bison genassym gencat lorder tsort statHook ];
+                          byacc genassym gencat lorder tsort statHook ];
     NIX_CFLAGS_COMPILE = "-B${csu}/lib";
     meta.platforms = lib.platforms.netbsd;
     SHLIBINSTALLDIR = "$(out)/lib";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

With these changes, I was able to cross-compile a statically linked NetBSD program from Linux, which I then tested on NetBSD:

```
nix-build -A pkgsCross.amd64-netbsd.pkgsStatic.netbsd.column
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
