### PR TITLE
sayonara: 1.6.0-beta6 -> 1.6.0-beta7

### DIFF
--- a/pkgs/applications/audio/sayonara/default.nix
+++ b/pkgs/applications/audio/sayonara/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , cmake
 , fetchFromGitLab
+, nix-update-script
 , gst_all_1
 , lib
 , libpulseaudio
@@ -11,17 +12,23 @@
 , qttools
 , taglib
 , zlib
+, python3
 }:
 
+let
+  py = python3.withPackages (ps: with ps; [
+    pydbus
+  ]);
+in
 mkDerivation rec {
-  pname = "sayonara-player";
-  version = "1.6.0-beta6";
+  pname = "sayonara";
+  version = "1.6.0-beta7";
 
   src = fetchFromGitLab {
     owner = "luciocarreras";
     repo = "sayonara-player";
     rev = version;
-    sha256 = "sha256-SbJS0DQvbW++CNXbuDHQxFlLRb1kTtDdIdHOqu0YxeQ=";
+    sha256 = "14svszfldx32vn937rszd21rgl31vb5kzs0hnrg41ygx0br61rvd";
   };
 
   nativeBuildInputs = [ cmake ninja pkg-config qttools ];
@@ -32,6 +39,7 @@ mkDerivation rec {
     qtbase
     taglib
     zlib
+    py
   ]
   ++ (with gst_all_1; [
     gstreamer
@@ -53,6 +61,12 @@ mkDerivation rec {
   postInstall = ''
     qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
 
   meta = with lib; {
     description = "Sayonara music player";


### PR DESCRIPTION
###### Motivation for this change
- Closes #119419
- Closes #119420
- Adds update script
- Matching pname with attribute so the update script works
  `sayonara` seems to be used by more distros than `sayonara-player` judging by repology - https://repology.org/project/sayonara/versions vs https://repology.org/project/sayonara-player/versions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
