### PR TITLE
yarn2nix: use yarn lockfile integrity field whenever possible

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/internal/fixup_yarn_lock.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/internal/fixup_yarn_lock.js
@@ -25,14 +25,14 @@ const result = []
 
 readFile
   .on('line', line => {
-    const arr = line.match(/^ {2}resolved "([^#]+)#([^"]+)"$/)
+    const arr = line.match(/^ {2}resolved "([^#]+)(#[^"]+)?"$/)
 
     if (arr !== null) {
       const [_, url, shaOrRev] = arr
 
       const fileName = urlToName(url)
 
-      result.push(`  resolved "${fileName}#${shaOrRev}"`)
+      result.push(`  resolved "${fileName}${shaOrRev ?? ''}"`)
     } else {
       result.push(line)
     }

--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
@@ -69,7 +69,7 @@ function fetchgit(fileName, url, rev, branch, builtinFetchGit) {
 
 function fetchLockedDep(builtinFetchGit) {
   return function (pkg) {
-    const { nameWithVersion, resolved } = pkg
+    const { integrity, nameWithVersion, resolved } = pkg
 
     if (!resolved) {
       console.error(
@@ -102,14 +102,14 @@ function fetchLockedDep(builtinFetchGit) {
       return fetchgit(fileName, urlForGit, rev, branch || 'master', builtinFetchGit)
     }
 
-    const sha = sha1OrRev
+    const [algo, hash] = integrity ? integrity.split('-') : ['sha1', sha1OrRev]
 
     return `    {
       name = "${fileName}";
       path = fetchurl {
         name = "${fileName}";
         url  = "${url}";
-        sha1 = "${sha}";
+        ${algo} = "${hash}";
       };
     }`
   }


### PR DESCRIPTION
Whenever available use the SRI hashes from the integrity field to create
the fetchurl calls instead of entirely relying on the `resolved` sha1
which may or may not exist with recent yarn versions.

Also introduce offline option which is useful when yarn.nix is generated
in IFD mode with no network access.

Related issues:

- https://github.com/nix-community/yarn2nix/issues/125
- https://github.com/NixOS/nixpkgs/issues/77238

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
