### PR TITLE
qtModule: use pname and version

### DIFF
--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -7,15 +7,14 @@ let inherit (lib) licenses maintainers platforms; in
 args:
 
 let
-  inherit (args) name;
-  version = args.version or srcs.${name}.version;
-  src = args.src or srcs.${name}.src;
+  pname = args.name;
+  version = args.version or srcs.${pname}.version;
+  src = args.src or srcs.${pname}.src;
 in
 
 mkDerivation (args // {
-  name = "${name}-${version}";
-  inherit src;
-  patches = args.patches or patches.${name} or [];
+  inherit pname version src;
+  patches = args.patches or patches.${pname} or [];
 
   nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ perl self.qmake ];
   propagatedBuildInputs = args.qtInputs ++ (args.propagatedBuildInputs or []);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Making `lib.getVersion` (possibly) more reliable. See https://github.com/NixOS/nixpkgs/pull/119376#issuecomment-820279986.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/qt-kde 