### PR TITLE
llvmPackages*: fix paths to libcxx-0001-musl-hacks.patch

### DIFF
--- a/pkgs/development/compilers/llvm/10/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/10/libc++abi/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   '' + lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
+    patch -p1 -d $(ls -d libcxx-*) -i ${../../libcxx-0001-musl-hacks.patch}
   '' + lib.optionalString stdenv.hostPlatform.isWasm ''
     patch -p1 -d $(ls -d llvm-*) -i ${./wasm.patch}
   '';

--- a/pkgs/development/compilers/llvm/11/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/11/libc++abi/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   '' + lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -d libcxx -i ${../libcxx-0001-musl-hacks.patch}
+    patch -p1 -d libcxx -i ${../../libcxx-0001-musl-hacks.patch}
   '' + lib.optionalString stdenv.hostPlatform.isWasm ''
     patch -p1 -d llvm -i ${./wasm.patch}
   '';

--- a/pkgs/development/compilers/llvm/5/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++abi/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   '' + lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
+    patch -p1 -d $(ls -d libcxx-*) -i ${../../libcxx-0001-musl-hacks.patch}
   '';
 
   installPhase = if stdenv.isDarwin

--- a/pkgs/development/compilers/llvm/6/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++abi/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   '' + lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
+    patch -p1 -d $(ls -d libcxx-*) -i ${../../libcxx-0001-musl-hacks.patch}
   '';
 
   installPhase = if stdenv.isDarwin

--- a/pkgs/development/compilers/llvm/7/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++abi/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   '' + lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
+    patch -p1 -d $(ls -d libcxx-*) -i ${../../libcxx-0001-musl-hacks.patch}
   '';
 
   cmakeFlags =

--- a/pkgs/development/compilers/llvm/8/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/8/libc++abi/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   '' + lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
+    patch -p1 -d $(ls -d libcxx-*) -i ${../../libcxx-0001-musl-hacks.patch}
   '' + lib.optionalString stdenv.hostPlatform.isWasm ''
     patch -p1 -d $(ls -d llvm-*) -i ${./wasm.patch}
   '';

--- a/pkgs/development/compilers/llvm/9/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/9/libc++abi/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   '' + lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
+    patch -p1 -d $(ls -d libcxx-*) -i ${../../libcxx-0001-musl-hacks.patch}
   '' + lib.optionalString stdenv.hostPlatform.isWasm ''
     patch -p1 -d $(ls -d llvm-*) -i ${./wasm.patch}
   '';


### PR DESCRIPTION
This patches are included from libcxx and libcxxabi when
stdenv.hostPlatform.isMusl. After #117433 the patchs to that patch
wasn't adjusted for the new structure, likely because it doesn't come up
during normal eval. This fixes (among other attribute paths):

* pkgsMusl.llvmPackages_12.libcxxabi
* pkgsMusl.llvmPackages_12.libcxx
* pkgsMusl.llvmPackages_11.libcxxabi
* pkgsMusl.llvmPackages_11.libcxx
* pkgsMusl.llvmPackages_10.libcxxabi
* pkgsMusl.llvmPackages_10.libcxx
* pkgsMusl.llvmPackages_9.libcxxabi
* pkgsMusl.llvmPackages_9.libcxx
* pkgsMusl.llvmPackages_8.libcxxabi
* pkgsMusl.llvmPackages_8.libcxx
* pkgsMusl.llvmPackages_7.libcxxabi
* pkgsMusl.llvmPackages_7.libcxx
* pkgsMusl.llvmPackages_6.libcxxabi
* pkgsMusl.llvmPackages_6.libcxx
* pkgsMusl.llvmPackages_5.libcxxabi
* pkgsMusl.llvmPackages_5.libcxx

Only evaluation was tested, not compilation though.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
