### PR TITLE
python3Packages.aioimaplib: 0.7.18 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/aioimaplib/default.nix
+++ b/pkgs/development/python-modules/aioimaplib/default.nix
@@ -8,20 +8,22 @@
 , nose
 , pyopenssl
 , pytestCheckHook
-, pythonOlder
+, pythonAtLeast
 , pytz
 , tzlocal
 }:
 
 buildPythonPackage rec {
   pname = "aioimaplib";
-  version = "0.7.18";
+  version = "0.8.0";
+
+  disabled = pythonAtLeast "3.9";
 
   src = fetchFromGitHub {
     owner = "bamthomas";
     repo = pname;
     rev = version;
-    sha256 = "037fxwmkdfb95cqcykrhn37p138wg9pvlsgdf45vyn1mhz5crky5";
+    sha256 = "sha256-ume25EwLNB6szokHXonDXHGKVK76CiZYOBXVUf37/x8=";
   };
 
   checkInputs = [
@@ -36,9 +38,6 @@ buildPythonPackage rec {
     tzlocal
   ];
 
-  # Project is using asynctest with doesn't work with Python 3.8 and above
-  # https://github.com/bamthomas/aioimaplib/issues/54
-  doCheck = pythonOlder "3.8";
   pythonImportsCheck = [ "aioimaplib" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
