### PR TITLE
go-org: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/applications/misc/go-org/default.nix
+++ b/pkgs/applications/misc/go-org/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "go-org";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "niklasfasching";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-nMZzRbu3lxunIlnnmb49Ljt8oSiYpj+8gZ0u/OFRRDM=";
+    sha256 = "sha256-Wp8WEfRcrtn+VdcbehYcOJI5FkPQiyo6nLsTDvR7riE=";
   };
 
   vendorSha256 = "sha256-njx89Ims7GZql8sbVmH/E9gM/ONRWiPRLVs+FzsCSzI=";


### PR DESCRIPTION
###### Motivation for this change
Upstream package update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
