### PR TITLE
firecracker: 0.23.0 -> 0.24.2

### DIFF
--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, lib, stdenv }:
 
 let
-  version = "0.23.0";
+  version = "0.24.2";
 
   suffix = {
     x86_64-linux  = "x86_64";
@@ -9,33 +9,28 @@ let
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   baseurl = "https://github.com/firecracker-microvm/firecracker/releases/download";
-  fetchbin = name: sha256: fetchurl {
-    url    = "${baseurl}/v${version}/${name}-v${version}-${suffix}";
+
+  dlbin = sha256: fetchurl {
+    url    = "${baseurl}/v${version}/firecracker-v${version}-${suffix}.tgz";
     sha256 = sha256."${stdenv.hostPlatform.system}";
-  };
-
-  firecracker-bin = fetchbin "firecracker" {
-    x86_64-linux  = "11h6qkq55y1w0mlkfkbnpxxai73rzxkiz07i747m7a9azbrmldp8";
-    aarch64-linux = "0zyx7md54w0fhqk1anfyjfdqrkg2mjyy17y9jk17p34yrw8j9y29";
-  };
-
-  jailer-bin = fetchbin "jailer" {
-    x86_64-linux  = "15slr2azqvyqlhvlh7zk1n0rkfq282kj0pllp19r0yl1w8ns1gw5";
-    aarch64-linux = "1d92jhd6fb7w7ciz15rcfp8jf74r2503w2fl1b6pznpc8h4qscfd";
   };
 
 in
 stdenv.mkDerivation {
   pname = "firecracker";
   inherit version;
-  srcs = [ firecracker-bin jailer-bin ];
 
-  unpackPhase    = ":";
+  sourceRoot = ".";
+  src = dlbin {
+    x86_64-linux  = "0l7x9sfyx52n0mwrmicdcnhm8z10q57kk1a5wf459l8lvp59xw08";
+    aarch64-linux = "0m7xs12g97z1ipzaf7dgknf3azlah0p6bdr9i454azvzg955238b";
+  };
+
   configurePhase = ":";
 
   buildPhase     = ''
-    cp ${firecracker-bin} firecracker
-    cp ${jailer-bin}      jailer
+    mv firecracker-* firecracker
+    mv jailer-*      jailer
     chmod +x firecracker jailer
   '';
 


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
