### PR TITLE
openethereum: 3.2.1 -> 3.2.3

### DIFF
--- a/pkgs/applications/blockchains/openethereum/default.nix
+++ b/pkgs/applications/blockchains/openethereum/default.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1j7wfgpnvf9pcprd53sbd3pa7yz9588z81i1bx12wmj1fja3xa0j";
   };
 
-  cargoSha256 = "1qgl15sd32s0r4q5xmx7lyp92sc81hd4ddc18ynbxjdxgl7knm4k";
+  cargoSha256 = "0ha18caw8mxzrh984y2z148cmdijrjxf0rc8j4ccwvmrbdsaz1xn";
 
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
   nativeBuildInputs = [

--- a/pkgs/applications/blockchains/openethereum/default.nix
+++ b/pkgs/applications/blockchains/openethereum/default.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "openethereum";
-  version = "3.2.1";
+  version = "3.2.3";
 
   src = fetchFromGitHub {
     owner = "openethereum";
     repo = "openethereum";
     rev = "v${version}";
-    sha256 = "sha256-+bzMo0s+wdp8T/YjPk6mrPSPid1G8WScB8FJhXdL9JQ=";
+    sha256 = "1j7wfgpnvf9pcprd53sbd3pa7yz9588z81i1bx12wmj1fja3xa0j";
   };
 
-  cargoSha256 = "sha256-ibjjJ5zGF6wbO24/RoYKsTYsMNXHb1EdekDwSICPc5g=";
+  cargoSha256 = "1qgl15sd32s0r4q5xmx7lyp92sc81hd4ddc18ynbxjdxgl7knm4k";
 
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

See: https://github.com/openethereum/openethereum/pull/366

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
