### PR TITLE
fuse: fix mount.fuse -o setuid=...

### DIFF
--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -1,7 +1,7 @@
 { version, sha256Hash }:
 
 { lib, stdenv, fetchFromGitHub, fetchpatch
-, fusePackages, util-linux, gettext
+, fusePackages, util-linux, gettext, shadow
 , meson, ninja, pkg-config
 , autoreconfHook
 , python3Packages, which
@@ -54,13 +54,14 @@ in stdenv.mkDerivation rec {
     # $PATH, so it should also work on non-NixOS systems.
     export NIX_CFLAGS_COMPILE="-DFUSERMOUNT_DIR=\"/run/wrappers/bin\""
 
-    sed -e 's@/bin/@${util-linux}/bin/@g' -i lib/mount_util.c
+    substituteInPlace lib/mount_util.c --replace "/bin/" "${util-linux}/bin/"
     '' + (if isFuse3 then ''
       # The configure phase will delete these files (temporary workaround for
       # ./fuse3-install_man.patch)
       install -D -m444 doc/fusermount3.1 $out/share/man/man1/fusermount3.1
       install -D -m444 doc/mount.fuse3.8 $out/share/man/man8/mount.fuse3.8
     '' else ''
+      substituteInPlace util/mount.fuse.c --replace '"su"' '"${shadow.su}/bin/su"'
       sed -e 's@CONFIG_RPATH=/usr/share/gettext/config.rpath@CONFIG_RPATH=${gettext}/share/gettext/config.rpath@' -i makeconf.sh
       ./makeconf.sh
     '');


### PR DESCRIPTION
###### Motivation for this change

mount.fuse foo bar -o setuid= fails with

/bin/sh: su: command not found


To test:
```
$  sudo env -i result/bin/mount.fuse "$(which fuseiso)#/path/to.iso" /tmp/mnt -o setuid=$(id -u) 
```

cc @primeos as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
