### PR TITLE
wayland-proxy-virtwl: init at unstable-2021-04-15

### DIFF
--- a/pkgs/tools/wayland/wayland-proxy-virtwl/default.nix
+++ b/pkgs/tools/wayland/wayland-proxy-virtwl/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, ocamlPackages
+}:
+
+ocamlPackages.buildDunePackage rec {
+  pname = "wayland-proxy-virtwl";
+  version = "unstable-2021-04-15";
+
+  src = fetchFromGitHub {
+    owner = "talex5";
+    repo = pname;
+    rev = "09321a28f3d4c0fa7e41ebb3014106b62090b649";
+    sha256 = "03rc2jp5d2y9y7mfis6kk9gchd49gvq0jg6fq5gi9r21ckb4k5v4";
+  };
+
+  postPatch = ''
+    # no need to vendor
+    rm -r ocaml-wayland
+  '';
+
+  useDune2 = true;
+  minimumOCamlVersion = "4.08";
+
+  buildInputs = with ocamlPackages; [
+    wayland
+    cmdliner
+    logs
+  ];
+
+  meta = {
+    homepage = "https://github.com/talex5/wayland-virtwl-proxy";
+    description = "Proxy Wayland connections across a VM boundary";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2097,6 +2097,8 @@ in
 
   wayland-utils = callPackage ../tools/wayland/wayland-utils { };
 
+  wayland-proxy-virtwl = callPackage ../tools/wayland/wayland-proxy-virtwl { };
+
   wev = callPackage ../tools/wayland/wev { };
 
   wl-clipboard = callPackage ../tools/wayland/wl-clipboard { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
