### PR TITLE
c2ffi: init at 2021-06-16

### DIFF
--- a/pkgs/development/tools/misc/c2ffi/default.nix
+++ b/pkgs/development/tools/misc/c2ffi/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, fetchFromGitHub
+, cmake
+, llvmPackages_11
+, unstableGitUpdater
+}:
+
+let
+  c2ffiBranch = "llvm-11.0.0";
+  llvmPackages = llvmPackages_11;
+in
+
+llvmPackages.stdenv.mkDerivation {
+  pname = "c2ffi-${c2ffiBranch}";
+  version = "unstable-2021-04-15";
+
+  src = fetchFromGitHub {
+    owner = "rpav";
+    repo = "c2ffi";
+    rev = "0255131f80b21334e565231331c2b451b6bba8c4";
+    sha256 = "0ihysgqjyg5xwi098hxf15lpdi6g4nwpzczp495is912c48fy6b6";
+  };
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/rpav/c2ffi.git";
+    branch = c2ffiBranch;
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    llvmPackages.llvm
+    llvmPackages.clang
+    llvmPackages.libclang
+  ];
+
+  # This isn't much, but...
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/c2ffi --help 2>&1 >/dev/null
+  '';
+
+  # LLVM may be compiled with -fno-rtti, so let's just turn it off.
+  # A mismatch between lib{clang,LLVM}* and us can lead to the link time error:
+  # undefined reference to `typeinfo for clang::ASTConsumer'
+  CXXFLAGS="-fno-rtti";
+
+  meta = with lib; {
+    homepage = "https://github.com/rpav/c2ffi";
+    description = "An LLVM based tool for extracting definitions from C, C++, and Objective C header files for use with foreign function call interfaces";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ attila-lendvai ];
+ };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14085,6 +14085,8 @@ in
   swig = swig3;
   swigWithJava = swig;
 
+  c2ffi = callPackage ../development/tools/misc/c2ffi { };
+
   swfmill = callPackage ../tools/video/swfmill { };
 
   swftools = callPackage ../tools/video/swftools {


### PR DESCRIPTION
[upstream](https://github.com/rpav/c2ffi/) doesn't have releases, i used the date as version.

###### Motivation for this change

i'm using this LLVM based tool to generate FFI for various projects, and once i had a working default.nix, i thought i'll share it with the world.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
