### PR TITLE
passExtensions.pass-import: install extension script and completion

### DIFF
--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -4,6 +4,7 @@
 , python3Packages
 , gnupg
 , pass
+, makeWrapper
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -48,6 +49,16 @@ python3Packages.buildPythonApplication rec {
   ];
   postCheck = ''
     $out/bin/pimport --list-exporters --list-importers
+  '';
+
+  postInstall = ''
+    mkdir -p $out/lib/password-store/extensions
+    cp ${src}/scripts/import.bash $out/lib/password-store/extensions/import.bash
+    wrapProgram $out/lib/password-store/extensions/import.bash \
+      --prefix PATH : "${python3Packages.python.withPackages(_: propagatedBuildInputs)}/bin" \
+      --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}" \
+      --run "export PREFIX"
+    cp -r ${src}/share $out/
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The changes added in [40b9f4e](https://github.com/NixOS/nixpkgs/commit/40b9f4ef8777e927fdbcbcad104a359f21e4c122) meant that running the extension
from within pass, i.e. running `pass import` no longer worked because
the extension script didn't get installed and the completion scripts
for pimport don't get installed. This commit fixes that by manually
copying and wrapping the extension script and completion scripts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
