### PR TITLE
python3Packages.sparse: 0.11.2 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/sparse/default.nix
+++ b/pkgs/development/python-modules/sparse/default.nix
@@ -2,38 +2,39 @@
 , buildPythonPackage
 , fetchPypi
 , isPy3k
-, dask
+, numba
 , numpy
 , scipy
-, numba
-, pytest
+  # Test Inputs
+, pytestCheckHook
+, dask
 }:
 
 buildPythonPackage rec {
   pname = "sparse";
-  version = "0.11.2";
+  version = "0.12.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bc5c35dbc81242237feb7a8e1f7d9c5e9dd9bb0910f6ec55f50dcc379082864f";
+    sha256 = "2c95c3b8ee00211a5aa4ef5e46006d25bf35009a66e406b7ea9b25b327fb9516";
   };
 
-  checkInputs = [ pytest dask ];
   propagatedBuildInputs = [
+    numba
     numpy
     scipy
-    numba
   ];
+  checkInputs = [ pytestCheckHook dask ];
 
-  checkPhase = ''
-    pytest sparse
-  '';
+  pythonImportsCheck = [ "sparse" ];
 
   meta = with lib; {
     description = "Sparse n-dimensional arrays computations";
-    homepage = "https://github.com/pydata/sparse/";
+    homepage = "https://sparse.pydata.org/en/stable/";
+    changelog = "https://sparse.pydata.org/en/stable/changelog.html";
+    downloadPage = "https://github.com/pydata/sparse/releases/tag/${version}";
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
<!-- To help with the large amounts of pull requests, we would 
appreciate your reviews of other pull requests, especially simple 
package updates. Just leave a comment describing what you have tested in 
the relevant package/service. Reviewing helps to reduce the average 
time-to-merge for everyone. Thanks a lot if you do! List of open PRs: 
https://github.com/NixOS/nixpkgs/pulls Reviewing guidelines: 
https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions 
-->

###### Motivation for this change

Bump to latest version.
Changelog: https://github.com/pydata/sparse/releases/tag/0.12.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
