### PR TITLE
python3Packages.karton-mwdb-reporter: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/beautifultable/default.nix
+++ b/pkgs/development/python-modules/beautifultable/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "beautifultable";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "pri22296";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12ci6jy8qmbphsvzvj98466nlhclfzs0a0pmbsv3mf5bfcdwvbh7";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "test.py" ];
+
+  pythonImportsCheck = [ "beautifultable" ];
+
+  meta = with lib; {
+    description = "Python package for printing visually appealing tables";
+    homepage = "https://github.com/CERT-Polska/mwdblib";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/karton-mwdb-reporter/default.nix
+++ b/pkgs/development/python-modules/karton-mwdb-reporter/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, chardet
+, fetchFromGitHub
+, karton-core
+, mwdblib
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "karton-mwdb-reporter";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "CERT-Polska";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ks8jrc4v87q6zhwqg40w6xv2wfkzslmnfmsmmkfjj8mak8nk70f";
+  };
+
+  propagatedBuildInputs = [
+    karton-core
+    mwdblib
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "karton-core==4.0.4" "karton-core" \
+      --replace "mwdblib==3.3.1" "mwdblib"
+  '';
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "karton.mwdb_reporter" ];
+
+  meta = with lib; {
+    description = "Karton service that uploads analyzed artifacts and metadata to MWDB Core";
+    homepage = "https://github.com/CERT-Polska/karton-mwdb-reporter";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mwdblib/default.nix
+++ b/pkgs/development/python-modules/mwdblib/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, beautifultable
+, buildPythonPackage
+, click
+, click-default-group
+, fetchFromGitHub
+, humanize
+, keyring
+, python
+, python-dateutil
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "mwdblib";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "CERT-Polska";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0dbdmps4a3mav02m4h37bj2bw8pg6h52yf3gpdkhi3k9hl9f942h";
+  };
+
+  propagatedBuildInputs = [
+    beautifultable
+    click
+    click-default-group
+    humanize
+    keyring
+    python-dateutil
+    requests
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m unittest discover
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "mwdblib" ];
+
+  meta = with lib; {
+    description = "Python client library for the mwdb service";
+    homepage = "https://github.com/CERT-Polska/mwdblib";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3689,6 +3689,8 @@ in {
 
   karton-core = callPackage ../development/python-modules/karton-core { };
 
+  karton-mwdb-reporter = callPackage ../development/python-modules/karton-mwdb-reporter { };
+
   karton-yaramatcher = callPackage ../development/python-modules/karton-yaramatcher { };
 
   kazoo = callPackage ../development/python-modules/kazoo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4518,6 +4518,8 @@ in {
 
   mwclient = callPackage ../development/python-modules/mwclient { };
 
+  mwdblib = callPackage ../development/python-modules/mwdblib { };
+
   mwlib = callPackage ../development/python-modules/mwlib { };
 
   mwlib-ext = callPackage ../development/python-modules/mwlib-ext { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -992,6 +992,8 @@ in {
 
   beautifulsoup4 = callPackage ../development/python-modules/beautifulsoup4 { };
 
+  beautifultable = callPackage ../development/python-modules/beautifultable { };
+
   bedup = callPackage ../development/python-modules/bedup { };
 
   behave = callPackage ../development/python-modules/behave { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Karton service that uploads analyzed artifacts and metadata to MWDB Core

https://github.com/CERT-Polska/karton-mwdb-reporter

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @chivay

