### PR TITLE
gmrender-resurrect: 0.0.8 -> 0.0.9

### DIFF
--- a/pkgs/tools/networking/gmrender-resurrect/default.nix
+++ b/pkgs/tools/networking/gmrender-resurrect/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config, makeWrapper, gstreamer
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, makeWrapper, gstreamer
 , gst-plugins-base, gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-libav, libupnp }:
 
 let
-  version = "0.0.8";
+  version = "0.0.9";
 
   makePluginPath = plugins: builtins.concatStringsSep ":" (map (p: p + "/lib/gstreamer-1.0") plugins);
 
@@ -16,16 +16,8 @@ in
       owner = "hzeller";
       repo = "gmrender-resurrect";
       rev = "v${version}";
-      sha256 = "14i5jrry6qiap5l2x2jqj7arymllajl3wgnk29ccvr8d45zp4jn1";
+      sha256 = "0byxd28hnhkhf3lqsad43n6czfajvc1ksg9zikxb95wwk4ljqv1q";
     };
-
-    patches = [
-      (fetchpatch {
-        url = "https://github.com/hzeller/gmrender-resurrect/commit/dc8c4d4dc234311b3099e7f1efadf5d9733c81e9.patch";
-        sha256 = "0fqi58viaq9jg5h5j1725qrach4c3wmfmh0q43q4r8az2pn7dszw";
-        name = "libupnp.patch";
-      })
-    ];
 
     buildInputs = [ gstreamer libupnp ];
     nativeBuildInputs = [ autoreconfHook pkg-config makeWrapper ];
@@ -39,8 +31,8 @@ in
     meta = with lib; {
       description = "Resource efficient UPnP/DLNA renderer, optimal for Raspberry Pi, CuBox or a general MediaServer";
       homepage = "https://github.com/hzeller/gmrender-resurrect";
-      license = licenses.gpl2;
+      license = licenses.gpl2Plus;
       platforms = platforms.linux;
-      maintainers = with maintainers; [ koral ashkitten ];
+      maintainers = with maintainers; [ koral hzeller ];
     };
   }


### PR DESCRIPTION
Updating the latest version of gmrender-resurrect lets
us skip adding the cherrypick patch, as this is already
included in 0.0.9.

(Note, I am not maintainer of this nix package, but
 maintainer of gmrender-resurrect)

Signed-off-by: Henner Zeller <h.zeller@acm.org>

###### Motivation for this change
Version Upgrade; reduce complexity by not having to cherrypick a patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
