### PR TITLE
haruna: init at 0.6.1

### DIFF
--- a/pkgs/applications/video/haruna/default.nix
+++ b/pkgs/applications/video/haruna/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, fetchFromGitHub
+, mkDerivation
+, breeze-icons
+, breeze-qt5
+, cmake
+, extra-cmake-modules
+, kcodecs
+, kconfig
+, kcoreaddons
+, kfilemetadata
+, ki18n
+, kiconthemes
+, kio
+, kio-extras
+, kirigami2
+, kxmlgui
+, mpv
+, pkg-config
+, qqc2-desktop-style
+, qtbase
+, qtquickcontrols2
+, qtwayland
+, youtube-dl
+}:
+
+mkDerivation rec {
+  pname = "haruna";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "g-fb";
+    repo = "haruna";
+    rev = version;
+    sha256 = "sha256-8MauKmvQUwzq4Ssmm6g7/y6ADkye+eg/zyR3v/Wu848=";
+  };
+
+  buildInputs = [
+    breeze-icons
+    breeze-qt5
+    kcodecs
+    kconfig
+    kcoreaddons
+    kfilemetadata
+    ki18n
+    kiconthemes
+    kio
+    kio-extras
+    kirigami2
+    kxmlgui
+    mpv
+    qqc2-desktop-style
+    qtbase
+    qtquickcontrols2
+    qtwayland
+    youtube-dl
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/g-fb/haruna";
+    description = "Open source video player built with Qt/QML and libmpv";
+    license = with licenses; [ bsd3 cc-by-40 gpl3Plus wtfpl ];
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22667,6 +22667,8 @@ in
 
   gspeech = callPackage ../applications/audio/gspeech { };
 
+  haruna = libsForQt5.callPackage ../applications/video/haruna { };
+
   icesl = callPackage ../applications/misc/icesl { };
 
   keepassx = callPackage ../applications/misc/keepassx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add package for package request by @colemickens. Closes #119256.

I did play some local and remote videos (https from jellyfin and a youtube video).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/a6b7gcn5j4kkqjir4m91k43g28yj7wic-haruna-0.6.1	   1.4G
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
