### PR TITLE
nixos/containers: make kernel assertion lenient

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -272,7 +272,13 @@ let
   };
 
   system = config.nixpkgs.localSystem.system;
-  kernelVersion = config.boot.kernelPackages.kernel.version;
+
+  # Sometimes ^1 the `kernel.version` property is not present; when it happens,
+  # we want for all kernel-based assertions to pass and, in the worst case,
+  # error-out at runtime.
+  #
+  # [1]: https://github.com/NixOS/nixpkgs/issues/38509#issuecomment-817200996
+  kernelVersion = config.boot.kernelPackages.kernel.version or null;
 
   bindMountOpts = { name, ... }: {
 
@@ -482,7 +488,8 @@ in
                           assertions = [
                             {
                               assertion =
-                                (builtins.compareVersions kernelVersion "5.8" <= 0)
+                                kernelVersion != null
+                                -> builtins.compareVersions kernelVersion "5.8" <= 0
                                 -> config.privateNetwork
                                 -> stringLength name <= 11;
                               message = ''


### PR DESCRIPTION
###### Motivation for this change

Sometimes ^1 the `kernel.version` property is not present; when it
happens, we want for all kernel-based assertions to pass and, in the
worst case, error-out at runtime.

1: https://github.com/NixOS/nixpkgs/issues/38509#issuecomment-817200996

This is more of a _bandaid_ to get https://github.com/erikarvstedt/extra-container (and possibly other solutions) to work; a proper fix will require thinking about how we can perform kernel version assertions during both build-time (for `nix-build` to early-fail if the configuration doesn't make sense) and run-time.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
