### PR TITLE
pythonPackages.tqdm: Fix build on i686 architecture

### DIFF
--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , setuptools_scm
@@ -30,10 +31,11 @@ buildPythonPackage rec {
     pytest-timeout
     # tests of optional features
     numpy
-    pandas
     rich
     tkinter
-  ];
+  ] ++
+    # pandas is not supported on i686
+    lib.optional (!stdenv.isi686) pandas;
 
   # Remove performance testing.
   # Too sensitive for on Hydra.


### PR DESCRIPTION
###### Motivation for this change
The tqdm package was not building on i686 architectures. This was due to the pandas package not supporting i686.

###### Things done

pandas is only a testing dependency for a optional feature. As a consequence the optional tests were disabled on i686 systems.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
