### PR TITLE
unstable-updater.nix now understands a branch argument

### DIFF
--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -1,4 +1,5 @@
-{ writeShellScript
+{ lib
+, writeShellScript
 , coreutils
 , git
 , nix
@@ -8,6 +9,7 @@
 # This is an updater for unstable packages that should always use the latest
 # commit.
 { url ? null # The git url, if empty it will be set to src.url
+, branch ? null
 }:
 
 let
@@ -25,7 +27,9 @@ let
 
     # Get info about HEAD from a shallow git clone
     tmpdir="$(${coreutils}/bin/mktemp -d)"
-    ${git}/bin/git clone --bare --depth=1 "$url" "$tmpdir"
+    ${git}/bin/git clone --bare --depth=1 \
+      ${lib.optionalString (branch != null) "--branch ${branch}"} \
+      "$url" "$tmpdir"
     pushd "$tmpdir"
     commit_date="$(${git}/bin/git show -s --pretty='format:%cs')"
     commit_sha="$(${git}/bin/git show -s --pretty='format:%H')"


### PR DESCRIPTION
###### Motivation for this change

the c2ffi project uses custom branches, and i would like to use an updater script for it.

see: https://github.com/NixOS/nixpkgs/pull/119564

###### Status

This is pretty much untested, and requires someone who understand the updater machinery. I was hopelessly far from being able to test it.