### PR TITLE
spice-protocol: 0.14.1 -> 0.14.3

### DIFF
--- a/pkgs/development/libraries/spice-protocol/default.nix
+++ b/pkgs/development/libraries/spice-protocol/default.nix
@@ -1,13 +1,15 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, meson, ninja }:
 
 stdenv.mkDerivation rec {
   pname = "spice-protocol";
-  version = "0.14.1";
+  version = "0.14.3";
 
   src = fetchurl {
-    url = "https://www.spice-space.org/download/releases/${pname}-${version}.tar.bz2";
-    sha256 = "0ahk5hlanwhbc64r80xmchdav3ls156cvh9l68a0l22bhdhxmrkr";
+    url = "https://www.spice-space.org/download/releases/${pname}-${version}.tar.xz";
+    sha256 = "0yj8k7gcirrsf21w0q6146n5g4nzn2pqky4p90n5760m5ayfb1pr";
   };
+
+  nativeBuildInputs = [ meson ninja ];
 
   postInstall = ''
     mkdir -p $out/lib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog:
https://gitlab.freedesktop.org/spice/spice-protocol/-/blob/v0.14.3/CHANGELOG.md

This upgrade will also allow to upgrade `spice-vdagent` to 0.21.0 to solve CVE-2020-25650, CVE-2020-25651, CVE-2020-25652 and CVE-2020-25653 (it requires `spice-protocol` >= 0.14.03).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


The 8 failures seems to be unrelated to this change as they can be reproduced on master.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>aqemu</li>
    <li>linuxPackages-libre.virtualbox</li>
    <li>linuxPackages_latest-libre.virtualbox</li>
    <li>multibootusb</li>
  </ul>
</details>
<details>
  <summary>8 packages failed to build:</summary>
  <ul>
    <li>cot (python38Packages.cot)</li>
    <li>libvmi</li>
    <li>python39Packages.cot</li>
    <li>qemu_xen (qemu_xen_4_10)</li>
    <li>qemu_xen-light (qemu_xen_4_10-light)</li>
    <li>qubes-core-vchan-xen</li>
    <li>xen</li>
    <li>xen-slim</li>
  </ul>
</details>
<details>
  <summary>50 packages built:</summary>
  <ul>
    <li>alpine-make-vm-image</li>
    <li>cloud-init</li>
    <li>cloud-utils</li>
    <li>gnome3.gnome-boxes</li>
    <li>kvm (qemu_kvm)</li>
    <li>libguestfs</li>
    <li>libguestfs-with-appliance</li>
    <li>linuxPackages.virtualbox</li>
    <li>linuxPackages_4_14.virtualbox</li>
    <li>linuxPackages_4_19.virtualbox</li>
    <li>linuxPackages_4_4.virtualbox</li>
    <li>linuxPackages_4_9.virtualbox</li>
    <li>linuxPackages_5_11.virtualbox</li>
    <li>linuxPackages_5_4.virtualbox</li>
    <li>linuxPackages_hardened.virtualbox</li>
    <li>linuxPackages_latest_hardened.virtualbox</li>
    <li>linuxPackages_latest_xen_dom0.virtualbox</li>
    <li>linuxPackages_latest_xen_dom0_hardened.virtualbox</li>
    <li>linuxPackages_lqx.virtualbox</li>
    <li>linuxPackages_testing_bcachefs.virtualbox</li>
    <li>linuxPackages_xanmod.virtualbox</li>
    <li>linuxPackages_xen_dom0.virtualbox</li>
    <li>linuxPackages_xen_dom0_hardened.virtualbox</li>
    <li>linuxPackages_zen.virtualbox</li>
    <li>looking-glass-client</li>
    <li>ocamlPackages.ocaml-freestanding</li>
    <li>open-watcom-bin</li>
    <li>out-of-tree</li>
    <li>python38Packages.guestfs</li>
    <li>python39Packages.guestfs</li>
    <li>qemu</li>
    <li>qemu-utils</li>
    <li>qemu_full</li>
    <li>qtemu</li>
    <li>remmina</li>
    <li>solo5</li>
    <li>spice</li>
    <li>spice-gtk (spice_gtk)</li>
    <li>spice-protocol (spice_protocol)</li>
    <li>spice-vdagent</li>
    <li>vagrant</li>
    <li>virtmanager (virt-manager)</li>
    <li>virtmanager-qt (virt-manager-qt)</li>
    <li>virtviewer (virt-viewer)</li>
    <li>virtualbox</li>
    <li>virtualboxHardened</li>
    <li>virtualboxHeadless</li>
    <li>virtualboxWithExtpack</li>
    <li>x11spice</li>
    <li>xorg.xf86videoqxl</li>
  </ul>
</details>