### PR TITLE
ocamlPackages.sedlex_2: 2.2 -> 2.3

### DIFF
--- a/pkgs/development/ocaml-modules/sedlex/2.nix
+++ b/pkgs/development/ocaml-modules/sedlex/2.nix
@@ -4,12 +4,11 @@
 , buildDunePackage
 , ocaml
 , gen
-, ppx_tools_versioned
-, ocaml-migrate-parsetree
+, ppxlib
 , uchar
 }:
 
-if lib.versionOlder ocaml.version "4.02.3"
+if lib.versionOlder ocaml.version "4.08"
 then throw "sedlex is not available for OCaml ${ocaml.version}"
 else
 
@@ -32,7 +31,7 @@ let
 in
 buildDunePackage rec {
   pname = "sedlex";
-  version = "2.2";
+  version = "2.3";
 
   useDune2 = true;
 
@@ -40,11 +39,11 @@ buildDunePackage rec {
     owner = "ocaml-community";
     repo = "sedlex";
     rev = "v${version}";
-    sha256 = "18dwl2is5j26z6b1c47b81wvcpxw44fasppdadsrs9vsw63rwcm3";
+    sha256 = "0iw3phlaqr27jdf857hmj5v5hdl0vngbb2h37p2ll18sw991fxar";
   };
 
   propagatedBuildInputs = [
-    gen uchar ocaml-migrate-parsetree ppx_tools_versioned
+    gen uchar ppxlib
   ];
 
   preBuild = ''
@@ -60,6 +59,7 @@ buildDunePackage rec {
 
   meta = {
     homepage = "https://github.com/ocaml-community/sedlex";
+    changelog = "https://github.com/ocaml-community/sedlex/raw/v${version}/CHANGES";
     description = "An OCaml lexer generator for Unicode";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.marsam ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/ocaml-community/sedlex/releases/tag/v2.3
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
