### PR TITLE
cryptomator: 1.5.13 -> 1.5.14

### DIFF
--- a/pkgs/tools/security/cryptomator/default.nix
+++ b/pkgs/tools/security/cryptomator/default.nix
@@ -6,20 +6,20 @@
 
 let
   pname = "cryptomator";
-  version = "1.5.13";
+  version = "1.5.14";
 
   src = fetchFromGitHub {
     owner = "cryptomator";
     repo = "cryptomator";
     rev = version;
-    sha256 = "1s9jl3nl6yfjzmilz9b8azk8592nd39xflzfdf38v6s4iiq86r8j";
+    sha256 = "05zgan1i2dzipzw8x510lg2l40dz9hvk43nrwpi0kg9l1qs9sxrq";
   };
 
   icons = fetchFromGitHub {
     owner = "cryptomator";
     repo = "cryptomator-linux";
     rev = version;
-    sha256 = "1x6h6wp6yxnj576874xj3d2jm8jmb7918wprqvlz4sryxhlcssa7";
+    sha256 = "0gb5sd5bkpxv4hff1i09rxr90pi5d15vjsfrk9m8221xiypqmccp";
   };
 
   # perform fake build to make a fixed-output derivation out of the files downloaded from maven central (120MB)
@@ -44,7 +44,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "06q8bqdz3c4i84wxl9z5861zwdsw8jzcvsbgxqrnh8rwi7500sa7";
+    outputHash = "0gvpjc77g99vcwk77nknvg8z33xbskcfwx3015nhhc089b2frq02";
   };
 
 in stdenv.mkDerivation rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest version now that OpenJDK 16 is availale and merged to master https://github.com/NixOS/nixpkgs/pull/116717.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
