### PR TITLE
seaweedfs: add version check to passthru.tests

### DIFF
--- a/pkgs/applications/networking/seaweedfs/default.nix
+++ b/pkgs/applications/networking/seaweedfs/default.nix
@@ -1,4 +1,9 @@
-{ lib, fetchFromGitHub, buildGoModule }:
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, runCommand
+, seaweedfs
+}:
 
 buildGoModule rec {
   pname = "seaweedfs";
@@ -14,6 +19,11 @@ buildGoModule rec {
   vendorSha256 = "sha256-qdgnoh+53o3idCfpkEFGK88aUVb2F6oHlSRZncs2hyY=";
 
   subPackages = [ "weed" ];
+
+  passthru.tests.check-version = runCommand "weed-version" { meta.timeout = 3; } ''
+    ${seaweedfs}/bin/weed version | grep -Fw ${version}
+    touch $out
+  '';
 
   meta = with lib; {
     description = "Simple and highly scalable distributed file system";


### PR DESCRIPTION
###### Motivation for this change

This is basically the extent of testing I usually do when an upgrade
is proposed, so this takes that manual step away.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).