### PR TITLE
oh-my-git: init at 0.6.4

### DIFF
--- a/pkgs/development/tools/godot/export-templates.nix
+++ b/pkgs/development/tools/godot/export-templates.nix
@@ -1,0 +1,17 @@
+{ godot, lib }:
+
+# https://docs.godotengine.org/en/stable/development/compiling/compiling_for_x11.html#building-export-templates
+godot.overrideAttrs (oldAttrs: rec {
+  pname = "godot-export-templates";
+  sconsFlags = "target=release platform=x11 tools=no";
+  installPhase = ''
+    # The godot export command expects the export templates at
+    # .../share/godot/templates/3.2.3.stable with 3.2.3 being the godot version.
+    mkdir -p "$out/share/godot/templates/${oldAttrs.version}.stable"
+    cp bin/godot.x11.opt.64 $out/share/godot/templates/${oldAttrs.version}.stable/linux_x11_64_release
+  '';
+  outputs = [ "out" ];
+  meta.description =
+    "Free and Open Source 2D and 3D game engine (export templates)";
+  meta.maintainers = with lib.maintainers; [ twey jojosch ];
+})

--- a/pkgs/games/oh-my-git/default.nix
+++ b/pkgs/games/oh-my-git/default.nix
@@ -1,0 +1,115 @@
+{ lib
+, copyDesktopItems
+, fetchFromGitHub
+, makeDesktopItem
+, stdenv
+, alsaLib
+, gcc-unwrapped
+, git
+, godot-export-templates
+, godot-headless
+, libGLU
+, libX11
+, libXcursor
+, libXext
+, libXfixes
+, libXi
+, libXinerama
+, libXrandr
+, libXrender
+, libglvnd
+, libpulseaudio
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "oh-my-git";
+  version = "0.6.4";
+
+  src = fetchFromGitHub {
+    owner = "git-learning-game";
+    repo = "oh-my-git";
+    rev = version;
+    sha256 = "sha256-GQLHyBUXF+yqEZ/LYutAn6TBCXFX8ViOaERQEm2J6CY=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    godot-headless
+  ];
+
+  buildInputs = [
+    alsaLib
+    gcc-unwrapped.lib
+    git
+    libGLU
+    libX11
+    libXcursor
+    libXext
+    libXfixes
+    libXi
+    libXinerama
+    libXrandr
+    libXrender
+    libglvnd
+    libpulseaudio
+    zlib
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "oh-my-git";
+      exec = "oh-my-git";
+      icon = "oh-my-git";
+      desktopName = "oh-my-git";
+      comment = "An interactive Git learning game!";
+      genericName = "An interactive Git learning game!";
+      categories = "Game;";
+    })
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Cannot create file '/homeless-shelter/.config/godot/projects/...'
+    export HOME=$TMPDIR
+
+    # Link the export-templates to the expected location. The --export commands
+    # expects the template-file at .../templates/3.2.3.stable/linux_x11_64_release
+    # with 3.2.3 being the version of godot.
+    mkdir -p $HOME/.local/share/godot
+    ln -s ${godot-export-templates}/share/godot/templates $HOME/.local/share/godot
+
+    mkdir -p $out/share/oh-my-git
+    godot-headless --export "Linux" $out/share/oh-my-git/oh-my-git
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ln -s $out/share/oh-my-git/oh-my-git $out/bin
+
+    # Patch binaries.
+    interpreter=$(cat $NIX_CC/nix-support/dynamic-linker)
+    patchelf \
+      --set-interpreter $interpreter \
+      --set-rpath ${lib.makeLibraryPath buildInputs} \
+      $out/share/oh-my-git/oh-my-git
+
+    mkdir -p $out/share/pixmaps
+    cp images/oh-my-git.png $out/share/pixmaps/oh-my-git.png
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://ohmygit.org/";
+    description = "An interactive Git learning game";
+    license = with licenses; [ blueOak100 ];
+    platforms   = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5046,6 +5046,8 @@ in
 
   godot = callPackage ../development/tools/godot {};
 
+  godot-export-templates = callPackage ../development/tools/godot/export-templates.nix { };
+
   godot-headless = callPackage ../development/tools/godot/headless.nix { };
 
   godot-server = callPackage ../development/tools/godot/server.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2753,6 +2753,8 @@ in
 
   meritous = callPackage ../games/meritous { };
 
+  oh-my-git = callPackage ../games/oh-my-git { };
+
   opendune = callPackage ../games/opendune { };
 
   merriweather = callPackage ../data/fonts/merriweather { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the package for @davidak's package request. Closes #112341. I played about half of the levels and there seem to be no problems running the game.

The godot export commands expects a copy of the godot export templates at `$HOME/.local/share/godot/templates/3.2.3.stable/...`. First i downloaded the zip archive from https://godotengine.org/download and copied the templates to the expected location. But the version of these export templates and the godot compiler need to be in sync.

Therefore i added `godot-export-templates` based on the `headless`/`server` package. Now the version of godot and the export templates are automatically in sync.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/xx9zihn59643p47b2qgyl05qxk4b8qrq-oh-my-git-0.6.4	 396.7M
/nix/store/hk6l3krh3aps7a6pkxbf6p1kp1zyvbc4-godot-export-templates-3.2.3	 391.6M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
