### PR TITLE
zeroad: Split data from binaries again

### DIFF
--- a/pkgs/games/0ad/data.nix
+++ b/pkgs/games/0ad/data.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     description = "A free, open-source game of ancient warfare -- data files";
     homepage = "https://play0ad.com/";
     license = licenses.cc-by-sa-30;
+    maintainers = with maintainers; [ chvp ];
     platforms = platforms.linux;
     hydraPlatforms = [];
   };

--- a/pkgs/games/0ad/game.nix
+++ b/pkgs/games/0ad/game.nix
@@ -101,6 +101,7 @@ stdenv.mkDerivation rec {
       gpl2 lgpl21 mit cc-by-sa-30
       licenses.zlib # otherwise masked by pkgs.zlib
     ];
+    maintainers = with maintainers; [ chvp ];
     platforms = subtractLists platforms.i686 platforms.linux;
   };
 }

--- a/pkgs/games/0ad/game.nix
+++ b/pkgs/games/0ad/game.nix
@@ -2,7 +2,7 @@
 , pkg-config, spidermonkey_78, boost, icu, libxml2, libpng, libsodium
 , libjpeg, zlib, curl, libogg, libvorbis, enet, miniupnpc
 , openal, libGLU, libGL, xorgproto, libX11, libXcursor, nspr, SDL2
-, gloox, nvidia-texture-tools, zeroad-data
+, gloox, nvidia-texture-tools
 , withEditor ? true, wxGTK
 }:
 
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
     "-I${fmt.dev}/include"
   ];
 
+  patches = [ ./rootdir_env.patch ];
+
   configurePhase = ''
     # Delete shipped libraries which we don't need.
     rm -rf libraries/source/{enet,miniupnpc,nvtt,spidermonkey}
@@ -62,7 +64,6 @@ stdenv.mkDerivation rec {
       ${lib.optionalString withEditor "--enable-atlas"} \
       --bindir="$out"/bin \
       --libdir="$out"/lib/0ad \
-      --datadir="$out"/share/0ad/data \
       --without-tests \
       -j $NIX_BUILD_CORES
     popd
@@ -84,11 +85,6 @@ stdenv.mkDerivation rec {
 
     # Copy l10n data.
     install -Dm755 -t $out/share/0ad/data/l10n binaries/data/l10n/*
-
-    # Link in game data from package
-    ln -s ${zeroad-data}/share/0ad/data/config $out/share/0ad/data/config
-    ln -s ${zeroad-data}/share/0ad/data/mods $out/share/0ad/data/mods
-    ln -s ${zeroad-data}/share/0ad/data/tools $out/share/0ad/data/tools
 
     # Copy libraries.
     install -Dm644 -t $out/lib/0ad        binaries/system/*.so

--- a/pkgs/games/0ad/rootdir_env.patch
+++ b/pkgs/games/0ad/rootdir_env.patch
@@ -1,0 +1,39 @@
+diff --git a/source/ps/GameSetup/Paths.cpp b/source/ps/GameSetup/Paths.cpp
+index 474364e..bf084b4 100644
+--- a/source/ps/GameSetup/Paths.cpp
++++ b/source/ps/GameSetup/Paths.cpp
+@@ -155,32 +155,8 @@ Paths::Paths(const CmdLineArgs& args)
+ 
+ /*static*/ OsPath Paths::Root(const OsPath& argv0)
+ {
+-#if OS_ANDROID
+-	return OsPath("/sdcard/0ad"); // TODO: this is kind of bogus
+-#else
+-
+-	// get full path to executable
+-	OsPath pathname = sys_ExecutablePathname();	// safe, but requires OS-specific implementation
+-	if(pathname.empty())	// failed, use argv[0] instead
+-	{
+-		errno = 0;
+-		pathname = wrealpath(argv0);
+-		if(pathname.empty())
+-			WARN_IF_ERR(StatusFromErrno());
+-	}
+-
+-	// make sure it's valid
+-	if(!FileExists(pathname))
+-	{
+-		LOGERROR("Cannot find executable (expected at '%s')", pathname.string8());
+-		WARN_IF_ERR(StatusFromErrno());
+-	}
+-
+-	for(size_t i = 0; i < 2; i++)	// remove "system/name.exe"
+-		pathname = pathname.Parent();
+-	return pathname;
+-
+-#endif
++        UNUSED2(argv0);
++        return OsPath(getenv("ZEROAD_ROOTDIR"));
+ }
+ 
+ /*static*/ OsPath Paths::RootData(const OsPath& argv0)


### PR DESCRIPTION
###### Motivation for this change

The rootdir patch was lost in the update to 0.0.24. Adding it allows hydra to build the game (which takes a few minutes). It can't when the binaries depend on the data since the data is too big for hydra.

ZHF: #122042
CC @NixOS/nixos-release-managers

###### Things done

I started a game using this build.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
