### PR TITLE
ntp: set platforms to unix

### DIFF
--- a/pkgs/tools/networking/ntp/default.nix
+++ b/pkgs/tools/networking/ntp/default.nix
@@ -47,6 +47,6 @@ stdenv.mkDerivation rec {
       url = "https://www.eecis.udel.edu/~mills/ntp/html/copyright.html";
     };
     maintainers = with maintainers; [ eelco thoughtpolice ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/networking/ntp/default.nix
+++ b/pkgs/tools/networking/ntp/default.nix
@@ -47,6 +47,6 @@ stdenv.mkDerivation rec {
       url = "https://www.eecis.udel.edu/~mills/ntp/html/copyright.html";
     };
     maintainers = with maintainers; [ eelco thoughtpolice ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Compiles fine and ntpdate works on macOS

```
% /nix/store/y6kb8669c3hg2qrmqdqwn17jnij62zkz-ntp-4.2.8p15/bin/ntpdate -s -d -6 time.facebook.com
16 Apr 10:05:18 ntpdate[10171]: ntpdate 4.2.8p15@1.3728-o Tue Jun 23 09:22:22 UTC 2020 (1)
Looking for host time.facebook.com and service ntp
2a03:2880:ff0c::123 reversed to time2.facebook.com
host found : time2.facebook.com
transmit(2a03:2880:ff0c::123)
receive(2a03:2880:ff0c::123)
transmit(2a03:2880:ff0c::123)
receive(2a03:2880:ff0c::123)
transmit(2a03:2880:ff0c::123)
receive(2a03:2880:ff0c::123)
transmit(2a03:2880:ff0c::123)
receive(2a03:2880:ff0c::123)

server 2a03:2880:ff0c::123, port 123
stratum 1, precision -32, leap 00, trust 000
refid [FB  ], root delay 0.000000, root dispersion 0.000153
reference time:      e4243f80.00000000  Fri, Apr 16 2021  9:53:20.000
originate timestamp: e4244254.7b41957f  Fri, Apr 16 2021 10:05:24.481
transmit timestamp:  e4244254.66480e8d  Fri, Apr 16 2021 10:05:24.399
filter delay:  1.16045    1.15857    1.16492    1.16583   
               ----       ----       ----       ----      
filter offset: +0.009114  +0.010462  +0.011685  +0.011715 
               ----       ----       ----       ----      
delay 1.15857, dispersion 0.00113, offset +0.010462

16 Apr 10:05:24 ntpdate[10171]: adjust time server 2a03:2880:ff0c::123 offset +0.010462 sec
```


###### Things done



- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
