### PR TITLE
dmd: mark unbroken

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -170,6 +170,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ThomasMader lionello ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
     # many tests are failing
-    broken = true;
   };
 }


### PR DESCRIPTION
It is building fine locally, tested by myself and @SuperSandro2000 (who had added the broken tag).

Should this be tested on hydra before removing it?  I don't know if that is even possible.

Solves #119548