### PR TITLE
python3Packages.sphinx: 3.3.1 -> 3.5.4

### DIFF
--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -33,11 +33,11 @@
 
 buildPythonPackage rec {
   pname = "sphinx";
-  version = "3.3.1";
+  version = "3.5.4";
   src = fetchPypi {
     pname = "Sphinx";
     inherit version;
-    sha256 = "1e8d592225447104d1172be415bc2972bd1357e3e12fdc76edf2261105db4300";
+    sha256 = "19010b7b9fa0dc7756a6e105b2aacd3a80f798af3c25c273be64d7beeb482cb1";
   };
   LC_ALL = "en_US.UTF-8";
 
@@ -74,7 +74,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "A tool that makes it easy to create intelligent and beautiful documentation for Python projects";
-    homepage = "http://sphinx.pocoo.org/";
+    homepage = "https://www.sphinx-doc.org";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ nand0p ];
   };


### PR DESCRIPTION
###### Motivation for this change

Update sphinx to latest version 3.5.4.

Changelog:

https://github.com/sphinx-doc/sphinx/blob/9f44ee4dd1761e12a25b63671dcc4b8ace1f2555/CHANGES#L199-L553

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
