### PR TITLE
tmpmail: init at master

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5534,6 +5534,12 @@
     githubId = 4158274;
     name = "Michiel Leenaars";
   };
+  legendofmiracles = {
+    email = "legendofmiracles@protonmail.com";
+    github = "legendofmiracles";
+    githubId = 30902201;
+    name = "legendofmiracles";
+  };
   lejonet = {
     email = "daniel@kuehn.se";
     github = "lejonet";

--- a/pkgs/applications/networking/tmpmail/default.nix
+++ b/pkgs/applications/networking/tmpmail/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchFromGitHub, stdenvNoCC, w3m, curl, jq, makeWrapper, installShellFiles }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "tmpmail";
+  version = "unstable-2021-02-10";
+
+   src = fetchFromGitHub {
+    owner = "sdushantha";
+    repo = "tmpmail";
+    rev = "150b32083d36006cf7f496e112715ae12ee87727";
+    sha256 = "sha256-yQ9/UUxBTEXK5z3f+tvVRUzIGrAnrqurQ0x56Ad7RKE=";
+  };
+
+  dontConfigure = true;
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -Dm755 -t $out/bin tmpmail
+    installManPage tmpmail.1
+    wrapProgram $out/bin/tmpmail --prefix PATH : ${lib.makeBinPath [ w3m curl jq ]}
+  '';
+
+   meta = with lib; {
+    homepage = "https://github.com/sdushantha/tmpmail";
+    description = "A temporary email right from your terminal written in POSIX sh ";
+    license = licenses.mit;
+    maintainers = [ maintainers.legendofmiracles ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8779,6 +8779,8 @@ in
 
   tmpwatch = callPackage ../tools/misc/tmpwatch  { };
 
+  tmpmail = callPackage ../applications/networking/tmpmail { };
+
   tmux = callPackage ../tools/misc/tmux { };
 
   tmux-cssh = callPackage ../tools/misc/tmux-cssh { };


### PR DESCRIPTION
###### Motivation for this change
Adds `tmpmail` to nixpkgs

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
