### PR TITLE
profanity: Enable clipboard support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   # Enable feature flags, so that build fail if libs are missing
   configureFlags = [ "--enable-c-plugins" "--enable-otr" ]
     ++ optionals notifySupport       [ "--enable-notifications" ]
-    ++ optionals traySupport         [ "--enable-icons" ]
+    ++ optionals traySupport         [ "--enable-icons-and-clipboard" ]
     ++ optionals pgpSupport          [ "--enable-pgp" ]
     ++ optionals pythonPluginSupport [ "--enable-python-plugins" ]
     ++ optionals omemoSupport        [ "--enable-omemo" ];


### PR DESCRIPTION
###### Motivation for this change

Clipboard support was actually introduced in version `0.8.0`, and this
change flew completely over my head. Now the /paste command should
actually work by default and as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
