### PR TITLE
nixos/iso-image: Use fixed-order mcopy instead of file globbing

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -405,7 +405,8 @@ let
         "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}" ./boot/
       touch --date=@0 ./EFI ./boot
 
-      usage_size=$(du -sb --apparent-size . | tr -cd '[:digit:]')
+      # Round up to the nearest multiple of 1MB, for more deterministic du output
+      usage_size=$(( $(du -s --block-size=1M --apparent-size . | tr -cd '[:digit:]') * 1024 * 1024 ))
       # Make the image 110% as big as the files need to make up for FAT overhead
       image_size=$(( ($usage_size * 110) / 100 ))
       # Make the image fit blocks of 1M

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -418,19 +418,11 @@ let
       faketime "2000-01-01 00:00:00" mkfs.vfat -i 12345678 -n EFIBOOT "$out"
 
       # Force a fixed order in mcopy for better determinism, and avoid file globbing
-      for d in $(find EFI -type d | sort); do
+      for d in $(find EFI boot -type d | sort); do
         faketime "2000-01-01 00:00:00" mmd -i "$out" "::/$d"
       done
 
-      for d in $(find boot -type d | sort); do
-        faketime "2000-01-01 00:00:00" mmd -i "$out" "::/$d"
-      done
-
-      for f in $(find EFI -type f | sort); do
-        mcopy -pvm -i "$out" "$f" "::/$f"
-      done
-
-      for f in $(find boot -type f | sort); do
+      for f in $(find EFI boot -type f | sort); do
         mcopy -pvm -i "$out" "$f" "::/$f"
       done
 


### PR DESCRIPTION
mcopy file globbing is non-deterministic with respect to the underlying file
system. As a result, the current mcopy approach is less likely to reproduce
efi.img on different machines. We replace mcopy file globbing with
fixed-order mmd and mcopy operations for better determinism. We also use
faketime on mmd for the same reason.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Make is less difficult to (re)produce efi.img deterministically

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
      - Tested ISO building on a few Ubuntu x86_64 systems including 16.04 and 18.04, in physical machines and in a virtualbox VM
      - Tested ISO booting on a physical machine and with qemu-system-x86_64
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
   - Tested that the ISO after this change boots
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
   - Tested using a methodology described in https://github.com/syncom/custom_nixos_iso/blob/59e4cb7631e72dd8881d1f596397290f839450a8/README.md. The outputs of `nix path-info -S -f iso.nix` are as follows.
   - Before: /nix/store/l9rmc6lspd6m1ip8v2q5vh1k9qiagx06-nixos-21.05pre-git-x86_64-linux.iso	 4243710040
   - After:   /nix/store/zpiscj1x68asg55zc9gbl2x5kz4hrg9a-nixos-21.05pre-git-x86_64-linux.iso	 4243710520
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

For determinism, 
- Tested on 5 Ubuntu x86_64 systems and got the same sha256sum for the built ISO images on all these systems.
- Tested on a NixOS VM (with the image corresponding to https://releases.nixos.org/nixos/20.09/nixos-20.09.4154.33824cdf8e4/nixos-20.09.4154.33824cdf8e4-x86_64-linux.ova.sha256), and got the same sha256sum that @misuzu reported in the comment thread.
- The built ISO images are not identical across a NixOS builder machine and a Ubuntu builder machine, with respect to the first commit in this pull request, due to the non-deterministic `du` output ([reference](https://github.com/NixOS/nixpkgs/blob/e3cd6444584dc2d018a39ad7f94769caf043e621/nixos/modules/installer/cd-dvd/iso-image.nix#L408)) on different file systems.
- A workaround with respect to the above `du` issue is in [the second commit](https://github.com/NixOS/nixpkgs/pull/119657/commits/4db7eb476f30a819eacd1459d78bf8fe5b3bccb3) in this pull request, which resulted in identical ISO images across Ubuntu and NixOS builder machines. The repro steps are described in https://github.com/syncom/custom_nixos_iso/blob/71d94dcc0118c0b536e2c152f94e7647a689827d/README.md.