### PR TITLE
ostree: fix TLS errors

### DIFF
--- a/pkgs/tools/misc/ostree/default.nix
+++ b/pkgs/tools/misc/ostree/default.nix
@@ -12,6 +12,8 @@
 , xz
 , e2fsprogs
 , libsoup
+, glib-networking
+, wrapGAppsHook
 , gpgme
 , which
 , makeWrapper
@@ -78,6 +80,7 @@ in stdenv.mkDerivation rec {
     libxslt
     docbook-xsl-nons
     docbook_xml_dtd_42
+    wrapGAppsHook
   ];
 
   buildInputs = [
@@ -85,6 +88,7 @@ in stdenv.mkDerivation rec {
     systemd
     e2fsprogs
     libsoup
+    glib-networking
     gpgme
     fuse
     libselinux


### PR DESCRIPTION
###### Motivation for this change
Fixes #119634. In short, `ostree` wasn't able to pull from `https://` remotes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
