### PR TITLE
ocenaudio: 3.10.2 -> 3.10.6

### DIFF
--- a/pkgs/applications/audio/ocenaudio/default.nix
+++ b/pkgs/applications/audio/ocenaudio/default.nix
@@ -11,17 +11,17 @@
 
 stdenv.mkDerivation rec {
   pname = "ocenaudio";
-  version = "3.10.2";
+  version = "3.10.6";
 
   src = fetchurl {
     url = "https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian9_64.deb?version=${version}";
-    sha256 = "sha256-mmo6/zc/3R8ptXfY01RKUOLgmDhWTHiYBMlGqpdMTAo=";
+    sha256 = "0fgvm1xw2kgrqj3w6slpfxbb3pw9k8i0dz16q9d5d8gyyvr2mh8g";
   };
-
 
   nativeBuildInputs = [
     autoPatchelfHook
     qt5.qtbase
+    qt5.wrapQtAppsHook
     libjack2
     libpulseaudio
     bzip2
@@ -33,7 +33,6 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
   dontBuild = true;
   dontStrip = true;
-  dontWrapQtApps = true;
 
   installPhase = ''
     mkdir -p $out


### PR DESCRIPTION
###### Motivation for this change

build fails

fixes https://github.com/NixOS/nixpkgs/issues/119667

cc @onny 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
