### PR TITLE
kodi.packages.youtube: init at 6.8.10+matrix.1

### DIFF
--- a/pkgs/applications/video/kodi-packages/youtube/default.nix
+++ b/pkgs/applications/video/kodi-packages/youtube/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, six, requests, inputstreamhelper }:
+
+buildKodiAddon rec {
+  pname = "youtube";
+  namespace = "plugin.video.youtube";
+  version = "6.8.10+matrix.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "18z9zh6yqihnmfwd6cc4kpy2frzbarvhg8qpyc3w851ad053q7v0";
+  };
+
+  propagatedBuildInputs = [
+    six
+    requests
+    inputstreamhelper
+  ];
+
+  passthru.updateScript = addonUpdateScript {
+    attrPath = "kodi.packages.youtube";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/anxdpanic/plugin.video.youtube";
+    description = "YouTube is one of the biggest video-sharing websites of the world";
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -94,6 +94,8 @@ let self = rec {
 
   vfs-libarchive = callPackage ../applications/video/kodi-packages/vfs-libarchive { };
 
+  youtube = callPackage ../applications/video/kodi-packages/youtube { };
+
   # addon packages (dependencies)
 
   certifi = callPackage ../applications/video/kodi-packages/certifi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://discourse.nixos.org/t/kodi-plugin-with-python-dependencies/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
