### PR TITLE
lbry: fix .desktop file

### DIFF
--- a/pkgs/applications/video/lbry/default.nix
+++ b/pkgs/applications/video/lbry/default.nix
@@ -29,7 +29,7 @@ in appimageTools.wrapAppImage rec {
     # Now, install assets such as the desktop file and icons
     install -m 444 -D ${src}/lbry.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/lbry.desktop \
-      --replace 'AppRun' '$out/bin/lbry'
+      --replace 'AppRun' $out/bin/lbry
     cp -r ${src}/usr/share/icons $out/share
   '';
 


### PR DESCRIPTION
###### Motivation for this change
During testing the `lbry` package, I found that due to the use of single quotes in the substitution of the desktop file, the path for `$out` is never expanded, thus breaking the desktop file. I missed this because said desktop file was being overriden by a local one, which I was unaware of.

###### Things done

- N/A Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- N/A Determined the impact on package closure size (by running `nix path-info -S` before and after)
- N/A Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
