### PR TITLE
featherpad: 0.10.0 -> 0.18.0

### DIFF
--- a/pkgs/applications/editors/featherpad/default.nix
+++ b/pkgs/applications/editors/featherpad/default.nix
@@ -1,23 +1,24 @@
-{ lib, mkDerivation, pkg-config, qmake, qttools, qtbase, qtsvg, qtx11extras, fetchFromGitHub }:
+{ lib, mkDerivation, cmake, hunspell, pkg-config, qttools, qtbase, qtsvg, qtx11extras
+, fetchFromGitHub }:
 mkDerivation rec {
   pname = "featherpad";
-  version = "0.10.0";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "tsujan";
     repo = "FeatherPad";
     rev = "V${version}";
-    sha256 = "1wrbs6kni9s3x39cckm9kzpglryxn5vyarilvh9pafbzpc6rc57p";
+    sha256 = "0av96yx9ir1ap5adn2cvr6n5y7qjrspk73and21m65dmpwlfdiqb";
   };
 
-  nativeBuildInputs = [ qmake pkg-config qttools ];
-  buildInputs = [ qtbase qtsvg qtx11extras ];
+  nativeBuildInputs = [ cmake pkg-config qttools ];
+  buildInputs = [ hunspell qtbase qtsvg qtx11extras ];
 
   meta = with lib; {
     description = "Lightweight Qt5 Plain-Text Editor for Linux";
     homepage = "https://github.com/tsujan/FeatherPad";
     platforms = platforms.linux;
     maintainers = [ maintainers.flosse ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
   };
 }

--- a/pkgs/applications/editors/featherpad/default.nix
+++ b/pkgs/applications/editors/featherpad/default.nix
@@ -1,5 +1,6 @@
 { lib, mkDerivation, cmake, hunspell, pkg-config, qttools, qtbase, qtsvg, qtx11extras
 , fetchFromGitHub }:
+
 mkDerivation rec {
   pname = "featherpad";
   version = "0.18.0";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bumping from v0.10.0 released in May 2019, to v0.18.0 released in March 2021.  There are many improvements listed in the [changelog](https://github.com/tsujan/FeatherPad/blob/b1de5e41e01013157d8f0b026cfeb6049dee4c67/ChangeLog).  In terms of the derivation, there's a new dependency on Hunspell, and we switch from qmake to cmake as qmake doesn't find the hunspell library correctly.  (It tries to link against `-lhunspell`, whereas cmake finds the correct `-lhunspell-1.7`.)

Since there's a PR open to bump LXQT, it seems like a good time to bump FeatherPad too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - +2,726,520 bytes.
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
