### PR TITLE
llvmPackages_*.llvm: fix building on older CPUs

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -55,6 +55,12 @@ in stdenv.mkDerivation (rec {
 
   propagatedBuildInputs = [ ncurses zlib ];
 
+  patches = [
+    # Force a test to evaluate the saved benchmark for a CPU for which LLVM has
+    # an execution model. See NixOS/nixpkgs#119673.
+    ../../exegesis-force-bdver2.patch
+  ];
+
   postPatch = optionalString stdenv.isDarwin ''
     substituteInPlace cmake/modules/AddLLVM.cmake \
       --replace 'set(_install_name_dir INSTALL_NAME_DIR "@rpath")' "set(_install_name_dir)" \

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -55,6 +55,12 @@ in stdenv.mkDerivation (rec {
 
   propagatedBuildInputs = [ ncurses zlib ];
 
+  patches = [
+    # Force a test to evaluate the saved benchmark for a CPU for which LLVM has
+    # an execution model. See NixOS/nixpkgs#119673.
+    ../../exegesis-force-bdver2.patch
+  ];
+
   postPatch = optionalString stdenv.isDarwin ''
     substituteInPlace cmake/modules/AddLLVM.cmake \
       --replace 'set(_install_name_dir INSTALL_NAME_DIR "@rpath")' "set(_install_name_dir)" \

--- a/pkgs/development/compilers/llvm/9/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/9/llvm/default.nix
@@ -55,6 +55,12 @@ in stdenv.mkDerivation (rec {
 
   propagatedBuildInputs = [ ncurses zlib ];
 
+  patches = [
+    # Force a test to evaluate the saved benchmark for a CPU for which LLVM has
+    # an execution model. See NixOS/nixpkgs#119673.
+    ../../exegesis-force-bdver2.patch
+  ];
+
   postPatch = optionalString stdenv.isDarwin ''
     substituteInPlace cmake/modules/AddLLVM.cmake \
       --replace 'set(_install_name_dir INSTALL_NAME_DIR "@rpath")' "set(_install_name_dir)" \

--- a/pkgs/development/compilers/llvm/exegesis-force-bdver2.patch
+++ b/pkgs/development/compilers/llvm/exegesis-force-bdver2.patch
@@ -1,0 +1,11 @@
+diff --git a/test/tools/llvm-exegesis/X86/uops-CMOV16rm-noreg.s b/test/tools/llvm-exegesis/X86/uops-CMOV16rm-noreg.s
+index 3fc1f31d54dc..a4c9bdd92131 100644
+--- a/test/tools/llvm-exegesis/X86/uops-CMOV16rm-noreg.s
++++ b/test/tools/llvm-exegesis/X86/uops-CMOV16rm-noreg.s
+@@ -1,5 +1,6 @@
+ # RUN: llvm-exegesis -mode=uops -opcode-name=CMOV16rm  -benchmarks-file=%t.CMOV16rm-uops.yaml
+ # RUN: FileCheck -check-prefixes=CHECK-YAML -input-file=%t.CMOV16rm-uops.yaml %s
++# RUN: sed -i 's,cpu_name:.*,cpu_name: bdver2,g' %t.CMOV16rm-uops.yaml
+ # RUN: llvm-exegesis -mcpu=bdver2 -mode=analysis -benchmarks-file=%t.CMOV16rm-uops.yaml -analysis-clusters-output-file=- -analysis-clustering-epsilon=0.1 -analysis-inconsistency-epsilon=0.1 -analysis-numpoints=1 -analysis-clustering=naive | FileCheck -check-prefixes=CHECK-CLUSTERS %s
+ 
+ # https://bugs.llvm.org/show_bug.cgi?id=41448


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This commit patches one of the llvm-exegesis tests to swap out whatever
CPU model happens to be on the build host for bdver2 (AMD Family
15h/Piledriver), which was picked because it looks like that was the
intent of the test author. This provides a more predictable compilation
behaviour when running on older (or possibly even newer!) machines.

One of the machines that is currently part of the NixOS Hydra build
farm, wendy, is using an old AMD Opteron CPU for which LLVM has no
scheduling machine model. This causes one of the tests for llvm-exegesis
to fail, because it segfaults trying to use the machine model to produce
useful analysis results.

Note that this particular test only runs on x86-64 build hosts anyway;
aarch64 isn't affected.

This will contribute towards fixing #119673 for LLVM 9, 10, and 11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
