### PR TITLE
hyperkitty: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/development/python-modules/flufl/lock.nix
+++ b/pkgs/development/python-modules/flufl/lock.nix
@@ -1,13 +1,16 @@
-{ buildPythonPackage, fetchPypi, atpublic }:
+{ buildPythonPackage, fetchPypi, pytestCheckHook
+, atpublic, psutil, pytestcov, sybil
+}:
 
 buildPythonPackage rec {
   pname = "flufl.lock";
-  version = "3.2";
-
-  propagatedBuildInputs = [ atpublic ];
+  version = "5.0.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0nzzd6l30ff6cwsrlrb94xzfja4wkyrqv3ydc6cz0hdbr766mmm8";
+    sha256 = "1bnapkg99r6mixn3kh314bqcfk8q54y0cvhjpj87j7dhjpsakfpz";
   };
+
+  propagatedBuildInputs = [ atpublic psutil ];
+  checkInputs = [ pytestCheckHook pytestcov sybil ];
 }

--- a/pkgs/development/python-modules/flufl/lock.nix
+++ b/pkgs/development/python-modules/flufl/lock.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchPypi, pytestCheckHook
+{ lib, buildPythonPackage, fetchPypi, pytestCheckHook
 , atpublic, psutil, pytestcov, sybil
 }:
 
@@ -13,4 +13,12 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ atpublic psutil ];
   checkInputs = [ pytestCheckHook pytestcov sybil ];
+
+  meta = with lib; {
+    homepage = "https://flufllock.readthedocs.io/";
+    description = "NFS-safe file locking with timeouts for POSIX and Windows";
+    maintainers = with maintainers; [ qyliss ];
+    license = licenses.asl20;
+    platforms = platforms.all;
+  };
 }

--- a/pkgs/servers/mail/mailman/hyperkitty.nix
+++ b/pkgs/servers/mail/mailman/hyperkitty.nix
@@ -9,12 +9,12 @@ buildPythonPackage rec {
   pname = "HyperKitty";
   # Note: Mailman core must be on the latest version before upgrading HyperKitty.
   # See: https://gitlab.com/mailman/postorius/-/issues/516#note_544571309
-  version = "1.3.3";
+  version = "1.3.4";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0p85r9q6mn5as5b39xp9hkkipnk0156acx540n2ygk3qb3jd4a5n";
+    sha256 = "1lbh8n66fp3l5s0xvmvsbfvgs3z4knx0gwf0q117n2nfkslf13zp";
   };
 
   nativeBuildInputs = [ isort ];


### PR DESCRIPTION
Tested on my deployment.  Seems to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
