### PR TITLE
ocamlformat: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -52,5 +52,9 @@ rec {
     version = "0.17.0";
   };
 
-  ocamlformat = ocamlformat_0_17_0;
+  ocamlformat_0_18_0 = mkOCamlformat {
+    version = "0.18.0";
+  };
+
+  ocamlformat = ocamlformat_0_18_0;
 }

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -21,11 +21,10 @@ let src =
       "0.15.1" = "1x6fha495sgk4z05g0p0q3zfqm5l6xzmf6vjm9g9g7c820ym2q9a";
       "0.16.0" = "1vwjvvwha0ljc014v8jp8snki5zsqxlwd7x0dl0rg2i9kcmwc4mr";
       "0.17.0" = "0f1lxp697yq61z8gqxjjaqd2ns8fd1vjfggn55x0gh9dx098p138";
+      "0.18.0" = "0571kzmb1h03qj74090n3mg8wfbh29qqrkdjkai6rnl5chll86lq";
     }."${version}";
-  }
-; in
-
-let ocamlPackages =
+  };
+  ocamlPackages =
   if lib.versionAtLeast version "0.14.3"
   then ocaml-ng.ocamlPackages
   else ocaml-ng.ocamlPackages_4_07
@@ -33,7 +32,7 @@ let ocamlPackages =
 
 with ocamlPackages;
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "ocamlformat";
   inherit src version;
 
@@ -45,7 +44,24 @@ buildDunePackage rec {
   useDune2 = true;
 
   buildInputs =
-    if lib.versionAtLeast version "0.17.0"
+    if lib.versionAtLeast version "0.18.0"
+    then [
+      base
+      cmdliner
+      fpath
+      odoc
+      re
+      stdio
+      uuseg
+      uutf
+      fix
+      menhir
+      dune-build-info
+      ocaml-version
+      # Changed since 0.16.0:
+      (ppxlib.override { version = "0.22.0"; })
+    ]
+    else if lib.versionAtLeast version "0.17.0"
     then [
       base
       cmdliner


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/ocaml-ppx/ocamlformat/releases/tag/0.18.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
