### PR TITLE
gnome3.{gnome-shell,metacity,gnome-flashback}: fix build

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -57,6 +57,7 @@
 , gnome-autoar
 , asciidoc-full
 , bash-completion
+, mesa
 }:
 
 # http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/gnome-base/gnome-shell/gnome-shell-3.10.2.1.ebuild?revision=1.3&view=markup
@@ -147,6 +148,7 @@ stdenv.mkDerivation rec {
     gnome-desktop
     gnome-settings-daemon
     gobject-introspection
+    mesa
 
     # recording
     pipewire

--- a/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
@@ -25,6 +25,7 @@
 , writeTextFile
 , writeShellScriptBin
 , xkeyboard_config
+, xorg
 , runCommand
 }:
 let
@@ -101,6 +102,7 @@ let
       libcanberra-gtk3
       libpulseaudio
       libxkbfile
+      xorg.libXxf86vm
       polkit
       gdm
       gnome-panel

--- a/pkgs/desktops/gnome-3/misc/metacity/default.nix
+++ b/pkgs/desktops/gnome-3/misc/metacity/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     xorg.libXres
     xorg.libXpresent
+    xorg.libXdamage
     glib
     gsettings-desktop-schemas
     gtk3


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Resolve these errors,
- the gnome-shell missing EGL header (`mesa` dependency fixed this)
- metacity missing `xorg.libXdestroy`
- gnome-flashback missing `xorg.libXxf86vm`

For #117081 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
