### PR TITLE
tdrop: unstable-2020-05-14 -> 0.4.0

### DIFF
--- a/pkgs/applications/misc/tdrop/default.nix
+++ b/pkgs/applications/misc/tdrop/default.nix
@@ -2,15 +2,15 @@
 , xwininfo, xdotool, xprop, gawk, coreutils
 , gnugrep, procps }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "tdrop";
-  version = "unstable-2020-05-14";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "noctuid";
     repo = "tdrop";
-    rev = "a9f2862515e5c190ac61d394e7fe7e1039871b89";
-    sha256 = "1zxhihgba33k8byjsracsyhby9qpdngbly6c8hpz3pbsyag5liwc";
+    rev = version;
+    sha256 = "sha256-1umHwzpv4J8rZ0c0q+2dPsEk4vhFB4UerwI8ctIJUZg=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
