### PR TITLE
plover.dev-with-plugins: init

### DIFF
--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -1,5 +1,8 @@
-{ lib, fetchurl, python27Packages, python36Packages, wmctrl,
-  qtbase, mkDerivationWith }:
+{ lib
+, fetchFromGitHub
+, python3Packages, python27Packages
+, wmctrl, qtbase, mkDerivationWith
+}:
 
 {
   stable = with python27Packages; buildPythonPackage rec {
@@ -12,9 +15,11 @@
       license     = licenses.gpl2;
     };
 
-    src = fetchurl {
-      url    = "https://github.com/openstenoproject/plover/archive/v${version}.tar.gz";
-      sha256 = "1hdg5491phx6svrxxsxp8v6n4b25y7y4wxw7x3bxlbyhaskgj53r";
+    src = fetchFromGitHub {
+      owner = "openstenoproject";
+      repo = "plover";
+      rev = "v${version}";
+      sha256 = "114rlxvq471fyifwcdcgdad79ak7q3w2lk8z9nqhz1i9fg05721c";
     };
 
     nativeBuildInputs     = [ setuptools_scm ];
@@ -24,19 +29,21 @@
     ];
   };
 
-  dev = with python36Packages; mkDerivationWith buildPythonPackage rec {
+  dev = with python3Packages; mkDerivationWith buildPythonPackage rec {
     pname = "plover";
-    version = "4.0.0.dev8";
+    version = "4.0.0.dev9";
 
     meta = with lib; {
       description = "OpenSteno Plover stenography software";
       maintainers = with maintainers; [ twey kovirobi ];
-      license     = licenses.gpl2;
+      license     = licenses.gpl2Plus;
     };
 
-    src = fetchurl {
-      url    = "https://github.com/openstenoproject/plover/archive/v${version}.tar.gz";
-      sha256 = "1wxkmik1zyw5gqig5r0cas5v6f5408fbnximzw610rdisqy09rxp";
+    src = fetchFromGitHub {
+      owner = "openstenoproject";
+      repo = "plover";
+      rev = "54dbcf4ea73cc1ecc1d7c70dbe7bdb13f055d101";
+      sha256 = "1jm6rajlh8nm1b1331pyvp20vxxfwi4nb8wgqlkznf0kkdvfa78a";
     };
 
     # I'm not sure why we don't find PyQt5 here but there's a similar
@@ -44,7 +51,11 @@
     postPatch = "sed -i /PyQt5/d setup.cfg";
 
     checkInputs           = [ pytest mock ];
-    propagatedBuildInputs = [ Babel pyqt5 xlib pyserial appdirs wcwidth setuptools ];
+    propagatedBuildInputs = [
+      Babel pyqt5 xlib pyserial
+      appdirs wcwidth setuptools
+      certifi
+    ];
 
     dontWrapQtApps = true;
 

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -4,7 +4,7 @@
 , wmctrl, qtbase, mkDerivationWith
 }:
 
-{
+rec {
   stable = with python27Packages; buildPythonPackage rec {
     pname = "plover";
     version = "3.1.1";
@@ -62,5 +62,37 @@
     preFixup = ''
       makeWrapperArgs+=("''${qtWrapperArgs[@]}")
     '';
+  };
+
+  plugins-manager = with python3Packages; buildPythonPackage rec {
+    pname = "plover-plugins-manager";
+    version = "0.6.1";
+
+    src = fetchFromGitHub {
+      owner = "benoit-pierre";
+      repo = "plover_plugins_manager";
+      rev = version;
+      sha256 = "sha256-7OyGmSwOvoqwbBgXdfUUmwvjszUNRPlD4XyBeJ29vBg=";
+    };
+
+    propagatedBuildInputs = [
+      # plover.dev
+      dev
+
+      pip pkginfo pygments
+      readme_renderer requests
+      requests-cache requests-futures
+      setuptools wheel
+    ];
+
+    # tests try to instantiate a virtualenv and lack permission
+    doCheck = false;
+
+    meta = with lib; {
+      description = "OpenSteno Plover stenography software plugin manager";
+      homepage = "https://github.com/benoit-pierre/plover_plugins_manager";
+      license = licenses.gpl2Plus;
+      maintainers = with maintainers; [ evils ];
+    };
   };
 }

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -46,10 +46,6 @@ rec {
       sha256 = "1jm6rajlh8nm1b1331pyvp20vxxfwi4nb8wgqlkznf0kkdvfa78a";
     };
 
-    # I'm not sure why we don't find PyQt5 here but there's a similar
-    # sed on many of the platforms Plover builds for
-    postPatch = "sed -i /PyQt5/d setup.cfg";
-
     checkInputs           = [ pytest mock ];
     propagatedBuildInputs = [
       Babel pyqt5 xlib pyserial

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -71,6 +71,8 @@ rec {
       sha256 = "sha256-7OyGmSwOvoqwbBgXdfUUmwvjszUNRPlD4XyBeJ29vBg=";
     };
 
+    patches = [ ./plugins_manager.patch ];
+
     buildInputs = [
       # plover.dev
       dev

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -46,11 +46,6 @@ rec {
       sha256 = "1jm6rajlh8nm1b1331pyvp20vxxfwi4nb8wgqlkznf0kkdvfa78a";
     };
 
-    # upstream recommendation
-    postPatch = ''
-      sed -i 's/^\(\s*plover = plover.\)main:main$/\1dist_main:main/' setup.cfg
-    '';
-
     checkInputs           = [ pytest mock ];
     propagatedBuildInputs = [
       Babel pyqt5 xlib pyserial

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -75,10 +75,12 @@ rec {
       sha256 = "sha256-7OyGmSwOvoqwbBgXdfUUmwvjszUNRPlD4XyBeJ29vBg=";
     };
 
-    propagatedBuildInputs = [
+    buildInputs = [
       # plover.dev
       dev
+    ];
 
+    propagatedBuildInputs = [
       pip pkginfo pygments
       readme_renderer requests
       requests-cache requests-futures
@@ -95,4 +97,12 @@ rec {
       maintainers = with maintainers; [ evils ];
     };
   };
+
+  dev-with-plugins = dev.overrideAttrs (old: {
+    pname = "plover-with-plugins";
+    propagatedBuildInputs = old.propagatedBuildInputs ++ [ plugins-manager ];
+
+    # the plugin manager installs plugins as local python packages
+    permitUserSite = true;
+  });
 }

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -46,6 +46,11 @@ rec {
       sha256 = "1jm6rajlh8nm1b1331pyvp20vxxfwi4nb8wgqlkznf0kkdvfa78a";
     };
 
+    # upstream recommendation
+    postPatch = ''
+      sed -i 's/^\(\s*plover = plover.\)main:main$/\1dist_main:main/' setup.cfg
+    '';
+
     checkInputs           = [ pytest mock ];
     propagatedBuildInputs = [
       Babel pyqt5 xlib pyserial

--- a/pkgs/applications/misc/plover/plugins_manager.patch
+++ b/pkgs/applications/misc/plover/plugins_manager.patch
@@ -1,0 +1,22 @@
+diff --git a/plover_plugins_manager/__main__.py b/plover_plugins_manager/__main__.py
+index 9e03097..6204472 100644
+--- a/plover_plugins_manager/__main__.py
++++ b/plover_plugins_manager/__main__.py
+@@ -42,16 +42,7 @@ def pip(args, stdin=None, stdout=None, stderr=None, **kwargs):
+            'plover_plugins_manager.pip_wrapper',
+            '--disable-pip-version-check']
+     env = dict(os.environ)
+-    # Make sure user plugins are handled
+-    # even if user site is not enabled.
+-    if not running_under_virtualenv() and not site.ENABLE_USER_SITE:
+-        pypath = env.get('PYTHONPATH')
+-        if pypath is None:
+-            pypath = []
+-        else:
+-            pypath = pypath.split(os.pathsep)
+-        pypath.insert(0, site.USER_SITE)
+-        env['PYTHONPATH'] = os.pathsep.join(pypath)
++    env['PYTHONPATH'] = os.pathsep.join(sys.path + [site.USER_SITE])
+     command = args.pop(0)
+     if command == 'check':
+         cmd.append('check')

--- a/pkgs/development/python-modules/requests-futures/default.nix
+++ b/pkgs/development/python-modules/requests-futures/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "requests-futures";
+  version = "0.9.9-27-gf126048";
+  disabled = pythonOlder "3.3";
+
+  src = fetchFromGitHub {
+    owner = "ross";
+    repo = "requests-futures";
+    rev = "f12604869b80c730192a84403f8a9b513c3f2520";
+    sha256 = "0a2n4gxpv7wlp7wxjppnigbwvc36zjam97xdzk1g8xg43jb6pjhd";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # tests try to access network
+  doCheck = false;
+
+  pythonImportsCheck = [ "requests_futures" ];
+
+  meta = with lib; {
+    description = "Asynchronous Python HTTP Requests for Humans using Futures";
+    homepage = "https://github.com/ross/requests-futures";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7354,6 +7354,8 @@ in {
 
   requests-cache = callPackage ../development/python-modules/requests-cache { };
 
+  requests-futures = callPackage ../development/python-modules/requests-futures { };
+
   requests-hawk = callPackage ../development/python-modules/requests-hawk { };
 
   requests = callPackage ../development/python-modules/requests { };


### PR DESCRIPTION
based on / closes #110658
closes #89341

###### Motivation for this change
help some community members

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


### remaining issues (help wanted)

plugins don't work in a nix-shell
upstream recommendations (don't use the patch, use dist_main entry point) break things
