### PR TITLE
Revert "grub2: Properly disable zfs by default"

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -6,7 +6,7 @@
 , runtimeShell
 , zfs ? null
 , efiSupport ? false
-, zfsSupport ? false
+, zfsSupport ? true
 , xenSupport ? false
 , kbdcompSupport ? false, ckbcomp
 }:


### PR DESCRIPTION
Reverts NixOS/nixpkgs#99386

Probably not really worth it and [it breaks peoples config without updating it](https://github.com/NixOS/nixpkgs/pull/99386#issuecomment-798813567). https://github.com/NixOS/nixpkgs/pull/117071 tries to fix that but seems like it won't be merged soon.