### PR TITLE
awstats: 7.7.0 -> 7.8.0

### DIFF
--- a/pkgs/tools/system/awstats/default.nix
+++ b/pkgs/tools/system/awstats/default.nix
@@ -2,11 +2,11 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "awstats";
-  version = "7.7";
+  version = "7.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/awstats/${pname}-${version}.tar.gz";
-    sha256 = "0z3p77jnpjilajs9yv87r8xla2x1gjqlvrhpbgbh5ih73386v3j2";
+    sha256 = "1f6l0hd01jmz7hpg0py8qixxiq50n8gl37iypayskxmy05z8craa";
   };
 
   postPatch = ''
@@ -54,7 +54,7 @@ perlPackages.buildPerlPackage rec {
 
   meta = with lib; {
     description = "Real-time logfile analyzer to get advanced statistics";
-    homepage = "http://awstats.org";
+    homepage = "https://awstats.org";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2020-29600.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>awstats</li>
  </ul>
</details>
