### PR TITLE
[20.09] jhead: 3.04 -> 3.06.0.1

### DIFF
--- a/pkgs/tools/graphics/jhead/default.nix
+++ b/pkgs/tools/graphics/jhead/default.nix
@@ -1,30 +1,19 @@
-{ stdenv, fetchurl, fetchpatch, libjpeg }:
+{ stdenv, fetchFromGitHub, libjpeg }:
 
 stdenv.mkDerivation rec {
   pname = "jhead";
-  version = "3.04";
+  version = "3.06.0.1";
 
-  src = fetchurl {
-    url = "http://www.sentex.net/~mwandel/jhead/${pname}-${version}.tar.gz";
-    sha256 = "1j831bqw1qpkbchdriwcy3sgzvbagaj45wlc124fs9bc9z7vp2gg";
+  src = fetchFromGitHub {
+    owner = "Matthias-Wandel";
+    repo = "jhead";
+    rev = version;
+    sha256 = "0zgh36486cpcnf7xg6dwf7rhz2h4gpayqvdk8hmrx6y418b2pfyf";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/j/jhead/1:3.04-2/debian/patches/01_gpsinfo.c";
-      sha256 = "0r8hdbfrdxip4dwz5wqsv47a29j33cx7w5zx4jdhp5l1ihg003lz";
-    })
-  ];
 
   buildInputs = [ libjpeg ];
 
   makeFlags = [ "CPPFLAGS=" "CFLAGS=-O3" "LDFLAGS=" ];
-
-  patchPhase = ''
-    sed -i '/dpkg-buildflags/d' makefile
-    substituteInPlace jhead.c \
-      --replace "jpegtran -trim" "${libjpeg.bin}/bin/jpegtran -trim"
-  '';
 
   installPhase = ''
     mkdir -p \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2020-6624 and CVE-2020-6625.

(cherry picked from commit 7050620e332eaf117dca4fd8130ae16a8f942b60)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
