### PR TITLE
Make cross stdenv with llvmPackages_7 and useLLVM work again

### DIFF
--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -43,6 +43,9 @@ let
       ./purity.patch
       # make clang -xhip use $PATH to find executables
       ./HIP-use-PATH-7.patch
+      # Backport for the `--unwindlib=[libgcc|compiler-rt]` flag, which is
+      # needed for our bootstrapping to not interfere with C.
+      ./unwindlib.patch
     ];
 
     postPatch = ''

--- a/pkgs/development/compilers/llvm/7/clang/unwindlib.patch
+++ b/pkgs/development/compilers/llvm/7/clang/unwindlib.patch
@@ -1,0 +1,227 @@
+commit a5cacb5ba7f1f18e7bb6f6709e42683eeb7e6470
+Author: Sterling Augustine <saugustine@google.com>
+Date:   Tue Mar 19 20:01:59 2019 +0000
+
+    Add --unwindlib=[libgcc|compiler-rt] to parallel --rtlib= [take 2]
+    
+    "clang++ hello.cc --rtlib=compiler-rt"
+    
+    now can works without specifying additional unwind or exception
+    handling libraries.
+    
+    This reworked version of the feature no longer modifies today's default
+    unwind library for compiler-rt: which is nothing. Rather, a user
+    can specify -DCLANG_DEFAULT_UNWINDLIB=libunwind when configuring
+    the compiler.
+    
+    This should address the issues from the previous version.
+    
+    Update tests for new --unwindlib semantics.
+    
+    Differential Revision: https://reviews.llvm.org/D59109
+    
+    llvm-svn: 356508
+
+diff --git clang/CMakeLists.txt clang/CMakeLists.txt
+index 52b881939499..2c3fb62f6e73 100644
+--- clang/CMakeLists.txt
++++ clang/CMakeLists.txt
+@@ -244,6 +244,24 @@ if (NOT(CLANG_DEFAULT_RTLIB STREQUAL "" OR
+     "Default runtime library to use (\"libgcc\" or \"compiler-rt\", empty for platform default)" FORCE)
+ endif()
+ 
++set(CLANG_DEFAULT_UNWINDLIB "" CACHE STRING
++  "Default unwind library to use (\"none\" \"libgcc\" or \"libunwind\", empty to match runtime library.)")
++if (CLANG_DEFAULT_UNWINDLIB STREQUAL "")
++  if (CLANG_DEFAULT_RTLIB STREQUAL "libgcc")
++    set (CLANG_DEFAULT_UNWINDLIB "libgcc" CACHE STRING "" FORCE)
++  elseif (CLANG_DEFAULT_RTLIBS STREQUAL "libunwind")
++    set (CLANG_DEFAULT_UNWINDLIB "none" CACHE STRING "" FORCE)
++  endif()
++endif()
++
++if (NOT(CLANG_DEFAULT_UNWINDLIB STREQUAL "none" OR
++        CLANG_DEFAULT_UNWINDLIB STREQUAL "libgcc" OR
++        CLANG_DEFAULT_UNWINDLIB STREQUAL "libunwind"))
++  message(WARNING "Resetting default unwindlib to use platform default")
++  set(CLANG_DEFAULT_UNWINDLIB "" CACHE STRING
++    "Default unwind library to use (\"none\" \"libgcc\" or \"libunwind\", empty for none)" FORCE)
++endif()
++
+ set(CLANG_DEFAULT_OBJCOPY "objcopy" CACHE STRING
+   "Default objcopy executable to use.")
+ 
+diff --git clang/include/clang/Basic/DiagnosticDriverKinds.td clang/include/clang/Basic/DiagnosticDriverKinds.td
+index 7f75f45c6578..7e1bb33b5cef 100644
+--- clang/include/clang/Basic/DiagnosticDriverKinds.td
++++ clang/include/clang/Basic/DiagnosticDriverKinds.td
+@@ -52,6 +52,10 @@ def err_drv_invalid_rtlib_name : Error<
+   "invalid runtime library name in argument '%0'">;
+ def err_drv_unsupported_rtlib_for_platform : Error<
+   "unsupported runtime library '%0' for platform '%1'">;
++def err_drv_invalid_unwindlib_name : Error<
++  "invalid unwind library name in argument '%0'">;
++def err_drv_incompatible_unwindlib : Error<
++  "--rtlib=libgcc requires --unwindlib=libgcc">;
+ def err_drv_invalid_stdlib_name : Error<
+   "invalid library name in argument '%0'">;
+ def err_drv_invalid_output_with_multiple_archs : Error<
+diff --git clang/include/clang/Config/config.h.cmake clang/include/clang/Config/config.h.cmake
+index 1d624450b9d9..2d4cb747e87e 100644
+--- clang/include/clang/Config/config.h.cmake
++++ clang/include/clang/Config/config.h.cmake
+@@ -23,6 +23,9 @@
+ /* Default runtime library to use. */
+ #define CLANG_DEFAULT_RTLIB "${CLANG_DEFAULT_RTLIB}"
+ 
++/* Default unwind library to use. */
++#define CLANG_DEFAULT_UNWINDLIB "${CLANG_DEFAULT_UNWINDLIB}"
++
+ /* Default objcopy to use */
+ #define CLANG_DEFAULT_OBJCOPY "${CLANG_DEFAULT_OBJCOPY}"
+ 
+diff --git clang/include/clang/Driver/Options.td clang/include/clang/Driver/Options.td
+index 601aa8744967..0e74a2d36dea 100644
+--- clang/include/clang/Driver/Options.td
++++ clang/include/clang/Driver/Options.td
+@@ -2428,6 +2428,8 @@ def std_EQ : Joined<["-", "--"], "std=">, Flags<[CC1Option]>,
+   }]>;
+ def stdlib_EQ : Joined<["-", "--"], "stdlib=">, Flags<[CC1Option]>,
+   HelpText<"C++ standard library to use">, Values<"libc++,libstdc++,platform">;
++def unwindlib_EQ : Joined<["-", "--"], "unwindlib=">, Flags<[CC1Option]>,
++  HelpText<"Unwind library to use">, Values<"libgcc,unwindlib,platform">;
+ def sub__library : JoinedOrSeparate<["-"], "sub_library">;
+ def sub__umbrella : JoinedOrSeparate<["-"], "sub_umbrella">;
+ def system_header_prefix : Joined<["--"], "system-header-prefix=">,
+diff --git clang/include/clang/Driver/ToolChain.h clang/include/clang/Driver/ToolChain.h
+index 2f9c2c190e32..d5b131bcf112 100644
+--- clang/include/clang/Driver/ToolChain.h
++++ clang/include/clang/Driver/ToolChain.h
+@@ -99,6 +99,12 @@ public:
+     RLT_Libgcc
+   };
+ 
++  enum UnwindLibType {
++    UNW_None,
++    UNW_CompilerRT,
++    UNW_Libgcc
++  };
++
+   enum RTTIMode {
+     RM_Enabled,
+     RM_Disabled,
+@@ -352,6 +358,10 @@ public:
+     return ToolChain::CST_Libstdcxx;
+   }
+ 
++  virtual UnwindLibType GetDefaultUnwindLibType() const {
++    return ToolChain::UNW_None;
++  }
++
+   virtual std::string getCompilerRTPath() const;
+ 
+   virtual std::string getCompilerRT(const llvm::opt::ArgList &Args,
+@@ -484,6 +494,10 @@ public:
+   // given compilation arguments.
+   virtual CXXStdlibType GetCXXStdlibType(const llvm::opt::ArgList &Args) const;
+ 
++  // GetUnwindLibType - Determine the unwind library type to use with the
++  // given compilation arguments.
++  virtual UnwindLibType GetUnwindLibType(const llvm::opt::ArgList &Args) const;
++
+   /// AddClangCXXStdlibIncludeArgs - Add the clang -cc1 level arguments to set
+   /// the include paths to use for the given C++ standard library type.
+   virtual void
+diff --git clang/lib/Driver/ToolChain.cpp clang/lib/Driver/ToolChain.cpp
+index cf3db34688df..d980dd5d23fb 100644
+--- clang/lib/Driver/ToolChain.cpp
++++ clang/lib/Driver/ToolChain.cpp
+@@ -665,6 +665,33 @@ ToolChain::RuntimeLibType ToolChain::GetRuntimeLibType(
+   return GetDefaultRuntimeLibType();
+ }
+ 
++ToolChain::UnwindLibType ToolChain::GetUnwindLibType(
++    const ArgList &Args) const {
++  const Arg *A = Args.getLastArg(options::OPT_unwindlib_EQ);
++  StringRef LibName = A ? A->getValue() : CLANG_DEFAULT_UNWINDLIB;
++
++  if (LibName == "none")
++    return ToolChain::UNW_None;
++  else if (LibName == "platform" || LibName == "") {
++    ToolChain::RuntimeLibType RtLibType = GetRuntimeLibType(Args);
++    if (RtLibType == ToolChain::RLT_CompilerRT)
++      return ToolChain::UNW_None;
++    else if (RtLibType == ToolChain::RLT_Libgcc)
++      return ToolChain::UNW_Libgcc;
++  } else if (LibName == "libunwind") {
++    if (GetRuntimeLibType(Args) == RLT_Libgcc)
++      getDriver().Diag(diag::err_drv_incompatible_unwindlib);
++    return ToolChain::UNW_CompilerRT;
++  } else if (LibName == "libgcc")
++    return ToolChain::UNW_Libgcc;
++
++  if (A)
++    getDriver().Diag(diag::err_drv_invalid_unwindlib_name)
++        << A->getAsString(Args);
++
++  return GetDefaultUnwindLibType();
++}
++
+ ToolChain::CXXStdlibType ToolChain::GetCXXStdlibType(const ArgList &Args) const{
+   const Arg *A = Args.getLastArg(options::OPT_stdlib_EQ);
+   StringRef LibName = A ? A->getValue() : CLANG_DEFAULT_CXX_STDLIB;
+diff --git clang/test/Driver/compiler-rt-unwind.c clang/test/Driver/compiler-rt-unwind.c
+new file mode 100644
+index 000000000000..00024dfa7ed3
+--- /dev/null
++++ clang/test/Driver/compiler-rt-unwind.c
+@@ -0,0 +1,49 @@
++// General tests that the driver handles combinations of --rtlib=XXX and
++// --unwindlib=XXX properly.
++//
++// RUN: %clang -no-canonical-prefixes %s -### -o %t.o 2>&1 \
++// RUN:     --target=x86_64-unknown-linux \
++// RUN:     --gcc-toolchain="" \
++// RUN:   | FileCheck --check-prefix=RTLIB-EMPTY %s
++// RTLIB-EMPTY: "{{.*}}lgcc"
++// RTLIB-EMPTY: "{{.*}}-lgcc_s"
++//
++// RUN: %clang -no-canonical-prefixes %s -### -o %t.o 2>&1 \
++// RUN:     --target=x86_64-unknown-linux -rtlib=libgcc \
++// RUN:     --gcc-toolchain="" \
++// RUN:   | FileCheck --check-prefix=RTLIB-GCC %s
++// RTLIB-GCC: "{{.*}}lgcc"
++// RTLIB-GCC: "{{.*}}lgcc_s"
++//
++// RUN: %clang -no-canonical-prefixes %s -### -o %t.o 2>&1 \
++// RUN:     --target=x86_64-unknown-linux -rtlib=libgcc --unwindlib=libunwind \
++// RUN:     --gcc-toolchain="" \
++// RUN:   | FileCheck --check-prefix=RTLIB-GCC-UNWINDLIB-COMPILER-RT %s
++// RTLIB-GCC-UNWINDLIB-COMPILER-RT: "{{.*}}lgcc"
++// RTLIB-GCC-UNWINDLIB-COMPILER-RT: "{{.*}}lunwind"
++//
++// RUN: %clang -no-canonical-prefixes %s -### -o %t.o 2>&1   \
++// RUN:     --target=x86_64-unknown-linux -rtlib=compiler-rt \
++// RUN:     --gcc-toolchain="" \
++// RUN:   | FileCheck --check-prefix=RTLIB-COMPILER-RT %s
++// RTLIB-COMPILER-RT: "{{.*}}libclang_rt.builtins-x86_64.a"
++//
++// RUN: %clang -no-canonical-prefixes %s -### -o %t.o 2>&1   \
++// RUN:     --target=x86_64-unknown-linux -rtlib=compiler-rt --unwindlib=libgcc \
++// RUN:     --gcc-toolchain="" \
++// RUN:   | FileCheck --check-prefix=RTLIB-COMPILER-RT-UNWINDLIB-GCC %s
++// RTLIB-COMPILER-RT-UNWINDLIB-GCC: "{{.*}}libclang_rt.builtins-x86_64.a"
++// RTLIB-COMPILER-RT-UNWINDLIB-GCC: "{{.*}}lgcc_s"
++//
++// RUN: %clang -no-canonical-prefixes %s -### -o %t.o 2>&1              \
++// RUN:     --target=x86_64-unknown-linux -rtlib=compiler-rt --unwindlib=libgcc \
++// RUN:     -static --gcc-toolchain="" \
++// RUN:   | FileCheck --check-prefix=RTLIB-COMPILER-RT-UNWINDLIB-GCC-STATIC %s
++// RTLIB-COMPILER-RT-UNWINDLIB-GCC-STATIC: "{{.*}}libclang_rt.builtins-x86_64.a"
++// RTLIB-COMPILER-RT-UNWINDLIB-GCC-STATIC: "{{.*}}lgcc_eh"
++//
++// RUN: not %clang -no-canonical-prefixes %s -o %t.o 2> %t.err              \
++// RUN:     --target=x86_64-unknown-linux -rtlib=libgcc --unwindlib=libunwind \
++// RUN:     --gcc-toolchain="" \
++// RUN: FileCheck --input-file=%t.err --check-prefix=RTLIB-GCC-UNWINDLIB-COMPILER_RT %s
++// RTLIB-GCC-UNWINDLIB-COMPILER_RT: "{{[.|\\\n]*}}--rtlib=libgcc requires --unwindlib=libgcc"

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -181,6 +181,12 @@ let
         libunwind = libraries.libunwind;
       }));
 
+    libunwind = callPackage ./libunwind ({
+      inherit (buildLlvmTools) llvm;
+    } // lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
+      stdenv = overrideCC stdenv buildLlvmTools.lldClangNoLibcxx;
+    });
+
     openmp = callPackage ./openmp.nix {};
   });
 

--- a/pkgs/development/compilers/llvm/7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++/default.nix
@@ -37,7 +37,8 @@ stdenv.mkDerivation {
     "-DLIBCXX_LIBCPPABI_VERSION=2"
     "-DLIBCXX_CXX_ABI=libcxxabi"
   ] ++ lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1"
-  ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF" ;
+    ++ lib.optional (stdenv.hostPlatform.useLLVM or false) "-DLIBCXX_USE_COMPILER_RT=ON"
+    ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF" ;
 
   passthru = {
     isLLVM = true;

--- a/pkgs/development/compilers/llvm/7/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++abi/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, cmake, fetch, libcxx, llvm, version
-, standalone ? false
+{ lib, stdenv, cmake, fetch, libcxx, libunwind, llvm, version
+, standalone ? stdenv.hostPlatform.useLLVM or false
   # on musl the shared objects don't build
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
@@ -11,6 +11,7 @@ stdenv.mkDerivation {
   src = fetch "libcxxabi" "1zcqxsdjhawgz1cvpk07y3jl6fg9p3ay4nl69zsirqb2ghgyhhb2";
 
   nativeBuildInputs = [ cmake ];
+  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;
 
   postUnpack = ''
     unpackFile ${libcxx.src}
@@ -22,9 +23,10 @@ stdenv.mkDerivation {
     patch -p1 -d $(ls -d libcxx-*) -i ${../../libcxx-0001-musl-hacks.patch}
   '';
 
-  cmakeFlags =
-     lib.optional standalone "-DLLVM_ENABLE_LIBCXX=ON" ++
-     lib.optional (!enableShared) "-DLIBCXXABI_ENABLE_SHARED=OFF";
+  cmakeFlags = lib.optionals standalone [
+    "-DLLVM_ENABLE_LIBCXX=ON"
+    "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
+  ] ++ lib.optional (!enableShared) "-DLIBCXXABI_ENABLE_SHARED=OFF";
 
   installPhase = if stdenv.isDarwin
     then ''

--- a/pkgs/development/compilers/llvm/7/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/7/libunwind/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, version, fetch, fetchpatch, cmake, llvm, libcxx
+, enableShared ? !stdenv.hostPlatform.isStatic
+}:
+
+stdenv.mkDerivation {
+  pname = "libunwind";
+  inherit version;
+
+  src = fetch "libunwind" "035dsxs10nyiqd00q07yycvmkjl01yz4jdlrjvmch8klxg4pyjhp";
+
+  patches = lib.optional (stdenv.hostPlatform.useLLVM or false) [
+    # removes use of `new` that require libc++
+    (fetchpatch {
+      url = "https://github.com/llvm-mirror/libunwind/commit/34a45c630d4c79af403661d267db42fbe7de1178.patch";
+      sha256 = "0n0pv6jvcky8pn3srhrf9x5kbnd0d2kia9xlx2g590f5q0bgwfhv";
+    })
+    # cleans up remaining libc++ dependencies (mostly header inclusions)
+    (fetchpatch {
+      url = "https://github.com/llvm-mirror/libunwind/commit/e050272d2eb57eb4e56a37b429a61df2ebb8aa3e.patch";
+      sha256 = "170mwmj0wf40iyk1kzdpaiy36rz9n8dpl881h4h7s5da0rh51xya";
+      includes = [ "src/libunwind.cpp" "src/UnwindCursor.hpp" ];
+    })
+  ];
+
+  nativeBuildInputs = [ cmake llvm ];
+
+  cmakeFlags = lib.optionals (!enableShared) [
+    "-DLIBUNWIND_ENABLE_SHARED=OFF"
+  ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
+    "-DLIBUNWIND_HAS_NOSTDINCXX_FLAG=ON"
+    "-DLLVM_ENABLE_LIBCXX=ON"
+  ];
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This makes cross compilation work again when `stdenv.hostPlatform.useLLVM` is true and `llvmPackages` points to `llvmPackages_7`. There were the following problems:

* `libcxxabi` wouldn't evaluate for `useLLVM == true` since in that case `libunwind` would be passed as an argument. This PR makes `libunwind` an optional dependency of `libcxxabi` again and packages `libunwind` of llvm 7 as well.
* `lldClang` passed `--unwindlib` to `clang`, but this option was introduced for clang 9. This PR backports this change for clang 7 similarly to how it was done for clang 8.

`tests.cross.llvm.hello.musl64` now works again!


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
