### PR TITLE
yabridge, yabridgectl: 3.0.2 -> 3.1.0

### DIFF
--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -45,25 +45,25 @@ let
 
   # Derived from vst3.wrap
   vst3 = rec {
-    version = "e2fbb41f28a4b311f2fc7d28e9b4330eec1802b6";
+    version = "3.7.2_build_28-patched";
     src = fetchFromGitHub {
       owner = "robbert-vdh";
       repo = "vst3sdk";
-      rev = version;
+      rev = "v${version}";
       fetchSubmodules = true;
-      sha256 = "sha256-4oLOa6kVB053Hrq7BBbZFdruAXuqnC944y5Kuib1F7s=";
+      sha256 = "sha256-39pvfcg4fvf7DAbAPzEHA1ja1LFL6r88nEwNYwaDC8w=";
     };
   };
 in stdenv.mkDerivation rec {
   pname = "yabridge";
-  version = "3.0.2";
+  version = "3.1.0";
 
   # NOTE: Also update yabridgectl's cargoHash when this is updated
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = pname;
     rev = version;
-    hash = "sha256-3uZCYGqo9acpANy5tQl3U0LK6wuOzjQpfjHDvaPSGlI=";
+    hash = "sha256-xvKjb+ql3WxnGHqcn3WnxunY5+s9f8Gt/n6EFSBrNdI=";
   };
 
   # Unpack subproject sources

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -6,7 +6,7 @@ rustPlatform.buildRustPackage rec {
 
   src = yabridge.src;
   sourceRoot = "source/tools/yabridgectl";
-  cargoHash = "sha256-mSp/IH7ZB7YSOBCFwNtHLYDz7CvWo2sO9VuPdqpl/u0=";
+  cargoHash = "sha256-TcjFaDo5IUs6Z3tgb+6jqyyrB2BLcif6Ycw++5FzuDY=";
 
   patches = [
     # By default, yabridgectl locates libyabridge.so by using

--- a/pkgs/tools/audio/yabridgectl/libyabridge-from-nix-profiles.patch
+++ b/pkgs/tools/audio/yabridgectl/libyabridge-from-nix-profiles.patch
@@ -1,8 +1,8 @@
 diff --git a/tools/yabridgectl/src/config.rs b/tools/yabridgectl/src/config.rs
-index c1c89cf..d7bd822 100644
+index 6e05e34..656eef3 100644
 --- a/tools/yabridgectl/src/config.rs
 +++ b/tools/yabridgectl/src/config.rs
-@@ -23,6 +23,7 @@ use std::collections::{BTreeMap, BTreeSet};
+@@ -23,6 +23,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
  use std::env;
  use std::fmt::Display;
  use std::fs;
@@ -10,7 +10,7 @@ index c1c89cf..d7bd822 100644
  use std::path::{Path, PathBuf};
  use which::which;
  use xdg::BaseDirectories;
-@@ -216,34 +217,24 @@ impl Config {
+@@ -222,34 +223,24 @@ impl Config {
                  }
              }
              None => {
@@ -56,10 +56,10 @@ index c1c89cf..d7bd822 100644
                          ));
                      }
 diff --git a/tools/yabridgectl/src/main.rs b/tools/yabridgectl/src/main.rs
-index 0db1bd4..221cdd0 100644
+index ce701b8..b6b9633 100644
 --- a/tools/yabridgectl/src/main.rs
 +++ b/tools/yabridgectl/src/main.rs
-@@ -102,7 +102,7 @@ fn main() -> Result<()> {
+@@ -150,7 +150,7 @@ fn main() -> Result<()> {
                          .about("Path to the directory containing 'libyabridge-{vst2,vst3}.so'")
                          .long_about(
                              "Path to the directory containing 'libyabridge-{vst2,vst3}.so'. If this \


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version: https://github.com/robbert-vdh/yabridge/releases/tag/3.1.0

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).