### PR TITLE
treewide: use https for github URIs

### DIFF
--- a/pkgs/applications/radio/rtl-sdr/default.nix
+++ b/pkgs/applications/radio/rtl-sdr/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Turns your Realtek RTL2832 based DVB dongle into a SDR receiver";
-    homepage = "http://github.com/librtlsdr/librtlsdr";
+    homepage = "https://github.com/librtlsdr/librtlsdr";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ bjornfor ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/development/compilers/ghcjs-ng/8.6/stage0.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.6/stage0.nix
@@ -108,7 +108,7 @@
         base binary bytestring containers ghc-prim ghci-ghcjs
         template-haskell-ghcjs
       ];
-      homepage = "http://github.com/ghcjs";
+      homepage = "https://github.com/ghcjs";
       license = lib.licenses.mit;
     }) {};
 

--- a/pkgs/development/libraries/librtlsdr/default.nix
+++ b/pkgs/development/libraries/librtlsdr/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Turns your Realtek RTL2832 based DVB dongle into a SDR receiver";
-    homepage = "http://github.com/librtlsdr/librtlsdr";
+    homepage = "https://github.com/librtlsdr/librtlsdr";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ bjornfor ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/development/ocaml-modules/xenstore_transport/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore_transport/default.nix
@@ -22,6 +22,6 @@ buildDunePackage rec {
   meta = with lib; {
     description = "Low-level libraries for connecting to a xenstore service on a xen host";
     license = licenses.lgpl21Only;
-    homepage = "http://github.com/xapi-project/ocaml-xenstore-clients";
+    homepage = "https://github.com/xapi-project/ocaml-xenstore-clients";
   };
 }

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A microframework based on uvloop, httptools, and learnings of flask";
-    homepage = "http://github.com/channelcat/sanic/";
+    homepage = "https://github.com/channelcat/sanic/";
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/tools/analysis/radare2/update.py
+++ b/pkgs/development/tools/analysis/radare2/update.py
@@ -32,7 +32,7 @@ def prefetch_github(owner: str, repo: str, ref: str) -> str:
 
 
 def get_radare2_rev() -> str:
-    feed_url = "http://github.com/radareorg/radare2/releases.atom"
+    feed_url = "https://github.com/radareorg/radare2/releases.atom"
     with urllib.request.urlopen(feed_url) as resp:
         tree = ET.fromstring(resp.read())
     releases = tree.findall(".//{http://www.w3.org/2005/Atom}entry")

--- a/pkgs/development/web/remarkjs/node-packages.nix
+++ b/pkgs/development/web/remarkjs/node-packages.nix
@@ -3712,7 +3712,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Portable Unix shell commands for Node.js";
-      homepage = "http://github.com/shelljs/shelljs";
+      homepage = "https://github.com/shelljs/shelljs";
       license = "BSD-3-Clause";
     };
     production = true;

--- a/pkgs/os-specific/darwin/chunkwm/default.nix
+++ b/pkgs/os-specific/darwin/chunkwm/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "chunkwm";
   version = "0.4.9";
   src = fetchzip {
-    url = "http://github.com/koekeishiya/chunkwm/archive/v${version}.tar.gz";
+    url = "https://github.com/koekeishiya/chunkwm/archive/v${version}.tar.gz";
     sha256 = "0w8q92q97fdvbwc3qb5w44jn4vi3m65ssdvjp5hh6b7llr17vspl";
   };
 

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -38,7 +38,7 @@ buildBazelPackage rec {
 
   patches = [
     # Quiche needs to be updated to compile under newer GCC.
-    # This is a manual backport of http://github.com/envoyproxy/envoy/pull/13949.
+    # This is a manual backport of https://github.com/envoyproxy/envoy/pull/13949.
     ./0001-quiche-update-QUICHE-tar-13949.patch
 
     # upb needs to be updated to compile under newer GCC.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
