### PR TITLE
python3Packages.slob: unstable-2016-11-03 -> unstable-2020-06-26

### DIFF
--- a/pkgs/development/python-modules/slob/default.nix
+++ b/pkgs/development/python-modules/slob/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage {
   pname = "slob";
-  version = "unstable-2016-11-03";
+  version = "unstable-2020-06-26";
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "itkach";
     repo = "slob";
-    rev = "d1ed71e4778729ecdfc2fe27ed783689a220a6cd";
-    sha256 = "1r510s4r124s121wwdm9qgap6zivlqqxrhxljz8nx0kv0cdyypi5";
+    rev = "018588b59999c5c0eb42d6517fdb84036f3880cb";
+    sha256 = "01195hphjnlcvgykw143rf06s6y955sjc1r825a58vhjx7hj54zh";
   };
 
   propagatedBuildInputs = [ PyICU ];
@@ -24,10 +24,11 @@ buildPythonPackage {
     ${python.interpreter} -m unittest slob
   '';
 
+  pythonImportsCheck = [ "slob" ];
+
   meta = with lib; {
     homepage = "https://github.com/itkach/slob/";
     description = "Reference implementation of the slob (sorted list of blobs) format";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- update to latest

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
