### PR TITLE
flexoptix-app: Init at 5.9.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -131,6 +131,7 @@
   ./programs/file-roller.nix
   ./programs/firejail.nix
   ./programs/fish.nix
+  ./programs/flexoptix-app.nix
   ./programs/freetds.nix
   ./programs/fuse.nix
   ./programs/geary.nix

--- a/nixos/modules/programs/flexoptix-app.nix
+++ b/nixos/modules/programs/flexoptix-app.nix
@@ -1,0 +1,25 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.flexoptix-app;
+in {
+  options = {
+    programs.flexoptix-app = {
+      enable = mkEnableOption "FLEXOPTIX app + udev rules";
+
+      package = mkOption {
+        description = "FLEXOPTIX app package to use";
+        type = types.package;
+        default = pkgs.flexoptix-app;
+        defaultText = "\${pkgs.flexoptix-app}";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
+  };
+}

--- a/pkgs/tools/misc/flexoptix-app/default.nix
+++ b/pkgs/tools/misc/flexoptix-app/default.nix
@@ -1,0 +1,47 @@
+{ lib, appimageTools, fetchurl }: let
+  pname = "flexoptix-app";
+  version = "5.9.0";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    name = "${name}.AppImage";
+    url = "https://flexbox.reconfigure.me/download/electron/linux/x64/FLEXOPTIX%20App.${version}.AppImage";
+    sha256 = "0gbqaj9b11mxx0knmmh2d5863kaslbb3r6c4h8rjhg8qy4cws7hj";
+  };
+
+  udevRules = fetchurl {
+    url = "https://www.flexoptix.net/skin/udev_rules/99-tprogrammer.rules";
+    sha256 = "0mr1bhgvavq1ax4206z1vr2y64s3r676w9jjl9ysziklbrsvk5rr";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  multiPkgs = null; # no 32bit needed
+  extraPkgs = { pkgs, ... }@args: [
+    pkgs.hidapi
+  ] ++ appimageTools.defaultFhsEnvArgs.multiPkgs args;
+
+  extraInstallCommands = ''
+    mv $out/bin/{${name},${pname}}
+    install -Dm444 ${appimageContents}/flexoptix-app.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/flexoptix-app.png -t $out/share/pixmaps
+    substituteInPlace $out/share/applications/flexoptix-app.desktop \
+      --replace 'Exec=AppRun' "Exec=$out/bin/${pname}"
+    mkdir -p $out/lib/udev/rules.d
+    ln -s ${udevRules} $out/lib/udev/rules.d/99-tprogrammer.rules
+  '';
+
+  meta = {
+    description = "Configure FLEXOPTIX Universal Transcievers in seconds";
+    homepage = "https://www.flexoptix.net";
+    changelog = "https://www.flexoptix.net/en/flexoptix-app/?os=linux#flexapp__modal__changelog";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ das_j ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4472,6 +4472,8 @@ in
 
   flent = python3Packages.callPackage ../applications/networking/flent { };
 
+  flexoptix-app = callPackage ../tools/misc/flexoptix-app { };
+
   flpsed = callPackage ../applications/editors/flpsed { };
 
   fluentd = callPackage ../tools/misc/fluentd { };


### PR DESCRIPTION
###### Motivation for this change

Weird SFP flex but okay

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date - theere is none
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
