### PR TITLE
oobicpl: unstable-2016-03-02 -> unstable-2020-08-12

### DIFF
--- a/pkgs/development/libraries/science/biology/bicpl/default.nix
+++ b/pkgs/development/libraries/science/biology/bicpl/default.nix
@@ -2,16 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "bicpl";
-  version = "unstable-2017-09-10";
-
-  owner = "BIC-MNI";
+  version = "unstable-2020-10-15";
 
   # current master is significantly ahead of most recent release, so use Git version:
   src = fetchFromGitHub {
-    inherit owner;
+    owner  = "BIC-MNI";
     repo   = pname;
-    rev    = "612a63e740fadb162fcf27ee00da6a18dec4d5a9";
-    sha256 = "1vv9gi184bkvp3f99v9xmmw1ly63ip5b09y7zdjn39g7kmwzrga7";
+    rev    = "a58af912a71a4c62014975b89ef37a8e72de3c9d";
+    sha256 = "0iw0pmr8xrifbx5l8a0xidfqbm1v8hwzqrw0lcmimxlzdihyri0g";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -23,7 +21,7 @@ stdenv.mkDerivation rec {
   # internal_volume_io.h: No such file or directory
 
   meta = with lib; {
-    homepage = "https://github.com/${owner}/${pname}";
+    homepage = "https://github.com/BIC-MNI/bicpl";
     description = "Brain Imaging Centre programming library";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/science/biology/oobicpl/default.nix
+++ b/pkgs/development/libraries/science/biology/oobicpl/default.nix
@@ -1,28 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libminc, bicpl, arguments, pcre-cpp }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, libminc
+, bicpl
+, arguments
+, pcre-cpp }:
 
 stdenv.mkDerivation rec {
   pname = "oobicpl";
-  version = "unstable-2016-03-02";
-
-  owner = "BIC-MNI";
+  version = "unstable-2020-08-12";
 
   src = fetchFromGitHub {
-    inherit owner;
+    owner  = "BIC-MNI";
     repo   = pname;
-    rev    = "bc062a65dead2e58461f5afb37abedfa6173f10c";
-    sha256 = "05l4ml9djw17bgdnrldhcxydrzkr2f2scqlyak52ph5azj5n4zsx";
+    rev    = "a9409da8a5bb4925438f32aff577b6333faec28b";
+    sha256 = "0b4chjhr32wbb1sash8cq1jfnr7rzdq84hif8anlrjqd3l0gw357";
   };
 
   nativeBuildInputs = [ cmake ];
+
   buildInputs = [ libminc bicpl arguments pcre-cpp ];
 
-  cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/cmake"
-                 "-DBICPL_DIR=${bicpl}/lib"
-                 "-DARGUMENTS_DIR=${arguments}/lib"
-                 "-DOOBICPL_BUILD_SHARED_LIBS=TRUE" ];
+  cmakeFlags = [
+    "-DLIBMINC_DIR=${libminc}/lib/cmake"
+    "-DBICPL_DIR=${bicpl}/lib"
+    "-DARGUMENTS_DIR=${arguments}/lib"
+    "-DOOBICPL_BUILD_SHARED_LIBS=TRUE"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/${owner}/${pname}";
+    homepage = "https://github.com/BIC-MNI/oobicpl";
     description = "Brain Imaging Centre object-oriented programming library (and tools)";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- update bicpl and oobicpl to latest

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
