### PR TITLE
macchina: init at 0.6.9

### DIFF
--- a/pkgs/tools/misc/macchina/default.nix
+++ b/pkgs/tools/misc/macchina/default.nix
@@ -1,0 +1,29 @@
+{ lib, rustPlatform, fetchFromGitHub, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "macchina";
+  version = "0.6.9";
+
+  src = fetchFromGitHub {
+    owner = "Macchina-CLI";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-y23gpYDnYoiTJcNyWKslVenPTXcCrOvxq+0N9PjQN3g=";
+  };
+
+  cargoSha256 = "sha256-jfLj8kLBG6AeeYo421JCl1bMqWwOGiwQgv7AEomtFcY=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion target/completions/*.{bash,fish}
+  '';
+
+  meta = with lib; {
+    description = "A fast, minimal and customizable system information fetcher";
+    homepage = "https://github.com/Macchina-CLI/macchina";
+    changelog = "https://github.com/Macchina-CLI/macchina/releases/tag/v${version}";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ _414owen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6436,6 +6436,8 @@ in
 
   macchanger = callPackage ../os-specific/linux/macchanger { };
 
+  macchina = callPackage ../tools/misc/macchina { };
+
   madlang = haskell.lib.justStaticExecutables haskellPackages.madlang;
 
   maeparser = callPackage ../development/libraries/maeparser { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Macchina is a blazing-fast system info fetcher, similar to screenfetch or neofetch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
