### PR TITLE
remake: 4.1 -> 4.3

### DIFF
--- a/pkgs/development/tools/build-managers/remake/default.nix
+++ b/pkgs/development/tools/build-managers/remake/default.nix
@@ -1,27 +1,40 @@
-{ lib, stdenv, fetchurl, readline }:
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, readline
+, guileSupport ? false
+, guile
+}:
 
 stdenv.mkDerivation rec {
   pname = "remake";
-  remakeVersion = "4.1";
-  dbgVersion = "1.1";
+  remakeVersion = "4.3";
+  dbgVersion = "1.5";
   version = "${remakeVersion}+dbg-${dbgVersion}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/bashdb/remake/${version}/remake-${remakeVersion}+dbg${dbgVersion}.tar.bz2";
-    sha256 = "1zi16pl7sqn1aa8b7zqm9qnd9vjqyfywqm8s6iap4clf86l7kss2";
+    url = "mirror://sourceforge/project/bashdb/remake/${version}/remake-${remakeVersion}+dbg-${dbgVersion}.tar.gz";
+    sha256 = "0xlx2485y0israv2pfghmv74lxcv9i5y65agy69mif76yc4vfvif";
   };
 
   patches = [
     ./glibc-2.27-glob.patch
   ];
 
-  buildInputs = [ readline ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [ readline ] ++
+      lib.optionals guileSupport [ guile ];
+
+  # make check fails, see https://github.com/rocky/remake/issues/117
 
   meta = {
     homepage = "http://bashdb.sourceforge.net/remake/";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     description = "GNU Make with comprehensible tracing and a debugger";
     platforms = with lib.platforms; linux ++ darwin;
-    maintainers = with lib.maintainers; [ bjornfor ];
+    maintainers = with lib.maintainers; [ bjornfor shamilton ];
   };
 }

--- a/pkgs/development/tools/build-managers/remake/default.nix
+++ b/pkgs/development/tools/build-managers/remake/default.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
   ];
-  buildInputs = [ readline ] ++
-      lib.optionals guileSupport [ guile ];
+  buildInputs = [ readline ]
+    ++ lib.optionals guileSupport [ guile ];
 
   # make check fails, see https://github.com/rocky/remake/issues/117
 


### PR DESCRIPTION
###### Motivation for this change

###### Things done
~~remark builds directly from source using autoreconfHook~~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

______

Pinging maintainer : @bjornfor 