### PR TITLE
passphrase2pgp: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/tools/security/passphrase2pgp/default.nix
+++ b/pkgs/tools/security/passphrase2pgp/default.nix
@@ -1,4 +1,4 @@
-{ lib, pandoc, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "passphrase2pgp";

--- a/pkgs/tools/security/passphrase2pgp/default.nix
+++ b/pkgs/tools/security/passphrase2pgp/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "passphrase2pgp";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "skeeto";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-Nje77tn55CKRU6igEA/6IquDhXVVQAdiez6nmN49di4";
+    hash = "sha256-VNOoYYnHsSgiSbVxlBwYUq0JsLa4BwZQSvMVSiyB6rg=";
   };
 
   vendorSha256 = "sha256-7q5nwkj4TP7VgHmV9YBbCB11yTPL7tK4gD+uN4Vw3Cs";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
