### PR TITLE
fosspay: init at unstable-2020-12-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11226,6 +11226,16 @@
     github = "yanganto";
     githubId = 10803111;
   };
+  pniedzwiedzinski = {
+    name = "Patryk Niedźwiedziński";
+    email = "pniedzwiedzinski19@gmail.com";
+    github = "pniedzwiedzinski";
+    githubId = 19212948;
+    keys = [{
+      longkeyid = "rsa4096/0xFC6AE50A8309FBE9";
+      fingerprint = "4414 ADCF BF17 155A 7797  D6C4 FC6A E50A 8309 FBE9";
+    }];
+  };
   starcraft66 = {
     name = "Tristan Gosselin-Hane";
     email = "starcraft66@gmail.com";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1010,6 +1010,7 @@
   ./services/x11/xbanish.nix
   ./services/x11/xfs.nix
   ./services/x11/xserver.nix
+  ./services/web-apps/fosspay.nix
   ./system/activation/activation-script.nix
   ./system/activation/top-level.nix
   ./system/boot/binfmt.nix

--- a/nixos/modules/services/web-apps/fosspay.nix
+++ b/nixos/modules/services/web-apps/fosspay.nix
@@ -1,0 +1,125 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.fosspay;
+
+  package = pkgs.fosspay.override { conf = "${stateDir}/config.ini"; };
+  format = pkgs.formats.ini {};
+  stateDir = "/var/lib/fosspay";
+  configFile = format.generate "config.ini" cfg.settings;
+in
+{
+  options.services.fosspay = {
+    enable = lib.mkEnableOption "Donation collection for FOSS groups and individuals.";
+
+    secretKeyFile = lib.mkOption {
+      type = lib.types.path;
+      example = "/run/keys/fosspay-secret-key";
+      description = ''
+        A file containing a key for use with fosspay.
+      '';
+    };
+
+    database = {
+      connectionString = mkOption {
+        type = types.str;
+        default = "postgresql:///fosspay";
+        description = "URI for connecting to database";
+      };
+
+      createLocally = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Create the database and database user locally.";
+      };
+    };
+
+    settings = lib.mkOption {
+      type = format.type;
+      default = {};
+      example = literalExample ''
+        dev = {
+          protocol = "http";
+          domain = "localhost:5000";
+
+          your-name = "Joe Bloe";
+          your-email = "joe@example.org";
+
+          currency = "usd";
+          default-amounts = "3 5 10 20";
+          default-amount = 5;
+          default-type = "monthly";
+          public-income = true;
+          goal = 500;
+        };
+      '';
+      description = ''
+        fosspay configuration. Refer to
+        <link xlink:href="https://git.sr.ht/~sircmpwn/fosspay/blob/master/config.ini.example"/>
+        for details on supported values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.fosspay = {
+      description = "fosspay website";
+      wantedBy = [ "multi-user.target" ];
+      after = lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+      bindsTo = lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+
+      preStart = ''
+        cp -f ${configFile} ${stateDir}/config.ini
+        chmod 640 ${stateDir}/config.ini
+
+        # insert our secret files into config.ini that we'll use
+        ${pkgs.crudini}/bin/crudini --set ${stateDir}/config.ini dev secret-key "$(head -n1 ${cfg.secretKeyFile})"
+      '' + lib.optionals cfg.database.createLocally ''
+        ${pkgs.crudini}/bin/crudini --set ${stateDir}/config.ini dev connection-string "${cfg.database.connectionString}"
+      '';
+
+      serviceConfig = {
+        User = "fosspay";
+        Group = "fosspay";
+        StateDirectory = "fosspay";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = "${package}/share";
+        ExecStart = "${package}/bin/gunicorn app:app -b 127.0.0.1:5000";
+        ExecStop = "${pkgs.busybox}/bin/pkill gunicorn";
+      };
+    };
+
+    services.postgresql = lib.optionalAttrs cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ "fosspay" ];
+
+      # auth needs to be set to trust if we want do connect locally without password
+      # I couldn't find any other example of setting up passwordless connection with psycopg2
+      authentication = ''
+        local all all trust
+        host all all 127.0.0.1/32 trust
+        host all all ::1/128 trust
+      '';
+
+      ensureUsers = [
+        {
+          name = "fosspay";
+          ensurePermissions = { "DATABASE fosspay" = "ALL PRIVILEGES"; };
+        }
+      ];
+    };
+
+    users.users = {
+      fosspay = {
+        isSystemUser = true;
+        group = "fosspay";
+      };
+    };
+
+    users.groups = {
+      fosspay = {};
+    };
+  };
+}

--- a/pkgs/servers/fosspay/default.nix
+++ b/pkgs/servers/fosspay/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, lib, writeText, python3, fetchFromSourcehut, conf ? null }:
+let
+  py3 = python3.withPackages(ps: with ps; [
+    stripe
+    flask
+    jinja2
+    flask_login
+    psycopg2
+    bcrypt
+    sqlalchemy-utils
+    pystache
+    gunicorn
+  ]);
+
+in stdenv.mkDerivation {
+  pname = "fosspay";
+  version = "unstable-2020-12-02";
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "fosspay";
+    rev = "3b957a1b964f1d741876e5efe187d0c4cbb9443e";
+    sha256 = "0bgdqiasb7jvpmg0p7c4hs97f05iq8w1k1cdgxwl1rx5dg9brn5v";
+  };
+
+  postPatch = lib.optionalString (conf != null) ''
+    sed -i s:config.ini:${conf}:g cronjob.py
+    sed -i s:config.ini:${conf}:g fosspay/config.py
+  '';
+
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share
+    [ -f config.ini ] || cp config.ini.example config.ini
+    cp -r * $out/share
+    cat > $out/bin/fosspay << EOF
+    #!/bin/sh
+    cd $out/share
+    ${py3}/bin/python3 $out/share/app.py
+    EOF
+    chmod +x $out/bin/fosspay
+    cp ${py3}/bin/gunicorn $out/bin/gunicorn
+  '';
+
+  meta = with lib; {
+    description = "Donation collection for FOSS groups and individuals.";
+    homepage = "https://git.sr.ht/~sircmpwn/fosspay";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ pniedzwiedzinski ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -527,6 +527,8 @@ in
 
   fetchgx = callPackage ../build-support/fetchgx { };
 
+  fosspay = callPackage ../servers/fosspay { };
+
   resolveMirrorURLs = {url}: fetchurl {
     showURLs = true;
     inherit url;


### PR DESCRIPTION
###### Motivation for this change
#119290

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Testing

```nix
{
  imports = [
    /home/pn/code/nixpkgs/nixos/modules/services/web-apps/fosspay.nix
  ];

  services.fosspay.enable = true;
  services.fosspay.config = ''
[dev]
# Change this to the actual location of your site
# You can include a path in the domain if it's a subdirectory
# i.e. domain=drewdevault.com/donate
# omit the trailing slash
protocol=http
domain=localhost:5000
# Change this value to something random and secret
secret-key=hello world

# On the debug server, this lets you choose what to bind to
debug-host=0.0.0.0
debug-port=5000

# Fill out these details with your mail server
smtp-host=mail.example.org
smtp-port=587
smtp-user=you
smtp-password=password
smtp-from=donate@example.org

# Your information
your-name=Joe Bloe
your-email=joe@example.org
# ^ you should have a gravatar that works with this email

# SQL connection string
connection-string=postgresql://postgres@localhost/fosspay

# Stripe API info: https://dashboard.stripe.com/account/apikeys
stripe-secret=
stripe-publish=

# Currency to use
# "usd" for dollar, "eur" for euro
# refer to stripe documentation for details : https://stripe.com/docs/currencies
currency=usd

# Separate with spaces
default-amounts=3 5 10 20
# Which one to pick when they arrive?
default-amount=5

# Pick between "monthly" and "once"
default-type=monthly

# Display monthly donations publicly
public-income=yes

# How much are you hoping to earn monthly, in cents
goal=500

# Optional Patreon integration
# Register a client here: https://www.patreon.com/portal/registration/register-clients
# And put in the "Creator's Access Token" here:
patreon-access-token=
# And the "Creator's Refresh Token" here:
patreon-refresh-token=
# Client ID
patreon-client-id=
# Client secret
patreon-client-secret=
# And the Patreon campaign you want to connect with:
patreon-campaign=

# Optional LiberaPay integration, fill in your username here
liberapay-campaign=

# Optional GitHub sponsors integration
# Generate personal access key at https://github.com/settings/tokens
# Must have "user" access.
github-token=

# Command to reload fosspay (send it a SIGHUP)
reload-command=kill -HUP $(pgrep -xf '/usr/bin/python3.*app.py' | tail -n 1)
  '';

  nixpkgs.config.packageOverrides = pkgs: {
    fosspay = pkgs.callPackage /home/pn/code/nixpkgs/pkgs/servers/fosspay {};
  };

  system.stateVersion = "20.03";
}
```