### PR TITLE
ptcollab: 0.3.5.1 -> 0.4.0

### DIFF
--- a/pkgs/applications/audio/ptcollab/default.nix
+++ b/pkgs/applications/audio/ptcollab/default.nix
@@ -1,26 +1,40 @@
 { mkDerivation
-, lib, stdenv
+, lib
+, stdenv
 , fetchFromGitHub
+, nix-update-script
 , qmake
 , qtbase
 , qtmultimedia
 , libvorbis
+, rtmidi
 }:
 
 mkDerivation rec {
   pname = "ptcollab";
-  version = "0.3.5.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "yuxshao";
     repo = "ptcollab";
     rev = "v${version}";
-    sha256 = "1ahfxjm1chz8k65rs7rgn4s2bgippq58fjcxl8fr21pzn718wqf1";
+    sha256 = "1yfnf47saxxj17x0vyxihr343kp7gz3fashzky79j80sqlm6ng85";
   };
+
+  postPatch = ''
+    substituteInPlace src/editor.pro \
+      --replace '/usr/include/rtmidi' '${rtmidi}/include/rtmidi'
+  '';
 
   nativeBuildInputs = [ qmake ];
 
-  buildInputs = [ qtbase qtmultimedia libvorbis ];
+  buildInputs = [ qtbase qtmultimedia libvorbis rtmidi ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
 
   meta = with lib; {
     description = "Experimental pxtone editor where you can collaborate with friends";


### PR DESCRIPTION
###### Motivation for this change
Simple version bump.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
