### PR TITLE
btrfs-heatmap: 8 -> 9; python.pkgs.btrfs: 11 -> 12

### DIFF
--- a/pkgs/development/python-modules/btrfs/default.nix
+++ b/pkgs/development/python-modules/btrfs/default.nix
@@ -1,16 +1,22 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 }:
 
 buildPythonPackage rec {
   pname = "btrfs";
-  version = "11";
+  version = "12";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1w92sj47wy53ygz725xr613k32pk5khi0g9lrpp6img871241hrx";
+  src = fetchFromGitHub {
+    owner = "knorrie";
+    repo = "python-btrfs";
+    rev = "v${version}";
+    sha256 = "sha256-ZQSp+pbHABgBTrCwC2YsUUXAf/StP4ny7MEhBgCRqgE=";
   };
+
+  # no tests (in v12)
+  doCheck = false;
+  pythonImportsCheck = [ "btrfs" ];
 
   meta = with lib; {
     description = "Inspect btrfs filesystems";

--- a/pkgs/tools/filesystems/btrfs-heatmap/default.nix
+++ b/pkgs/tools/filesystems/btrfs-heatmap/default.nix
@@ -2,25 +2,17 @@
 , fetchFromGitHub
 , python3
 , installShellFiles
-, fetchurl
 }:
 
 stdenv.mkDerivation rec {
   pname = "btrfs-heatmap";
-  version = "8";
+  version = "9";
 
   src = fetchFromGitHub {
     owner = "knorrie";
     repo = "btrfs-heatmap";
     rev = "v${version}";
-    sha256 = "035frvk3s7g18y81srssvm550nfq7jylr7w60nvixidxvrc0yrnh";
-  };
-
-  # man page is currently only in the debian branch
-  # https://github.com/knorrie/btrfs-heatmap/issues/11
-  msrc = fetchurl {
-    url = "https://raw.githubusercontent.com/knorrie/btrfs-heatmap/45d844e12d7f5842ebb99e65d7b968a5e1a89066/debian/man/btrfs-heatmap.8";
-    sha256 = "1md7xc426sc8lq4w29gjd6gv7vjqhcwrqqcr6z39kihvi04d5f6q";
+    sha256 = "sha256-yCkuZqWwxrs2eS7EXY6pAOVVVSq7dAMxJtf581gX8vg=";
   };
 
   buildInputs = [ python3 ];
@@ -29,11 +21,15 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "man" ];
 
   installPhase = ''
-    install -Dm 0755 heatmap.py $out/sbin/btrfs-heatmap
-    installManPage ${msrc}
+    runHook preInstall
+
+    install -Dm 0755 btrfs-heatmap $out/sbin/btrfs-heatmap
+    installManPage man/btrfs-heatmap.1
 
     buildPythonPath ${python3.pkgs.btrfs}
     patchPythonScript $out/sbin/btrfs-heatmap
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
new versions came out a while ago

###### Things done
updated btrfs-heatmap to latest version
change btrfs-heatmap to use in-tree man page
changed btfs-heatmap to use the renamed executable

updated python.pkgs.btrfs to latest version (in this PR as btfrs-heatmap's docs refer to v12)
  (this is a dependency of btfs-heatmap, though it works with v11 and v12)
change python.pkgs.btfs to get source from github as v12 isn't published on pypi

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/41g33y7dqdnsd7gbpq457v3a6dk5g3dp-python3.8-btrfs-11	   98558656`
  - `/nix/store/dyhjxhbmrjr2dccwvjl7acdyd5fqy1zp-btrfs-heatmap-8	   98584136`
  - `/nix/store/c1vicpq9idgmdq2kdqcmilqgdwfl148i-python3.8-btrfs-12	   98604088`
  - `/nix/store/96qp7vchj1pwbfzp66sz450lbni72lw0-btrfs-heatmap-9	   98630440`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
