### PR TITLE
checkbashisms: 2.0.0.2 -> 2.21.1

### DIFF
--- a/pkgs/development/tools/misc/checkbashisms/default.nix
+++ b/pkgs/development/tools/misc/checkbashisms/default.nix
@@ -1,20 +1,24 @@
-{ lib, stdenv, fetchurl, perl }:
+{ lib, stdenv, fetchurl, perl, installShellFiles }:
 stdenv.mkDerivation rec {
-  version = "2.0.0.2";
+  version = "2.21.1";
   pname = "checkbashisms";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/checkbaskisms/${version}/checkbashisms";
-    sha256 = "1vm0yykkg58ja9ianfpm3mgrpah109gj33b41kl0jmmm11zip9jd";
+    url = "mirror://debian/pool/main/d/devscripts/devscripts_${version}.tar.xz";
+    hash = "sha256-1ZbIiUrFd38uMVLy7YayLLm5RrmcovsA++JTb8PbTFI=";
   };
 
+  nativeBuildInputs = [ installShellFiles ];
   buildInputs = [ perl ];
 
-  # The link returns directly the script. No need for unpacking
-  dontUnpack = true;
-
+  buildPhase = ''
+    substituteInPlace ./scripts/checkbashisms.pl \
+      --replace '###VERSION###' "$version"
+  '';
   installPhase = ''
-    install -D -m755 $src $out/bin/checkbashisms
+    installManPage scripts/$pname.1
+    installShellCompletion --bash --name $pname scripts/$pname.bash_completion
+    install -D -m755 scripts/$pname.pl $out/bin/$pname
   '';
 
   meta = {

--- a/pkgs/development/tools/misc/checkbashisms/default.nix
+++ b/pkgs/development/tools/misc/checkbashisms/default.nix
@@ -12,19 +12,28 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl ];
 
   buildPhase = ''
+    runHook preBuild
+
     substituteInPlace ./scripts/checkbashisms.pl \
       --replace '###VERSION###' "$version"
+
+    runHook postBuild
   '';
   installPhase = ''
+    runHook preInstall
+
     installManPage scripts/$pname.1
     installShellCompletion --bash --name $pname scripts/$pname.bash_completion
     install -D -m755 scripts/$pname.pl $out/bin/$pname
+
+    runHook postInstall
   '';
 
   meta = {
     homepage = "https://sourceforge.net/projects/checkbaskisms/";
     description = "Check shell scripts for non-portable syntax";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ kaction ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Project on sourceforge is long unmaintained, development moved to
Debian devtools.

 * Upgrade to version from latest released devtools
 * Install manual page
 * Install bash completion script.

I do not use Bash, so I am not sure whether bash completion works.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
