### PR TITLE
[20.09] Added mime info path for mimemagic

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -25,7 +25,7 @@
 , cairo, re2, rake, gobject-introspection, gdk-pixbuf, zeromq, czmq, graphicsmagick, libcxx
 , file, libvirt, glib, vips, taglib, libopus, linux-pam, libidn, protobuf, fribidi, harfbuzz
 , bison, flex, pango, python3, patchelf, binutils, freetds, wrapGAppsHook, atk
-, bundler, libsass, libselinux ? null, libsepol ? null
+, bundler, libsass, libselinux ? null, libsepol ? null, shared-mime-info
 }@args:
 
 let
@@ -377,6 +377,10 @@ in
     preInstall = ''
       export HOME=$TMPDIR
     '';
+  };
+  
+  mimemagic = attrs: {
+    FREEDESKTOP_MIME_TYPES_PATH="${shared-mime-info}";
   };
 
   msgpack = attrs: {

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -380,7 +380,7 @@ in
   };
 
   mimemagic = attrs: {
-    FREEDESKTOP_MIME_TYPES_PATH="${shared-mime-info}";
+    FREEDESKTOP_MIME_TYPES_PATH="${shared-mime-info}/share/mime/packages/freedesktop.org.xml";
   };
 
   msgpack = attrs: {

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -378,7 +378,7 @@ in
       export HOME=$TMPDIR
     '';
   };
-  
+
   mimemagic = attrs: {
     FREEDESKTOP_MIME_TYPES_PATH="${shared-mime-info}";
   };


### PR DESCRIPTION
###### Motivation for this change

The fixes done to make mimemagic continue to work with Nix should be backported to the current stable version since there is currently no version of mimemagic available that can be built without these fixes.

Original commits/discussion in https://github.com/NixOS/nixpkgs/pull/117702

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
