### PR TITLE
kissfft: 131 -> 131.1.0

### DIFF
--- a/pkgs/development/libraries/kissfft/0001-pkgconfig-darwin.patch
+++ b/pkgs/development/libraries/kissfft/0001-pkgconfig-darwin.patch
@@ -1,0 +1,48 @@
+From c0dc376be9154d143574a818417ceed23308b5f2 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <christoph.neidahl@gmail.com>
+Date: Sun, 18 Apr 2021 01:45:20 +0200
+Subject: [PATCH] pkgconfig darwin
+
+---
+ Makefile | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 971c6d6..0f4be0c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -153,7 +153,6 @@ endif
+ # -DKISS_FFT_BUILD to TYPEFLAGS
+ #
+ 
+-ifneq ($(shell uname -s),Darwin)
+ 	PKGCONFIG_KISSFFT_VERSION = $(KFVER_MAJOR).$(KFVER_MINOR).$(KFVER_PATCH)
+ 	PKGCONFIG_KISSFFT_OUTPUT_NAME = $(KISSFFTLIB_SHORTNAME)
+ 	PKGCONFIG_PKG_KISSFFT_DEFS = $(TYPEFLAGS)
+@@ -170,7 +169,6 @@ ifneq ($(shell uname -s),Darwin)
+ 	PKGCONFIG_KISSFFT_LIBDIR = $(ABS_LIBDIR)
+   endif
+ 	PKGCONFIG_KISSFFT_PKGINCLUDEDIR = $${includedir}/kissfft
+-endif
+ 
+ export TYPEFLAGS
+ 
+@@ -226,7 +224,6 @@ ifneq ($(KISSFFT_STATIC), 1)
+ 	ln -sf $(KISSFFTLIB_NAME) $(KISSFFTLIB_SODEVELNAME)
+   endif
+ endif
+-ifneq ($(shell uname -s),Darwin)
+ 	mkdir "$(ABS_LIBDIR)/pkgconfig"
+ 	sed \
+ 		-e 's+@PKGCONFIG_KISSFFT_VERSION@+$(PKGCONFIG_KISSFFT_VERSION)+' \
+@@ -238,7 +235,6 @@ ifneq ($(shell uname -s),Darwin)
+ 		-e 's+@PKGCONFIG_KISSFFT_LIBDIR@+$(PKGCONFIG_KISSFFT_LIBDIR)+' \
+ 		-e 's+@PKGCONFIG_KISSFFT_PKGINCLUDEDIR@+$(PKGCONFIG_KISSFFT_PKGINCLUDEDIR)+' \
+ 		kissfft.pc.in 1>"$(ABS_LIBDIR)/pkgconfig/$(KISSFFT_PKGCONFIG)"
+-endif
+ ifneq ($(KISSFFT_TOOLS), 0)
+ 	make -C tools install
+ endif
+-- 
+2.29.3
+

--- a/pkgs/development/libraries/kissfft/default.nix
+++ b/pkgs/development/libraries/kissfft/default.nix
@@ -1,44 +1,79 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, fetchpatch
+, fftw
+, fftwFloat
+, python3
+, datatype ? "double"
+, withTools ? false
+, libpng
+, enableStatic ? stdenv.hostPlatform.isStatic
+, enableOpenmp ? false
+, llvmPackages
 }:
-
+let
+  py = python3.withPackages (ps: with ps; [ numpy ]);
+  option = cond: if cond then "1" else "0";
+in
 stdenv.mkDerivation rec {
-  pname = "kissfft";
-  version = "131";
+  pname = "kissfft-${datatype}${lib.optionalString enableOpenmp "-openmp"}";
+  version = "131.1.0";
 
   src = fetchFromGitHub {
     owner = "mborgerding";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0axmqav2rclw02mix55cch9xl5py540ac15xbmq7xq6n3k492ng2";
+    repo = "kissfft";
+    rev = version;
+    sha256 = "1yfws5bn4kh62yk6hdyp9h9775l6iz7wsfisbn58jap6b56s8j5s";
   };
 
   patches = [
-    # Allow installation into our prefix
-    # Fix installation on Darwin
-    # Create necessary directories
-    # Make datatype configurable
-    (fetchpatch {
-      url = "https://github.com/mborgerding/kissfft/pull/38.patch";
-      sha256 = "0cp1awl7lr2vqmcwm9lfjs4b4dv9da8mg4hfd821r5ryadpyijj6";
-    })
-    # Install headers as well
-    (fetchpatch {
-      url = "https://github.com/mborgerding/kissfft/commit/71df949992d2dbbe15ce707cf56c3fa1e43b1080.patch";
-      sha256 = "13h4kzsj388mxxv6napp4gx2ymavz9xk646mnyp1i852dijpmapm";
-    })
+    ./0001-pkgconfig-darwin.patch
   ];
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace "gcc" "${stdenv.cc.targetPrefix}cc" \
-      --replace "ar" "${stdenv.cc.targetPrefix}ar"
+  # https://bugs.llvm.org/show_bug.cgi?id=45034
+  postPatch = lib.optionalString (stdenv.hostPlatform.isLinux && stdenv.cc.isClang && lib.versionOlder stdenv.cc.version "10") ''
+    substituteInPlace test/Makefile \
+      --replace "-ffast-math" ""
+  ''
+  + lib.optionalString (stdenv.hostPlatform.isDarwin) ''
+    substituteInPlace test/Makefile \
+      --replace "LD_LIBRARY_PATH" "DYLD_LIBRARY_PATH"
+    # Don't know how to make math.h's double long constants available
+    substituteInPlace test/testcpp.cc \
+      --replace "M_PIl" "M_PI"
   '';
+
   makeFlags = [
     "PREFIX=${placeholder "out"}"
-    "DATATYPE=double"
+    "KISSFFT_DATATYPE=${datatype}"
+    "KISSFFT_TOOLS=${option withTools}"
+    "KISSFFT_STATIC=${option enableStatic}"
+    "KISSFFT_OPENMP=${option enableOpenmp}"
   ];
+
+  buildInputs = lib.optionals (withTools && datatype != "simd") [ libpng ]
+    # TODO: This may mismatch the LLVM version in the stdenv, see #79818.
+    ++ lib.optional (enableOpenmp && stdenv.cc.isClang) llvmPackages.openmp;
+
+  doCheck = true;
+
+  checkInputs = [
+    py
+    (if datatype == "float" then fftwFloat else fftw)
+  ];
+
+  checkFlags = [ "testsingle" ];
+
+  postInstall = ''
+    ln -s ${pname}.pc $out/lib/pkgconfig/kissfft.pc
+  '';
+
+  # Tools can't find kissfft libs on Darwin
+  postFixup = lib.optionalString (withTools && stdenv.hostPlatform.isDarwin) ''
+    for bin in $out/bin/*; do
+      install_name_tool -change lib${pname}.dylib $out/lib/lib${pname}.dylib $bin
+    done
+  '';
 
   meta = with lib; {
     description = "A mixed-radix Fast Fourier Transform based up on the KISS principle";


### PR DESCRIPTION
###### Motivation for this change
- Version bump.
- Added more options
  - data type
  - static or shared library
  - with or without OpenMP
  - with or without tools
- Enabled tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
