### PR TITLE
flightgear, simgear: 2020.4.{4,6} -> 2020.4.8

### DIFF
--- a/pkgs/development/libraries/simgear/default.nix
+++ b/pkgs/development/libraries/simgear/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, fetchurl, plib, freeglut, xorgproto, libX11, libXext, libXi
 , libICE, libSM, libXt, libXmu, libGLU, libGL, boost, zlib, libjpeg, freealut
-, openscenegraph, openal, expat, cmake, apr
+, openscenegraph, openal, expat, cmake, apr, xz
 , curl
 }:
 let
-  version = "2020.3.6";
+  version = "2020.3.8";
   shortVersion = builtins.substring 0 6 version;
 in
 stdenv.mkDerivation rec {
@@ -13,13 +13,13 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/flightgear/release-${shortVersion}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-7D7KRNIffgUr6vwbni1XwW+8GtXwM6vJZ7V6/QLDVmk=";
+    sha256 = "sha256-UXcWV9MPu7c+QlFjrhxtQ6ruAcxuKtewwphu4tt5dWc=";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ plib freeglut xorgproto libX11 libXext libXi
                   libICE libSM libXt libXmu libGLU libGL boost zlib libjpeg freealut
-                  openscenegraph openal expat apr curl ];
+                  openscenegraph openal expat apr curl xz ];
 
   meta = with lib; {
     description = "Simulation construction toolkit";

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -6,15 +6,15 @@
 }:
 
 let
-  version = "2020.3.4";
+  version = "2020.3.8";
   shortVersion = builtins.substring 0 6 version;
   data = stdenv.mkDerivation rec {
     pname = "flightgear-data";
     inherit version;
 
     src = fetchurl {
-      url = "mirror://sourceforge/flightgear/release-${shortVersion}/FlightGear-${version}-data.tar.bz2";
-      sha256 = "1cqikbqvidfaynml9bhqfr9yw5ga35gpqrbz62z94a1skdijkpkg";
+      url = "mirror://sourceforge/flightgear/release-${shortVersion}/FlightGear-${version}-data.txz";
+      sha256 = "sha256-/KFumHRkmRvsU/L1i11jG/KbqobnOEP7l4lyPMKHycA=";
     };
 
     phases = [ "installPhase" ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/flightgear/release-${shortVersion}/${pname}-${version}.tar.bz2";
-    sha256 = "02d9h10p8hyn0a25csragj6pbwmrir1z8zb92023s9vi21j7bwy8";
+    sha256 = "XXDqhZ9nR+FwQ3LauZe8iGxOjlyDXDrEtj61BQGVDYc=";
   };
 
   # Of all the files in the source and data archives, there doesn't seem to be


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Flightgear 2020.4.7 added streaming download of OSM building

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested:
building openstreetmap scenery, according to the wiki.yasim-proptest print a crude error message due to not having input arguments.
