### PR TITLE
looking-glass-client: B2 -> B3

### DIFF
--- a/pkgs/applications/virtualization/looking-glass-client/0001-client-all-fix-more-maybe-uninitialized-when-O3-is-i.patch
+++ b/pkgs/applications/virtualization/looking-glass-client/0001-client-all-fix-more-maybe-uninitialized-when-O3-is-i.patch
@@ -1,0 +1,45 @@
+From 95a7293b30ff7b89d615daea00269ed32f4b70a2 Mon Sep 17 00:00:00 2001
+From: Geoffrey McRae <geoff@hostfission.com>
+Date: Tue, 23 Feb 2021 20:25:30 +1100
+Subject: [PATCH] [client] all: fix more `maybe-uninitialized` when `-O3` is in
+ use
+
+Closes #475
+---
+ client/renderers/EGL/egl.c | 3 ++-
+ client/src/main.c          | 5 +++--
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/client/renderers/EGL/egl.c b/client/renderers/EGL/egl.c
+index b7a5644..72ce50d 100644
+--- a/client/renderers/EGL/egl.c
++++ b/client/renderers/EGL/egl.c
+@@ -271,7 +271,8 @@ static void egl_calc_mouse_size(struct Inst * this)
+   if (!this->formatValid)
+     return;
+ 
+-  int w, h;
++  int w  = 0, h = 0;
++
+   switch(this->format.rotate)
+   {
+     case LG_ROTATE_0:
+diff --git a/client/src/main.c b/client/src/main.c
+index f05e929..f5d6fad 100644
+--- a/client/src/main.c
++++ b/client/src/main.c
+@@ -186,8 +186,9 @@ static void updatePositionInfo(void)
+   if (!g_state.haveSrcSize)
+     goto done;
+ 
+-  float srcW;
+-  float srcH;
++  float srcW = 0.0f;
++  float srcH = 0.0f;
++
+   switch(params.winRotate)
+   {
+     case LG_ROTATE_0:
+-- 
+2.30.1
+

--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -1,17 +1,18 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config, SDL2, SDL2_ttf, spice-protocol
 , fontconfig, libX11, freefont_ttf, nettle, libpthreadstubs, libXau, libXdmcp
-, libXi, libXext, wayland, libffi, libGLU, expat, libbfd
+, libXi, libXext, wayland, wayland-protocols, libffi, libGLU, libXScrnSaver
+, expat, libbfd
 }:
 
 stdenv.mkDerivation rec {
   pname = "looking-glass-client";
-  version = "B2";
+  version = "B3";
 
   src = fetchFromGitHub {
     owner = "gnif";
     repo = "LookingGlass";
     rev = version;
-    sha256 = "100b5kzh8gr81kzw5fdqz2jsms25hv3815d31vy3qd6lrlm5gs3d";
+    sha256 = "1vmabjzn85p0brdian9lbpjq39agzn8k0limn8zjm713lh3n3c0f";
     fetchSubmodules = true;
   };
 
@@ -19,9 +20,17 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     SDL2 SDL2_ttf spice-protocol fontconfig libX11 freefont_ttf nettle
-    libpthreadstubs libXau libXdmcp libXi libXext wayland libffi libGLU expat
-    libbfd
+    libpthreadstubs libXau libXdmcp libXi libXext wayland wayland-protocols
+    libffi libGLU libXScrnSaver expat libbfd
   ];
+
+  patches = [
+    # error: ‘h’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+    # Fixed upstream in master in 8771103abbfd04da9787dea760405364af0d82de, but not in B3.
+    # Including our own patch here since upstream commit patch doesnt apply cleanly on B3
+    ./0001-client-all-fix-more-maybe-uninitialized-when-O3-is-i.patch
+  ];
+  patchFlags = "-p2";
 
   sourceRoot = "source/client";
   NIX_CFLAGS_COMPILE = "-mavx"; # Fix some sort of AVX compiler problem.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bump to latest version. Release notes [here](https://github.com/gnif/LookingGlass/releases/tag/B3). Tested working with the matching B3 version on a windows guest VM.

CC @alexbakker

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
