### PR TITLE
kernel: Remove CONFIG_BLK_DEV_RAM=y (remove /dev/ram* devices)

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -715,7 +715,6 @@ let
       MD                 = yes;     # Device mapper (RAID, LVM, etc.)
 
       # Enable initrd support.
-      BLK_DEV_RAM       = yes;
       BLK_DEV_INITRD    = yes;
 
       PM_TRACE_RTC         = no; # Disable some expensive (?) features.


### PR DESCRIPTION
The option CONFIG_BLK_DEV_RAM allows to use portions of the system RAM as block devices. It was configured to 'y' (built-in, therefore not unloadable or reconfigurable) and created 16 4MB RAM disks which, to my knowledge, currently have no purpose in NixOS.

Removing the option restores it to it's default value of 'm', which enables it to be loaded at runtime (which is also required to be able to change it's configuration without rebuilding the kernel).

I cannot find any use of the the `/dev/ram*` devices throughout the NixOS codebase, and given that size and count are left unconfigured I'm pretty sure this is a relic of a very old kernel configuration.

The documentation mentions "It is usually used to load and store a copy of a minimal root file system off of a floppy into RAM during the initial install of Linux." but I'm very sure we are *not* loading our initrd into a 4MB BD :grin: 

###### Motivation for the change

I was using `fdisk -l`, wondered for the 42th time where all the ramdisks came from and decided to find out.
Apparently [Ubuntu had the same problem once](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1593293).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/marvin opt-in
/status awaiting_reviewer