### PR TITLE
coqPackages.tlc: 20200328 → 20210316

### DIFF
--- a/pkgs/development/coq-modules/tlc/default.nix
+++ b/pkgs/development/coq-modules/tlc/default.nix
@@ -1,18 +1,18 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+with lib; (mkCoqDerivation {
   pname = "tlc";
   owner = "charguer";
   inherit version;
   displayVersion = { tlc = false; };
   defaultVersion = with versions; switch coq.coq-version [
+    { case = range "8.12" "8.13"; out = "20210316"; }
     { case = range "8.10" "8.12"; out = "20200328"; }
     { case = range "8.6"  "8.12"; out = "20181116"; }
   ] null;
+  release."20210316".sha256 = "1hlavnx20lxpf2iydbbxqmim9p8wdwv4phzp9ypij93yivih0g4a";
   release."20200328".sha256 = "16vzild9gni8zhgb3qhmka47f8zagdh03k6nssif7drpim8233lx";
   release."20181116".sha256 = "032lrbkxqm9d3fhf6nv1kq2z0mqd3czv3ijlbsjwnfh12xck4vpl";
-
-  installFlags = [ "CONTRIB=$(out)/lib/coq/${coq.coq-version}/user-contrib" ];
 
   meta = {
     homepage = "http://www.chargueraud.org/softs/tlc/";
@@ -20,4 +20,10 @@ with lib; mkCoqDerivation {
     license = licenses.free;
     maintainers = [ maintainers.vbgl ];
   };
-}
+}).overrideAttrs (x:
+  if versionAtLeast x.version "20210316"
+  then {}
+  else {
+    installFlags = [ "CONTRIB=$(out)/lib/coq/${coq.coq-version}/user-contrib" ];
+  }
+)


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.13

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
