### PR TITLE
qt5.qtwebengine, webkitgtk: try harder to avoid timeouts

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -236,6 +236,8 @@ qtModule {
     sed 's/${lib.head (lib.splitString "-" version)} /${qtCompatVersion} /' -i "$out"/lib/cmake/*/*Config.cmake
   '';
 
+  requiredSystemFeatures = [ "big-parallel" ];
+
   meta = with lib; {
     description = "A web engine based on the Chromium web browser";
     maintainers = with maintainers; [ matthewbauer ];

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -177,6 +177,8 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
+  requiredSystemFeatures = [ "big-parallel" ];
+
   meta = {
     description = "Web content rendering engine, GTK port";
     homepage = "https://webkitgtk.org/";


### PR DESCRIPTION
I hope this will improve the situation on aarch64-linux.
I don't think it could make anything worse.
Recent staging-next timeouts:
https://hydra.nixos.org/build/141551270
https://hydra.nixos.org/build/141547098