### PR TITLE
cudnn_cudatoolkit_11_0: 8.1.0 -> 8.1.1

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -58,7 +58,7 @@ in rec {
     # 8.1.0 is compatible with CUDA 11.0, 11.1, and 11.2:
     # https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
     srcName = "cudnn-11.2-linux-x64-v8.1.1.33.tgz";
-    sha256 = "sha256-mKh4TpKGLyABjSDCgbMNSgzZUfk2lPZDPM9K6cUCumo=";
+    hash = "sha256-mKh4TpKGLyABjSDCgbMNSgzZUfk2lPZDPM9K6cUCumo=";
   };
 
   cudnn_cudatoolkit_11_1 = cudnn_cudatoolkit_11_0.override {

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -53,12 +53,12 @@ in rec {
   cudnn_cudatoolkit_10 = cudnn_cudatoolkit_10_2;
 
   cudnn_cudatoolkit_11_0 = generic rec {
-    version = "8.1.0";
+    version = "8.1.1";
     cudatoolkit = cudatoolkit_11_0;
     # 8.1.0 is compatible with CUDA 11.0, 11.1, and 11.2:
     # https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
-    srcName = "cudnn-11.2-linux-x64-v8.1.0.77.tgz";
-    sha256 = "sha256-2+gvrwcdkbqbzwBIAUatM/RiSC3+5WyvRHnBuNq+Pss=";
+    srcName = "cudnn-11.2-linux-x64-v8.1.1.33.tgz";
+    sha256 = "sha256-mKh4TpKGLyABjSDCgbMNSgzZUfk2lPZDPM9K6cUCumo=";
   };
 
   cudnn_cudatoolkit_11_1 = cudnn_cudatoolkit_11_0.override {

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -1,7 +1,10 @@
 { version
 , srcName
-, sha256
+, hash ? null
+, sha256 ? null
 }:
+
+assert (hash != null) || (sha256 != null);
 
 { stdenv
 , lib
@@ -22,11 +25,13 @@ stdenv.mkDerivation {
   name = "cudatoolkit-${cudatoolkit.majorVersion}-cudnn-${version}";
 
   inherit version;
-  src = fetchurl {
+
+  src = let
+    hash_ = if hash != null then { inherit hash; } else { inherit sha256; };
+  in fetchurl ({
     # URL from NVIDIA docker containers: https://gitlab.com/nvidia/cuda/blob/centos7/7.0/runtime/cudnn4/Dockerfile
     url = "https://developer.download.nvidia.com/compute/redist/cudnn/v${version}/${srcName}";
-    inherit sha256;
-  };
+  } // hash_);
 
   nativeBuildInputs = [ addOpenGLRunpath ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog:

https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html#rel-811

Also change the builder to accept the `hash` argument for SRI hashes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
