### PR TITLE
[20.09] python3Packages.pikepdf: add patch for CVE-2021-29421

### DIFF
--- a/pkgs/development/python-modules/pikepdf/1.18.0-CVE-2021-29421.patch
+++ b/pkgs/development/python-modules/pikepdf/1.18.0-CVE-2021-29421.patch
@@ -1,0 +1,106 @@
+Based on upstream 3f38f73218e5e782fe411ccbb3b44a793c0b343a, modified by ris to make
+the added test apply cleanly
+
+diff --git a/src/pikepdf/_xml.py b/src/pikepdf/_xml.py
+new file mode 100644
+index 0000000..f0e1c38
+--- /dev/null
++++ b/src/pikepdf/_xml.py
+@@ -0,0 +1,30 @@
++# This Source Code Form is subject to the terms of the Mozilla Public
++# License, v. 2.0. If a copy of the MPL was not distributed with this
++# file, You can obtain one at http://mozilla.org/MPL/2.0/.
++#
++# Copyright (C) 2021, James R. Barlow (https://github.com/jbarlow83/)
++
++
++from typing import IO, Any, AnyStr, Union
++
++from lxml.etree import XMLParser as _UnsafeXMLParser
++from lxml.etree import parse as _parse
++
++
++class _XMLParser(_UnsafeXMLParser):
++    def __init__(self, *args, **kwargs):
++        # Prevent XXE attacks
++        # https://rules.sonarsource.com/python/type/Vulnerability/RSPEC-2755
++        kwargs['resolve_entities'] = False
++        kwargs['no_network'] = True
++        super().__init__(*args, **kwargs)
++
++
++def parse_xml(source: Union[AnyStr, IO[Any]], recover: bool = False):
++    """Wrapper around lxml's parse to provide protection against XXE attacks."""
++
++    parser = _XMLParser(recover=recover, remove_pis=False)
++    return _parse(source, parser=parser)
++
++
++__all__ = ['parse_xml']
+diff --git a/src/pikepdf/models/metadata.py b/src/pikepdf/models/metadata.py
+index 086eed1..9cb2203 100644
+--- a/src/pikepdf/models/metadata.py
++++ b/src/pikepdf/models/metadata.py
+@@ -26,10 +26,11 @@
+ from warnings import warn
+ 
+ from lxml import etree
+-from lxml.etree import QName, XMLParser, XMLSyntaxError, parse
++from lxml.etree import QName, XMLSyntaxError
+ 
+ from .. import Name, Stream, String
+ from .. import __version__ as pikepdf_version
++from .._xml import parse_xml
+ 
+ if sys.version_info < (3, 9):  # pragma: no cover
+     from typing import Iterable, MutableMapping
+@@ -413,14 +414,13 @@ def _load_from(self, data: bytes) -> None:
+             data = XMP_EMPTY  # on some platforms lxml chokes on empty documents
+ 
+         def basic_parser(xml):
+-            return parse(BytesIO(xml))
++            return parse_xml(BytesIO(xml))
+ 
+         def strip_illegal_bytes_parser(xml):
+-            return parse(BytesIO(re_xml_illegal_bytes.sub(b'', xml)))
++            return parse_xml(BytesIO(re_xml_illegal_bytes.sub(b'', xml)))
+ 
+         def recovery_parser(xml):
+-            parser = XMLParser(recover=True)
+-            return parse(BytesIO(xml), parser)
++            return parse_xml(BytesIO(xml), recover=True)
+ 
+         def replace_with_empty_xmp(_xml=None):
+             log.warning("Error occurred parsing XMP, replacing with empty XMP.")
+diff --git a/tests/test_metadata.py b/tests/test_metadata.py
+index d27f9a4..d6f35a2 100644
+--- a/tests/test_metadata.py
++++ b/tests/test_metadata.py
+@@ -587,3 +587,27 @@ def test_exception_undoes_edits(graph):
+         UserWarning, match="no XMP equivalent"
+     ):
+         m.load_from_docinfo({'/AAPL:Example': pikepdf.Array([42])})
++
++
++def test_xxe(trivial, outdir):
++    secret = outdir / 'secret.txt'
++    secret.write_text("This is a secret")
++    trivial.Root.Metadata = Stream(
++        trivial,
++        b"""\
++<?xpacket begin='\xef\xbb\xbf' id='W5M0MpCehiHzreSzNTczkc9d'?>
++<!DOCTYPE rdf:RDF [<!ENTITY xxe SYSTEM "file://%s">]>
++<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='Image'>
++<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
++<note>
++<to>&xxe;</to>
++<from>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</from>
++</note>
++</rdf:RDF>
++</x:xmpmeta>
++<?xpacket end='w'?>
++    """
++        % os.fsencode(secret),
++    )
++    with trivial.open_metadata() as m:
++        assert 'This is a secret' not in str(m)

--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -30,6 +30,10 @@ buildPythonPackage rec {
     sha256 = "4d0840a5c16b535f9b6e56fb4421a43f88760e6cabcf7fd44bdd0436107b61dc";
   };
 
+  patches = [
+    ./1.18.0-CVE-2021-29421.patch
+  ];
+
   buildInputs = [
     pybind11
     qpdf


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-29421

Going by version numbers this looks like a huge leap to backport a patch, but the patch is actually quite simple and applies cleanly apart from the addition of the new test, which simply has a trailing-content conflict, requiring the manual patch alteration.

Said test passes fine though, so I'm quite confident in the validity of this backport.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
