### PR TITLE
asterisk: 13.38.0 -> 13.38.2, 16.15.0 -> 16.17.0, 17.9.0 -> 17.9.3, 18.1.0 -> 18.3.0

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -105,8 +105,8 @@ in rec {
   asterisk = asterisk_18;
 
   asterisk_13 = common {
-    version = "13.38.0";
-    sha256 = "1kxff6pbry8nydkspi0mqllidz2lw3d3g3r127x8jwgx021x0rik";
+    version = "13.38.2";
+    sha256 = "1v7wgsa9vf7qycg3xpvmn2bkandkfh3x15pr8ylg0w0gvfkkf5b9";
     externals = {
       "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;
@@ -114,8 +114,8 @@ in rec {
   };
 
   asterisk_16 = common {
-    version = "16.15.0";
-    sha256 = "12nc7ywm6w1xyn720kdc1sqz5wkjjrkxr25wisl02f4v5wz8py7m";
+    version = "16.17.0";
+    sha256 = "1bzlsk9k735qf8a693b6sa548my7m9ahavmdicwmc14px70wrvnw";
     externals = {
       "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;
@@ -123,8 +123,8 @@ in rec {
   };
 
   asterisk_17 = common {
-    version = "17.9.0";
-    sha256 = "1fnm1z7g45m883ivkm36r4kqb7163bzazi70mwf0fc2rc28jd1z4";
+    version = "17.9.3";
+    sha256 = "0nhk0izrxx24pz806fwnhidjmciwrkcrsvxvhrdvibiqyvfk8yk7";
     externals = {
       "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;
@@ -132,8 +132,8 @@ in rec {
   };
 
   asterisk_18 = common {
-    version = "18.1.0";
-    sha256 = "1pq2nrf60xnvh2h1rv82bdfbxxxd277g68xas0vbfgr4531gc4nc";
+    version = "18.3.0";
+    sha256 = "1xb953i9ay82vcdv8izi5dd5xnspcsvg10ajiyph377jw2xnd5fb";
     externals = {
       "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -74,7 +74,7 @@ let
     meta = with lib; {
       description = "Software implementation of a telephone private branch exchange (PBX)";
       homepage = "https://www.asterisk.org/";
-      license = licenses.gpl2;
+      license = licenses.gpl2Only;
       maintainers = with maintainers; [ auntie DerTim1 yorickvp ];
     };
   };


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Security fixes. Please backport.

Fixes #116855, #116856, #116857, #116858

I don't currently run asterisk, so I've only tested the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
