### PR TITLE
mpir: Add --enable-fat build option

### DIFF
--- a/pkgs/development/libraries/mpir/default.nix
+++ b/pkgs/development/libraries/mpir/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ m4 which yasm ];
 
   src = fetchurl {
-    url = "http://mpir.org/mpir-${version}.tar.bz2";
+    url = "https://mpir.org/mpir-${version}.tar.bz2";
     sha256 = "1fvmhrqdjs925hzr2i8bszm50h00gwsh17p2kn2pi51zrxck9xjj";
   };
 
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl3Plus;
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.unix;
-    downloadPage = "http://mpir.org/downloads.html";
-    homepage = "http://mpir.org/";
+    downloadPage = "https://mpir.org/downloads.html";
+    homepage = "https://mpir.org/";
     updateWalker = true;
   };
 }

--- a/pkgs/development/libraries/mpir/default.nix
+++ b/pkgs/development/libraries/mpir/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1fvmhrqdjs925hzr2i8bszm50h00gwsh17p2kn2pi51zrxck9xjj";
   };
 
-  configureFlags = [ "--enable-cxx --enable-fat" ];
+  configureFlags = [ "--enable-cxx" "--enable-fat" ];
 
   meta = {
     inherit version;

--- a/pkgs/development/libraries/mpir/default.nix
+++ b/pkgs/development/libraries/mpir/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1fvmhrqdjs925hzr2i8bszm50h00gwsh17p2kn2pi51zrxck9xjj";
   };
 
-  configureFlags = [ "--enable-cxx" ];
+  configureFlags = [ "--enable-cxx --enable-fat" ];
 
   meta = {
     inherit version;


### PR DESCRIPTION
Add --enable-fat to configuration options of mpir so that CPU-features of the build-machine are not relied upon in the library which may cause issues on older CPUs where these features are not present.

###### Motivation for this changeNixOS/nixpkgs/compare/master...polygon:mpir?expand=1

Programs using mpir can crash on older CPUs because newer CPU features from the build host are baked into the library due to CPU feature detection during build. This is also a major issue for reproducible builds since the outcome depends on the CPU architecture of the build machine.

In my case, using 'gqrx' failed with 'Illegal Instruction' because a SHRX instruction was not available. See the following Github issues and Reddit threads where this was discussed:

https://github.com/NixOS/nixpkgs/issues/58950
https://www.reddit.com/r/NixOS/comments/msqvb1/illegal_instruction_with_binaries_from_nix_store/

The --enable-fat option builds a combined x86_64 and x86_32 binary with runtime CPU feature detection which should alleviate these issues. On other CPU architectures, this will not change the build (according to documentation, untested)

###### Things done

I've built the binaries on a newer build-host and transferred them using `nix copy` to an old machine. Without this patch, the binaries crash on the old machine. With the patch, the binaries work on the old machine.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
