### PR TITLE
netbsd.sys: fix build

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/builder.sh
+++ b/pkgs/os-specific/bsd/netbsd/builder.sh
@@ -105,9 +105,10 @@ moveUsrDir() {
   if [ -d $prefix ]; then
     # Remove lingering /usr references
     if [ -d $prefix/usr ]; then
-      cd $prefix/usr
+      pushd $prefix/usr
       find . -type d -exec mkdir -p $out/\{} \;
       find . \( -type f -o -type l \) -exec mv \{} $out/\{} \;
+      popd
     fi
 
     find $prefix -type d -empty -delete

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -379,6 +379,13 @@ let
       (fetchNetBSD "tools/Makefile.host" "8.0" "1p23dsc4qrv93vc6gzid9w2479jwswry9qfn88505s0pdd7h6nvp")
     ];
   };
+
+  uudecode = mkDerivation {
+    path = "usr.bin/uudecode";
+    version = "8.0";
+    sha256 = "00a3zmh15pg4vx6hz0kaa5mi8d2b1sj4h512d7p6wbvxq6mznwcn";
+    NIX_CFLAGS_COMPILE = lib.optional stdenv.isLinux "-DNO_BASE64";
+  };
   ##
   ## END COMMAND LINE TOOLS
   ##

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -417,6 +417,7 @@ let
     version = "8.0";
     sha256 = "123ilg8fqmp69bw6bs6nh98fpi1v2n9lamrzar61p27ji6sj7g0w";
     propagatedBuildInputs = [ include ];
+    nativeBuildInputs = [ makeMinimal install tsort lorder statHook uudecode ];
     #meta.platforms = lib.platforms.netbsd;
     extraPaths = [ common.src ];
     MKKMOD = "no";

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -418,7 +418,7 @@ let
     sha256 = "123ilg8fqmp69bw6bs6nh98fpi1v2n9lamrzar61p27ji6sj7g0w";
     propagatedBuildInputs = [ include ];
     nativeBuildInputs = [ makeMinimal install tsort lorder statHook uudecode ];
-    #meta.platforms = lib.platforms.netbsd;
+    meta.platforms = lib.platforms.netbsd;
     extraPaths = [ common.src ];
     MKKMOD = "no";
     makeFlags = [ "FIRMWAREDIR=$(out)/libdata/firmware" ];

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -421,6 +421,7 @@ let
     #meta.platforms = lib.platforms.netbsd;
     extraPaths = [ common.src ];
     MKKMOD = "no";
+    makeFlags = [ "FIRMWAREDIR=$(out)/libdata/firmware" ];
   };
 
   headers = symlinkJoin {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tested with

    nix-build -A pkgsCross.x86_64-netbsd.netbsd.sys

I haven't tested what happens if I try to build it on Linux without going through pkgsCross.

Note that despite the comment above the package definition, this is **not** the full NetBSD kernel, only the headers, firmware and bootloader.  I would like it to also build the kernel, but haven't managed to get that working yet (but I'm probably close).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
