### PR TITLE
screenkey: 1.2 -> 1.4

### DIFF
--- a/pkgs/applications/video/screenkey/default.nix
+++ b/pkgs/applications/video/screenkey/default.nix
@@ -1,9 +1,7 @@
 { lib
 , fetchFromGitLab
 # native
-, intltool
 , wrapGAppsHook
-, file
 # not native
 , xorg
 , gobject-introspection
@@ -13,22 +11,16 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "screenkey";
-  version = "1.2";
+  version = "1.4";
 
   src = fetchFromGitLab {
     owner = "screenkey";
     repo = "screenkey";
     rev = "v${version}";
-    sha256 = "1x13n57iy2pg3h3r994q3g5nbmh2gwk3qidmmcv0g7qa89n2gwbj";
+    sha256 = "1rfngmkh01g5192pi04r1fm7vsz6hg9k3qd313sn9rl9xkjgp11l";
   };
 
   nativeBuildInputs = [
-    python3.pkgs.distutils_extra
-    # Shouldn't be needed once https://gitlab.com/screenkey/screenkey/-/issues/122 is fixed.
-    intltool
-    # We are not sure why is this needed, but without it we get "file: command
-    # not found" errors during build.
-    file
     wrapGAppsHook
     # for setup hook
     gobject-introspection
@@ -39,6 +31,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
+    Babel
     pycairo
     pygobject3
   ];


### PR DESCRIPTION
Thankfully some weird dependencies have been dropped in the new
releases.

###### Motivation for this change
The new version fixes a bug I encountered.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
