### PR TITLE
taskwarrior-tui: 0.10.4 -> 0.13.12

### DIFF
--- a/pkgs/applications/misc/taskwarrior-tui/default.nix
+++ b/pkgs/applications/misc/taskwarrior-tui/default.nix
@@ -1,6 +1,8 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, makeWrapper
+, taskwarrior
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -16,6 +18,11 @@ rustPlatform.buildRustPackage rec {
 
   # Because there's a test that requires terminal access
   doCheck = false;
+
+  nativeBuildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/taskwarrior-tui --prefix PATH : "${lib.makeBinPath [ taskwarrior ]}"
+  '';
 
   cargoSha256 = "1sk0xlbllgpc5sawbr88mpwyyl2yrl5qsbj46ih38q8f4hfp365n";
 

--- a/pkgs/applications/misc/taskwarrior-tui/default.nix
+++ b/pkgs/applications/misc/taskwarrior-tui/default.nix
@@ -5,19 +5,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "taskwarrior-tui";
-  version = "0.10.4";
+  version = "0.13.12";
 
   src = fetchFromGitHub {
     owner = "kdheepak";
     repo = "taskwarrior-tui";
     rev = "v${version}";
-    sha256 = "1rs6xpnmqzp45jkdzi8x06i8764gk7zl86sp6s0hiirbfqf7vwsy";
+    sha256 = "0q38vb7sqip18wv2d1m95bb8y0y187rqcdfcx551rgvan4x4jq70";
   };
 
   # Because there's a test that requires terminal access
   doCheck = false;
 
-  cargoSha256 = "0xblxsp7jgqbb3kr5k7yy6ziz18a8wlkrhls0vz9ak2n0ngddg3r";
+  cargoSha256 = "1sk0xlbllgpc5sawbr88mpwyyl2yrl5qsbj46ih38q8f4hfp365n";
 
   meta = with lib; {
     description = "A terminal user interface for taskwarrior ";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update package to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
