### PR TITLE
zrepl: 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/tools/backup/zrepl/default.nix
+++ b/pkgs/tools/backup/zrepl/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "zrepl";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "zrepl";
     repo = "zrepl";
     rev = "v${version}";
-    sha256 = "sha256-wtUL8GGSJxn9yEdyTWKtkHODfxxLOxojNPlPLRjI9xo=";
+    sha256 = "5Bp8XGCjibDJgeAjW98rcABuddI+CV4Fh3hFJaKKwbo=";
   };
 
-  vendorSha256 = "sha256-4LBX0bD8qirFaFkV52QFU50lEW4eae6iObIa5fFT/wA=";
+  vendorSha256 = "MwmYiK2z7ZK5kKBZV7K6kCZRSd7v5Sgjoih1eeOh6go=";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
https://github.com/zrepl/zrepl/compare/v0.3.1...v0.4.0

Most notably (IMO), a new status UI!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
