### PR TITLE
netbeans: Enable antialiasing for texts in NetBeans IDE

### DIFF
--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -36,7 +36,8 @@ stdenv.mkDerivation {
     makeWrapper $out/netbeans/bin/netbeans $out/bin/netbeans \
       --prefix PATH : ${lib.makeBinPath [ jdk which ]} \
       --prefix JAVA_HOME : ${jdk.home} \
-      --add-flags "--jdkhome ${jdk.home}"
+      --add-flags "--jdkhome ${jdk.home} \
+      -J-Dawt.useSystemAAFontSettings=on -J-Dswing.aatext=true"
 
     # Extract pngs from the Apple icon image and create
     # the missing ones from the 1024x1024 image.


### PR DESCRIPTION
###### Motivation for this change
Previously anti antialiasing was disabled which makes it harder to read the entire IDE. This change enables anti aliasing for   

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 asbachb@nixo-t14s  ~/dev/src/nix/nixpkgs   enable-anatialising-netbeans  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (3.00 MiB download, 14.20 MiB unpacked):
  /nix/store/14cb3i39hz9pjslk7wfr82bvilgdl2rx-nixpkgs-review-2.5.0
  /nix/store/629aa8phfs5pc1sqda27sa0yf3750r0q-nix-2.4pre20210326_dd77f71
  /nix/store/a1ydkn0b99wbxvlvs6wcmgwkvq51bkfq-libcpuid-0.5.1
  /nix/store/k51bp7462c4xdhyfq0ph69xqmp2r50ig-lowdown-0.8.3-lib
  /nix/store/x6swbw1rr96mfpzn4ap552vqxl5ywvc2-nix-2.4pre20210326_dd77f71-man
copying path '/nix/store/x6swbw1rr96mfpzn4ap552vqxl5ywvc2-nix-2.4pre20210326_dd77f71-man' from 'https://cache.nixos.org'...
copying path '/nix/store/a1ydkn0b99wbxvlvs6wcmgwkvq51bkfq-libcpuid-0.5.1' from 'https://cache.nixos.org'...
copying path '/nix/store/k51bp7462c4xdhyfq0ph69xqmp2r50ig-lowdown-0.8.3-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/629aa8phfs5pc1sqda27sa0yf3750r0q-nix-2.4pre20210326_dd77f71' from 'https://cache.nixos.org'...
copying path '/nix/store/14cb3i39hz9pjslk7wfr82bvilgdl2rx-nixpkgs-review-2.5.0' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 54, done.
remote: Counting objects: 100% (53/53), done.
remote: Compressing objects: 100% (38/38), done.
remote: Total 54 (delta 23), reused 26 (delta 13), pack-reused 1
Unpacking objects: 100% (54/54), 242.23 KiB | 363.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   e3597057e72..fd6370f9e7c  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-a68d6172b810405a90e9605cef60263a186c7f84-dirty/nixpkgs fd6370f9e7c5badc10dea5597ae34409c7396610
Preparing worktree (detached HEAD fd6370f9e7c)
Updating files: 100% (25458/25458), done.
HEAD is now at fd6370f9e7c Merge pull request #119774 from Hoverbear/languageclient-neovim-0.1.161
$ nix-env -f /home/asbachb/.cache/nixpkgs-review/rev-a68d6172b810405a90e9605cef60263a186c7f84-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
