### PR TITLE
brscan4: 0.4.9-1 -> 0.4.10-1

### DIFF
--- a/pkgs/applications/graphics/sane/backends/brscan4/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan4/default.nix
@@ -11,16 +11,15 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "brscan4";
-  version = "0.4.9-1";
+  version = "0.4.10-1";
   src = {
     "i686-linux" = fetchurl {
       url = "http://download.brother.com/welcome/dlf006646/${pname}-${version}.i386.deb";
-      sha256 = "0pkg9aqvnkpjnb9cgzf7lxw2g4jqrf2w98irkv22r0gfsfs3nwma";
+      sha256 = "sha256-ymIAg+rfSYP5uzsAM1hUYZacJ0PXmKEoljNtb0pgGMw=";
     };
     "x86_64-linux" = fetchurl {
-
       url = "https://download.brother.com/welcome/dlf006645/${pname}-${version}.amd64.deb";
-      sha256 = "0kakkl8rmsi2yr3f8vd1kk8vsl9g2ijhqil1cvvbwrhwgi0b7ai7";
+      sha256 = "sha256-Gpr5456MCNpyam3g2qPo7S3aEZFMaUGR8bu7YmRY8xk=";
     };
   }."${stdenv.hostPlatform.system}";
 

--- a/pkgs/applications/graphics/sane/backends/brscan4/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan4/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libusb-compat-0_1 ];
   dontBuild = true;
 
-  patchPhase = ''
+  postPatch = ''
     ${myPatchElf "opt/brother/scanner/brscan4/brsaneconfig4"}
 
     RPATH=${libusb-compat-0_1.out}/lib
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = with lib; ''
+    runHook preInstall
     PATH_TO_BRSCAN4="opt/brother/scanner/brscan4"
     mkdir -p $out/$PATH_TO_BRSCAN4
     cp -rp $PATH_TO_BRSCAN4/* $out/$PATH_TO_BRSCAN4
@@ -78,6 +79,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/etc/udev/rules.d
     cp -p ${udevRules}/etc/udev/rules.d/*.rules \
       $out/etc/udev/rules.d
+    runHook postInstall
   '';
 
   dontStrip = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The previous driver is not longer available from the Brother website.

###### Things done

Tested with my Brother scanner.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
