### PR TITLE
netbsd.sys: actually build the kernel

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -433,12 +433,35 @@ let
     path = "sys";
     version = "8.0";
     sha256 = "123ilg8fqmp69bw6bs6nh98fpi1v2n9lamrzar61p27ji6sj7g0w";
+
+    CONFIG = "GENERIC";
+
     propagatedBuildInputs = [ include ];
-    nativeBuildInputs = [ makeMinimal install tsort lorder statHook uudecode ];
+    nativeBuildInputs = [
+      makeMinimal install tsort lorder statHook uudecode config genassym
+    ];
+
+    postConfigure = ''
+      pushd arch/$MACHINE/conf
+      config $CONFIG
+      popd
+    '';
+
+    makeFlags = [ "FIRMWAREDIR=$(out)/libdata/firmware" ];
+    hardeningDisable = [ "pic" ];
+    MKKMOD = "no";
+    NIX_CFLAGS_COMPILE = [ "-Wa,--no-warn" ];
+
+    postBuild = ''
+      make -C arch/$MACHINE/compile/$CONFIG $makeFlags
+    '';
+
+    postInstall = ''
+      cp arch/$MACHINE/compile/$CONFIG/netbsd $out
+    '';
+
     meta.platforms = lib.platforms.netbsd;
     extraPaths = [ common.src ];
-    MKKMOD = "no";
-    makeFlags = [ "FIRMWAREDIR=$(out)/libdata/firmware" ];
   };
 
   headers = symlinkJoin {

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -386,6 +386,13 @@ let
     sha256 = "00a3zmh15pg4vx6hz0kaa5mi8d2b1sj4h512d7p6wbvxq6mznwcn";
     NIX_CFLAGS_COMPILE = lib.optional stdenv.isLinux "-DNO_BASE64";
   };
+
+  cksum = mkDerivation {
+    path = "usr.bin/cksum";
+    version = "8.0";
+    sha256 = "0327820171djn9dzb2q1arypxw2zsxiixnd1ahy34dagd9cwcphj";
+    meta.platforms = lib.platforms.netbsd;
+  };
   ##
   ## END COMMAND LINE TOOLS
   ##

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -393,6 +393,16 @@ let
     sha256 = "0327820171djn9dzb2q1arypxw2zsxiixnd1ahy34dagd9cwcphj";
     meta.platforms = lib.platforms.netbsd;
   };
+
+  config = mkDerivation {
+    path = "usr.bin/config";
+    version = "8.0";
+    sha256 = "0piyn8lgdqxwz9wkgc2plzp2xpj93fs4xncri8l0jfas9rv5j2m5";
+    NIX_CFLAGS_COMPILE = [ "-DMAKE_BOOTSTRAP" ];
+    buildInputs = [ compat ];
+    nativeBuildInputs = [ makeMinimal install mandoc byacc flex ];
+    extraPaths = [ cksum.src ];
+  };
   ##
   ## END COMMAND LINE TOOLS
   ##


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

netbsd.sys: actually build the kernel

Before, we were only building the headers, firmware, and bootloader.

CONFIG could be overridden to use another pre-defined kernel, but
there's no way to pass a custom kernel configuration yet.

Tested booting the built kernel in a NetBSD VM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
