### PR TITLE
lib.systems.doubles.all: reorganize

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -6,43 +6,51 @@ let
   inherit (lib.attrsets) matchAttrs;
 
   all = [
-    "aarch64-linux"
-    "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux"
+    # Cygwin
+    "i686-cygwin" "x86_64-cygwin"
 
-    "mipsel-linux"
-
-    "i686-cygwin" "i686-freebsd" "i686-linux" "i686-netbsd" "i686-openbsd"
-
-    "x86_64-cygwin" "x86_64-freebsd" "x86_64-linux"
-    "x86_64-netbsd" "x86_64-openbsd" "x86_64-solaris"
-
+    # Darwin
     "x86_64-darwin" "i686-darwin" "aarch64-darwin" "armv7a-darwin"
 
-    "x86_64-windows" "i686-windows"
+    # FreeBSD
+    "i686-freebsd" "x86_64-freebsd"
 
-    "wasm64-wasi" "wasm32-wasi"
+    # Genode
+    "aarch64-genode" "i686-genode" "x86_64-genode"
 
-    "x86_64-redox"
+    # illumos
+    "x86_64-solaris"
 
-    "powerpc64-linux"
-    "powerpc64le-linux"
-
-    "riscv32-linux" "riscv64-linux"
-
-    "arm-none" "armv6l-none" "aarch64-none"
-    "avr-none"
-    "i686-none" "x86_64-none"
-    "powerpc-none"
-    "msp430-none"
-    "riscv64-none" "riscv32-none"
-    "vc4-none"
-    "or1k-none"
-
-    "mmix-mmixware"
-
+    # JS
     "js-ghcjs"
 
-    "aarch64-genode" "i686-genode" "x86_64-genode"
+    # Linux
+    "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux"
+    "armv7l-linux" "i686-linux" "mipsel-linux" "powerpc64-linux"
+    "powerpc64le-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux"
+
+    # MMIXware
+    "mmix-mmixware"
+
+    # NetBSD
+    "i686-netbsd" "x86_64-netbsd"
+
+    # none
+    "aarch64-none" "arm-none" "armv6l-none" "avr-none" "i686-none" "msp430-none"
+    "or1k-none" "powerpc-none" "riscv32-none" "riscv64-none" "vc4-none"
+    "x86_64-none"
+
+    # OpenBSD
+    "i686-openbsd" "x86_64-openbsd"
+
+    # Redox
+    "x86_64-redox"
+
+    # WASI
+    "wasm64-wasi" "wasm32-wasi"
+
+    # Windows
+    "x86_64-windows" "i686-windows"
   ];
 
   allParsed = map parse.mkSystemFromString all;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The previous mess was partially grouped by OS, and partially grouped
by architecture, which made it very difficult to know where to add new
entries.

I've chosen to group by OS entirely, because OSes are likely to
maintain exhaustive lists of supported architectures, but it's far
less likely we'd be able to find exhaustive lists of supported OSes
for every architecture.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
