### PR TITLE
[20.09] python3Packages.bleach: add patches for CVE-2021-23980

### DIFF
--- a/pkgs/development/python-modules/bleach/3.1.5-CVE-2021-23980.patch
+++ b/pkgs/development/python-modules/bleach/3.1.5-CVE-2021-23980.patch
@@ -1,0 +1,85 @@
+Based on upstream 1334134d34397966a7f7cfebd38639e9ba2c680e, modified by ris to apply
+cleanly to 3.1.5
+
+--- a/bleach/html5lib_shim.py
++++ b/bleach/html5lib_shim.py
+@@ -25,7 +25,7 @@ from html5lib.filters.base import Filter
+ from bleach._vendor.html5lib.filters.sanitizer import allowed_protocols
+ from bleach._vendor.html5lib.filters.sanitizer import Filter as SanitizerFilter
+ from bleach._vendor.html5lib._inputstream import HTMLInputStream
+-from bleach._vendor.html5lib.serializer import HTMLSerializer
++from bleach._vendor.html5lib.serializer import escape, HTMLSerializer
+ from bleach._vendor.html5lib._tokenizer import HTMLTokenizer
+ from bleach._vendor.html5lib._trie import Trie
+ 
+--- a/bleach/sanitizer.py
++++ b/bleach/sanitizer.py
+@@ -371,6 +371,10 @@ def sanitize_token(self, token):
+ 
+         elif token_type == "Comment":
+             if not self.strip_html_comments:
++                # call lxml.sax.saxutils to escape &, <, and > in addition to " and '
++                token["data"] = html5lib_shim.escape(
++                    token["data"], entities={'"': "&quot;", "'": "&#x27;"}
++                )
+                 return token
+             else:
+                 return None
+diff --git a/tests/test_clean.py b/tests/test_clean.py
+index 1cd58df..7c56575 100644
+--- a/tests/test_clean.py
++++ b/tests/test_clean.py
+@@ -739,6 +739,53 @@ def test_namespace_rc_data_element_strip_false(
+     )
+ 
+ 
++@pytest.mark.parametrize(
++    "namespace_tag, end_tag, data, expected",
++    [
++        (
++            "math",
++            "p",
++            "<math></p><style><!--</style><img src/onerror=alert(1)>",
++            "<math><p></p><style><!--&lt;/style&gt;&lt;img src/onerror=alert(1)&gt;--></style></math>",
++        ),
++        (
++            "math",
++            "br",
++            "<math></br><style><!--</style><img src/onerror=alert(1)>",
++            "<math><br><style><!--&lt;/style&gt;&lt;img src/onerror=alert(1)&gt;--></style></math>",
++        ),
++        (
++            "svg",
++            "p",
++            "<svg></p><style><!--</style><img src/onerror=alert(1)>",
++            "<svg><p></p><style><!--&lt;/style&gt;&lt;img src/onerror=alert(1)&gt;--></style></svg>",
++        ),
++        (
++            "svg",
++            "br",
++            "<svg></br><style><!--</style><img src/onerror=alert(1)>",
++            "<svg><br><style><!--&lt;/style&gt;&lt;img src/onerror=alert(1)&gt;--></style></svg>",
++        ),
++    ],
++)
++def test_html_comments_escaped(namespace_tag, end_tag, data, expected):
++    # refs: bug 1689399 / GHSA-vv2x-vrpj-qqpq
++    #
++    # p and br can be just an end tag (e.g. </p> == <p></p>)
++    #
++    # In browsers:
++    #
++    # * img and other tags break out of the svg or math namespace (e.g. <svg><img></svg> == <svg><img></svg>)
++    # * style does not (e.g. <svg><style></svg> == <svg><style></style></svg>)
++    # * the breaking tag ejects trailing elements (e.g. <svg><img><style></style></svg> == <svg></svg><img><style></style>)
++    #
++    # the ejected elements can trigger XSS
++    assert (
++        clean(data, tags=[namespace_tag, end_tag, "style"], strip_comments=False)
++        == expected
++    )
++
++
+ def get_ids_and_tests():
+     """Retrieves regression tests from data/ directory
+ 

--- a/pkgs/development/python-modules/bleach/default.nix
+++ b/pkgs/development/python-modules/bleach/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , pytest
 , pytestrunner
 , six
@@ -17,6 +18,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b";
   };
+
+  patches = [
+    ./3.1.5-CVE-2021-23980.patch
+    (fetchpatch {
+      name = "CVE-2021-23980-extra-tests.patch";
+      url = "https://github.com/mozilla/bleach/commit/d398c89e54ced6b1039d3677689707456ba42dec.patch";
+      sha256 = "1p7z6y1kfj9kfvw7cwhxmzp0inv3i3h9vzvqgls6iz7j2dxq5s2j";
+    })
+  ];
 
   checkInputs = [ pytest pytestrunner ];
   propagatedBuildInputs = [ packaging six html5lib setuptools ];


### PR DESCRIPTION
###### Motivation for this change
https://security-tracker.debian.org/tracker/CVE-2021-23980
aka https://github.com/mozilla/bleach/security/advisories/GHSA-vv2x-vrpj-qqpq

Actual fix needed a little adjustment, but added tests applied cleanly. Fix is fairly simple and this is effectively the same as debian's patch (but not identical so couldn't reuse that). Added tests pass.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
