### PR TITLE
dwmblocks: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9191,6 +9191,12 @@
       fingerprint = "0EC3 FA89 EFBA B421 F82E  40B0 2567 6BCB FFAD 76B1";
     }];
   };
+  sophrosyne = {
+    email = "joshuaortiz@tutanota.com";
+    github = "sophrosyne97";
+    githubId = 53029739;
+    name = "Joshua Ortiz";
+  };
   sorki = {
     email = "srk@48.io";
     github = "sorki";

--- a/pkgs/applications/misc/dwmblocks/default.nix
+++ b/pkgs/applications/misc/dwmblocks/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, libX11, patches ? [ ], writeText, conf ? null }:
+
+stdenv.mkDerivation {
+  pname = "dwmblocks";
+  version = "unstable-2020-12-27";
+
+  src = fetchFromGitHub {
+    owner = "torrinfail";
+    repo = "dwmblocks";
+    rev = "96cbb453e5373c05372fd4bf3faacfa53e409067";
+    sha256 = "00lxfxsrvhm60zzqlcwdv7xkqzya69mgpi2mr3ivzbc8s9h8nwqx";
+  };
+
+  buildInputs = [ libX11 ];
+
+  inherit patches;
+
+  postPatch =
+    let
+      configFile =
+        if lib.isDerivation conf || builtins.isPath conf
+        then conf else writeText "blocks.def.h" conf;
+    in
+      lib.optionalString (conf != null) "cp ${configFile} blocks.def.h";
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Modular status bar for dwm written in c";
+    homepage = "https://github.com/torrinfail/dwmblocks";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sophrosyne ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22526,6 +22526,8 @@ in
 
   dwm = callPackage ../applications/window-managers/dwm { };
 
+  dwmblocks = callPackage ../applications/misc/dwmblocks { };
+
   dwm-status = callPackage ../applications/window-managers/dwm/dwm-status.nix { };
 
   dynamips = callPackage ../applications/virtualization/dynamips { };


### PR DESCRIPTION
 <!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
As a dwm user I find it convenient to use dwmblocks as a simple status bar to display system information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
