### PR TITLE
seren: init at 0.0.21

### DIFF
--- a/pkgs/applications/networking/instant-messengers/seren/default.nix
+++ b/pkgs/applications/networking/instant-messengers/seren/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchurl
+, alsaLib
+, libopus
+, libogg
+, gmp
+, ncurses
+}:
+
+stdenv.mkDerivation rec {
+  pname = "seren";
+  version = "0.0.21";
+
+  buildInputs = [ alsaLib libopus libogg gmp ncurses ];
+
+  src = fetchurl {
+    url = "http://holdenc.altervista.org/seren/downloads/${pname}-${version}.tar.gz";
+    sha256 = "sha256-adI365McrJkvTexvnWjMzpHcJkLY3S/uWfE8u4yuqho=";
+  };
+
+  meta = with lib; {
+    description = "A simple ncurses VoIP program based on the Opus codec";
+    longDescription = ''
+      Seren is a simple VoIP program based on the Opus codec
+      that allows you to create a voice conference from the terminal, with up to 10
+      participants, without having to register accounts, exchange emails, or add
+      people to contact lists. All you need to join an existing conference is the
+      host name or IP address of one of the participants.
+    '';
+    homepage = "http://holdenc.altervista.org/seren/";
+    changelog = "http://holdenc.altervista.org/seren/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ matthewcroughan nixinator ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11420,6 +11420,8 @@ in
     gputils = null;
   };
 
+  seren = callPackage ../applications/networking/instant-messengers/seren { };
+
   serialdv = callPackage ../development/libraries/serialdv {  };
 
   serpent = callPackage ../development/compilers/serpent { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds Seren, a great TUI/Ncurses VoIP app to nixpkgs

I compiled using `pkgsCross` for all of the listed `platforms`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
