### PR TITLE
mbedtls: 2.16.9 -> 2.26.0

### DIFF
--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -11,6 +11,10 @@
 
 stdenv.mkDerivation rec {
   pname = "mbedtls";
+  # Auto updates are disabled due to repology listing dev releases as release
+  # versions. See
+  #  * https://github.com/NixOS/nixpkgs/pull/119838#issuecomment-822100428
+  #  * https://github.com/NixOS/nixpkgs/commit/0ee02a9d42b5fe1825b0f7cee7a9986bb4ba975d
   version = "2.26.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mbedtls";
-  version = "2.16.9"; # nixpkgs-update: no auto update
+  version = "2.26.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "ARMmbed";
     repo = "mbedtls";
     rev = "${pname}-${version}";
-    sha256 = "0mz7n373b8d287crwi6kq2hb8ryyi228j38h25744lqai23qj5cf";
+    sha256 = "0scwpmrgvg6q7rvqkc352d2fqlsx0aylcbyibcp1f1rsn8iiif2m";
   };
 
   nativeBuildInputs = [ cmake ninja perl python3 ];
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [ "-DUSE_SHARED_MBEDTLS_LIBRARY=on" ];
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=format"
+    "-Wno-error=format-truncation"
+  ];
 
   meta = with lib; {
     homepage = "https://tls.mbed.org/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Progress in the julia packaging (https://github.com/NixOS/nixpkgs/pull/117881) has revealed that nixpkg's version of mbedtls is a few months old. Julia 1.6 now requires >= 2.24.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
