### PR TITLE
beets: assorted updates

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -105,13 +105,13 @@ in pythonPackages.buildPythonApplication rec {
   # unstable does not require bs1770gain[2].
   # [1]: https://discourse.beets.io/t/forming-a-beets-core-team/639
   # [2]: https://github.com/NixOS/nixpkgs/pull/90504
-  version = "unstable-2021-03-24";
+  version = "unstable-2021-04-17";
 
   src = fetchFromGitHub {
     owner = "beetbox";
     repo = "beets";
-    rev = "854b4ab48324afe8884fcd11fa47bd6258d2f4f7";
-    sha256 = "sha256-y5EWVNF4bd9fNvU6VkucMpenyFZuqdPkrqQDgG9ZPJY=";
+    rev = "50163b373f527d1b1f8b2442240ca547e846744e";
+    sha256 = "sha256-l7drav4Qx2JCF+F5OA0s641idcKM3S4Yx2lM2evJQWE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/tools/audio/beets/plugins/alternatives.nix
+++ b/pkgs/tools/audio/beets/plugins/alternatives.nix
@@ -2,13 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "beets-alternatives";
-  version = "0.10.2";
+  version = "unstable-2021-02-01";
 
   src = fetchFromGitHub {
     repo = "beets-alternatives";
     owner = "geigerzaehler";
-    rev = "v${version}";
-    sha256 = "1dsz94fb29wra1f9580w20bz2f1bgkj4xnsjgwgbv14flbfw4bp0";
+    rev = "288299e3aa9a1602717b04c28696fce5ce4259bf";
+    sha256 = "sha256-Xl7AHr33hXQqQDuFbWuj8HrIugeipJFPmvNXpCkU/mI=";
   };
 
   postPatch = ''
@@ -23,10 +23,10 @@ pythonPackages.buildPythonApplication rec {
     mock
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Beets plugin to manage external files";
     homepage = "https://github.com/geigerzaehler/beets-alternatives";
-    maintainers = [ lib.maintainers.aszlig ];
-    license = lib.licenses.mit;
+    maintainers = with maintainers; [ aszlig lovesegfault ];
+    license = licenses.mit;
   };
 }

--- a/pkgs/tools/audio/beets/plugins/copyartifacts.nix
+++ b/pkgs/tools/audio/beets/plugins/copyartifacts.nix
@@ -1,13 +1,14 @@
 { lib, fetchFromGitHub, beets, pythonPackages, glibcLocales }:
 
 pythonPackages.buildPythonApplication {
-  name = "beets-copyartifacts";
+  pname = "beets-copyartifacts";
+  version = "unstable-2020-02-15";
 
   src = fetchFromGitHub {
     repo = "beets-copyartifacts";
-    owner = "sbarakat";
-    rev = "d0bb75c8fc8fe125e8191d73de7ade6212aec0fd";
-    sha256 = "19b4lqq1p45n348ssmql60jylw2fw7vfj9j22nly5qj5qx51j3g5";
+    owner = "adammillerio";
+    rev = "85eefaebf893cb673fa98bfde48406ec99fd1e4b";
+    sha256 = "sha256-bkT2BZZ2gdcacgvyrVe2vMrOMV8iMAm8Q5xyrZzyqU0=";
   };
 
   postPatch = ''

--- a/pkgs/tools/audio/beets/plugins/extrafiles.nix
+++ b/pkgs/tools/audio/beets/plugins/extrafiles.nix
@@ -2,13 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "beets-extrafiles";
-  version = "0.0.7";
+  version = "unstable-2020-12-13";
 
   src = fetchFromGitHub {
     repo = "beets-extrafiles";
     owner = "Holzhaus";
-    rev = "v${version}";
-    sha256 = "0ah7mgax9zrhvvd5scf2z0v0bhd6xmmv5sdb6av840ixpl6vlvm6";
+    rev = "a1d6ef9a9682b6bf7af9483541e56a3ff12247b8";
+    sha256 = "sha256-ajuEbieWjTCNjdRZuGUwvStZwjx260jmY0m+ZqNd7ec=";
   };
 
   postPatch = ''
@@ -17,6 +17,8 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   nativeBuildInputs = [ beets ];
+
+  propagatedBuildInputs = with pythonPackages; [ mediafile ];
 
   preCheck = ''
     HOME=$TEMPDIR


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
###### Motivation for this change

Since we moved beets to tracking master I figured we ought to do the same for
the plugins we maintain, which also don't seem to ever get releases.

- beets: unstable-2021-03-24 -> unstable-2021-04-17
- beetsExternalPlugins.alternatives: 0.10.2 -> unstable-2021-02-01
- beetsExternalPlugins.copyartifacts: unstable-2020-02-15
- beetsExternalPlugins.extrafiles: 0.0.7 -> unstable-2020-12-13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
