### PR TITLE
[staging] openssh: 8.5p1 -> 8.6p1

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -5,11 +5,11 @@ in {
 
   openssh = common rec {
     pname = "openssh";
-    version = "8.5p1";
+    version = "8.6p1";
 
     src = fetchurl {
       url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
-      sha256 = "09gc8rv7728chxraab85dzkdikaw4aph1wlcwcc9kai9si0kybzm";
+      sha256 = "1bnpivgk98h2f9afpp88jv6g9ps83vnpxd031n2jqxi12vdf9rn3";
     };
 
     extraPatches = [ ./ssh-keysign-8.5.patch ];


### PR DESCRIPTION
###### Motivation for this change

New OpenSSH release

<details>
<summary>Changelog</summary>

Security
========

 * sshd(8): OpenSSH 8.5 introduced the LogVerbose keyword. When this
   option was enabled with a set of patterns that activated logging
   in code that runs in the low-privilege sandboxed sshd process, the
   log messages were constructed in such a way that printf(3) format
   strings could effectively be specified the low-privilege code.

   An attacker who had sucessfully exploited the low-privilege
   process could use this to escape OpenSSH's sandboxing and attack
   the high-privilege process. Exploitation of this weakness is
   highly unlikely in practice as the LogVerbose option is not
   enabled by default and is typically only used for debugging. No
   vulnerabilities in the low-privilege process are currently known
   to exist.

   Thanks to Ilja Van Sprundel for reporting this bug.

Changes since OpenSSH 8.5
=========================

This release contains mostly bug fixes.

New features
------------

 * sftp-server(8): add a new limits@openssh.com protocol extension
   that allows a client to discover various server limits, including
   maximum packet size and maximum read/write length.

 * sftp(1): use the new limits@openssh.com extension (when available)
   to select better transfer lengths in the client.

 * sshd(8): Add ModuliFile keyword to sshd_config to specify the
   location of the "moduli" file containing the groups for DH-GEX.

 * unit tests: Add a TEST_SSH_ELAPSED_TIMES environment variable to
   enable printing of the elapsed time in seconds of each test.

Bugfixes
--------

 * ssh_config(5), sshd_config(5): sync CASignatureAlgorithms lists in
   manual pages with the current default. GHPR#174

 * ssh(1): ensure that pkcs11_del_provider() is called before exit.
   GHPR#234

 * ssh(1), sshd(8): fix problems in string->argv conversion. Multiple
   backslashes were not being dequoted correctly and quoted space in
   the middle of a string was being incorrectly split. GHPR#223

 * ssh(1): return non-zero exit status when killed by signal; bz#3281

 * sftp-server(8): increase maximum SSH2_FXP_READ to match the maximum
   packet size. Also handle zero-length reads that are not explicitly
   banned by the spec.

Portability
-----------

 * sshd(8): don't mistakenly exit on transient read errors on the
   network socket (e.g. EINTR, EAGAIN); bz3297

 * Create a dedicated contrib/gnome-ssk-askpass3.c source instead of
   building it from the same file as used for GNOME2. Use the GNOME3
   gdk_seat_grab() to manage keyboard/mouse/server grabs for better
   compatibility with Wayland.

 * Fix portability build errors bz3293 bz3292 bz3291 bz3278

 * sshd(8): soft-disallow the fstatat64 syscall in the Linux
   seccomp-bpf sandbox. bz3276

 * unit tests: enable autoopt and misc unit tests that were
   previously skipped
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) - ssh, sshd, ssh-add, ssh-agent
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
