### PR TITLE
jellyfin-media-player: 1.3.1 -> 1.4.0

### DIFF
--- a/pkgs/applications/video/jellyfin-media-player/default.nix
+++ b/pkgs/applications/video/jellyfin-media-player/default.nix
@@ -26,18 +26,18 @@
 
 mkDerivation rec {
   pname = "jellyfin-media-player";
-  version = "1.3.1";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
-    owner = "iwalton3";
+    owner = "jellyfin";
     repo = "jellyfin-media-player";
     rev = "v${version}";
-    sha256 = "sha256-rXW6vC0Ow8xFblXjGYaDExAZM8RgqLkDHiX7R8vAWjI=";
+    sha256 = "sha256-zNEjhBya2loqFYS8Rjs8CMCfvie2/UbxreF8CUwDWWk=";
   };
 
   jmpDist = fetchzip {
-    url = "https://github.com/iwalton3/jellyfin-web-jmp/releases/download/jwc-10.7.2/dist.zip";
-    sha256 = "sha256-EpNAN4nzINiwMrmg0e4x3uJRTy5ovx4ZkmP83Kbn4S0=";
+    url = "https://github.com/iwalton3/jellyfin-web-jmp/releases/download/jwc-10.7.2-1/dist.zip";
+    sha256 = "sha256-oTZyIh2m9z55sNIeKtHxVijBMcTtJgpojG5HUToMYoA=";
   };
 
   patches = [
@@ -99,7 +99,7 @@ mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/iwalton3/jellyfin-media-player";
+    homepage = "https://github.com/jellyfin/jellyfin-media-player";
     description = "Jellyfin Desktop Client based on Plex Media Player";
     license = with licenses; [ gpl2Plus mit ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release (https://github.com/jellyfin/jellyfin-media-player/releases/tag/v1.4.0).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```bash
# NixOS
/nix/store/sdm4hxdkagz7j034q1lan39ir4ci0y71-jellyfin-media-player-1.3.1	  893643840
/nix/store/37d9zcq3jif9l5i4ghnji42jf9wqsccm-jellyfin-media-player-1.4.0	  893912160

# macOS
/nix/store/8i0n56yym92k8qzcaka3ddfx8jc58mrh-jellyfin-media-player-1.3.1	  651206032
/nix/store/naf7vc2v722f16rzg0by26g65fkqxg6r-jellyfin-media-player-1.4.0	  651469816
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
