### PR TITLE
alt-ergo: 2.3.3 → 2.4.0

### DIFF
--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -1,12 +1,14 @@
-{ fetchurl, lib, which, ocamlPackages }:
+{ fetchFromGitHub, lib, which, ocamlPackages }:
 
 let
   pname = "alt-ergo";
-  version = "2.3.3";
+  version = "2.4.0";
 
-  src = fetchurl {
-    url = "https://alt-ergo.ocamlpro.com/http/alt-ergo-${version}/alt-ergo-${version}.tar.gz";
-    sha256 = "124k2a4ikk4wdpmvgjpgl97x9skvr9qznk8m68dzsynzpv6yksaj";
+  src = fetchFromGitHub {
+    owner = "OCamlPro";
+    repo = pname;
+    rev = version;
+    sha256 = "1jm1yrvsg8iyfp9bb728zdx2i7yb6z7minjrfs27k5ncjqkjm65g";
   };
 
   useDune2 = true;
@@ -19,6 +21,7 @@ let alt-ergo-lib = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-lib";
   inherit version src useDune2 nativeBuildInputs;
   configureFlags = pname;
+  buildInputs = with ocamlPackages; [ dune-configurator ];
   propagatedBuildInputs = with ocamlPackages; [ num ocplib-simplex stdlib-shims zarith ];
 }; in
 
@@ -36,7 +39,9 @@ ocamlPackages.buildDunePackage {
 
   configureFlags = pname;
 
-  buildInputs = [ alt-ergo-parsers ocamlPackages.menhir ];
+  buildInputs = [ alt-ergo-parsers ] ++ (with ocamlPackages; [
+    cmdliner menhir ])
+  ;
 
   meta = {
     description = "High-performance theorem prover and SMT solver";


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/OCamlPro/alt-ergo/blob/2.4.0/docs/sphinx_docs/About/changes.md#version-240-january-22-2021

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
