### PR TITLE
[20.09] networkmanager: 1.26.6 -> 1.26.8

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -10,11 +10,11 @@ let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   pname = "network-manager";
-  version = "1.26.6";
+  version = "1.26.8";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${stdenv.lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "00wn7rjr588ipd2nc2v8d48a4rna0qlbrzkkfi5kskz7is6x4dqn";
+    sha256 = "1lcv7rxz22fxclawd6v9clm1mpl9vlvhlyfckwgbwymlfah0klp5";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```
===============================================
NetworkManager-1.26.8
Overview of changes since NetworkManager-1.26.6
===============================================

* Fix delay in activating Wi-Fi connections after wake-up.
* Fix configuring a large number of allowed-ips on WireGuard link.
* cloud-setup: fix replacing IPv4 addresses during update.
* initrd: apply the MTU from bond= argument to the bond connection.
* initrd: add support for rd.net.timeout.carrier.
* Fix crash evaluating match setting properties (CVE-2021-20297).
* Various minor fixes.
```

Fixes: CVE-2021-20297

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
