### PR TITLE
giph: init at 1.1.1

### DIFF
--- a/pkgs/applications/video/giph/default.nix
+++ b/pkgs/applications/video/giph/default.nix
@@ -1,0 +1,43 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, ffmpeg
+, xdotool
+, slop
+, libnotify
+, procps
+, makeWrapper
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "giph";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "phisch";
+    repo = pname;
+    rev = version;
+    sha256 = "19l46m1f32b3bagzrhaqsfnl5n3wbrmg3sdy6fdss4y1yf6nqayk";
+  };
+
+  dontConfigure = true;
+
+  dontBuild = true;
+
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/giph \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg xdotool libnotify slop procps ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/phisch/giph";
+    description = "Simple gif recorder";
+    license = licenses.mit;
+    maintainers = [ maintainers.legendofmiracles ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2540,6 +2540,8 @@ in
 
   gif-for-cli = callPackage ../tools/misc/gif-for-cli { };
 
+  giph = callPackage ../applications/video/giph { };
+
   gir-rs = callPackage ../development/tools/gir { };
 
   gist = callPackage ../tools/text/gist { };


### PR DESCRIPTION
###### Motivation for this change
Adds [giph](https://github.com/phisch/giph) (I already once opened this PR, but was overwhelmed by the feedback. So now after learning a bit more here I am again)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
