### PR TITLE
home-assistant: 2021.4.5 -> 2021.4.6

### DIFF
--- a/pkgs/development/python-modules/pymetno/default.nix
+++ b/pkgs/development/python-modules/pymetno/default.nix
@@ -9,18 +9,29 @@
 
 buildPythonPackage rec {
   pname = "PyMetno";
-  version = "0.8.1";
+  version = "0.8.2";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "Danielhiversen";
     rev = version;
-    sha256 = "1jngf0mbn5hn166pqh1ga5snwwvv7n5kv1k9kaksrfibixkvpw6h";
+    sha256 = "0b1zm60yqj1mivc3zqw2qm9rqh8cbmx0r58jyyvm3pxzq5cafdg5";
   };
 
-  propagatedBuildInputs = [ aiohttp async-timeout pytz xmltodict ];
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    pytz
+    xmltodict
+  ];
 
-  pythonImportsCheck = [ "metno"];
+  pythonImportsCheck = [
+    "metno"
+  ];
+
+  # no tests
+  doCheck = false;
 
   meta = with lib; {
     description = "A library to communicate with the met.no api";

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.4.5";
+  version = "2021.4.6";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -23,7 +23,7 @@ let
     # Override the version of some packages pinned in Home Assistant's setup.py
 
     # Pinned due to API changes in astral>=2.0, required by the sun/moon plugins
-    # https://github.com/home-assistant/core/issues/36636
+    # https://github.com/home-assistant/core/pull/48573; Remove >= 2021.5
     (mkOverride "astral" "1.10.1"
       "d2a67243c4503131c856cafb1b1276de52a86e5b8a1d507b7e08bee51cb67bf1")
 
@@ -43,6 +43,7 @@ let
     })
 
     # Pinned due to API changes in pylilterbot>=2021.3.0
+    # https://github.com/home-assistant/core/pull/48300; Remove >= 2021.5
     (self: super: {
       pylitterbot = super.pylitterbot.overridePythonAttrs (oldAttrs: rec {
         version = "2021.2.8";
@@ -108,7 +109,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.4.5";
+  hassVersion = "2021.4.6";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -127,7 +128,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "106d1n9z8pfcnqm594vkhczrrrjap801w6fdr0psv5vhdxrqh4sj";
+    sha256 = "1s1slwcqls2prz9kgyhggs8xi3x7ghwdi33j983kvpg0gva7d2f0";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/2021.4.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
