### PR TITLE
python3Packages.pywemo: fix tests

### DIFF
--- a/pkgs/development/python-modules/pywemo/default.nix
+++ b/pkgs/development/python-modules/pywemo/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , ifaddr
 , lxml
 , poetry-core
@@ -24,6 +25,14 @@ buildPythonPackage rec {
     sha256 = "1hm1vs6m65vqar0lcjnynz0d9y9ri5s75fzhvp0yfjkcnp06gnfa";
   };
 
+  patches = [
+    (fetchpatch {
+      # https://github.com/pywemo/pywemo/issues/264
+      url = "https://github.com/pywemo/pywemo/commit/4fd7af8ccc7cb2412f61d5e04b79f83c9ca4753c.patch";
+      sha256 = "1x0rm5dxr0z5llmv446bx3i1wvgcfhx22zn78qblcr0m4yv3mif4";
+    })
+  ];
+
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [
@@ -36,11 +45,6 @@ buildPythonPackage rec {
   checkInputs = [
     pytest-vcr
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # https://github.com/pywemo/pywemo/issues/264
-    "test_rules_db_from_device"
   ];
 
   pythonImportsCheck = [ "pywemo" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Testdriving https://github.com/pywemo/pywemo/issues/264.

Adds a patch that flushes the db, before relying on it during further
tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
