### PR TITLE
runLaTeX: added dependency search path argument.

### DIFF
--- a/pkgs/tools/typesetting/tex/nix/default.nix
+++ b/pkgs/tools/typesetting/tex/nix/default.nix
@@ -76,7 +76,7 @@ rec {
                 else [""];
               fn = pkgs.lib.findFirst (fn: builtins.pathExists fn) null
                 (builtins.concatLists
-                  (map (path: map (ext: toString "${path}/${dep.name}${ext}") exts) searchPath')
+                  (map (path: map (ext: path + "/" + dep.name + ext) exts) searchPath')
                 );
             in if fn != null then [{key = fn;}] ++ xs
                else xs;

--- a/pkgs/tools/typesetting/tex/nix/default.nix
+++ b/pkgs/tools/typesetting/tex/nix/default.nix
@@ -75,7 +75,7 @@ rec {
                 else if dep.type == "tex" then [".tex" ""]
                 else [""];
               fn = pkgs.lib.findFirst (fn: builtins.pathExists fn) null
-                (builtins.concatLists 
+                (builtins.concatLists
                   (map (path: map (ext: toString "${path}/${dep.name}${ext}") exts) searchPath')
                 );
             in if fn != null then [{key = fn;}] ++ xs


### PR DESCRIPTION
###### Motivation for this change

It is sometimes useful to specify where LaTeX dependencies should be searched for. (For example when the root file is processed as a separate derivation.)

There was also a `TODO` mentioning the exact same feature.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
