### PR TITLE
pgsync: init at 0.6.6

### DIFF
--- a/pkgs/development/tools/database/pgsync/Gemfile
+++ b/pkgs/development/tools/database/pgsync/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'pgsync'

--- a/pkgs/development/tools/database/pgsync/Gemfile.lock
+++ b/pkgs/development/tools/database/pgsync/Gemfile.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    parallel (1.20.1)
+    pg (1.2.3)
+    pgsync (0.6.6)
+      parallel
+      pg (>= 0.18.2)
+      slop (>= 4.8.2)
+      tty-spinner
+    slop (4.8.2)
+    tty-cursor (0.7.1)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pgsync
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/development/tools/database/pgsync/default.nix
+++ b/pkgs/development/tools/database/pgsync/default.nix
@@ -1,0 +1,15 @@
+{ lib, bundlerApp }:
+
+bundlerApp rec {
+  gemdir = ./.;
+  pname = "pgsync";
+  exes = [ "pgsync" ];
+
+  meta = with lib; {
+    description = "Sync data from one Postgres database to another (like `pg_dump`/`pg_restore`)";
+    homepage    = "https://github.com/ankane/pgsync";
+    license     = with licenses; mit;
+    maintainers = with maintainers; [ fabianhjr ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/development/tools/database/pgsync/gemset.nix
+++ b/pkgs/development/tools/database/pgsync/gemset.nix
@@ -1,0 +1,64 @@
+{
+  parallel = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0055br0mibnqz0j8wvy20zry548dhkakws681bhj3ycb972awkzd";
+      type = "gem";
+    };
+    version = "1.20.1";
+  };
+  pg = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13mfrysrdrh8cka1d96zm0lnfs59i5x2g6ps49r2kz5p3q81xrzj";
+      type = "gem";
+    };
+    version = "1.2.3";
+  };
+  pgsync = {
+    dependencies = ["parallel" "pg" "slop" "tty-spinner"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wjvcfsgm7xxhb2lxil19qjxvvihqxbjd2ykmm5d43p0h2l9wvxr";
+      type = "gem";
+    };
+    version = "0.6.6";
+  };
+  slop = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05d1xv8r9cmd0mmlqpa853yzd7xhcyha063w1g8dpf84scxbxmd3";
+      type = "gem";
+    };
+    version = "4.8.2";
+  };
+  tty-cursor = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0j5zw041jgkmn605ya1zc151bxgxl6v192v2i26qhxx7ws2l2lvr";
+      type = "gem";
+    };
+    version = "0.7.1";
+  };
+  tty-spinner = {
+    dependencies = ["tty-cursor"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hh5awmijnzw9flmh5ak610x1d00xiqagxa5mbr63ysggc26y0qf";
+      type = "gem";
+    };
+    version = "0.9.3";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7481,6 +7481,8 @@ in
 
   pgmetrics = callPackage ../tools/misc/pgmetrics { };
 
+  pgsync = callPackage ../development/tools/database/pgsync { };
+
   pdsh = callPackage ../tools/networking/pdsh {
     rsh = true;          # enable internal rsh implementation
     ssh = openssh;


### PR DESCRIPTION
###### Motivation for this change

Need the tool and using `gem install` fails due to being unable to find openssl/libressl libssl.so.10.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
