### PR TITLE
openarena: Update link from oa_ded to openarena-server

### DIFF
--- a/pkgs/games/openarena/default.nix
+++ b/pkgs/games/openarena/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
 
     makeWrapper "${gameDir}/openarena.${arch}" "$out/bin/openarena" \
       --prefix LD_LIBRARY_PATH : "${libPath}"
-    makeWrapper "${gameDir}/oa_ded.${arch}" "$out/bin/oa_ded"
+    makeWrapper "${gameDir}/oa_ded.${arch}" "$out/bin/openarena-server"
   '';
 
   meta = {


### PR DESCRIPTION
$ ofborg-viewer --version
ofborg-viewer, version 0.3.4 (4816c247aed7ba8f617d29603b67423e70ca5b48)
$ man ofborg-viewer

ofborg-viewer(web)            ofborg web interface           ofborg-viewer(web)

NAME
    ofborg-viewer — Build logs web interface

DESCRIPTION
    ofborg-viewer is a web interface that aggregates  the currently in-progress
    build logs made by ofborg.

    New logs for the given build will  be added to  the discovered logs  at the
    top of the interface. Clicking them or activating them through the keyboard
    shortcuts of your browser will show them.

    The  log will  autoscroll  when  the logger  interface  is scrolled  at the
    bottom. Scrolling up will stop the autoscroll until scrolled back down.

→ logger starting
→ fetching existing attempts for nixos/nixpkgs.115558
Socket created...
Connected...
Subscribing to "nixos/nixpkgs.115558"...