### PR TITLE
coqPackages.coqhammer: 1.3 → 1.3.1

### DIFF
--- a/pkgs/development/coq-modules/coqhammer/default.nix
+++ b/pkgs/development/coq-modules/coqhammer/default.nix
@@ -5,18 +5,27 @@ with lib; mkCoqDerivation {
   pname = "coqhammer";
   owner = "lukaszcz";
   defaultVersion = with versions; switch coq.coq-version [
-    { case = "8.12"; out = "1.3-coq8.12"; }
-    { case = "8.11"; out = "1.3-coq8.11"; }
-    { case = "8.10"; out = "1.3-coq8.10"; }
+    { case = "8.13"; out = "1.3.1-coq8.13"; }
+    { case = "8.12"; out = "1.3.1-coq8.12"; }
+    { case = "8.11"; out = "1.3.1-coq8.11"; }
+    { case = "8.10"; out = "1.3.1-coq8.10"; }
     { case = "8.9";  out = "1.1.1-coq8.9"; }
     { case = "8.8";  out = "1.1-coq8.8"; }
   ] null;
+  release."1.3.1-coq8.13".sha256 = "033j6saw24anb1lqbgsg1zynxi2rnxq7pgqwh11k8r8y3xisz78w";
+  release."1.3.1-coq8.12".sha256 = "0xy3vy4rv8w5ydwb9nq8y4dcimd91yr0hak2j4kn02svssg1kv1y";
+  release."1.3.1-coq8.11".sha256 = "0i9nlcayq0ac95vc09d1w8sd221gdjs0g215n086qscqjwimnz8j";
+  release."1.3.1-coq8.10".sha256 = "0aq9qwqx680lkidhb77fmyq403rvfcdxch849x1pzy6a48rz5yra";
   release."1.3-coq8.12".sha256   = "1q1y3cwhd98pkm98g71fsdjz85bfwgcz2xn7s7wwmiraifv5l6z8";
   release."1.3-coq8.11".sha256   = "08zf8qfna7b9p2myfaz4g7bas3a1q1156x78n5isqivlnqfrjc1b";
   release."1.3-coq8.10".sha256   = "1fj8497ir4m79hyrmmmmrag01001wrby0h24wv6525vz0w5py3cd";
   release."1.1.1-coq8.9".sha256  = "1knjmz4hr8vlp103j8n4fyb2lfxysnm512gh3m2kp85n6as6fvb9";
   release."1.1-coq8.8".sha256    = "0ms086wp4jmrzyglb8wymchzyflflk01nsfsk4r6qv8rrx81nx9h";
 
+  release."1.3.1-coq8.13".version  = "1.3.1";
+  release."1.3.1-coq8.12".version  = "1.3.1";
+  release."1.3.1-coq8.11".version  = "1.3.1";
+  release."1.3.1-coq8.10".version  = "1.3.1";
   release."1.3-coq8.12".version  = "1.3";
   release."1.3-coq8.11".version  = "1.3";
   release."1.3-coq8.10".version  = "1.3";


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.13

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
