### PR TITLE
matrix-commander: init at unstable-2021-04-18

### DIFF
--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -23,9 +23,13 @@ stdenv.mkDerivation {
     ]))];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     cp $src/matrix-commander.py $out/bin/matrix-commander
     chmod +x $out/bin/matrix-commander
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -35,8 +35,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Simple but convenient CLI-based Matrix client app for sending and receiving";
     homepage = "https://github.com/8go/matrix-commander";
-    # currently unknown if gpl3Only or gpl3Plus: https://github.com/8go/matrix-commander/issues/29
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = [ maintainers.seb314 ];
   };

--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Simple but convenient CLI-based Matrix client app for sending and receiving";
     homepage = "https://github.com/8go/matrix-commander";
+    # currently unknown if gpl3Only or gpl3Plus: https://github.com/8go/matrix-commander/issues/29
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = [ maintainers.seb314 ];

--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -1,24 +1,26 @@
-{ pkgs, fetchFromGitHub, lib }:
+{ stdenv, lib, fetchFromGitHub, cacert, python3 }:
 
-pkgs.stdenv.mkDerivation {
-  name = "matrix-commander";
+stdenv.mkDerivation {
+  pname = "matrix-commander";
+  version = "unstable-2021-04-18";
 
   src = fetchFromGitHub {
     owner = "8go";
     repo = "matrix-commander";
-    rev = "379bc7446f790eaf5b3b54225ad65e0f0c78637d";
-    sha256 = "1cny7z793ln4xgf7cbgfd0jd4hi8mp8qr91siqjhy0nmyd9lmszv";
+    rev = "3e89a5f4c98dd191880ae371cc63eb9282d7d91f";
+    sha256 = "08nwwszp1kv5b7bgf6mmfn42slxkyhy98x18xbn4pglc4bj32iql";
   };
 
-  propagatedBuildInputs = [
-    pkgs.cacert ] ++
-    (with pkgs.python38Packages; [
+  buildInputs = [
+    cacert
+    (python3.withPackages(ps: with ps; [
       matrix-nio
       magic
       markdown
       pillow
       urllib3
-    ]);
+      aiofiles
+    ]))];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -26,11 +28,11 @@ pkgs.stdenv.mkDerivation {
     chmod +x $out/bin/matrix-commander
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Simple but convenient CLI-based Matrix client app for sending and receiving";
     homepage = "https://github.com/8go/matrix-commander";
-    license = lib.licenses.gpl3;
-    platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.seb314 ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.seb314 ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -1,0 +1,36 @@
+{ pkgs, fetchFromGitHub, lib }:
+
+pkgs.stdenv.mkDerivation {
+  name = "matrix-commander";
+
+  src = fetchFromGitHub {
+    owner = "8go";
+    repo = "matrix-commander";
+    rev = "379bc7446f790eaf5b3b54225ad65e0f0c78637d";
+    sha256 = "1cny7z793ln4xgf7cbgfd0jd4hi8mp8qr91siqjhy0nmyd9lmszv";
+  };
+
+  propagatedBuildInputs = [
+    pkgs.cacert ] ++
+    (with pkgs.python38Packages; [
+      matrix-nio
+      magic
+      markdown
+      pillow
+      urllib3
+    ]);
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/matrix-commander.py $out/bin/matrix-commander
+    chmod +x $out/bin/matrix-commander
+  '';
+
+  meta = {
+    description = "Simple but convenient CLI-based Matrix client app for sending and receiving";
+    homepage = "https://github.com/8go/matrix-commander";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.seb314 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23946,7 +23946,7 @@ in
       canonicaljson;
   };
 
-  matrix-commander = callPackage ../applications/networking/instant-messengers/matrix-commander {};
+  matrix-commander = callPackage ../applications/networking/instant-messengers/matrix-commander { };
 
   matrix-dl = callPackage ../applications/networking/instant-messengers/matrix-dl { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23946,6 +23946,8 @@ in
       canonicaljson;
   };
 
+  matrix-commander = callPackage ../applications/networking/instant-messengers/matrix-commander {};
+
   matrix-dl = callPackage ../applications/networking/instant-messengers/matrix-dl { };
 
   matrix-recorder = callPackage ../applications/networking/instant-messengers/matrix-recorder {};


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (tested the python script in bin/matrix-commander, sending messages works)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
