### PR TITLE
mpvScripts.mpv-playlistmanager: init at unstable-2021-03-09

### DIFF
--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -1,0 +1,37 @@
+{ lib, stdenvNoCC, fetchFromGitHub, youtube-dl }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "mpv-playlistmanager";
+  version = "unstable-2021-03-09";
+
+  src = fetchFromGitHub {
+    owner = "jonniek";
+    repo = "mpv-playlistmanager";
+    rev = "c15a0334cf6d4581882fa31ddb1e6e7f2d937a3e";
+    sha256 = "uxcvgcSGS61UU8MmuD6qMRqpIa53iasH/vkg1xY7MVc=";
+  };
+
+  postPatch = ''
+    substituteInPlace playlistmanager.lua \
+    --replace "'youtube-dl'" "'${youtube-dl}/bin/youtube-dl'" \
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/mpv/scripts
+    cp playlistmanager.lua $out/share/mpv/scripts
+    runHook postInstall
+  '';
+
+  passthru.scriptName = "playlistmanager.lua";
+
+  meta = with lib; {
+    description = "Mpv lua script to create and manage playlists";
+    homepage = "https://github.com/jonniek/mpv-playlistmanager";
+    license = licenses.unlicense;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ lunik1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24623,6 +24623,7 @@ in
     autoload = callPackage ../applications/video/mpv/scripts/autoload.nix {};
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
+    mpv-playlistmanager = callPackage ../applications/video/mpv/scripts/mpv-playlistmanager.nix {};
     mpvacious = callPackage ../applications/video/mpv/scripts/mpvacious.nix {};
     simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix {};
     sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix {};


### PR DESCRIPTION
###### Motivation for this change

mpv lua scripts that allows manipulation of playlists

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
