### PR TITLE
[20.09] oauth2_proxy: add patch for CVE-2021-21291

### DIFF
--- a/pkgs/servers/oauth2_proxy/default.nix
+++ b/pkgs/servers/oauth2_proxy/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, fetchpatch }:
 
 buildGoModule rec {
   pname = "oauth2-proxy";
@@ -10,6 +10,14 @@ buildGoModule rec {
     sha256 = "0mbjg0d0w173xpq69frjdvgyx5k74pkrfx3phc3lq8snvhnf1c2n";
     rev = "v${version}";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-21291.patch";
+      url = "https://github.com/oauth2-proxy/oauth2-proxy/commit/780ae4f3c99b579cb2ea9845121caebb6192f725.patch";
+      sha256 = "066cr6ml69pinw3j9rspjy2h3dvqmf4bvmdxvalb1ws3z0xkn4ag";
+    })
+  ];
 
   vendorSha256 = "1hrk3h729kcc77fq44kiywmyzk5a78v7bm5d2yl76lfxxdcdric7";
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-21291

The function in patched hasn't been touched in 13 months previous to the patch, other than being relocated in the same file. The interface around it looks to be the same judging by its tests. `OAuthProxy.whitelistDomains` is still an array of strings in the same format. And sure enough the patch applies without a hitch and the added test passes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
