### PR TITLE
nwipe: 0.28 -> 0.30

### DIFF
--- a/pkgs/tools/security/nwipe/default.nix
+++ b/pkgs/tools/security/nwipe/default.nix
@@ -1,22 +1,42 @@
-{ lib, stdenv, fetchFromGitHub, ncurses, parted, automake, autoconf, pkg-config }:
+{ lib
+, stdenv
+, autoreconfHook
+, fetchFromGitHub
+, ncurses
+, parted
+, pkg-config
+}:
 
 stdenv.mkDerivation rec {
-  version = "0.28";
   pname = "nwipe";
+  version = "0.30";
+
   src = fetchFromGitHub {
     owner = "martijnvanbrummelen";
     repo = "nwipe";
     rev = "v${version}";
-    sha256 = "1aw905lmn1vm6klqn3q7445dwmwbjhcmwnkygpq9rddacgig1gdx";
+    sha256 = "sha256-cNZMFnk4L95jKTyGEUN3DlAChUNZlIjDdZqkkwPjehE=";
   };
-  nativeBuildInputs = [ automake autoconf pkg-config ];
-  buildInputs = [ ncurses parted ];
-  preConfigure = "sh init.sh || :";
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    ncurses
+    parted
+  ];
+
+  preConfigure = ''
+    sh init.sh || :
+  '';
+
   meta = with lib; {
     description = "Securely erase disks";
     homepage = "https://github.com/martijnvanbrummelen/nwipe";
-    license = licenses.gpl2;
-    maintainers = [ maintainers.woffs ];
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ woffs ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.30

Change log: https://github.com/martijnvanbrummelen/nwipe/releases/tag/v0.30

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
