### PR TITLE
[20.09] clamav: 0.102.4 -> 0.103.2

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "clamav";
-  version = "0.103.1";
+  version = "0.103.2";
 
   src = fetchurl {
     url = "https://www.clamav.net/downloads/production/${pname}-${version}.tar.gz";
-    sha256 = "sha256-cwjEe4myaK87nzYUBSiSekn/PmM6nJwKrCcS2BBW4lc=";
+    sha256 = "sha256-1LXQrGZiYuQjoyb7VHeMqnxpYk1sP5VCiV/rhHgnG9I=";
   };
 
   # don't install sample config files into the absolute sysconfdir folder

--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "clamav";
-  version = "0.102.4";
+  version = "0.103.0";
 
   src = fetchurl {
     url = "https://www.clamav.net/downloads/production/${pname}-${version}.tar.gz";
-    sha256 = "06rrzyrhnr0rswryijpbbzywr6387rv8qjq8sb8cl3h2d1m45ggf";
+    sha256 = "0ih5x1rscg2m64y0z20njj7435q8k7ss575cfw7aipdzfx979a9j";
   };
 
   # don't install sample config files into the absolute sysconfdir folder

--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "clamav";
-  version = "0.103.0";
+  version = "0.103.1";
 
   src = fetchurl {
     url = "https://www.clamav.net/downloads/production/${pname}-${version}.tar.gz";
-    sha256 = "0ih5x1rscg2m64y0z20njj7435q8k7ss575cfw7aipdzfx979a9j";
+    sha256 = "sha256-cwjEe4myaK87nzYUBSiSekn/PmM6nJwKrCcS2BBW4lc=";
   };
 
   # don't install sample config files into the absolute sysconfdir folder


### PR DESCRIPTION
(cherry picked from commit 52d5ebe0671e90a66689136124486f2a7eba19c9)<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backports
- #119217 
- #112261
- #101391

Fixes:
- https://nvd.nist.gov/vuln/detail/CVE-2021-1404
- https://nvd.nist.gov/vuln/detail/CVE-2021-1405
- https://nvd.nist.gov/vuln/detail/CVE-2021-1252

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
