### PR TITLE
OCaml: default to version 4.12

### DIFF
--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -2,7 +2,7 @@
 
 let
   ocamlDependencies = version:
-    if lib.versionAtLeast version "4.0"
+    if lib.versionAtLeast version "4.2"
     then with ocaml-ng.ocamlPackages; [
       ocaml
       findlib
@@ -13,8 +13,19 @@ let
       sha
       dune_2
       luv
-      (if lib.versionAtLeast version "4.2"
-      then ocaml_extlib else ocaml_extlib-1-7-7)
+      ocaml_extlib
+    ] else if lib.versionAtLeast version "4.0"
+    then with ocaml-ng.ocamlPackages_4_10; [
+      ocaml
+      findlib
+      sedlex_2
+      xml-light
+      ptmap
+      camlp5
+      sha
+      dune_2
+      luv
+      ocaml_extlib-1-7-7
     ] else with ocaml-ng.ocamlPackages_4_05; [
       ocaml
       camlp4

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   '';
   configureFlags = [ "--disable-appliance" "--disable-daemon" "--with-distro=NixOS" ]
     ++ lib.optionals (!javaSupport) [ "--disable-java" "--without-java" ];
-  patches = [ ./libguestfs-syms.patch ];
+  patches = [ ./libguestfs-syms.patch ./ocaml-4.12.patch ];
   NIX_CFLAGS_COMPILE="-I${libxml2.dev}/include/libxml2/";
   installFlags = [ "REALLY_INSTALL=yes" ];
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libguestfs/ocaml-4.12.patch
+++ b/pkgs/development/libraries/libguestfs/ocaml-4.12.patch
@@ -1,0 +1,11 @@
+--- a/common/mlstdutils/std_utils.ml	2019-02-07 15:45:56.516955598 +0100
++++ b/common/mlstdutils/std_utils.ml	2019-02-07 15:45:56.516955598 +0100
+@@ -305,7 +305,7 @@
+       | x::xs, y::ys, z::zs -> (x, y, z) :: combine3 xs ys zs
+       | _ -> invalid_arg "combine3"
+ 
+-    let rec assoc_lbl ?(cmp = compare) ~default x = function
++    let rec assoc_lbl ?(cmp = Pervasives.compare) ~default x = function
+       | [] -> default
+       | (y, y') :: _ when cmp x y = 0 -> y'
+       | _ :: ys -> assoc_lbl ~cmp ~default x ys

--- a/pkgs/development/ocaml-modules/extlib/1.7.7.nix
+++ b/pkgs/development/ocaml-modules/extlib/1.7.7.nix
@@ -1,11 +1,14 @@
 # Older version of extlib for Haxe 4.0 and 4.1.
 # May be replaceable by the next extlib + extlib-base64 release.
-{ fetchurl, ocaml_extlib }:
+{ lib, fetchurl, ocaml, ocaml_extlib }:
 
-ocaml_extlib.overrideAttrs (_: rec {
+ocaml_extlib.overrideAttrs (x: rec {
   version = "1.7.7";
   src = fetchurl {
     url = "https://github.com/ygrek/ocaml-extlib/releases/download/${version}/extlib-${version}.tar.gz";
     sha256 = "1sxmzc1mx3kg62j8kbk0dxkx8mkf1rn70h542cjzrziflznap0s1";
+  };
+  meta = x.meta // {
+    broken = lib.versionAtLeast ocaml.version "4.12";
   };
 })

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -1,4 +1,5 @@
 { self
+, lib
 , openssl
 , zstd
 }:
@@ -40,6 +41,7 @@ with self;
     version = "0.14.1";
     hash = "1cdkv34m6czhacivpbb2sasj83fgcid6gnqk30ig9i84z8nh2gw2";
     meta.description = "Accessors for Core types, for use with the Accessor library";
+    meta.broken = lib.versionAtLeast ocaml.version "4.12";
     propagatedBuildInputs = [ accessor_base core_kernel ];
   };
 

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -25,8 +25,10 @@ let src =
     }."${version}";
   };
   ocamlPackages =
-  if lib.versionAtLeast version "0.14.3"
+  if lib.versionAtLeast version "0.17.0"
   then ocaml-ng.ocamlPackages
+  else if lib.versionAtLeast version "0.14.3"
+  then ocaml-ng.ocamlPackages_4_10
   else ocaml-ng.ocamlPackages_4_07
 ; in
 

--- a/pkgs/development/tools/ocaml/ocp-build/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-build/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ocaml, findlib, ncurses, cmdliner, re }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ocaml, findlib, ncurses, cmdliner, re }:
 let
   version = "1.99.21";
 in
@@ -12,6 +12,14 @@ stdenv.mkDerivation {
     rev = "v${version}";
     sha256 = "1641xzik98c7xnjwxpacijd6d9jzx340fmdn6i372z8h554jjlg9";
   };
+
+  patches = [
+    # Fix compilation with OCaml 4.12
+    (fetchpatch {
+      url = "https://github.com/OCamlPro/ocp-build/commit/104e4656ca6dba9edb03b62539c9f1e10abcaae8.patch";
+      sha256 = "0sbyi4acig9q8x1ky4hckfg5pm2nad6zasi51ravaf1spgl148c2";
+    })
+  ];
 
   buildInputs = [ ocaml findlib cmdliner re ];
   propagatedBuildInputs = [ ncurses ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22981,7 +22981,7 @@ in
 
   gomuks = callPackage ../applications/networking/instant-messengers/gomuks { };
 
-  inherit (ocamlPackages) google-drive-ocamlfuse;
+  inherit (ocaml-ng.ocamlPackages_4_10) google-drive-ocamlfuse;
 
   googler = callPackage ../applications/misc/googler {
     python = python3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2335,7 +2335,8 @@ in
 
   duf = callPackage ../tools/misc/duf { };
 
-  inherit (ocamlPackages) dune_1 dune_2 dune-release;
+  inherit (ocaml-ng.ocamlPackages_4_10) dune_1;
+  inherit (ocamlPackages) dune_2 dune-release;
 
   duperemove = callPackage ../tools/filesystems/duperemove { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1264,7 +1264,7 @@ let
     if lib.versionOlder "4.08" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.14.nix {
       inherit self;
-      inherit (pkgs) openssl zstd;
+      inherit (pkgs) lib openssl zstd;
     }
     else if lib.versionOlder "4.07" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.12.nix {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1482,5 +1482,5 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_latest = ocamlPackages_4_12;
 
-  ocamlPackages = ocamlPackages_4_10;
+  ocamlPackages = ocamlPackages_4_12;
 }


### PR DESCRIPTION
###### Motivation for this change

`nixpkgs` is ready to use the latest version of OCaml.

cc @sternenseemann 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
