### PR TITLE
jellyfin-media-player: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/applications/video/jellyfin-media-player/default.nix
+++ b/pkgs/applications/video/jellyfin-media-player/default.nix
@@ -26,23 +26,25 @@
 
 mkDerivation rec {
   pname = "jellyfin-media-player";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin-media-player";
     rev = "v${version}";
-    sha256 = "sha256-zNEjhBya2loqFYS8Rjs8CMCfvie2/UbxreF8CUwDWWk=";
+    sha256 = "sha256-500Qlxpqkf+9D/jrzkrYkkFwxs0soLG/I5mgFV1UOc8=";
   };
 
   jmpDist = fetchzip {
-    url = "https://github.com/iwalton3/jellyfin-web-jmp/releases/download/jwc-10.7.2-1/dist.zip";
-    sha256 = "sha256-oTZyIh2m9z55sNIeKtHxVijBMcTtJgpojG5HUToMYoA=";
+    url = "https://github.com/iwalton3/jellyfin-web-jmp/releases/download/jwc-10.7.2-2/dist.zip";
+    sha256 = "sha256-9oxOcSCV1Gm8WLpwVLanyUlhPx5PWUrkkWvKmwND94g=";
   };
 
   patches = [
     # the webclient-files are not copied in the regular build script. Copy them just like the linux build
     ./fix-osx-resources.patch
+    # disable update notifications since the end user can't simply download the release artifacts to update
+    ./disable-update-notifications.patch
   ];
 
   buildInputs = [

--- a/pkgs/applications/video/jellyfin-media-player/disable-update-notifications.patch
+++ b/pkgs/applications/video/jellyfin-media-player/disable-update-notifications.patch
@@ -1,0 +1,13 @@
+diff --git a/resources/settings/settings_description.json b/resources/settings/settings_description.json
+index 20fff81..9979de5 100644
+--- a/resources/settings/settings_description.json
++++ b/resources/settings/settings_description.json
+@@ -118,7 +118,7 @@
+       },
+       {
+         "value": "checkForUpdates",
+-        "default": true
++        "default": false
+       },
+       {
+         "value": "enableInputRepeat",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release https://github.com/jellyfin/jellyfin-media-player/releases/tag/v1.4.1 [(changes)](https://github.com/jellyfin/jellyfin-media-player/compare/v1.4.0...v1.4.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/37d9zcq3jif9l5i4ghnji42jf9wqsccm-jellyfin-media-player-1.4.0	  893912160
/nix/store/ys4a7cff6npry246jpw3nc1w017mlfc2-jellyfin-media-player-1.4.1	  893912768
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
