### PR TITLE
jellyfin-mpv-shim: 1.10.4 -> 2.0.1

### DIFF
--- a/pkgs/applications/video/jellyfin-mpv-shim/default.nix
+++ b/pkgs/applications/video/jellyfin-mpv-shim/default.nix
@@ -5,7 +5,6 @@
 , jinja2
 , mpv
 , pillow
-, pydantic
 , pystray
 , python-mpv-jsonipc
 , pywebview
@@ -14,18 +13,17 @@
 
 buildPythonApplication rec {
   pname = "jellyfin-mpv-shim";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-YAZnNSzgAGYSb45VINRCPeUUbbtuOp/bLbIqz/90W6g=";
+    sha256 = "sha256-NXDLqQzCUfDPoKNPrmIn5FMedMKYxtDhkawRE2lg/vI=";
   };
 
   propagatedBuildInputs = [
     jellyfin-apiclient-python
     mpv
     pillow
-    pydantic
     python-mpv-jsonipc
 
     # gui dependencies

--- a/pkgs/applications/video/jellyfin-mpv-shim/default.nix
+++ b/pkgs/applications/video/jellyfin-mpv-shim/default.nix
@@ -1,30 +1,24 @@
 { lib
 , buildPythonApplication
-, copyDesktopItems
 , fetchPypi
-, makeDesktopItem
-, flask
 , jellyfin-apiclient-python
 , jinja2
 , mpv
 , pillow
 , pydantic
-, pyqtwebengine
 , pystray
 , python-mpv-jsonipc
 , pywebview
-, qt5
 , tkinter
-, werkzeug
 }:
 
 buildPythonApplication rec {
   pname = "jellyfin-mpv-shim";
-  version = "1.10.4";
+  version = "2.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-QMyb69S8Ln4X0oUuLpL6vtgxJwq8f+Q4ReNckrN4E+E=";
+    sha256 = "sha256-YAZnNSzgAGYSb45VINRCPeUUbbtuOp/bLbIqz/90W6g=";
   };
 
   propagatedBuildInputs = [
@@ -41,28 +35,6 @@ buildPythonApplication rec {
     # display_mirror dependencies
     jinja2
     pywebview
-
-    # desktop dependencies
-    flask
-    pyqtwebengine
-    werkzeug
-  ];
-
-  nativeBuildInputs = [
-    copyDesktopItems
-    qt5.wrapQtAppsHook
-  ];
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "Jellyfin Desktop";
-      exec = "jellyfin-desktop";
-      icon = "jellyfin-desktop";
-      desktopName = "jellyfin-desktop";
-      comment = "MPV-based desktop and cast client for Jellyfin";
-      genericName = "MPV-based desktop and cast client for Jellyfin";
-      categories = "Video;AudioVideo;TV;Player";
-    })
   ];
 
   # override $HOME directory:
@@ -82,24 +54,33 @@ buildPythonApplication rec {
       --replace "notify_updates: bool = True" "notify_updates: bool = False"
   '';
 
-  postInstall = ''
-    mkdir -p $out/share/pixmaps
-    cp jellyfin_mpv_shim/integration/jellyfin-256.png $out/share/pixmaps/jellyfin-desktop.png
-  '';
-
-  postFixup = ''
-    wrapQtApp $out/bin/jellyfin-desktop
-    wrapQtApp $out/bin/jellyfin-mpv-desktop
-  '';
-
   # no tests
   doCheck = false;
   pythonImportsCheck = [ "jellyfin_mpv_shim" ];
 
   meta = with lib; {
-    homepage = "https://github.com/jellyfin/jellyfin-desktop";
+    homepage = "https://github.com/jellyfin/jellyfin-mpv-shim";
     description = "Allows casting of videos to MPV via the jellyfin mobile and web app";
-    license = licenses.gpl3;
+    longDescription = ''
+      Jellyfin MPV Shim is a client for the Jellyfin media server which plays media in the
+      MPV media player. The application runs in the background and opens MPV only
+      when media is cast to the player. The player supports most file formats, allowing you
+      to prevent needless transcoding of your media files on the server. The player also has
+      advanced features, such as bulk subtitle updates and launching commands on events.
+    '';
+    license = with licenses; [
+      # jellyfin-mpv-shim
+      gpl3Only
+      mit
+
+      # shader-pack licenses (github:iwalton3/default-shader-pack)
+      # KrigBilateral, SSimDownscaler, NNEDI3
+      gpl3Plus
+      # Anime4K, FSRCNNX
+      mit
+      # Static Grain
+      unlicense
+    ];
     maintainers = with maintainers; [ jojosch ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release https://github.com/jellyfin/jellyfin-mpv-shim/releases/tag/v2.0.0 [(changes)](https://github.com/jellyfin/jellyfin-mpv-shim/compare/v1.10.4...v2.0.0)

Upstream removed the desktop mode, since now there is the new `jellyfin-media-player` as a replacement for the desktop mode. Should there be a notice / changelog for that? The desktop mode was not in a stable channel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/y06995wa30h49rir7zwpy84a35js3ckp-jellyfin-mpv-shim-1.10.4	  953988312
/nix/store/9pvi8dcpf0d5fqlbg3zfs26kvnwfrm4y-jellyfin-mpv-shim-2.0.0	  904213992
/nix/store/iaamjq35jhdpk8nl15mk2k2kmaamzcr0-jellyfin-mpv-shim-2.0.1	  901268936
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
