### PR TITLE
rubygems: 3.1.3 -> 3.2.16

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems/default.nix
+++ b/pkgs/development/interpreters/ruby/rubygems/default.nix
@@ -1,23 +1,18 @@
-{ stdenv, lib, fetchurl, fetchpatch }:
+{ stdenv, lib, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "rubygems";
-  version = "3.1.3";
+  version = "3.2.16";
 
   src = fetchurl {
     url = "https://rubygems.org/rubygems/rubygems-${version}.tgz";
-    sha256 = "181wjclxnq5lrwnr53famy9pg8911hi9w2v0vy7dqgjqnc4iy1hp";
+    sha256 = "1bpn45hchcbirqvqwxcxyk1xy2xkdd915jci2hfjq4y6zc4idns0";
   };
 
   patches = [
     ./0001-add-post-extract-hook.patch
     ./0002-binaries-with-env-shebang.patch
     ./0003-gem-install-default-to-user.patch
-
-    (fetchpatch {
-      url = "https://github.com/rubygems/rubygems/commit/0af4d2d369ff580ef54839ec15a8c7ec419978cb.patch";
-      sha256 = "13gyfxn4rmxq1dbxq5rzphnhagn8n8kpp8lb9h6h4s9d4zaklax9";
-    })
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

- Package update
- Avoid downgrading rubygems from 3.2.x to 3.1.x in the case of ruby 3.0.
- Fixes require behavior observed locally, but also fixes #106545.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
