### PR TITLE
stdenv.mkDerivation: overlay style overridable recursive attributes

### DIFF
--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -178,6 +178,7 @@ NixOS tests run in a VM, so they are slower than regular package tests. For more
 Alternatively, you can specify other derivations as tests. You can make use of
 the optional parameter (here: `self`) to inject the correct package without
 relying on non-local definitions, even in the presence of `overrideAttrs`. This
+means `(mypkg.overrideAttrs f).passthru.tests` will be as expected, as long as the
 definition of `tests` does not rely on the original `mypkg` or overrides it in
 all places.
 

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -176,18 +176,21 @@ The NixOS tests are available as `nixosTests` in parameters of derivations. For 
 NixOS tests run in a VM, so they are slower than regular package tests. For more information see [NixOS module tests](https://nixos.org/manual/nixos/stable/#sec-nixos-tests).
 
 Alternatively, you can specify other derivations as tests. You can make use of
-the optional parameter (here: `self`) to inject the correct package without
-relying on non-local definitions, even in the presence of `overrideAttrs`. This
-means `(mypkg.overrideAttrs f).passthru.tests` will be as expected, as long as the
+the optional parameter to inject the correct package without
+relying on non-local definitions, even in the presence of `overrideAttrs`.
+Here that's `finalAttrs.public`, but you could choose a different name if
+`finalAttrs` already exists in your scope.
+
+`(mypkg.overrideAttrs f).passthru.tests` will be as expected, as long as the
 definition of `tests` does not rely on the original `mypkg` or overrides it in
 all places.
 
 ```nix
 # my-package/default.nix
 { stdenv, callPackage }:
-stdenv.mkDerivation (self: {
+stdenv.mkDerivation (finalAttrs: {
   # ...
-  passthru.tests.example = callPackage ./example.nix { my-package = self.public; }
+  passthru.tests.example = callPackage ./example.nix { my-package = finalAttrs.public; }
 })
 ```
 

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -175,6 +175,36 @@ The NixOS tests are available as `nixosTests` in parameters of derivations. For 
 
 NixOS tests run in a VM, so they are slower than regular package tests. For more information see [NixOS module tests](https://nixos.org/manual/nixos/stable/#sec-nixos-tests).
 
+Alternatively, you can specify other derivations as tests. You can make use of
+the optional parameter (here: `self`) to inject the correct package without
+relying on non-local definitions, even in the presence of `overrideAttrs`. This
+definition of `tests` does not rely on the original `mypkg` or overrides it in
+all places.
+
+```nix
+# my-package/default.nix
+{ stdenv, callPackage }:
+stdenv.mkDerivation (self: {
+  # ...
+  passthru.tests.example = callPackage ./example.nix { my-package = self; };
+})
+```
+
+```nix
+# my-package/example.nix
+{ runCommand, lib, my-package, ... }:
+runCommand "my-package-test" {
+  nativeBuildInputs = [ my-package ];
+  src = lib.sources.sourcesByRegex ./. [ ".*.in" ".*.expected" ];
+} ''
+  my-package --help
+  my-package <example.in >example.actual
+  diff -U3 --color=auto example.expected example.actual
+  mkdir $out
+''
+```
+
+
 ### `timeout` {#var-meta-timeout}
 
 A timeout (in seconds) for building the derivation. If the derivation takes longer than this time to build, it can fail due to breaking the timeout. However, all computers do not have the same computing power, hence some builders may decide to apply a multiplicative factor to this value. When filling this value in, try to keep it approximately consistent with other values already present in `nixpkgs`.

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -187,7 +187,7 @@ all places.
 { stdenv, callPackage }:
 stdenv.mkDerivation (self: {
   # ...
-  passthru.tests.example = callPackage ./example.nix { my-package = self; };
+  passthru.tests.example = callPackage ./example.nix { my-package = self.public; }
 })
 ```
 

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -178,7 +178,7 @@ NixOS tests run in a VM, so they are slower than regular package tests. For more
 Alternatively, you can specify other derivations as tests. You can make use of
 the optional parameter to inject the correct package without
 relying on non-local definitions, even in the presence of `overrideAttrs`.
-Here that's `finalAttrs.public`, but you could choose a different name if
+Here that's `finalAttrs.finalPackage`, but you could choose a different name if
 `finalAttrs` already exists in your scope.
 
 `(mypkg.overrideAttrs f).passthru.tests` will be as expected, as long as the
@@ -190,7 +190,7 @@ all places.
 { stdenv, callPackage }:
 stdenv.mkDerivation (finalAttrs: {
   # ...
-  passthru.tests.example = callPackage ./example.nix { my-package = finalAttrs.public; }
+  passthru.tests.example = callPackage ./example.nix { my-package = finalAttrs.finalPackage; };
 })
 ```
 

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -319,7 +319,7 @@ For information about how to run the updates, execute `nix-shell maintainers/scr
 
 ### Recursive attributes in `mkDerivation`
 
-If you pass a function to `mkDerivation`, it will receive as its argument the final arguments, considering use of `overrideAttrs`. For example:
+If you pass a function to `mkDerivation`, it will receive as its argument the final arguments, including the overrides when reinvoked via `overrideAttrs`. For example:
 
 ```nix
 mkDerivation (finalAttrs: {

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -336,8 +336,7 @@ The `rec` keyword works at the syntax level and is unaware of overriding.
 Instead, the definition references `finalAttrs`, allowing users to change `withFeature`
 consistently with `overrideAttrs`.
 
-`finalAttrs` also contains the attribute `public`, which represents the final package,
-including the output paths, etc.
+`finalAttrs` also contains the attribute `finalPackage`, which includes the output paths, etc.
 
 Let's look at a more elaborate example to understand the differences between
 various bindings:
@@ -352,11 +351,11 @@ let pkg =
     packages = [];
 
     # `passthru.tests` is a commonly defined attribute.
-    passthru.tests.simple = f finalAttrs.public;
+    passthru.tests.simple = f finalAttrs.finalPackage;
 
     # An example of an attribute containing a function
     passthru.appendPackages = packages':
-      finalAttrs.public.overrideAttrs (newSelf: super: {
+      finalAttrs.finalPackage.overrideAttrs (newSelf: super: {
         packages = super.packages ++ packages';
       });
 
@@ -368,7 +367,7 @@ let pkg =
 in pkg
 ```
 
-Unlike the `pkg` binding in the above example, the `finalAttrs` parameter always references the final attributes. For instance `(pkg.overrideAttrs(x)).finalAttrs.public` is identical to `pkg.overrideAttrs(x)`, whereas `(pkg.overrideAttrs(x)).original` is the same as the original `pkg`.
+Unlike the `pkg` binding in the above example, the `finalAttrs` parameter always references the final attributes. For instance `(pkg.overrideAttrs(x)).finalAttrs.finalPackage` is identical to `pkg.overrideAttrs(x)`, whereas `(pkg.overrideAttrs(x)).original` is the same as the original `pkg`.
 
 See also the section about [`passthru.tests`](#var-meta-tests).
 

--- a/doc/using/overrides.chapter.md
+++ b/doc/using/overrides.chapter.md
@@ -48,7 +48,7 @@ In the above example, the `separateDebugInfo` attribute is overridden to be true
 
 The argument `previousAttrs` is conventionally used to refer to the attr set originally passed to `stdenv.mkDerivation`.
 
-The argument `finalAttrs` refers to the final attributes passed to `mkDerivation`, plus the `public` attribute which is the result of `mkDerivation` — the derivation or package.
+The argument `finalAttrs` refers to the final attributes passed to `mkDerivation`, plus the `finalPackage` attribute which is equal to the result of `mkDerivation` or subsequent `overrideAttrs` calls.
 
 If only a one-argument function is written, the argument has the meaning of `previousAttrs`.
 

--- a/doc/using/overrides.chapter.md
+++ b/doc/using/overrides.chapter.md
@@ -39,14 +39,18 @@ The function `overrideAttrs` allows overriding the attribute set passed to a `st
 Example usage:
 
 ```nix
-helloWithDebug = pkgs.hello.overrideAttrs (oldAttrs: rec {
+helloWithDebug = pkgs.hello.overrideAttrs (finalAttrs: previousAttrs: {
   separateDebugInfo = true;
 });
 ```
 
 In the above example, the `separateDebugInfo` attribute is overridden to be true, thus building debug info for `helloWithDebug`, while all other attributes will be retained from the original `hello` package.
 
-The argument `oldAttrs` is conventionally used to refer to the attr set originally passed to `stdenv.mkDerivation`.
+The argument `previousAttrs` is conventionally used to refer to the attr set originally passed to `stdenv.mkDerivation`.
+
+The argument `finalAttrs` refers to the final attributes passed to `mkDerivation`, plus the `public` attribute which is the result of `mkDerivation` — the derivation or package.
+
+If only a one-argument function is written, the argument has the meaning of `previousAttrs`.
 
 ::: {.note}
 Note that `separateDebugInfo` is processed only by the `stdenv.mkDerivation` function, not the generated, raw Nix derivation. Thus, using `overrideDerivation` will not work in this case, as it overrides only the attributes of the final derivation. It is for this reason that `overrideAttrs` should be preferred in (almost) all cases to `overrideDerivation`, i.e. to allow using `stdenv.mkDerivation` to process input arguments, as well as the fact that it is easier to use (you can use the same attribute names you see in your Nix code, instead of the ones generated (e.g. `buildInputs` vs `nativeBuildInputs`), and it involves less typing).

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -45,6 +45,33 @@
       </listitem>
       <listitem>
         <para>
+          <literal>stdenv.mkDerivation</literal> now supports a
+          self-referencing <literal>finalAttrs:</literal> parameter
+          containing the final <literal>mkDerivation</literal> arguments
+          including overrides. <literal>drv.overrideAttrs</literal> now
+          supports two parameters
+          <literal>finalAttrs: previousAttrs:</literal>. This allows
+          packaging configuration to be overridden in a consistent
+          manner by providing an alternative to
+          <literal>rec {}</literal> syntax.
+        </para>
+        <para>
+          Additionally, <literal>passthru</literal> can now reference
+          <literal>finalAttrs.public</literal> containing the final
+          package, including attributes such as the output paths and
+          <literal>overrideAttrs</literal>.
+        </para>
+        <para>
+          New language integrations can be simplified by overriding a
+          <quote>prototype</quote> package containing the
+          language-specific logic. This removes the need for a extra
+          layer of overriding for the <quote>generic builder</quote>
+          arguments, thus removing a usability problem and source of
+          error.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           PHP 8.1 is now available
         </para>
       </listitem>

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -57,9 +57,9 @@
         </para>
         <para>
           Additionally, <literal>passthru</literal> can now reference
-          <literal>finalAttrs.public</literal> containing the final
-          package, including attributes such as the output paths and
-          <literal>overrideAttrs</literal>.
+          <literal>finalAttrs.finalPackage</literal> containing the
+          final package, including attributes such as the output paths
+          and <literal>overrideAttrs</literal>.
         </para>
         <para>
           New language integrations can be simplified by overriding a

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -17,6 +17,21 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - GNOME has been upgraded to 42. Please take a look at their [Release Notes](https://release.gnome.org/42/) for details. Notably, it replaces gedit with GNOME Text Editor, GNOME Terminal with GNOME Console (formerly King’s Cross), and GNOME Screenshot with a tool built into the Shell.
 
+- `stdenv.mkDerivation` now supports a self-referencing `finalAttrs:` parameter
+  containing the final `mkDerivation` arguments including overrides.
+  `drv.overrideAttrs` now supports two parameters `finalAttrs: previousAttrs:`.
+  This allows packaging configuration to be overridden in a consistent manner by
+  providing an alternative to `rec {}` syntax.
+
+  Additionally, `passthru` can now reference `finalAttrs.public` containing
+  the final package, including attributes such as the output paths and
+  `overrideAttrs`.
+
+  New language integrations can be simplified by overriding a "prototype"
+  package containing the language-specific logic. This removes the need for a
+  extra layer of overriding for the "generic builder" arguments, thus removing a
+  usability problem and source of error.
+
 - PHP 8.1 is now available
 
 - Mattermost has been updated to extended support release 6.3, as the previously packaged extended support release 5.37 is [reaching its end of life](https://docs.mattermost.com/upgrade/extended-support-release.html).

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -23,7 +23,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   This allows packaging configuration to be overridden in a consistent manner by
   providing an alternative to `rec {}` syntax.
 
-  Additionally, `passthru` can now reference `finalAttrs.public` containing
+  Additionally, `passthru` can now reference `finalAttrs.finalPackage` containing
   the final package, including attributes such as the output paths and
   `overrideAttrs`.
 

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.12";
 
   src = fetchurl {
-    url = "mirror://gnu/hello/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "mirror://gnu/hello/hello-${finalAttrs.version}.tar.gz";
     sha256 = "1ayhp9v4m4rdhjmnl2bq3cibrbqqkgjbl3s7yk2nhlh8vj3ay16g";
   };
 

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -1,4 +1,5 @@
 { lib
+, runCommand
 , stdenv
 , fetchurl
 , nixos
@@ -6,12 +7,12 @@
 , hello
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (self: {
   pname = "hello";
   version = "2.12";
 
   src = fetchurl {
-    url = "mirror://gnu/hello/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/hello/${self.pname}-${self.version}.tar.gz";
     sha256 = "1ayhp9v4m4rdhjmnl2bq3cibrbqqkgjbl3s7yk2nhlh8vj3ay16g";
   };
 
@@ -27,6 +28,13 @@ stdenv.mkDerivation rec {
         (nixos { environment.noXlibs = true; }).pkgs.hello;
   };
 
+  passthru.tests.run = runCommand "hello-test-run" {
+    nativeBuildInputs = [ self ];
+  } ''
+    diff -U3 --color=auto <(hello) <(echo 'Hello, world!')
+    touch $out
+  '';
+
   meta = with lib; {
     description = "A program that produces a familiar, friendly greeting";
     longDescription = ''
@@ -34,9 +42,9 @@ stdenv.mkDerivation rec {
       It is fully customizable.
     '';
     homepage = "https://www.gnu.org/software/hello/manual/";
-    changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${version}";
+    changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${self.version}";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.eelco ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
         (nixos { environment.noXlibs = true; }).pkgs.hello;
   };
 
-  passthru.tests.run = callPackage ./test.nix { hello = finalAttrs.public; };
+  passthru.tests.run = callPackage ./test.nix { hello = finalAttrs.finalPackage; };
 
   meta = with lib; {
     description = "A program that produces a familiar, friendly greeting";

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (self: {
         (nixos { environment.noXlibs = true; }).pkgs.hello;
   };
 
-  passthru.tests.run = callPackage ./test.nix { hello = self; };
+  passthru.tests.run = callPackage ./test.nix { hello = self.public; };
 
   meta = with lib; {
     description = "A program that produces a familiar, friendly greeting";

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -7,12 +7,12 @@
 , hello
 }:
 
-stdenv.mkDerivation (self: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hello";
   version = "2.12";
 
   src = fetchurl {
-    url = "mirror://gnu/hello/${self.pname}-${self.version}.tar.gz";
+    url = "mirror://gnu/hello/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "1ayhp9v4m4rdhjmnl2bq3cibrbqqkgjbl3s7yk2nhlh8vj3ay16g";
   };
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation (self: {
         (nixos { environment.noXlibs = true; }).pkgs.hello;
   };
 
-  passthru.tests.run = callPackage ./test.nix { hello = self.public; };
+  passthru.tests.run = callPackage ./test.nix { hello = finalAttrs.public; };
 
   meta = with lib; {
     description = "A program that produces a familiar, friendly greeting";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (self: {
       It is fully customizable.
     '';
     homepage = "https://www.gnu.org/software/hello/manual/";
-    changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${self.version}";
+    changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${finalAttrs.version}";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.eelco ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -1,5 +1,5 @@
-{ lib
-, runCommand
+{ callPackage
+, lib
 , stdenv
 , fetchurl
 , nixos
@@ -28,12 +28,7 @@ stdenv.mkDerivation (self: {
         (nixos { environment.noXlibs = true; }).pkgs.hello;
   };
 
-  passthru.tests.run = runCommand "hello-test-run" {
-    nativeBuildInputs = [ self ];
-  } ''
-    diff -U3 --color=auto <(hello) <(echo 'Hello, world!')
-    touch $out
-  '';
+  passthru.tests.run = callPackage ./test.nix { hello = self; };
 
   meta = with lib; {
     description = "A program that produces a familiar, friendly greeting";

--- a/pkgs/applications/misc/hello/test.nix
+++ b/pkgs/applications/misc/hello/test.nix
@@ -1,0 +1,8 @@
+{ runCommand, hello }:
+
+runCommand "hello-test-run" {
+  nativeBuildInputs = [ hello ];
+} ''
+  diff -U3 --color=auto <(hello) <(echo 'Hello, world!')
+  touch $out
+''

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -10,7 +10,7 @@ let
     inherit (stdenv) hostPlatform;
   };
 
-  makeOverlayable = mkDerivationSimple: # TODO(@robert): turn mkDerivationSimple into let binding.
+  makeOverlayable = mkDerivationSimple:
     fnOrAttrs:
       if builtins.isFunction fnOrAttrs
       then makeDerivationExtensible mkDerivationSimple fnOrAttrs
@@ -65,7 +65,6 @@ let
 
 in
 
-# TODO(@roberth): inline makeOverlayable; reindenting whole rest of this file.
 makeOverlayable (overrideAttrs:
 
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -19,7 +19,14 @@ let
   # Based off lib.makeExtensible, with modifications:
   makeDerivationExtensible = mkDerivationSimple: rattrs:
     let
+      # NOTE: The following is a hint that will be printed by the Nix cli when
+      # encountering an infinite recursion. It must not be formatted into
+      # separate lines, because Nix would only show the last line of the comment.
+
+      # An infinite recursion here can be caused by having the attribute names of expression `e` in `.overrideAttrs(finalAttrs: previousAttrs: e)` depend on `finalAttrs`. Only the attribute values of `e` can depend on `finalAttrs`.
       args = rattrs (args // { inherit public; });
+      #              ^^^^
+
       public =
         mkDerivationSimple
           (f0:

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -24,10 +24,10 @@ let
       # separate lines, because Nix would only show the last line of the comment.
 
       # An infinite recursion here can be caused by having the attribute names of expression `e` in `.overrideAttrs(finalAttrs: previousAttrs: e)` depend on `finalAttrs`. Only the attribute values of `e` can depend on `finalAttrs`.
-      args = rattrs (args // { inherit public; });
+      args = rattrs (args // { inherit finalPackage; });
       #              ^^^^
 
-      public =
+      finalPackage =
         mkDerivationSimple
           (f0:
             let
@@ -51,7 +51,7 @@ let
               makeDerivationExtensible mkDerivationSimple
                 (self: let super = rattrs self; in super // f self super))
           args;
-    in public;
+    in finalPackage;
 
   # makeDerivationExtensibleConst == makeDerivationExtensible (_: attrs),
   # but pre-evaluated for a slight improvement in performance.


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 - Allows to get rid of confusing `rec { }` in `mkDerivation` calls. Overriding an attribute in this style causes derived attributes to be overridden as expected.

 - Allows `passthru` attributes to reference the outputs

 - Fixes #119407, the problem where if you use `overrideAttrs`, the tests in `passthru` still use the old package.

 - Should allow cleanup of python and rust packaging functions by using "overlay" layers on a prototype derivation, rather than the current workarounds.

See updated manual for usage explanation.

Update: this problem was also brought up in this discussion: https://github.com/NixOS/nixpkgs/pull/119731#pullrequestreview-638309038

Update: "overlay" part minus `public` was also discovered and implemented by lilyball https://github.com/NixOS/nixpkgs/pull/94198

<!--
# :rotating_light: Please prioritize reviews and fixes for the release first!

### Consider that your reviewer is already busy with stabilization work and other reviews, so now is not really a time for refactoring, unless you need the change to solve a significant problem. Thank you.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing **not applicable:** changes are evaluation-only ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
