### PR TITLE
ocamlPackages.dns*: 4.6.3 -> 5.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/dns/certify.nix
+++ b/pkgs/development/ocaml-modules/dns/certify.nix
@@ -1,6 +1,6 @@
 { buildDunePackage, dns, dns-tsig, dns-mirage, randomconv, x509
 , mirage-random, mirage-time, mirage-clock, mirage-stack
-, logs, mirage-crypto-pk, mirage-crypto-rng, tls, lwt
+, logs, mirage-crypto-pk, mirage-crypto-rng, mirage-crypto-ec, lwt
 }:
 
 buildDunePackage {
@@ -21,7 +21,7 @@ buildDunePackage {
     logs
     mirage-crypto-pk
     mirage-crypto-rng
-    tls
+    mirage-crypto-ec
     lwt
   ];
 

--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -4,14 +4,14 @@
 
 buildDunePackage rec {
   pname = "dns";
-  version = "4.6.3";
+  version = "5.0.0";
 
   useDune2 = true;
   minimumOCamlVersion = "4.07";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-v${version}.tbz";
-    sha256 = "0g7xw43jm5hv0w9lsnhhi0w3243mxl615cdsvz29yh39fcqvqsdy";
+    sha256 = "ef93435407955a46e51e3be857a1b00a6765ec3b673d4a859a9536c7e3365111";
   };
 
   propagatedBuildInputs = [ rresult astring fmt logs ptime domain-name gmap cstruct ipaddr lru duration metrics ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/mirage/ocaml-dns/releases/tag/v5.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
