### PR TITLE
nixos/doc/manual: refine extraLayouts, add warnings an test commands

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -204,18 +204,18 @@
     XKB
    </link>
    keyboard layouts using the option
-   <option>
-    <link linkend="opt-services.xserver.extraLayouts">
-     services.xserver.extraLayouts
-    </link>
-   </option>.
+   <option><link linkend="opt-services.xserver.extraLayouts">
+     services.xserver.extraLayouts</link></option>.
+  </para>
+  <para>
    As a first example, we are going to create a layout based on the basic US
    layout, with an additional layer to type some greek symbols by pressing the
    right-alt key.
   </para>
   <para>
-   To do this we are going to create a <literal>us-greek</literal> file
-   with a <literal>xkb_symbols</literal> section.
+   Create a file called <literal>us-greek</literal> with the following
+   content (under a directory called <literal>symbols</literal>; it's
+   an XKB peculiarity that will help with testing):
   </para>
 <programlisting>
 xkb_symbols &quot;us-greek&quot;
@@ -231,14 +231,13 @@ xkb_symbols &quot;us-greek&quot;
 };
 </programlisting>
   <para>
-   To install the layout, the filepath, a description and the list of
-   languages must be given:
+   A minimal layout specification must include the following:
   </para>
 <programlisting>
 <xref linkend="opt-services.xserver.extraLayouts"/>.us-greek = {
   description = "US layout with alt-gr greek";
   languages   = [ "eng" ];
-  symbolsFile = /path/to/us-greek;
+  symbolsFile = /yourpath/symbols/us-greek;
 }
 </programlisting>
   <note>
@@ -248,9 +247,27 @@ xkb_symbols &quot;us-greek&quot;
   </para>
   </note>
   <para>
-   The layout should now be installed and ready to use: try it by
-   running <literal>setxkbmap us-greek</literal> and type
-   <literal>&lt;alt&gt;+a</literal>. To change the default the usual
+   Applying this customization requires rebuilding several packages,
+   and a broken XKB file can lead to the X session crashing at login.
+   Therefore, you're strongly advised to <emphasis role="strong">test
+   your layout before applying it</emphasis>:
+<screen>
+<prompt>$ </prompt>nix-shell -p xorg.xkbcomp
+<prompt>$ </prompt>setxkbmap -I/yourpath us-greek -print | xkbcomp -I/yourpath - $DISPLAY
+</screen>
+  </para>
+  <para>
+   You can inspect the predefined XKB files for examples:
+<screen>
+<prompt>$ </prompt>echo "$(nix-build --no-out-link '&lt;nixpkgs&gt;' -A xorg.xkeyboardconfig)/etc/X11/xkb/"
+</screen>
+  </para>
+  <para>
+   Once the configuration is applied, and you did a logout/login
+   cycle, the layout should be ready to use. You can try it by e.g.
+   running <literal>setxkbmap us-greek</literal> and then type
+   <literal>&lt;alt&gt;+a</literal> (it may not get applied in your
+   terminal straight away). To change the default, the usual
    <option>
     <link linkend="opt-services.xserver.layout">
      services.xserver.layout


### PR DESCRIPTION
###### Motivation for this change

i have wasted quite some times, and had several questions after i tried to use this feature.

note that i put the closing xml tags are at the end of the line at one place to avoid adding a superfluous space in the output.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
