### PR TITLE
linode-cli: enable/add test; add bash auto-completion

### DIFF
--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -7,6 +7,7 @@
 , requests
 , pyyaml
 , setuptools
+, installShellFiles
 }:
 
 let
@@ -48,14 +49,21 @@ buildPythonApplication rec {
     cp data-3 linodecli/
   '';
 
-  # requires linode access token for unit tests, and running executable
-  doCheck = false;
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/linode-cli --skip-config --version | grep ${version} > /dev/null
+  '';
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    installShellCompletion --cmd linode-cli --bash <($out/bin/linode-cli --skip-config completion bash)
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/linode/linode-cli";
     description = "The Linode Command Line Interface";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ryantm ];
+    maintainers = with maintainers; [ ryantm superherointj ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

- Enables tests.
- Add a test for version.
- Add bash auto-completion.
- Add myself (superherointj) as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
