### PR TITLE
python3Packages.openshift: init at 0.12.0

### DIFF
--- a/pkgs/development/python-modules/openshift/default.nix
+++ b/pkgs/development/python-modules/openshift/default.nix
@@ -1,0 +1,39 @@
+{
+  lib
+  , buildPythonPackage
+  , fetchPypi
+  , jinja2
+  , kubernetes
+  , ruamel-yaml
+  , six
+  , python-string-utils
+}:
+
+buildPythonPackage rec {
+  pname = "openshift";
+  version = "0.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-aggRnD4goiZJPp4cngp8AIrJC/V46378cwUSfq8Xml4=";
+  };
+
+  propagatedBuildInputs = [
+    jinja2
+    kubernetes
+    python-string-utils
+    ruamel-yaml
+    six
+  ];
+
+  # tries to connect to the network
+  doCheck = false;
+  pythonImportsCheck = ["openshift"];
+
+  meta = with lib; {
+    description = "Python client for the OpenShift API";
+    homepage = "https://github.com/openshift/openshift-restclient-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/development/python-modules/python-string-utils/default.nix
+++ b/pkgs/development/python-modules/python-string-utils/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "python-string-utils";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-3PkGCwPwdkfApgNAjciwP4B/O1SgXG4Z6xRGAlb6wMs=";
+  };
+
+  pythonImportsCheck = ["string_utils"];
+
+  # tests are not available in pypi tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A handy Python library to validate, manipulate and generate strings.";
+    homepage = "https://github.com/daveoncode/python-string-utils";
+    license = licenses.mit;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6359,6 +6359,8 @@ in {
 
   pytest-shutil = callPackage ../development/python-modules/pytest-shutil { };
 
+  python-string-utils = callPackage ../development/python-modules/python-string-utils { };
+
   pytest-socket = callPackage ../development/python-modules/pytest-socket { };
 
   pytest-subtesthack = callPackage ../development/python-modules/pytest-subtesthack { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4624,6 +4624,8 @@ in {
 
   opensensemap-api = callPackage ../development/python-modules/opensensemap-api { };
 
+  openshift = callPackage ../development/python-modules/openshift { };
+
   opentimestamps = callPackage ../development/python-modules/opentimestamps { };
 
   opentracing = callPackage ../development/python-modules/opentracing { };


### PR DESCRIPTION


###### Motivation for this change

I needed openshift for the official kubernetes ansible module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
