### PR TITLE
cagebreak: 1.6.0 -> 1.7.0

### DIFF
--- a/nixos/tests/cagebreak.nix
+++ b/nixos/tests/cagebreak.nix
@@ -75,6 +75,10 @@ in
     user = nodes.machine.config.users.users.alice;
     XDG_RUNTIME_DIR = "/run/user/${toString user.uid}";
   in ''
+    # Normal QEMU drivers don't work after wlroots 0.13 it seems, fix ported
+    # from #119615
+    os.environ["QEMU_OPTS"] = "-vga virtio"
+
     start_all()
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_file("${XDG_RUNTIME_DIR}/wayland-0")

--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -3,25 +3,29 @@
 , wlroots, wayland-protocols, pixman, libxkbcommon
 , cairo , pango, fontconfig, pandoc, systemd, mesa
 , withXwayland ? true, xwayland
-, nixosTests
+, nixosTests, libdrm
 }:
 
 stdenv.mkDerivation rec {
   pname = "cagebreak";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "project-repo";
     repo = "cagebreak";
     rev = version;
-    hash = "sha256-F7fqDVbJS6pVgmj6C1/l9PAaz5yzcYpaq6oc6a6v/Qk=";
+    sha256 = "10ps59dbvxalkdy0rs67k4dgkhy16xspdwpxl551dcxrgcj2740y";
   };
+
+  postPatch = ''
+    substituteInPlace message.c --replace '<drm_fourcc.h>' '<libdrm/drm_fourcc.h>'
+  '';
 
   nativeBuildInputs = [ meson ninja pkg-config wayland scdoc makeWrapper ];
 
   buildInputs = [
     wlroots wayland wayland-protocols pixman libxkbcommon cairo
-    pango fontconfig pandoc systemd
+    pango fontconfig pandoc systemd libdrm
     mesa # for libEGL headers
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31242,9 +31242,7 @@ in
 
   bottom = callPackage ../tools/system/bottom {};
 
-  cagebreak = callPackage ../applications/window-managers/cagebreak/default.nix {
-    wlroots = wlroots_0_12;
-  };
+  cagebreak = callPackage ../applications/window-managers/cagebreak/default.nix { };
 
   psftools = callPackage ../os-specific/linux/psftools {};
 


### PR DESCRIPTION
###### Motivation for this change
Tests still failing, related to the failure in https://github.com/NixOS/nixpkgs/pull/119615

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
