### PR TITLE
wemux: init at 2021-04-16

### DIFF
--- a/pkgs/tools/misc/wemux/default.nix
+++ b/pkgs/tools/misc/wemux/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchFromGitHub, tmux, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "wemux";
+  version = "unstable-2021-04-16";
+
+  src = fetchFromGitHub {
+    owner = "zolrath";
+    repo = "wemux";
+    rev = "01c6541f8deceff372711241db2a13f21c4b210c";
+    sha256 = "1y962nzvs7sf720pl3wa582l6irxc8vavd0gp4ag4243b2gs4qvm";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+
+    substituteInPlace wemux \
+        --replace tmux ${tmux}/bin/tmux \
+        --replace "/usr/local/etc" "/etc"
+
+    substituteInPlace man/wemux.1 --replace "/usr/local/etc" "/etc"
+
+    install -Dm755 wemux -t $out/bin
+    installManPage man/wemux.1
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/zolrath/wemux";
+    description = "Multi-user tmux made easy";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ bsima ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9221,6 +9221,8 @@ in
 
   welkin = callPackage ../tools/graphics/welkin {};
 
+  wemux = callPackage ../tools/misc/wemux { };
+
   wf-recorder = callPackage ../applications/video/wf-recorder { };
 
   whipper = callPackage ../applications/audio/whipper { };


### PR DESCRIPTION
The usual wemux.conf location is /usr/local/etc, but that directory doesn't
exist, so we patch the script to look in /etc.

Reviewed-by: William Casarin <jb55@jb55.com>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
