### PR TITLE
init: lib/flake

### DIFF
--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -1,0 +1,5 @@
+{
+  description = "Library of low-level helper functions for nix expressions.";
+
+  outputs = { self }: { lib = import ./lib; };
+}


### PR DESCRIPTION
A subflake that can be indidividually accessed without also providing
an interface to the whole of nixpkgs.

Usage:
```
inputs.nixpkgs-lib.url = "github:NixOS/nixpkgs?dir=lib"
```

###### Motivation for this change
https://discourse.nixos.org/t/cheaper-nixpkgs-lib-for-flake-users/12444?u=blaggacao

> - Some projects choose to not depend on `nixpkgs` for a variety of reasons.
> 
> - Such projects often re-implement library function just to work around that restriction.

This change gives such projects a conceptually clean way to depend on nixpkgs library functions without depending on nixpkgs itself.

