### PR TITLE
mpvScripts: use stdenvNoCC and misc. cleanup

### DIFF
--- a/pkgs/applications/video/mpv/scripts/autoload.nix
+++ b/pkgs/applications/video/mpv/scripts/autoload.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, mpv-unwrapped, lib }:
+{ stdenvNoCC, fetchurl, mpv-unwrapped, lib }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "mpv-autoload";
   version = mpv-unwrapped.version;
   src = "${mpv-unwrapped.src.outPath}/TOOLS/lua/autoload.lua";

--- a/pkgs/applications/video/mpv/scripts/autoload.nix
+++ b/pkgs/applications/video/mpv/scripts/autoload.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchurl, mpv-unwrapped, lib }:
+{ stdenvNoCC, mpv-unwrapped, lib }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "mpv-autoload";

--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -30,14 +30,15 @@ stdenvNoCC.mkDerivation {
   '';
   passthru.scriptName = "convert_script.lua";
 
-  meta = {
+  meta = with lib; {
     description = "Convert parts of a video while you are watching it in mpv";
     homepage = "https://gist.github.com/Zehkul/25ea7ae77b30af959be0";
-    maintainers = [ lib.maintainers.Profpatsch ];
+    maintainers = [ maintainers.Profpatsch ];
     longDescription = ''
       When this script is loaded into mpv, you can hit Alt+W to mark the beginning
       and Alt+W again to mark the end of the clip. Then a settings window opens.
     '';
+    license = licenses.unfree;
   };
 }
 

--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -39,6 +39,8 @@ stdenvNoCC.mkDerivation {
       and Alt+W again to mark the end of the clip. Then a settings window opens.
     '';
     license = licenses.unfree;
+    # script crashes mpv. See https://github.com/NixOS/nixpkgs/issues/113202
+    broken = true;
   };
 }
 

--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchgit, lib
+{ stdenvNoCC, fetchgit, lib
 , yad, mkvtoolnix-cli, libnotify }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "mpv-convert-script";
   version = "2016-03-18";
   src = fetchgit {

--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, curl, xclip }:
+{ lib, stdenvNoCC, fetchFromGitHub, curl, xclip }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "mpvacious";
   version = "0.14";
 

--- a/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
+++ b/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ lib, stdenvNoCC
 , fetchFromGitHub }:
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "simple-mpv-ui";
   version = "1.0.0";
 

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, python3 }:
+{ lib, stdenvNoCC, fetchFromGitHub, fetchpatch, python3 }:
 
 # Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.sponsorblock ]; }`
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "mpv_sponsorblock";
   version = "unstable-2020-07-05";
 

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -1,6 +1,6 @@
-{ fetchFromGitHub, lib, python3, stdenv }:
+{ fetchFromGitHub, lib, python3, stdenvNoCC }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "mpv_thumbnail_script";
   version = "unstable-2020-01-16";
 


### PR DESCRIPTION
###### Motivation for this change

A few cleanup items for mpv plugins:

1. Use `stdenvNoCC` when building, as a C compiler is not needed (`mpvScripts.mpdris` notwithstanding)
2. Drop the unused `fetchurl` dependency in `mpvScripts.autoload`
3. Set the license of `mpvScripts.convert` to `unfree` since the upstream gist has no license

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
