### PR TITLE
iso-image: Fix GRUB graphical menu on AArch64

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -365,11 +365,13 @@ let
     }
 
     ${lib.optionalString (refindBinary != null) ''
-    menuentry 'rEFInd' --class refind {
-      # UUID is hard-coded in the derivation.
-      search --set=root --no-floppy --fs-uuid 1234-5678
-      chainloader (\$root)/EFI/boot/${refindBinary}
-    }
+    # GRUB apparently cannot do "chainloader" operations on "CD".
+    if [ "\$root" != "cd0" ]; then
+      menuentry 'rEFInd' --class refind {
+        # \$root defaults to the drive the EFI is found on.
+        chainloader (\$root)/EFI/boot/${refindBinary}
+      }
+    fi
     ''}
     menuentry 'Firmware Setup' --class settings {
       fwsetup

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -186,7 +186,7 @@ let
 
     # Fonts can be loaded?
     # (This font is assumed to always be provided as a fallback by NixOS)
-    if loadfont (hd0)/EFI/boot/unicode.pf2; then
+    if loadfont /EFI/boot/unicode.pf2; then
       # Use graphical term, it can be either with background image or a theme.
       # input is "console", while output is "gfxterm".
       # This enables "serial" input and output only when possible.
@@ -207,11 +207,11 @@ let
     ${ # When there is a theme configured, use it, otherwise use the background image.
     if config.isoImage.grubTheme != null then ''
       # Sets theme.
-      set theme=(hd0)/EFI/boot/grub-theme/theme.txt
+      set theme=/EFI/boot/grub-theme/theme.txt
       # Load theme fonts
-      $(find ${config.isoImage.grubTheme} -iname '*.pf2' -printf "loadfont (hd0)/EFI/boot/grub-theme/%P\n")
+      $(find ${config.isoImage.grubTheme} -iname '*.pf2' -printf "loadfont /EFI/boot/grub-theme/%P\n")
     '' else ''
-      if background_image (hd0)/EFI/boot/efi-background.png; then
+      if background_image /EFI/boot/efi-background.png; then
         # Black background means transparent background when there
         # is a background image set... This seems undocumented :(
         set color_normal=black/black

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -187,6 +187,9 @@ let
     # Fonts can be loaded?
     # (This font is assumed to always be provided as a fallback by NixOS)
     if loadfont /EFI/boot/unicode.pf2; then
+      set with_fonts=true
+    fi
+    if [ "\$textmode" != "true" -a "\$with_fonts" == "true" ]; then
       # Use graphical term, it can be either with background image or a theme.
       # input is "console", while output is "gfxterm".
       # This enables "serial" input and output only when possible.
@@ -264,6 +267,8 @@ let
 
     cat <<EOF > $out/EFI/boot/grub.cfg
 
+    set with_fonts=false
+    set textmode=false
     # If you want to use serial for "terminal_*" commands, you need to set one up:
     #   Example manual configuration:
     #    → serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
@@ -273,7 +278,27 @@ let
     export with_serial
     clear
     set timeout=10
+
+    # This message will only be viewable when "gfxterm" is not used.
+    echo ""
+    echo "Loading graphical boot menu..."
+    echo ""
+    echo "Press 't' to use the text boot menu on this console..."
+    echo ""
+
     ${grubMenuCfg}
+
+    hiddenentry 'Text mode' --hotkey 't' {
+      loadfont /EFI/boot/unicode.pf2
+      set textmode=true
+      terminal_output gfxterm console
+    }
+    hiddenentry 'GUI mode' --hotkey 'g' {
+      $(find ${config.isoImage.grubTheme} -iname '*.pf2' -printf "loadfont /EFI/boot/grub-theme/%P\n")
+      set textmode=false
+      terminal_output gfxterm
+    }
+
 
     # If the parameter iso_path is set, append the findiso parameter to the kernel
     # line. We need this to allow the nixos iso to be booted from grub directly.

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -1,6 +1,8 @@
 { lib, stdenv, fetchgit, flex, bison, python3, autoconf, automake, gnulib, libtool
 , gettext, ncurses, libusb-compat-0_1, freetype, qemu, lvm2, unifont, pkg-config
 , buildPackages
+, fetchpatch
+, pkgsBuildBuild
 , nixosTests
 , fuse # only needed for grub-mount
 , runtimeShell
@@ -55,6 +57,12 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix-bash-completion.patch
+    (fetchpatch {
+      name = "Add-hidden-menu-entries.patch";
+      # https://lists.gnu.org/archive/html/grub-devel/2016-04/msg00089.html
+      url = "https://marc.info/?l=grub-devel&m=146193404929072&q=mbox";
+      sha256 = "00wa1q5adiass6i0x7p98vynj9vsz1w0gn1g4dgz89v35mpyw2bi";
+    })
   ];
 
   postPatch = if kbdcompSupport then ''


### PR DESCRIPTION

![IMG_20210420_202309](https://user-images.githubusercontent.com/132835/115480767-2f841700-a219-11eb-8d13-475a537d053f.jpg)


This is going to get a bit confusing later on. Be warned.

First, there's a commit to introduce a hidden menu entry option to GRUB. The patch comes from the upstream mailing list. The patch is used by SUSE for the same purpose we'll be using it, to provide a hotkey to force the "console" GRUB menu to be used.

The second commit fixes file paths. They were prefixed with `(hd0)`, which turns out is not needed here. The EFI volume used for boot is already the "PWD".

The third commit introduces the required changes so that the console interface can be used. And here's where it gets confusing. GRUB supports the `serial` interface, which is for when *GRUB itself* speaks to a serial device. On AArch64, serial interfaces with U-Boot will not be used by *GRUB itself*. Rather, the *console* is present. The console is the text interface provided by the UEFI firmware. So this change is a total no-op for serial users, like `qemu ... -serial mon:stdio`.

The last two commits are about rEFInd. There was an uninvestigated issue with the rEFInd entry. It wouldn't work on qemu, when the image was used as a `-cdrom`. Turns out GRUB apparently cannot chainload the EFI program from `(cd0)`. The same issue can be observed on U-Boot on AArch64. The first commit adds rEFInd for AArch64, the second hides the menu entry from being shown in "cd" situations, where GRUB wouldn't be able to load it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

And:

 - Tested with qemu and OVMF.
 - Tested on misc. SBCs with U-Boot's UEFI implementation

~~Currently draft since I've just realized how to fix the rEFInd menu option for AArch64.~~ Won't work, but it's not an AArch64 issue.