### PR TITLE
git-interactive-rebase-tool: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
@@ -2,21 +2,28 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "git-interactive-rebase-tool";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "MitMaro";
     repo = pname;
     rev = version;
-    sha256 = "117zwxyq2vc33nbnfpjbdr5vc2l5ymf6ln1dm5551ha3y3gdq3bf";
+    sha256 = "sha256-DYl/GUbeNtKmXoR3gq8mK8EfsZNVNlrdngAwfzG+epw=";
   };
 
-  cargoSha256 = "051llwk9swq03xdqwyj0hlyv2ywq2f1cnks95nygyy393q7v930x";
+  cargoSha256 = "sha256-1joMWPfn0s+pLsO6NHMT6AoXZ33R8MY2AWSrROY2mw8=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security ];
 
-  # external_editor::tests::* tests fail
-  doCheck = false;
+  checkFlags = [
+    "--skip=external_editor::tests::edit_success"
+    "--skip=external_editor::tests::editor_non_zero_exit"
+    "--skip=external_editor::tests::empty_edit_abort_rebase"
+    "--skip=external_editor::tests::empty_edit_error"
+    "--skip=external_editor::tests::empty_edit_noop"
+    "--skip=external_editor::tests::empty_edit_re_edit_rebase_file"
+    "--skip=external_editor::tests::empty_edit_undo_and_edit"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/MitMaro/git-interactive-rebase-tool";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
