### PR TITLE
matrix-synapse: 1.30 -> 1.32.2

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -12,11 +12,11 @@ let
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.30.0";
+  version = "1.31.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ca69v479537bbj2hjliwk9zzy9fqqsf7fm188k6xxj0a37q9y41";
+    sha256 = "0yr1lij66s9sc6razzjr9r6xvl462ff31xg0a3m7ys2f9zzrms0v";
   };
 
   patches = [

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -12,11 +12,11 @@ let
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.32.1";
+  version = "1.32.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-A9ZWoZq+ZeUeQkqb84q1PG7BEBL2sVyG3qwRq0AqsNk=";
+    sha256 = "sha256-Biwj/zORBsU8XvpMMlSjR3Nqx0q1LqaSX/vX+UDeXI8=";
   };
 
   patches = [

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -12,11 +12,11 @@ let
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.32.0";
+  version = "1.32.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-CuPO5+zZitDvMjAxAkmEyVFxdZeqzjFH/7wDLvcUgSM=";
+    sha256 = "sha256-A9ZWoZq+ZeUeQkqb84q1PG7BEBL2sVyG3qwRq0AqsNk=";
   };
 
   patches = [

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -12,11 +12,11 @@ let
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.31.0";
+  version = "1.32.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0yr1lij66s9sc6razzjr9r6xvl462ff31xg0a3m7ys2f9zzrms0v";
+    sha256 = "sha256-CuPO5+zZitDvMjAxAkmEyVFxdZeqzjFH/7wDLvcUgSM=";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Closes #118864

https://github.com/matrix-org/synapse/releases/tag/v1.31.0
https://github.com/matrix-org/synapse/releases/tag/v1.32.0
https://github.com/matrix-org/synapse/releases/tag/v1.32.1
https://github.com/matrix-org/synapse/releases/tag/v1.32.2

Note: from this release onwards at least Postgres 9.6 and Python 3.6 is needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
