### PR TITLE
kicad: 5.1.9 -> 5.1.10; plus bunch of cleanup

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -61,7 +61,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "kicad-base";
-  version = kicadVersion;
+  version = if (stable) then kicadVersion else builtins.substring 0 10 src.rev;
 
   src = kicadSrc;
 

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -50,12 +50,18 @@
 , withNgspice
 , withScripting
 , debug
+, sanitizeAddress
+, sanitizeThreads
 , withI18n
 }:
 
 assert lib.asserts.assertMsg (!(withOCE && stdenv.isAarch64)) "OCE fails a test on Aarch64";
 assert lib.asserts.assertMsg (!(withOCC && withOCE))
   "Only one of OCC and OCE may be enabled";
+assert lib.assertMsg (!(stable && (sanitizeAddress || sanitizeThreads)))
+  "Only kicad-unstable(-small) supports address/thread sanitation";
+assert lib.assertMsg (!(sanitizeAddress && sanitizeThreads))
+  "'sanitizeAddress' and 'sanitizeThreads' are mutually exclusive, use one.";
 let
   inherit (lib) optional optionals;
 in
@@ -98,6 +104,12 @@ stdenv.mkDerivation rec {
     "-DCMAKE_BUILD_TYPE=Debug"
     "-DKICAD_STDLIB_DEBUG=ON"
     "-DKICAD_USE_VALGRIND=ON"
+  ]
+  ++ optionals (sanitizeAddress) [
+    "-DKICAD_SANITIZE_ADDRESS=ON"
+  ]
+  ++ optionals (sanitizeThreads) [
+    "-DKICAD_SANITIZE_THREADS=ON"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -15,10 +15,30 @@
 , boost
 , pkg-config
 , doxygen
+, graphviz
 , pcre
 , libpthreadstubs
 , libXdmcp
 , lndir
+
+, util-linux
+, libselinux
+, libsepol
+, libthai
+, libdatrie
+, libxkbcommon
+, epoxy
+, dbus
+, at-spi2-core
+, libXtst
+
+, swig
+, python
+, wxPython
+, opencascade
+, opencascade-occt
+, libngspice
+, valgrind
 
 , stable
 , baseName
@@ -26,19 +46,11 @@
 , kicadVersion
 , i18n
 , withOCE
-, opencascade
 , withOCC
-, opencascade-occt
 , withNgspice
-, libngspice
 , withScripting
-, swig
-, python
-, wxPython
 , debug
-, valgrind
 , withI18n
-, gtk3
 }:
 
 assert lib.asserts.assertMsg (!(withOCE && stdenv.isAarch64)) "OCE fails a test on Aarch64";
@@ -56,43 +68,59 @@ stdenv.mkDerivation rec {
   # tagged releases don't have "unknown"
   # kicad nightlies use git describe --dirty
   # nix removes .git, so its approximated here
-  # "-1" appended to indicate we're adding a patch
   postPatch = ''
     substituteInPlace CMakeModules/KiCadVersion.cmake \
-      --replace "unknown" "${builtins.substring 0 10 src.rev}-1" \
-      --replace "${version}" "${version}-1"
+      --replace "unknown" "${builtins.substring 0 10 src.rev}" \
   '';
 
-  makeFlags = optional (debug) [ "CFLAGS+=-Og" "CFLAGS+=-ggdb" ];
+  makeFlags = optionals (debug) [ "CFLAGS+=-Og" "CFLAGS+=-ggdb" ];
 
-  cmakeFlags =
-    optionals (withScripting) [
-      "-DKICAD_SCRIPTING=ON"
-      "-DKICAD_SCRIPTING_MODULES=ON"
-      "-DKICAD_SCRIPTING_PYTHON3=ON"
-      "-DKICAD_SCRIPTING_WXPYTHON_PHOENIX=ON"
-    ]
-    ++ optional (!withScripting)
-      "-DKICAD_SCRIPTING=OFF"
-    ++ optional (withNgspice) "-DKICAD_SPICE=ON"
-    ++ optional (!withOCE) "-DKICAD_USE_OCE=OFF"
-    ++ optional (!withOCC) "-DKICAD_USE_OCC=OFF"
-    ++ optionals (withOCE) [
-      "-DKICAD_USE_OCE=ON"
-      "-DOCE_DIR=${opencascade}"
-    ]
-    ++ optionals (withOCC) [
-      "-DKICAD_USE_OCC=ON"
-      "-DOCC_INCLUDE_DIR=${opencascade-occt}/include/opencascade"
-    ]
-    ++ optionals (debug) [
-      "-DCMAKE_BUILD_TYPE=Debug"
-      "-DKICAD_STDLIB_DEBUG=ON"
-      "-DKICAD_USE_VALGRIND=ON"
-    ]
-  ;
+  cmakeFlags = optionals (withScripting) [
+    "-DKICAD_SCRIPTING=ON"
+    "-DKICAD_SCRIPTING_MODULES=ON"
+    "-DKICAD_SCRIPTING_PYTHON3=ON"
+    "-DKICAD_SCRIPTING_WXPYTHON_PHOENIX=ON"
+  ]
+  ++ optional (!withScripting)
+    "-DKICAD_SCRIPTING=OFF"
+  ++ optional (withNgspice) "-DKICAD_SPICE=ON"
+  ++ optional (!withOCE) "-DKICAD_USE_OCE=OFF"
+  ++ optional (!withOCC) "-DKICAD_USE_OCC=OFF"
+  ++ optionals (withOCE) [
+    "-DKICAD_USE_OCE=ON"
+    "-DOCE_DIR=${opencascade}"
+  ]
+  ++ optionals (withOCC) [
+    "-DKICAD_USE_OCC=ON"
+    "-DOCC_INCLUDE_DIR=${opencascade-occt}/include/opencascade"
+  ]
+  ++ optionals (debug) [
+    "-DCMAKE_BUILD_TYPE=Debug"
+    "-DKICAD_STDLIB_DEBUG=ON"
+    "-DKICAD_USE_VALGRIND=ON"
+  ];
 
-  nativeBuildInputs = [ cmake doxygen pkg-config lndir ];
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    graphviz
+    pkg-config
+    lndir
+  ]
+  # wanted by configuration on linux, doesn't seem to affect performance
+  # no effect on closure size
+  ++ optionals (stdenv.isLinux) [
+    util-linux
+    libselinux
+    libsepol
+    libthai
+    libdatrie
+    libxkbcommon
+    epoxy
+    dbus.daemon
+    at-spi2-core
+    libXtst
+  ];
 
   buildInputs = [
     libGLU
@@ -100,6 +128,7 @@ stdenv.mkDerivation rec {
     zlib
     libX11
     wxGTK
+    wxGTK.gtk
     pcre
     libXdmcp
     gettext
@@ -110,7 +139,6 @@ stdenv.mkDerivation rec {
     curl
     openssl
     boost
-    gtk3
   ]
   ++ optionals (withScripting) [ swig python wxPython ]
   ++ optional (withNgspice) libngspice

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -195,14 +195,29 @@ stdenv.mkDerivation rec {
     # wrapGAppsHook did these two as well, no idea if it matters...
     "--prefix XDG_DATA_DIRS : ${cups}/share"
     "--prefix GIO_EXTRA_MODULES : ${dconf}/lib/gio/modules"
-
+  ]
+  ++ optionals (stable)
+  [
     "--set-default KISYSMOD ${footprints}/share/kicad/modules"
     "--set-default KICAD_SYMBOL_DIR ${symbols}/share/kicad/library"
     "--set-default KICAD_TEMPLATE_DIR ${templates}/share/kicad/template"
     "--prefix KICAD_TEMPLATE_DIR : ${symbols}/share/kicad/template"
     "--prefix KICAD_TEMPLATE_DIR : ${footprints}/share/kicad/template"
   ]
-  ++ optionals (with3d) [ "--set-default KISYS3DMOD ${packages3d}/share/kicad/modules/packages3d" ]
+  ++ optionals (stable && with3d) [ "--set-default KISYS3DMOD ${packages3d}/share/kicad/modules/packages3d" ]
+  ++ optionals (!stable)
+  [
+    "--set-default KICAD6_FOOTPRINT_DIR ${footprints}/share/kicad/modules"
+    "--set-default KICAD6_SYMBOL_DIR ${symbols}/share/kicad/library"
+    "--set-default KICAD6_TEMPLATE_DIR ${templates}/share/kicad/template"
+    "--prefix KICAD6_TEMPLATE_DIR : ${symbols}/share/kicad/template"
+    "--prefix KICAD6_TEMPLATE_DIR : ${footprints}/share/kicad/template"
+  ]
+  ++ optionals (!stable && with3d)
+  [
+    "--set-default KISYS3DMOD ${packages3d}/share/kicad/3dmodels"
+    "--set-default KICAD6_3DMODEL_DIR ${packages3d}/share/kicad/3dmodels"
+  ]
   ++ optionals (withNgspice) [ "--prefix LD_LIBRARY_PATH : ${libngspice}/lib" ]
 
   # infinisil's workaround for #39493

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -155,11 +155,8 @@ in
 stdenv.mkDerivation rec {
 
   # Common libraries, referenced during runtime, via the wrapper.
-  passthru.libraries = callPackages ./libraries.nix { inherit libSrc libVersion; };
-  passthru.i18n = callPackage ./i18n.nix {
-    src = i18nSrc;
-    version = i18nVersion;
-  };
+  passthru.libraries = callPackages ./libraries.nix { inherit libSrc; };
+  passthru.i18n = callPackage ./i18n.nix { src = i18nSrc; };
   base = callPackage ./base.nix {
     inherit stable baseName;
     inherit kicadSrc kicadVersion;
@@ -169,7 +166,7 @@ stdenv.mkDerivation rec {
   };
 
   inherit pname;
-  version = kicadVersion;
+  version = if (stable) then kicadVersion else builtins.substring 0 10 src.src.rev;
 
   src = base;
   dontUnpack = true;

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -146,7 +146,9 @@ let
       };
 
   python = python3;
-  wxPython = python.pkgs.wxPython_4_0;
+  wxPython = if (stable)
+    then python.pkgs.wxPython_4_0
+    else python.pkgs.wxPython_4_1;
 
   inherit (lib) concatStringsSep flatten optionalString optionals;
 in

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -255,6 +255,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share
     ln -s ${base}/share/applications $out/share/applications
+    ln -s ${base}/share/metainfo $out/share/metainfo
     ln -s ${base}/share/icons $out/share/icons
     ln -s ${base}/share/mime $out/share/mime
   '';

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -195,6 +195,8 @@ stdenv.mkDerivation rec {
     # wrapGAppsHook did these two as well, no idea if it matters...
     "--prefix XDG_DATA_DIRS : ${cups}/share"
     "--prefix GIO_EXTRA_MODULES : ${dconf}/lib/gio/modules"
+    # required to open a bug report link in firefox-wayland
+    "--set-default MOZ_DBUS_REMOTE 1"
   ]
   ++ optionals (stable)
   [
@@ -278,8 +280,7 @@ stdenv.mkDerivation rec {
       The Programs handle Schematic Capture, and PCB Layout with Gerber output.
     '';
     license = lib.licenses.gpl3Plus;
-    # berce seems inactive...
-    maintainers = with lib.maintainers; [ evils kiwi berce ];
+    maintainers = with lib.maintainers; [ evils kiwi ];
     # kicad is cross platform
     platforms = lib.platforms.all;
     # despite that, nipkgs' wxGTK for darwin is "wxmac"

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -25,6 +25,8 @@
 , withScripting ? true
 , python3
 , debug ? false
+, sanitizeAddress ? false
+, sanitizeThreads ? false
 , with3d ? true
 , withI18n ? true
 , srcs ? { }
@@ -162,7 +164,8 @@ stdenv.mkDerivation rec {
     inherit kicadSrc kicadVersion;
     inherit (passthru) i18n;
     inherit wxGTK python wxPython;
-    inherit debug withI18n withOCC withOCE withNgspice withScripting;
+    inherit withI18n withOCC withOCE withNgspice withScripting;
+    inherit debug sanitizeAddress sanitizeThreads;
   };
 
   inherit pname;

--- a/pkgs/applications/science/electronics/kicad/i18n.nix
+++ b/pkgs/applications/science/electronics/kicad/i18n.nix
@@ -2,13 +2,13 @@
 , cmake
 , gettext
 , src
-, version
 }:
 
 stdenv.mkDerivation {
-  inherit src version;
+  inherit src;
 
   pname = "kicad-i18n";
+  version = builtins.substring 0 10 src.rev;
 
   nativeBuildInputs = [ cmake gettext ];
   meta = with lib; {

--- a/pkgs/applications/science/electronics/kicad/libraries.nix
+++ b/pkgs/applications/science/electronics/kicad/libraries.nix
@@ -2,13 +2,12 @@
 , cmake
 , gettext
 , libSrc
-, libVersion
 }:
 let
   mkLib = name:
     stdenv.mkDerivation {
       pname = "kicad-${name}";
-      version = libVersion;
+      version = builtins.substring 0 10 (libSrc name).rev;
 
       src = libSrc name;
 

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,23 +27,23 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2020-12-23";
+      version =			"2021-05-13";
       src = {
-        rev =			"912657dd238ad78cfc5d9d5e426ea850d5554fb3";
-        sha256 =		"1p5kr4d4zpajwdmya1f351y1ix8qmvsx1hrnvhzh7yc3g72kgxah";
+        rev =			"8513ca974c28d76d9f74a7dc96601d98e66e87fd";
+        sha256 =		"1xlj6jwzwxsa14djqhj0csziii21mr9czvdj6fxqp6px84cifjsh";
       };
     };
     libVersion = {
-      version =			"2020-12-23";
+      version =			"2021-05-13";
       libSources = {
         i18n.rev =		"e89d9a89bec59199c1ade56ee2556591412ab7b0";
         i18n.sha256 =		"04zaqyhj3qr4ymyd3k5vjpcna64j8klpsygcgjcv29s3rdi8glfl";
-        symbols.rev =		"e538abb015b4f289910a6f26b2f1b9cb8bf2efdb";
-        symbols.sha256 =	"117y4cm46anlrnw6y6mdjgl1a5gab6h6m7cwx3q7qb284m9bs5gi";
-        templates.rev =		"32a4f6fab863976fdcfa232e3e08fdcf3323a954";
-        templates.sha256 =	"13r94dghrh9slpj7nkzv0zqv5hk49s6pxm4q5ndqx0y8037ivmhk";
-        footprints.rev =	"15ffd67e01257d4d8134dbd6708cb58977eeccbe";
-        footprints.sha256 =	"1ad5k3wh2zqfibrar7pd3g363jk2q51dvraxnq3zlxa2x4znh7mw";
+        symbols.rev =		"32de73ea01347a005790119eb4102c550815685c";
+        symbols.sha256 =	"0gj10v06rkxlxngc40d1sfmlcagy5p7jfxid0lch4w0wxfjmks7z";
+        templates.rev =		"073d1941c428242a563dcb5301ff5c7479fe9c71";
+        templates.sha256 =	"14p06m2zvlzzz2w74y83f2zml7mgv5dhy2nyfkpblanxawrzxv1x";
+        footprints.rev =	"8fa36dfa3423d8777472e3475c1c2b0b2069624f";
+        footprints.sha256 =	"138xfkr0prxw2djkwc1m4mlp9km99v12sivbqhm1jkq5yxngdbin";
         packages3d.rev =	"d8b7e8c56d535f4d7e46373bf24c754a8403da1f";
         packages3d.sha256 =	"0dh8ixg0w43wzj5h3164dz6l1vl4llwxhi3qcdgj1lgvrs28aywd";
       };

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,17 +3,17 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"5.1.9";
+      version =			"5.1.10";
       src = {
-        rev =			"73d0e3b20dec05c4350efa5b69916eb29a7bfcb5";
-        sha256 =		"1cqh3bc9y140hbryfk9qavs2y3lj5sm9q0qjxcf4mm472afzckky";
+        rev =			"88a1d61d58fdd62149bd1e00984e01540148ca1b";
+        sha256 =		"10ix560bqy0lprnik1bprxw9ix4g8w2ipvyikx551ak9ryvgwjcc";
       };
     };
     libVersion = {
-      version =			"5.1.9";
+      version =			"5.1.10";
       libSources = {
-        i18n.rev =		"04f3231f60d55400cb81564b2cd465a57d5192d5";
-        i18n.sha256 =		"04jq1dcag6i2ljjfqrib65mn4wg4c4nmi7i946l3bywc0rkqsx1f";
+        i18n.rev =		"f081afe79be4660d5c49a9d674e3cb666d76d4d0";
+        i18n.sha256 =		"0y51l0r62cnxkvpc21732p3cx7pjvaqjih8193502hlv9kv1j9p6";
         symbols.rev =		"6dec5004b6a2679c19d4857bda2f90c5ab3a5726";
         symbols.sha256 =	"0n25rq32jwyigfw26faqraillwv6zbi2ywy26dkz5zqlf5xp56ad";
         templates.rev =		"1ccbaf3704e8ff4030d0915f71e051af621ef7d7";


### PR DESCRIPTION
###### Motivation for this change
upstream my local changes

supersedes / closes #120129

###### Things done
cleanup version string post patch removal
use latest wxPython package for kicad-unstable
link through the new /share/metainfo
bump kicad-unstable to latest commit
bump kicad to latest release

bit of cleanup
including adding a bunch of inputs in response to configuration warnings (all linux specific)

expose the new address and threads sanitation options

revert https://github.com/NixOS/nixpkgs/pull/100066/files#diff-42931fe739a41421fbba1e00b70d4ec50f620a254b86430a40df5e2a355cd820R54
as embedding the date causes a large rebuild after midnight (UTC)
additionally, reverted such a change in the libraries, as they change less often than the date does and just generates store garbage

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/2rgrws9iz17rbzd3ni7pky4ps5d3zsal-kicad-5.1.9	 6751202712`
  - `/nix/store/s5nzi6n6w88yxvarha6yc3v7iwsrzs7z-kicad-5.1.10	 6751000128`
  - `/nix/store/zdzrngcbl71wbg7wsvc6zbrravc4vr6c-kicad-unstable-2020-12-23	 6914682792`
  - `/nix/store/0pl7p5176k287zxqz8m6gdhny4kmspwh-kicad-unstable-8513ca974c	 6949715408`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

