### PR TITLE
sish: init at 1.1.5

### DIFF
--- a/pkgs/tools/networking/sish/default.nix
+++ b/pkgs/tools/networking/sish/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "sish";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "antoniomika";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06ckgxhnijs7yrj0hhwh1vk2fvapwn6wb44w3g6qs6n6fmqh92mb";
+  };
+
+  vendorSha256 = "0vfazbaiaqka5nd7imh5ls7k3asf1c17y081nzkban98svg3l3sj";
+
+  meta = with lib; {
+    description = "HTTP(S)/WS(S)/TCP Tunnels to localhost";
+    homepage = "https://github.com/antoniomika/sish";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25728,6 +25728,8 @@ in
 
   siproxd = callPackage ../applications/networking/siproxd { };
 
+  sish = callPackage ../tools/networking/sish { };
+
   skypeforlinux = callPackage ../applications/networking/instant-messengers/skypeforlinux { };
 
   skype4pidgin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/skype4pidgin { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
HTTP(S)/WS(S)/TCP Tunnels to localhost

https://github.com/antoniomika/sish

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
