### PR TITLE
dropwatch. 1.5.1 -> 1.5.3

### DIFF
--- a/pkgs/os-specific/linux/dropwatch/default.nix
+++ b/pkgs/os-specific/linux/dropwatch/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Linux kernel dropped packet monitor";
     homepage = "https://github.com/nhorman/dropwatch";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ c0bw3b ];
   };

--- a/pkgs/os-specific/linux/dropwatch/default.nix
+++ b/pkgs/os-specific/linux/dropwatch/default.nix
@@ -1,22 +1,39 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config
-, libnl, readline, libbfd, ncurses, zlib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, libbfd
+, libnl
+, libpcap
+, ncurses
+, readline
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "dropwatch";
-  version = "1.5.1";
+  version = "1.5.3";
 
   src = fetchFromGitHub {
     owner = "nhorman";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1qmax0l7z1qik42c949fnvjh5r6awk4gpgzdsny8iwnmwzjyp8b8";
+    sha256 = "0axx0zzrs7apqnl0r70jyvmgk7cs5wk185id479mapgngibwkyxy";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ libbfd libnl ncurses readline zlib ];
-
-  # To avoid running into https://sourceware.org/bugzilla/show_bug.cgi?id=14243 we need to define:
-  NIX_CFLAGS_COMPILE = "-DPACKAGE=${pname} -DPACKAGE_VERSION=${version}";
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs = [
+    libbfd
+    libnl
+    libpcap
+    ncurses
+    readline
+    zlib
+  ];
 
   enableParallelBuilding = true;
 
@@ -25,6 +42,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/nhorman/dropwatch";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.c0bw3b ];
+    maintainers = with maintainers; [ c0bw3b ];
   };
 }


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/nhorman/dropwatch/releases/tag/v1.5.2
https://github.com/nhorman/dropwatch/releases/tag/v1.5.3

```
❯ sudo ./result/bin/dropwatch -l kas
Initializing kallsyms db
dropwatch> start
Enabling monitoring...
Kernel monitoring activated.
Issue Ctrl-C to stop monitoring
1 drops at igmp_rcv+29a (0xffffffffb073390a) [software]
3 drops at unix_release_sock+1e6 (0xffffffffb076d9e6) [software]
1 drops at icmpv6_rcv+1df (0xffffffffb07a632f) [software]
^CGot a stop message
dropwatch> Terminating dropwatch...
Shutting down ...
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
