### PR TITLE
python3.pkgs.telfhash: init at unstable-2021-01-29

### DIFF
--- a/pkgs/development/python-modules/telfhash/default.nix
+++ b/pkgs/development/python-modules/telfhash/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, capstone
+, pyelftools
+, tlsh
+, nose
+}:
+buildPythonPackage {
+  pname = "telfhash";
+  version = "unstable-2021-01-29";
+
+  src = fetchFromGitHub {
+    owner = "trendmicro";
+    repo = "telfhash";
+    rev = "b5e398e59dc25a56a28861751c1fccc74ef71617";
+    sha256 = "jNu6qm8Q/UyJVaCqwFOPX02xAR5DwvCK3PaH6Fvmakk=";
+  };
+
+  # The tlsh library's name is just "tlsh"
+  postPatch = ''
+    substituteInPlace requirements.txt --replace "python-tlsh" "tlsh"
+  '';
+
+  propagatedBuildInputs = [
+    capstone
+    pyelftools
+    tlsh
+  ];
+
+  checkInputs = [
+    nose
+  ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  pythonImportsCheck = [
+    "telfhash"
+  ];
+
+  meta = with lib; {
+    description = "Symbol hash for ELF files";
+    homepage = "https://github.com/trendmicro/telfhash";
+    license = licenses.asl20;
+    maintainers = teams.determinatesystems.members;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8142,6 +8142,8 @@ in {
 
   telethon-session-sqlalchemy = callPackage ../development/python-modules/telethon-session-sqlalchemy { };
 
+  telfhash = callPackage ../development/python-modules/telfhash { };
+
   tempita = callPackage ../development/python-modules/tempita { };
 
   tempora = callPackage ../development/python-modules/tempora { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
