### PR TITLE
python3.pkgs.cve-bin-tool: init at unstable-2021-04-15

### DIFF
--- a/pkgs/development/python-modules/cve-bin-tool/default.nix
+++ b/pkgs/development/python-modules/cve-bin-tool/default.nix
@@ -1,0 +1,83 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, jsonschema
+, plotly
+, pytest
+, pytest-xdist
+, pytest-cov
+, pytest-asyncio
+, beautifulsoup4
+, pyyaml
+, isort
+, py
+, jinja2
+, rpmfile
+, reportlab
+, zstandard
+, rich
+, aiohttp
+, toml
+  # aiohttp[speedups]
+, aiodns
+, brotlipy
+, cchardet
+, pillow
+, pytestCheckHook
+}:
+buildPythonPackage {
+  pname = "cve-bin-tool";
+  version = "unstable-2021-04-15";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "cve-bin-tool";
+    rev = "10cb6fd0baffe35babfde024bc8c70aa58629237";
+    sha256 = "STf0tJBpadBqsbC+MghBai8zahDkrXfLoFRJ+84wvvY=";
+  };
+
+  # Wants to open a sqlite database, access the internet, etc
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    jsonschema
+    plotly
+    pytest
+    pytest-xdist
+    pytest-cov
+    pytest-asyncio
+    beautifulsoup4
+    pyyaml
+    isort
+    py
+    jinja2
+    rpmfile
+    reportlab
+    zstandard
+    rich
+    aiohttp
+    toml
+
+    # aiohttp[speedups]
+    aiodns
+    brotlipy
+    cchardet
+    # needed by brotlipy
+    pillow
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "cve_bin_tool"
+  ];
+
+  meta = with lib; {
+    description = "CVE Binary Checker Tool";
+    homepage = "https://github.com/intel/cve-bin-tool";
+    license = licenses.gpl3Only;
+    maintainers = teams.determinatesystems.members;
+  };
+}

--- a/pkgs/development/python-modules/rpmfile/default.nix
+++ b/pkgs/development/python-modules/rpmfile/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+}:
+buildPythonPackage rec {
+  pname = "rpmfile";
+  version = "1.0.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e56cfc10e1a7d953b1890d81652a89400c614f4cdd9909464aece434d93c3a3e";
+  };
+
+  # Tests access the internet
+  doCheck = false;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  pythonImportsCheck = [
+    "rpmfile"
+  ];
+
+  meta = with lib; {
+    description = "Read rpm archive files";
+    homepage = "https://github.com/srossross/rpmfile";
+    license = licenses.mit;
+    maintainers = teams.determinatesystems.members;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7106,6 +7106,8 @@ in {
     inherit python;
   });
 
+  rpmfile = callPackage ../development/python-modules/rpmfile { };
+
   rpmfluff = callPackage ../development/python-modules/rpmfluff { };
 
   rpy2 = callPackage ../development/python-modules/rpy2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1603,6 +1603,8 @@ in {
 
   curve25519-donna = callPackage ../development/python-modules/curve25519-donna { };
 
+  cve-bin-tool = callPackage ../development/python-modules/cve-bin-tool { };
+
   cvxopt = callPackage ../development/python-modules/cvxopt { };
 
   cvxpy = callPackage ../development/python-modules/cvxpy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

----

~~Waiting on next staging-next merge for python3.pkgs.py 1.10.0 and python3.pkgs.pyyaml 5.4.1.~~