### PR TITLE
honeytrap: init at unstable-2020-12-10

### DIFF
--- a/pkgs/tools/security/honeytrap/default.nix
+++ b/pkgs/tools/security/honeytrap/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+buildGoModule {
+  pname = "honeytrap";
+  version = "unstable-2020-12-10";
+
+  src = fetchFromGitHub {
+    owner = "honeytrap";
+    repo = "honeytrap";
+    rev = "affd7b21a5aa1b57f086e6871753cb98ce088d76";
+    sha256 = "y1SWlBFgX3bFoSRGJ45DdC1DoIK5BfO9Vpi2h57wWtU=";
+  };
+
+  # Otherwise, will try to install a "scripts" binary; it's only used in
+  # dockerize.sh, which we don't care about.
+  subPackages = [ "." ];
+
+  vendorSha256 = "W8w66weYzCpZ+hmFyK2F6wdFz6aAZ9UxMhccNy1X1R8=";
+
+  meta = with lib; {
+    description = "Advanced Honeypot framework";
+    homepage = "https://github.com/honeytrap/honeytrap";
+    license = licenses.asl20;
+    maintainers = teams.determinatesystems.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29006,6 +29006,8 @@ in
 
   hologram = callPackage ../tools/security/hologram { };
 
+  honeytrap = callPackage ../tools/security/honeytrap { };
+
   tini = callPackage ../applications/virtualization/tini {};
 
   ifstat-legacy = callPackage ../tools/networking/ifstat-legacy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
