### PR TITLE
xorex: init at 0.3.0

### DIFF
--- a/pkgs/tools/security/xorex/default.nix
+++ b/pkgs/tools/security/xorex/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "xorex";
+  version = "0.3.0";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "Neo23x0";
+    repo = "xorex";
+    rev = version;
+    sha256 = "rBsOSXWnHRhpLmq20XBuGx8gGBM8ouMyOISkbzUcvE4=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    chmod +x xorex.py
+    mv xorex.py $out/bin/xorex
+
+    runHook postInstall
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    colorama
+    pefile
+  ];
+
+  meta = with lib; {
+    description = "XOR Key Extractor";
+    homepage = "https://github.com/Neo23x0/xorex";
+    license = licenses.asl20;
+    maintainers = teams.determinatesystems.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30568,6 +30568,8 @@ in
 
   xortool = python3Packages.callPackage ../tools/security/xortool { };
 
+  xorex = callPackage ../tools/security/xorex { };
+
   xow = callPackage ../misc/drivers/xow { };
 
   xbps = callPackage ../tools/package-management/xbps { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
