### PR TITLE
dcs: init at unstable-2021-04-07

### DIFF
--- a/pkgs/tools/text/dcs/default.nix
+++ b/pkgs/tools/text/dcs/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, python3Packages
+, perl
+, zopfli
+, stdenv
+}:
+buildGoModule {
+  pname = "dcs";
+  version = "unstable-2021-04-07";
+
+  src = fetchFromGitHub {
+    owner = "Debian";
+    repo = "dcs";
+    rev = "da46accc4d55e9bfde1a6852ac5a9e730fcbbb2c";
+    sha256 = "N+6BXlKn1YTlh0ZdPNWa0nuJNcQtlUIc9TocM8cbzQk=";
+  };
+
+  vendorSha256 = "l2mziuisx0HzuP88rS5M+Wha6lu8P036wJYZlmzjWfs=";
+
+  # Depends on dcs binaries
+  doCheck = false;
+
+  nativeBuildInputs = [
+    python3Packages.slimit
+    (perl.withPackages (p: [ p.CSSMinifier ]))
+    zopfli
+  ];
+
+  postBuild = ''
+    make -C static -j$NIX_BUILD_CORES
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/dcs
+    cp -r cmd/dcs-web/templates $out/share/dcs
+    cp -r static $out/share/dcs
+  '';
+
+  meta = with lib; {
+    description = "Debian Code Search";
+    homepage = "https://github.com/Debian/dcs";
+    license = licenses.bsd3;
+    maintainers = teams.determinatesystems.members;
+    broken = stdenv.isAarch64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3752,6 +3752,8 @@ in
 
   dcraw = callPackage ../tools/graphics/dcraw { };
 
+  dcs = callPackage ../tools/text/dcs { };
+
   dcfldd = callPackage ../tools/system/dcfldd { };
 
   debianutils = callPackage ../tools/misc/debianutils { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4481,6 +4481,20 @@ let
     propagatedBuildInputs = [ Clone ];
   };
 
+  CSSMinifier = buildPerlPackage {
+    pname = "CSS-Minifier";
+    version = "0.01";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PM/PMICHAUX/CSS-Minifier-0.01.tar.gz";
+      sha256 = "0Kk0m46LfoOrcM+IVM+7Qv8pwfbHyCmPIlfdIaoMf+8=";
+    };
+    meta = with lib; {
+      description = "Perl extension for minifying CSS";
+      license = licenses.artistic1;
+      maintainers = teams.determinatesystems.members;
+    };
+  };
+
   CSSMinifierXS = buildPerlModule {
     pname = "CSS-Minifier-XS";
     version = "0.09";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
