### PR TITLE
yadm: 2.5.0 -> 3.1.0

### DIFF
--- a/pkgs/applications/version-management/yadm/default.nix
+++ b/pkgs/applications/version-management/yadm/default.nix
@@ -1,17 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, git, gnupg }:
+{ lib, stdenv, fetchFromGitHub, git, gnupg, installShellFiles }:
 
-let version = "2.5.0"; in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "yadm";
-  inherit version;
+  version = "3.1.0";
 
   buildInputs = [ git gnupg ];
+
+  nativeBuildInputs = [ installShellFiles ];
 
   src = fetchFromGitHub {
     owner  = "TheLocehiliosan";
     repo   = "yadm";
     rev    = version;
-    sha256 = "128qlx8mp7h5ifapqqgsj3fwghn3q6x6ya0y33h5r7gnassd3njr";
+    sha256 = "0ga0p28nvqilswa07bzi93adk7wx6d5pgxlacr9wl9v1h6cds92s";
   };
 
   dontConfigure = true;
@@ -20,10 +21,14 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
     install -Dt $out/bin yadm
-    install -Dt $out/share/man/man1 yadm.1
-    install -D completion/yadm.zsh_completion $out/share/zsh/site-functions/_yadm
-    install -D completion/yadm.bash_completion $out/share/bash-completion/completions/yadm.bash
     runHook postInstall
+  '';
+
+  postInstall = ''
+    installManPage yadm.1
+    installShellCompletion --cmd yadm \
+      --zsh completion/zsh/_yadm \
+      --bash completion/bash/yadm
   '';
 
   meta = {
@@ -35,7 +40,7 @@ stdenv.mkDerivation {
       * Provides a way to use alternate files on a specific OS or host.
       * Supplies a method of encrypting confidential data so it can safely be stored in your repository.
     '';
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ abathur ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
Fixed issue where source version wasn't getting updated.
Updated completions to pull from the new location.

Testing:
Built and installed the new version. Ran a few commands to see that it worked.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
