### PR TITLE
vector: add afterservices option

### DIFF
--- a/nixos/modules/services/logging/vector.nix
+++ b/nixos/modules/services/logging/vector.nix
@@ -16,6 +16,15 @@ in
       '';
     };
 
+    afterServices = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "loki.service" "systemd-journald.service" ];
+      description = ''
+        Your vector topology might depend on other services being started.
+      '';
+    };
+
     settings = mkOption {
       type = (pkgs.formats.json { }).type;
       default = { };
@@ -36,8 +45,8 @@ in
     systemd.services.vector = {
       description = "Vector event and log aggregator";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
-      requires = [ "network-online.target" ];
+      after = [ "network-online.target" ] ++ cfg.settings.afterServices;
+      requires = [ "network-online.target" ] ++ cfg.settings.afterServices;
       serviceConfig =
         let
           format = pkgs.formats.toml { };


### PR DESCRIPTION
###### Motivation for this change

The vector topology could depend on other services. If those services are not started vector will simply fail.
My first reflex is to provide a configurable parameter for defining the services that vector will depend on.
I had an error in production with loki.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
