### PR TITLE
zoom-us 5.6.13632.0328 -> 5.6.16775.0418

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -7,6 +7,7 @@
 , atk
 , cairo
 , dbus
+, dpkg
 , libGL
 , fontconfig
 , freetype
@@ -29,11 +30,11 @@
 assert pulseaudioSupport -> libpulseaudio != null;
 
 let
-  version = "5.6.13632.0328";
+  version = "5.6.16775.0418";
   srcs = {
     x86_64-linux = fetchurl {
-      url = "https://zoom.us/client/${version}/zoom_x86_64.pkg.tar.xz";
-      sha256 = "0nskpg3rbv40jcbih95sfdr0kfv5hjv50z9jdz1cddl8v7hbqg71";
+      url = "https://zoom.us/client/${version}/zoom_amd64.deb";
+      sha256 = "1fmzwxq8jv5k1b2kvg1ij9g6cdp1hladd8vm3cxzd8fywdjcndim";
     };
   };
 
@@ -70,17 +71,21 @@ in stdenv.mkDerivation rec {
   inherit version;
   src = srcs.${stdenv.hostPlatform.system};
 
-  dontUnpack = true;
-
   nativeBuildInputs = [
+    dpkg
     makeWrapper
   ];
+
+  unpackCmd = ''
+    mkdir out
+    dpkg -x $curSrc out
+  '';
 
   installPhase = ''
     runHook preInstall
     mkdir $out
-    tar -C $out -xf ${src}
-    mv $out/usr/* $out/
+    mv usr/* $out/
+    mv opt $out/
     runHook postInstall
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

zoom-us currently is in a broken state.

Version 5.6.13632.0328 is blocked from participating in calls, and fails with a "please upgrade to the latest version" message. At the same time, [the tar file](https://zoom.us/client/5.6.16775.0418/zoom_x86_64.pkg.tar.xz) that is supposed to be version 5.6.16775.0418 is bit-identical to [the previous version]((https://zoom.us/client/5.6.13632.0328/zoom_x86_64.pkg.tar.xz)).

Thus, no upgrade path to fix the issue is currently available using a tar file.

In consequence, this PR upgrades to the current version using the `.deb` file provided by Zoom for Debian/Ubuntu.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
