### PR TITLE
cosign: use buildFlagsArray

### DIFF
--- a/pkgs/tools/security/cosign/default.nix
+++ b/pkgs/tools/security/cosign/default.nix
@@ -21,13 +21,15 @@ buildGoModule rec {
 
   subPackages = [ "cmd/cosign" ];
 
-  buildFlagsArray = [ "-ldflags=-s -w -X github.com/sigstore/cosign/cmd/cosign/cli.gitVersion=${version}" ];
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-s -w -X github.com/sigstore/cosign/cmd/cosign/cli.gitVersion=v${version}")
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/sigstore/cosign";
     changelog = "https://github.com/sigstore/cosign/releases/tag/v${version}";
     description = "Container Signing CLI with support for ephemeral keys and Sigstore signing";
     license = licenses.asl20;
-    maintainers = with maintainers; [ lesuisse ];
+    maintainers = with maintainers; [ lesuisse jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

~Bump cosign to `0.3.1`~ Bump already done, details below still apply to what was changed in #120029


Add ldflags to make the release smaller (21 MB -> 19 MB) and version info

The upstream release looks like follows:

```
GitVersion:    v0.3.1
GitCommit:     76fde761a4e016c57293113ee1362f1c24a647cb
GitTreeState:  clean
BuildDate:     '2021-04-20T22:40:17Z'
GoVersion:     go1.16.3
Compiler:      gc
Platform:      linux/amd64
```

Left out the other parts that are commonly skipped in nixpkgs like date etc as they're better left as the default

```
GitVersion:    v0.3.1
GitCommit:     unknown
GitTreeState:  unknown
BuildDate:     unknown
GoVersion:     go1.16.3
Compiler:      gc
Platform:      linux/amd64
```

Move the ldflags change to set buildArrayFlags directly within bash. I was going to link the linter that catches this & the reason behind this change but I can't find it now :upside_down_face:  @SuperSandro2000 do you remember?

I've also added myself as a maintainer if you dont mind @LeSuisse 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
