### PR TITLE
mariadb-connector-c: 3.1.8 -> 3.1.12

### DIFF
--- a/pkgs/servers/sql/mariadb/connector-c/3_1.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/3_1.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./. (args // {
-  version = "3.1.8";
-  sha256 = "0yrzhsxmjiwkhchagx8dymzhvxl3k5h40wn9wpicqjvgjb9k8523";
+  version = "3.1.12";
+  sha256 = "0qzyahr8x9l1xz0l79wz3iahxz7648n1azc5yr7kx0dl113y2nig";
 })

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace mariadb_config/mariadb_config.c.in \
-      --replace '@CMAKE_SYSROOT@@CMAKE_INSTALL_PREFIX@/@INSTALL_INCLUDEDIR@' "$dev/include" \
-      --replace '@CMAKE_SYSROOT@@CMAKE_INSTALL_PREFIX@/@INSTALL_LIBDIR@' "$out/lib/mariadb"
+      --replace '-I%s/@INSTALL_INCLUDEDIR@' "-I$dev/include" \
+      --replace '-L%s/@INSTALL_LIBDIR@' "-L$out/lib/mariadb"
   '';
 
   # The cmake setup-hook uses $out/lib by default, this is not the case here.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update mariadb-connector-c to 3.1.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
