### PR TITLE
controller-tools: init at 0.5.0

### DIFF
--- a/pkgs/development/tools/controller-tools/default.nix
+++ b/pkgs/development/tools/controller-tools/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "controller-tools";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "kubernetes-sigs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-eAt9LaFtnRlk6L0m6ubXUVY8CsIsiHY4pxCFU7KkNpk=";
+  };
+
+  vendorSha256 = "sha256-R48IRSmDgESnYIhWINu6yMSwKF25CqgdYHzfzUbjmrU=";
+
+  meta = with lib; {
+    description = "Tools to use with the kubernetes-sigs controller-runtime libraries";
+    longDescription = ''
+      The Kubernetes controller-tools Project is a set of go libraries for building Controllers.
+    '';
+    homepage = "https://github.com/kubernetes-sigs/controller-tools";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12701,6 +12701,8 @@ in
 
   kustomize-sops = callPackage ../development/tools/kustomize/kustomize-sops.nix { };
 
+  controller-tools = callPackage ../development/tools/controller-tools { };
+
   ktlint = callPackage ../development/tools/ktlint { };
 
   kythe = callPackage ../development/tools/kythe { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).