### PR TITLE
python3Packages.sphinx-serve: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/sphinx-serve/default.nix
+++ b/pkgs/development/python-modules/sphinx-serve/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-serve";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8d90f6595114108500b1f935d3f4d07bf5192783c67ce83f944ef289099669c9";
+  };
+
+  doCheck = false; # No tests
+
+  pythonImportsCheck = [ "sphinx_serve" ];
+
+  meta = with lib; {
+    description = "Spawns a simple HTTP server to preview your sphinx documents";
+    homepage = "https://github.com/tlatsas/sphinx-serve";
+    maintainers = with maintainers; [ FlorianFranzen ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17474,6 +17474,8 @@ in
     fftw = fftwFloat;
   };
 
+  sphinx = with python3Packages; toPythonApplication sphinx;
+
   sphinx-serve = with python3Packages; toPythonApplication sphinx-serve;
 
   sphinxbase = callPackage ../development/libraries/sphinxbase { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17474,6 +17474,8 @@ in
     fftw = fftwFloat;
   };
 
+  sphinx-serve = with python3Packages; toPythonApplication sphinx-serve;
+
   sphinxbase = callPackage ../development/libraries/sphinxbase { };
 
   sphinxsearch = callPackage ../servers/search/sphinxsearch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8066,6 +8066,8 @@ in {
 
   sphinx_rtd_theme = callPackage ../development/python-modules/sphinx_rtd_theme { };
 
+  sphinx-serve = callPackage ../development/python-modules/sphinx-serve { };
+
   sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };
 
   spidev = callPackage ../development/python-modules/spidev { };


### PR DESCRIPTION
###### Motivation for this change

sphinx-serve was missing from nixpkgs

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
