### PR TITLE
argocd: 1.8.6 -> 2.0.1

### DIFF
--- a/pkgs/applications/networking/cluster/argocd/default.nix
+++ b/pkgs/applications/networking/cluster/argocd/default.nix
@@ -1,40 +1,74 @@
-{ lib, buildGoModule, fetchFromGitHub, packr }:
+{ lib, buildGoModule, fetchFromGitHub, packr, makeWrapper, installShellFiles, helm, kustomize }:
 
 buildGoModule rec {
   pname = "argocd";
-  version = "1.8.6";
-  commit = "28aea3dfdede00443b52cc584814d80e8f896200";
+  version = "2.0.1";
+  commit = "33eaf11e3abd8c761c726e815cbb4b6af7dcb030";
+  tag = "v${version}";
 
   src = fetchFromGitHub {
     owner = "argoproj";
     repo = "argo-cd";
-    rev = "v${version}";
-    sha256 = "sha256-kJ3/1owK5T+FbcvjmK2CO+i/KwmVZRSGzF6fCt8J9E8=";
+    rev = tag;
+    sha256 = "sha256-j/RdiMeaYxlmEvo5CKrGvkp25MrFsSYh+XNYWNcs0PE=";
   };
 
-  vendorSha256 = "sha256-rZ/ox180h9scocheYtMmKkoHY2/jH+I++vYX8R0fdlA=";
+  vendorSha256 = "sha256-8j5v99wOHM/SndJwpmGWiCFEyw4K513HEEbkPrD8C90=";
 
-  doCheck = false;
-
-  nativeBuildInputs = [ packr ];
-
-  buildFlagsArray = ''
-     -ldflags=
-      -X github.com/argoproj/argo-cd/common.version=${version}
-      -X github.com/argoproj/argo-cd/common.buildDate=unknown
-      -X github.com/argoproj/argo-cd/common.gitCommit=${commit}
-      -X github.com/argoproj/argo-cd/common.gitTreeState=clean
-  '';
+  nativeBuildInputs = [ packr makeWrapper installShellFiles ];
 
   # run packr to embed assets
   preBuild = ''
     packr
   '';
 
+  buildFlagsArray =
+    let package_url = "github.com/argoproj/argo-cd/v2/common"; in
+    [
+      "-ldflags="
+      "-s -w"
+      "-X ${package_url}.version=${version}"
+      "-X ${package_url}.buildDate=unknown"
+      "-X ${package_url}.gitCommit=${commit}"
+      "-X ${package_url}.gitTag=${tag}"
+      "-X ${package_url}.gitTreeState=clean"
+    ];
+
+  # Test is disabled because ksonnet is missing from nixpkgs.
+  # Log: https://gist.github.com/superherointj/79cbdc869dfd44d28a10dc6746ecb3f9
+  doCheck = false;
+  checkInputs = [
+    helm
+    kustomize
+    #ksonnet
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/argocd version --client | grep ${tag} > /dev/null
+    $out/bin/argocd-util version | grep ${tag} > /dev/null
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -Dm755 "$GOPATH/bin/cmd" -T $out/bin/argocd
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    for appname in argocd-util argocd-server argocd-repo-server argocd-application-controller argocd-dex ; do
+      makeWrapper $out/bin/argocd $out/bin/$appname --set ARGOCD_BINARY_NAME $appname
+    done
+    installShellCompletion --cmd argocd \
+      --bash <($out/bin/argocd completion bash) \
+      --zsh <($out/bin/argocd completion zsh)
+  '';
+
   meta = with lib; {
     description = "Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes";
     homepage = "https://github.com/argoproj/argo";
     license = licenses.asl20;
-    maintainers = with maintainers; [ shahrukh330 ];
+    maintainers = with maintainers; [ shahrukh330 superherointj ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
* Upgrade `argocd` from 1.86 to 2.0.1.
* Fix/include build version tag.
* Add test for version.
* Add shell autocompletion.
* Expose 6 applications: argocd, argocd-util, argocd-server, argocd-repo-server, argocd-application-controller, argocd-dex.
* Add myself (superherointj) as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
