### PR TITLE
[20.09] matrix-synapse: 1.30.0 -> 1.32.2

### DIFF
--- a/pkgs/servers/matrix-synapse/0001-Drop-strict-version-constraint-for-cryptography.patch
+++ b/pkgs/servers/matrix-synapse/0001-Drop-strict-version-constraint-for-cryptography.patch
@@ -1,0 +1,39 @@
+From 4de6e3d1977e20203d12c1e1959aeb98464c38d8 Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Wed, 21 Apr 2021 14:11:39 +0200
+Subject: [PATCH] Drop strict version constraint for `cryptography'
+
+As mentioned in the original upstream commit[1] this is only needed to
+ensure a cryptography version with latest openssl patches is used.
+
+`cryptography` at 3.3.2 also fixes CVE-2020-36242[2], however it is only a
+workaround for an underlying openssl vulnerability[3][4].
+
+Given that CVE-2021-23840[4] is fixed in openssl 1.1.1j which is
+backported to 20.09, there's nothing else to do here.
+
+[1] https://github.com/matrix-org/synapse/commit/12d61847133c4da60d3e511af37d6f7e548ccb7a#diff-20fcfa23c90d1385048e0cc6331196d126e147e8894eba8ef481088e664b91d2
+[2] https://nvd.nist.gov/vuln/detail/CVE-2020-36242
+[3] https://access.redhat.com/security/cve/cve-2020-36242
+[4] https://nvd.nist.gov/vuln/detail/CVE-2021-23840
+---
+ synapse/python_dependencies.py | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/synapse/python_dependencies.py b/synapse/python_dependencies.py
+index 2a1c925..0c99e37 100644
+--- a/synapse/python_dependencies.py
++++ b/synapse/python_dependencies.py
+@@ -83,9 +83,6 @@ REQUIREMENTS = [
+     "Jinja2>=2.9",
+     "bleach>=1.4.3",
+     "typing-extensions>=3.7.4",
+-    # We enforce that we have a `cryptography` version that bundles an `openssl`
+-    # with the latest security patches.
+-    "cryptography>=3.4.7;python_version>='3.6'",
+ ]
+ 
+ CONDITIONAL_REQUIREMENTS = {
+-- 
+2.29.3
+

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -10,11 +10,11 @@ let
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.32.1";
+  version = "1.32.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-A9ZWoZq+ZeUeQkqb84q1PG7BEBL2sVyG3qwRq0AqsNk=";
+    sha256 = "sha256-Biwj/zORBsU8XvpMMlSjR3Nqx0q1LqaSX/vX+UDeXI8=";
   };
 
   patches = [

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -10,11 +10,11 @@ let
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.31.0";
+  version = "1.32.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0yr1lij66s9sc6razzjr9r6xvl462ff31xg0a3m7ys2f9zzrms0v";
+    sha256 = "sha256-CuPO5+zZitDvMjAxAkmEyVFxdZeqzjFH/7wDLvcUgSM=";
   };
 
   patches = [

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -10,11 +10,11 @@ let
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.30.0";
+  version = "1.31.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ca69v479537bbj2hjliwk9zzy9fqqsf7fm188k6xxj0a37q9y41";
+    sha256 = "0yr1lij66s9sc6razzjr9r6xvl462ff31xg0a3m7ys2f9zzrms0v";
   };
 
   patches = [

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -10,11 +10,11 @@ let
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.32.0";
+  version = "1.32.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-CuPO5+zZitDvMjAxAkmEyVFxdZeqzjFH/7wDLvcUgSM=";
+    sha256 = "sha256-A9ZWoZq+ZeUeQkqb84q1PG7BEBL2sVyG3qwRq0AqsNk=";
   };
 
   patches = [

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -20,6 +20,10 @@ buildPythonApplication rec {
   patches = [
     # adds an entry point for the service
     ./homeserver-script.patch
+
+    # drop constraint on `cryptography'. The commit message
+    # at the top provides more context.
+    ./0001-Drop-strict-version-constraint-for-cryptography.patch
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

<del>__Note:__ please don't merge it yet, there's a known issue in 1.32.0 which isn't fixed in a patch-release yet.</del>

Filed this as PR since I had to change the version constraint for `cryptography`. Please read the commit message of the patch I added for full context.

Backport PR of #119981.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
