### PR TITLE
alertmanager-bot: pass version and revision variables

### DIFF
--- a/pkgs/servers/monitoring/alertmanager-bot/default.nix
+++ b/pkgs/servers/monitoring/alertmanager-bot/default.nix
@@ -17,6 +17,12 @@ buildGoModule rec {
     sed "s;/templates/default.tmpl;$out/share&;" -i cmd/alertmanager-bot/main.go
   '';
 
+  preBuild = ''
+    export buildFlagsArray=(
+      "-ldflags=-s -w -X main.Version=v${version} -X main.Revision=${src.rev}"
+    )
+  '';
+
   postInstall = ''
     install -Dm644 -t $out/share/templates $src/default.tmpl
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The bot outputs its own version/revision in the log during startup and
also in a response to the `/status` command.

So make sure both version and revision are set.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
