### PR TITLE
python3Packages.sphinx-material: init at 0.0.32

### DIFF
--- a/pkgs/development/python-modules/css-html-js-minify/default.nix
+++ b/pkgs/development/python-modules/css-html-js-minify/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "css-html-js-minify";
+  version = "2.5.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "4a9f11f7e0496f5284d12111f3ba4ff5ff2023d12f15d195c9c48bd97013746c";
+  };
+
+  doCheck = false; # Tests are useless and broken
+
+  pythonImportsCheck = [ "css_html_js_minify" ];
+
+  meta = with lib; {
+    description = "StandAlone Async cross-platform Minifier for the Web";
+    homepage = "https://github.com/juancarlospaco/css-html-js-minify";
+    license = with licenses; [ gpl3Plus lgpl3Plus mit ];
+    maintainers = with maintainers; [ FlorianFranzen ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-material/default.nix
+++ b/pkgs/development/python-modules/sphinx-material/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, sphinx
+, beautifulsoup4
+, python-slugify
+, unidecode
+, css-html-js-minify
+, lxml
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-material";
+  version = "0.0.32";
+
+  src = fetchPypi {
+    pname = "sphinx_material";
+    inherit version;
+    sha256 = "ec02825a1bbe8b662fe624c11b87f1cd8d40875439b5b18c38649cf3366201fa";
+  };
+
+  propagatedBuildInputs = [
+    sphinx
+    beautifulsoup4
+    python-slugify
+    unidecode
+    css-html-js-minify
+    lxml
+  ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "sphinx_material" ];
+
+  meta = with lib; {
+    description = "A material-based, responsive theme inspired by mkdocs-material";
+    homepage = "https://bashtage.github.io/sphinx-material";
+    license = licenses.mit;
+    maintainers = with maintainers; [ FlorianFranzen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12634,6 +12634,8 @@ in
 
   csslint = callPackage ../development/web/csslint { };
 
+  css-html-js-minify = with python3Packages; toPythonApplication css-html-js-minify;
+
   cvise = python3Packages.callPackage ../development/tools/misc/cvise {
     inherit (llvmPackages_11) llvm clang-unwrapped;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1631,6 +1631,8 @@ in {
 
   cssmin = callPackage ../development/python-modules/cssmin { };
 
+  css-html-js-minify = callPackage ../development/python-modules/css-html-js-minify { };
+
   css-parser = callPackage ../development/python-modules/css-parser { };
 
   cssselect2 = callPackage ../development/python-modules/cssselect2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8074,6 +8074,8 @@ in {
 
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
+  sphinx-material = callPackage ../development/python-modules/sphinx-material { };
+
   sphinx-navtree = callPackage ../development/python-modules/sphinx-navtree { };
 
   sphinx_pypi_upload = callPackage ../development/python-modules/sphinx_pypi_upload { };


### PR DESCRIPTION
###### Motivation for this change

sphinx-material and css-html-js-minify were not part of nixpkgs

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).