### PR TITLE
spago: 0.20.0 -> 0.20.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -85,7 +85,6 @@ self: super: {
   kademlia = dontCheck super.kademlia;
 
   # Tests require older versions of tasty.
-  cborg = (doJailbreak super.cborg).override { base16-bytestring = self.base16-bytestring_0_1_1_7; };
   hzk = dontCheck super.hzk;
   resolv = doJailbreak super.resolv;
   tdigest = doJailbreak super.tdigest;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -661,18 +661,24 @@ self: super: builtins.intersectAttrs super {
       # fine with newer versions.
       spagoWithOverrides = doJailbreak super.spago;
 
-      # This defines the version of the purescript-docs-search release we are using.
-      # This is defined in the src/Spago/Prelude.hs file in the spago source.
-      docsSearchVersion = "v0.0.10";
-
-      docsSearchAppJsFile = pkgs.fetchurl {
-        url = "https://github.com/spacchetti/purescript-docs-search/releases/download/${docsSearchVersion}/docs-search-app.js";
+      docsSearchApp_0_0_10 = pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript-docs-search/releases/download/v0.0.10/docs-search-app.js";
         sha256 = "0m5ah29x290r0zk19hx2wix2djy7bs4plh9kvjz6bs9r45x25pa5";
       };
 
-      purescriptDocsSearchFile = pkgs.fetchurl {
-        url = "https://github.com/spacchetti/purescript-docs-search/releases/download/${docsSearchVersion}/purescript-docs-search";
+      docsSearchApp_0_0_11 = pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript-docs-search/releases/download/v0.0.11/docs-search-app.js";
+        sha256 = "17qngsdxfg96cka1cgrl3zdrpal8ll6vyhhnazqm4hwj16ywjm02";
+      };
+
+      purescriptDocsSearch_0_0_10 = pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript-docs-search/releases/download/v0.0.10/purescript-docs-search";
         sha256 = "0wc1zyhli4m2yykc6i0crm048gyizxh7b81n8xc4yb7ibjqwhyj3";
+      };
+
+      purescriptDocsSearch_0_0_11 = pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript-docs-search/releases/download/v0.0.11/purescript-docs-search";
+        sha256 = "1hjdprm990vyxz86fgq14ajn0lkams7i00h8k2i2g1a0hjdwppq6";
       };
 
       spagoFixHpack = overrideCabal spagoWithOverrides (drv: {
@@ -695,13 +701,19 @@ self: super: builtins.intersectAttrs super {
           # However, they are not actually available in the spago source, so they
           # need to fetched with nix and put in the correct place.
           # https://github.com/spacchetti/spago/issues/510
-          cp ${docsSearchAppJsFile} "$sourceRoot/templates/docs-search-app.js"
-          cp ${purescriptDocsSearchFile} "$sourceRoot/templates/purescript-docs-search"
+          cp ${docsSearchApp_0_0_10} "$sourceRoot/templates/docs-search-app-0.0.10.js"
+          cp ${docsSearchApp_0_0_11} "$sourceRoot/templates/docs-search-app-0.0.11.js"
+          cp ${purescriptDocsSearch_0_0_10} "$sourceRoot/templates/purescript-docs-search-0.0.10"
+          cp ${purescriptDocsSearch_0_0_11} "$sourceRoot/templates/purescript-docs-search-0.0.11"
 
           # For some weird reason, on Darwin, the open(2) call to embed these files
           # requires write permissions. The easiest resolution is just to permit that
           # (doesn't cause any harm on other systems).
-          chmod u+w "$sourceRoot/templates/docs-search-app.js" "$sourceRoot/templates/purescript-docs-search"
+          chmod u+w \
+            "$sourceRoot/templates/docs-search-app-0.0.10.js" \
+            "$sourceRoot/templates/purescript-docs-search-0.0.10" \
+            "$sourceRoot/templates/docs-search-app-0.0.11.js" \
+            "$sourceRoot/templates/purescript-docs-search-0.0.11"
         '';
       });
 

--- a/pkgs/development/tools/purescript/spago/spago.nix
+++ b/pkgs/development/tools/purescript/spago/spago.nix
@@ -1,22 +1,22 @@
 { mkDerivation, aeson, aeson-pretty, ansi-terminal, async-pool
 , base, bower-json, bytestring, Cabal, containers, cryptonite
-, dhall, directory, either, exceptions, extra, fetchgit, file-embed
-, filepath, foldl, fsnotify, generic-lens, github, Glob, hpack
-, hspec, hspec-discover, hspec-megaparsec, http-client
-, http-conduit, http-types, lens-family-core, megaparsec, mtl
-, network-uri, open-browser, optparse-applicative, prettyprinter
-, process, QuickCheck, retry, rio, rio-orphans, safe, semver-range
-, lib, stm, stringsearch, tar, template-haskell, temporary, text
-, time, transformers, turtle, unliftio, unordered-containers
-, utf8-string, vector, versions, with-utf8, zlib
+, dhall, directory, either, extra, fetchgit, file-embed, filepath
+, foldl, fsnotify, generic-lens, Glob, hpack, hspec, hspec-discover
+, hspec-megaparsec, http-client, http-conduit, http-types
+, lens-family-core, lib, megaparsec, mtl, network-uri, open-browser
+, optparse-applicative, prettyprinter, process, QuickCheck, retry
+, rio, rio-orphans, safe, semver-range, stm, stringsearch
+, tar, template-haskell, temporary, text, time, transformers
+, turtle, unliftio, unordered-containers, utf8-string, versions
+, with-utf8, zlib
 }:
 mkDerivation {
   pname = "spago";
-  version = "0.20.0";
+  version = "0.20.1";
   src = fetchgit {
     url = "https://github.com/purescript/spago.git";
-    sha256 = "1n48p9ycry8bjnf9jlcfgyxsbgn5985l4vhbwlv46kbb41ddwi51";
-    rev = "7dfd2236aff92e5ae4f7a4dc336b50a7e14e4f44";
+    sha256 = "1j2yi6zz9m0k0298wllin39h244v8b2rx87yxxgdbjg77kn96vxg";
+    rev = "41ad739614f4f2c2356ac921308f9475a5a918f4";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -24,16 +24,17 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson aeson-pretty ansi-terminal async-pool base bower-json
     bytestring Cabal containers cryptonite dhall directory either
-    exceptions file-embed filepath foldl fsnotify generic-lens github
-    Glob http-client http-conduit http-types lens-family-core
-    megaparsec mtl network-uri open-browser optparse-applicative
-    prettyprinter process retry rio rio-orphans safe semver-range stm
-    stringsearch tar template-haskell temporary text time transformers
-    turtle unliftio unordered-containers utf8-string vector versions
-    with-utf8 zlib
+    file-embed filepath foldl fsnotify generic-lens Glob http-client
+    http-conduit http-types lens-family-core megaparsec mtl network-uri
+    open-browser optparse-applicative prettyprinter process retry rio
+    rio-orphans safe semver-range stm stringsearch tar template-haskell
+    temporary text time transformers turtle unliftio
+    unordered-containers utf8-string versions with-utf8 zlib
   ];
   libraryToolDepends = [ hpack ];
-  executableHaskellDepends = [ base text turtle with-utf8 ];
+  executableHaskellDepends = [
+    ansi-terminal base text turtle with-utf8
+  ];
   testHaskellDepends = [
     base containers directory extra hspec hspec-megaparsec megaparsec
     process QuickCheck temporary text turtle versions


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There was a new version of `spago` released: https://github.com/purescript/spago/releases/tag/0.20.1

There were a few small changes with documentation-related stuff: https://github.com/purescript/spago/pull/775

cc @f-f

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
