### PR TITLE
xinit: don't unset DBUS_SESSION_BUS_ADDRESS in startx

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -773,6 +773,14 @@ self: super:
       "--with-launchdaemons-dir=\${out}/LaunchDaemons"
       "--with-launchagents-dir=\${out}/LaunchAgents"
     ];
+    patches = [
+      # don't unset DBUS_SESSION_BUS_ADDRESS in startx
+      (fetchpatch {
+        name = "dont-unset-DBUS_SESSION_BUS_ADDRESS.patch";
+        url = "https://git.archlinux.org/svntogit/packages.git/plain/repos/extra-x86_64/fs46369.patch?h=packages/xorg-xinit&id=40f3ac0a31336d871c76065270d3f10e922d06f3";
+        sha256 = "18kb88i3s9nbq2jxl7l2hyj6p56c993hivk8mzxg811iqbbawkp7";
+      })
+    ];
     propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ self.xauth ]
                          ++ lib.optionals isDarwin [ self.libX11 self.xorgproto ];
     postFixup = ''


### PR DESCRIPTION
###### Motivation for this change

startx unsets DBUS_SESSION_BUS_ADDRESS, which makes the dbus session instance unavailable to some application started beneath startx (notably libreoffice, which starts its own private session bus and neglects to clean it up later, littering the system with unreachable dbus instances over time)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
    - startx only, didn't unset the env var anymore as expected
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
