### PR TITLE
ceph: 15.2.10 -> 16.2.1

### DIFF
--- a/nixos/tests/ceph-multi-node.nix
+++ b/nixos/tests/ceph-multi-node.nix
@@ -37,7 +37,7 @@ let
 
   generateHost = { pkgs, cephConfig, networkConfig, ... }: {
     virtualisation = {
-      memorySize = 512;
+      memorySize = 1024;
       emptyDiskImages = [ 20480 ];
       vlans = [ 1 ];
     };
@@ -120,6 +120,7 @@ let
     )
     monA.wait_for_unit("ceph-mon-${cfg.monA.name}")
     monA.succeed("ceph mon enable-msgr2")
+    monA.succeed("ceph config set mon auth_allow_insecure_global_id_reclaim false")
 
     # Can't check ceph status until a mon is up
     monA.succeed("ceph -s | grep 'mon: 1 daemons'")

--- a/nixos/tests/ceph-single-node-bluestore.nix
+++ b/nixos/tests/ceph-single-node-bluestore.nix
@@ -34,7 +34,7 @@ let
 
   generateHost = { pkgs, cephConfig, networkConfig, ... }: {
     virtualisation = {
-      memorySize = 512;
+      memorySize = 1024;
       emptyDiskImages = [ 20480 20480 20480 ];
       vlans = [ 1 ];
     };
@@ -95,6 +95,7 @@ let
     )
     monA.wait_for_unit("ceph-mon-${cfg.monA.name}")
     monA.succeed("ceph mon enable-msgr2")
+    monA.succeed("ceph config set mon auth_allow_insecure_global_id_reclaim false")
 
     # Can't check ceph status until a mon is up
     monA.succeed("ceph -s | grep 'mon: 1 daemons'")

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -34,7 +34,7 @@ let
 
   generateHost = { pkgs, cephConfig, networkConfig, ... }: {
     virtualisation = {
-      memorySize = 512;
+      memorySize = 1024;
       emptyDiskImages = [ 20480 20480 20480 ];
       vlans = [ 1 ];
     };
@@ -95,6 +95,7 @@ let
     )
     monA.wait_for_unit("ceph-mon-${cfg.monA.name}")
     monA.succeed("ceph mon enable-msgr2")
+    monA.succeed("ceph config set mon auth_allow_insecure_global_id_reclaim false")
 
     # Can't check ceph status until a mon is up
     monA.succeed("ceph -s | grep 'mon: 1 daemons'")

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, runCommand, fetchurl
-, fetchpatch
 , ensureNewerSourcesHook
 , cmake, pkg-config
 , which, git
@@ -14,6 +13,15 @@
 , libnl, libcap_ng
 , rdkafka
 , nixosTests
+, cryptsetup
+, sqlite
+, lua
+, icu
+, bzip2
+, doxygen
+, graphviz
+, fmt
+, python3
 
 # Optional Dependencies
 , yasm ? null, fcgi ? null, expat ? null
@@ -123,10 +131,10 @@ let
   ]);
   sitePackages = ceph-python-env.python.sitePackages;
 
-  version = "15.2.10";
+  version = "16.2.1";
   src = fetchurl {
     url = "http://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-    sha256 = "1xfijynfb56gydpwh6h4q781xymwxih6nx26idnkcjqih48nsn01";
+    sha256 = "1qqvfhnc94vfrq1ddizf6habjlcp77abry4v18zlq6rnhwr99zrh";
   };
 in rec {
   ceph = stdenv.mkDerivation {
@@ -142,12 +150,18 @@ in rec {
       pkg-config which git python3Packages.wrapPython makeWrapper
       python3Packages.python # for the toPythonPath function
       (ensureNewerSourcesHook { year = "1980"; })
+      python3
+      fmt
+      # for building docs/man-pages presumably
+      doxygen
+      graphviz
     ];
 
     buildInputs = cryptoLibsMap.${cryptoStr} ++ [
       boost ceph-python-env libxml2 optYasm optLibatomic_ops optLibs3
       malloc zlib openldap lttng-ust babeltrace gperf gtest cunit
       snappy lz4 oathToolkit leveldb libnl libcap_ng rdkafka
+      cryptsetup sqlite lua icu bzip2
     ] ++ lib.optionals stdenv.isLinux [
       linuxHeaders util-linux libuuid udev keyutils optLibaio optLibxfs optZfs
       # ceph 14
@@ -171,7 +185,6 @@ in rec {
     '';
 
     cmakeFlags = [
-      "-DWITH_PYTHON3=ON"
       "-DWITH_SYSTEM_ROCKSDB=OFF"  # breaks Bluestore
       "-DCMAKE_INSTALL_DATADIR=${placeholder "lib"}/lib"
 
@@ -182,6 +195,8 @@ in rec {
       "-DWITH_TESTS=OFF"
       # TODO breaks with sandbox, tries to download stuff with npm
       "-DWITH_MGR_DASHBOARD_FRONTEND=OFF"
+      # WITH_XFS has been set default ON from Ceph 16, keeping it optional in nixpkgs for now
+      ''-DWITH_XFS=${if optLibxfs != null then "ON" else "OFF"}''
     ];
 
     postFixup = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3313,7 +3313,8 @@ in
 
   libceph = ceph.lib;
   inherit (callPackages ../tools/filesystems/ceph {
-    boost = boost172.override { enablePython = true; python = python38; };
+    boost = boost17x.override { enablePython = true; python = python3; };
+    lua = lua5_4;
   })
     ceph
     ceph-client;


### PR DESCRIPTION

###### Motivation for this change

Major bump Ceph

There's a bunch of new features in Ceph 16 requiring new dependencies. We _could_ make some of them optional, but so far I've gone with keeping the cmake defaults from Ceph upstream, with one exception - **xfs** - which was already optional in nixpkgs in Ceph 15.

I also feel that the removal of `-DWITH_PYTHON3` requires some explanation: Turns out that this flag is in fact _not_ a boolean-flag. It's supposed to contain the _version_ of python 3. When this flag is removed, the cmake environment will try to auto-detect the version by invoking the interpreter binary, which partially for the same reason the interpreter is now passed as nativeBuildInput. Note: The interpreter is used in other corners of the build-process as well. 

###### Things done

Ceph single-node and multi-node tests run without issues locally.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
