### PR TITLE
protoc-gen-twirp_php: 0.6.0 -> 0.7.1

### DIFF
--- a/pkgs/development/tools/protoc-gen-twirp_php/default.nix
+++ b/pkgs/development/tools/protoc-gen-twirp_php/default.nix
@@ -2,22 +2,18 @@
 
 buildGoModule rec {
   pname = "protoc-gen-twirp_php";
-  version = "0.6.0";
+  version = "0.7.1";
 
   # fetchFromGitHub currently not possible, because go.mod and go.sum are export-ignored
   src = fetchgit {
     url = "https://github.com/twirphp/twirp.git";
     rev = "v${version}";
-    sha256 = "sha256-WnvCdAJIMA4A+f7H61qcVbKNn23bNVOC15vMCEKc+CI=";
+    sha256 = "sha256-94GN/Gq3RXXg83eUsmIcdF4VuK4syCgD0Zkc5eDiVYE=";
   };
 
-  vendorSha256 = "sha256-LIMxrWXlK7+JIRmtukdXPqfw8H991FCAOuyEf7ZLSTs=";
+  vendorSha256 = "sha256-gz4JELCffuh7dyFdBex8/SFZ1/PDXuC/93m3WNHwRss=";
 
   subPackages = [ "protoc-gen-twirp_php" ];
-
-  preBuild = ''
-    go generate ./...
-  '';
 
   meta = with lib; {
     description = "PHP port of Twitch's Twirp RPC framework";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release https://github.com/twirphp/twirp/releases/tag/v0.7.1 ([changes](https://github.com/twirphp/twirp/compare/v0.6.0...v0.7.1))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/jk5qigl6136k07ml97y9ljwvrqsjrq7h-protoc-gen-twirp_php-0.6.0	   41535008
/nix/store/1y5007hanc2c1kibd2bi4spa5ni6j412-protoc-gen-twirp_php-0.7.1	   43690712
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
