### PR TITLE
phpPackages.composer: 2.0.11 -> 2.0.12

### DIFF
--- a/pkgs/development/php-packages/composer/default.nix
+++ b/pkgs/development/php-packages/composer/default.nix
@@ -1,14 +1,14 @@
 { mkDerivation, fetchurl, makeWrapper, unzip, lib, php }:
 let
   pname = "composer";
-  version = "2.0.11";
+  version = "2.0.12";
 in
 mkDerivation {
   inherit pname version;
 
   src = fetchurl {
     url = "https://getcomposer.org/download/${version}/composer.phar";
-    sha256 = "sha256-6r8pFwcglqlGeRk3YlATGeYh4rNppKElaywn9OaYRHc=";
+    sha256 = "sha256-guqMFTfPrOt+VvYATHzN+Z3a/OcjfAc3TZIOY1cwpjE=";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release https://github.com/composer/composer/releases/tag/2.0.12 ([changes](https://github.com/composer/composer/compare/2.0.11...2.0.12)).

Fixes an issue i got today after switching to the new [GitHub Auth Token format](https://github.blog/changelog/2021-03-04-authentication-token-format-updates/):
```
  Your github oauth token for github.com contains invalid characters: "ghp_XXXX"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
8 packages updated:
adminer composer-bookstack php74Packages.composer (2.0.11 → 2.0.12) php80Packages.composer (2.0.11 → 2.0.12) php73Packages.composer (2.0.11 → 2.0.12) php-php-parallel-lint php-php-parallel-lint php-php-parallel-lint
8 packages built:
adminer bookstack php73Packages.composer php73Packages.php-parallel-lint php74Packages.composer php74Packages.php-parallel-lint php80Packages.composer php80Packages.php-parallel-lint
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/ccb2qa8avzfddad71c03h5mr3q3hh03c-php-composer-2.0.11	  280441344
/nix/store/b9v2rdwpchnwra1d5wlasnvyvfbd6kca-php-composer-2.0.12	  280444768
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).