### PR TITLE
mpg123: fix cross-compile to windows

### DIFF
--- a/pkgs/applications/audio/mpg123/default.nix
+++ b/pkgs/applications/audio/mpg123/default.nix
@@ -1,9 +1,9 @@
 { lib, stdenv
 , fetchurl
 , makeWrapper
-
 , alsaLib
 , perl
+, withConplay ? !stdenv.targetPlatform.isWindows
 }:
 
 stdenv.mkDerivation rec {
@@ -14,35 +14,36 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-UCqX4Nk1vn432YczgCHY8wG641wohPKoPVnEtSRm7wY=";
   };
 
-  outputs = [ "out" "conplay" ];
+  outputs = [ "out" ] ++ lib.optionals withConplay [ "conplay" ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = lib.optionals withConplay [ makeWrapper ];
 
-  buildInputs = [ perl ] ++ lib.optional (!stdenv.isDarwin) alsaLib;
+  buildInputs = lib.optionals withConplay [ perl ]
+    ++ lib.optionals (!stdenv.isDarwin && !stdenv.targetPlatform.isWindows) [ alsaLib ];
 
   configureFlags = lib.optional
     (stdenv.hostPlatform ? mpg123)
     "--with-cpu=${stdenv.hostPlatform.mpg123.cpu}";
 
-  postInstall = ''
+  postInstall = lib.optionalString withConplay ''
     mkdir -p $conplay/bin
     mv scripts/conplay $conplay/bin/
   '';
 
-  preFixup = ''
+  preFixup = lib.optionalString withConplay ''
     patchShebangs $conplay/bin/conplay
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString withConplay ''
     wrapProgram $conplay/bin/conplay \
       --prefix PATH : $out/bin
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Fast console MPEG Audio Player and decoder library";
-    homepage = "http://mpg123.org";
-    license = lib.licenses.lgpl21;
-    maintainers = [ lib.maintainers.ftrvxmtrx ];
-    platforms = lib.platforms.unix;
+    homepage = "https://mpg123.org";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.ftrvxmtrx ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This allows mpg123 to compile for windows. I'm not sure what conplay is, but it seems like a bonus add-on, and a lot of the infrastructure to get it working (perl, makeWrapper) don't work for windows right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
