### PR TITLE
orchis: 2021-02-28 -> 2021-04-20

### DIFF
--- a/pkgs/data/themes/orchis/default.nix
+++ b/pkgs/data/themes/orchis/default.nix
@@ -1,18 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, gnome-themes-extra, gtk-engine-murrine
-, accentColor ? "default" }:
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, gnome-themes-extra
+, gtk-engine-murrine
+, sassc
+, accentColor ? "default"
+}:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "orchis";
-  version = "2021-02-28";
+  version = "2021-04-20";
 
   src = fetchFromGitHub {
     repo = "Orchis-theme";
     owner = "vinceliuice";
     rev = version;
-    sha256 = "sha256-HmC2e34n1eThFGgw9OzSgp5VFJOylyozpXgk9SO84+I=";
+    sha256 = "sha256-cCUmainVTqFztZGpL2z2Zj6zcE2SQBWrec6yNFUMo5M=";
   };
 
-  nativeBuildInputs = [ gtk3 ];
+  nativeBuildInputs = [ gtk3 sassc ];
 
   buildInputs = [ gnome-themes-extra ];
 


### PR DESCRIPTION
###### Motivation for this change

Bump version to 2021-04-20.

Add `sassc` as a buildInput as mentioned in the project's readme.

Replaced `stdenv` with `stdenvNoCC` as described in [117451](https://github.com/NixOS/nixpkgs/pull/117451).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
