### PR TITLE
waypoint: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/applications/networking/cluster/waypoint/default.nix
+++ b/pkgs/applications/networking/cluster/waypoint/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "waypoint";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-lB9ELa/okNvtKFDP/vImEdYFJCKRgtAcpBG1kIoAysE=";
+    sha256 = "sha256-WzKUVfc7oGMh0TamL5b6gsm/BAfSCZ6EB3Hg4Tg/3Hw=";
   };
 
   deleteVendor = true;
@@ -36,7 +36,7 @@ buildGoModule rec {
     export HOME="$TMPDIR"
 
     $out/bin/waypoint --help
-    $out/bin/waypoint version | grep "Waypoint v${version}"
+    $out/bin/waypoint version | grep "CLI: v${version}"
     runHook postInstallCheck
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump waypoint to `0.3.1`

They changed the output of version so that also needed changing.

I've noticed there's a `-autocomplete-install` flag but it just adds `complete -C /nix/store/blah-0.3.1/bin/waypoint waypoint` to your `.bashrc`
I tried running `/nix/store/blah-0.3.1/bin/waypoint waypoint` but that just gave me the same output as `help`
If there's a way to extract that out to a completion file let me know

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
