### PR TITLE
meme: rename to meme-image-generator, unstable-2020-05-28 -> 1.0.1

### DIFF
--- a/pkgs/applications/graphics/meme-image-generator/default.nix
+++ b/pkgs/applications/graphics/meme-image-generator/default.nix
@@ -5,7 +5,7 @@
 }:
 
 buildGoModule {
-  pname = "meme";
+  pname = "meme-image-generator";
   version = "unstable-2020-05-28";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/graphics/meme-image-generator/default.nix
+++ b/pkgs/applications/graphics/meme-image-generator/default.nix
@@ -1,23 +1,20 @@
 { lib
-, unstableGitUpdater
 , buildGoModule
 , fetchFromGitHub
 }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "meme-image-generator";
-  version = "unstable-2020-05-28";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "nomad-software";
     repo = "meme";
-    rev = "33a8b7d0de6996294a0464a605dacc17b26a6b02";
-    sha256 = "05h8d6pjszhr49xqg02nw94hm95kb7w1i7nw8jxi582fxxm2qbnm";
+    rev = "v${version}";
+    sha256 = "089r0v5az2d2njn0s3d3wd0861pcs4slg6zl0rj4cm1k5cj8yd1k";
   };
 
   vendorSha256 = null;
-
-  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     description = "A command line utility for creating image macro style memes";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -421,6 +421,7 @@ mapAliases ({
   mathics = throw "mathics has been removed from nixpkgs, as it's unmaintained"; # added 2020-08-15
   matrique = spectral; # added 2020-01-27
   mbedtls_1_3 = throw "mbedtls_1_3 is end of life, see https://tls.mbed.org/kb/how-to/upgrade-2.0"; # added 2019-12-08
+  meme = meme-image-generator; # added 2021-04-21
   mess = mame; # added 2019-10-30
   mcgrid = throw "mcgrid has been removed from nixpkgs, as it's not compatible with rivet 3"; # added 2020-05-23
   mcomix = throw "mcomix has been removed from nixpkgs, as it's unmaintained; try mcomix3 a Python 3 fork"; # added 2019-12-10, modified 2020-11-25

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24387,7 +24387,7 @@ in
 
   melonDS = libsForQt5.callPackage ../misc/emulators/melonDS { };
 
-  meme = callPackage ../applications/graphics/meme { };
+  meme-image-generator = callPackage ../applications/graphics/meme-image-generator { };
 
   meme-suite = callPackage ../applications/science/biology/meme-suite { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There are established projects (not currently in nixpkgs) called
"meme" https://repology.org/projects/?search=meme
so I feel like it's better to free up the namespace.
I adopted the name used by repology.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
