### PR TITLE
stdenv/{native,nix}: add lib to cc-wrapper args

### DIFF
--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -129,7 +129,7 @@ in
       name = "cc-native";
       nativeTools = true;
       nativeLibc = true;
-      inherit nativePrefix;
+      inherit lib nativePrefix;
       bintools = import ../../build-support/bintools-wrapper {
         name = "bintools";
         inherit stdenvNoCC nativePrefix;

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -24,6 +24,7 @@ bootStages ++ [
       initialPath = (import ../common-path.nix) { pkgs = prevStage; };
 
       cc = import ../../build-support/cc-wrapper {
+        inherit lib;
         nativeTools = false;
         nativePrefix = lib.optionalString hostPlatform.isSunOS "/usr";
         nativeLibc = true;


### PR DESCRIPTION
###### Motivation for this change
It seems that in https://github.com/NixOS/nixpkgs/pull/110628 we forgot to make stdenv/native and stdenv/nix pass lib to cc-wrapper (this change *was* made in the other stdenvs). Someone was running into this problem on the IRC while trying to use nix on aarch64-darwin.

I haven't tested this at all because I'm not actually sure when these versions of stdenv get used ("native" seems to be the cover-all for not explicitly supported systems?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
