### PR TITLE
badtouch: init at 0.7.3

### DIFF
--- a/pkgs/tools/security/badtouch/default.nix
+++ b/pkgs/tools/security/badtouch/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, installShellFiles
+, libcap
+, openssl
+, pkg-config
+, rustPlatform
+, Security
+, zlib
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "badtouch";
+  version = "0.7.3";
+
+  src = fetchFromGitHub {
+    owner = "kpcyrd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "05dzwx9y8zh0y9zd4mibp02255qphc6iqy916fkm3ahaw0rg84h3";
+  };
+
+  cargoSha256 = "0mmglgz037dk3g7qagf1dyss5hvvsdy0m5m1h6c3rk5bp5kjzg87";
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  buildInputs = [
+    libcap
+    zlib
+    openssl
+  ] ++ lib.optional stdenv.isDarwin Security;
+
+  postInstall = ''
+    installManPage docs/${pname}.1
+  '';
+
+  # Tests requires access to httpin.org
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Scriptable network authentication cracker";
+    homepage = "https://github.com/kpcyrd/badtouch";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1666,6 +1666,10 @@ in
 
   backblaze-b2 = callPackage ../development/tools/backblaze-b2 { };
 
+  badtouch = callPackage ../tools/security/badtouch {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   bandwhich = callPackage ../tools/networking/bandwhich {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Scriptable network authentication cracker

https://github.com/kpcyrd/badtouch

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
