### PR TITLE
hunter: init at 1.3.5

### DIFF
--- a/pkgs/applications/misc/hunter/default.nix
+++ b/pkgs/applications/misc/hunter/default.nix
@@ -1,0 +1,77 @@
+{ lib, stdenv, pkg-config, rustPlatform, fetchFromGitHub, fetchpatch
+, makeWrapper, glib, gst_all_1, CoreServices, IOKit, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hunter";
+  version = "2020-05-25-unstable";
+
+  src = fetchFromGitHub {
+    owner = "rabite0";
+    repo = "hunter";
+    rev = "355d9a3101f6d8dc375807de79e368602f1cb87d";
+    sha256 = "sha256-R2wNkG8bFP7X2pdlebHK6GD15qmD/zD3L0MwVthvzzQ=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "remove-dependencies-on-rust-nightly";
+      url =
+        "https://github.com/06kellyjac/hunter/commit/a5943578e1ee679c8bc51b0e686c6dddcf74da2a.diff";
+      sha256 = "sha256-eOwBFfW5m8tPnu+whWY/53X9CaqiVj2WRr25G+Yy7qE=";
+    })
+    (fetchpatch {
+      name = "fix-accessing-core-when-moved-with-another-clone";
+      url =
+        "https://github.com/06kellyjac/hunter/commit/2e95cc567c751263f8c318399f3c5bb01d36962a.diff";
+      sha256 = "sha256-yTzIXUw5qEaR2QZHwydg0abyZVXfK6fhJLVHBI7EAro=";
+    })
+    (fetchpatch {
+      name = "fix-resolve-breaking-changes-from-package-updates";
+      url =
+        "https://github.com/06kellyjac/hunter/commit/2484f0db580bed1972fd5000e1e949a4082d2f01.diff";
+      sha256 = "sha256-K+WUxEr1eE68XejStj/JwQpMHlhkiOw6PmiSr1GO0kc=";
+    })
+  ];
+
+  cargoPatches = [
+    (fetchpatch {
+      name = "chore-cargo-update";
+      url =
+        "https://github.com/06kellyjac/hunter/commit/b0be49a82191a4420b6900737901a71140433efd.diff";
+      sha256 = "sha256-ctxoDwyIJgEhMbMUfrjCTy2SeMUQqMi971szrqEOJeg=";
+    })
+    (fetchpatch {
+      name = "chore-cargo-upgrade-+-cargo-update";
+      url =
+        "https://github.com/06kellyjac/hunter/commit/1b8de9248312878358afaf1dac569ebbccc4321a.diff";
+      sha256 = "sha256-+4DZ8SaKwKNmr2SEgJJ7KZBIctnYFMQFKgG+yCkbUv0=";
+    })
+  ];
+
+  RUSTC_BOOTSTRAP = 1;
+
+  nativeBuildInputs = [ makeWrapper pkg-config ];
+  buildInputs = [
+    glib
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-plugins-bad
+  ] ++ lib.optionals stdenv.isDarwin [ CoreServices IOKit Security ];
+
+  cargoBuildFlags = [ "--no-default-features" "--features=img,video" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/hunter --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+  '';
+
+  cargoSha256 = "sha256-Bd/gilebxC4H+/1A41OSSfWBlHcSczsFcU2b+USnI74=";
+
+  meta = with lib; {
+    description = "The fastest file manager in the galaxy!";
+    homepage = "https://github.com/rabite0/hunter";
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ fufexan ];
+  };
+}

--- a/pkgs/applications/misc/hunter/default.nix
+++ b/pkgs/applications/misc/hunter/default.nix
@@ -53,12 +53,13 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ makeWrapper pkg-config ];
   buildInputs = [
     glib
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-good
-    gst_all_1.gst-plugins-ugly
-    gst_all_1.gst-plugins-bad
-  ] ++ lib.optionals stdenv.isDarwin [ CoreServices IOKit Security ];
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-ugly
+    gst-plugins-bad
+  ]) ++ lib.optionals stdenv.isDarwin [ CoreServices IOKit Security ];
 
   cargoBuildFlags = [ "--no-default-features" "--features=img,video" ];
 

--- a/pkgs/applications/misc/hunter/default.nix
+++ b/pkgs/applications/misc/hunter/default.nix
@@ -15,20 +15,17 @@ rustPlatform.buildRustPackage rec {
   patches = [
     (fetchpatch {
       name = "remove-dependencies-on-rust-nightly";
-      url =
-        "https://github.com/06kellyjac/hunter/commit/a5943578e1ee679c8bc51b0e686c6dddcf74da2a.diff";
+      url = "https://github.com/06kellyjac/hunter/commit/a5943578e1ee679c8bc51b0e686c6dddcf74da2a.diff";
       sha256 = "sha256-eOwBFfW5m8tPnu+whWY/53X9CaqiVj2WRr25G+Yy7qE=";
     })
     (fetchpatch {
       name = "fix-accessing-core-when-moved-with-another-clone";
-      url =
-        "https://github.com/06kellyjac/hunter/commit/2e95cc567c751263f8c318399f3c5bb01d36962a.diff";
+      url = "https://github.com/06kellyjac/hunter/commit/2e95cc567c751263f8c318399f3c5bb01d36962a.diff";
       sha256 = "sha256-yTzIXUw5qEaR2QZHwydg0abyZVXfK6fhJLVHBI7EAro=";
     })
     (fetchpatch {
       name = "fix-resolve-breaking-changes-from-package-updates";
-      url =
-        "https://github.com/06kellyjac/hunter/commit/2484f0db580bed1972fd5000e1e949a4082d2f01.diff";
+      url = "https://github.com/06kellyjac/hunter/commit/2484f0db580bed1972fd5000e1e949a4082d2f01.diff";
       sha256 = "sha256-K+WUxEr1eE68XejStj/JwQpMHlhkiOw6PmiSr1GO0kc=";
     })
   ];
@@ -36,14 +33,12 @@ rustPlatform.buildRustPackage rec {
   cargoPatches = [
     (fetchpatch {
       name = "chore-cargo-update";
-      url =
-        "https://github.com/06kellyjac/hunter/commit/b0be49a82191a4420b6900737901a71140433efd.diff";
+      url = "https://github.com/06kellyjac/hunter/commit/b0be49a82191a4420b6900737901a71140433efd.diff";
       sha256 = "sha256-ctxoDwyIJgEhMbMUfrjCTy2SeMUQqMi971szrqEOJeg=";
     })
     (fetchpatch {
       name = "chore-cargo-upgrade-+-cargo-update";
-      url =
-        "https://github.com/06kellyjac/hunter/commit/1b8de9248312878358afaf1dac569ebbccc4321a.diff";
+      url = "https://github.com/06kellyjac/hunter/commit/1b8de9248312878358afaf1dac569ebbccc4321a.diff";
       sha256 = "sha256-+4DZ8SaKwKNmr2SEgJJ7KZBIctnYFMQFKgG+yCkbUv0=";
     })
   ];

--- a/pkgs/applications/misc/hunter/default.nix
+++ b/pkgs/applications/misc/hunter/default.nix
@@ -74,5 +74,9 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/rabite0/hunter";
     license = licenses.wtfpl;
     maintainers = with maintainers; [ fufexan ];
+    # error[E0308]: mismatched types
+    # --> src/files.rs:502:62
+    # expected raw pointer `*const u8`, found raw pointer `*const i8`
+    broken = stdenv.isAarch64;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14909,6 +14909,10 @@ in
 
   hunspellWithDicts = dicts: callPackage ../development/libraries/hunspell/wrapper.nix { inherit dicts; };
 
+  hunter = callPackage ../applications/misc/hunter {
+    inherit (darwin.apple_sdk.frameworks) CoreServices IOKit Security;
+  };
+
   hwloc = callPackage ../development/libraries/hwloc {};
 
   inherit (callPackage ../development/tools/misc/hydra { })


### PR DESCRIPTION
###### Motivation for this change

Add the hunter file manager. Builds on the work done in [99898](https://github.com/NixOS/nixpkgs/pull/99898), since @magnetophon isn't interested in maintaining this package anymore.

The maintainer of the project has disappeared, but there may be folks who decide to fork and continue its development. For this exact reason I have picked a fork as the repo, since it includes some fixes and allows building the package without Rust Nightly.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
