### PR TITLE
unify: init at 0.5

### DIFF
--- a/pkgs/development/python-modules/unify/default.nix
+++ b/pkgs/development/python-modules/unify/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, untokenize
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "unify";
+  version = "0.5";
+
+  # PyPi release is missing tests (see https://github.com/myint/unify/pull/18)
+  src = fetchFromGitHub {
+    owner = "myint";
+    repo = "unify";
+    rev = "v${version}";
+    sha256 = "1l6xxygaigacsxf0g5f7w5gpqha1ava6mcns81kqqy6vw91pyrbi";
+  };
+
+  propagatedBuildInputs = [ untokenize ];
+
+  checkPhase = "${python.interpreter} -m unittest discover";
+
+  meta = with lib; {
+    description = "Modifies strings to all use the same quote where possible";
+    homepage = "https://github.com/myint/unify";
+    license = licenses.mit;
+    maintainers = with maintainers; [ FlorianFranzen ];
+  };
+}

--- a/pkgs/development/python-modules/untokenize/default.nix
+++ b/pkgs/development/python-modules/untokenize/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "untokenize";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3865dbbbb8efb4bb5eaa72f1be7f3e0be00ea8b7f125c69cbd1f5fda926f37a2";
+  };
+
+  checkPhase = "${python.interpreter} -m unittest discover";
+
+  meta = with lib; {
+    description = "Transforms tokens into original source code while preserving whitespace";
+    homepage = "https://github.com/myint/untokenize";
+    license = licenses.mit;
+    maintainers = with maintainers; [ FlorianFranzen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3454,6 +3454,8 @@ in
 
   unifdef = callPackage ../development/tools/misc/unifdef { };
 
+  unify = with python3Packages; toPythonApplication unify;
+
   unionfs-fuse = callPackage ../tools/filesystems/unionfs-fuse { };
 
   usb-modeswitch = callPackage ../development/tools/misc/usb-modeswitch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8751,6 +8751,8 @@ in {
 
   untangle = callPackage ../development/python-modules/untangle { };
 
+  untokenize = callPackage ../development/python-modules/untokenize { };
+
   upass = callPackage ../development/python-modules/upass { };
 
   update_checker = callPackage ../development/python-modules/update_checker { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8733,6 +8733,8 @@ in {
 
   unifi = callPackage ../development/python-modules/unifi { };
 
+  unify = callPackage ../development/python-modules/unify { };
+
   unifiled = callPackage ../development/python-modules/unifiled { };
 
   units = callPackage ../development/python-modules/units { };


### PR DESCRIPTION
###### Motivation for this change

unify was missing from nixpkgs, but widely used.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
