### PR TITLE
esbuild: init at 0.11.12

### DIFF
--- a/pkgs/development/tools/esbuild/default.nix
+++ b/pkgs/development/tools/esbuild/default.nix
@@ -1,0 +1,26 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+let
+  pname = "esbuild";
+  version = "0.11.12";
+
+in buildGoModule {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "evanw";
+    repo = "esbuild";
+    rev = "v${version}";
+    sha256 = "1mxj4mrq1zbvv25alnc3s36bhnnhghivgwp45a7m3cp1389ffcd1";
+  };
+
+  vendorSha256 = "1n5538yik72x94vzfq31qaqrkpxds5xys1wlibw2gn2am0z5c06q";
+
+  meta = with lib; {
+    description = "An extremely fast JavaScript bundler";
+    homepage = "https://esbuild.github.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lucus16 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/esbuild/default.nix
+++ b/pkgs/development/tools/esbuild/default.nix
@@ -1,11 +1,8 @@
 { buildGoModule, fetchFromGitHub, lib }:
 
-let
+buildGoModule rec {
   pname = "esbuild";
   version = "0.11.12";
-
-in buildGoModule {
-  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "evanw";
@@ -21,6 +18,5 @@ in buildGoModule {
     homepage = "https://esbuild.github.io";
     license = licenses.mit;
     maintainers = with maintainers; [ lucus16 ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1347,6 +1347,8 @@ in
 
   enpass = callPackage ../tools/security/enpass { };
 
+  esbuild = callPackage ../development/tools/esbuild { };
+
   essentia-extractor = callPackage ../tools/audio/essentia-extractor { };
 
   esh = callPackage ../tools/text/esh { };


### PR DESCRIPTION
###### Motivation for this change

esbuild is an extremely fast javascript bundler

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
