### PR TITLE
wprecon: init at 1.6.3a

### DIFF
--- a/pkgs/tools/security/wprecon/default.nix
+++ b/pkgs/tools/security/wprecon/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "wprecon";
+  version = "1.6.3a";
+
+  src = fetchFromGitHub {
+    owner = "blackbinn";
+    repo = pname;
+    rev = version;
+    sha256 = "0gqi4799ha3mf8r7ini0wj4ilkfsh80vnnxijfv9a343r6z5w0dn";
+  };
+
+  vendorSha256 = "1sab58shspll96rqy1rp659s0yikqdcx59z9b88d6p4w8a98ns87";
+
+  meta = with lib; {
+    description = "WordPress vulnerability recognition tool";
+    homepage = "https://github.com/blackbinn/wprecon";
+    # License Zero Noncommercial Public License 2.0.1
+    # https://github.com/blackbinn/wprecon/blob/master/LICENSE
+    license = with licenses; [ unfree ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30637,6 +30637,8 @@ in
 
   wordpress = callPackage ../servers/web-apps/wordpress { };
 
+  wprecon = callPackage ../tools/security/wprecon { };
+
   wraith = callPackage ../applications/networking/irc/wraith {
     openssl = openssl_1_0_2;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
WordPress vulnerability recognition tool

https://github.com/blackbinn/wprecon

Related to #81418


This tool is licensed under `License Zero Noncommercial Public License 2.0.1`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
