### PR TITLE
[20.09] clamav: add patch for CVE-2021-1405

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig
+{ stdenv, fetchurl, fetchpatch, pkgconfig
 , zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl, libmilter, pcre2
 , libmspack, systemd, Foundation
 }:
@@ -11,6 +11,14 @@ stdenv.mkDerivation rec {
     url = "https://www.clamav.net/downloads/production/${pname}-${version}.tar.gz";
     sha256 = "06rrzyrhnr0rswryijpbbzywr6387rv8qjq8sb8cl3h2d1m45ggf";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-1405.patch";
+      url = "https://github.com/Cisco-Talos/clamav-devel/commit/0c1ec30f9a292b0a5eca4aaaa651150aa5712d6d.patch";
+      sha256 = "0ygqiv9ldwhhnlwxkz91bab4hnzfwczf96mqm1bsa4gz9wmshlks";
+    })
+  ];
 
   # don't install sample config files into the absolute sysconfdir folder
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-1405

An alternative to #119909

Noticed debian have just used the upstream mainline patch against their 0.102.4 - it applies & works just fine.

The two other concerning vulnerabilities, CVE-2021-1404 and CVE-2021-1252, don't appear to apply to clamav < 0.103.0, so by my judgement, applying this patch should deal with the situation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
