### PR TITLE
zellij: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9819,6 +9819,12 @@
     githubId = 3105057;
     name = "Jan Beinke";
   };
+  therealansh = {
+    email = "tyagiansh23@gmail.com";
+    github = "therealansh";
+    githubId = 57180880;
+    name = "Ansh Tyagi";
+  };
   thesola10 = {
     email = "me@thesola.io";
     github = "thesola10";

--- a/pkgs/tools/misc/zellij/default.nix
+++ b/pkgs/tools/misc/zellij/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchFromGitHub, rustPlatform, stdenv, installShellFiles, libiconv }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "zellij";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "zellij-org";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "102zw4napzx05rpmx6scl6il55syf3lw1gzmy1y66cg1f70sij4d";
+  };
+
+  cargoSha256 = "121fsch0an6d2hqaq0ws9cm7g5ppzfrycmmhajfacfg6wbiax1m5";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+
+  preCheck = ''
+    HOME=$TMPDIR
+  '';
+
+  postInstall = ''
+    installShellCompletion assets/completions/zellij.{bash,fish} --zsh assets/completions/_zellij
+  '';
+
+  meta = with lib; {
+    description = "A terminal workspace with batteries included";
+    homepage = "https://zellij.dev/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ therealansh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9716,6 +9716,8 @@ in
 
   zdelta = callPackage ../tools/compression/zdelta { };
 
+  zellij = callPackage ../tools/misc/zellij { };
+
   zenith = callPackage ../tools/system/zenith {
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
