### PR TITLE
coqPackages.paramcoq: enable for Coq 8.13

### DIFF
--- a/pkgs/development/coq-modules/paramcoq/default.nix
+++ b/pkgs/development/coq-modules/paramcoq/default.nix
@@ -3,9 +3,10 @@
 with lib; mkCoqDerivation {
   pname = "paramcoq";
   inherit version;
-  defaultVersion = if versions.range "8.7" "8.12" coq.coq-version
+  defaultVersion = if versions.range "8.7" "8.13" coq.coq-version
     then "1.1.2+coq${coq.coq-version}" else null;
   displayVersion = { paramcoq = "1.1.2"; };
+  release."1.1.2+coq8.13".sha256 = "02vnf8p04ynf3qk8myvjzsbga15395235mpdpj54pvxis3h5qq22";
   release."1.1.2+coq8.12".sha256 = "0qd72r45if4h7c256qdfiimv75zyrs0w0xqij3m866jxaq591v4i";
   release."1.1.2+coq8.11".sha256 = "09c6813988nvq4fpa45s33k70plnhxsblhm7cxxkg0i37mhvigsa";
   release."1.1.2+coq8.10".sha256 = "1lq1mw15w4yky79qg3rm0mpzqi2ir51b6ak04ismrdr7ixky49y8";


### PR DESCRIPTION
###### Motivation for this change

Add support for latest version of Coq.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
