### PR TITLE
python3Packages.hyperion-py: init at 0.7.4

### DIFF
--- a/pkgs/development/python-modules/hyperion-py/default.nix
+++ b/pkgs/development/python-modules/hyperion-py/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, poetry-core
+, pytest-aiohttp
+, pytest-asyncio
+}:
+
+buildPythonPackage rec {
+  pname = "hyperion-py";
+  version = "0.7.4";
+  disabled = pythonOlder "3.8";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "dermotduffy";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "00x12ppmvlxs3qbdxq06wnzakvwm2m39qhmpp27qfpl137b0qqyj";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-aiohttp
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace " --timeout=9 --cov=hyperion" ""
+  '';
+
+  pythonImportsCheck = [ "hyperion" ];
+
+  meta = with lib; {
+    description = "Python package for Hyperion Ambient Lighting";
+    homepage = "https://github.com/dermotduffy/hyperion-py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -373,7 +373,7 @@
     "hunterdouglas_powerview" = ps: with ps; [ ]; # missing inputs: aiopvapi
     "hvv_departures" = ps: with ps; [ ]; # missing inputs: pygti
     "hydrawise" = ps: with ps; [ hydrawiser ];
-    "hyperion" = ps: with ps; [ ]; # missing inputs: hyperion-py
+    "hyperion" = ps: with ps; [ hyperion-py ];
     "iammeter" = ps: with ps; [ ]; # missing inputs: iammeter
     "iaqualink" = ps: with ps; [ iaqualink ];
     "icloud" = ps: with ps; [ pyicloud ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -261,6 +261,7 @@ in with py.pkgs; buildPythonApplication rec {
     "html5"
     "http"
     "hue"
+    "hyperion"
     "iaqualink"
     "ifttt"
     "image"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3245,6 +3245,8 @@ in {
 
   hyperframe = callPackage ../development/python-modules/hyperframe { };
 
+  hyperion-py = callPackage ../development/python-modules/hyperion-py { };
+
   hyperkitty = callPackage ../servers/mail/mailman/hyperkitty.nix { };
 
   hyperlink = callPackage ../development/python-modules/hyperlink { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python package for Hyperion Ambient Lighting

https://github.com/dermotduffy/hyperion-py

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
