### PR TITLE
python3.pkgs.sphinx-markdown-parser: init at 0.2.4

### DIFF
--- a/pkgs/development/python-modules/sphinx-markdown-parser/default.nix
+++ b/pkgs/development/python-modules/sphinx-markdown-parser/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, sphinx
+, markdown
+, CommonMark
+, recommonmark
+, pydash
+, pyyaml
+, unify
+, yapf
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-markdown-parser";
+  version = "0.2.4";
+
+  # PyPi release does not include requirements.txt
+  src = fetchFromGitHub {
+    owner = "clayrisser";
+    repo = "sphinx-markdown-parser";
+    # Upstream maintainer currently does not tag releases
+    # https://github.com/clayrisser/sphinx-markdown-parser/issues/35
+    rev = "2fd54373770882d1fb544dc6524c581c82eedc9e";
+    sha256 = "0i0hhapmdmh83yx61lxi2h4bsmhnzddamz95844g2ghm132kw5mv";
+  };
+
+  propagatedBuildInputs = [ sphinx markdown CommonMark pydash pyyaml unify yapf recommonmark ];
+
+  # Avoids running broken tests in test_markdown.py
+  checkPhase = ''
+    ${python.interpreter} -m unittest -v tests/test_basic.py tests/test_sphinx.py
+  '';
+
+  pythonImportsCheck = [ "sphinx_markdown_parser" ];
+
+  meta = with lib; {
+    description = "Write markdown inside of docutils & sphinx projects";
+    homepage = "https://github.com/clayrisser/sphinx-markdown-parser";
+    license = licenses.mit;
+    maintainers = with maintainers; [ FlorianFranzen ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7635,6 +7635,8 @@ in {
 
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
+  sphinx-markdown-parser = callPackage ../development/python-modules/sphinx-markdown-parser { };
+
   sphinx-material = callPackage ../development/python-modules/sphinx-material { };
 
   sphinx-navtree = callPackage ../development/python-modules/sphinx-navtree { };


### PR DESCRIPTION
###### Motivation for this change

sphinx-markdown-parser was missing in nixpkgs

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
