### PR TITLE
nixos/nextcloud: Rename option disableImagemagick to enableImagemagick

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -10,7 +10,7 @@ let
     extensions = { enabled, all }:
       (with all;
         enabled
-        ++ optional (!cfg.disableImagemagick) imagick
+        ++ optional cfg.enableImagemagick imagick
         # Optionally enabled depending on caching settings
         ++ optional cfg.caching.apcu apcu
         ++ optional cfg.caching.redis redis
@@ -62,6 +62,9 @@ in {
 
       Further details about this can be found in the `Nextcloud`-section of the NixOS-manual
       (which can be openend e.g. by running `nixos-help`).
+    '')
+    (mkRemovedOptionModule [ "services" "nextcloud" "disableImagemagick" ] ''
+      Use services.nextcloud.nginx.enableImagemagick instead.
     '')
   ];
 
@@ -303,16 +306,14 @@ in {
       };
     };
 
-    disableImagemagick = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to not load the ImageMagick module into PHP.
+    enableImagemagick = mkEnableOption ''
+        Whether to load the ImageMagick module into PHP.
         This is used by the theming app and for generating previews of certain images (e.g. SVG and HEIF).
         You may want to disable it for increased security. In that case, previews will still be available
         for some images (e.g. JPEG and PNG).
         See https://github.com/nextcloud/server/issues/13099
-      '';
+    '' // {
+      default = true;
     };
 
     caching = {

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -51,7 +51,7 @@ in {
     nextcloudWithoutMagick = args@{ config, pkgs, lib, ... }:
       lib.mkMerge
       [ (nextcloud args)
-        { services.nextcloud.disableImagemagick = true; } ];
+        { services.nextcloud.enableImagemagick = false; } ];
   };
 
   testScript = { nodes, ... }: let


### PR DESCRIPTION
###### Motivation for this change

Enable options are preferred. Suggested here:
https://github.com/NixOS/nixpkgs/pull/115372#issuecomment-821900334

@dasJ @Ma27 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
