### PR TITLE
remote-touchpad: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8839,6 +8839,12 @@
     githubId = 15379000;
     name = "schneefux";
   };
+  schnusch = {
+    email = "schnusch@users.noreply.github.com";
+    github = "schnusch";
+    githubId = 5104601;
+    name = "schnusch";
+  };
   schristo = {
     email = "schristopher@konputa.com";
     name = "Scott Christopher";

--- a/pkgs/tools/inputmethods/remote-touchpad/default.nix
+++ b/pkgs/tools/inputmethods/remote-touchpad/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, libX11
+, libXi
+, libXt
+, libXtst
+}:
+
+buildGoModule rec {
+  pname = "remote-touchpad";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "unrud";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0zmbn4s3yhcgmijc96vja7zj2sh6q0nkybhqy0fwz6sqzk8hq02x";
+  };
+
+  buildInputs = [ libX11 libXi libXt libXtst ];
+  buildFlags = [ "-tags" "portal,x11" ];
+
+  vendorSha256 = "0q1qk5g7kqpcci5fgamvxa8989jglv69kwg5rvkphbnx1bzlivrl";
+
+  meta = with lib; {
+    description = "Control mouse and keyboard from the webbrowser of a smartphone.";
+    homepage = "https://github.com/unrud/remote-touchpad";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ schnusch ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7965,6 +7965,8 @@ in
 
   reftools = callPackage ../development/tools/reftools { };
 
+  remote-touchpad = callPackage ../tools/inputmethods/remote-touchpad { };
+
   reposurgeon = callPackage ../applications/version-management/reposurgeon { };
 
   reptyr = callPackage ../os-specific/linux/reptyr {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [remote-touchpad](https://github.com/unrud/remote-touchpad) to nixpkgs to easily control the PC's mouse from a smartphone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
