### PR TITLE
termsyn: init at 1.8.7

### DIFF
--- a/pkgs/data/fonts/termsyn/default.nix
+++ b/pkgs/data/fonts/termsyn/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl, mkfontscale }:
+
+stdenv.mkDerivation rec {
+  pname = "termsyn";
+  version = "1.8.7";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/termsyn/termsyn-${version}.tar.gz";
+    sha256 = "15vsmc3nmzl0pkgdpr2993da7p38fiw2rvcg01pwldzmpqrmkpn6";
+  };
+
+  nativeBuildInputs = [ mkfontscale ];
+
+  installPhase = ''
+    install -m 644 -D *.pcf -t "$out/share/fonts"
+    install -m 644 -D *.psfu -t "$out/share/kbd/consolefonts"
+    mkfontdir "$out/share/fonts"
+  '';
+
+  meta = with lib; {
+    description = "Monospaced font based on terminus and tamsyn";
+    homepage = "https://sourceforge.net/projects/termsyn/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ sophrosyne ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -910,6 +910,8 @@ in
     inherit (haskellPackages) ghcWithPackages;
   };
 
+  termsyn = callPackage ../data/fonts/termsyn { };
+
   tilda = callPackage ../applications/terminal-emulators/tilda {
     gtk = gtk3;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
To allow others to enjoy my preferred bitmap font.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
