### PR TITLE
stork: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/applications/misc/stork/default.nix
+++ b/pkgs/applications/misc/stork/default.nix
@@ -1,20 +1,26 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, openssl
+, pkg-config
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "stork";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "jameslittle230";
     repo = "stork";
     rev = "v${version}";
-    sha256 = "sha256-pBJ9n1pQafXagQt9bnj4N1jriczr47QLtKiv+UjWgTg=";
+    sha256 = "sha256-gPrXeS7XT38Dil/EBwmeKIJrmPlEK+hmiyHi4p28tl0=";
   };
 
-  cargoSha256 = "sha256-u8L4ZeST4ExYB2y8E+I49HCy41dOfhR1fgPpcVMVDuk=";
+  cargoSha256 = "sha256-9YKCtryb9mTPz9iWE7Iuk2SKgV0knWRbaouF+1DCjv8=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
 
   meta = with lib; {
     description = "Impossibly fast web search, made for static sites";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Stork has a new release, [v1.2.0](https://github.com/jameslittle230/stork/releases/tag/v1.2.0).

<details><summary>Run results</summary>

```
$ ../nixpkgs/result/bin/stork build --input stork/config.toml --output stork/index.st
Index built, 189,779 bytes written to stork/index.st.

$ ../nixpkgs/result/bin/stork search --index stork/index.st --query beta
{
  "results": [
    {
      "entry": {
        "url": "https://chuahou.dev/miso/uni/lc/notes/reductions.html",
        "title": "LC, Reductions",
        "fields": {}
      },
      "excerpts": [
        {
[...]

$ ../nixpkgs/result/bin/stork test --input stork/config.toml
Open <http://127.0.0.1:1612> in your web browser to visit the test page.
Press ctrl-C to stop the server.
^C%
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
