### PR TITLE
tree-sitter: Update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "70fd2cba742506903589b5e046c32e0e3e06404a",
-  "date": "2021-03-03T17:18:54-08:00",
-  "path": "/nix/store/m0pzbb0vg0fm9nycj05ay0yldzp7qwbi-tree-sitter-c-sharp",
-  "sha256": "12jj66rsn1klsk24yj0ymgsqwy7lc5kb3nkj7griip8rmi3kgy41",
+  "rev": "09749b7b5428e770cc2ebdf2e90029c0f4a2d411",
+  "date": "2021-04-13T07:05:48+01:00",
+  "path": "/nix/store/w99nivk866bglvijxb5m0c789qh99x1m-tree-sitter-c-sharp",
+  "sha256": "17n7r1j1ib3gzjf0qw88512flzamjrvilksbf1p15dqa17rmwyq1",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "5aa0bbbfc41868a3727b7a89a90e9f52e0964b2b",
-  "date": "2021-03-03T17:00:36-08:00",
-  "path": "/nix/store/2wa64ii39p31wpngvqk4ni8z8ws29r2g-tree-sitter-c",
-  "sha256": "1diys8yigvhm4ppbmp3a473yxjg2d5lk11y0ay7qprcz7233lakv",
+  "rev": "f05e279aedde06a25801c3f2b2cc8ac17fac52ae",
+  "date": "2021-03-28T09:12:10-07:00",
+  "path": "/nix/store/4bcxsfrgrcpjy3f6dsmqli2xawjpyz44-tree-sitter-c",
+  "sha256": "1rismmgaqii1sdnri66h75sgw3mky4aha9hff6fan1qzll4f3hif",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "05cf2030e5415e9e931f620f0924107f73976796",
-  "date": "2021-03-04T10:01:34-08:00",
-  "path": "/nix/store/fraya34acwl9i3cxpml9hwzfkyc8vs89-tree-sitter-cpp",
-  "sha256": "08ywv6n80sa541rr08bqz4zyg7byvjcabp68lvxmcahjk8xzcgwk",
+  "rev": "c61212414a3e95b5f7507f98e83de1d638044adc",
+  "date": "2021-03-27T10:08:51-07:00",
+  "path": "/nix/store/a8cd3sv1j900sd8l7cdjw91iw7pp3jhv-tree-sitter-cpp",
+  "sha256": "04nv9j03q20idk9pnm2lgw7rbwzy5jf9v0y6l102by68z4lv79fi",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/travonted/tree-sitter-fennel",
-  "rev": "5aad9d1f490b7fc8a847a5b260f23396c56024f5",
-  "date": "2020-11-03T09:22:17-05:00",
-  "path": "/nix/store/gsxg67brk198201h70lip7miwny084sy-tree-sitter-fennel",
-  "sha256": "1imv5nwmhsyxwq7b9z4qz72lfva40wgybdkmq0gbbfbszl9a9bgl",
+  "rev": "bc689e2ef264e2cba499cfdcd16194e8f5fe87d2",
+  "date": "2021-03-09T16:47:45-05:00",
+  "path": "/nix/store/3h4j1mrqvn0ybqjalic92bnhk7c15442-tree-sitter-fennel",
+  "sha256": "1jm21bmsdrz9x5skqmx433q9b4mfi88gzc4la5hqps4is28inqms",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "e41dd569d91eb58725baa7089c34fc3d785b2978",
-  "date": "2021-03-03T17:11:05-08:00",
-  "path": "/nix/store/87n5nl5p1fnmwgy0zshz90vyvha6b7mn-tree-sitter-go",
-  "sha256": "0nxs47vd2fc2fr0qlxq496y852rwg39flhg334s7dlyq7d3lcx4x",
+  "rev": "2a83dfdd759a632651f852aa4dc0af2525fae5cd",
+  "date": "2021-03-09T16:11:33-05:00",
+  "path": "/nix/store/2jk1bacllxsii8nlbc5lyi3k376ylf3q-tree-sitter-go",
+  "sha256": "001p8kb8g4vghn78690bnav42inkypld2k1mbd5pbmd5svvacfav",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "24cf84ff618e96528882c67c8740fadcd6c4a921",
-  "date": "2021-03-06T17:58:27+01:00",
-  "path": "/nix/store/46hpbz06d1p5n0rp6z3iwy2lpwrn8kgl-tree-sitter-haskell",
-  "sha256": "1l004x1z9g1p8313ipvrf581vr2wi82qcwc0281kg083m2z4535p",
+  "rev": "2e33ffa3313830faa325fe25ebc3769896b3a68b",
+  "date": "2021-04-19T23:45:03+02:00",
+  "path": "/nix/store/75mc2mfs4sm21c871s5lm9djnjk90r7n-tree-sitter-haskell",
+  "sha256": "0np7mzi1na1qscdxsjpyw314iwcmpzzrx1v7fk3yxc70qwzjcpp1",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "7ad106e81963b4d5c0aff99b93d16dc577fa3bc8",
-  "date": "2021-03-05T16:03:00-08:00",
-  "path": "/nix/store/ax9m7v0pv7q7xsnrjlfdpljs4f6xi2z3-tree-sitter-java",
-  "sha256": "1594mrhqcdfs8b7wmwpzcwna4m3ra8cbzq162flwrhcsb3w0rr9w",
+  "rev": "ee8e358637e05188f9f65d8d1ad88a4412c975ce",
+  "date": "2021-04-20T10:40:14-04:00",
+  "path": "/nix/store/8612qackwqdsvbfc03lzc5vds6mvqwxf-tree-sitter-java",
+  "sha256": "19qxfimy8w49gqc97siknd27kvkz73qp2v2118pvdbdz7c5dv27r",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "b3e7667995c065be724d10b69fbc3d0177ccef0b",
-  "date": "2021-03-08T13:12:59-08:00",
-  "path": "/nix/store/1y3nirw7bbnld4qy7ysm20bq0x9403wz-tree-sitter-javascript",
-  "sha256": "0bzyq5x8x1r34fzy1f05yqdlz51b1i1jmyssm0i571n9n6142s3j",
+  "rev": "a263a8f53266f8f0e47e21598e488f0ef365a085",
+  "date": "2021-04-20T10:37:09-04:00",
+  "path": "/nix/store/y6qbdzdx4g1g1sa2rb7dnk9snjs6lhpp-tree-sitter-javascript",
+  "sha256": "04s1jb9c96kwq0nrh6516idlh58d2b1k66amqa2sl5kk32pl9pmm",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-json",
-  "rev": "89607925e8989f2638cc935b8de7e44ac3c91907",
-  "date": "2021-03-04T14:55:58-08:00",
-  "path": "/nix/store/xpykb8mr4xarh6finzkz71z2bpqm8k26-tree-sitter-json",
-  "sha256": "06pjh31bv9ja9hlnykk257a6zh8bsxg2fqa54al7qk1r4n9ksnff",
+  "rev": "65bceef69c3b0f24c0b19ce67d79f57c96e90fcb",
+  "date": "2021-03-09T16:25:11-05:00",
+  "path": "/nix/store/bn5smxwwg4zzdc52wp2qb6s6yjdfi8mg-tree-sitter-json",
+  "sha256": "13p4ffmajirl9qh64d6qnng1gjnh5f6jkqbra0nlc1260nsf12hp",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ikatyang/tree-sitter-markdown",
-  "rev": "5a139bed455268a06410471bf48b19d11abdd367",
-  "date": "2021-01-24T15:17:18+08:00",
-  "path": "/nix/store/125cbxcqvwyq8b7kvmg7wxjjz16s2jvw-tree-sitter-markdown",
-  "sha256": "072b4nnpymrh90y4dk18kr8l1g7m83r3gvp6v0ad9f9dnq47fgax",
+  "rev": "8b8b77af0493e26d378135a3e7f5ae25b555b375",
+  "date": "2021-04-18T20:49:21+08:00",
+  "path": "/nix/store/4z2k0q6rwqmb7vbqr4vgc26w28szlan3-tree-sitter-markdown",
+  "sha256": "1a2899x7i6dgbsrf13qzmh133hgfrlvmjsr3bbpffi1ixw1h7azk",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "a6bae0619126d70c756c11e404d8f4ad5108242f",
-  "date": "2021-02-09T00:48:18-06:00",
-  "path": "/nix/store/1rfsi62v549h72vw7ysciaw17vr5h9yx-tree-sitter-nix",
-  "sha256": "08n496k0vn7c2751gywl1v40490azlri7c92dr2wfgw5jxhjmb0d",
+  "rev": "d5287aac195ab06da4fe64ccf93a76ce7c918445",
+  "date": "2021-04-21T19:11:29-05:00",
+  "path": "/nix/store/6labzn2qd3wyn4k2ddb09z2avpgqwbp1-tree-sitter-nix",
+  "sha256": "0mapqdqrinskdxlarrrvyd55mjg97gbd6jm9vbjmdm4xi2hhzvxa",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ocaml",
-  "rev": "19a8d2aab425c4c4c8dc6a882e67c37010620c3b",
-  "date": "2021-03-08T16:57:09-08:00",
-  "path": "/nix/store/y8jsf6vp278svqm4c6xnl4i6vanslrkk-tree-sitter-ocaml",
-  "sha256": "0c5wjanka87bhha0aq3m5p448apxhv8hndlqvhly6qafj99jp85i",
+  "rev": "2f962cf4eb0bee87bba755347a79ee501cd58313",
+  "date": "2021-03-11T02:13:42+01:00",
+  "path": "/nix/store/pwf6di3pdghsnb83c87vvm3w0d5aanvp-tree-sitter-ocaml",
+  "sha256": "1dfan7kbs7i0nz9dkxv8ipn0b341j1fr9fn0a2zfqsx6xxkra56r",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "ba231f9844e5a1bf60e1cb72c34c0a431239585a",
-  "date": "2021-03-03T17:17:11-08:00",
-  "path": "/nix/store/cn06h14pgq3psjq3ms0yvdm3x1wwbc1j-tree-sitter-php",
-  "sha256": "1xaml64b7cx3hn6x35bbgar8cp7ccxkwvxddjdvyj5nzfx1id8y3",
+  "rev": "4dcc061668fbc68b79421c72eb8a8baeeb0f3693",
+  "date": "2021-04-19T12:44:47-04:00",
+  "path": "/nix/store/2i80zds4dbynrdim9ngc8yp6yn825byb-tree-sitter-php",
+  "sha256": "0hs6dfw9n6sp7vbp7zfid0f0sxydyya3dyp5ghckz7al069g3vx2",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "dd98afca32aaceff9025f9e85031ac50bee8b08b",
-  "date": "2021-03-05T16:00:15-08:00",
-  "path": "/nix/store/6sbmzgva73fhgqhsdrg5zy7vbs9lzll9-tree-sitter-python",
-  "sha256": "01ykryrv1nn2y8dcbl64d31h1ipz2569ywzjp10pd93h1s6czpnl",
+  "rev": "d6210ceab11e8d812d4ab59c07c81458ec6e5184",
+  "date": "2021-03-27T09:41:53-07:00",
+  "path": "/nix/store/4v24ahydid4hr7kj0xi41mgbpglfnnki-tree-sitter-python",
+  "sha256": "173lpxi4vqa42dcdr9aj5phg5g6ny9ns04djw9n86pasx2w66dhk",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "20f064bd758f94b8f47ce5a21e4383c7349ca182",
-  "date": "2021-03-04T14:06:14-08:00",
-  "path": "/nix/store/za0yxqjjp9vxgwrp014qwv2v2qffl0di-tree-sitter-rust",
-  "sha256": "118vkhv7n3sw8y9pi0987cgdcd74sjqwviijw01mhnk3bkyczi3l",
+  "rev": "a360da0a29a19c281d08295a35ecd0544d2da211",
+  "date": "2021-03-27T09:50:22-07:00",
+  "path": "/nix/store/h4snh879ccy159fa390qr8l0nyaf5ndr-tree-sitter-rust",
+  "sha256": "0knaza3ww5h5w95hzdaalg5yrfpiv0r394q0imadxp5611132hxz",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "262797b1dfe0303818c2418c0a88f6be65f37245",
-  "date": "2021-03-04T15:02:28-08:00",
-  "path": "/nix/store/vc5fr00vqx5nf17r9grdwb11wci3xrkm-tree-sitter-scala",
-  "sha256": "1zf3b1x1s94dgzjbc6l8ind5fd1mmny3893d4bqc63h4qp0n0bp3",
+  "rev": "fb23ed9a99da012d86b7a5059b9d8928607cce29",
+  "date": "2021-04-01T10:11:15-07:00",
+  "path": "/nix/store/n1wvxkz4h38770lxvwakway34ac2a8h7-tree-sitter-scala",
+  "sha256": "05g95340g4labkdvfka5cbg7pr6vzigc40y54js1b5wml0w3d8f7",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/Himujjal/tree-sitter-svelte",
-  "rev": "a96899bd1ab6a18e3837f232fd688af69e3a8071",
-  "date": "2021-03-09T15:14:24+05:30",
-  "path": "/nix/store/nlpf6gilkk19aw7pk1kbys2alhnqagqj-tree-sitter-svelte",
-  "sha256": "04virfsiqqhh3gc3cmcjd4s1zn9wdxi47m55x938napaqiaw29nx",
+  "rev": "c696a13a587b0595baf7998f1fb9e95c42750263",
+  "date": "2021-03-20T16:45:11+05:30",
+  "path": "/nix/store/8krdxqwpi95ljrb5jgalwgygz3aljqr8-tree-sitter-svelte",
+  "sha256": "0ckmss5gmvffm6danlsvgh6gwvrlznxsqf6i6ipkn7k5lxg1awg3",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "7e119621b1d2ab1873ba14d8702f62458df70409",
-  "date": "2021-03-08T13:23:30-08:00",
-  "path": "/nix/store/k7vam1w5c2r0hhxy0bgpmj65bw5wnh96-tree-sitter-typescript",
-  "sha256": "1fv6q1bc0j6b89skz7x2ibi6bxx0ijrb676y23aahycvz2p8x4z0",
+  "rev": "82916165120f840164f11119f268a4de819ea90b",
+  "date": "2021-04-19T18:16:19-07:00",
+  "path": "/nix/store/0c0kkiiamms3yl3mf1clyrqcjwp5j920-tree-sitter-typescript",
+  "sha256": "1jnf0hn6hmn4x2cvy29mk8g1wlp0afs8immp461by3q5hcq8fzb4",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-verilog",
-  "rev": "ad551aae2649da56582bc0557478a7dc979c0be3",
-  "date": "2020-10-13T17:40:47-07:00",
-  "path": "/nix/store/nfaxfqrqkxpwaq8rnk7kcp28nnj8y6m2-tree-sitter-verilog",
-  "sha256": "0cy29i200rnc34d237s19r6a1n5vv4d3wgwpbywxg6ahcankc34m",
+  "rev": "1b624ab8b3f8d54ecc37847aa04512844f0226ac",
+  "date": "2021-03-31T21:27:26-07:00",
+  "path": "/nix/store/4j6hrf8bc8zjd7r9xnna9njpw0i4z817-tree-sitter-verilog",
+  "sha256": "0ygm6bdxqzpl3qn5l58mnqyj730db0mbasj373bbsx81qmmzkgzz",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ikatyang/tree-sitter-yaml",
-  "rev": "ab0ce67ce98f8d9cc0224ebab49c64d01fedc1a1",
-  "date": "2021-01-01T21:13:43+08:00",
-  "path": "/nix/store/3vnhqr4l2hb0ank13avj8af4qbni5szw-tree-sitter-yaml",
-  "sha256": "14f0abv68cjkwdcjjwa1nzjpwp6w59cj5v4m5h5h3jxi96z65459",
+  "rev": "6129a83eeec7d6070b1c0567ec7ce3509ead607c",
+  "date": "2021-04-18T14:25:59+08:00",
+  "path": "/nix/store/8wrwm71z9flfk00phrh9aaxpvsrw1m67-tree-sitter-yaml",
+  "sha256": "1bimf5fq85wn8dwlk665w15n2bj37fma5rsfxrph3i9yb0lvzi3q",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Mostly just to update `tree-sitter-nix` so it's compatible with the latest tree-sitter. All packages still build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
