### PR TITLE
python3Packages.pymavlink: 2.4.14 -> 2.4.15

### DIFF
--- a/pkgs/development/python-modules/pymavlink/default.nix
+++ b/pkgs/development/python-modules/pymavlink/default.nix
@@ -14,6 +14,8 @@ buildPythonPackage rec {
   # No tests included in PyPI tarball
   doCheck = false;
 
+  pythonImportsCheck = [ "pymavlink" ];
+
   meta = with lib; {
     description = "Python MAVLink interface and utilities";
     homepage = "https://github.com/ArduPilot/pymavlink";

--- a/pkgs/development/python-modules/pymavlink/default.nix
+++ b/pkgs/development/python-modules/pymavlink/default.nix
@@ -11,7 +11,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ future lxml ];
 
-  # No tests included in PyPI tarball
+  # No tests included in PyPI tarball. We cannot use the GitHub tarball because
+  # we would like to use the same commit of the mavlink messages repo as
+  # included in the PyPI tarball, and there is no easy way to determine what
+  # commit is included.
   doCheck = false;
 
   pythonImportsCheck = [ "pymavlink" ];

--- a/pkgs/development/python-modules/pymavlink/default.nix
+++ b/pkgs/development/python-modules/pymavlink/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python MAVLink interface and utilities";
     homepage = "https://github.com/ArduPilot/pymavlink";
-    license = licenses.lgpl3;
+    license = with licenses; [ lgpl3Only mit ];
     maintainers = with maintainers; [ lopsided98 ];
   };
 }

--- a/pkgs/development/python-modules/pymavlink/default.nix
+++ b/pkgs/development/python-modules/pymavlink/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pymavlink";
-  version = "2.4.14";
+  version = "2.4.15";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3bc3709c735ebb3f98f19e96c8887868f4671077d4808076cfc5445912633881";
+    sha256 = "106va20k0ahy0l2qvxf8k5pvqkgdmxbgzd9kij9fkrahlba5mx3v";
   };
 
   propagatedBuildInputs = [ future lxml ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates pymavlink to the latest version. Tested `MAVExplorer.py` from `mavproxy`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
