### PR TITLE
nixFlakes: enable flakes

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -227,13 +227,8 @@ in rec {
     inherit storeDir stateDir confDir boehmgc;
   });
 
-  nixFlakes = callPackage ({ makeWrapper, runCommand, ... }:
-    runCommand "nix-flakes" { buildInputs = [ makeWrapper ]; } ''
-      mkdir -p $out/bin
-        for bin in ${nixUnstable}/bin/*; do
-          makeWrapper $bin $out/bin/$(basename $bin) \
-            --suffix NIX_CONFIG "\n" "experimental-features = nix-command flakes"
-        done;
-    '') {};
+  nixFlakes = nixUnstable.overrideAttrs (prev: {
+    patches = (prev.patches or []) ++ [ ./enable-flakes.patch ];
+  });
 
 }

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -227,6 +227,10 @@ in rec {
     inherit storeDir stateDir confDir boehmgc;
   });
 
+  nixExperimental = nixUnstable.overrideAttrs (prev: {
+    patches = (prev.patches or []) ++ [ ./enable-all-experimental.patch ];
+  });
+
   nixFlakes = nixUnstable.overrideAttrs (prev: {
     patches = (prev.patches or []) ++ [ ./enable-flakes.patch ];
   });

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -227,6 +227,13 @@ in rec {
     inherit storeDir stateDir confDir boehmgc;
   });
 
-  nixFlakes = nixUnstable;
+  nixFlakes = callPackage ({ makeWrapper, runCommand, ... }:
+    runCommand "nix-flakes" { buildInputs = [ makeWrapper ]; } ''
+      mkdir -p $out/bin
+        for bin in ${nixUnstable}/bin/*; do
+          makeWrapper $bin $out/bin/$(basename $bin) \
+            --suffix NIX_CONFIG "\n" "experimental-features = nix-command flakes"
+        done;
+    '') {};
 
 }

--- a/pkgs/tools/package-management/nix/enable-all-experimental.patch
+++ b/pkgs/tools/package-management/nix/enable-all-experimental.patch
@@ -1,0 +1,14 @@
+diff --git a/src/libstore/globals.cc b/src/libstore/globals.cc
+index d3b27d7be..e7d002e1d 100644
+--- a/src/libstore/globals.cc
++++ b/src/libstore/globals.cc
+@@ -172,8 +172,7 @@ MissingExperimentalFeature::MissingExperimentalFeature(std::string feature)
+ 
+ void Settings::requireExperimentalFeature(const std::string & name)
+ {
+-    if (!isExperimentalFeatureEnabled(name))
+-        throw MissingExperimentalFeature(name);
++    return;
+ }
+ 
+ bool Settings::isWSL1()

--- a/pkgs/tools/package-management/nix/enable-flakes.patch
+++ b/pkgs/tools/package-management/nix/enable-flakes.patch
@@ -1,0 +1,14 @@
+diff --git a/src/libstore/globals.hh b/src/libstore/globals.hh
+index 3e4ead76c..81d407236 100644
+--- a/src/libstore/globals.hh
++++ b/src/libstore/globals.hh
+@@ -923,7 +923,8 @@ public:
+           value.
+           )"};
+ 
+-    Setting<Strings> experimentalFeatures{this, {}, "experimental-features",
++    Setting<Strings> experimentalFeatures{
++        this, {"flakes", "nix-command"}, "experimental-features",
+         "Experimental Nix features to enable."};
+ 
+     bool isExperimentalFeatureEnabled(const std::string & name);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30099,7 +30099,8 @@ in
     nix
     nixStable
     nixUnstable
-    nixFlakes;
+    nixFlakes
+    nixExperimental;
 
   nixStatic = pkgsStatic.nix;
 


### PR DESCRIPTION
###### Motivation for this change
I assume everyone who installs `nixFlakes` wants to use the flakes feature.
It is an unnecessary complication to have to edit the nix.conf or set config options via environment variables.
This makes it harder to instruct other people on how to install nix with flakes.
It also makes it harder to ship nix + flakes in a shell environment.

If someone really wants to have an unstable nix without flakes enabled, they can still refer to `nixUnstable`.

###### Things done
wrap nixFlakes to set `NIX_CONFIG="experimental-features = nix-command flakes"`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
