### PR TITLE
[20.09] vault: 1.6.3 -> 1.6.4

### DIFF
--- a/nixos/tests/vault.nix
+++ b/nixos/tests/vault.nix
@@ -8,6 +8,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     environment.systemPackages = [ pkgs.vault ];
     environment.variables.VAULT_ADDR = "http://127.0.0.1:8200";
     services.vault.enable = true;
+    virtualisation.memorySize = 512;
   };
 
   testScript =

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "vault";
-  version = "1.6.3";
+  version = "1.6.4";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "0ffynqk16bnc4nqnffbid4v72mxafzi0fy4cbrzfs9qfi56vcbm9";
+    sha256 = "1vpwjn900l55cbljvscp8nb81d23ff6hlbd7h3bbsni6zvh05avg";
   };
 
   goPackagePath = "github.com/hashicorp/vault";

--- a/pkgs/tools/security/vault/vault-bin.nix
+++ b/pkgs/tools/security/vault/vault-bin.nix
@@ -1,26 +1,26 @@
 { stdenv, fetchurl, unzip }:
 
 let
-  version = "1.6.3";
+  version = "1.6.4";
 
   sources = let
     base = "https://releases.hashicorp.com/vault/${version}";
   in {
     x86_64-linux = fetchurl {
       url = "${base}/vault_${version}_linux_amd64.zip";
-      sha256 = "0ijc80r9rbbbblmf5s3j5b2kk6zsriyxwhsijhgy86rr6bvdljl4";
+      sha256 = "0zywsnhip22lxsqz56xkvbprbhdd9ffmxd21m23j27q02i37kf7c";
     };
     i686-linux = fetchurl {
       url = "${base}/vault_${version}_linux_386.zip";
-      sha256 = "1blma0ywkmv8ykqc4sgcbk1g9jb9rjxqk2b6kmp5z31lilg4a7my";
+      sha256 = "1dxzaxgp1hdrhsqk02cvlh1np4qxznr94rmdr8np8f0r92hy5n20";
     };
     x86_64-darwin = fetchurl {
       url = "${base}/vault_${version}_darwin_amd64.zip";
-      sha256 = "1mzkj7ixpzfhn9i4092qw8g38dx4lh3kzp6g4fr5x84sbs6anl3j";
+      sha256 = "13wjrv3xb55ap0yn0pkayryfbm5a49q46hb15ywz1l8f1qdqmns0";
     };
     aarch64-linux = fetchurl {
       url = "${base}/vault_${version}_linux_arm64.zip";
-      sha256 = "14l8ic5hgsbq4q1b6832ss1wyrgqwyvgkrvcxbw5nqy5la95fl8i";
+      sha256 = "079lwfgv60in5p5l5s4r942jbszlcbfv2y2yn5jsgfj7v0wh0hfr";
     };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-27668 and CVE-2021-27400.

Changelog:
https://github.com/hashicorp/vault/blob/b41bb14cf6d6d2e0c6acc89c32deada52f744cd2/CHANGELOG.md#164

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
