### PR TITLE
python3Packages.gcsfs: init at 2021.04.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6977,6 +6977,12 @@
     githubId = 818502;
     name = "Nathan Yong";
   };
+  nbren12 = {
+    email = "nbren12@gmail.com";
+    github = "nbren12";
+    githubId = 1386642;
+    name = "Noah Brenowitz";
+  };
   nckx = {
     email = "github@tobias.gr";
     github = "nckx";

--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -5,34 +5,36 @@
 , pytestCheckHook
 , numpy
 , stdenv
+, aiohttp
+, pytest-vcr
+, requests
 }:
 
 buildPythonPackage rec {
   pname = "fsspec";
-  version = "0.8.3";
+  version = "2021.04.0";
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "intake";
     repo = "filesystem_spec";
     rev = version;
-    sha256 = "0mfy0wxjfwwnp5q2afhhfbampf0fk71wsv512pi9yvrkzzfi1hga";
+    sha256 = "sha256-9072kb1VEQ0xg9hB8yEzJMD2Ttd3UGjBmTuhE+Uya1k=";
   };
 
-  checkInputs = [
-    pytestCheckHook
-    numpy
-  ];
+  checkInputs = [ pytestCheckHook numpy pytest-vcr ];
+
+  __darwinAllowLocalNetworking = true;
+
+  propagatedBuildInputs = [ aiohttp requests ];
 
   disabledTests = [
     # Test assumes user name is part of $HOME
     # AssertionError: assert 'nixbld' in '/homeless-shelter/foo/bar'
     "test_strip_protocol_expanduser"
-    # flaky: works locally but fails on hydra
-    # as it uses the install dir for tests instead of a temp dir
-    # resolved in https://github.com/intake/filesystem_spec/issues/432 and
-    # can be enabled again from version 0.8.4
-    "test_pathobject"
+    # test accesses this remote ftp server:
+    # https://ftp.fau.de/debian-cd/current/amd64/log/success
+    "test_find"
   ] ++ lib.optionals (stdenv.isDarwin) [
     # works locally on APFS, fails on hydra with AssertionError comparing timestamps
     # darwin hydra builder uses HFS+ and has only one second timestamp resolution

--- a/pkgs/development/python-modules/gcsfs/default.nix
+++ b/pkgs/development/python-modules/gcsfs/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage, fetchFromGitHub, lib, pytestCheckHook, google-auth
+, google-auth-oauthlib, requests, decorator, fsspec, ujson, aiohttp, crcmod
+, pytest-vcr, vcrpy }:
+
+buildPythonPackage rec {
+  pname = "gcsfs";
+  version = "2021.04.0";
+
+  # github sources needed for test data
+  src = fetchFromGitHub {
+    owner = "dask";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-OA43DaQue7R5d6SzfKThEQFEwJndjLfznu1LMubs5fs=";
+  };
+
+  propagatedBuildInputs = [
+    google-auth
+    google-auth-oauthlib
+    requests
+    decorator
+    fsspec
+    aiohttp
+    ujson
+    crcmod
+  ];
+
+  checkInputs = [ pytestCheckHook pytest-vcr vcrpy ];
+  pythonImportsCheck = [ "gcsfs" ];
+
+  meta = with lib; {
+    description = "Convenient Filesystem interface over GCS";
+    homepage = "https://github.com/dask/gcsfs";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.nbren12 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2660,6 +2660,8 @@ in {
 
   gcovr = callPackage ../development/python-modules/gcovr { };
 
+  gcsfs = callPackage ../development/python-modules/gcsfs { };
+
   gdal = toPythonModule (pkgs.gdal.override { pythonPackages = self; });
 
   gdata = callPackage ../development/python-modules/gdata { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add gcsfs, a useful tool for working with Google Cloud Storage. gcsfs implements the interfaces described in fsspec, which is in nixpkgs. I needed to bump the versions fsspec to work with the latest release of gcsfs. These packages are developed in unison, so usually need very similar versions.

I sometimes contribute to this project and am in contact with its primary author.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
