### PR TITLE
maintainers: remove tavyc

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9687,12 +9687,6 @@
     githubId = 102685;
     name = "Thomas Friese";
   };
-  tavyc = {
-    email = "octavian.cerna@gmail.com";
-    github = "tavyc";
-    githubId = 3650609;
-    name = "Octavian Cerna";
-  };
   tazjin = {
     email = "mail@tazj.in";
     github = "tazjin";

--- a/nixos/modules/services/networking/quagga.nix
+++ b/nixos/modules/services/networking/quagga.nix
@@ -180,6 +180,6 @@ in
 
   };
 
-  meta.maintainers = with lib.maintainers; [ tavyc ];
+  meta.maintainers = with lib.maintainers; [ ];
 
 }

--- a/nixos/tests/quagga.nix
+++ b/nixos/tests/quagga.nix
@@ -24,7 +24,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
       name = "quagga";
 
       meta = with pkgs.lib.maintainers; {
-        maintainers = [ tavyc ];
+        maintainers = [ ];
       };
 
       nodes = {

--- a/pkgs/development/libraries/libraspberrypi/default.nix
+++ b/pkgs/development/libraries/libraspberrypi/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/raspberrypi/userland";
     license = licenses.bsd3;
     platforms = [ "armv6l-linux" "armv7l-linux" "aarch64-linux" "x86_64-linux" ];
-    maintainers = with maintainers; [ dezgeg tavyc tkerber ];
+    maintainers = with maintainers; [ dezgeg tkerber ];
   };
 }

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -25,6 +25,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Firmware for the Raspberry Pi board";
     homepage = "https://github.com/raspberrypi/firmware";
     license = licenses.unfreeRedistributableFirmware; # See https://github.com/raspberrypi/firmware/blob/master/boot/LICENCE.broadcom
-    maintainers = with maintainers; [ dezgeg tavyc ];
+    maintainers = with maintainers; [ dezgeg ];
   };
 }

--- a/pkgs/servers/quagga/default.nix
+++ b/pkgs/servers/quagga/default.nix
@@ -68,6 +68,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.nongnu.org/quagga/";
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ tavyc ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
Their last commit was dcc84d8 from 2017.
Thank you for your contributions.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/120088#issuecomment-824215370 and for properly showing unmaintained packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
