### PR TITLE
chromiumDev: 91.0.4472.10 -> 91.0.4472.19

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -163,11 +163,6 @@ let
       ./patches/fix-missing-atspi2-dependency.patch
     ++ optionals (chromiumVersionAtLeast "91") [
       ./patches/closure_compiler-Use-the-Java-binary-from-the-system.patch
-      (githubPatch
-        # Revert "Reland #7 of "Force Python 3 to be used in build.""
-        "38b6a9a8e5901766613879b6976f207aa163588a"
-        "1lvxbd7rl6hz5j6kh6q83yb6vd9g7anlqbai8g1w1bp6wdpgwvp9"
-      )
     ];
 
     postPatch = lib.optionalString (chromiumVersionAtLeast "91") ''

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "91.0.4472.10",
-    "sha256": "168121aznynks5waj3mm2m036mbrlmqmp2kmnn9r4ibq2x01dpxm",
-    "sha256bin64": "05bk6gmmfsh50jjlb6lmwqhhbs0v0hlijsmxpk9crdx2gw071rlr",
+    "version": "91.0.4472.19",
+    "sha256": "0p51cxz0dm9ss9k7b91c0nd560mgi2x4qdcpg12vdf8x24agai5x",
+    "sha256bin64": "1x1901f5782c6aj6sbj8i4hhj545vjl4pplf35i4bjbcaxq3ckli",
     "deps": {
       "gn": {
         "version": "2021-04-06",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
