### PR TITLE
terraform-provider-rancher2: 1.8.3 -> 1.13.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -823,11 +823,13 @@
     "version": "1.5.0"
   },
   "rancher2": {
-    "owner": "terraform-providers",
+    "owner": "rancher",
+    "provider-source-address": "registry.terraform.io/hashicorp/rancher2",
     "repo": "terraform-provider-rancher2",
-    "rev": "v1.8.3",
-    "sha256": "1k2d9j17b7sssliraww6as196ihdcra1ylhg1qbynklpr0asiwna",
-    "version": "1.8.3"
+    "rev": "v1.13.0",
+    "sha256": "0xczv9qsviryiw95yd6cl1nnb0daxs971fm733gfvwm36jvmyr89",
+    "vendorSha256": "0apy6qbmshfj4pzz9nqdhyk6h7l9qwrccz30q8ljl928pj49q04c",
+    "version": "1.13.0"
   },
   "random": {
     "owner": "hashicorp",


### PR DESCRIPTION
###### Motivation for this change

Also update the repository to be sourced from Rancher's org on GitHub,
as the old repo under `terraform-providers/` has been archived:

https://github.com/terraform-providers/terraform-provider-rancher2

The 'About' section mentions how the new location is under `rancher/`:

https://github.com/rancher/terraform-provider-rancher2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
