### PR TITLE
netbsd.ld_elf_so: fix build

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -633,7 +633,11 @@ let
     version = "8.0";
     sha256 = "1jmqpi0kg2daiqnvpwdyfy8rpnszxsm70sxizz0r7wn53xjr5hva";
     meta.platforms = lib.platforms.netbsd;
+    LIBC_PIC = "${stdenv.cc.libc}/lib/libc_pic.a";
+    # Hack to prevent a symlink being installed here for compatibility.
+    SHLINKINSTALLDIR = "/usr/libexec";
     USE_FORT = "yes";
+    makeFlags = [ "CLIBOBJ=${stdenv.cc.libc}/lib" ];
     extraPaths = [ libc.src ] ++ libc.extraPaths;
   };
 


### PR DESCRIPTION
Tested building pkgsCross.x86_64-netbsd.netbsd.ld_elf_so from
x86_64-linux.

This is one of those Nixpkgs NetBSD packages where I don't understand how it ever worked (maybe it just never did), because NetBSD has been installing a symlink in /usr/libexec since 2001.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
