### PR TITLE
[staging-next] python3Packages.httplib2: allow local networking on darwin

### DIFF
--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -1,5 +1,4 @@
-{ stdenv
-, lib
+{ lib
 , buildPythonPackage
 , fetchFromGitHub
 , isPy27
@@ -30,6 +29,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyparsing ];
 
+  pythonImportsCheck = [ "httplib2" ];
+
+  # Don't run tests for Python 2.7
+  doCheck = !isPy27;
+
   checkInputs = [
     mock
     pytest-forked
@@ -40,12 +44,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  # Don't run tests for Python 2.7 or Darwin
-  # Nearly 50% of the test suite requires local network access
-  # which isn't allowed on sandboxed Darwin builds
-  doCheck = !(isPy27 || stdenv.isDarwin);
   pytestFlagsArray = [ "--ignore python2" ];
-  pythonImportsCheck = [ "httplib2" ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "A comprehensive HTTP client library";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://hydra.nixos.org/build/141751890

This should hopefully fix the following testsuite error:

```
___________________________ test_timeout_subsequent ____________________________
tests/test_other.py:137: in test_timeout_subsequent
    assert response.status == 200
E   assert 408 == 200
E     +408
E     -200
        Handler    = <class 'tests.test_other.test_timeout_subsequent.<locals>.Handler'>
        _          = b'Request Timeout'
        http       = <httplib2.Http object at 0x10860f400>
        response   = {'content-type': 'text/plain', 'status': '408', 'content-length': 15}
        uri        = 'http://localhost:58287/'
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "/private/tmp/nix-build-python3.8-httplib2-0.19.1.drv-0/source/tests/__init__.py", line 311, in server_socket_thread
    fun(client, tick)
  File "/private/tmp/nix-build-python3.8-httplib2-0.19.1.drv-0/source/tests/__init__.py", line 392, in server_request_socket_handler
    request = HttpRequest.from_buffered(buf)
  File "/private/tmp/nix-build-python3.8-httplib2-0.19.1.drv-0/source/tests/__init__.py", line 177, in from_buffered
    return parse_http_message(cls, buf)
  File "/private/tmp/nix-build-python3.8-httplib2-0.19.1.drv-0/source/tests/__init__.py", line 120, in parse_http_message
    start_line = buf.readline()
  File "/private/tmp/nix-build-python3.8-httplib2-0.19.1.drv-0/source/tests/__init__.py", line 110, in readline
    self._fill(more=1)
  File "/private/tmp/nix-build-python3.8-httplib2-0.19.1.drv-0/source/tests/__init__.py", line 81, in _fill
    chunk = self._sock.recv(8 << 10)
ConnectionResetError: [Errno 54] Connection reset by peer
```

Needs to be build on x86-64-darwin.

#119398 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
