### PR TITLE
[staging-next] python3Packages.keyring: disable keychain tests on darwin

### DIFF
--- a/pkgs/development/python-modules/keyring/default.nix
+++ b/pkgs/development/python-modules/keyring/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, pythonOlder, fetchpatch
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
 , setuptools-scm
 , importlib-metadata
 , dbus-python
@@ -21,10 +25,6 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  checkInputs = [
-    pytestCheckHook
-  ];
-
   propagatedBuildInputs = [
     # this should be optional, however, it has a different API
     importlib-metadata # see https://github.com/jaraco/keyring/issues/503#issuecomment-798973205
@@ -34,7 +34,25 @@ buildPythonPackage rec {
     secretstorage
   ];
 
-  pythonImportsCheck = [ "keyring" "keyring.backend" ];
+  pythonImportsCheck = [
+    "keyring"
+    "keyring.backend"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # Keychain communications isn't possible in our build environment
+  # keyring.errors.KeyringError: Can't get password from keychain: (-25307, 'Unknown Error')
+  disabledTests = lib.optionals (stdenv.isDarwin) [
+    "test_multiprocess_get"
+    "test_multiprocess_get_after_native_get"
+  ];
+
+  disabledTestsPaths = [
+    "tests/backends/test_macOS.py"
+  ];
 
   meta = with lib; {
     description = "Store and access your passwords safely";


### PR DESCRIPTION
It is highly unlikely that we can communicate with keychain in our build
environment. The tests were only recently enabled and have blocked this
package ever since.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://nix-cache.s3.amazonaws.com/log/dj4appp2b8qq2vlakg6sgr218ky71ff4-python3.8-keyring-23.0.1.drv

Needs to be tested on x86_64-darwin

#119398 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
