### PR TITLE
python3Packages.whois: 0.9.7 -> 0.9.13

### DIFF
--- a/pkgs/development/python-modules/whois/default.nix
+++ b/pkgs/development/python-modules/whois/default.nix
@@ -1,19 +1,18 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
 , inetutils
 }:
 
 buildPythonPackage rec {
   pname = "whois";
-  version = "0.9.7";
+  version = "0.9.13";
 
   src = fetchFromGitHub {
     owner = "DannyCork";
     repo = "python-whois";
     rev = version;
-    sha256 = "1rbc4xif4dn455vc8dhxdvwszrb0nik5q9fy12db6mxfx6zikb7z";
+    sha256 = "0y2sfs6nkr2j2crrn81wkfdzn9aphb3iaddya5zd2midlgdqq7bw";
   };
 
   # whois is needed


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.9.13

Change log: https://github.com/DannyCork/python-whois/releases/tag/0.9.13

<s>The source was tagged wrong (https://github.com/DannyCork/python-whois/issues/159).</s>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
