### PR TITLE
ocamlPackages.camlimages_4_1: fix meta

### DIFF
--- a/pkgs/development/ocaml-modules/camlimages/4.1.2.nix
+++ b/pkgs/development/ocaml-modules/camlimages/4.1.2.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    branch = "4.0";
-    homepage = "https://bitbucket.org/camlspotter/camlimages";
+    branch = "4.1";
+    homepage = "https://gitlab.com/camlspotter/camlimages";
     description = "OCaml image processing library";
     license = licenses.lgpl2;
     maintainers = [ maintainers.vbgl ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I should have changed meta.branch in 70e33e3ae34 ("glsurf: use current giflib"),
but I overlooked it.

The bitbucket URL doesn't seem to exist any more, so I've updated the
homepage to the GitLab repository we fetch the sources from.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
