### PR TITLE
clj-kondo: 2021.02.13 -> 2021.03.31

### DIFF
--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -2,17 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "clj-kondo";
-  version = "2021.02.13";
+  version = "2021.03.31";
 
   reflectionJson = fetchurl {
     name = "reflection.json";
-    url = "https://raw.githubusercontent.com/borkdude/${pname}/v${version}/reflection.json";
-    sha256 = "ea5c18586fd8803b138a4dd197a0019d5e5a2c76ebe4925b9b54a10125a68c57";
+    url = "https://raw.githubusercontent.com/clj-kondo/${pname}/v${version}/reflection.json";
+    sha256 = "sha256-C4QYk5lLienCHKnWXXZPcKmsCTMtIIkXOkvCrZfyIhA=";
   };
 
   src = fetchurl {
-    url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
-    sha256 = "sha256-Rq7W5sP9nRB0TGRUSQIyC3U568uExmcM/gd+1HjAqac=";
+    url = "https://github.com/clj-kondo/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
+    sha256 = "sha256-XSs0u758wEuaqZvFIevBrL61YNPUJ9Sc1DS+O9agj94=";
   };
 
   dontUnpack = true;
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A linter for Clojure code that sparks joy";
-    homepage = "https://github.com/borkdude/clj-kondo";
+    homepage = "https://github.com/clj-kondo/clj-kondo";
     license = licenses.epl10;
     platforms = graalvm11-ce.meta.platforms;
     maintainers = with maintainers; [ jlesquembre bandresen ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Multiple changes: https://github.com/clj-kondo/clj-kondo/releases/tag/v2021.03.31

Also new upstream: https://github.com/clj-kondo/clj-kondo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
