### PR TITLE
myxer: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/applications/audio/myxer/default.nix
+++ b/pkgs/applications/audio/myxer/default.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "myxer";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "Aurailus";
     repo = pname;
     rev = version;
-    sha256 = "10m5qkys96n4v6qiffdiy0w660yq7b5sa70ww2zskc8d0gbmxp6x";
+    sha256 = "0bnhpzmx4yyasv0j7bp31q6jm20p0qwcia5bzmpkz1jhnc27ngix";
   };
 
-  cargoSha256 = "0nsscdjl5fh24sg87vdmijjmlihc0zk0p3vac701v60xlz55qipn";
+  cargoSha256 = "1cyh0nk627sgyr78rcnhj7af5jcahvjkiv5sz7xwqfdhvx5kqsk5";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Myxer updated to 1.2.1, additionally a build issue existed with 1.2.0 which should now be fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
