### PR TITLE
libreoffice: kill private dbus instance on exit

### DIFF
--- a/pkgs/applications/office/libreoffice/wrapper.sh
+++ b/pkgs/applications/office/libreoffice/wrapper.sh
@@ -2,7 +2,7 @@
 export JAVA_HOME="${JAVA_HOME:-@jdk@}"
 #export SAL_USE_VCLPLUGIN="${SAL_USE_VCLPLUGIN:-gen}"
 
-if uname | grep Linux > /dev/null && 
+if uname | grep Linux > /dev/null &&
        ! ( test -n "$DBUS_SESSION_BUS_ADDRESS" ); then
     dbus_tmp_dir="/run/user/$(id -u)/libreoffice-dbus"
     if ! test -d "$dbus_tmp_dir" && test -d "/run"; then
@@ -14,6 +14,7 @@ if uname | grep Linux > /dev/null &&
     fi
     dbus_socket_dir="$(mktemp -d -p "$dbus_tmp_dir")"
     "@dbus@"/bin/dbus-daemon --nopidfile --nofork --config-file "@dbus@"/share/dbus-1/session.conf --address "unix:path=$dbus_socket_dir/session"  &> /dev/null &
+    dbus_pid=$!
     export DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_socket_dir/session"
 fi
 
@@ -27,5 +28,5 @@ done
 "@libreoffice@/bin/$(basename "$0")" "$@"
 code="$?"
 
-test -n "$dbus_socket_dir" && rm -rf "$dbus_socket_dir"
+test -n "$dbus_socket_dir" && { rm -rf "$dbus_socket_dir"; kill $dbus_pid; }
 exit "$code"


### PR DESCRIPTION
###### Motivation for this change

libreoffice can start private dbus daemons, but doesn't clean them up on exit

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
