### PR TITLE
fix clangd wrapper

### DIFF
--- a/pkgs/development/tools/clang-tools/default.nix
+++ b/pkgs/development/tools/clang-tools/default.nix
@@ -1,22 +1,22 @@
 { lib, stdenv, llvmPackages }:
 
 let
-  clang = llvmPackages.clang-unwrapped;
+  unwrapped = llvmPackages.clang-unwrapped;
 
 in stdenv.mkDerivation {
   pname = "clang-tools";
-  version = lib.getVersion clang;
+  version = lib.getVersion unwrapped;
 
   dontUnpack = true;
+
+  clang = llvmPackages.clang;
+  inherit unwrapped;
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
-    export libc_includes="${lib.getDev stdenv.cc.libc}/include"
-    export libcpp_includes="${llvmPackages.libcxx}/include/c++/v1"
 
-    export clang=${clang}
     substituteAll ${./wrapper} $out/bin/clangd
     chmod +x $out/bin/clangd
     for tool in \
@@ -32,7 +32,7 @@ in stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = clang.meta // {
+  meta = unwrapped.meta // {
     description = "Standalone command line tools for C++ development";
     maintainers = with lib.maintainers; [ aherrmann ];
   };

--- a/pkgs/development/tools/clang-tools/wrapper
+++ b/pkgs/development/tools/clang-tools/wrapper
@@ -1,20 +1,27 @@
 #!/bin/sh
 
 buildcpath() {
-  local path
+  local path after
   while (( $# )); do
     case $1 in
         -isystem)
             shift
             path=$path${path:+':'}$1
+            ;;
+        -idirafter)
+            shift
+            after=$after${after:+':'}$1
+            ;;
     esac
     shift
   done
-  echo $path
+  echo $path${after:+':'}$after
 }
 
-export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE})
-export CPATH=${CPATH}${CPATH:+':'}@libc_includes@
-export CPLUS_INCLUDE_PATH=${CPATH}${CPATH:+':'}@libcpp_includes@
+export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                               $(<@clang@/nix-support/libc-cflags))
+export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                                                                      $(<@clang@/nix-support/libcxx-cxxflags) \
+                                                                                      $(<@clang@/nix-support/libc-cflags))
 
-exec -a "$0" @clang@/bin/$(basename $0) "$@"
+exec -a "$0" @unwrapped@/bin/$(basename $0) "$@"


### PR DESCRIPTION
* get libc-cflags and libcxx-cxxflags from the canonical locations &
  the correct compiler.

* fix the order of those for C++ (libc-cflags are -idirafter for a
  reason).

* make it easier to build custom clangd wrappers for different stdenvs
  by way of overriding the "cc" attribute (not tested).

###### Motivation for this change

clangd wasn't wrapped completely properly

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [v ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [v ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [v ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
