### PR TITLE
pythonPackages.dask-glm: add missing build dependency

### DIFF
--- a/pkgs/development/python-modules/dask-glm/default.nix
+++ b/pkgs/development/python-modules/dask-glm/default.nix
@@ -8,6 +8,7 @@
 , scipy
 , scikitlearn
 , pytest
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
@@ -20,6 +21,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest ];
+  nativeBuildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ cloudpickle dask numpy toolz multipledispatch scipy scikitlearn ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/dask-ml/default.nix
+++ b/pkgs/development/python-modules/dask-ml/default.nix
@@ -13,6 +13,7 @@
 , multipledispatch
 , packaging
 , distributed
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
@@ -38,6 +39,7 @@ buildPythonPackage rec {
     scipy
     six
     toolz
+    setuptools-scm
   ];
 
   # has non-standard build from source, and pypi doesn't include tests


### PR DESCRIPTION
setuptools-scm is a setup requirement of this package.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The hydra build was failing: https://hydra.nixos.org/build/141094247

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
