### PR TITLE
python3Packages.zwave-js-server-python: init at 0.23.1

### DIFF
--- a/pkgs/development/python-modules/zwave-js-server-python/default.nix
+++ b/pkgs/development/python-modules/zwave-js-server-python/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-aiohttp
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "zwave-js-server-python";
+  version = "0.23.1";
+  disabled = pythonOlder "3.8";
+
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = pname;
+    rev = version;
+    sha256 = "0kmmhn357k22ana0ysd8jlz1fyfaqlc8k74ryaik0rrw7nmn1n11";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  checkInputs = [
+    pytest-aiohttp
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "zwave_js_server" ];
+
+  meta = with lib; {
+    description = "Python wrapper for zwave-js-server";
+    homepage = "https://github.com/home-assistant-libs/zwave-js-server-python";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -984,6 +984,6 @@
     "zone" = ps: with ps; [ ];
     "zoneminder" = ps: with ps; [ zm-py ];
     "zwave" = ps: with ps; [ aiohttp-cors homeassistant-pyozw paho-mqtt pydispatcher python-openzwave-mqtt ];
-    "zwave_js" = ps: with ps; [ aiohttp-cors ]; # missing inputs: zwave-js-server-python
+    "zwave_js" = ps: with ps; [ aiohttp-cors zwave-js-server-python ];
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -381,6 +381,7 @@ in with py.pkgs; buildPythonApplication rec {
     "zha"
     "zone"
     "zwave"
+    "zwave_js"
   ];
 
   pytestFlagsArray = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9380,5 +9380,7 @@ in {
 
   zulip = callPackage ../development/python-modules/zulip { };
 
+  zwave-js-server-python = callPackage ../development/python-modules/zwave-js-server-python { };
+
   zxcvbn = callPackage ../development/python-modules/zxcvbn { };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python wrapper for zwave-js-server

https://github.com/home-assistant-libs/zwave-js-server-python

This is a Home Assistant dependency.

This is not the latest release. We can update to 0.24.0 with the update of Home Assistant to 2021.5.x.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
