### PR TITLE
rgp: 1.9 -> 1.10

### DIFF
--- a/pkgs/development/tools/rgp/default.nix
+++ b/pkgs/development/tools/rgp/default.nix
@@ -19,15 +19,15 @@
 }:
 
 let
-  buildNum = "2020-11-19-376";
+  buildNum = "2021-03-31-696";
 in
 stdenv.mkDerivation rec {
   pname = "rgp";
-  version = "1.9";
+  version = "1.10";
 
   src = fetchurl {
     url = "https://gpuopen.com/download/radeon-developer-tool-suite/RadeonDeveloperToolSuite-${buildNum}.tgz";
-    sha256 = "f71ibuMerd0SmXKSDjaTj7xtyy1dWzkZ5s0PlGtQ1+k=";
+    sha256 = "1GUV75KpYbeq7KkE86QqTfGnf/t3VEgviaAsbg/LWJI=";
   };
 
   nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
@@ -58,6 +58,9 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/opt/rgp $out/bin
     cp -r . $out/opt/rgp/
+
+    chmod +x $out/opt/rgp/scripts/*
+    patchShebangs $out/opt/rgp/scripts
 
     for prog in RadeonDeveloperPanel RadeonDeveloperService RadeonDeveloperServiceCLI RadeonGPUAnalyzer RadeonGPUProfiler rga rtda; do
       # makeWrapper is needed so that executables are started from the opt


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
RGP 1.10 was released: https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/tag/v1.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
