### PR TITLE
mpvScripts: update convert script patch to work with current mpv

### DIFF
--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -12,15 +12,17 @@ stdenvNoCC.mkDerivation {
 
   patches = [ ./convert.patch ];
 
-  postPatch =
-    let
-      t = k: v: '' 'local ${k} = "${v}"' '';
-      subs = var: orig: repl: "--replace " + t var orig + t var repl;
-    in ''
-      substituteInPlace convert_script.lua \
-        ${subs "NOTIFY_CMD" "notify-send" "${libnotify}/bin/notify-send"} \
-        ${subs "YAD_CMD" "yad" "${yad}/bin/yad"} \
-        ${subs "MKVMERGE_CMD" "mkvmerge" "${mkvtoolnix-cli}/bin/mkvmerge"}
+  postPatch = ''
+    substituteInPlace convert_script.lua \
+      --replace 'mkvpropedit_exe = "mkvpropedit"' \
+                'mkvpropedit_exe = "${mkvtoolnix-cli}/bin/mkvpropedit"' \
+      --replace 'mkvmerge_exe = "mkvmerge"' \
+                'mkvmerge_exe = "${mkvtoolnix-cli}/bin/mkvmerge"' \
+      --replace 'yad_exe = "yad"' \
+                'yad_exe = "${yad}/bin/yad"' \
+      --replace 'notify_send_exe = "notify-send"' \
+                'notify_send_exe = "${libnotify}/bin/notify-send"' \
+
   '';
 
   dontBuild = true;
@@ -38,9 +40,7 @@ stdenvNoCC.mkDerivation {
       When this script is loaded into mpv, you can hit Alt+W to mark the beginning
       and Alt+W again to mark the end of the clip. Then a settings window opens.
     '';
+    # author was asked to add a license https://gist.github.com/Zehkul/25ea7ae77b30af959be0#gistcomment-3715700
     license = licenses.unfree;
-    # script crashes mpv. See https://github.com/NixOS/nixpkgs/issues/113202
-    broken = true;
   };
 }
-

--- a/pkgs/applications/video/mpv/scripts/convert.patch
+++ b/pkgs/applications/video/mpv/scripts/convert.patch
@@ -1,17 +1,45 @@
---- convert/convert_script.lua	2016-03-18 19:30:49.675401969 +0100
-+++ convert_script.lua	2016-03-19 01:18:00.801897043 +0100
-@@ -3,6 +3,10 @@
+diff --git "a/Convert Script \342\200\223 README.md" "b/Convert Script \342\200\223 README.md"
+index 8e062c1..6e0d798 100644
+--- "a/Convert Script \342\200\223 README.md"	
++++ "b/Convert Script \342\200\223 README.md"	
+@@ -68,7 +68,7 @@ and set some options in ``mpv/lua-settings/convert_script.conf`` or with ``--scr
+     If you don’t want to upgrade your yad. Features like appending segments won’t be available. 
+ 
+     libvpx_fps
+-    Default: --oautofps
++    Default: ""
+     FPS settings (or any other settings really) for libvpx encoding. Set it to --ofps=24000/1001 for example. 
+ 
+-Warning: Some of these options aren’t very robust and setting them to bogus values will break the script. 
+\ No newline at end of file
++Warning: Some of these options aren’t very robust and setting them to bogus values will break the script. 
+diff --git a/convert_script.lua b/convert_script.lua
+index 17d3100..90f88ec 100644
+--- a/convert_script.lua
++++ b/convert_script.lua
+@@ -3,6 +3,12 @@ local msg = require 'mp.msg'
  local opt = require 'mp.options'
  local utils = require 'mp.utils'
  
-+local NOTIFY_CMD = "notify-send"
-+local YAD_CMD = "yad"
-+local MKVMERGE_CMD = "mkvmerge"
++-- executables
++local mkvpropedit_exe = "mkvpropedit"
++local mkvmerge_exe = "mkvmerge"
++local yad_exe = "yad"
++local notify_send_exe = "notify-send"
 +
  -- default options, convert_script.conf is read
  local options = {
      bitrate_multiplier = 0.975,			-- to make sure the file won’t go over the target file size, set it to 1 if you don’t care
-@@ -247,12 +247,12 @@
+@@ -14,7 +20,7 @@ local options = {
+     libvpx_options = "--ovcopts-add=cpu-used=0,auto-alt-ref=1,lag-in-frames=25,quality=good",
+     libvpx_vp9_options = "",
+     legacy_yad = false,				-- if you don’t want to upgrade to at least yad 0.18
+-    libvpx_fps = "--oautofps",			-- --ofps=24000/1001 for example
++    libvpx_fps = "",			-- --ofps=24000/1001 for example
+     audio_bitrate = 112,			-- mpv default, in kbps
+ }
+ 
+@@ -247,12 +253,12 @@ function encode(enc)
      if string.len(vf) > 0 then
          vf = vf .. ","
      end
@@ -26,42 +54,49 @@
      local audio_file = ""
      for index, param in pairs(audio_file_table) do
          audio_file = audio_file .. " --audio-file='" .. string.gsub(tostring(param), "'", "'\\''") .. "'"
-@@ -354,9 +358,9 @@
+@@ -354,9 +360,9 @@ function encode(enc)
      if ovc == "gif" then
          full_command = full_command .. ' --vf-add=lavfi=graph=\\"framestep=' .. framestep .. '\\" && convert ' 
          .. tmpfolder .. '/*.png -set delay ' .. delay .. ' -loop 0 -fuzz ' .. fuzz .. '% ' .. dither .. ' -layers optimize '
 -        .. full_output_path .. ' && rm -rf ' .. tmpfolder .. ' && notify-send "Gif done") & disown'
-+        .. full_output_path .. ' && rm -rf ' .. tmpfolder .. ' && ' .. NOTIFY_CMD .. ' "Gif done") & disown'
++        .. full_output_path .. ' && rm -rf ' .. tmpfolder .. ' && ' .. notify_send_exe .. ' "Gif done") & disown'
      else
 -        full_command = full_command .. ' && notify-send "Encoding done"; mkvpropedit '
-+        full_command = full_command .. ' && ' .. NOTIFY_CMD .. ' "Encoding done"; mkvpropedit '
++        full_command = full_command .. ' && ' .. notify_send_exe .. ' "Encoding done"; ' .. mkvpropedit_exe .. ' '
          .. full_output_path .. ' -s title="' .. metadata_title .. '") & disown'
      end
      
-@@ -409,7 +413,7 @@
+@@ -409,7 +415,7 @@ function encode_copy(enc)
      sep = ",+"
      
      if enc then
 -        local command = "mkvmerge '" .. video .. "' " .. mkvmerge_parts .. " -o " .. full_output_path
-+        local command = MKVMERGE_CMD .. " '" .. video .. "' " .. mkvmerge_parts .. " -o " .. full_output_path
++        local command = mkvmerge_exe .. " '" .. video .. "' " .. mkvmerge_parts .. " -o " .. full_output_path
          msg.info(command)
          os.execute(command)
          clear()
-@@ -508,7 +512,7 @@
+@@ -508,7 +514,7 @@ function call_gui ()
      end
      
      
 -    local yad_command = [[LC_NUMERIC=C yad --title="Convert Script" --center --form --fixed --always-print-result \
-+    local yad_command = [[LC_NUMERIC=C ]] .. YAD_CMD .. [[ --title="Convert Script" --center --form --fixed --always-print-result \
++    local yad_command = [[LC_NUMERIC=C ]] .. yad_exe .. [[ --title="Convert Script" --center --form --fixed --always-print-result \
      --name "convert script" --class "Convert Script" --field="Resize to height:NUM" "]] .. scale_sav		--yad_table 1
      .. [[" --field="Resize to width instead:CHK" ]] .. resize_to_width_instead .. " "				--yad_table 2
      if options.legacy_yad then
-@@ -543,7 +547,7 @@
-     yad_command = yad_command .. [[ --button="Crop:1" --button="gtk-cancel:2" --button="gtk-ok:0"; ret=$? && echo $ret]]
-     
-     if gif_dialog then
--        yad_command = [[echo $(LC_NUMERIC=C yad --title="Gif settings" --name "convert script" --class "Convert Script" \
-+        yad_command = [[echo $(LC_NUMERIC=C ]] .. YAD_CMD .. [[ --title="Gif settings" --name "convert script" --class "Convert Script" \
-         --center --form --always-print-result --separator="…" \
-         --field="Fuzz Factor:NUM" '1!0..100!0.5!1' \
-         --field="Framestep:NUM" '3!1..3!1' \
+@@ -524,7 +530,7 @@ function call_gui ()
+         yad_command = yad_command
+         .. [[--field="2pass:CHK" "false" ]]									--yad_table 5
+         .. [[--field="Encode options::CBE" '! --ovcopts=b=2000,cpu-used=0,auto-alt-ref=1,lag-in-frames=25,quality=good,threads=4' ]]	--yad_table 6
+-        .. [[--field="Output format::CBE" ' --ovc=libx264! --oautofps --of=webm --ovc=libvpx' ]]		
++        .. [[--field="Output format::CBE" ' --ovc=libx264! --of=webm --ovc=libvpx' ]]
+         .. [[--field="Simple:FBTN" 'bash -c "echo \"simple\" && kill -s SIGUSR1 \"$YAD_PID\""' ]]
+         advanced = true
+     else
+@@ -734,4 +740,4 @@ mp.set_key_bindings({
+ 
+ mp.add_key_binding("alt+w", "convert_script", convert_script_hotkey_call)
+ 
+-mp.register_event("tick", tick)
+\ No newline at end of file
++mp.register_event("tick", tick)


### PR DESCRIPTION
mpv has finally made some options an error that they removed in 0.30,
a few versions ago.

Plus, refactors the tool overrides a bit.

Fixes https://github.com/NixOS/nixpkgs/issues/113202

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
