### PR TITLE
python3Packages.pydroid-ipcam: init at unstable-2021-04-16

### DIFF
--- a/pkgs/development/python-modules/pydroid-ipcam/default.nix
+++ b/pkgs/development/python-modules/pydroid-ipcam/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "pydroid-ipcam";
+  version = "unstable-2021-04-16";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = pname;
+    rev = "9f22682c6f9182aa5e42762f52223337b8b6909c";
+    sha256 = "1lvppyzmwg0fp8zch11j51an4sb074yl9shzanakvjmbqpnif6s6";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    yarl
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pydroid_ipcam" ];
+
+  meta = with lib; {
+    description = "Python library for Android IP Webcam";
+    homepage = "https://github.com/home-assistant-libs/pydroid-ipcam";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -32,7 +32,7 @@
     "amcrest" = ps: with ps; [ amcrest ha-ffmpeg ];
     "ampio" = ps: with ps; [ ]; # missing inputs: asmog
     "analytics" = ps: with ps; [ aiohttp-cors ];
-    "android_ip_webcam" = ps: with ps; [ ]; # missing inputs: pydroid-ipcam
+    "android_ip_webcam" = ps: with ps; [ pydroid-ipcam ];
     "androidtv" = ps: with ps; [ adb-shell androidtv pure-python-adb ];
     "anel_pwrctrl" = ps: with ps; [ ]; # missing inputs: anel_pwrctrl-homeassistant
     "anthemav" = ps: with ps; [ ]; # missing inputs: anthemav

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5785,6 +5785,8 @@ in {
 
   pydrive = callPackage ../development/python-modules/pydrive { };
 
+  pydroid-ipcam = callPackage ../development/python-modules/pydroid-ipcam  { };
+
   pydsdl = callPackage ../development/python-modules/pydsdl { };
 
   pydub = callPackage ../development/python-modules/pydub { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for Android IP Webcam

https://github.com/home-assistant-libs/pydroid-ipcam

<s>This is a Home Assistant dependency. Not sure, why `parse-requirements.py` is not able to pick it up. Could be the same issue as with `slackclient`. Fixed with https://github.com/NixOS/nixpkgs/pull/120281 </s>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
