### PR TITLE
python3Packages.hdate: init 0.10.2

### DIFF
--- a/pkgs/development/python-modules/hdate/default.nix
+++ b/pkgs/development/python-modules/hdate/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, astral
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "hdate";
+  version = "0.10.2";
+  disabled = pythonOlder "3.6";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "py-libhdate";
+    repo = "py-libhdate";
+    rev = "v${version}";
+    sha256 = "07b0c7q8w6flj4q72v58d3wymsxfp5qz8z97qhhc2977mjx5fsxd";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    astral
+    pytz
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Version was not updated for the release
+    (fetchpatch {
+      name = "update-version.patch";
+      url = "https://github.com/py-libhdate/py-libhdate/commit/b8186a891b29fed99def5ce0985ee0ae1e0dd77e.patch";
+      sha256 = "1pmhgh57x9390ff5gyisng0l6b79sd6dxmf172hpk1gr03c3hv98";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace "^2020.5" ">=2020.5"
+  '';
+
+  pytestFlagsArray = [
+    "tests"
+  ];
+
+  pythonImportsCheck = [ "hdate" ];
+
+  meta = with lib; {
+    description = "Python module for Jewish/Hebrew date and Zmanim";
+    homepage = "https://github.com/py-libhdate/py-libhdate";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -413,7 +413,7 @@
     "itach" = ps: with ps; [ ]; # missing inputs: pyitachip2ir
     "itunes" = ps: with ps; [ ];
     "izone" = ps: with ps; [ ]; # missing inputs: python-izone
-    "jewish_calendar" = ps: with ps; [ ]; # missing inputs: hdate
+    "jewish_calendar" = ps: with ps; [ hdate ];
     "joaoapps_join" = ps: with ps; [ ]; # missing inputs: python-join-api
     "juicenet" = ps: with ps; [ ]; # missing inputs: python-juicenet
     "kaiterra" = ps: with ps; [ ]; # missing inputs: kaiterra-async-client

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -272,6 +272,7 @@ in with py.pkgs; buildPythonApplication rec {
     "intent"
     "intent_script"
     "ipp"
+    "jewish_calendar"
     "kmtronic"
     "knx"
     "kodi"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2985,6 +2985,8 @@ in {
 
   hachoir = callPackage ../development/python-modules/hachoir { };
 
+  hdate = callPackage ../development/python-modules/hdate { };
+
   ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };
 
   halo = callPackage ../development/python-modules/halo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for Jewish/Hebrew date and Zmanim

https://github.com/py-libhdate/py-libhdate

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
