### PR TITLE
python3Packages.connectedcars: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/connectedcars/default.nix
+++ b/pkgs/development/python-modules/connectedcars/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, aiohttp
+, attrs
+, python-dateutil
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "connectedcars";
+  version = "0.1.5";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "niklascp";
+    repo = "connectedcars-python";
+    rev = "v${version}";
+    sha256 = "062fzhg9qd7gzkzanzi2nq27kx7599abcjssxcx8caqzididz0h6";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    attrs
+    python-dateutil
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "connectedcars" ];
+
+  meta = with lib; {
+    description = "Python package for the ConnectedCars REST API";
+    homepage = "https://github.com/niklascp/connectedcars-python";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1294,6 +1294,8 @@ in {
 
   connect-box = callPackage ../development/python-modules/connect_box { };
 
+  connectedcars = callPackage ../development/python-modules/connectedcars { };
+
   cerberus = callPackage ../development/python-modules/cerberus { };
 
   cert-chain-resolver = callPackage ../development/python-modules/cert-chain-resolver { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python package for the ConnectedCars REST API

https://github.com/niklascp/connectedcars-python

This is a potential Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
