### PR TITLE
python3Packages.ondilo: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/ondilo/default.nix
+++ b/pkgs/development/python-modules/ondilo/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, oauthlib
+, pythonOlder
+, requests
+, requests_oauthlib
+}:
+
+buildPythonPackage rec {
+  pname = "ondilo";
+  version = "0.2.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "JeromeHXP";
+    repo = pname;
+    rev = version;
+    sha256 = "0k7c9nacf7pxvfik3hkv9vvvda2sx5jrf6zwq7r077x7fw5l8d2b";
+  };
+
+  propagatedBuildInputs = [
+    oauthlib
+    requests
+    requests_oauthlib
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "ondilo" ];
+
+  meta = with lib; {
+    description = "Python package to access Ondilo ICO APIs";
+    homepage = "https://github.com/JeromeHXP/ondilo";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -583,7 +583,7 @@
     "ombi" = ps: with ps; [ ]; # missing inputs: pyombi
     "omnilogic" = ps: with ps; [ omnilogic ];
     "onboarding" = ps: with ps; [ aiohttp-cors pillow ];
-    "ondilo_ico" = ps: with ps; [ aiohttp-cors ]; # missing inputs: ondilo
+    "ondilo_ico" = ps: with ps; [ aiohttp-cors ondilo ];
     "onewire" = ps: with ps; [ ]; # missing inputs: pi1wire pyownet
     "onkyo" = ps: with ps; [ onkyo-eiscp ];
     "onvif" = ps: with ps; [ ha-ffmpeg zeep ]; # missing inputs: WSDiscovery onvif-zeep-async

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -309,6 +309,7 @@ in with py.pkgs; buildPythonApplication rec {
     "notion"
     "number"
     "omnilogic"
+    "ondilo_ico"
     "ozw"
     "panel_custom"
     "panel_iframe"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4857,6 +4857,8 @@ in {
 
   omnilogic = callPackage ../development/python-modules/omnilogic { };
 
+  ondilo = callPackage ../development/python-modules/ondilo { };
+
   onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };
 
   onnx = callPackage ../development/python-modules/onnx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python package to access Ondilo ICO APIs

https://github.com/JeromeHXP/ondilo

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
