### PR TITLE
nixos/matrix-synapse: migrate to generators.toYAML and other cleanup

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -97,7 +97,7 @@ let
       getName getVersion
       nameFromURL enableFeature enableFeatureAs withFeature
       withFeatureAs fixedWidthString fixedWidthNumber isStorePath
-      toInt readPathsFromFile fileContents;
+      toFloat toInt readPathsFromFile fileContents;
     inherit (self.stringsWithDeps) textClosureList textClosureMap
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (self.customisation) overrideDerivation makeOverridable

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -15,6 +15,7 @@ rec {
     filter
     fromJSON
     head
+    isFloat
     isInt
     isList
     isString
@@ -673,6 +674,25 @@ rec {
       && dirOf str == storeDir
     else
       false;
+
+  /* Parse a string as a float.
+
+     Type: string -> float
+
+     Example:
+       toFloat "1.2"
+       => 1.2
+       toFloat "-4.2"
+       => -4
+       toFloat "1"
+       => error: Could not convert 1 to float.
+  */
+  # Obviously, it is a bit hacky to use fromJSON this way.
+  toFloat = str:
+    let mayBeFloat = fromJSON str; in
+    if isFloat mayBeFloat
+    then mayBeFloat
+    else throw "Could not convert ${str} to float.";
 
   /* Parse a string as an int.
 

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -49,7 +49,6 @@ let
     # Media Store
     inherit (cfg) max_upload_size max_image_pixels dynamic_thumbnails;
     media_store_path = "${cfg.dataDir}/media";
-    uploads_path = "${cfg.dataDir}/uploads"; # https://github.com/matrix-org/synapse/pull/9462
   } // optionalAttrs cfg.url_preview_enabled {
     url_preview_enabled = true;
     url_preview_ip_range_blacklist = cfg.url_preview_ip_range_blacklist;

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -64,7 +64,6 @@ let
 
     # Registration
     inherit (cfg) enable_registration registration_shared_secret bcrypt_rounds allow_guest_access;
-    inherit (cfg) user_creation_max_duration; # deprecated, but keeping for backwards compatibility
 
     account_threepid_delegates = filterAttrs (_: v: v != null) {
       inherit (cfg.account_threepid_delegates) email msisdn;
@@ -77,7 +76,6 @@ let
 
     # API Configuration
     inherit (cfg) macaroon_secret_key app_service_config_files room_prejoin_state;
-    inherit (cfg) expire_access_token; # deprecated by https://github.com/matrix-org/synapse/pull/5782
 
     # Signing Keys
     inherit (cfg) key_refresh_interval;
@@ -605,13 +603,6 @@ in
           Secret key for authentication tokens
         '';
       };
-      expire_access_token = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable access token expiration.
-        '';
-      };
       key_refresh_interval = mkOption {
         type = types.str;
         default = "1d";
@@ -784,6 +775,10 @@ in
     (mkRemovedOptionModule (optionPath "tls_dh_params_path") ''
       The `tls_dh_params_path` option was been removed in `matrix-synapse` v0.99.0
       since configuring and generating dh_params is no longer required.
+    '')
+    (mkRemovedOptionModule (optionPath "expire_access_token") ''
+      The `expire_access_token` option was been removed in `matrix-synapse` v1.3.0
+      since it was non-functional.
     '')
     (mkRemovedOptionModule (optionPath "trusted_third_party_id_servers") ''
       The `trusted_third_party_id_servers` option as been removed in `matrix-synapse` v1.4.0

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -26,7 +26,6 @@ let
 
     # TLS
     inherit (cfg) tls_certificate_path tls_private_key_path no_tls;
-    inherit (cfg) tls_dh_params_path; # deprecated, but keeping for backwards compatibility
 
     # Federation
 
@@ -191,14 +190,6 @@ in
         description = ''
           PEM encoded private key for TLS. Specify null if synapse is not
           speaking TLS directly.
-        '';
-      };
-      tls_dh_params_path = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "${cfg.dataDir}/homeserver.tls.dh";
-        description = ''
-          PEM dh parameters for ephemeral keys
         '';
       };
       server_name = mkOption {
@@ -789,6 +780,10 @@ in
     # Removed Options
     (mkRemovedOptionModule (optionPath "user_creation_max_duration") ''
       The `user_creation_max_duration` option has been removed.
+    '')
+    (mkRemovedOptionModule (optionPath "tls_dh_params_path") ''
+      The `tls_dh_params_path` option was been removed in `matrix-synapse` v0.99.0
+      since configuring and generating dh_params is no longer required.
     '')
     (mkRemovedOptionModule (optionPath "trusted_third_party_id_servers") ''
       The `trusted_third_party_id_servers` option as been removed in `matrix-synapse` v1.4.0

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -553,14 +553,6 @@ in
           from a precalculated list.
         '';
       };
-      user_creation_max_duration = mkOption {
-        type = types.str;
-        default = "1209600000";
-        description = ''
-          Sets the expiry for the short term user creation in
-          milliseconds. The default value is two weeks.
-        '';
-      };
       bcrypt_rounds = mkOption {
         type = with types; coercedTo string toInt int;
         default = 12;
@@ -796,6 +788,9 @@ in
       (optionPath [ "rc_federation" "concurrent" ]))
 
     # Removed Options
+    (mkRemovedOptionModule (optionPath "user_creation_max_duration") ''
+      The `user_creation_max_duration` option has been removed.
+    '')
     (mkRemovedOptionModule (optionPath "trusted_third_party_id_servers") ''
       The `trusted_third_party_id_servers` option as been removed in `matrix-synapse` v1.4.0
       as the behavior is now obsolete.

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -304,8 +304,8 @@ in
         '';
       };
       verbose = mkOption {
-        type = types.str;
-        default = "0";
+        type = with types; coercedTo string toInt int;
+        default = 0;
         description = "Logging verbosity level.";
       };
       rc_message = mkOption {
@@ -562,8 +562,8 @@ in
         '';
       };
       bcrypt_rounds = mkOption {
-        type = types.str;
-        default = "12";
+        type = with types; coercedTo string toInt int;
+        default = 12;
         description = ''
           Set the number of bcrypt rounds used to generate password hash.
           Larger numbers increase the work factor needed to generate the hash.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

##### Motivation for this change

* The current method of generating the synapse config involves manually creating the YAML. This PR converts it to use the `generators.toYAML` function which is more maintainable.
* This PR adds the ability to use a Nix attrset to add additional settings to Synapse.
* This PR adds a `toFloat` library function to assist in converting strings to floats (this is modeled after `toInt`).
* This PR changes moves the rate limiting configurations to submodules, and converts them to the correct types.
* This PR converts the `verbose` and `bcrypt_rounds` options to `int`s
* This PR removes the `user_creation_max_duration` option (not found in synapse codebase at all)
* This PR removes the `uploads_path` option (Removed here: matrix-org/synapse#9462)
* This PR removes the `tls_dh_params_path` option (matrix-org/synapse#4229)
* This PR removes the `expire_access_token` option (matrix-org/synapse#5782)

I am doing all of these deprecations at once to try and avoid `mkChangedOptionModule` chains.

##### Note to Reviewers

* I recommend going through each commit one-by-one.

##### Manual testing performed

###### Test 1

I tested using the following config:

<details>
<summary>Test 1 Nix config</summary>

```nix
services.matrix-synapse = {
  enable = true;
  enable_metrics = true;
  enable_registration = false;
  database_type = "sqlite3";
  server_name = "localhost";
  max_upload_size = "250M";
  listeners = [
    {
      port = 8008;
      bind_address = "::1";
      type = "http";
      tls = false;
      x_forwarded = true;
      resources = [
        {
          names = [ "client" "federation" ];
          compress = false;
        }
      ];
    }
  ];
};
```

</details>

* I ensured that Synapse runs without error.
* I inspected the systemd service config to ensure that everything looked right. This is the `ExecStart` line:
    ```
    ExecStart=/nix/store/8gbwdy0m7hda76mjycs7pifyry172kci-matrix-synapse-1.34.0/bin/homeserver \
      --config-path /nix/store/pihg9l7jgy2ii9hs8w4h8kn97n73xv60-homeserver.yaml --config-path /nix/store/47xi81pm06p6cpm211wl68cxac4zl0z8-extra-homeserver.yaml \
      --keys-directory /var/lib/matrix-synapse
    ```
* I looked at the generated homeserver.yaml file to ensure that everything looked correct. Here is the generated config (piped through `jq` for clarity):

<details>
<summary>Generated config (piped through `jq`)</summary>

```
{
  "account_threepid_delegates": {},
  "allow_guest_access": false,
  "app_service_config_files": [],
  "bcrypt_rounds": 12,
  "database": {
    "args": {
      "database": "/var/lib/matrix-synapse/homeserver.db"
    },
    "name": "sqlite3"
  },
  "dynamic_thumbnails": false,
  "enable_metrics": true,
  "enable_registration": false,
  "enable_registration_captcha": false,
  "event_cache_size": "10K",
  "key_refresh_interval": "1d",
  "listeners": [
    {
      "bind_address": "::1",
      "port": 8008,
      "resources": [
        {
          "compress": false,
          "names": [
            "client",
            "federation"
          ]
        }
      ],
      "tls": false,
      "type": "http",
      "x_forwarded": true
    }
  ],
  "log_config": "/nix/store/2x89r9ji20wy2sggd017jfhlmn9ygsj3-log_config.yaml",
  "max_image_pixels": "32M",
  "max_upload_size": "250M",
  "media_store_path": "/var/lib/matrix-synapse/media",
  "no_tls": false,
  "perspectives": {
    "servers": {
      "matrix.org": {
        "verify_keys": {
          "ed25519:auto": {
            "key": "Noi6WqcDj0QmPxCNQqgezwTlBKrfqehY1u2FyWP9uYw"
          }
        }
      }
    }
  },
  "pid_file": "/run/matrix-synapse.pid",
  "rc_federation": {
    "concurrent": 3,
    "reject_limit": 50,
    "sleep_delay": 500,
    "sleep_limit": 10,
    "window_size": 1000
  },
  "rc_message": {
    "burst_count": 10,
    "per_second": 0.2
  },
  "recaptcha_private_key": "",
  "recaptcha_public_key": "",
  "recaptcha_siteverify_api": "https://www.google.com/recaptcha/api/siteverify",
  "redaction_retention_period": 7,
  "report_stats": false,
  "room_prejoin_state": {
    "additional_event_types": [],
    "disable_default_event_types": false
  },
  "server_name": "localhost",
  "signing_key_path": "/var/lib/matrix-synapse/homeserver.signing.key",
  "turn_shared_secret": "",
  "turn_uris": [],
  "turn_user_lifetime": "1h",
  "verbose": 0
}
```

</details>

###### Test 2 (deprecated conversions)

I tested using the following config:

<details>
<summary>Test 2 Nix config</summary>

```nix
  services.matrix-synapse = {
    enable = true;
    enable_metrics = true;
    enable_registration = false;

    rc_messages_per_second = "1.2";
    rc_message_burst_count = "11.0";
    federation_rc_window_size = "1024";
    federation_rc_sleep_limit = "42";
    federation_rc_sleep_delay = "404";
    federation_rc_reject_limit = "80";
    federation_rc_concurrent = "4";

    database_type = "sqlite3";
    server_name = "localhost";
    max_upload_size = "250M";
    listeners = [
      {
        port = 8008;
        bind_address = "::1";
        type = "http";
        tls = false;
        x_forwarded = true;
        resources = [
          {
            names = [ "client" "federation" ];
            compress = false;
          }
        ];
      }
    ];
  };
```

</details>

* The following warnings were shown:
    ```
    trace: warning: The option `services.matrix-synapse.federation_rc_concurrent' defined in `/etc/nixos/host-configurations/coruscant.nix' has been changed to `services.matrix-synapse.rc_federation.concurrent' that has a different type. Please read `services.matrix-synapse.rc_federation.concurrent' documentation and update your configuration accordingly.
    trace: warning: The option `services.matrix-synapse.federation_rc_reject_limit' defined in `/etc/nixos/host-configurations/coruscant.nix' has been changed to `services.matrix-synapse.rc_federation.reject_limit' that has a different type. Please read `services.matrix-synapse.rc_federation.reject_limit' documentation and update your configuration accordingly.
    trace: warning: The option `services.matrix-synapse.federation_rc_sleep_delay' defined in `/etc/nixos/host-configurations/coruscant.nix' has been changed to `services.matrix-synapse.rc_federation.sleep_delay' that has a different type. Please read `services.matrix-synapse.rc_federation.sleep_delay' documentation and update your configuration accordingly.
    trace: warning: The option `services.matrix-synapse.federation_rc_sleep_limit' defined in `/etc/nixos/host-configurations/coruscant.nix' has been changed to `services.matrix-synapse.rc_federation.sleep_limit' that has a different type. Please read `services.matrix-synapse.rc_federation.sleep_limit' documentation and update your configuration accordingly.
    trace: warning: The option `services.matrix-synapse.federation_rc_window_size' defined in `/etc/nixos/host-configurations/coruscant.nix' has been changed to `services.matrix-synapse.rc_federation.window_size' that has a different type. Please read `services.matrix-synapse.rc_federation.window_size' documentation and update your configuration accordingly.
    trace: warning: The option `services.matrix-synapse.rc_message_burst_count' defined in `/etc/nixos/host-configurations/coruscant.nix' has been changed to `services.matrix-synapse.rc_message.burst_count' that has a different type. Please read `services.matrix-synapse.rc_message.burst_count' documentation and update your configuration accordingly.
    trace: warning: The option `services.matrix-synapse.rc_messages_per_second' defined in `/etc/nixos/host-configurations/coruscant.nix' has been changed to `services.matrix-synapse.rc_message.per_second' that has a different type. Please read `services.matrix-synapse.rc_message.per_second' documentation and update your configuration accordingly.
    ```

* I ensured that Synapse runs without error.
* I looked at the generated homeserver.yaml file to ensure that everything looked correct. Here is the generated config (piped through `jq` for clarity):

<details>
<summary>Generated config (piped through `jq`)</summary>

```
{
  "account_threepid_delegates": {},
  "allow_guest_access": false,
  "app_service_config_files": [],
  "bcrypt_rounds": 13,
  "database": {
    "args": {
      "database": "/var/lib/matrix-synapse/homeserver.db"
    },
    "name": "sqlite3"
  },
  "dynamic_thumbnails": false,
  "enable_metrics": true,
  "enable_registration": false,
  "enable_registration_captcha": false,
  "event_cache_size": "10K",
  "key_refresh_interval": "1d",
  "listeners": [
    {
      "bind_address": "::1",
      "port": 8008,
      "resources": [
        {
          "compress": false,
          "names": [
            "client",
            "federation"
          ]
        }
      ],
      "tls": false,
      "type": "http",
      "x_forwarded": true
    }
  ],
  "log_config": "/nix/store/2x89r9ji20wy2sggd017jfhlmn9ygsj3-log_config.yaml",
  "max_image_pixels": "32M",
  "max_upload_size": "250M",
  "media_store_path": "/var/lib/matrix-synapse/media",
  "no_tls": false,
  "perspectives": {
    "servers": {
      "matrix.org": {
        "verify_keys": {
          "ed25519:auto": {
            "key": "Noi6WqcDj0QmPxCNQqgezwTlBKrfqehY1u2FyWP9uYw"
          }
        }
      }
    }
  },
  "pid_file": "/run/matrix-synapse.pid",
  "rc_federation": {
    "concurrent": 4,
    "reject_limit": 80,
    "sleep_delay": 404,
    "sleep_limit": 42,
    "window_size": 1024
  },
  "rc_message": {
    "burst_count": 11,
    "per_second": 1.2
  },
  "recaptcha_private_key": "",
  "recaptcha_public_key": "",
  "recaptcha_siteverify_api": "https://www.google.com/recaptcha/api/siteverify",
  "redaction_retention_period": 7,
  "report_stats": false,
  "room_prejoin_state": {
    "additional_event_types": [],
    "disable_default_event_types": false
  },
  "server_name": "localhost",
  "signing_key_path": "/var/lib/matrix-synapse/homeserver.signing.key",
  "turn_shared_secret": "",
  "turn_uris": [],
  "turn_user_lifetime": "1h",
  "verbose": 10
}
```

</details>

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
