### PR TITLE
python3Packages.aiopvpc: init at 2.0.2

### DIFF
--- a/pkgs/development/python-modules/aiopvpc/default.nix
+++ b/pkgs/development/python-modules/aiopvpc/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, aiohttp
+, async-timeout
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, pytest-asyncio
+, pytest-timeout
+, pytestCheckHook
+, pythonOlder
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "aiopvpc";
+  version = "2.0.2";
+  disabled = pythonOlder "3.7";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "azogue";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ajs4kbdlfn4h7f3d6lwkp4yl1rl7zyvj997nhsz93jjwxbajkpv";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    pytz
+    async-timeout
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/azogue/aiopvpc/pull/10
+    (fetchpatch {
+      name = "use-peotry-core.patch";
+      url = "https://github.com/azogue/aiopvpc/commit/4bc2740ffd485a60acf579b4f3eb5ee6a353245c.patch";
+      sha256 = "0ynj7pqq3akdvdrvqcwnnslay3mn1q92qhk8fg95ppflzscixli6";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pytest.ini --replace \
+      " --cov --cov-report term --cov-report html" ""
+  '';
+
+  pythonImportsCheck = [ "aiopvpc" ];
+
+  meta = with lib; {
+    description = "Python module to download Spanish electricity hourly prices (PVPC)";
+    homepage = "https://github.com/azogue/aiopvpc";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -653,7 +653,7 @@
     "pushover" = ps: with ps; [ pushover-complete ];
     "pushsafer" = ps: with ps; [ ];
     "pvoutput" = ps: with ps; [ jsonpath xmltodict ];
-    "pvpc_hourly_pricing" = ps: with ps; [ ]; # missing inputs: aiopvpc
+    "pvpc_hourly_pricing" = ps: with ps; [ aiopvpc ];
     "pyload" = ps: with ps; [ ];
     "python_script" = ps: with ps; [ restrictedpython ];
     "qbittorrent" = ps: with ps; [ ]; # missing inputs: python-qbittorrent

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -318,6 +318,7 @@ in with py.pkgs; buildPythonApplication rec {
     "prometheus"
     "proximity"
     "push"
+    "pvpc_hourly_pricing"
     "python_script"
     "random"
     "recorder"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -319,6 +319,8 @@ in {
 
   aiopulse = callPackage ../development/python-modules/aiopulse { };
 
+  aiopvpc = callPackage ../development/python-modules/aiopvpc { };
+
   aiopylgtv = callPackage ../development/python-modules/aiopylgtv { };
 
   aiorecollect = callPackage ../development/python-modules/aiorecollect { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to download Spanish electricity hourly prices (PVPC)

https://github.com/azogue/aiopvpc

This is a Home Assistant dependency
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
