### PR TITLE
python3Packages.pynx584: init at 0.6

### DIFF
--- a/pkgs/development/python-modules/pynx584/default.nix
+++ b/pkgs/development/python-modules/pynx584/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flask
+, mock
+, prettytable
+, pyserial
+, pytestCheckHook
+, pythonOlder
+, requests
+, stevedore
+}:
+
+buildPythonPackage rec {
+  pname = "pynx584";
+  version = "0.6";
+  disabled = pythonOlder "3.6";
+
+
+  src = fetchFromGitHub {
+    owner = "kk7ds";
+    repo = pname;
+    rev = version;
+    sha256 = "0if1jq8qiqp4w4zhf2xzzcb8y70hr5pxqzh96i008p6izjha89y6";
+  };
+
+  propagatedBuildInputs = [
+    flask
+    prettytable
+    pyserial
+    requests
+    stevedore
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "nx584" ];
+
+  meta = with lib; {
+    description = "Python package for communicating to NX584/NX8E interfaces";
+    homepage = "https://github.com/kk7ds/pynx584";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -573,7 +573,7 @@
     "number" = ps: with ps; [ ];
     "nut" = ps: with ps; [ ]; # missing inputs: pynut2
     "nws" = ps: with ps; [ pynws ];
-    "nx584" = ps: with ps; [ ]; # missing inputs: pynx584
+    "nx584" = ps: with ps; [ pynx584 ];
     "nzbget" = ps: with ps; [ ]; # missing inputs: pynzbgetapi
     "oasa_telematics" = ps: with ps; [ ]; # missing inputs: oasatelematics
     "obihai" = ps: with ps; [ ]; # missing inputs: pyobihai

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -308,6 +308,7 @@ in with py.pkgs; buildPythonApplication rec {
     "notify"
     "notion"
     "number"
+    "nx584"
     "omnilogic"
     "ozw"
     "panel_custom"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5263,6 +5263,8 @@ in {
 
   pynws = callPackage ../development/python-modules/pynws { };
 
+  pynx584 = callPackage ../development/python-modules/pynx584 { };
+
   pysbd = callPackage ../development/python-modules/pysbd { };
 
   pyshark = callPackage ../development/python-modules/pyshark { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python package for communicating to NX584/NX8E interfaces

https://github.com/kk7ds/pynx584

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
