### PR TITLE
ckb-next: 0.4.2 -> 0.4.4

### DIFF
--- a/pkgs/tools/misc/ckb-next/default.nix
+++ b/pkgs/tools/misc/ckb-next/default.nix
@@ -1,21 +1,25 @@
 { lib, mkDerivation, fetchFromGitHub, substituteAll, udev
-, pkg-config, qtbase, cmake, zlib, kmod }:
+, pkg-config, qtbase, cmake, zlib, kmod, libXdmcp, qttools, qtx11extras, libdbusmenu }:
 
 mkDerivation rec {
-  version = "0.4.2";
+  version = "0.4.4";
   pname = "ckb-next";
 
   src = fetchFromGitHub {
     owner = "ckb-next";
     repo = "ckb-next";
     rev = "v${version}";
-    sha256 = "1mkx1psw5xnpscdfik1kpzsnfhhkn3571i7acr9gxyjr27sckplc";
+    sha256 = "1fgvh2hsrm8vqbqq9g45skhyyrhhka4d8ngmyldkldak1fgmrvb7";
   };
 
   buildInputs = [
     udev
     qtbase
     zlib
+    libXdmcp
+    qttools
+    qtx11extras
+    libdbusmenu
   ];
 
   nativeBuildInputs = [

--- a/pkgs/tools/misc/ckb-next/install-dirs.patch
+++ b/pkgs/tools/misc/ckb-next/install-dirs.patch
@@ -1,12 +1,12 @@
 diff --git a/src/daemon/CMakeLists.txt b/src/daemon/CMakeLists.txt
-index 2fc10a8..22dbd14 100644
+index a04b80c..2969b3b 100644
 --- a/src/daemon/CMakeLists.txt
 +++ b/src/daemon/CMakeLists.txt
-@@ -421,7 +421,7 @@ if ("${CKB_NEXT_INIT_SYSTEM}" STREQUAL "launchd")
+@@ -437,7 +437,7 @@ if ("${CKB_NEXT_INIT_SYSTEM}" STREQUAL "launchd")
  elseif ("${CKB_NEXT_INIT_SYSTEM}" STREQUAL "systemd")
      install(
          FILES "${CMAKE_CURRENT_BINARY_DIR}/service/ckb-next-daemon.service"
--        DESTINATION "/usr/lib/systemd/system"
+-        DESTINATION "${SYSTEMD_UNIT_INSTALL_DIR}"
 +        DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/systemd/system"
          PERMISSIONS
          OWNER_READ OWNER_WRITE

--- a/pkgs/tools/misc/ckb-next/modprobe.patch
+++ b/pkgs/tools/misc/ckb-next/modprobe.patch
@@ -1,21 +1,21 @@
 diff --git a/src/daemon/input_linux.c b/src/daemon/input_linux.c
-index 8489f5b..b851419 100644
+index 933e628..c4f97f2 100644
 --- a/src/daemon/input_linux.c
 +++ b/src/daemon/input_linux.c
-@@ -63,7 +63,7 @@ int os_inputopen(usbdevice* kb){
+@@ -70,7 +70,7 @@ int os_inputopen(usbdevice* kb){
  
      // If not available, load the module
      if(fd < 0){
 -        if(system("modprobe uinput") != 0) {
 +        if(system("@kmod@/bin/modprobe uinput") != 0) {
-             ckb_fatal("Failed to load uinput module\n");
+             ckb_fatal("Failed to load uinput module");
              return 1;
          }
 diff --git a/src/gui/mainwindow.cpp b/src/gui/mainwindow.cpp
-index 1eb95bd..f7d38ba 100644
+index eeadaf8..87de71f 100644
 --- a/src/gui/mainwindow.cpp
 +++ b/src/gui/mainwindow.cpp
-@@ -284,7 +284,7 @@ void MainWindow::updateVersion(){
+@@ -309,7 +309,7 @@ void MainWindow::updateVersion(){
  #elif defined(Q_OS_LINUX)
              if(!(QFileInfo("/dev/uinput").exists() || QFileInfo("/dev/input/uinput").exists())){
                  QProcess modprobe;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

My Corsair Strafe RGB was broken under Wayland under version 0.4.2 so I updated it to 0.4.4 which has fixes for Wayland compatibility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
