### PR TITLE
python3packages.pyotgw: unstable-2021-03-25

### DIFF
--- a/pkgs/development/python-modules/pyotgw/default.nix
+++ b/pkgs/development/python-modules/pyotgw/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial-asyncio
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyotgw";
+  version = "unstable-2021-03-25";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mvn23";
+    repo = pname;
+    rev = "1854ef4ffb907524ff457ba558e4979ba7fabd02";
+    sha256 = "0zckd85dmzpz0drcgx16ly6kzh1f1slcxb9lrcf81wh1p4q9bcaa";
+  };
+
+  propagatedBuildInputs = [
+    pyserial-asyncio
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests" ];
+
+  pythonImportsCheck = [ "pyotgw" ];
+
+  meta = with lib; {
+    description = "Python module to interact the OpenTherm Gateway";
+    homepage = "https://github.com/mvn23/pyotgw";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -598,7 +598,7 @@
     "openhome" = ps: with ps; [ openhomedevice ];
     "opensensemap" = ps: with ps; [ opensensemap-api ];
     "opensky" = ps: with ps; [ ];
-    "opentherm_gw" = ps: with ps; [ ]; # missing inputs: pyotgw
+    "opentherm_gw" = ps: with ps; [ pyotgw ];
     "openuv" = ps: with ps; [ pyopenuv ];
     "openweathermap" = ps: with ps; [ pyowm ];
     "opnsense" = ps: with ps; [ pyopnsense ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -335,6 +335,7 @@ in with py.pkgs; buildPythonApplication rec {
     "omnilogic"
     "ondilo_ico"
     "openerz"
+    "opentherm_gw"
     "ozw"
     "panel_custom"
     "panel_iframe"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5843,6 +5843,8 @@ in {
     inherit (pkgs) lz4;
   };
 
+  pyotgw = callPackage ../development/python-modules/pyotgw { };
+
   pyotp = callPackage ../development/python-modules/pyotp { };
 
   pyowm = callPackage ../development/python-modules/pyowm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to interact the OpenTherm Gateway

https://github.com/mvn23/pyotgw

This is a Home Assistant dependency. Not sure, why `parse-requirements.py` is not able to pick it up. Could be the same issue as with `slackclient`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
