### PR TITLE
python3Packages.async-upnp-client: 0.16.0 -> 0.16.1; python3Packages.clldutils: 3.7.0 -> 3.8.0; + deepmerge, sacn

### DIFF
--- a/pkgs/development/python-modules/async-upnp-client/default.nix
+++ b/pkgs/development/python-modules/async-upnp-client/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "async-upnp-client";
-  version = "0.16.0";
+  version = "0.16.2";
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "StevenLooman";
     repo = "async_upnp_client";
     rev = version;
-    sha256 = "sha256-vgy/zn1Xm7Fm7u/YMe/nJa3tyRNKx/WHz0AHfhFaVKo=";
+    sha256 = "0raq3jgh2aqllycvvi0x2j5f602vv8ggmyd3879jzqbz2znngsgb";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/clldutils/default.nix
+++ b/pkgs/development/python-modules/clldutils/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "clldutils";
-  version = "3.7.0";
+  version = "3.8.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "clld";
     repo = pname;
     rev = "v${version}";
-    sha256 = "13shas7krf7j04gqxjn09ipy318hmrp1s3b5d576d5r1xfxakam4";
+    sha256 = "18sjcqzprf96s7bkn5zm3lh83hxfxj56nycxyldrwz7ndgkgxxx2";
   };
 
   patchPhase = ''

--- a/pkgs/development/python-modules/deepmerge/default.nix
+++ b/pkgs/development/python-modules/deepmerge/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "deepmerge";
-  version = "0.2.1";
+  version = "0.3.0";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "082bvlk65pkf9qzkzzl8fq7s6zfz1b2v5pcb0ikwg1nx0xspggaz";
+    sha256 = "1zfl8rkw98vj7jdpb29ably50x46pq6pazhrkrczndf5jc97zzgn";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/sacn/default.nix
+++ b/pkgs/development/python-modules/sacn/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "sacn";
-  version = "1.6.2";
+  version = "1.6.4";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2fea82a1dd83b0a67dc0be68a53b1fef1c44b12f3f018e47ac736bd15b36c068";
+    sha256 = "1abkalzpy8bj2hpx563bxii5h0gv9v89f0yp9clc1l76amyf6dj2";
   };
 
   # no tests


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates to python packages i maintain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
