### PR TITLE
netbsd: Remove some env vars that are probably not needed.

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -63,8 +63,7 @@ in lib.makeScopeWithSplicing
     ];
     buildInputs = with self; compatIfNeeded;
 
-    OBJCOPY = if stdenv.isDarwin then "true" else "objcopy";
-    HOST_SH = "${buildPackages.bash}/bin/sh";
+    HOST_SH = stdenv'.shell;
 
     MACHINE_ARCH = {
       i686 = "i386";
@@ -78,13 +77,6 @@ in lib.makeScopeWithSplicing
     }.${stdenv'.hostPlatform.parsed.cpu.name}
       or stdenv'.hostPlatform.parsed.cpu.name;
 
-    AR = "${stdenv'.cc.targetPrefix or ""}ar";
-    CC = "${stdenv'.cc.targetPrefix or ""}cc";
-    CPP = "${stdenv'.cc.targetPrefix or ""}cpp";
-    CXX = "${stdenv'.cc.targetPrefix or ""}c++";
-    LD = "${stdenv'.cc.targetPrefix or ""}ld";
-    STRIP = "${stdenv'.cc.targetPrefix or ""}strip";
-
     BSD_PATH = attrs.path;
 
     strictDeps = true;
@@ -94,6 +86,9 @@ in lib.makeScopeWithSplicing
       platforms = platforms.unix;
       license = licenses.bsd2;
     };
+  } // lib.optionalAttrs stdenv'.hasCC {
+    # TODO should CC wrapper set this?
+    CPP = "${stdenv'.cc.targetPrefix}cpp";
   } // lib.optionalAttrs stdenv'.isDarwin {
     MKRELRO = "no";
   } // lib.optionalAttrs (stdenv'.cc.isClang or false) {

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -104,7 +104,7 @@ in rec {
                                       ++ depsHostHost ++ depsHostHostPropagated
                                       ++ buildInputs ++ propagatedBuildInputs
                                       ++ depsTargetTarget ++ depsTargetTargetPropagated) == 0;
-      dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || (stdenv.noCC or false);
+      dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenv.hasCC;
       supportedHardeningFlags = [ "fortify" "stackprotector" "pie" "pic" "strictoverflow" "format" "relro" "bindnow" ];
                               # Musl-based platforms will keep "pie", other platforms will not.
       defaultHardeningFlags = if stdenv.hostPlatform.isMusl &&

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30,7 +30,7 @@ in
   # just the plain stdenv.
   stdenv_32bit = lowPrio (if stdenv.hostPlatform.is32bit then stdenv else multiStdenv);
 
-  stdenvNoCC = stdenv.override { cc = null; extraAttrs.noCC = true; };
+  stdenvNoCC = stdenv.override { cc = null; hasCC = false; };
 
   mkStdenvNoLibs = stdenv: let
     bintools = stdenv.cc.bintools.override {


### PR DESCRIPTION
###### Motivation for this change

Tool setup hooks will set most.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
