### PR TITLE
systemd: fix lxd support with ubuntu patches

### DIFF
--- a/pkgs/os-specific/linux/systemd/UBUNTU-Revert-namespace-be-more-careful-when-handling-namespacin.patch
+++ b/pkgs/os-specific/linux/systemd/UBUNTU-Revert-namespace-be-more-careful-when-handling-namespacin.patch
@@ -1,0 +1,34 @@
+From: Balint Reczey <balint.reczey@canonical.com>
+Date: Thu, 12 Dec 2019 12:56:44 +0100
+Subject: Revert "namespace: be more careful when handling namespacing
+ failures gracefully"
+
+This partially reverts commit 1beab8b0d0ff2d7d1436b52d4a0c3d56dc908962.
+
+Until after the lowest LXD version running this packaged systemd contains
+https://github.com/lxc/lxd/commit/a6b780703350faff8328f3d565f6bac7b6dcf59f
+
+The first LXD version fixed is 3.10. Ubuntu 18.04 LTS has LXD 3.0.3 and is
+supported until 2028.
+---
+ src/core/execute.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/core/execute.c b/src/core/execute.c
+index 0ec1bd6..823db9c 100644
+--- a/src/core/execute.c
++++ b/src/core/execute.c
+@@ -3234,6 +3234,13 @@ static int apply_mount_namespace(
+ 
+ finalize:
+         bind_mount_free_many(bind_mounts, n_bind_mounts);
++
++        /* If we couldn't set up the namespace this is probably due to a
++         * missing capability. In this case, silently proceeed. */
++        if (IN_SET(r, -EPERM, -EACCES)) {
++                log_unit_debug_errno(u, r, "Failed to set up namespace, assuming containerized execution, ignoring: %m");
++                return 0;
++        }
+         return r;
+ }
+ 

--- a/pkgs/os-specific/linux/systemd/UBUNTU-units-block-CAP_SYS_MODULE-units-in-containers-too.patch
+++ b/pkgs/os-specific/linux/systemd/UBUNTU-units-block-CAP_SYS_MODULE-units-in-containers-too.patch
@@ -1,0 +1,38 @@
+From: Dimitri John Ledkov <xnox@ubuntu.com>
+Date: Thu, 26 Jul 2018 14:22:25 +0100
+Subject: units: block CAP_SYS_MODULE units in containers too
+
+lxd/lxc usually keep the usernamespace capabilities, whilst in practice one
+does not have these in the initial namespace. Thus add additional condition
+!container, such that sys-kernel-config.mount and systemd-modules.load.service
+are not started in the lxd containers. This should make default lxd containers
+start non-degraded.
+---
+ units/sys-kernel-config.mount         | 1 +
+ units/systemd-modules-load.service.in | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/units/sys-kernel-config.mount b/units/sys-kernel-config.mount
+index b99b4f4..c6dff31 100644
+--- a/units/sys-kernel-config.mount
++++ b/units/sys-kernel-config.mount
+@@ -14,6 +14,7 @@ Documentation=https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems
+ DefaultDependencies=no
+ ConditionPathExists=/sys/kernel/config
+ ConditionCapability=CAP_SYS_RAWIO
++ConditionVirtualization=!container
+ Before=sysinit.target
+ 
+ # These dependencies are used to make certain that the module is fully
+diff --git a/units/systemd-modules-load.service.in b/units/systemd-modules-load.service.in
+index fdb5b3a..920ae5e 100644
+--- a/units/systemd-modules-load.service.in
++++ b/units/systemd-modules-load.service.in
+@@ -14,6 +14,7 @@ DefaultDependencies=no
+ Conflicts=shutdown.target
+ Before=sysinit.target shutdown.target
+ ConditionCapability=CAP_SYS_MODULE
++ConditionVirtualization=!container
+ ConditionDirectoryNotEmpty=|/lib/modules-load.d
+ ConditionDirectoryNotEmpty=|/usr/lib/modules-load.d
+ ConditionDirectoryNotEmpty=|/usr/local/lib/modules-load.d

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -151,6 +151,9 @@ stdenv.mkDerivation {
     ./0017-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
     ./0018-logind-seat-debus-show-CanMultiSession-again.patch
     ./0019-pkg-config-derive-prefix-from-prefix.patch
+    # those are from the ubuntu devel version's systemd package sources
+    ./UBUNTU-Revert-namespace-be-more-careful-when-handling-namespacin.patch
+    ./UBUNTU-units-block-CAP_SYS_MODULE-units-in-containers-too.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Currently things are like this:

systemd: if /sys is writeable we can use namespaces
ubuntu: no, not on lxd.
so systemd fails to start things properly based on wrong assumptions.

currently there's no upstream patch for it, so ubuntu has one that makes it work. it makes sense to add it here so we're compatible with lxd.

So that's the patch and some others to fix startup errors in lxd

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
