### PR TITLE
python3Packages.notify-py: fix build on Darwin

### DIFF
--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -1,53 +1,40 @@
-{ lib, buildPythonPackage, fetchPypi, pythonAtLeast, pythonOlder
-, click
-, click-completion
-, factory_boy
-, faker
-, inquirer
-, notify-py
-, pbr
-, pendulum
-, ptable
-, pytest
-, pytestcov
-, pytest-mock
-, requests
-, twine
-, validate-email
-}:
-
+{ lib, buildPythonPackage, fetchPypi, pythonAtLeast, pythonOlder, click
+, click-completion, factory_boy, faker, inquirer, notify-py, pbr, pendulum
+, ptable, pytestCheckHook, pytestcov, pytest-mock, requests, twine
+, validate-email }:
 
 buildPythonPackage rec {
   pname = "toggl-cli";
-  version = "2.4.1";
+  version = "2.4.2";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     pname = "togglCli";
     inherit version;
-    sha256 = "19lry8adcznzmzbvghyid3yl4j05db6931bw38af5vrkkyzyf62i";
+    sha256 = "1wgh231r16jyvaj1ch1pajvl9szflb4srs505pfdwdlqvz7rzww8";
   };
 
   postPatch = ''
-   substituteInPlace requirements.txt \
-     --replace "inquirer==2.6.3" "inquirer>=2.6.3" \
-     --replace "notify-py==0.2.2" "notify-py>=0.2.2"
+    substituteInPlace requirements.txt \
+      --replace "notify-py==0.3.1" "notify-py>=0.3.1"
   '';
 
   nativeBuildInputs = [ pbr twine ];
-  checkInputs = [ pbr pytest pytestcov pytest-mock faker factory_boy ];
+  checkInputs = [ pbr pytestCheckHook pytestcov pytest-mock faker factory_boy ];
 
   preCheck = ''
     export TOGGL_API_TOKEN=your_api_token
     export TOGGL_PASSWORD=toggl_password
     export TOGGL_USERNAME=user@example.com
-    '';
-
-  checkPhase = ''
-   runHook preCheck
-   pytest -k "not premium and not TestDateTimeType and not TestDateTimeField" tests/unit --maxfail=20
-   runHook postCheck
   '';
+
+  disabledTests = [
+    "integration"
+    "premium"
+    "test_parsing"
+    "test_type_check"
+    "test_now"
+  ];
 
   propagatedBuildInputs = [
     click


### PR DESCRIPTION
###### Motivation for this change

Upgrades package and fixes https://github.com/NixOS/nixpkgs/issues/119863.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).