### PR TITLE
beekeeper-studio: init at 1.10.2

### DIFF
--- a/pkgs/development/tools/database/beekeeper-studio/default.nix
+++ b/pkgs/development/tools/database/beekeeper-studio/default.nix
@@ -1,0 +1,92 @@
+{ lib, stdenv, makeWrapper, fetchurl, dpkg, alsaLib, atk, cairo, cups, dbus, expat
+, fontconfig, freetype, gdk-pixbuf, glib, gnome2, pango, nspr, nss, gtk3, gtk2
+, at-spi2-atk, gsettings-desktop-schemas, gobject-introspection, wrapGAppsHook
+, libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
+, libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, nghttp2
+, libudev0-shim, glibc, curl, openssl, autoPatchelfHook }:
+
+let
+  runtimeLibs = lib.makeLibraryPath [
+    curl
+    glibc
+    libudev0-shim
+    nghttp2
+    openssl
+    stdenv.cc.cc
+  ];
+in stdenv.mkDerivation rec {
+  pname = "beekeeper-studio";
+  version = "1.10.2";
+
+  src = fetchurl {
+    url =
+      "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v${version}/beekeeper-studio_${version}_amd64.deb";
+    sha256 = "5ada21ded5afd15a9fde1d02a0fe150bd4bba4b3d5cb0cbc533fe4ea1049c720";
+  };
+
+  nativeBuildInputs =
+    [ autoPatchelfHook dpkg makeWrapper gobject-introspection wrapGAppsHook ];
+
+  buildInputs = [
+    alsaLib
+    at-spi2-atk
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gnome2.GConf
+    pango
+    gtk2
+    gtk3
+    gsettings-desktop-schemas
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libxcb
+    nspr
+    nss
+    stdenv.cc.cc
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    mkdir -p $out/share/beekeeper-studio $out/lib $out/bin
+
+    mv usr/share/* $out/share/
+    mv opt/Beekeeper\ Studio/* $out/share/beekeeper-studio/
+    mv $out/share/beekeeper-studio/*.so $out/lib/
+
+    ln -s $out/share/beekeeper-studio/beekeeper-studio-bin $out/bin/beekeeper-studio
+    sed -i 's|\/opt\/Beekeeper Studio|'$out'/bin|g' $out/share/applications/beekeeper-studio.desktop
+  '';
+
+  preFixup = ''
+    wrapProgram "$out/bin/beekeeper-studio" --prefix LD_LIBRARY_PATH : ${runtimeLibs}
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.beekeeperstudio.io/";
+    description = "Open Source SQL Editor and Database Manager";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ Mdsp9070 ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13837,6 +13837,8 @@ in
 
   beecrypt = callPackage ../development/libraries/beecrypt { };
 
+  beekeeper-studio = callPackage ../development/tools/database/beekeeper-studio { };
+
   belcard = callPackage ../development/libraries/belcard { };
 
   belr = callPackage ../development/libraries/belr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the open source SQL editor and database manager `beekeeper-studio`! It's agnostic of
which database you use so you can connect to `MySQL`, `MariaDB`, `PostgreSQL` and many others
in a cool GUI app.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
