### PR TITLE
postgresqlPackages.pgvector: init at 0.1.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pgvector.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvector.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "pgvector";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ankane";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "03i8rq9wp9j2zdba82q31lzbrqpnhrqc8867pxxy3z505fxsvfzb";
+  };
+
+  buildInputs = [ postgresql ];
+
+  installPhase = ''
+    install -D -t $out/lib vector.so
+    install -D -t $out/share/postgresql/extension vector-*.sql
+    install -D -t $out/share/postgresql/extension vector.control
+  '';
+
+  meta = with lib; {
+    description = "Open-source vector similarity search for PostgreSQL";
+    homepage = "https://github.com/ankane/pgvector";
+    license = licenses.postgresql;
+    platforms = postgresql.meta.platforms;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -25,6 +25,8 @@ self: super: {
 
     pgroonga = super.callPackage ./ext/pgroonga.nix { };
 
+    pgvector = super.callPackage ./ext/pgvector.nix { };
+
     plpgsql_check = super.callPackage ./ext/plpgsql_check.nix { };
 
     plr = super.callPackage ./ext/plr.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add https://github.com/ankane/pgvector

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
