### PR TITLE
elixir_ls: fix_build

### DIFF
--- a/pkgs/development/beam-modules/elixir_ls.nix
+++ b/pkgs/development/beam-modules/elixir_ls.nix
@@ -9,7 +9,7 @@ mixRelease rec {
   src = fetchFromGitHub {
     owner = "elixir-lsp";
     repo = "elixir-ls";
-    rev = "v{version}";
+    rev = "v${version}";
     sha256 = "0d0hqc35hfjkpm88vz21mnm2a9rxiqfrdi83whhhh6d2ba216b7s";
     fetchSubmodules = true;
   };


### PR DESCRIPTION
###### Motivation for this change

elixir_ls build is broken.

I have to say I'm a little puzzled, this is a syntax fix, I don't know how this could have slipped through the cracks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
