### PR TITLE
pythonImportsCheckPhase: run {pre,post}PythonImportsCheck

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
@@ -5,8 +5,10 @@ pythonImportsCheckPhase () {
     echo "Executing pythonImportsCheckPhase"
 
     if [ -n "$pythonImportsCheck" ]; then
+        runHook prePythonImportsCheck
         echo "Check whether the following modules can be imported: $pythonImportsCheck"
         ( cd $out && eval "@pythonCheckInterpreter@ -c 'import os; import importlib; list(map(lambda mod: importlib.import_module(mod), os.environ[\"pythonImportsCheck\"].split()))'" )
+        runHook postPythonImportsCheck
     fi
 }
 

--- a/pkgs/development/python-modules/scancode-toolkit/default.nix
+++ b/pkgs/development/python-modules/scancode-toolkit/default.nix
@@ -100,11 +100,12 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  # Importing scancode needs a writeable home, and preCheck happens in between
-  # pythonImportsCheckPhase and pytestCheckPhase.
-  postInstall = ''
+  # Importing scancode needs a writeable home
+  prePythonImportsCheck = ''
     export HOME=$(mktemp -d)
   '';
+
+  preCheck = prePythonImportsCheck;
 
   pythonImportsCheck = [
     "scancode"


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Some packages require e.g. setting environment variables in order for them to be importable.
See https://github.com/NixOS/nixpkgs/pull/120009#discussion_r617729298.

I'm sure thise will break stuff such as when `preCheck` uses `rm` without `-f` because it would try to remove files twice.
Hence `prePythonImportsCheck` might be preferred.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
