### PR TITLE
[staging-next] Revert "python2Packages.scandir: python 2 only"

### DIFF
--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -1,6 +1,4 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
+{ lib, buildPythonPackage, fetchPypi
 , django
 , memcached
 , txamqp
@@ -11,6 +9,7 @@
 , cairocffi
 , whisper
 , whitenoise
+, scandir
 , urllib3
 , six
 }:
@@ -39,6 +38,7 @@ buildPythonPackage rec {
     cairocffi
     whisper
     whitenoise
+    scandir
     urllib3
     six
   ];

--- a/pkgs/development/python-modules/pathlib2/default.nix
+++ b/pkgs/development/python-modules/pathlib2/default.nix
@@ -3,9 +3,9 @@
 , fetchPypi
 , six
 , pythonOlder
-, scandir ? null
+, scandir
 , glibcLocales
-, mock ? null
+, mock
 }:
 
 buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7113,6 +7113,8 @@ in {
 
   scales = callPackage ../development/python-modules/scales { };
 
+  scandir = callPackage ../development/python-modules/scandir { };
+
   scapy = callPackage ../development/python-modules/scapy { };
 
   schedule = callPackage ../development/python-modules/schedule { };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -516,8 +516,6 @@ with self; with super; {
 
   sandboxlib = callPackage ../development/python-modules/sandboxlib { };
 
-  scandir = callPackage ../development/python-modules/scandir { };
-
   scikitlearn = callPackage ../development/python-modules/scikitlearn/0.20.nix {
     inherit (pkgs) gfortran glibcLocales;
   };


### PR DESCRIPTION
This reverts commit 24896293e40cecb2f22cc4db0a13c41697745049.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I couldn't find a reason for why this was done, but scandir does run on Python 3, and my [PR for yarGen](https://github.com/NixOS/nixpkgs/pull/119998), a Python 3 tool, uses it.

This fixes evaluation on staging-next.

cc @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
