### PR TITLE
yarGen: patch get_abs_path function, install strings.xml

### DIFF
--- a/pkgs/tools/security/yarGen/default.nix
+++ b/pkgs/tools/security/yarGen/default.nix
@@ -22,6 +22,12 @@ python3.pkgs.buildPythonApplication rec {
       url = "https://github.com/Neo23x0/yarGen/commit/cae14ac8efeb5536885792cae99d1d0f7fb6fde3.patch";
       sha256 = "0z6925r7n1iysld5c8li5nkm1dbxg8j7pn0626a4vic525vf8ndl";
     })
+    # https://github.com/Neo23x0/yarGen/pull/34
+    (fetchpatch {
+      name = "use-cwd-for-abspath.patch";
+      url = "https://github.com/Neo23x0/yarGen/commit/441dafb702149f5728c2c6736fc08741a46deb26.patch";
+      sha256 = "lNp3oC2BM7tBzN4AetvPr+xJLz6KkZxQmsldeZaxJQU=";
+    })
   ];
 
   installPhase = ''

--- a/pkgs/tools/security/yarGen/default.nix
+++ b/pkgs/tools/security/yarGen/default.nix
@@ -30,10 +30,16 @@ python3.pkgs.buildPythonApplication rec {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace yarGen.py \
+      --replace "./3rdparty/strings.xml" "$out/share/yarGen/3rdparty/strings.xml"
+  '';
+
   installPhase = ''
     runHook preInstall
 
     install -Dt "$out/bin" yarGen.py
+    install -Dt "$out/share/yarGen/3rdparty" 3rdparty/strings.xml
 
     runHook postInstall
   '';


### PR DESCRIPTION
Otherwise, it would return a path inside the Nix store, which needs to be
writable for proper operation.<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
