### PR TITLE
nixos/home-assistant: change systemd network target

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -233,7 +233,7 @@ in {
 
     systemd.services.home-assistant = {
       description = "Home Assistant";
-      after = [ "network.target" ];
+      after = [ "network-online.target" ];
       preStart = optionalString (cfg.config != null) (if cfg.configWritable then ''
         cp --no-preserve=mode ${configFile} "${cfg.configDir}/configuration.yaml"
       '' else ''


### PR DESCRIPTION
###### Motivation for this change

Many Home Assistant integrations pull in information from websites at early stages and therefore need a fully set-up network when they start. If Home Assistant is starts directly after `network.target`, a connection to the internet might not be established, but it (probably) is after `network-online.target`. More info: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
