### PR TITLE
python3Packages.dask: fix sandboxed builds

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -1,6 +1,7 @@
 { lib
 , bokeh
 , buildPythonPackage
+, fetchpatch
 , fetchFromGitHub
 , fsspec
 , pytestCheckHook
@@ -42,7 +43,7 @@ buildPythonPackage rec {
     distributed
   ];
 
-  doCheck = false;
+  doCheck = true;
 
   checkInputs = [
     pytestCheckHook
@@ -51,6 +52,16 @@ buildPythonPackage rec {
   ];
 
   dontUseSetuptoolsCheck = true;
+
+  patches = [
+    # dask dataframe cannot be imported in sandboxed builds
+    # See https://github.com/dask/dask/pull/7601
+    (fetchpatch {
+      url = "https://github.com/dask/dask/commit/9ce5b0d258cecb3ef38fd844135ad1f7ac3cea5f.patch";
+      sha256 = "sha256-1EVRYwAdTSEEH9jp+UOnrijzezZN3iYR6q6ieYJM3kY=";
+      name = "fix-dask-dataframe-imports-in-sandbox.patch";
+    })
+  ];
 
   postPatch = ''
     # versioneer hack to set version of github package
@@ -66,7 +77,12 @@ buildPythonPackage rec {
   disabledTests = [
     "test_annotation_pack_unpack"
     "test_annotations_blockwise_unpack"
+    # this test requires features of python3Packages.psutil that are
+    # blocked in sandboxed-builds
+    "test_auto_blocksize_csv"
   ];
+
+  pythonImportsCheck = [ "dask.dataframe" "dask" "dask.array" ];
 
   meta = with lib; {
     description = "Minimal task scheduling abstraction";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Allow `dask.dataframe` to be used in sandboxed builds. See #120307.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
