### PR TITLE
Make it easy to try out content-addressed derivations

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -91,8 +91,7 @@ in rec {
 
     , __contentAddressed ?
       (! attrs ? outputHash) # Fixed-output drvs can't be content addressed too
-      && (config.contentAddressedByDefault or false
-          || builtins.getEnv "NIXPKGS_CA_BY_DEFAULT" == "1")
+      && (config.contentAddressedByDefault or false)
 
     , ... } @ attrs:
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -89,7 +89,10 @@ in rec {
 
     , patches ? []
 
-    , __contentAddressed ? false
+    , __contentAddressed ?
+      (! attrs ? outputHash) # Fixed-output drvs can't be content addressed too
+      && (config.contentAddressedByDefault or false
+          || builtins.getEnv "NIXPKGS_CA_BY_DEFAULT" == "1")
 
     , ... } @ attrs:
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -89,6 +89,8 @@ in rec {
 
     , patches ? []
 
+    , __contentAddressed ? false
+
     , ... } @ attrs:
 
     let
@@ -253,6 +255,12 @@ in rec {
           inherit doCheck doInstallCheck;
 
           inherit outputs;
+        } // lib.optionalAttrs (__contentAddressed) {
+          inherit __contentAddressed;
+          # Provide default values for outputHashMode and outputHashAlgo because
+          # most people won't care about these anyways
+          outputHashAlgo = attrs.outputHashAlgo or "sha256";
+          outputHashMode = attrs.outputHashMode or "recursive";
         } // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
           cmakeFlags =
             (/**/ if lib.isString cmakeFlags then [cmakeFlags]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Make it easier to try [content-addressed derivations](https://github.com/tweag/rfcs/blob/cas-rfc/rfcs/0062-content-addressed-paths.md) in nixpkgs:

1. Make it easy to mark an individual derivation as ca, by just setting `__contentAddressed = true`
2. Add a mechanism to make all the derivations content-addressed by default (*via* a config field or an environment variable)[^1]

Unless I messed something up, this shouldn't cause any rebuild by default.

[^1]: I don't know whether that's the best way to do it. It might be better to instead/in addition have a dedicated package set (like `pkgsStatic`). I defer to more competent people on that matter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
    Ensured that `nixpkgs-review` wasn't reporting any change
- [x] Ensured that relevant documentation is up to date
    I intentionally didn't document it as it's still experimental
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @edolstra @Ericson2314
