### PR TITLE
dupeguru: 4.0.4 -> 4.1.1

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -450,7 +450,9 @@ with pkgs;
 
   dispad = callPackage ../tools/X11/dispad { };
 
-  dupeguru = callPackage ../applications/misc/dupeguru { };
+  dupeguru = with python3Packages; callPackage ../applications/misc/dupeguru {
+    inherit (qt5) wrapQtAppsHook;
+  };
 
   dump1090 = callPackage ../applications/radio/dump1090 { };
 


### PR DESCRIPTION
###### Motivation for this change
#Closes https://github.com/NixOS/nixpkgs/issues/120205

###### Things done
I've tried to make the checks work, I've opened an issue here https://github.com/arsenetar/dupeguru/issues/875.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
