### PR TITLE
angrop: init at 9.0.6790

### DIFF
--- a/pkgs/development/python-modules/angrop/default.nix
+++ b/pkgs/development/python-modules/angrop/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, angr
+, buildPythonPackage
+, fetchFromGitHub
+, progressbar
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "angrop";
+  version = "9.0.6790";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "angr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "16r22ajkj8sxbgsym0i85xdjvphgf1566p5s7d915kkj37qdrrpy";
+  };
+
+  propagatedBuildInputs = [
+    angr
+    progressbar
+  ];
+
+  # Tests have additional requirements, e.g., angr binaries
+  # cle is executing the tests with the angr binaries already and is a requirement of angr
+  doCheck = false;
+  pythonImportsCheck = [ "angrop" ];
+
+  meta = with lib; {
+    description = "ROP gadget finder and chain builder";
+    homepage = "https://github.com/angr/angrop";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -395,6 +395,8 @@ in {
 
   angr = callPackage ../development/python-modules/angr { };
 
+  angrop = callPackage ../development/python-modules/angrop { };
+
   aniso8601 = callPackage ../development/python-modules/aniso8601 { };
 
   annexremote = callPackage ../development/python-modules/annexremote { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ROP gadget finder and chain builder

https://github.com/angr/angrop

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
