### PR TITLE
netbsd.libterminfo: fix build (again)

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -602,10 +602,10 @@ in lib.makeScopeWithSplicing
         --replace '#include <curses.h>' 'void use_env(bool);'
     '';
     postBuild = ''
-      make -C $BSDSRCDIR/share/terminfo BINDIR=$out/share
+      make -C $BSDSRCDIR/share/terminfo $makeFlags BINDIR=$out/share
     '';
     postInstall = ''
-      make -C $BSDSRCDIR/share/terminfo BINDIR=$out/share install
+      make -C $BSDSRCDIR/share/terminfo $makeFlags BINDIR=$out/share install
     '';
     extraPaths = with self; [
       (fetchNetBSD "share/terminfo" "8.0" "18db0fk1dw691vk6lsm6dksm4cf08g8kdm0gc4052ysdagg2m6sm")

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -591,6 +591,7 @@ in lib.makeScopeWithSplicing
     version = "8.0";
     sha256 = "14gp0d6fh6zjnbac2yjhyq5m6rca7gm6q1s9gilhzpdgl9m7vb9r";
     nativeBuildInputs = with buildPackages.netbsd; [
+      bsdSetupHook
       makeMinimal install tsort lorder mandoc statHook nbperf tic
     ];
     buildInputs = with self; compatIfNeeded;
@@ -601,7 +602,7 @@ in lib.makeScopeWithSplicing
         --replace '#include <curses.h>' 'void use_env(bool);'
     '';
     postBuild = ''
-      make -C $NETBSDSRCDIR/share/terminfo BINDIR=$out/share
+      make -C $BSDSRCDIR/share/terminfo BINDIR=$out/share
     '';
     postInstall = ''
       make -C $BSDSRCDIR/share/terminfo BINDIR=$out/share install


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See commit messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
