### PR TITLE
wallgen: init at unstable-2021-02-21

### DIFF
--- a/pkgs/applications/misc/wallgen/default.nix
+++ b/pkgs/applications/misc/wallgen/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonApplication, fetchFromGitHub, pillow, click, cython, scipy, flask, gevent, numpy, scikitimage, loguru }:
+
+buildPythonApplication rec {
+  pname = "wallgen";
+  version = "unstable-2021-02-21";
+
+  src = fetchFromGitHub {
+    owner = "SubhrajitPrusty";
+    repo = "wallgen";
+    rev = "cf9cfbd35d6c54fc3679833784ebbdc85e3a5aea";
+    sha256 = "sha256-OdJiecevw2rSzotcmARil/YQZgHoBrtPBKjrDv4e1qE=";
+  };
+
+  propagatedBuildInputs = [
+    pillow
+    click
+    cython
+    scipy
+    flask
+    gevent
+    numpy
+    scikitimage
+    loguru
+  ];
+
+  meta = with lib; {
+    maintainers = with maintainers; [ j0hax ];
+    description = "Generate HQ poly wallpapers";
+    homepage = "https://github.com/SubhrajitPrusty/wallgen";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30623,6 +30623,8 @@ in
 
   wacomtablet = libsForQt5.callPackage ../tools/misc/wacomtablet { };
 
+  wallgen = python3Packages.callPackage ../applications/misc/wallgen { };
+
   wasmer = callPackage ../development/interpreters/wasmer { };
 
   yabasic = callPackage ../development/interpreters/yabasic { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package a Python application to generate wallpapers ([demo](https://subhrajitprusty.github.io/wallgen/))

I should add that as this Project doesn't have specific versioning, I opted to use short commit hashes. If there are preffered ways instead, LMK.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
