### PR TITLE
stm32cubemx: 6.0.1 -> 6.2.1

### DIFF
--- a/pkgs/development/tools/misc/stm32cubemx/default.nix
+++ b/pkgs/development/tools/misc/stm32cubemx/default.nix
@@ -1,52 +1,57 @@
-{ lib, stdenv, requireFile, makeDesktopItem, libicns, imagemagick, jre, fetchzip }:
-
+{ lib, stdenv, makeDesktopItem, copyDesktopItems, icoutils, fdupes, imagemagick, jdk11, fetchzip }:
+# TODO: JDK16 causes STM32CubeMX to crash right now, so we fixed the version to JDK11
+# This may be fixed in a future version of STM32CubeMX. This issue has been reported to ST:
+# https://community.st.com/s/question/0D53W00000jnOzPSAU/stm32cubemx-crashes-on-launch-with-openjdk16
+# If you're updating this derivation, check the link above to see if it's been fixed upstream
+# and try replacing all occurrences of jdk11 with jre and test whether it works.
 let
-  version = "6.0.1";
-  desktopItem = makeDesktopItem {
-    name = "stm32CubeMX";
-    exec = "stm32cubemx";
-    desktopName = "STM32CubeMX";
-    categories = "Development;";
-    icon = "stm32cubemx";
-  };
+  iconame = "STM32CubeMX";
 in
 stdenv.mkDerivation rec {
   pname = "stm32cubemx";
-  inherit version;
-
+  version = "6.2.1";
 
   src = fetchzip {
-    url = "https://sw-center.st.com/packs/resource/library/stm32cube_mx_v${builtins.replaceStrings ["."] [""] version}.zip";
-    sha256 = "15vxca1pgpgxgiz4wisrw0lylffdwnn4n46z9n0q37f8hmzlrk8f";
-    stripRoot= false;
+    url = "https://sw-center.st.com/packs/resource/library/stm32cube_mx_v${builtins.replaceStrings ["."] [""] version}-lin.zip";
+    sha256 = "0m5h01iq0mgrr9svj4gmykfi9lsyjpqzrkvlizff26c8dqad59c5";
+    stripRoot = false;
   };
 
-  nativeBuildInputs = [ libicns imagemagick ];
+  nativeBuildInputs = [ icoutils fdupes imagemagick copyDesktopItems];
+  desktopItems = [
+    (makeDesktopItem {
+      name = "stm32CubeMX";
+      exec = "stm32cubemx";
+      desktopName = "STM32CubeMX";
+      categories = "Development;";
+      comment = "STM32Cube initialization code generator";
+      icon = "stm32cubemx";
+    })
+  ];
 
   buildCommand = ''
-    mkdir -p $out/{bin,opt/STM32CubeMX,share/applications}
-    cp -r $src/. $out/opt/STM32CubeMX/
-    chmod +rx $out/opt/STM32CubeMX/STM32CubeMX.exe
+    mkdir -p $out/{bin,opt/STM32CubeMX}
+    cp -r $src/MX/. $out/opt/STM32CubeMX/
+    chmod +rx $out/opt/STM32CubeMX/STM32CubeMX
     cat << EOF > $out/bin/${pname}
     #!${stdenv.shell}
-    ${jre}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX.exe
+    ${jdk11}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX
     EOF
     chmod +x $out/bin/${pname}
 
-    icns2png --extract $out/opt/STM32CubeMX/${pname}.icns
+    icotool --extract $out/opt/STM32CubeMX/help/${iconame}.ico
+    fdupes -dN . > /dev/null
     ls
     for size in 16 24 32 48 64 128 256; do
       mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps
-      if [ -e ${pname}_"$size"x"$size"x32.png ]; then
-        mv ${pname}_"$size"x"$size"x32.png \
+      if [ $size -eq 256 ]; then
+        mv ${iconame}_*_"$size"x"$size"x32.png \
           $out/share/icons/hicolor/"$size"x"$size"/apps/${pname}.png
       else
-        convert -resize "$size"x"$size" ${pname}_256x256x32.png \
+        convert -resize "$size"x"$size" ${iconame}_*_256x256x32.png \
           $out/share/icons/hicolor/"$size"x"$size"/apps/${pname}.png
       fi
     done;
-
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Upstream changes:
Main files moved from . to MX.
JAR file has no .exe extension anymore
Icon format changed from icns to ico.
There is now a bundled JRE, should we use it? It may only be compatible with Linux, not macOS.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to a never version of CubeMX. All changes since 6.0.1 can be found [here (PDF)](https://www.st.com/content/ccc/resource/technical/document/release_note/b2/02/4b/e3/81/32/49/c4/DM00107607.pdf/files/DM00107607.pdf/jcr:content/translations/en.DM00107607.pdf).

Unfortunately, it seems like CubeMX doesn't work with the newer OpenJDK16, which contains the JRE on master. OpenJDK 15 works, though. 
The two derivations I tested against:

- 9ryn07zmn2rp9nsiyvpq0jcw771lrgmi-openjdk-15.0.1-ga
- b8pk4qfj00rppf3nn0jzqi5va5d543mp-openjdk-16+36

**I'm not quite sure how to proceed with testing here.**

@wucke13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
