### PR TITLE
lefthook: 0.7.2 -> 0.7.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/lefthook/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lefthook/default.nix
@@ -1,11 +1,5 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
-# Currently `buildGo114Module` is passed as `buildGoModule` from
-# `../default.nix`. Please remove the fixed 1.14 once a new release has been
-# made and the issue linked below has been closed upstream.
-
-# https://github.com/Arkweid/lefthook/issues/151
-
 buildGoModule rec {
   pname = "lefthook";
   version = "0.7.3";

--- a/pkgs/applications/version-management/git-and-tools/lefthook/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lefthook/default.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "lefthook";
-  version = "0.7.2";
+  version = "0.7.3";
 
   src = fetchFromGitHub {
     rev = "v${version}";
-    owner = "Arkweid";
+    owner = "evilmartians";
     repo = "lefthook";
-    sha256 = "1ciyxjx3r3dcl8xas49kqsjshs1bv4pafmfmhdfyfdvlaj374hgj";
+    sha256 = "sha256-VrAkmLRsYNDX5VfAxsvjsOv1bv7Nk53OjdaJm/D2GRk=";
   };
 
-  vendorSha256 = "1pdrw4vwbj9cka2pjbjvxviigfvnrf8sgws27ixwwiblbkj4isc8";
+  vendorSha256 = "sha256-XR7xJZfgt0Hx2DccdNlwEmuduuVU8IBR0pcIUyRhdko=";
 
   doCheck = false;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5950,7 +5950,6 @@ in
   lbreakout2 = callPackage ../games/lbreakout2 { };
 
   lefthook = callPackage ../applications/version-management/git-and-tools/lefthook {
-    buildGoModule = buildGoModule;
   };
 
   lego = callPackage ../tools/admin/lego { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5950,9 +5950,7 @@ in
   lbreakout2 = callPackage ../games/lbreakout2 { };
 
   lefthook = callPackage ../applications/version-management/git-and-tools/lefthook {
-    # Please use empty attrset once upstream bugs have been fixed
-    # https://github.com/Arkweid/lefthook/issues/151
-    buildGoModule = buildGo114Module;
+    buildGoModule = buildGoModule;
   };
 
   lego = callPackage ../tools/admin/lego { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5949,8 +5949,7 @@ in
 
   lbreakout2 = callPackage ../games/lbreakout2 { };
 
-  lefthook = callPackage ../applications/version-management/git-and-tools/lefthook {
-  };
+  lefthook = callPackage ../applications/version-management/git-and-tools/lefthook { };
 
   lego = callPackage ../tools/admin/lego { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Lefthook (finally) got updated upstream. This fixes the problem that it can't be
used when built with a Go newer than 1.14 (which is marked insecure).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
