### PR TITLE
netbsd.librt: fix build

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -665,6 +665,11 @@ in lib.makeScopeWithSplicing
     version = "8.0";
     sha256 = "078qsi4mg1hyyxr1awvjs9b0c2gicg3zw4vl603g1m9vm8gfxw9l";
     meta.platforms = lib.platforms.netbsd;
+    extraPaths = with self; [ common.src libc.src ];
+    postPatch = ''
+      sed -i 's,/usr\(/include/sys/syscall.h\),${self.headers}\1,g' \
+        $BSDSRCDIR/lib/{libc,librt}/sys/Makefile.inc
+    '';
   };
 
   libcrypt = mkDerivation {
@@ -807,10 +812,7 @@ in lib.makeScopeWithSplicing
       make -C $BSDSRCDIR/lib/libcrypt $makeFlags
       make -C $BSDSRCDIR/lib/libcrypt $makeFlags install
     '';
-    postPatch = ''
-      sed -i 's,/usr\(/include/sys/syscall.h\),${self.headers}\1,g' \
-        sys/Makefile.inc ../librt/sys/Makefile.inc
-    '';
+    inherit (self.librt) postPatch;
   };
   #
   # END LIBRARIES


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is another one of those packages that's just a rebuild of a
certain part of libc...

Tested by building pkgsCross.x86_64-netbsd.netbsd.librt on
x86_64-linux.

libc's postPatch was entirely fixes for librt, so move that to librt
and inherit it in libc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
