### PR TITLE
openvpn3: init at 13_beta

### DIFF
--- a/pkgs/tools/networking/openvpn3/default.nix
+++ b/pkgs/tools/networking/openvpn3/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, autoconf-archive
+, git
+, pkg-config
+, glib
+, jsoncpp
+, libcap_ng
+, libnl
+, libuuid
+, lz4
+, openssl
+, protobuf
+, python3
+, tinyxml
+
+, docutils
+, jinja2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openvpn3";
+  version = "13_beta";
+
+  src = fetchFromGitHub {
+    owner = "OpenVPN";
+    repo = "openvpn3-linux";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+    sha256 = "087y3j8ndfbw71igv5gk4i7qmyga2ly74v62wpjyfwx0p4cp8wky";
+  };
+
+  postPatch = ''
+    ./update-version-m4.sh
+    patchShebangs ./openvpn3-core/scripts/version
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    docutils
+    git
+    jinja2
+    pkg-config
+  ];
+  propagatedBuildInputs = [
+    python3
+  ];
+  buildInputs = [
+    glib
+    jsoncpp
+    libcap_ng
+    libnl
+    libuuid
+    lz4
+    openssl
+    protobuf
+    tinyxml
+  ];
+
+  configureFlags = [ "--disable-selinux-build" ];
+
+  NIX_LDFLAGS = "-lpthread";
+
+  meta = with lib; {
+    description = "OpenVPN 3 Linux client";
+    license = licenses.agpl3Plus;
+    homepage = "https://github.com/OpenVPN/openvpn3-linux/";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/openvpn3/disable-selinux-build.patch
+++ b/pkgs/tools/networking/openvpn3/disable-selinux-build.patch
@@ -1,0 +1,51 @@
+diff --color -ur a/configure.ac b/configure.ac
+--- a/configure.ac	2021-04-23 13:34:21.169989045 +0200
++++ b/configure.ac	2021-04-23 14:53:29.992437006 +0200
+@@ -472,38 +472,17 @@
+ dnl  completely disabled explicitly by providing --disable-selinux-build.
+ dnl  This will also remove related SELinux code paths in the various programs.
+ dnl
+-AC_ARG_ENABLE(
+-     [selinux-build],
+-     [AS_HELP_STRING([--disable-selinux-build],
+-                     [Disables building the SELinux policy])],
+-     [],
+-     [enable_selinux_build="yes"]
+-)
++# AC_ARG_ENABLE(
++#      [selinux-build],
++#      [AS_HELP_STRING([--disable-selinux-build],
++#                      [Disables building the SELinux policy])],
++# )
++AC_ARG_ENABLE([selinux-build],
++    AS_HELP_STRING([--enable-selinux-build], [Enable selinux build]))
+ 
+ dnl  This path is used to detect if the SELinux policy
+ dnl  development files.  By default it will use /usr/share/selinux/devel
+ dnl
+-if test "${enable_selinux_build}" = "yes"; then
+-   AC_ARG_VAR([SELINUX_DEVEL_PATH],
+-           [Directory containing the SELinux policy development files (default: ${datarootdir}/selinux/devel)])
+-   if test -n "${SELINUX_DEVEL_PATH}"; then
+-        selinux_devel_path="${SELINUX_DEVEL_PATH}"
+-   else
+-        AX_RECURSIVE_EVAL([${datarootdir}/selinux/devel], [selinux_devel_path])
+-   fi
+-   AC_MSG_NOTICE([Checking for SELinux policy development files])
+-   AC_CHECK_FILE([${selinux_devel_path}/Makefile], [],
+-                 [AC_CHECK_FILE([/usr/share/selinux/devel],
+-                                [selinux_devel_path="/usr/share/selinux/devel"],
+-                                [enable_selinux_build="no"])])
+-
+-   AC_SUBST([selinux_devel_path])
+-
+-
+-   if test "${enable_selinux_build}" = "yes"; then
+-        AC_DEFINE([ENABLE_SELINUX_BUILD], [1], [Build SELinux policy and enable related code paths])
+-   fi
+-fi
+ AC_SUBST([ENABLE_SELINUX_BUILD])
+ AM_CONDITIONAL([ENABLE_SELINUX_BUILD], [test "$enable_selinux_build" = "yes"])
+ 
+Seulement dans b: good.patch
+Seulement dans b/m4: index.html?p=autoconf-archive.git;a=blob_plain;f=m4%2Fax_pthread.m4

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7233,6 +7233,10 @@ in
     openvpn_24
     openvpn;
 
+  openvpn3 = callPackage ../tools/networking/openvpn3 {
+    inherit (python3Packages) docutils jinja2;
+  };
+
   openvpn_learnaddress = callPackage ../tools/networking/openvpn/openvpn_learnaddress.nix { };
 
   openvpn-auth-ldap = callPackage ../tools/networking/openvpn/openvpn-auth-ldap.nix {


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/120116

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
