### PR TITLE
Update emacs2nix and update-melpa.el

### DIFF
--- a/pkgs/applications/editors/emacs-modes/emacs2nix.nix
+++ b/pkgs/applications/editors/emacs-modes/emacs2nix.nix
@@ -4,8 +4,8 @@ let
   src = pkgs.fetchgit {
     url = "https://github.com/ttuegel/emacs2nix.git";
     fetchSubmodules = true;
-    rev = "b815a9323c1f58f6c163a1f968939c57a8b6cfa0";
-    sha256 = "183xlmhjmj4z2zssc0pw990h7bf3bam8zqswnf1zcsyp8z7yrl5g";
+    rev = "860da04ca91cbb69c9b881a54248d16bdaaf9923";
+    sha256 = "1r3xmyk9rfgx7ln69dk8mgbnh3awcalm3r1c5ia2shlsrymvv1df";
   };
 
 in pkgs.mkShell {

--- a/pkgs/applications/editors/emacs-modes/update-melpa.el
+++ b/pkgs/applications/editors/emacs-modes/update-melpa.el
@@ -99,7 +99,10 @@ return Promise to resolve in that process."
             ("github"    (list "nix-prefetch-url"
                                "--unpack" (concat "https://github.com/" repo "/archive/" commit ".tar.gz")))
             ("gitlab"    (list "nix-prefetch-url"
-                               "--unpack" (concat "https://gitlab.com/" repo "/repository/archive.tar.gz?ref=" commit)))
+                               "--unpack" (concat "https://gitlab.com/api/v4/projects/"
+                                                  (url-hexify-string repo)
+                                                  "/repository/archive.tar.gz?ref="
+                                                  commit)))
             ("bitbucket" (list "nix-prefetch-hg"
                                (concat "https://bitbucket.com/" repo) commit))
             ("hg"        (list "nix-prefetch-hg"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Emacs packages sourced from GitLab have not been building since they are downloaded using incorrect addresses.  This change uses the GitLab API path for downloading archives.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested changes by running the `update-melpa` script in the `pkgs/applications/editors/emacs-modes` directory, checked the output of `emacs-geiser/geiser` and other known GitLab emacs packages to ensure the warnings about unable to download were removed from the resulting JSON file.  I am *not* submitting updates to the JSON file as I'm **not** confident this is the correct procedure for updating it.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
