### PR TITLE
wireguard: wg-quick userspaceImplementation option

### DIFF
--- a/nixos/modules/services/networking/wg-quick.nix
+++ b/nixos/modules/services/networking/wg-quick.nix
@@ -12,14 +12,14 @@ let
     options = {
       address = mkOption {
         example = [ "192.168.2.1/24" ];
-        default = [];
+        default = [ ];
         type = with types; listOf str;
         description = "The IP addresses of the interface.";
       };
 
       dns = mkOption {
         example = [ "192.168.2.2" ];
-        default = [];
+        default = [ ];
         type = with types; listOf str;
         description = "The IP addresses of DNS servers to configure.";
       };
@@ -125,9 +125,18 @@ let
       };
 
       peers = mkOption {
-        default = [];
+        default = [ ];
         description = "Peers linked to the interface.";
         type = with types; listOf (submodule peerOpts);
+      };
+
+      userspaceImplementation = mkOption {
+        default = null;
+        example = "\${pkgs.boringtun}/bin/boringtun";
+        description = ''
+          Userspace WireGuard implementation
+        '';
+        type = types.nullOr types.str;
       };
     };
   };
@@ -210,10 +219,10 @@ let
     let
       preUpFile = if values.preUp != "" then writeScriptFile "preUp.sh" values.preUp else null;
       postUp =
-            optional (values.privateKeyFile != null) "wg set ${name} private-key <(cat ${values.privateKeyFile})" ++
-            (concatMap (peer: optional (peer.presharedKeyFile != null) "wg set ${name} peer ${peer.publicKey} preshared-key <(cat ${peer.presharedKeyFile})") values.peers) ++
-            optional (values.postUp != null) values.postUp;
-      postUpFile = if postUp != [] then writeScriptFile "postUp.sh" (concatMapStringsSep "\n" (line: line) postUp) else null;
+        optional (values.privateKeyFile != null) "wg set ${name} private-key <(cat ${values.privateKeyFile})" ++
+        (concatMap (peer: optional (peer.presharedKeyFile != null) "wg set ${name} peer ${peer.publicKey} preshared-key <(cat ${peer.presharedKeyFile})") values.peers) ++
+        optional (values.postUp != null) values.postUp;
+      postUpFile = if postUp != [ ] then writeScriptFile "postUp.sh" (concatMapStringsSep "\n" (line: line) postUp) else null;
       preDownFile = if values.preDown != "" then writeScriptFile "preDown.sh" values.preDown else null;
       postDownFile = if values.postDown != "" then writeScriptFile "postDown.sh" values.postDown else null;
       configDir = pkgs.writeTextFile {
@@ -221,32 +230,34 @@ let
         executable = false;
         destination = "/${name}.conf";
         text =
-        ''
-        [interface]
-        ${concatMapStringsSep "\n" (address:
-          "Address = ${address}"
-        ) values.address}
-        ${concatMapStringsSep "\n" (dns:
-          "DNS = ${dns}"
-        ) values.dns}
-        '' +
-        optionalString (values.table != null) "Table = ${values.table}\n" +
-        optionalString (values.mtu != null) "MTU = ${toString values.mtu}\n" +
-        optionalString (values.privateKey != null) "PrivateKey = ${values.privateKey}\n" +
-        optionalString (values.listenPort != null) "ListenPort = ${toString values.listenPort}\n" +
-        optionalString (preUpFile != null) "PreUp = ${preUpFile}\n" +
-        optionalString (postUpFile != null) "PostUp = ${postUpFile}\n" +
-        optionalString (preDownFile != null) "PreDown = ${preDownFile}\n" +
-        optionalString (postDownFile != null) "PostDown = ${postDownFile}\n" +
-        concatMapStringsSep "\n" (peer:
-          assert assertMsg (!((peer.presharedKeyFile != null) && (peer.presharedKey != null))) "Only one of presharedKey or presharedKeyFile may be set";
-          "[Peer]\n" +
-          "PublicKey = ${peer.publicKey}\n" +
-          optionalString (peer.presharedKey != null) "PresharedKey = ${peer.presharedKey}\n" +
-          optionalString (peer.endpoint != null) "Endpoint = ${peer.endpoint}\n" +
-          optionalString (peer.persistentKeepalive != null) "PersistentKeepalive = ${toString peer.persistentKeepalive}\n" +
-          optionalString (peer.allowedIPs != []) "AllowedIPs = ${concatStringsSep "," peer.allowedIPs}\n"
-        ) values.peers;
+          ''
+            [interface]
+            ${concatMapStringsSep "\n" (address:
+              "Address = ${address}"
+            ) values.address}
+            ${concatMapStringsSep "\n" (dns:
+              "DNS = ${dns}"
+            ) values.dns}
+          '' +
+          optionalString (values.table != null) "Table = ${values.table}\n" +
+          optionalString (values.mtu != null) "MTU = ${toString values.mtu}\n" +
+          optionalString (values.privateKey != null) "PrivateKey = ${values.privateKey}\n" +
+          optionalString (values.listenPort != null) "ListenPort = ${toString values.listenPort}\n" +
+          optionalString (preUpFile != null) "PreUp = ${preUpFile}\n" +
+          optionalString (postUpFile != null) "PostUp = ${postUpFile}\n" +
+          optionalString (preDownFile != null) "PreDown = ${preDownFile}\n" +
+          optionalString (postDownFile != null) "PostDown = ${postDownFile}\n" +
+          concatMapStringsSep "\n"
+            (peer:
+              assert assertMsg (!((peer.presharedKeyFile != null) && (peer.presharedKey != null))) "Only one of presharedKey or presharedKeyFile may be set";
+              "[Peer]\n" +
+              "PublicKey = ${peer.publicKey}\n" +
+              optionalString (peer.presharedKey != null) "PresharedKey = ${peer.presharedKey}\n" +
+              optionalString (peer.endpoint != null) "Endpoint = ${peer.endpoint}\n" +
+              optionalString (peer.persistentKeepalive != null) "PersistentKeepalive = ${toString peer.persistentKeepalive}\n" +
+              optionalString (peer.allowedIPs != [ ]) "AllowedIPs = ${concatStringsSep "," peer.allowedIPs}\n"
+            )
+            values.peers;
       };
       configPath = "${configDir}/${name}.conf";
     in
@@ -266,6 +277,7 @@ let
 
         script = ''
           ${optionalString (!config.boot.isContainer) "modprobe wireguard"}
+          ${optionalString (values.userspaceImplementation != null) "export WG_QUICK_USERSPACE_IMPLEMENTATION=${values.userspaceImplementation}"}
           wg-quick up ${configPath}
         '';
 
@@ -273,7 +285,8 @@ let
           wg-quick down ${configPath}
         '';
       };
-in {
+in
+{
 
   ###### interface
 
@@ -281,15 +294,17 @@ in {
     networking.wg-quick = {
       interfaces = mkOption {
         description = "Wireguard interfaces.";
-        default = {};
+        default = { };
         example = {
           wg0 = {
             address = [ "192.168.20.4/24" ];
             privateKey = "yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk=";
             peers = [
-              { allowedIPs = [ "192.168.20.1/32" ];
-                publicKey  = "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=";
-                endpoint   = "demo.wireguard.io:12913"; }
+              {
+                allowedIPs = [ "192.168.20.1/32" ];
+                publicKey = "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=";
+                endpoint = "demo.wireguard.io:12913";
+              }
             ];
           };
         };
@@ -301,7 +316,7 @@ in {
 
   ###### implementation
 
-  config = mkIf (cfg.interfaces != {}) {
+  config = mkIf (cfg.interfaces != { }) {
     boot.extraModulePackages = optional (versionOlder kernel.kernel.version "5.6") kernel.wireguard;
     environment.systemPackages = [ pkgs.wireguard-tools ];
     # This is forced to false for now because the default "--validmark" rpfilter we apply on reverse path filtering


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
