### PR TITLE
neofetch: 7.1.0 -> unstable-2020-11-26

### DIFF
--- a/pkgs/tools/misc/neofetch/default.nix
+++ b/pkgs/tools/misc/neofetch/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenvNoCC, fetchFromGitHub, bash, makeWrapper, pciutils }:
+{ lib, stdenvNoCC, fetchFromGitHub, bash, makeWrapper, pciutils, ueberzug }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "neofetch";
-  version = "7.1.0";
+  version = "unstable-2020-11-26";
 
   src = fetchFromGitHub {
     owner = "dylanaraps";
     repo = "neofetch";
-    rev = version;
-    sha256 = "0i7wpisipwzk0j62pzaigbiq42y1mn4sbraz4my2jlz6ahwf00kv";
+    rev = "6dd85d67fc0d4ede9248f2df31b2cd554cca6c2f";
+    sha256 = "sha256-PZjFF/K7bvPIjGVoGqaoR8pWE6Di/qJVKFNcIz7G8xE=";
   };
 
   strictDeps = true;
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/neofetch \
-      --prefix PATH : ${lib.makeBinPath [ pciutils ]}
+      --prefix PATH : ${lib.makeBinPath [ pciutils ueberzug ]}
   '';
 
   makeFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
neofetch hasn't seen any activity for a while, update it to latest master

also add ueberzug as a dependency for the script

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
