### PR TITLE
googleearth-pro: fix xkb keyboard and use nixpkgs libs

### DIFF
--- a/pkgs/applications/misc/googleearth-pro/default.nix
+++ b/pkgs/applications/misc/googleearth-pro/default.nix
@@ -1,42 +1,54 @@
-{ lib, stdenv, fetchurl, glibc, libGLU, libGL, freetype, glib, libSM, libICE, libXi, libXv
-, libXrender, libXrandr, libXfixes, libXcursor, libXinerama, libXext, libX11, libXcomposite
-, libxcb, sqlite, zlib, fontconfig, dpkg, libproxy, libxml2, gst_all_1, dbus, makeWrapper
-, xkeyboardconfig }:
+{ lib
+, stdenv
+, mkDerivation
+, fetchurl
+, ffmpeg_3
+, freetype
+, gdal_2
+, glib
+, libGL
+, libGLU
+, libICE
+, libSM
+, libXi
+, libXv
+, libav_12
 
+, libXrender
+, libXrandr
+, libXfixes
+, libXcursor
+, libXinerama
+, libXext
+, libX11
+, libXcomposite
+
+, libxcb
+, sqlite
+, zlib
+, fontconfig
+, dpkg
+, libproxy
+, libxml2
+, gst_all_1
+, dbus
+, makeWrapper
+
+, qtlocation
+, qtwebkit
+, qtx11extras
+, qtsensors
+, qtscript
+
+, xkeyboardconfig
+, autoPatchelfHook
+}:
 let
   arch =
     if stdenv.hostPlatform.system == "x86_64-linux" then "amd64"
     else throw "Unsupported system ${stdenv.hostPlatform.system} ";
-  fullPath = lib.makeLibraryPath [
-    glibc
-    glib
-    stdenv.cc.cc
-    libSM
-    libICE
-    libXi
-    libXv
-    libGLU libGL
-    libXrender
-    libXrandr
-    libXfixes
-    libXcursor
-    libXinerama
-    libXcomposite
-    freetype
-    libXext
-    libX11
-    libxcb
-    sqlite
-    zlib
-    fontconfig
-    libproxy
-    libxml2
-    dbus
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base
-  ];
 in
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "googleearth-pro";
   version = "7.3.3.7786";
 
@@ -45,14 +57,47 @@ stdenv.mkDerivation rec {
     sha256 = "1s3cakwrgf702g33rh8qs657d8bl68wgg8k89rksgvswwpd2zbb3";
   };
 
-  nativeBuildInputs = [ dpkg makeWrapper ];
+  nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook ];
   propagatedBuildInputs = [ xkeyboardconfig ];
+  buildInputs = [
+    dbus
+    ffmpeg_3
+    fontconfig
+    freetype
+    gdal_2
+    glib
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    libGL
+    libGLU
+    libICE
+    libSM
+    libX11
+    libXcomposite
+    libXcursor
+    libXext
+    libXfixes
+    libXi
+    libXinerama
+    libXrandr
+    libXrender
+    libXv
+    libav_12
+    libproxy
+    libxcb
+    libxml2
+    qtlocation
+    qtscript
+    qtsensors
+    qtwebkit
+    qtx11extras
+    sqlite
+    zlib
+  ];
 
   doInstallCheck = true;
 
   dontBuild = true;
-
-  dontPatchELF = true;
 
   unpackPhase = ''
     # deb file contains a setuid binary, so 'dpkg -x' doesn't work here
@@ -60,6 +105,8 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase =''
+    runHook preInstall
+
     mkdir $out
     mv usr/* $out/
     rmdir usr
@@ -68,20 +115,9 @@ stdenv.mkDerivation rec {
 
     # patch and link googleearth binary
     ln -s $out/opt/google/earth/pro/googleearth-bin $out/bin/googleearth-pro
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${fullPath}:\$ORIGIN" \
-      $out/opt/google/earth/pro/googleearth-bin
 
     # patch and link gpsbabel binary
     ln -s $out/opt/google/earth/pro/gpsbabel $out/bin/gpsbabel
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${fullPath}:\$ORIGIN" \
-      $out/opt/google/earth/pro/gpsbabel
-
-    # patch libraries
-    for a in $out/opt/google/earth/pro/*.so* ; do
-      patchelf --set-rpath "${fullPath}:\$ORIGIN" $a
-    done
 
     # Add desktop config file and icons
     mkdir -p $out/share/{applications,icons/hicolor/{16x16,22x22,24x24,32x32,48x48,64x64,128x128,256x256}/apps,pixmaps}
@@ -91,25 +127,37 @@ stdenv.mkDerivation rec {
       ln -s $out/opt/google/earth/pro/product_logo_"$size".png $out/share/icons/hicolor/"$size"x"$size"/apps/google-earth-pro.png
     done
     ln -s $out/opt/google/earth/pro/product_logo_256.png $out/share/pixmaps/google-earth-pro.png
+
+    runHook postInstall
   '';
+
+  postInstall = ''
+    find "$out/opt/google/earth/pro" -name "*.so.*" | \
+      egrep -v 'libssl*|libcrypto*|libicu*' | \
+      xargs rm
+    find "$out/opt/google/earth/pro" -name "*.so" | \
+      egrep -v 'libgoogle*|libauth*|libbase*|libcommon*|libcommon_gui*|libcommon_platform*|libcommon_webbrowser*|libcomponentframework*|libgeobase*|libgeobaseutils*|libge_net*|libgdata*|libgoogleapi*|libmath*|libmoduleframework*|libmaps*|libport*|libprintmodule*|libprofile*|librender*|libreporting*|libsgutil*|libspatial*|libxsltransform*|libbase*|libport*|libport*|libbase*|libcomponentframework*|libIGCore*|libIGUtils*|libaction*|libapiloader*|libapiloader*|libIGCore*|libIGUtils*|libIGMath*|libfusioncommon*|libge_exif*|libaction*|libfusioncommon*|libapiloader*|liblayer*|libapiloader*|libIGAttrs*|libIGCore*|libIGGfx*|libIGMath*|libIGSg*|libIGUtils*|libwmsbase*|libwebbrowser*|libevllpro*|libalchemyext*|libge_cache*|libflightsim*|libnpgeinprocessplugin*|libmeasure*|libviewsync*|libcapture*|libtheme*|libgps*|libgisingest*|libsearchmodule*|libinput_plugin*|libnavigate*|libspnav*|libsearch*|libLeap*' | \
+      xargs rm
+  '';
+
+  autoPatchelfIgnoreMissingDeps=true;
 
   installCheckPhase = ''
     $out/bin/gpsbabel -V > /dev/null
   '';
 
   # wayland is not supported by Qt included in binary package, so make sure it uses xcb
-  fixupPhase = ''
+  postFixup = ''
     wrapProgram $out/bin/googleearth-pro \
       --set QT_QPA_PLATFORM xcb \
       --set QT_XKB_CONFIG_ROOT "${xkeyboardconfig}/share/X11/xkb"
   '';
 
-
   meta = with lib; {
     description = "A world sphere viewer";
-    homepage = "https://earth.google.com";
+    homepage = "https://www.google.com/earth/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ friedelino ];
+    maintainers = with maintainers; [ friedelino shamilton ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/googleearth-pro/default.nix
+++ b/pkgs/applications/misc/googleearth-pro/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl, glibc, libGLU, libGL, freetype, glib, libSM, libICE, libXi, libXv
 , libXrender, libXrandr, libXfixes, libXcursor, libXinerama, libXext, libX11, libXcomposite
-, libxcb, sqlite, zlib, fontconfig, dpkg, libproxy, libxml2, gst_all_1, dbus, makeWrapper }:
+, libxcb, sqlite, zlib, fontconfig, dpkg, libproxy, libxml2, gst_all_1, dbus, makeWrapper
+, xkeyboardconfig }:
 
 let
   arch =
@@ -45,6 +46,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ dpkg makeWrapper ];
+  propagatedBuildInputs = [ xkeyboardconfig ];
 
   doInstallCheck = true;
 
@@ -97,7 +99,9 @@ stdenv.mkDerivation rec {
 
   # wayland is not supported by Qt included in binary package, so make sure it uses xcb
   fixupPhase = ''
-    wrapProgram $out/bin/googleearth-pro --set QT_QPA_PLATFORM xcb
+    wrapProgram $out/bin/googleearth-pro \
+      --set QT_QPA_PLATFORM xcb \
+      --set QT_XKB_CONFIG_ROOT "${xkeyboardconfig}/share/X11/xkb"
   '';
 
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23477,7 +23477,7 @@ in
 
   googleearth = callPackage ../applications/misc/googleearth { };
 
-  googleearth-pro = callPackage ../applications/misc/googleearth-pro { };
+  googleearth-pro = libsForQt5.callPackage ../applications/misc/googleearth-pro { };
 
   google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
 


### PR DESCRIPTION
###### Motivation for this change
Fixes googleearth-pro keyboard not working.

Using Nixpkgs latest Qt libs makes it work way better.

## Security Issues
Among others, googleearth-pro uses : 
 - openssl 1.0.0
 - libav_12
 - icu54

libav_12 still exists on nixpkgs but the two left aren't even there anymore so I had to use the bundled dlls.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

**Pinging Maintainers**
@friedelino 
