### PR TITLE
liburing: fix build on 32-bit ARM

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "0has1yd1ns5q5jgcmhrbgwhbwq0wix3p7xv3dyrwdf784p56izkn";
   };
 
+  patches = [
+    # Fix build on 32-bit ARM
+    (fetchpatch {
+      url = "https://github.com/axboe/liburing/commit/808b6c72ab753bda0c300b5683cfd31750d1d49b.patch";
+      sha256 = "1x7a9c5a6rwhfsbjqmhbnwh2aiin6yylckrqdjbzljrprzf11wrd";
+    })
+  ];
+
   separateDebugInfo = true;
   enableParallelBuilding = true;
   # Upstream's configure script is not autoconf generated, but a hand written one.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Both cross and native builds on 32-bit ARM fail with the following error:
```
double-poll-crash.c:69: warning: "__NR_io_uring_setup" redefined
   69 | #define __NR_io_uring_setup 425
      |
In file included from /nix/store/83q8jcps9kqg0w7bnf9ddyyh9jx3ac5l-glibc-2.32-40-dev/include/asm/unistd.h:27,
                 from /nix/store/83q8jcps9kqg0w7bnf9ddyyh9jx3ac5l-glibc-2.32-40-dev/include/sys/syscall.h:24,
                 from double-poll-crash.c:12:
/nix/store/83q8jcps9kqg0w7bnf9ddyyh9jx3ac5l-glibc-2.32-40-dev/include/asm/unistd-common.h:382: note: this is the location of the previous definition
  382 | #define __NR_io_uring_setup (__NR_SYSCALL_BASE + 425)
      |
double-poll-crash.c: In function 'main':
double-poll-crash.c:153:11: error: '__NR_mmap' undeclared (first use in this function)
  153 |   syscall(__NR_mmap, 0x1ffff000ul, 0x1000ul, 0ul, 0x32ul, -1, 0ul);
      |           ^~~~~~~~~
double-poll-crash.c:153:11: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [Makefile:144: double-poll-crash] Error 1
make[1]: Leaving directory '/build/liburing/test'
make: *** [Makefile:13: all] Error 2
builder for '/nix/store/2z8qpmjia5jq1nibw83k9jv2xj7xhcwa-liburing-2.0.drv' failed with exit code 2
```

This issue has been fixed upstream, so I just applied the relevant patch.

cc @thoughtpolice 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
