### PR TITLE
nsjail: fix bison link error

### DIFF
--- a/pkgs/tools/security/nsjail/001-fix-bison-link-error.patch
+++ b/pkgs/tools/security/nsjail/001-fix-bison-link-error.patch
@@ -1,0 +1,30 @@
+From 8e309a0af0851ab54ca7c6d51b6f3d19ee42c8ee Mon Sep 17 00:00:00 2001
+From: Evangelos Foutras <evangelos@foutrelis.com>
+Date: Wed, 17 Mar 2021 16:36:40 +0200
+Subject: [PATCH] Replace YYUSE call with void cast in src/parser.y
+
+The YYUSE macro was renamed to YY_USE in bison 3.7.5; we might as well
+avoid using it altogether and cast the unused variable to void instead.
+
+Fixes the following linker error:
+
+/usr/bin/ld: kafel/libkafel.a(libkafel.o): in function `kafel_yyerror':
+arm_syscalls.c:(.text+0x6984): undefined reference to `YYUSE'
+---
+ src/parser.y | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/parser.y b/src/parser.y
+index e0f109c..0e01373 100644
+--- a/kafel/src/parser.y
++++ b/kafel/src/parser.y
+@@ -420,8 +420,8 @@ const_def
+ 
+ void yyerror(YYLTYPE * loc, struct kafel_ctxt* ctxt, yyscan_t scanner,
+              const char *msg) {
++  (void)scanner; /* suppress unused-parameter warning */
+   if (!ctxt->lexical_error) {
+-    YYUSE(scanner);
+     if (loc->filename != NULL) {
+       append_error(ctxt, "%s:%d:%d: %s", loc->filename, loc->first_line, loc->first_column, msg);
+     } else {

--- a/pkgs/tools/security/nsjail/default.nix
+++ b/pkgs/tools/security/nsjail/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "nsjail";
-  version = "3.0";
+  version = "3.0"; # Bumping? Remove the bison patch.
 
   src = fetchFromGitHub {
     owner           = "google";
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf bison flex libtool pkg-config which ];
   buildInputs = [ libnl protobuf protobufc ];
   enableParallelBuilding = true;
+
+  patches = [
+    # To remove after bumping 3.0
+    ./001-fix-bison-link-error.patch
+  ];
 
   preBuild = ''
     makeFlagsArray+=(USER_DEFINES='-DNEWUIDMAP_PATH=${shadow}/bin/newuidmap -DNEWGIDMAP_PATH=${shadow}/bin/newgidmap')


### PR DESCRIPTION
###### Motivation for this change

The nsjail build has been broken since the 3.7.5 bison bump:

```
  /nix/store/(...)/bin/ld: kafel/libkafel.a(libkafel.o):
    in function `kafel_yyerror':
  arm_syscalls.c:(.text+0x6833): undefined reference to `YYUSE'
```

###### Things done

The issue is coming from kafel and has been fixed upstream. More infos
at: https://github.com/google/kafel/pull/28.

Kafel being distributed through a git submodule in the nsjail repo, we
can't directly fetchpatch the fix from Github. We had to manually
modify the said patch to add a /kafel prefix.

We'll need to remove this patch for the next nsjail version bump.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @dtzWill @c0bw3b @arcz 
