### PR TITLE
chromiumDev: Fix the configuration phase

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -7,7 +7,7 @@
 , xdg-utils, yasm, nasm, minizip, libwebp
 , libusb1, pciutils, nss, re2
 
-, python2Packages, perl, pkg-config
+, python2Packages, python3Packages, perl, pkg-config
 , nspr, systemd, libkrb5
 , util-linux, alsaLib
 , bison, gperf
@@ -42,6 +42,16 @@ with lib;
 
 let
   jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
+  # TODO: Python 3 support is incomplete and "python3 ../../build/util/python2_action.py"
+  # currently doesn't work due to mixed Python 2/3 dependencies:
+  pythonPackages = if chromiumVersionAtLeast "93"
+    then python3Packages
+    else python2Packages;
+  forcePython3Patch = (githubPatch
+    # Reland #8 of "Force Python 3 to be used in build."":
+    "a2d3c362802d9e6b62f895fcda75a3695b77b1b8"
+    "1r9spr2wmjk9x9l3m1gzn6692mlvbxdz0r5hlr5rfwiwr900rxi2"
+  );
 
   # The additional attributes for creating derivations based on the chromium
   # source tree.
@@ -127,9 +137,9 @@ let
 
     nativeBuildInputs = [
       llvmPackages.lldClang.bintools
-      ninja which python2Packages.python perl pkg-config
-      python2Packages.ply python2Packages.jinja2 nodejs
-      gnutar python2Packages.setuptools
+      ninja which pythonPackages.python perl pkg-config
+      pythonPackages.ply pythonPackages.jinja2 nodejs
+      gnutar pythonPackages.setuptools
     ];
 
     buildInputs = defaultDependencies ++ [
@@ -168,6 +178,8 @@ let
     postPatch = lib.optionalString (chromiumVersionAtLeast "91") ''
       # Required for patchShebangs (unsupported):
       chmod -x third_party/webgpu-cts/src/tools/deno
+    '' + optionalString (chromiumVersionAtLeast "92") ''
+      patch -p1 --reverse < ${forcePython3Patch}
     '' + ''
       # remove unused third-party
       for lib in ${toString gnSystemLibraries}; do


### PR DESCRIPTION
The Python 3 support still isn't ready...

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
