### PR TITLE
Unbreak openapi3 and servant-openapi3

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -10045,7 +10045,6 @@ broken-packages:
   - servant-multipart
   - servant-namedargs
   - servant-nix
-  - servant-openapi3
   - servant-pagination
   - servant-pandoc
   - servant-polysemy

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8691,7 +8691,6 @@ broken-packages:
   - openai-servant
   - openapi-petstore
   - openapi-typed
-  - openapi3
   - openapi3-code-generator
   - opench-meteo
   - OpenCL


### PR DESCRIPTION
###### Motivation for this change

Both packages build fine.

###### Things done

Built both successfully using `nix-build -A haskellPackages.servant-openapi3 --arg config '{ allowBroken = true; }'`.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
