### PR TITLE
python3Packages.watchdog: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -2,31 +2,21 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , argh
 , pathtools
 , pyyaml
-, pytest-cov
 , pytestCheckHook
 , CoreServices
 }:
 
 buildPythonPackage rec {
   pname = "watchdog";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-Uy/t2ZPnVVRnH6o2zQTFgM7T+uCEJUp3mvu9iq8AVms=";
+    sha256 = "sha256-QojTqYQyTbSS5XqhaWZiOKJXjwr1oIFoVSZgj7n2vWE=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Fix test flakiness on Apple Silicon, remove after upgrade to 2.0.6.
-      url = "https://github.com/gorakhargosh/watchdog/commit/331fd7c2c819663be39bc146e78ce67553f265fa.patch";
-      sha256 = "sha256-pLkZmbPN3qRNHs53OP0HIyDxqYCPPo6yOcBLD3aO2YE=";
-    })
-  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
 
@@ -37,9 +27,14 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest-cov
     pytestCheckHook
   ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=watchdog" "" \
+      --replace "--cov-report=term-missing" ""
+  '';
 
   pythonImportsCheck = [ "watchdog" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.3

Change log: https://github.com/gorakhargosh/watchdog/releases/tag/v2.0.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
