### PR TITLE
openttd: 11.1.0 -> 11.1.1

### DIFF
--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -29,11 +29,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "openttd";
-  version = "1.11.0";
+  version = "1.11.1";
 
   src = fetchurl {
     url = "https://cdn.openttd.org/openttd-releases/${version}/${pname}-${version}-source.tar.xz";
-    sha256 = "sha256-XmUYTgc2i6Gvpi27PjWrrubE2mcw/0vJ60RH1TNjx6g=";
+    sha256 = "sha256-qZGeLkKbsI+in+jme6m8dckOnvb6ZCSOs0IjoyXUAKM=";
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];

--- a/pkgs/games/openttd/jgrpp.nix
+++ b/pkgs/games/openttd/jgrpp.nix
@@ -2,12 +2,12 @@
 
 openttd.overrideAttrs (oldAttrs: rec {
   pname = "openttd-jgrpp";
-  version = "0.40.5";
+  version = "0.41.0";
 
   src = fetchFromGitHub rec {
     owner = "JGRennison";
     repo = "OpenTTD-patches";
     rev = "jgrpp-${version}";
-    sha256 = "sha256-g1RmgVjefOrOVLTvFBiPEd19aLoFvB9yX/hMiKgGcGw=";
+    sha256 = "sha256-DrtxqXyeqA+X4iLTvTSPFDKDoLCyVd458+nJWc+9MF4=";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

Upstream bugfix release.
Also update the patch pack.

###### Things done

```
$ nixpkgs-review rev openttd-update
[...]
2 packages updated:
openttd (1.11.0 → 1.11.1) openttd-jgrpp (0.40.5 → 0.41.0)
[...]
2 packages built:
openttd openttd-jgrpp
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
