### PR TITLE
python3Packages.{muscima, mung, omrdatasettools}: init

### DIFF
--- a/pkgs/development/python-modules/mung/default.nix
+++ b/pkgs/development/python-modules/mung/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, lxml
+, matplotlib
+, midiutil
+, numpy
+, pytestCheckHook
+, scikitimage
+, scikit-learn
+}:
+let
+  rev = "8d0ce91d831b0592c111ddb38fc9aa8eba130ed2";
+in
+buildPythonPackage {
+  pname = "mung";
+  version = "unstable-2022-07-10";
+
+  src = fetchFromGitHub {
+    owner = "OMR-Research";
+    repo = "mung";
+    inherit rev;
+    hash = "sha256-QzCkB9Wj4dTPuMCMweFw6IsSwBBzV0Nfx7+VX7Plnio=";
+  };
+
+  format = "setuptools";
+
+  propagatedBuildInputs = [
+    lxml
+    numpy
+    scikitimage
+    scikit-learn
+    matplotlib
+    midiutil
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Music Notation Graph: a data model for optical music recognition";
+    homepage = "https://github.com/OMR-Research/mung";
+    changelog = "https://github.com/OMR-Research/mung/blob/${rev}/CHANGES.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ piegames ];
+  };
+}

--- a/pkgs/development/python-modules/muscima/default.nix
+++ b/pkgs/development/python-modules/muscima/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, lxml
+, matplotlib
+, numpy
+, pytestCheckHook
+, scikitimage
+, scikit-learn
+}:
+
+let
+  rev = "9a016380625927f385e699664026c90356557850";
+in
+buildPythonPackage {
+  pname = "muscima";
+  version = "unstable-2023-04-26";
+
+  src = fetchFromGitHub {
+    owner = "hajicj";
+    repo = "muscima";
+    inherit rev;
+    hash = "sha256-0mRLJATn+6dYswgDg2zs7RHKSvY4+gNt4SBHeF0G3Xg=";
+  };
+
+  format = "setuptools";
+
+  propagatedBuildInputs = [
+    lxml
+    numpy
+    scikitimage
+    scikit-learn
+    matplotlib
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # They hard-code the path to the dataset and expect you to edit the test to update it to your value
+    "test/test_dataset.py"
+  ];
+
+  meta = with lib; {
+    description = "Tools for working with the MUSCIMA++ dataset of handwritten music notation";
+    homepage = "https://github.com/hajicj/muscima";
+    changelog = "https://github.com/hajicj/muscima/blob/${rev}/CHANGES.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ piegames ];
+  };
+}

--- a/pkgs/development/python-modules/omrdatasettools/default.nix
+++ b/pkgs/development/python-modules/omrdatasettools/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, h5py
+, ipython
+, lxml
+, mung
+, muscima
+, numpy
+, pillow
+, pytestCheckHook
+, scikitimage
+, sphinx-rtd-theme
+, sympy
+, pandas
+, pyhamcrest
+, tqdm
+, twine
+}:
+
+buildPythonPackage rec {
+  pname = "omrdatasettools";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0cdq02jp8vh78yjq9bncjjl0pb554idrcxkd62rzwk4l6ss2fkw5";
+  };
+
+  propagatedBuildInputs = [
+    pillow
+    scikitimage
+    h5py
+    pyhamcrest
+    muscima
+    mung
+    numpy
+    lxml
+    tqdm
+    twine
+    sympy
+    sphinx-rtd-theme
+    pandas
+    ipython
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # The download tests require internet access
+    "omrdatasettools/tests/test_downloader.py"
+  ];
+
+  disabledTests = [
+    # The download tests require internet access
+    "test_download_extract_and_crop_bitmaps"
+    "test_download_extract_and_render_all_symbols"
+    "test_download_extract_and_draw_bitmaps"
+    # Other failures
+    "test_render_node_masks_instance_segmentation_of_staff_blobs"
+    "test_render_node_masks_instance_segmentation_of_staff_lines"
+    "test_render_node_masks_semantic_segmentation_of_nodes"
+  ];
+
+  meta = with lib; {
+    description = "Collection of datasets used for Optical Music Recognition";
+    homepage = "https://github.com/apacha/OMR-Datasets";
+    changelog = "https://github.com/apacha/OMR-Datasets/blob/${version}/CHANGES.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ piegames ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6931,6 +6931,8 @@ self: super: with self; {
 
   omnilogic = callPackage ../development/python-modules/omnilogic { };
 
+  omrdatasettools = callPackage ../development/python-modules/omrdatasettools { };
+
   ondilo = callPackage ../development/python-modules/ondilo { };
 
   onetimepass = callPackage ../development/python-modules/onetimepass { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6430,6 +6430,8 @@ self: super: with self; {
 
   murmurhash = callPackage ../development/python-modules/murmurhash { };
 
+  muscima = callPackage ../development/python-modules/muscima { };
+
   musicbrainzngs = callPackage ../development/python-modules/musicbrainzngs { };
 
   mutag = callPackage ../development/python-modules/mutag { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6426,6 +6426,8 @@ self: super: with self; {
 
   munch = callPackage ../development/python-modules/munch { };
 
+  mung = callPackage ../development/python-modules/mung { };
+
   munkres = callPackage ../development/python-modules/munkres { };
 
   murmurhash = callPackage ../development/python-modules/murmurhash { };


### PR DESCRIPTION
###### Motivation for this change
I use a project that depends on them

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
