### PR TITLE
handlr: 0.5.0 -> 0.6.1

### DIFF
--- a/pkgs/tools/misc/handlr/default.nix
+++ b/pkgs/tools/misc/handlr/default.nix
@@ -1,20 +1,23 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, rustPlatform, fetchFromGitHub, shared-mime-info }:
 
 rustPlatform.buildRustPackage rec {
   pname = "handlr";
-  version = "0.5.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "chmln";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1f4gmlqzgw1r8n0w9dr9lpsn94f2hlnak9bbq5xgf6jwgc9mwqzg";
+    sha256 = "0mxkirsicagvfyihcb06g2bsz5h0zp7xc87vldp4amgddzaxhpbg";
   };
 
-  cargoSha256 = "16d4dywwkgvvxw6ninrx87rqhx0whdq3yy01m27qjy4gz6z6ad8p";
+  cargoSha256 = "11glh6f0cjrq76212h80na2rgwpzjmk0j78y3i98nv203rkrczid";
 
-  # Most tests fail (at least some due to directory permissions)
-  doCheck = false;
+  nativeBuildInputs = [ shared-mime-info ];
+
+  preCheck = ''
+    export HOME=$TEMPDIR
+  '';
 
   meta = with lib; {
     description = "Alternative to xdg-open to manage default applications with ease";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/chmln/handlr/releases/tag/v0.6.0
https://github.com/chmln/handlr/releases/tag/v0.6.1

Adds the missing shared-mime-info dependency and fixes tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
