### PR TITLE
castty: init at 2020-11-10

### DIFF
--- a/pkgs/tools/misc/castty/default.nix
+++ b/pkgs/tools/misc/castty/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub, libsoundio, lame }:
+
+stdenv.mkDerivation {
+  pname = "castty";
+  version = "2020-11-10";
+
+  src = fetchFromGitHub {
+    owner = "dhobsd";
+    repo = "castty";
+    rev = "333a2bafd96d56cd0bb91577ae5ba0f7d81b3d99";
+    sha256 = "0p84ivwsp8ds4drn0hx2ax04gp0xyq6blj1iqfsmrs4slrajdmqs";
+  };
+
+  buildInputs = [ libsoundio lame ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "CLI tool to record audio-enabled screencasts of your terminal, for the web";
+    homepage = "https://github.com/dhobsd/castty";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ iblech ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/castty/default.nix
+++ b/pkgs/tools/misc/castty/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "castty";
-  version = "2020-11-10";
+  version = "unstable-2020-11-10";
 
   src = fetchFromGitHub {
     owner = "dhobsd";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1231,6 +1231,8 @@ in
 
   inherit (nodePackages) castnow;
 
+  castty = callPackage ../tools/misc/castty { };
+
   certigo = callPackage ../tools/admin/certigo { };
 
   catcli = python3Packages.callPackage ../tools/filesystems/catcli { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[castty](https://github.com/dhobsd/castty) is a small CLI tool to record terminal screencasts, like asciinema, but with the option of recording sound.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
