### PR TITLE
libchewing: 0.5.1 -> unstable-2020-06-27

### DIFF
--- a/pkgs/development/libraries/libchewing/default.nix
+++ b/pkgs/development/libraries/libchewing/default.nix
@@ -1,20 +1,24 @@
-{ lib, stdenv, fetchurl, sqlite }:
+{ lib, stdenv, fetchFromGitHub, sqlite, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "libchewing";
-  version = "0.5.1";
+  version = "unstable-2020-06-27";
 
-  src = fetchurl {
-    url = "https://github.com/chewing/libchewing/releases/download/v${version}/libchewing-${version}.tar.bz2";
-    sha256 = "0aqp2vqgxczydpn7pxi7r6xf3l1hgl710f0gbi1k8q7s2lscc24p";
+  src = fetchFromGitHub {
+    owner = "chewing";
+    repo = "libchewing";
+    rev = "452f6221fbad90c0706a3963b17e226216e40dd7";
+    sha256 = "sha256-w3/K2O/CU+XVzqzVCYJyq1vLgToN6iIUhJ9J7ia4p9E=";
   };
 
   buildInputs = [ sqlite ];
 
+  nativeBuildInputs = [ cmake ];
+
   meta = with lib; {
     description = "Intelligent Chinese phonetic input method";
     homepage = "http://chewing.im/";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Only;
     maintainers = [ maintainers.ericsagnes ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is the working library of the chewing input method, the program that is wrapped by input-method addons like ibus-chewing and fcitx-chewing)

There have been almost 5 years since v0.5.1 was released.
Many important bugfix such as
https://github.com/chewing/libchewing/pull/277
the fix for
https://github.com/chewing/libchewing/issues/232
the error of incorrect phrases being stored into the user vocabulary database.

There has almost been a year since the last commit on master,
and it is quite stable on my laptop.

If applied, users will be able to benefit from several bug fixes that stops the program from polluting their vocabulary database.

###### CC

@ericsagnes 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) (Tested fcitx-chewing with fcitx on NixOS 20.09 on my laptop)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
