### PR TITLE
just: fix Darwin build

### DIFF
--- a/pkgs/development/tools/just/default.nix
+++ b/pkgs/development/tools/just/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPlatform, coreutils, bash, installShellFiles }:
+{ lib, fetchFromGitHub, stdenv, rustPlatform, coreutils, bash, installShellFiles, libiconv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "just";
@@ -14,6 +14,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-YDIGZRbszhgWM7iAc2i89jyndZvZZsg63ADQfqFxfXw=";
 
   nativeBuildInputs = [ installShellFiles ];
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 
   postInstall = ''
     installManPage man/just.1


### PR DESCRIPTION
###### Motivation for this change

Looks like following the [upgrade to `just` 0.9](https://github.com/NixOS/nixpkgs/pull/119943) it fails to build on macOS due to new dependency `libiconv`.

```sh
   Compiling just v0.9.0 (/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-just-0.9.0.drv-0/source)
error: linking with `/nix/store/2pb1r2zgw6yiabv4v3d4j66d3vwgdd5q-clang-wrapper-7.1.0/bin/cc` failed: exit code: 1
  |
  = note: "/nix/store/2pb1r2zgw6yiabv4v3d4j66d3vwgdd5q-clang-wrapper-7.1.0/bin/cc" "-m64" "-arch" "x86_64" "-L" "/nix/store/akm781c35gr7mb14g5h0kqlk3cvyzmij-rustc-1.51.0/lib/rustlib/x86_64-apple-darwin/lib" "/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-just-0.9.0.drv-0/source/target/x86_64-apple-darwin/release/deps/just.just.5y0vo6mm-cgu.1.rcgu.o" "-o" "/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-just-0.9.0.drv-0/source/target/x86_64-apple-darwin/release/deps/just" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-just-0.9.0.drv-0/source/target/x86_64-apple-darwin/release/deps" "-L" "/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-just-0.9.0.drv-0/source/target/release/deps" "-L" "/nix/store/akm781c35gr7mb14g5h0kqlk3cvyzmij-rustc-1.51.0/lib/rustlib/x86_64-apple-darwin/lib" "/nix/store/akm781c35gr7mb14g5h0kqlk3cvyzmij-rustc-1.51.0/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-94ac56476cd78265.rlib" "-liconv" "-lSystem" "-lresolv" "-lc" "-lm"
  = note: ld: library not found for -liconv
          clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).