### PR TITLE
git-review: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/applications/version-management/git-review/default.nix
+++ b/pkgs/applications/version-management/git-review/default.nix
@@ -1,8 +1,14 @@
-{ lib, fetchurl, buildPythonApplication, pbr, requests, setuptools }:
+{ lib
+, fetchurl
+, buildPythonApplication
+, pbr
+, requests
+, setuptools
+}:
 
 buildPythonApplication rec {
   pname = "git-review";
-  version = "2.0.0";
+  version = "2.1.0";
 
   # Manually set version because prb wants to get it from the git
   # upstream repository (and we are installing from tarball instead)
@@ -10,17 +16,28 @@ buildPythonApplication rec {
 
   src = fetchurl {
     url = "https://opendev.org/opendev/${pname}/archive/${version}.tar.gz";
-    sha256 = "0dkyd5g2xmvsa114is3cd9qmki3hi6c06wjnra0f4xq3aqm0ajnj";
+    hash = "sha256-3A1T+/iXhNeMS2Aww5jISoiNExdv9N9/kwyATSuwVTE=";
   };
 
-  propagatedBuildInputs = [ pbr requests setuptools ];
+  nativeBuildInputs = [
+    pbr
+  ];
 
-  # Don't do tests because they require gerrit which is not packaged
+  propagatedBuildInputs = [
+    requests
+    setuptools # implicit dependency, used to get package version through pkg_resources
+  ];
+
+  # Don't run tests because they pull in external dependencies
+  # (a specific build of gerrit + maven plugins), and I haven't figured
+  # out how to work around this yet.
   doCheck = false;
 
+  pythonImportsCheck = [ "git_review" ];
+
   meta = with lib; {
-    homepage = "https://opendev.org/opendev/git-review";
     description = "Tool to submit code to Gerrit";
+    homepage = "https://opendev.org/opendev/git-review";
     license = licenses.asl20;
     maintainers = with maintainers; [ metadark ];
   };


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://pypi.org/project/git-review/2.1.0/#history

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).