### PR TITLE
treewide: revert auto disk sizing for images

### DIFF
--- a/nixos/maintainers/scripts/cloudstack/cloudstack-image.nix
+++ b/nixos/maintainers/scripts/cloudstack/cloudstack-image.nix
@@ -10,6 +10,7 @@ with lib;
 
   system.build.cloudstackImage = import ../../../lib/make-disk-image.nix {
     inherit lib config pkgs;
+    diskSize = 8192;
     format = "qcow2";
     configFile = pkgs.writeText "configuration.nix"
       ''

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -41,8 +41,7 @@ in {
 
     sizeMB = mkOption {
       type = with types; either (enum [ "auto" ]) int;
-      # TODO(lukegb): this should be "auto"; see #120473
-      default = if config.ec2.hvm then 2048 else 8192;
+      default = "auto";
       example = 8192;
       description = "The size in MB of the image";
     };

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -40,9 +40,8 @@ in {
     };
 
     sizeMB = mkOption {
-      type = with types; either (enum [ "auto" ]) int;
-      default = "auto";
-      example = 8192;
+      type = types.int;
+      default = if config.ec2.hvm then 2048 else 8192;
       description = "The size in MB of the image";
     };
 

--- a/nixos/maintainers/scripts/openstack/openstack-image.nix
+++ b/nixos/maintainers/scripts/openstack/openstack-image.nix
@@ -12,8 +12,8 @@ with lib;
 
   system.build.openstackImage = import ../../../lib/make-disk-image.nix {
     inherit lib config;
-    additionalSpace = "1024M";
     pkgs = import ../../../.. { inherit (pkgs) system; }; # ensure we use the regular qemu-kvm package
+    diskSize = 8192;
     format = "qcow2";
     configFile = pkgs.writeText "configuration.nix"
       ''

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -9,9 +9,8 @@ in
 
   options = {
     virtualisation.azureImage.diskSize = mkOption {
-      type = with types; either (enum [ "auto" ]) int;
-      default = "auto";
-      example = 2048;
+      type = with types; int;
+      default = 2048;
       description = ''
         Size of disk image. Unit is MB.
       '';

--- a/nixos/modules/virtualisation/digital-ocean-image.nix
+++ b/nixos/modules/virtualisation/digital-ocean-image.nix
@@ -10,9 +10,8 @@ in
 
   options = {
     virtualisation.digitalOceanImage.diskSize = mkOption {
-      type = with types; either (enum [ "auto" ]) int;
-      default = "auto";
-      example = 4096;
+      type = with types; int;
+      default = 4096;
       description = ''
         Size of disk image. Unit is MB.
       '';

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -18,9 +18,8 @@ in
 
   options = {
     virtualisation.googleComputeImage.diskSize = mkOption {
-      type = with types; either (enum [ "auto" ]) int;
-      default = "auto";
-      example = 1536;
+      type = with types; int;
+      default = 1536;
       description = ''
         Size of disk image. Unit is MB.
       '';

--- a/nixos/modules/virtualisation/hyperv-image.nix
+++ b/nixos/modules/virtualisation/hyperv-image.nix
@@ -9,9 +9,8 @@ in {
   options = {
     hyperv = {
       baseImageSize = mkOption {
-        type = with types; either (enum [ "auto" ]) int;
-        default = "auto";
-        example = 2048;
+        type = types.int;
+        default = 2048;
         description = ''
           The size of the hyper-v base image in MiB.
         '';

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -11,9 +11,8 @@ in {
   options = {
     virtualbox = {
       baseImageSize = mkOption {
-        type = with types; either (enum [ "auto" ]) int;
-        default = "auto";
-        example = 50 * 1024;
+        type = types.int;
+        default = 50 * 1024;
         description = ''
           The size of the VirtualBox base image in MiB.
         '';

--- a/nixos/modules/virtualisation/vmware-image.nix
+++ b/nixos/modules/virtualisation/vmware-image.nix
@@ -18,9 +18,8 @@ in {
   options = {
     vmware = {
       baseImageSize = mkOption {
-        type = with types; either (enum [ "auto" ]) int;
-        default = "auto";
-        example = 2048;
+        type = types.int;
+        default = 2048;
         description = ''
           The size of the VMWare base image in MiB.
         '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Auto sizing of disk images currently doesn't quite work properly on filesystems where files can take *less* size than their contents, such as zfs with transparent compression enabled.

This includes the Packet Hydra builders, and, as a result, will cause sporadic build failures until the underlying calculation is fixed.

Reverts #120481, which did this only for EC2.
Reverts #107212.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
