### PR TITLE
common-updater-scripts: Support flake-compat repos

### DIFF
--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -99,11 +99,10 @@ if [[ -z "$oldUrl" ]]; then
     die "Couldn't evaluate source url from '$attr.src'!"
 fi
 
-drvName=$(nix-instantiate $systemArg --eval -E "with import ./. {}; lib.getName $attr" | tr -d '"')
-oldVersion=$(nix-instantiate $systemArg --eval -E "with import ./. {}; $attr.${versionKey} or (lib.getVersion $attr)" | tr -d '"')
+oldVersion=$(nix-instantiate $systemArg --eval -E "with import ./. {}; $attr.${versionKey} or (builtins.parseDrvName $attr.name).version" | tr -d '"')
 
-if [[ -z "$drvName" || -z "$oldVersion" ]]; then
-    die "Couldn't evaluate name and version from '$attr.name'!"
+if [[ -z "$oldVersion" ]]; then
+    die "Couldn't find out the old version of '$attr'!"
 fi
 
 if [[ "$oldVersion" = "$newVersion" ]]; then

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -83,6 +83,14 @@ if [[ -z "$nixFile" ]]; then
     if [[ ! -f "$nixFile" ]]; then
         die "Couldn't evaluate '$attr.meta.position' to locate the .nix file!"
     fi
+
+    # flake-compat will return paths in the Nix store, we need to correct for that.
+    possiblyOutPath=$(nix-instantiate $systemArg --eval -E "with $importTree; outPath" | tr -d '"')
+    if [[ -n "$possiblyOutPath" ]]; then
+        outPathEscaped=$(echo "$possiblyOutPath" | sed 's#[$^*\\.[|]#\\&#g')
+        pwdEscaped=$(echo "$PWD" | sed 's#[$^*\\.[|]#\\&#g')
+        nixFile=$(echo "$nixFile" | sed "s|^$outPathEscaped|$pwdEscaped|")
+    fi
 fi
 
 oldHashAlgo=$(nix-instantiate $systemArg --eval --strict -A "$attr.src.drvAttrs.outputHashAlgo" | tr -d '"')

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -59,6 +59,9 @@ newVersion=${args[1]}
 newHash=${args[2]}
 newUrl=${args[3]}
 
+# Third-party repositories might not accept arguments in their default.nix.
+importTree="(let tree = import ./.; in if builtins.isFunction tree then tree {} else tree)"
+
 if (( "${#args[*]}" < 2 )); then
     echo "$scriptName: Too few arguments"
     usage
@@ -93,13 +96,13 @@ if [[ $(grep --count "$oldHash" "$nixFile") != 1 ]]; then
     die "Couldn't locate old source hash '$oldHash' (or it appeared more than once) in '$nixFile'!"
 fi
 
-oldUrl=$(nix-instantiate $systemArg --eval -E "with import ./. {}; builtins.elemAt ($attr.src.drvAttrs.urls or [ $attr.src.url ]) 0" | tr -d '"')
+oldUrl=$(nix-instantiate $systemArg --eval -E "with $importTree; builtins.elemAt ($attr.src.drvAttrs.urls or [ $attr.src.url ]) 0" | tr -d '"')
 
 if [[ -z "$oldUrl" ]]; then
     die "Couldn't evaluate source url from '$attr.src'!"
 fi
 
-oldVersion=$(nix-instantiate $systemArg --eval -E "with import ./. {}; $attr.${versionKey} or (builtins.parseDrvName $attr.name).version" | tr -d '"')
+oldVersion=$(nix-instantiate $systemArg --eval -E "with $importTree; $attr.${versionKey} or (builtins.parseDrvName $attr.name).version" | tr -d '"')
 
 if [[ -z "$oldVersion" ]]; then
     die "Couldn't find out the old version of '$attr'!"
@@ -114,7 +117,7 @@ if [[ "$oldVersion" = "$newVersion" ]]; then
 fi
 
 if [[ -n "$newRevision" ]]; then
-    oldRevision=$(nix-instantiate $systemArg --eval -E "with import ./. {}; $attr.src.rev" | tr -d '"')
+    oldRevision=$(nix-instantiate $systemArg --eval -E "with $importTree; $attr.src.rev" | tr -d '"')
     if [[ -z "$oldRevision" ]]; then
         die "Couldn't evaluate source revision from '$attr.src'!"
     fi

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -19,6 +19,7 @@ args=()
 for arg in "$@"; do
     case $arg in
         --system=*)
+            system="${arg#*=}"
             systemArg="--system ${arg#*=}"
         ;;
         --version-key=*)
@@ -76,6 +77,26 @@ fi
 
 if [[ -z "$versionKey" ]]; then
     versionKey=version
+fi
+
+# Allow finding packages among flake outputs in repos using flake-compat.
+pname=$(nix-instantiate $systemArg --eval --strict -A "$attr.name" || echo)
+if [[ -z "$pname" ]]; then
+    if [[ -z "$system" ]]; then
+        system=$(nix-instantiate --eval -E 'builtins.currentSystem' | tr -d '"')
+    fi
+
+    pname=$(nix-instantiate $systemArg --eval --strict -A "packages.$system.$attr.name" || echo)
+    if [[ -n "$pname" ]]; then
+        attr="packages.$system.$attr"
+    else
+        pname=$(nix-instantiate $systemArg --eval --strict -A "legacyPackages.$system.$attr.name" || echo)
+        if [[ -n "$pname" ]]; then
+            attr="legacyPackages.$system.$attr"
+        else
+            die "Could not find attribute '$attr'!"
+        fi
+    fi
 fi
 
 if [[ -z "$nixFile" ]]; then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
