### PR TITLE
python3Packages.survey: 3.4.2 -> 3.4.3

### DIFF
--- a/pkgs/development/python-modules/survey/default.nix
+++ b/pkgs/development/python-modules/survey/default.nix
@@ -1,16 +1,19 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchPypi
 , wrapio
 }:
 
 buildPythonPackage rec {
   pname = "survey";
-  version = "3.4.2";
+  version = "3.4.3";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-aF7ZS5oxeIOb7mJsrusdc3HefcPE+3OTXcJB/pjJxFY=";
+    sha256 = "sha256-TK89quY3bpNIEz1n3Ecew4FnTH6QgeSLdDNV86gq7+I=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Bugfix release.
Also add version constraint as listed on PyPi.

###### Things done

```
$ nixpkgs-review wip
[...]
6 packages updated:
maestral maestral-qt python3.8-maestral python38Packages.survey (3.4.2 → 3.4.3) python3.9-maestral python39Packages.survey (3.4.2 → 3.4.3)
[...]
5 packages built:
maestral maestral-gui python38Packages.survey python39Packages.maestral python39Packages.survey
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
