### PR TITLE
Add VLS (new Vue language server) as a new node package

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -252,6 +252,7 @@
 , "vega-cli"
 , "vega-lite"
 , "vim-language-server"
+, "vls"
 , "vscode-css-languageserver-bin"
 , "vscode-html-languageserver-bin"
 , "vscode-json-languageserver"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -49,13 +49,22 @@ let
         sha512 = "o/xdK8b4P0t/xpCARgWXAeaiWeh9jeua6bP1jrcbfN39+Z4zC4x2jg4NysHNhz6spRG8dJFH3kJIUoIbs0Ckww==";
       };
     };
-    "@angular-devkit/architect-0.1102.9" = {
+    "@angular-devkit/architect-0.1102.10" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.1102.9";
+      version = "0.1102.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1102.9.tgz";
-        sha512 = "AU7i0VqWUwBc04oyT98Pp6sMDMp67JTZd/Cfrz5AM4MqrCZsDJMsTlWH26fAbESSLHgNst7H91Eq0cnC8rCmOQ==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1102.10.tgz";
+        sha512 = "jb/Df6l7XHU7b2hu5gG1WItMo9cDjrqY0i6UzntUQ/QsSMqbnU6yWoRT6orLgN9tGdA4AjIyv+9mfMXHwM2maw==";
+      };
+    };
+    "@angular-devkit/core-11.2.10" = {
+      name = "_at_angular-devkit_slash_core";
+      packageName = "@angular-devkit/core";
+      version = "11.2.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.10.tgz";
+        sha512 = "3QBluhsnXsntbl0ybHuXtuH/HBChqibXKmzrENj2n+SKlHFOYhE9PJCSfE6q1kwKN+zg6avOETVziI2pP5xtJQ==";
       };
     };
     "@angular-devkit/core-11.2.4" = {
@@ -76,13 +85,13 @@ let
         sha512 = "3dA0Z6sIIxCDjZS/DucgmIKti7EZ/LgHoHgCO72Q50H5ZXbUSNBz5wGl5hVq2+gzrnFgU/0u40MIs6eptk30ZA==";
       };
     };
-    "@angular-devkit/core-11.2.9" = {
-      name = "_at_angular-devkit_slash_core";
-      packageName = "@angular-devkit/core";
-      version = "11.2.9";
+    "@angular-devkit/schematics-11.2.10" = {
+      name = "_at_angular-devkit_slash_schematics";
+      packageName = "@angular-devkit/schematics";
+      version = "11.2.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.9.tgz";
-        sha512 = "TqihgUEKjX4C1hSd8RgUyCwuezFRdput9Ctcq8c4VgOcseEnXq3BkCSJbXtUh4Fln8WPxM7WHM8HClcWya/41g==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.10.tgz";
+        sha512 = "T1V6mCwc2GYKAWMtCy2HaCxLw1kydu36tGV+dKjKHEwE+8cDgRRT5FhQ+XZzehVDeK9GvDu8Znur1F6i/WmKgw==";
       };
     };
     "@angular-devkit/schematics-11.2.4" = {
@@ -101,15 +110,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.6.tgz";
         sha512 = "bhi2+5xtVAjtr3bsXKT8pnoBamQrArd/Y20ueA4Od7cd38YT97nzTA1wyHBFG0vWd0HMyg42ZS0aycNBuOebaA==";
-      };
-    };
-    "@angular-devkit/schematics-11.2.9" = {
-      name = "_at_angular-devkit_slash_schematics";
-      packageName = "@angular-devkit/schematics";
-      version = "11.2.9";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.9.tgz";
-        sha512 = "NqcBMK9ZbfXykj+2/cSlZcLVmbep/N+yYb+dUSfvRup3rW3uYSpMMJAnys3ro0m7TnUrI7h7t0UTgX8oxjlCow==";
       };
     };
     "@angular-devkit/schematics-cli-0.1102.6" = {
@@ -238,22 +238,22 @@ let
         sha512 = "QdwOGF1+eeyFh+17v2Tz626WX0nucd1iKOm6JUTUvCZdbolblCOOQCxGrQPY0f7jEhn36PiAWqZnsC2r5vmUWg==";
       };
     };
-    "@apollo/protobufjs-1.0.5" = {
+    "@apollo/protobufjs-1.2.0" = {
       name = "_at_apollo_slash_protobufjs";
       packageName = "@apollo/protobufjs";
-      version = "1.0.5";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.5.tgz";
-        sha512 = "ZtyaBH1icCgqwIGb3zrtopV2D5Q8yxibkJzlaViM08eOhTQc7rACdYu0pfORFfhllvdMZ3aq69vifYHszY4gNA==";
+        url = "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.0.tgz";
+        sha512 = "TBgsADig/K4Hx71uQO6KPLxgoE/ORhPGh/HgouHru+cum8RLDfAfEY5Dde+cNala+luGI2X4Rs42pLWRud7/WA==";
       };
     };
-    "@apollographql/apollo-tools-0.4.9" = {
+    "@apollographql/apollo-tools-0.4.12" = {
       name = "_at_apollographql_slash_apollo-tools";
       packageName = "@apollographql/apollo-tools";
-      version = "0.4.9";
+      version = "0.4.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.9.tgz";
-        sha512 = "M50pk8oo3CGTu4waGOklIX3YtTZoPfWG9K/G9WB8NpyQGA1OwYTiBFv94XqUtKElTDoFwoMXpMQd3Wy5dINvxA==";
+        url = "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.12.tgz";
+        sha512 = "JdC7aBzMUO6SaGH5g6MvIG8TWd+7cU/G9cyjKS/woYVtqyICLamyG21R8SmjiBnd5c1UgPWOxjSIxYBL2ln8Mg==";
       };
     };
     "@apollographql/graphql-playground-html-1.6.27" = {
@@ -310,13 +310,13 @@ let
         sha1 = "e70187f8a862e191b1bce6c0268f13acd3a56b20";
       };
     };
-    "@babel/cli-7.13.14" = {
+    "@babel/cli-7.13.16" = {
       name = "_at_babel_slash_cli";
       packageName = "@babel/cli";
-      version = "7.13.14";
+      version = "7.13.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/cli/-/cli-7.13.14.tgz";
-        sha512 = "zmEFV8WBRsW+mPQumO1/4b34QNALBVReaiHJOkxhUsdo/AvYM62c+SKSuLi2aZ42t3ocK6OI0uwUXRvrIbREZw==";
+        url = "https://registry.npmjs.org/@babel/cli/-/cli-7.13.16.tgz";
+        sha512 = "cL9tllhqvsQ6r1+d9Invf7nNXg/3BlfL1vvvL/AdH9fZ2l5j0CeBcoq6UjsqHpvyN1v5nXSZgqJZoGeK+ZOAbw==";
       };
     };
     "@babel/code-frame-7.10.4" = {
@@ -364,13 +364,13 @@ let
         sha512 = "O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==";
       };
     };
-    "@babel/core-7.13.15" = {
+    "@babel/core-7.13.16" = {
       name = "_at_babel_slash_core";
       packageName = "@babel/core";
-      version = "7.13.15";
+      version = "7.13.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz";
-        sha512 = "6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==";
+        url = "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz";
+        sha512 = "sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==";
       };
     };
     "@babel/core-7.9.0" = {
@@ -382,13 +382,13 @@ let
         sha512 = "kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==";
       };
     };
-    "@babel/generator-7.13.9" = {
+    "@babel/generator-7.13.16" = {
       name = "_at_babel_slash_generator";
       packageName = "@babel/generator";
-      version = "7.13.9";
+      version = "7.13.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz";
-        sha512 = "mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==";
+        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz";
+        sha512 = "grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==";
       };
     };
     "@babel/helper-annotate-as-pure-7.12.13" = {
@@ -409,13 +409,13 @@ let
         sha512 = "CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==";
       };
     };
-    "@babel/helper-compilation-targets-7.13.13" = {
+    "@babel/helper-compilation-targets-7.13.16" = {
       name = "_at_babel_slash_helper-compilation-targets";
       packageName = "@babel/helper-compilation-targets";
-      version = "7.13.13";
+      version = "7.13.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz";
-        sha512 = "q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==";
+        url = "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz";
+        sha512 = "3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==";
       };
     };
     "@babel/helper-create-class-features-plugin-7.13.11" = {
@@ -472,13 +472,13 @@ let
         sha512 = "DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==";
       };
     };
-    "@babel/helper-hoist-variables-7.13.0" = {
+    "@babel/helper-hoist-variables-7.13.16" = {
       name = "_at_babel_slash_helper-hoist-variables";
       packageName = "@babel/helper-hoist-variables";
-      version = "7.13.0";
+      version = "7.13.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz";
-        sha512 = "0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==";
+        url = "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.16.tgz";
+        sha512 = "1eMtTrXtrwscjcAeO4BVK+vvkxaLJSPFz1w1KLawz6HLNi9bPFGBNwwDyVfiu1Tv/vRRFYfoGaKhmAQPGPn5Wg==";
       };
     };
     "@babel/helper-member-expression-to-functions-7.13.12" = {
@@ -607,13 +607,13 @@ let
         sha512 = "1UX9F7K3BS42fI6qd2A4BjKzgGjToscyZTdp1DjknHLCIvpgne6918io+aL5LXFcER/8QWiwpoY902pVEqgTXA==";
       };
     };
-    "@babel/helpers-7.13.10" = {
+    "@babel/helpers-7.13.17" = {
       name = "_at_babel_slash_helpers";
       packageName = "@babel/helpers";
-      version = "7.13.10";
+      version = "7.13.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz";
-        sha512 = "4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==";
+        url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz";
+        sha512 = "Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==";
       };
     };
     "@babel/highlight-7.13.10" = {
@@ -625,13 +625,13 @@ let
         sha512 = "5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==";
       };
     };
-    "@babel/parser-7.13.15" = {
+    "@babel/parser-7.13.16" = {
       name = "_at_babel_slash_parser";
       packageName = "@babel/parser";
-      version = "7.13.15";
+      version = "7.13.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz";
-        sha512 = "b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==";
+        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz";
+        sha512 = "6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==";
       };
     };
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12" = {
@@ -994,13 +994,13 @@ let
         sha512 = "zNyFqbc3kI/fVpqwfqkg6RvBgFpC4J18aKKMmv7KdQ/1GgREapSJAykLMVNwfRGO3BtHj3YQZl8kxCXPcVMVeg==";
       };
     };
-    "@babel/plugin-transform-block-scoping-7.12.13" = {
+    "@babel/plugin-transform-block-scoping-7.13.16" = {
       name = "_at_babel_slash_plugin-transform-block-scoping";
       packageName = "@babel/plugin-transform-block-scoping";
-      version = "7.12.13";
+      version = "7.13.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz";
-        sha512 = "Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.13.16.tgz";
+        sha512 = "ad3PHUxGnfWF4Efd3qFuznEtZKoBp0spS+DgqzVzRPV7urEBvPLue3y2j80w4Jf2YLzZHj8TOv/Lmvdmh3b2xg==";
       };
     };
     "@babel/plugin-transform-classes-7.13.0" = {
@@ -1021,13 +1021,13 @@ let
         sha512 = "RRqTYTeZkZAz8WbieLTvKUEUxZlUTdmL5KGMyZj7FnMfLNKV4+r5549aORG/mgojRmFlQMJDUupwAMiF2Q7OUg==";
       };
     };
-    "@babel/plugin-transform-destructuring-7.13.0" = {
+    "@babel/plugin-transform-destructuring-7.13.17" = {
       name = "_at_babel_slash_plugin-transform-destructuring";
       packageName = "@babel/plugin-transform-destructuring";
-      version = "7.13.0";
+      version = "7.13.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz";
-        sha512 = "zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.17.tgz";
+        sha512 = "UAUqiLv+uRLO+xuBKKMEpC+t7YRNVRqBsWWq1yKXbBZBje/t3IXCiSinZhjn/DC3qzBfICeYd2EFGEbHsh5RLA==";
       };
     };
     "@babel/plugin-transform-dotall-regex-7.12.13" = {
@@ -1426,22 +1426,22 @@ let
         sha512 = "LXJwxrHy0N3f6gIJlYbLta1D9BDtHpQeqwzM0LIfjDlr6UE/D5Mc7W4iDiQzaE+ks0sTjT26ArcHWnJVt0QiHw==";
       };
     };
-    "@babel/register-7.13.14" = {
+    "@babel/register-7.13.16" = {
       name = "_at_babel_slash_register";
       packageName = "@babel/register";
-      version = "7.13.14";
+      version = "7.13.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/register/-/register-7.13.14.tgz";
-        sha512 = "iyw0hUwjh/fzN8qklVqZodbyWjEBOG0KdDnBOpv3zzIgK3NmuRXBmIXH39ZBdspkn8LTHvSboN+oYb4MT43+9Q==";
+        url = "https://registry.npmjs.org/@babel/register/-/register-7.13.16.tgz";
+        sha512 = "dh2t11ysujTwByQjXNgJ48QZ2zcXKQVdV8s0TbeMI0flmtGWCdTwK9tJiACHXPLmncm5+ktNn/diojA45JE4jg==";
       };
     };
-    "@babel/runtime-7.13.10" = {
+    "@babel/runtime-7.13.17" = {
       name = "_at_babel_slash_runtime";
       packageName = "@babel/runtime";
-      version = "7.13.10";
+      version = "7.13.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz";
-        sha512 = "4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==";
+        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz";
+        sha512 = "NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==";
       };
     };
     "@babel/runtime-7.13.9" = {
@@ -1462,22 +1462,22 @@ let
         sha512 = "cTIudHnzuWLS56ik4DnRnqqNf8MkdUzV4iFFI1h7Jo9xvrpQROYaAnaSd2mHLQAzzZAPfATynX5ord6YlNYNMA==";
       };
     };
-    "@babel/runtime-corejs3-7.13.10" = {
+    "@babel/runtime-corejs3-7.13.17" = {
       name = "_at_babel_slash_runtime-corejs3";
       packageName = "@babel/runtime-corejs3";
-      version = "7.13.10";
+      version = "7.13.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz";
-        sha512 = "x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==";
+        url = "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.17.tgz";
+        sha512 = "RGXINY1YvduBlGrP+vHjJqd/nK7JVpfM4rmZLGMx77WoL3sMrhheA0qxii9VNn1VHnxJLEyxmvCB+Wqc+x/FMw==";
       };
     };
-    "@babel/standalone-7.13.15" = {
+    "@babel/standalone-7.13.17" = {
       name = "_at_babel_slash_standalone";
       packageName = "@babel/standalone";
-      version = "7.13.15";
+      version = "7.13.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/standalone/-/standalone-7.13.15.tgz";
-        sha512 = "gKEx9cfMLJegKYYVnI1/4swITcWQa2/e0HlAU9S/+h94xGdyXtoYVQiz8gcXabQ/8MMlOwGclkRoTL3cAxplZg==";
+        url = "https://registry.npmjs.org/@babel/standalone/-/standalone-7.13.17.tgz";
+        sha512 = "Y9P198T45MIIu+AvGOCcjsdKl79+BCL2nA+6ODA5p/DhGzymvzaTgtzvNcjZDcJmbPszcmohjLLgvma3tmvVtg==";
       };
     };
     "@babel/template-7.12.13" = {
@@ -1489,22 +1489,22 @@ let
         sha512 = "/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==";
       };
     };
-    "@babel/traverse-7.13.15" = {
+    "@babel/traverse-7.13.17" = {
       name = "_at_babel_slash_traverse";
       packageName = "@babel/traverse";
-      version = "7.13.15";
+      version = "7.13.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz";
-        sha512 = "/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==";
+        url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz";
+        sha512 = "BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==";
       };
     };
-    "@babel/types-7.13.14" = {
+    "@babel/types-7.13.17" = {
       name = "_at_babel_slash_types";
       packageName = "@babel/types";
-      version = "7.13.14";
+      version = "7.13.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz";
-        sha512 = "A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==";
+        url = "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz";
+        sha512 = "RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==";
       };
     };
     "@braintree/sanitize-url-3.1.0" = {
@@ -1570,13 +1570,13 @@ let
         sha512 = "htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==";
       };
     };
-    "@cdktf/hcl2json-0.2.2" = {
+    "@cdktf/hcl2json-0.3.0" = {
       name = "_at_cdktf_slash_hcl2json";
       packageName = "@cdktf/hcl2json";
-      version = "0.2.2";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@cdktf/hcl2json/-/hcl2json-0.2.2.tgz";
-        sha512 = "C/IOl8ARTRiafC9mdZiIuJbqys6LRmaVM/grux7OASkVbkyYy2RHKPVXRBsD5mtfLBXQaL/NGjLLJ4aSC7jFZQ==";
+        url = "https://registry.npmjs.org/@cdktf/hcl2json/-/hcl2json-0.3.0.tgz";
+        sha512 = "iZ5eKhlZSpoWM0+ULUEkxY+qzBGhr3EVkXoYdUbNf/nPx8bd2Qqgk87x4uvqFK8+uNMuINR0HCbCdHFgkfho4A==";
       };
     };
     "@chemzqm/neovim-5.2.13" = {
@@ -2011,22 +2011,22 @@ let
         sha512 = "Ydf4LidRB/EBI+YrB+cVLqIseiRfjUI/AeHBgjGMtq3GroraDu81OV7zqophRgupngoL3iS3JUMDMnxO7g39qA==";
       };
     };
-    "@expo/config-3.3.36" = {
+    "@expo/config-3.3.38" = {
       name = "_at_expo_slash_config";
       packageName = "@expo/config";
-      version = "3.3.36";
+      version = "3.3.38";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/config/-/config-3.3.36.tgz";
-        sha512 = "qUaq3Ct3O2uML3ISsjekol3UNTQUvJm2AMrRjlwYXHzxG2EVIHNaWseOZoFtXxrfAj3IqWXEtS9avfho+nbgBg==";
+        url = "https://registry.npmjs.org/@expo/config/-/config-3.3.38.tgz";
+        sha512 = "0SsvF7yTy+kdJaAc2W75yhwnaXIRasnA1Vygna83tlPhCx6ynIBzTbJAvdkddSk5euUTJpXc5nePaflGvNboXw==";
       };
     };
-    "@expo/config-plugins-1.0.26" = {
+    "@expo/config-plugins-1.0.28" = {
       name = "_at_expo_slash_config-plugins";
       packageName = "@expo/config-plugins";
-      version = "1.0.26";
+      version = "1.0.28";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.26.tgz";
-        sha512 = "zfdNL7FgM2yCYSX0sq7PUkcE9pk+w6GfgCnnXuYH5JOOi2UYtiOu0FgYc0M+ZmUlhNkTtiBZDt8aPGcikopwpw==";
+        url = "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.28.tgz";
+        sha512 = "i5SpC6U3LjRQlwi1xM4SRj8dR2Qm+0dykPo0GeesByB7IvT36AT1ZjI7VjecuoZ6yKbLpaa5tWvU3JGObxIPSw==";
       };
     };
     "@expo/config-types-40.0.0-beta.2" = {
@@ -2047,22 +2047,22 @@ let
         sha512 = "HsukM03X5/EXSucVsLN/oLqyFq/1jAjpADkgU1HLaezFpkr+TOquI6yDwdDp1450kcm891PE/SYJ+mCdPxzDLw==";
       };
     };
-    "@expo/dev-server-0.1.62" = {
+    "@expo/dev-server-0.1.64" = {
       name = "_at_expo_slash_dev-server";
       packageName = "@expo/dev-server";
-      version = "0.1.62";
+      version = "0.1.64";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.1.62.tgz";
-        sha512 = "ZNBQI/Q9Di19TjU7QT2lNxT+VEf8Aq6puwCNVQx2ohdKQjqh4+YSlvvChXY+x25SG1CorWc8SfLjTtXnIcheJg==";
+        url = "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.1.64.tgz";
+        sha512 = "6yRkV0qVyz0bZsfPkpPsDRmMIHQQ9Lw3Nn5BAgCNvo7SzjINeNfcpWJXvwcxrU76kKUS+r5NaXNCRlDUkqGTHg==";
       };
     };
-    "@expo/dev-tools-0.13.92" = {
+    "@expo/dev-tools-0.13.94" = {
       name = "_at_expo_slash_dev-tools";
       packageName = "@expo/dev-tools";
-      version = "0.13.92";
+      version = "0.13.94";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/dev-tools/-/dev-tools-0.13.92.tgz";
-        sha512 = "Fu5Bw5lk3Pl1aj9XMOSNP8trzksrmb4w969qiBzCGxVrrSql93xBPDwpd40oOiAesk+X7Qg6eF/IIJpYNfgUCg==";
+        url = "https://registry.npmjs.org/@expo/dev-tools/-/dev-tools-0.13.94.tgz";
+        sha512 = "T3jIIGB1yLk+1JVcOG3VJI5CTFcOoWEOT4e0/3hONp6CnDQG0L2qpuzd4ypWO411iZ5q3aCyYKNN10AIEZLqzA==";
       };
     };
     "@expo/devcert-1.0.0" = {
@@ -2074,49 +2074,49 @@ let
         sha512 = "cahGyQCmpZmHpn2U04NR9KwsOIZy7Rhsw8Fg4q+A6563lIJxbkrgPnxq/O3NQAh3ohEvOXOOnoFx0b4yycCkpQ==";
       };
     };
-    "@expo/image-utils-0.3.12" = {
+    "@expo/image-utils-0.3.13" = {
       name = "_at_expo_slash_image-utils";
       packageName = "@expo/image-utils";
-      version = "0.3.12";
+      version = "0.3.13";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.12.tgz";
-        sha512 = "QMMAjyCJUFXI8b6AOrVC40gubkt++qYfRJdKgbegf9JHQNul/O4Q1ENWTgid+PH0EUqlMLbv6kJ6ai0ZjO08kw==";
+        url = "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.13.tgz";
+        sha512 = "BpKoFVJBjG9H5AU040Skrm3R2uDGpWXBU/4TivB5H10cyJphoJKp3GNJVPHYLOVc70OtAxjWDIhLMW6xsWfrgw==";
       };
     };
-    "@expo/json-file-8.2.28" = {
+    "@expo/json-file-8.2.29" = {
       name = "_at_expo_slash_json-file";
       packageName = "@expo/json-file";
-      version = "8.2.28";
+      version = "8.2.29";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.28.tgz";
-        sha512 = "C28McDuCIOmCmp6e2ZgIpNaT/fZG+L3/WFv5x2DCrooOQmamrkLSH/4Dib0NUmLgWVhgIhXL2hU4RB+LjzVvkQ==";
+        url = "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.29.tgz";
+        sha512 = "9C8XwpJiJN9fyClnnNDSTh034zJU9hon6MCUqbBa4dZYQN7OZ00KFZEpbtjy+FndE7YD+KagDxRD6O1HS5vU0g==";
       };
     };
-    "@expo/metro-config-0.1.62" = {
+    "@expo/metro-config-0.1.64" = {
       name = "_at_expo_slash_metro-config";
       packageName = "@expo/metro-config";
-      version = "0.1.62";
+      version = "0.1.64";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.1.62.tgz";
-        sha512 = "CvEtzryyLCDky9faY0/+rilkF4wS/KlbdtCbRk5esu5eH3dc0hztEap6TrIP4axQJ481uHRxy/dN2FBivQfLdg==";
+        url = "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.1.64.tgz";
+        sha512 = "ooD+XOVGnKPIIZbyfVTvMeQ3p9HpRt4aNCehSM6H1ueQm8+IpVwrhw8sJjL5xr+FVxFqj0+Ga9DI8d0AXS8U4g==";
       };
     };
-    "@expo/osascript-2.0.25" = {
+    "@expo/osascript-2.0.26" = {
       name = "_at_expo_slash_osascript";
       packageName = "@expo/osascript";
-      version = "2.0.25";
+      version = "2.0.26";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/osascript/-/osascript-2.0.25.tgz";
-        sha512 = "rB+RLHCp72q0OBWmisoBswfTpyzc91OJMs3UQVWJP9mXVNJhemONt7PKjE+FinBm33uH1HCC6U7JPGigpVsJBg==";
+        url = "https://registry.npmjs.org/@expo/osascript/-/osascript-2.0.26.tgz";
+        sha512 = "DJXmVZsAbScxQ3sfSFQrLERwsmJ4x/Tk8yXmtJZKqO4hplcGa2xLwjKUEh8nSRV5RX/v40yWr9J7aK5cHxTy0A==";
       };
     };
-    "@expo/package-manager-0.0.40" = {
+    "@expo/package-manager-0.0.41" = {
       name = "_at_expo_slash_package-manager";
       packageName = "@expo/package-manager";
-      version = "0.0.40";
+      version = "0.0.41";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/package-manager/-/package-manager-0.0.40.tgz";
-        sha512 = "JE5i/IYQ7ActzugX1MgzK5vUjAJHtEm+btEyNtZyf8SQKOlk+DMeSUdQuC6h07IgTlFIfqFiw1O8GW/x8RD77A==";
+        url = "https://registry.npmjs.org/@expo/package-manager/-/package-manager-0.0.41.tgz";
+        sha512 = "QkKH2AIwbw3wdmkZpw9DwFBQn1E3w/oDKfwPxFXtrwi+7OWonJXzkmYnj26KnVkh4Ajzu7Cwj/zTQ5aBrhwDfw==";
       };
     };
     "@expo/plist-0.0.12" = {
@@ -2137,13 +2137,13 @@ let
         sha512 = "qECzzXX5oJot3m2Gu9pfRDz50USdBieQVwYAzeAtQRUTD3PVeTK1tlRUoDcrK8PSruDLuVYdKkLebX4w/o55VA==";
       };
     };
-    "@expo/schemer-1.3.27" = {
+    "@expo/schemer-1.3.28" = {
       name = "_at_expo_slash_schemer";
       packageName = "@expo/schemer";
-      version = "1.3.27";
+      version = "1.3.28";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/schemer/-/schemer-1.3.27.tgz";
-        sha512 = "cuCvSo6qErgK7OOM8CoCtCsVifq+WX1wUCeu+fmSyhnZcqnz45ZTK20Ghk5bT3OrTNQipbTiCjn9RCDrkEMMkg==";
+        url = "https://registry.npmjs.org/@expo/schemer/-/schemer-1.3.28.tgz";
+        sha512 = "9wmnhlD1X1ro8FTFzM/J3nSxaFpI9X+bcaimP3hKkc3flIR8cGjQcLmE+MOEgE2LET0ScxRBtM3hteernFI6Ww==";
       };
     };
     "@expo/simple-spinner-1.0.2" = {
@@ -2164,13 +2164,13 @@ let
         sha512 = "LB7jWkqrHo+5fJHNrLAFdimuSXQ2MQ4lA7SQW5bf/HbsXuV2VrT/jN/M8f/KoWt0uJMGN4k/j7Opx4AvOOxSew==";
       };
     };
-    "@expo/webpack-config-0.12.66" = {
+    "@expo/webpack-config-0.12.68" = {
       name = "_at_expo_slash_webpack-config";
       packageName = "@expo/webpack-config";
-      version = "0.12.66";
+      version = "0.12.68";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-0.12.66.tgz";
-        sha512 = "8U3m44Q2VMmoOl9Gw9djOsdCIX5yT8yD5ZnVyfyQHMGILz9uXkqn3kM0QNFFWhT8TZN/zCP6YkmYrH8yL3rTkg==";
+        url = "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-0.12.68.tgz";
+        sha512 = "GS15Vd/VkaITWnQYe4qROGHi95R6HF8x8vDZ1msxfYEVSjdXMU9eo8BPiyTtLTIAaCyNUQEOX5N+91mKHXJPeQ==";
       };
     };
     "@expo/xcpretty-2.0.0" = {
@@ -2218,13 +2218,13 @@ let
         sha512 = "XqPS7l3YoMwxdNlaYF6S2Mp0K3FmVIOIy2K3YkMc+eRxu9wFK6emr2Q/3rBhtG5u/On37NExRT7/5CTLnoi9gw==";
       };
     };
-    "@fluentui/keyboard-key-0.2.16" = {
+    "@fluentui/keyboard-key-0.2.17" = {
       name = "_at_fluentui_slash_keyboard-key";
       packageName = "@fluentui/keyboard-key";
-      version = "0.2.16";
+      version = "0.2.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.16.tgz";
-        sha512 = "T4eQ0uqhbTScsoXVx10Tlp0C2RgNdAzlbe52qJ0Tn288/Nuztda5Z/aTCRd5Rp5MRYBycjAf4iNot6ZHAP864g==";
+        url = "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.17.tgz";
+        sha512 = "iT1bU56rKrKEOfODoW6fScY11qj3iaYrZ+z11T6fo5+TDm84UGkkXjLXJTE57ZJzg0/gbccHQWYv+chY7bJN8Q==";
       };
     };
     "@fluentui/react-7.168.0" = {
@@ -2398,13 +2398,13 @@ let
         sha512 = "ZY76hmcJlF1iyg3Im0sQ3ASRkiShjgv102vLTVcH22lEGJeCaCyyS/GF1eUHom418S60bS8Th6+autRUxfBiBg==";
       };
     };
-    "@graphql-tools/url-loader-6.8.2" = {
+    "@graphql-tools/url-loader-6.8.3" = {
       name = "_at_graphql-tools_slash_url-loader";
       packageName = "@graphql-tools/url-loader";
-      version = "6.8.2";
+      version = "6.8.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.8.2.tgz";
-        sha512 = "YzsXSCOwlSj8UqOMhQThPzgEChgS/MonyWV7f0WKmN9gAT/f3fPaUcYhVamsH0vGbvTkfNM4JdoZO/39amRs5Q==";
+        url = "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.8.3.tgz";
+        sha512 = "X1IxyURTbynqBPBJJeSW3hvvc+Pgw/P5IpT/yyTkA7utjRRiNCaGdLbBQO5MaXvD1HpVzBiMgdKG8v7Um3ft7w==";
       };
     };
     "@graphql-tools/utils-6.2.4" = {
@@ -3109,13 +3109,13 @@ let
         sha512 = "4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==";
       };
     };
-    "@jsii/spec-1.28.0" = {
+    "@jsii/spec-1.29.0" = {
       name = "_at_jsii_slash_spec";
       packageName = "@jsii/spec";
-      version = "1.28.0";
+      version = "1.29.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@jsii/spec/-/spec-1.28.0.tgz";
-        sha512 = "5mcupuCCXyhZwNmX/RDBn3WUYtd0oPXEDa3E+qOSjT30vaO8u9ZQ+mxwl4qsecx3m51LhXKnR1C9U9t4VlAmqA==";
+        url = "https://registry.npmjs.org/@jsii/spec/-/spec-1.29.0.tgz";
+        sha512 = "Y0ouCaYVPy7KjQ8di6Hu4xizKYp4klqqDf08BaEgqd38TzqBuO0abgcd9OJFUQyoDnCCWTdGBfqTo2xfvW9Pbw==";
       };
     };
     "@kwsites/file-exists-1.1.1" = {
@@ -3694,13 +3694,13 @@ let
         sha512 = "7AQsO0hMmpqDledV7AhBuSYqYPFsKP9PaltMecX9nlnsyFxqtsqUg9/pvB2L/jxvskrDrNkdKYz2KTbQznCtng==";
       };
     };
-    "@mdn/browser-compat-data-3.1.3" = {
+    "@mdn/browser-compat-data-3.2.4" = {
       name = "_at_mdn_slash_browser-compat-data";
       packageName = "@mdn/browser-compat-data";
-      version = "3.1.3";
+      version = "3.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.1.3.tgz";
-        sha512 = "Qdqeox4APsYwAQQSO68D1p75DL9an1wS8b/51m+nH98unN4jbS5bvg22WQrg+TMq2/3Mg/E5zprqfUzJD84qgw==";
+        url = "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.2.4.tgz";
+        sha512 = "jEUurwoeiHOB7SceVnsg3ULxNlf9XxqMfcKNM+eJduPgCcoCnbLi/6og+e764fTAZCcBkqGcWUMhLQXwcqpbJQ==";
       };
     };
     "@mdx-js/util-2.0.0-next.8" = {
@@ -3721,13 +3721,13 @@ let
         sha512 = "/NdX1Ql8hKNM0vHFJnEr/bcw6BG0ULHD3HhInpniZw5ixpl+n/QIRfMEEmLCn7acedbM1zGdZvU5ZMbn9kcF5Q==";
       };
     };
-    "@microsoft/load-themed-styles-1.10.161" = {
+    "@microsoft/load-themed-styles-1.10.165" = {
       name = "_at_microsoft_slash_load-themed-styles";
       packageName = "@microsoft/load-themed-styles";
-      version = "1.10.161";
+      version = "1.10.165";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.161.tgz";
-        sha512 = "ReHtvRknb3iYVUPl4c2PDEUWp18Jzh5x5MQE9zqHtSvYzpG6TGCWaqVBHKablshELqHv0dMf69929RB6VXiqyA==";
+        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.165.tgz";
+        sha512 = "3xMvFn1q27wctE701ZmdKDKgkj4b4DMHaJ8hnKk+c/E3Zvoo/5lviPZ0IGkD+zyfe7GMSp2kONalvX7Ez7HaKA==";
       };
     };
     "@mitmaro/errors-1.0.0" = {
@@ -3793,13 +3793,13 @@ let
         sha512 = "b+MGNyP9/LXkapreJzNUzcvuzZslj/RGgdVVJ16P2wSlYatfLycPObImqVJSmNAdyeShvNeM/pl3sVZsObFueg==";
       };
     };
-    "@netlify/build-11.1.0" = {
+    "@netlify/build-11.2.5" = {
       name = "_at_netlify_slash_build";
       packageName = "@netlify/build";
-      version = "11.1.0";
+      version = "11.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/build/-/build-11.1.0.tgz";
-        sha512 = "544/wWXcFtiOb+XmTUqsn3OFxd/vyeggd2uM8t/V9mWg1PuP5UG4AqubnKglzxiwEHa7KGym8fQCq4HChTtLow==";
+        url = "https://registry.npmjs.org/@netlify/build/-/build-11.2.5.tgz";
+        sha512 = "VjBtlEnCTjrYN9tTrgJdRjkauqN1gQ+fdtoVsZ0Lyz1Ja1LUnIPkCUHhsOmupMlvW/Yyl/QHTSPojg/wpMf1Zw==";
       };
     };
     "@netlify/cache-utils-1.0.7" = {
@@ -3811,13 +3811,13 @@ let
         sha512 = "yrdrnQkzg/qMovoFYwQ24UVt/OyHtP+t0KpQFd7eBl6gnuuGGgxFocaFFv6eKpMVwzHTsOwx/y9B/FcC3/6cfA==";
       };
     };
-    "@netlify/config-6.0.1" = {
+    "@netlify/config-6.2.0" = {
       name = "_at_netlify_slash_config";
       packageName = "@netlify/config";
-      version = "6.0.1";
+      version = "6.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/config/-/config-6.0.1.tgz";
-        sha512 = "rytv9UUW0QkBqwd0OkNF9SyEZLbGIbLmSms6h2Ob6pGiMUQd1wUwuX0PyS3ueIF/ZFB3PVKE8gUHNBC4wxyUrg==";
+        url = "https://registry.npmjs.org/@netlify/config/-/config-6.2.0.tgz";
+        sha512 = "CK8GpGf8v10GlY/gLhb27PEc9cWQaVpLi9/KQZhsEiLCmwVV+oLkfev2wOuIuPakTaCWJbwDbNGtCF+o3f3Crg==";
       };
     };
     "@netlify/framework-info-3.3.0" = {
@@ -3829,22 +3829,22 @@ let
         sha512 = "oWlP+sWfnr0tXSqd3nfma9Abq1NvZc4lFbHPMvxU6UhAcrBOpizsMaVT9sUK0UcMwzR8xwESdskZajtFoHA28g==";
       };
     };
-    "@netlify/functions-utils-1.3.25" = {
+    "@netlify/functions-utils-1.3.28" = {
       name = "_at_netlify_slash_functions-utils";
       packageName = "@netlify/functions-utils";
-      version = "1.3.25";
+      version = "1.3.28";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-1.3.25.tgz";
-        sha512 = "iCGVHlj6XNqOIQxREDbhfWEs8RBLGpXLrZKNHisG8PnJvRmnlS+EyVb1on2yV7+nvMqoqssNUeDY6tvQmwuPng==";
+        url = "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-1.3.28.tgz";
+        sha512 = "8swtLIVmzsokQfgr/2qZGf8C6GmrhP/okPzFZjmoDbfaHKqkkXthg0G/iY83CwRiofAuwMUkLtsrf1g3+aDiuA==";
       };
     };
-    "@netlify/git-utils-1.0.8" = {
+    "@netlify/git-utils-1.0.9" = {
       name = "_at_netlify_slash_git-utils";
       packageName = "@netlify/git-utils";
-      version = "1.0.8";
+      version = "1.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-1.0.8.tgz";
-        sha512 = "YWK2H6qjBmspTIibE/ai8YTsSnqROtubqWUuXz/RoQXYf03KWx/F9BFRm1S/TOoQM9v4fozRhVeHyH45Ki0ztA==";
+        url = "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-1.0.9.tgz";
+        sha512 = "qdkbEK3jRhfCbCqHAJGyQmBXxa66Kx1zwkm4dXBS8Wimv0zFGuyWWkMQomo6t2VGGoJyC+Ocy+E4ubTC13MUqA==";
       };
     };
     "@netlify/open-api-1.3.0" = {
@@ -3865,13 +3865,13 @@ let
         sha512 = "7L5pkXlwPfyUrmm9cu2+nOQYW1FMx6waMbl2Uj5SmxjLz5Dvt2zkUYbNU2ImNmJ10mxziv3LABSFn2k2qy2nLw==";
       };
     };
-    "@netlify/plugins-list-2.6.0" = {
+    "@netlify/plugins-list-2.8.0" = {
       name = "_at_netlify_slash_plugins-list";
       packageName = "@netlify/plugins-list";
-      version = "2.6.0";
+      version = "2.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-2.6.0.tgz";
-        sha512 = "XtBrsd4M0OW3RT9O7omqBhWevPoxVfkEX9BJ2Hv5J3gpujTN6IZEYmyprxhQ+Y98r4VvZVUX8dPzR99aF15YcQ==";
+        url = "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-2.8.0.tgz";
+        sha512 = "bjmObzm6qrZigS6ht85zgyHGTsk8dk3OspvQ3BED4VWFMDhl323WwswSJIQg2j7EdxEEOvGsM+gbh0FFWl6pqg==";
       };
     };
     "@netlify/run-utils-1.0.7" = {
@@ -3919,67 +3919,67 @@ let
         sha512 = "ea6S9ik5X0TlA2e+jXk5D7lfvArPZjyQoIBEo7G1Tjw/vUU5Fx6KLfXv1iy7eJy+ENTLoyidscAjJ2wXlHI47g==";
       };
     };
-    "@netlify/zip-it-and-ship-it-3.4.0" = {
+    "@netlify/zip-it-and-ship-it-3.7.0" = {
       name = "_at_netlify_slash_zip-it-and-ship-it";
       packageName = "@netlify/zip-it-and-ship-it";
-      version = "3.4.0";
+      version = "3.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-3.4.0.tgz";
-        sha512 = "/wHeHVcpVyo8nD93VdmluSJeipQrTt4mXp08krqQbPZPgA2HyupyYT4ZgjWKCh00Mrh2/k1XRbbxJYRc70lzkw==";
+        url = "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-3.7.0.tgz";
+        sha512 = "WPdJ8UulZxv+Niobjp49v8TO2+7V7Kks+1me4Zl4zuv09z8ZTE2/6b8bOCnB+tysTINrmTfi8ZMweB44gyLFLg==";
       };
     };
-    "@node-red/editor-api-1.3.2" = {
+    "@node-red/editor-api-1.3.3" = {
       name = "_at_node-red_slash_editor-api";
       packageName = "@node-red/editor-api";
-      version = "1.3.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-1.3.2.tgz";
-        sha512 = "meAJ4n9amAWxoWe5/rdigd8Wa0OKpwaNIn9Vqp+xqV4BqFa9RRe3ttO9FRUOuBeHwplDsMiWNnEVEdE9NCWlig==";
+        url = "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-1.3.3.tgz";
+        sha512 = "PafnnsKUYDQy+bQfk7THSCTy0zncDMvbn4HXGkavqN4nEuvm0bdvA6ZhBNa5G/WaKPt0srptl2KKCsavd3O8jA==";
       };
     };
-    "@node-red/editor-client-1.3.2" = {
+    "@node-red/editor-client-1.3.3" = {
       name = "_at_node-red_slash_editor-client";
       packageName = "@node-red/editor-client";
-      version = "1.3.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-1.3.2.tgz";
-        sha512 = "9YGb7PeLUmr7bMZYOn08euTOZzy+wIAqTo8R288sjbqLke0NKnFWhZsgl01pqPXv7rNjiyZpxTpU1uZLH49gDg==";
+        url = "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-1.3.3.tgz";
+        sha512 = "08vlp1s5yrUSidgjUg6/3sQIZ/c7r08oUNYZaN9kEgKVhYBRizet0fHBev8OWEO7nrMJAs8nQmYQGTRg4P/2uA==";
       };
     };
-    "@node-red/nodes-1.3.2" = {
+    "@node-red/nodes-1.3.3" = {
       name = "_at_node-red_slash_nodes";
       packageName = "@node-red/nodes";
-      version = "1.3.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/nodes/-/nodes-1.3.2.tgz";
-        sha512 = "NAblXeu0/tdVu8lU/gpMDVbclqkbiRGUcUforJSGeTiXod2wk4brGtLjEhAN1ouehUaIGXwiF0QN+KgfXnHg2Q==";
+        url = "https://registry.npmjs.org/@node-red/nodes/-/nodes-1.3.3.tgz";
+        sha512 = "ztCxN5ZWlUf8YkMD9NZd+izrnFVkIgv1ayzZzwCx8gsqLyGIQkzESgfKnqqU4ID8ih/r5Xs2SNl+XP9+OJEO6w==";
       };
     };
-    "@node-red/registry-1.3.2" = {
+    "@node-red/registry-1.3.3" = {
       name = "_at_node-red_slash_registry";
       packageName = "@node-red/registry";
-      version = "1.3.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/registry/-/registry-1.3.2.tgz";
-        sha512 = "VB0em51luT17rhTa7tkOXHOQbuEBczUEI2goJaSQSv5c032yPvzh4KyAf3Xa7sDafENg33wfSZfePx2tGrdg+w==";
+        url = "https://registry.npmjs.org/@node-red/registry/-/registry-1.3.3.tgz";
+        sha512 = "JaHsvXxz9/DJ02NwlBLeUTYPGZEpRvOFR99D34YHF753bw8ocROnYAJemNTmNbua/jW4RRL0tCXuJlrOQZNSGA==";
       };
     };
-    "@node-red/runtime-1.3.2" = {
+    "@node-red/runtime-1.3.3" = {
       name = "_at_node-red_slash_runtime";
       packageName = "@node-red/runtime";
-      version = "1.3.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/runtime/-/runtime-1.3.2.tgz";
-        sha512 = "HMrHfkH4wklp0tI3SjZR6Yzdf/swPg7FsYjzikv8HV/KBHV/Oe73gtE8CqXkP+rqUfhqdQC/X97Tq8vD6bC4WQ==";
+        url = "https://registry.npmjs.org/@node-red/runtime/-/runtime-1.3.3.tgz";
+        sha512 = "+tjva7c1lI+87ho1XTS5Lj0t+OapuA+/W3hRb1zXUTNfflUrkVcMMSujMw5v+V2Z5/cMNJBRgEYj38svj9pG3w==";
       };
     };
-    "@node-red/util-1.3.2" = {
+    "@node-red/util-1.3.3" = {
       name = "_at_node-red_slash_util";
       packageName = "@node-red/util";
-      version = "1.3.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/util/-/util-1.3.2.tgz";
-        sha512 = "AHrUP2mYTmy40Q0gP1X4GSwuJ1xWCgUL0RlEA843HpdTi7Gl6WB8xnJvcGFqptiuHiqE6mUFNrRMLmotctZqWg==";
+        url = "https://registry.npmjs.org/@node-red/util/-/util-1.3.3.tgz";
+        sha512 = "xB76cff/HlXJcbZlOe1duqBiCoqJTHM4KKFElcSJGNVjQSeOhZgxMsuECFHCCCh8Y9TVkL96VFwWybq2fKonew==";
       };
     };
     "@nodelib/fs.scandir-2.1.4" = {
@@ -4018,6 +4018,15 @@ let
         sha512 = "8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==";
       };
     };
+    "@npmcli/arborist-2.4.0" = {
+      name = "_at_npmcli_slash_arborist";
+      packageName = "@npmcli/arborist";
+      version = "2.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.4.0.tgz";
+        sha512 = "rCoRrUSmXdBDBBgL/O0oehIR53ey99Pds8dId7gztARZmx6/NBoeiUOu9RnvXSe15XZLc3JSz9sHPcbQ9NQ53Q==";
+      };
+    };
     "@npmcli/ci-detect-1.3.0" = {
       name = "_at_npmcli_slash_ci-detect";
       packageName = "@npmcli/ci-detect";
@@ -4045,6 +4054,24 @@ let
         sha512 = "9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==";
       };
     };
+    "@npmcli/map-workspaces-1.0.3" = {
+      name = "_at_npmcli_slash_map-workspaces";
+      packageName = "@npmcli/map-workspaces";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-1.0.3.tgz";
+        sha512 = "SdlRlOoQw4WKD4vtb/n5gUkobEABYBEOo8fRE4L8CtBkyWDSvIrReTfKvQ/Jc/LQqDaaZ5iv1iMSQzKCUr1n1A==";
+      };
+    };
+    "@npmcli/metavuln-calculator-1.1.1" = {
+      name = "_at_npmcli_slash_metavuln-calculator";
+      packageName = "@npmcli/metavuln-calculator";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-1.1.1.tgz";
+        sha512 = "9xe+ZZ1iGVaUovBVFI9h3qW+UuECUzhvZPxK9RaEA2mjU26o5D0JloGYWwLYvQELJNmBdQB6rrpuN8jni6LwzQ==";
+      };
+    };
     "@npmcli/move-file-1.1.2" = {
       name = "_at_npmcli_slash_move-file";
       packageName = "@npmcli/move-file";
@@ -4052,6 +4079,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz";
         sha512 = "1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==";
+      };
+    };
+    "@npmcli/name-from-folder-1.0.1" = {
+      name = "_at_npmcli_slash_name-from-folder";
+      packageName = "@npmcli/name-from-folder";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-1.0.1.tgz";
+        sha512 = "qq3oEfcLFwNfEYOQ8HLimRGKlD8WSeGEdtUa7hmzpR8Sa7haL1KVQrvgO6wqMjhWFFVjgtrh1gIxDz+P8sjUaA==";
       };
     };
     "@npmcli/node-gyp-1.0.2" = {
@@ -4072,13 +4108,13 @@ let
         sha512 = "QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==";
       };
     };
-    "@npmcli/run-script-1.8.4" = {
+    "@npmcli/run-script-1.8.5" = {
       name = "_at_npmcli_slash_run-script";
       packageName = "@npmcli/run-script";
-      version = "1.8.4";
+      version = "1.8.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.4.tgz";
-        sha512 = "Yd9HXTtF1JGDXZw0+SOn+mWLYS0e7bHBHVC/2C8yqs4wUrs/k8rwBSinD7rfk+3WG/MFGRZKxjyoD34Pch2E/A==";
+        url = "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.5.tgz";
+        sha512 = "NQspusBCpTjNwNRFMtz2C5MxoxyzlbuJ4YEhxAKrIonTiirKDtatsZictx9RgamQIx6+QuHMNmPl0wQdoESs9A==";
       };
     };
     "@oclif/color-0.1.2" = {
@@ -4243,13 +4279,13 @@ let
         sha512 = "2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==";
       };
     };
-    "@octokit/openapi-types-6.0.0" = {
+    "@octokit/openapi-types-6.1.1" = {
       name = "_at_octokit_slash_openapi-types";
       packageName = "@octokit/openapi-types";
-      version = "6.0.0";
+      version = "6.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz";
-        sha512 = "CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ==";
+        url = "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.1.1.tgz";
+        sha512 = "ICBhnEb+ahi/TTdNuYb/kTyKVBgAM0VD4k6JPzlhJyzt3Z+Tq/bynwCD+gpkJP7AEcNnzC8YO5R39trmzEo2UA==";
       };
     };
     "@octokit/plugin-enterprise-rest-6.0.1" = {
@@ -4297,13 +4333,13 @@ let
         sha512 = "EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==";
       };
     };
-    "@octokit/plugin-rest-endpoint-methods-5.0.0" = {
+    "@octokit/plugin-rest-endpoint-methods-5.0.1" = {
       name = "_at_octokit_slash_plugin-rest-endpoint-methods";
       packageName = "@octokit/plugin-rest-endpoint-methods";
-      version = "5.0.0";
+      version = "5.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz";
-        sha512 = "Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==";
+        url = "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz";
+        sha512 = "vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==";
       };
     };
     "@octokit/request-5.4.15" = {
@@ -4342,13 +4378,13 @@ let
         sha512 = "ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==";
       };
     };
-    "@octokit/rest-18.5.2" = {
+    "@octokit/rest-18.5.3" = {
       name = "_at_octokit_slash_rest";
       packageName = "@octokit/rest";
-      version = "18.5.2";
+      version = "18.5.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz";
-        sha512 = "Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==";
+        url = "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz";
+        sha512 = "KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==";
       };
     };
     "@octokit/types-2.16.2" = {
@@ -4360,13 +4396,13 @@ let
         sha512 = "O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==";
       };
     };
-    "@octokit/types-6.13.0" = {
+    "@octokit/types-6.13.2" = {
       name = "_at_octokit_slash_types";
       packageName = "@octokit/types";
-      version = "6.13.0";
+      version = "6.13.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz";
-        sha512 = "W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==";
+        url = "https://registry.npmjs.org/@octokit/types/-/types-6.13.2.tgz";
+        sha512 = "jN5LImYHvv7W6SZargq1UMJ3EiaqIz5qkpfsv4GAb4b16SGqctxtOU2TQAZxvsKHkOw2A4zxdsi5wR9en1/ezQ==";
       };
     };
     "@open-policy-agent/opa-wasm-1.2.0" = {
@@ -5071,13 +5107,13 @@ let
         sha512 = "c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==";
       };
     };
-    "@schematics/angular-11.2.9" = {
+    "@schematics/angular-11.2.10" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "11.2.9";
+      version = "11.2.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-11.2.9.tgz";
-        sha512 = "yiuWCf+naAaS8cib2a9KKAhkwLx4LVnxE4lpF1Q2mEE5znQ7npYwzQYxgMHD70eMuSrki/L5nM9s7ZdVr5OKyg==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-11.2.10.tgz";
+        sha512 = "WcqiUl2HcE5E6HbAFKhFOUeqQEqNL++o6UsKcgk8rQkx5RM7ZkT6uksxiwhfpKzSIqUjwx+xe66fP6pweNZ/yQ==";
       };
     };
     "@schematics/schematics-0.1102.6" = {
@@ -5089,13 +5125,13 @@ let
         sha512 = "x77kbJL/HqR4gx0tbt35VCOGLyMvB7jD/x7eB1njhQRF8E/xynEOk3i+7A5VmK67QP5NJxU8BQKlPkJ55tBDmg==";
       };
     };
-    "@schematics/update-0.1102.9" = {
+    "@schematics/update-0.1102.10" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.1102.9";
+      version = "0.1102.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1102.9.tgz";
-        sha512 = "JIbuvX4a87h7G9d3lsKTUceKXhE/lXtJEkGaQ2jv2sxFRxBkmMO2o2OmsKRDpIMtSRs7VTUTccK6RAOVZJX66w==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1102.10.tgz";
+        sha512 = "aU5fUT9ddw3n5ZOzx/x1W4Xo2fz+sDtDnrRdKI0Jip/9HE1PaoKxWT6gB5ouDnKETrvgDOArn68zIM8eOAVarg==";
       };
     };
     "@segment/loosely-validate-event-2.0.0" = {
@@ -5125,13 +5161,13 @@ let
         sha512 = "lOUyRopNTKJYVEU9T6stp2irwlTDsYMmUKBOUjnMcwGveuUfIJqrCOtFLtIPPj3XJlbZy5F68l4KP9rZ8Ipang==";
       };
     };
-    "@serverless/components-3.8.3" = {
+    "@serverless/components-3.9.0" = {
       name = "_at_serverless_slash_components";
       packageName = "@serverless/components";
-      version = "3.8.3";
+      version = "3.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/components/-/components-3.8.3.tgz";
-        sha512 = "rdteMdPgsnJdfL8AcCguB1aFEII3cL2GL5XoOLwYUTJIZyJCC0kCkYl/gbN1H67XDASr5KD0eDyf8Dw0oCyfNA==";
+        url = "https://registry.npmjs.org/@serverless/components/-/components-3.9.0.tgz";
+        sha512 = "70RIPd9eW/T6vZ7y4Rn7xVBCqPlN7cPq0NRAkxlT6sa7efgSkVDb+JCtKzST2EJpz7w2V/G+eWZjIbbYw6ueMw==";
       };
     };
     "@serverless/core-1.1.2" = {
@@ -5197,22 +5233,22 @@ let
         sha512 = "aI/cpGVUhWbJUR8QDMtPue28EU4ViG/L4/XKuZDfAN2uNQv3NRjwEFIBi/cxyfQnMTYVtMLe9wDjuwzOT4ENzA==";
       };
     };
-    "@serverless/utils-4.0.1" = {
+    "@serverless/utils-4.1.0" = {
       name = "_at_serverless_slash_utils";
       packageName = "@serverless/utils";
-      version = "4.0.1";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/utils/-/utils-4.0.1.tgz";
-        sha512 = "3/+Tw/kcIpBlrPyN244Ci7IZXVhGH9WLiLZcSwL0U96g0QQBofIGbv5v2h3Q6J4rBpPUOiZJcabJc7cIvlcP6Q==";
+        url = "https://registry.npmjs.org/@serverless/utils/-/utils-4.1.0.tgz";
+        sha512 = "cl5uPaGg72z0sCUpF0zsOhwYYUV72Gxc1FwFfxltO8hSvMeFDvwD7JrNE4kHcIcKRjwPGbSH0fdVPUpErZ8Mog==";
       };
     };
-    "@serverless/utils-china-1.0.14" = {
+    "@serverless/utils-china-1.0.15" = {
       name = "_at_serverless_slash_utils-china";
       packageName = "@serverless/utils-china";
-      version = "1.0.14";
+      version = "1.0.15";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.0.14.tgz";
-        sha512 = "7ku9ePjb+bneFV1Akmz0t8pU8hhHfPJsBjG/Kf6IjyGAQrEjN/PcY2QUDm0emdCNyCsuido1wp0DWMGiwuhC8Q==";
+        url = "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.0.15.tgz";
+        sha512 = "+fSVqyhiITJZ/9wz7fNA6QsJ0XLq3k+UQi8iX7TQNmXdWEtjfslKv2cbnW3A19jbuG2rQ0jzwNShnuLeMuqnSw==";
       };
     };
     "@sideway/address-4.1.1" = {
@@ -5296,13 +5332,13 @@ let
         sha512 = "JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==";
       };
     };
-    "@sindresorhus/is-4.0.0" = {
+    "@sindresorhus/is-4.0.1" = {
       name = "_at_sindresorhus_slash_is";
       packageName = "@sindresorhus/is";
-      version = "4.0.0";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz";
-        sha512 = "FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==";
+        url = "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz";
+        sha512 = "Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==";
       };
     };
     "@sindresorhus/slugify-1.1.2" = {
@@ -5332,13 +5368,13 @@ let
         sha512 = "mPZe3gBAV4ZDeYZbEs6WpNZuHHj7Hse9p44z6lrKBcbAMWnvApVOC7zZUpeQsUuWPTOWQRu/QSYElDKNajQ2oA==";
       };
     };
-    "@skorfmann/terraform-cloud-1.9.1" = {
+    "@skorfmann/terraform-cloud-1.10.0" = {
       name = "_at_skorfmann_slash_terraform-cloud";
       packageName = "@skorfmann/terraform-cloud";
-      version = "1.9.1";
+      version = "1.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@skorfmann/terraform-cloud/-/terraform-cloud-1.9.1.tgz";
-        sha512 = "R28bedoGjAmDiEYHu2cmeVd3R6vxq6anQQlGCpdjk5oqnSiROFFm8dzywvMon4/9C+CErhgY7fr76NVErS/U2w==";
+        url = "https://registry.npmjs.org/@skorfmann/terraform-cloud/-/terraform-cloud-1.10.0.tgz";
+        sha512 = "Yd5WWmmUjFYBpQpsAnAntwQMerilNRpHILNPA7x0EkwHhf+5KTSKYZwzYL/bOY1QfGJX6DTnOSHXIRStHZDUgg==";
       };
     };
     "@slack/client-3.16.0" = {
@@ -5422,13 +5458,13 @@ let
         sha512 = "E/Pfdze/WFfxwyuTFcfhQN1SwyUsc43yuCoW63RVBCaxTD6OzhVD2Pvc/Sy7BjiWUfmelzyKkIBpoow8zZX7Zg==";
       };
     };
-    "@snyk/fix-1.547.0" = {
+    "@snyk/fix-1.554.0" = {
       name = "_at_snyk_slash_fix";
       packageName = "@snyk/fix";
-      version = "1.547.0";
+      version = "1.554.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/fix/-/fix-1.547.0.tgz";
-        sha512 = "ANTkn8PHsmPelQ8W8aiS+R3JBzUr0fjcHT67eTvr2a0h51qzzgBFEwhd8GH1Wuo0Nmvm3bsKkk5DxkxTtQWPtw==";
+        url = "https://registry.npmjs.org/@snyk/fix/-/fix-1.554.0.tgz";
+        sha512 = "q2eRVStgspPeI2wZ2EQGLpiWZMRg7o+4tsCk6m/kHZgQGDN4Bb7L3xslFW3OgF0+ZksYSaHl2cW2HmGiLRaYcA==";
       };
     };
     "@snyk/gemfile-1.2.0" = {
@@ -5485,13 +5521,13 @@ let
         sha512 = "NX8bpIu7oG5cuSSm6WvtxqcCuJs2gRjtKhtuSeF1p5TYXyESs3FXQ0nHjfY90LiyTTc+PW/UBq6SKbBA6bCBww==";
       };
     };
-    "@snyk/mix-parser-1.3.1" = {
+    "@snyk/mix-parser-1.3.2" = {
       name = "_at_snyk_slash_mix-parser";
       packageName = "@snyk/mix-parser";
-      version = "1.3.1";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/mix-parser/-/mix-parser-1.3.1.tgz";
-        sha512 = "XvANfbbaRkCpmIxYJGa+nSy1hUvGOHPTY+J3lpJrJAsEPB3fCT/z9hMuIJJ2c4RXZ9HndkpoSz2oj27m/DiBKQ==";
+        url = "https://registry.npmjs.org/@snyk/mix-parser/-/mix-parser-1.3.2.tgz";
+        sha512 = "0Aq9vcgmjH0d9Gk5q0k6l4ZOvSHPf6/BCQGDVOpKp0hwOkXWnpDOLLPxL+uBCktuH9zTYQFB0aTk91kQImZqmA==";
       };
     };
     "@snyk/rpm-parser-2.2.1" = {
@@ -5521,13 +5557,13 @@ let
         sha512 = "hiFiSmWGLc2tOI7FfgIhVdFzO2f69im8O6p3OV4xEZ/Ss1l58vwtqudItoswsk7wj/azRlgfBW8wGu2MjoudQg==";
       };
     };
-    "@snyk/snyk-hex-plugin-1.1.2" = {
+    "@snyk/snyk-hex-plugin-1.1.4" = {
       name = "_at_snyk_slash_snyk-hex-plugin";
       packageName = "@snyk/snyk-hex-plugin";
-      version = "1.1.2";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/snyk-hex-plugin/-/snyk-hex-plugin-1.1.2.tgz";
-        sha512 = "8zj19XxlBqTfe12CoeVgT0WtRBk0HEjJVO8hYB/AM71XVjucFzQT4/e/hR8mCUSA7i+B/F8X8iGPhs7Uj3J+zA==";
+        url = "https://registry.npmjs.org/@snyk/snyk-hex-plugin/-/snyk-hex-plugin-1.1.4.tgz";
+        sha512 = "kLfFGckSmyKe667UGPyWzR/H7/Trkt4fD8O/ktElOx1zWgmivpLm0Symb4RCfEmz9irWv+N6zIKRrfSNdytcPQ==";
       };
     };
     "@starptech/expression-parser-0.10.0" = {
@@ -6797,6 +6833,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz";
         sha512 = "o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==";
+      };
+    };
+    "@types/node-fetch-2.5.8" = {
+      name = "_at_types_slash_node-fetch";
+      packageName = "@types/node-fetch";
+      version = "2.5.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz";
+        sha512 = "fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==";
       };
     };
     "@types/normalize-package-data-2.4.0" = {
@@ -8518,22 +8563,22 @@ let
         sha1 = "6a7990437ca736d5e1288db92bd3266d5f5cb2aa";
       };
     };
-    "addons-linter-2.21.0" = {
+    "addons-linter-3.2.0" = {
       name = "addons-linter";
       packageName = "addons-linter";
-      version = "2.21.0";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-2.21.0.tgz";
-        sha512 = "1XfqeVbvaEpjRlWJq/Ti0W6bH3RszaIDPeKl+4ZmXCx+C8ovRqy4CJmitqNffLr+2KpY4h5ei2eRygbvJYDyrw==";
+        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-3.2.0.tgz";
+        sha512 = "b6oViLOBgXWsld5L3DJiJSt77DYjVrk2Yam2/gD5e2bsj5xfNvavugwhlJP/MIF0j5yetYT/XFQDXY1Hs0flOA==";
       };
     };
-    "addons-scanner-utils-4.2.0" = {
+    "addons-scanner-utils-4.4.0" = {
       name = "addons-scanner-utils";
       packageName = "addons-scanner-utils";
-      version = "4.2.0";
+      version = "4.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-4.2.0.tgz";
-        sha512 = "VKLYNlKg2RCMvmOKmbWlu14hjdyk2vcTHscQGmDlnHfWcf6fAb8E7vY9/ajWdLykVVKZEUiGOoD5EIkIp1FyUA==";
+        url = "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-4.4.0.tgz";
+        sha512 = "fEUGQIqLYeLl5cV6FFSHU+XFlOYETXqm8jxmYGsVayjZaAqWEkIjTXNu4+pDEiqIkrqjPYP2izjrnhBpHRsyog==";
       };
     };
     "addr-to-ip-port-1.5.1" = {
@@ -9301,6 +9346,15 @@ let
         sha512 = "hXI9PjJtzmD34XviBU+4sPMOxnifYrHVmxpjykqI/dUD2G3yTiuRaiQqwRwB2RCdwC1Ug/jBfoQ/NHDTnnjndQ==";
       };
     };
+    "apollo-env-0.9.0" = {
+      name = "apollo-env";
+      packageName = "apollo-env";
+      version = "0.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-env/-/apollo-env-0.9.0.tgz";
+        sha512 = "oMSaFiCYEULXTv1sLhuPpAg0SykJNzEu5QWvCw0844yq14MyETXFERmAYD9b8nNjQLAdpjbbkBGKTWcw5wgd5Q==";
+      };
+    };
     "apollo-graphql-0.6.1" = {
       name = "apollo-graphql";
       packageName = "apollo-graphql";
@@ -9533,15 +9587,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/archiver/-/archiver-4.0.2.tgz";
         sha512 = "B9IZjlGwaxF33UN4oPbfBkyA4V1SxNLeIhR1qY8sRXSsbdUkEHrrOvwlYFPx+8uQeCe9M+FG6KgO+imDmQ79CQ==";
-      };
-    };
-    "archiver-5.2.0" = {
-      name = "archiver";
-      packageName = "archiver";
-      version = "5.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/archiver/-/archiver-5.2.0.tgz";
-        sha512 = "QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==";
       };
     };
     "archiver-5.3.0" = {
@@ -10678,6 +10723,15 @@ let
         sha512 = "Eh6pW+fRC2/1RxPq3hO8+PkZKv+wujzKky2MP/n69eC8yMkbNFfuEb/riZHqf13M7gr6Hvglpk/kISgBSBb6bQ==";
       };
     };
+    "atomic-file-rw-0.2.1" = {
+      name = "atomic-file-rw";
+      packageName = "atomic-file-rw";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/atomic-file-rw/-/atomic-file-rw-0.2.1.tgz";
+        sha512 = "73oEZ7tkhd/7QjvsNts9saHY9BYJQWD4izzI/bKJmwVl/BGT7J6wBFUC5qxNlQZlFORguqfsTQwvJA1lm3RoFw==";
+      };
+    };
     "atomic-sleep-1.0.0" = {
       name = "atomic-sleep";
       packageName = "atomic-sleep";
@@ -10694,15 +10748,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz";
         sha512 = "Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==";
-      };
-    };
-    "atomically-universal-0.1.1" = {
-      name = "atomically-universal";
-      packageName = "atomically-universal";
-      version = "0.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/atomically-universal/-/atomically-universal-0.1.1.tgz";
-        sha512 = "0bqmz+wKlA9hIiH/C4R3K8dpsVV6mM/X76QZ70LMHW0XzCDXzxdWD5gfkmRXxTM5txlbYE/06iz0IziohUQVzw==";
       };
     };
     "attach-ware-1.1.1" = {
@@ -10795,13 +10840,13 @@ let
         sha512 = "+KBkqH7t/XE91Fqn8eyJeNIWsnhSWL8bSUqFD7TfE3FN07MTlC0nprGYp+2WfcYNz5i8Bus1vY2DHNVhtTImnw==";
       };
     };
-    "aws-sdk-2.888.0" = {
+    "aws-sdk-2.892.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.888.0";
+      version = "2.892.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.888.0.tgz";
-        sha512 = "9Rg14eneXnrs5Wh5FL42qGEXf7QaqaV/gMHU9SfvAA0SEM390QnwVjCSKF5YAReWjSuJriKJTDiodMI39J+Nrg==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.892.0.tgz";
+        sha512 = "OOXJ15AnJJMHZYXJQVy22Wjnp5GrZCfvCxmoZuXdsLNs8M+BL4mfBqma82+UkM2NhJgLYuAhDfvFUBob6VGIWw==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -12073,6 +12118,15 @@ let
         sha1 = "dd3a862b2fedf66fee8471320069428d0d84427a";
       };
     };
+    "bin-links-2.2.1" = {
+      name = "bin-links";
+      packageName = "bin-links";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bin-links/-/bin-links-2.2.1.tgz";
+        sha512 = "wFzVTqavpgCCYAh8SVBdnZdiQMxTkGR+T3b14CNpBXIBe2neJWaMGAZ55XWWHELJJ89dscuq0VCBqcVaIOgCMg==";
+      };
+    };
     "bin-version-2.0.0" = {
       name = "bin-version";
       packageName = "bin-version";
@@ -12145,13 +12199,13 @@ let
         sha1 = "7dbb3b210fdca082450dad2334c304af39bdc784";
       };
     };
-    "binaryextensions-2.3.0" = {
+    "binaryextensions-4.15.0" = {
       name = "binaryextensions";
       packageName = "binaryextensions";
-      version = "2.3.0";
+      version = "4.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz";
-        sha512 = "nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==";
+        url = "https://registry.npmjs.org/binaryextensions/-/binaryextensions-4.15.0.tgz";
+        sha512 = "MkUl3szxXolQ2scI1PM14WOT951KnaTNJ0eMKg7WzOI4kvSxyNo/Cygx4LOBNhwyINhAuSQpJW1rYD9aBSxGaw==";
       };
     };
     "bindings-1.2.1" = {
@@ -12244,13 +12298,13 @@ let
         sha512 = "O1htyufFTYy3EO0JkHg2CLykdXEtV2ssqw47Gq9A0WByp662xpJnMEB9m43LZjsSDjIAOozWRExlFQk2hlV1XQ==";
       };
     };
-    "bipf-1.5.0" = {
+    "bipf-1.5.1" = {
       name = "bipf";
       packageName = "bipf";
-      version = "1.5.0";
+      version = "1.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bipf/-/bipf-1.5.0.tgz";
-        sha512 = "EjpRVanEn4/Z2ilD2OeTfkWnogvxe+PZ8Gxzt7m+2xRT9rg6g1pETAdYy2vmJhNNZYX9axiV3Zf8HxuaYb0W3w==";
+        url = "https://registry.npmjs.org/bipf/-/bipf-1.5.1.tgz";
+        sha512 = "SrLwMzrpETJDiH9z12EMcqtApgcQo9XsPi+S9Aodezu53ALcGjBBQ7+C+IWbsSCBlSvNEec8sqfh3itO/j/QUw==";
       };
     };
     "bitcoin-core-2.3.0" = {
@@ -13225,13 +13279,13 @@ let
         sha512 = "HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==";
       };
     };
-    "browserslist-4.16.4" = {
+    "browserslist-4.16.5" = {
       name = "browserslist";
       packageName = "browserslist";
-      version = "4.16.4";
+      version = "4.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz";
-        sha512 = "d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==";
+        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz";
+        sha512 = "C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==";
       };
     };
     "brq-0.1.8" = {
@@ -14179,13 +14233,13 @@ let
         sha512 = "bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==";
       };
     };
-    "caniuse-lite-1.0.30001209" = {
+    "caniuse-lite-1.0.30001214" = {
       name = "caniuse-lite";
       packageName = "caniuse-lite";
-      version = "1.0.30001209";
+      version = "1.0.30001214";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz";
-        sha512 = "2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA==";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz";
+        sha512 = "O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==";
       };
     };
     "canvas-2.7.0" = {
@@ -14341,13 +14395,13 @@ let
         sha512 = "G6SIJSg6mxeEzWEWNY8NAn/jqysTPegV79mOQ6eYj1uyKYggyzP5MzuWt8fKmYShM5BTDadnCRajwDnku9LZeQ==";
       };
     };
-    "cdktf-0.2.2" = {
+    "cdktf-0.3.0" = {
       name = "cdktf";
       packageName = "cdktf";
-      version = "0.2.2";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cdktf/-/cdktf-0.2.2.tgz";
-        sha512 = "SMiDV99ruSGhjBm+dj30XmtV20BKesjY75SGGB3sTcFeaqn5d1Gf8gAaG69QTm3zqI8SbYO12MDslkoX1BY5Zw==";
+        url = "https://registry.npmjs.org/cdktf/-/cdktf-0.3.0.tgz";
+        sha512 = "+Nk6eKVMjcnIlu5KPZ02vo2VuD1B+wFydGS00BvvpwDjymhNnMTc5ADjPtGhwpi067i30j/HCFRHDKG04dgVbg==";
       };
     };
     "center-align-0.1.3" = {
@@ -14474,6 +14528,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz";
         sha512 = "qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==";
+      };
+    };
+    "chalk-4.1.1" = {
+      name = "chalk";
+      packageName = "chalk";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz";
+        sha512 = "diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==";
       };
     };
     "chance-1.0.18" = {
@@ -15826,13 +15889,13 @@ let
         sha512 = "3WQV/Fpa77nvzjUlc+0u53uIroJyyMB2Qwl++aXpAiDIsrsiAQq4uCURwdRBRX+eLkOTIAmT0L4qna3T7+2pUg==";
       };
     };
-    "codemaker-1.28.0" = {
+    "codemaker-1.29.0" = {
       name = "codemaker";
       packageName = "codemaker";
-      version = "1.28.0";
+      version = "1.29.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/codemaker/-/codemaker-1.28.0.tgz";
-        sha512 = "TlpvV3q/68cZk7aljYW6b/5EvyB4uw523xJISTATrCrQu/UTA79/mxpA2ug8uhPcJoGYcfWXH4BHVVLNIuEtrg==";
+        url = "https://registry.npmjs.org/codemaker/-/codemaker-1.29.0.tgz";
+        sha512 = "dNUTiOhxNYB7MV75bLLCie1gr0SUh6wEOPc5OyZob4mLj51OETYIeRYILEiz39QVKLRx6YSbKoCY/S4PqQ0PNQ==";
       };
     };
     "codepage-1.4.0" = {
@@ -16339,6 +16402,15 @@ let
         sha512 = "ovx/7NkTrnPuIV8sqk/GjUIIM1+iUQeqA3ye2VNpq9sVoiZsooObWlQy+OPWGI17GDaEoybuAGJm6U8yC077BA==";
       };
     };
+    "commander-7.1.0" = {
+      name = "commander";
+      packageName = "commander";
+      version = "7.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz";
+        sha512 = "pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==";
+      };
+    };
     "commander-7.2.0" = {
       name = "commander";
       packageName = "commander";
@@ -16364,6 +16436,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz";
         sha512 = "rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==";
+      };
+    };
+    "common-ancestor-path-1.0.1" = {
+      name = "common-ancestor-path";
+      packageName = "common-ancestor-path";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz";
+        sha512 = "L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==";
       };
     };
     "common-path-prefix-2.0.0" = {
@@ -16870,6 +16951,15 @@ let
         sha512 = "3KFtTsA7OV27m/+pJhN4iJkKzHbPIPvyvEX5BQ/JCAWjfCHOQEVpIgxHLpT4i8L1OFta+pJrzcEVAHo6UitwqA==";
       };
     };
+    "constructs-3.3.74" = {
+      name = "constructs";
+      packageName = "constructs";
+      version = "3.3.74";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/constructs/-/constructs-3.3.74.tgz";
+        sha512 = "qLjLFw9jcPxPdZ838lFIzd/SwWSj6dHY8mgPQlfjPptmJLlDnsy+8VOCEeuzjMcYHFDa++8AoikPiHUzn58CaQ==";
+      };
+    };
     "consume-http-header-1.0.0" = {
       name = "consume-http-header";
       packageName = "consume-http-header";
@@ -16952,13 +17042,13 @@ let
         sha1 = "0e790b3abfef90f6ecb77ae8585db9099caf7578";
       };
     };
-    "contentful-management-7.15.1" = {
+    "contentful-management-7.17.1" = {
       name = "contentful-management";
       packageName = "contentful-management";
-      version = "7.15.1";
+      version = "7.17.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/contentful-management/-/contentful-management-7.15.1.tgz";
-        sha512 = "Wk4gpoNDXThkof49W0S3WgdW42T9kKQZj+7V7aDs+VrW0/WfTiNh5fMiMt0rxLqkWjxFrsa1TMAxR0WzT3lLyQ==";
+        url = "https://registry.npmjs.org/contentful-management/-/contentful-management-7.17.1.tgz";
+        sha512 = "t2stBJNvvY347d84GuNoHxPvPMGKQHAIC/2CwEL0y47yas+30A4jkbTugqermgZS2l52gnasjo6xBTE27Rqb0w==";
       };
     };
     "contentful-sdk-core-6.7.0" = {
@@ -17375,13 +17465,13 @@ let
         sha512 = "Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==";
       };
     };
-    "core-js-3.10.1" = {
+    "core-js-3.11.0" = {
       name = "core-js";
       packageName = "core-js";
-      version = "3.10.1";
+      version = "3.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-3.10.1.tgz";
-        sha512 = "pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==";
+        url = "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz";
+        sha512 = "bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==";
       };
     };
     "core-js-3.8.3" = {
@@ -17393,22 +17483,22 @@ let
         sha512 = "KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==";
       };
     };
-    "core-js-compat-3.10.1" = {
+    "core-js-compat-3.11.0" = {
       name = "core-js-compat";
       packageName = "core-js-compat";
-      version = "3.10.1";
+      version = "3.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.1.tgz";
-        sha512 = "ZHQTdTPkqvw2CeHiZC970NNJcnwzT6YIueDMASKt+p3WbZsLXOcoD392SkcWhkC0wBBHhlfhqGKKsNCQUozYtg==";
+        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.11.0.tgz";
+        sha512 = "3wsN9YZJohOSDCjVB0GequOyHax8zFiogSX3XWLE28M1Ew7dTU57tgHjIylSBKSIouwmLBp3g61sKMz/q3xEGA==";
       };
     };
-    "core-js-pure-3.10.1" = {
+    "core-js-pure-3.11.0" = {
       name = "core-js-pure";
       packageName = "core-js-pure";
-      version = "3.10.1";
+      version = "3.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.10.1.tgz";
-        sha512 = "PeyJH2SE0KuxY5eCGNWA+W+CeDpB6M1PN3S7Am7jSv/Ttuxz2SnWbIiVQOn/TDaGaGtxo8CRWHkXwJscbUHtVw==";
+        url = "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.11.0.tgz";
+        sha512 = "PxEiQGjzC+5qbvE7ZIs5Zn6BynNeZO9zHhrrWmkRff2SZLq0CE/H5LuZOJHhmOQ8L38+eMzEHAmPYWrUtDfuDQ==";
       };
     };
     "core-util-is-1.0.2" = {
@@ -17724,15 +17814,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz";
         sha512 = "KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==";
-      };
-    };
-    "cross-fetch-3.1.1" = {
-      name = "cross-fetch";
-      packageName = "cross-fetch";
-      version = "3.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.1.tgz";
-        sha512 = "eIF+IHQpRzoGd/0zPrwQmHwDC90mdvjk+hcbYhKoaRrEk4GEIDqdjs/MljmdPPoHTQudbmWS+f0hZsEpFaEvWw==";
       };
     };
     "cross-fetch-3.1.4" = {
@@ -18284,13 +18365,13 @@ let
         sha1 = "d1cfd8743c2f849a0abb2fd544db56695d19a490";
       };
     };
-    "csv-parse-4.15.3" = {
+    "csv-parse-4.15.4" = {
       name = "csv-parse";
       packageName = "csv-parse";
-      version = "4.15.3";
+      version = "4.15.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/csv-parse/-/csv-parse-4.15.3.tgz";
-        sha512 = "jlTqDvLdHnYMSr08ynNfk4IAUSJgJjTKy2U5CQBSu4cN9vQOJonLVZP4Qo4gKKrIgIQ5dr07UwOJdi+lRqT12w==";
+        url = "https://registry.npmjs.org/csv-parse/-/csv-parse-4.15.4.tgz";
+        sha512 = "OdBbFc0yZhOm17lSxqkirrHlFFVpKRT0wp4DAGoJelsP3LbGzV9LNr7XmM/lrr0uGkCtaqac9UhP8PDHXOAbMg==";
       };
     };
     "csv-parser-1.12.1" = {
@@ -18914,15 +18995,6 @@ let
         sha512 = "JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==";
       };
     };
-    "dargs-6.1.0" = {
-      name = "dargs";
-      packageName = "dargs";
-      version = "6.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dargs/-/dargs-6.1.0.tgz";
-        sha512 = "5dVBvpBLBnPwSsYXqfybFyehMmC/EenKEcf23AhCTgTf48JFBbmJKqoZBsERDnjL0FyiVTYWdFsRfTLHxLyKdQ==";
-      };
-    };
     "dargs-7.0.0" = {
       name = "dargs";
       packageName = "dargs";
@@ -19173,6 +19245,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz";
         sha512 = "jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==";
+      };
+    };
+    "dateformat-4.5.1" = {
+      name = "dateformat";
+      packageName = "dateformat";
+      version = "4.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dateformat/-/dateformat-4.5.1.tgz";
+        sha512 = "OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==";
       };
     };
     "dayjs-1.10.4" = {
@@ -20561,13 +20642,13 @@ let
         sha512 = "EAyaxl8hy4Ph07kzlzGTfpbZMNAAAHXSZtNEMwdlnSd1noHzvA6HsgKt4fEMSvaEXQYLSphe5rPMxN4WOj0hcQ==";
       };
     };
-    "dispensary-0.61.0" = {
+    "dispensary-0.62.0" = {
       name = "dispensary";
       packageName = "dispensary";
-      version = "0.61.0";
+      version = "0.62.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.61.0.tgz";
-        sha512 = "5BK13jrYQ+0bHgZBv7IOQsff5ydeNcnp87w3c7T8x5im21RDFQyiHrTlH0DoouZDyAVHILpat4Ytf7gRuhMRgw==";
+        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.62.0.tgz";
+        sha512 = "x8vqPX7owhzDp3Y6t/iOuTuNoWx5hlZKITlzlybETsZoY05cYDubGpwt0soLfRLAWLuxX1lq0lTc/vXtk/CDCw==";
       };
     };
     "diveSync-0.3.0" = {
@@ -21173,15 +21254,6 @@ let
         sha512 = "N8hWXD4hXqmEcNoR8TBYFntaOcYvEQ7Bz90mgm3bZRTuteGQqwT32VDMnTyD0KTEvb8BWrMc1tVmzuV9u/WrAg==";
       };
     };
-    "download-stats-0.3.4" = {
-      name = "download-stats";
-      packageName = "download-stats";
-      version = "0.3.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/download-stats/-/download-stats-0.3.4.tgz";
-        sha512 = "ic2BigbyUWx7/CBbsfGjf71zUNZB4edBGC3oRliSzsoNmvyVx3Ycfp1w3vp2Y78Ee0eIIkjIEO5KzW0zThDGaA==";
-      };
-    };
     "draftlog-1.0.13" = {
       name = "draftlog";
       packageName = "draftlog";
@@ -21389,13 +21461,13 @@ let
         sha1 = "94a44248bb87da35db0eff7af0aa576168117f59";
       };
     };
-    "editions-2.3.1" = {
+    "editions-6.1.0" = {
       name = "editions";
       packageName = "editions";
-      version = "2.3.1";
+      version = "6.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz";
-        sha512 = "ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==";
+        url = "https://registry.npmjs.org/editions/-/editions-6.1.0.tgz";
+        sha512 = "h6nWEyIocfgho9J3sTSuhU/WoFOu1hTX75rPBebNrbF38Y9QFDjCDizYXdikHTySW7Y3mSxli8bpDz9RAtc7rA==";
       };
     };
     "editor-1.0.0" = {
@@ -21497,13 +21569,13 @@ let
         sha512 = "1sQ1DRtQGpglFhc3urD4olMJzt/wxlbnAAsf+WY2xHf5c50ZovivZvCXSpVgTOP9f4TzOMvelWyspyfhxQKHzQ==";
       };
     };
-    "electron-to-chromium-1.3.717" = {
+    "electron-to-chromium-1.3.720" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.717";
+      version = "1.3.720";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz";
-        sha512 = "OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.720.tgz";
+        sha512 = "B6zLTxxaOFP4WZm6DrvgRk8kLFYWNhQ5TrHMC0l5WtkMXhU5UbnvWoTfeEwqOruUSlNMhVLfYak7REX6oC5Yfw==";
       };
     };
     "electrum-client-git://github.com/janoside/electrum-client" = {
@@ -21949,13 +22021,13 @@ let
         sha512 = "Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==";
       };
     };
-    "enhanced-resolve-5.7.0" = {
+    "enhanced-resolve-5.8.0" = {
       name = "enhanced-resolve";
       packageName = "enhanced-resolve";
-      version = "5.7.0";
+      version = "5.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz";
-        sha512 = "6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==";
+        url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.0.tgz";
+        sha512 = "Sl3KRpJA8OpprrtaIswVki3cWPiPKxXuFxJXBp+zNb6s6VwNWwFRUdtmzd2ReUut8n+sCPx7QCtQ7w5wfJhSgQ==";
       };
     };
     "enquirer-2.3.6" = {
@@ -22147,13 +22219,13 @@ let
         sha512 = "GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==";
       };
     };
-    "errlop-2.2.0" = {
+    "errlop-4.1.0" = {
       name = "errlop";
       packageName = "errlop";
-      version = "2.2.0";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz";
-        sha512 = "e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==";
+        url = "https://registry.npmjs.org/errlop/-/errlop-4.1.0.tgz";
+        sha512 = "vul6gGBuVt0M2TPi1/WrcL86+Hb3Q2Tpu3TME3sbVhZrYf7J1ZMHCodI25RQKCVurh56qTfvgM0p3w5cT4reSQ==";
       };
     };
     "errno-0.1.8" = {
@@ -22165,6 +22237,15 @@ let
         sha512 = "dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==";
       };
     };
+    "error-10.4.0" = {
+      name = "error";
+      packageName = "error";
+      version = "10.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/error/-/error-10.4.0.tgz";
+        sha512 = "YxIFEJuhgcICugOUvRx5th0UM+ActZ9sjY0QJmeVwsQdvosZ7kYzc9QqS0Da3R5iUmgU5meGIxh0xBeZpMVeLw==";
+      };
+    };
     "error-7.0.2" = {
       name = "error";
       packageName = "error";
@@ -22172,15 +22253,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/error/-/error-7.0.2.tgz";
         sha1 = "a5f75fff4d9926126ddac0ea5dc38e689153cb02";
-      };
-    };
-    "error-7.2.1" = {
-      name = "error";
-      packageName = "error";
-      version = "7.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/error/-/error-7.2.1.tgz";
-        sha512 = "fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==";
       };
     };
     "error-ex-1.3.2" = {
@@ -22381,13 +22453,13 @@ let
         sha512 = "p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==";
       };
     };
-    "esbuild-0.11.12" = {
+    "esbuild-0.11.13" = {
       name = "esbuild";
       packageName = "esbuild";
-      version = "0.11.12";
+      version = "0.11.13";
       src = fetchurl {
-        url = "https://registry.npmjs.org/esbuild/-/esbuild-0.11.12.tgz";
-        sha512 = "c8cso/1RwVj+fbDvLtUgSG4ZJQ0y9Zdrl6Ot/GAjyy4pdMCHaFnDMts5gqFnWRPLajWtEnI+3hlET4R9fVoZng==";
+        url = "https://registry.npmjs.org/esbuild/-/esbuild-0.11.13.tgz";
+        sha512 = "d5coY4dd4rVWle0WzrR8+32ukKtZroVJ/wJzOwbBEmoSFB/H3QME0l+3IAN5Sf3LtuoUSivdv1/b5rD7OykXeg==";
       };
     };
     "esc-exit-2.0.2" = {
@@ -22561,15 +22633,6 @@ let
         sha512 = "S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==";
       };
     };
-    "eslint-7.21.0" = {
-      name = "eslint";
-      packageName = "eslint";
-      version = "7.21.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz";
-        sha512 = "W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==";
-      };
-    };
     "eslint-7.24.0" = {
       name = "eslint";
       packageName = "eslint";
@@ -22577,6 +22640,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz";
         sha512 = "k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==";
+      };
+    };
+    "eslint-7.25.0" = {
+      name = "eslint";
+      packageName = "eslint";
+      version = "7.25.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz";
+        sha512 = "TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==";
       };
     };
     "eslint-import-resolver-node-0.3.4" = {
@@ -23227,15 +23299,6 @@ let
         sha512 = "Kd3EgYfODHueq6GzVfs/VUolh2EgJsS8hkO3KpnDrxVjU3eq63eXM2ujXkhPP+OkeUOhL8CxdfZbQXzryb5C4g==";
       };
     };
-    "events-to-array-1.1.2" = {
-      name = "events-to-array";
-      packageName = "events-to-array";
-      version = "1.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz";
-        sha1 = "2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6";
-      };
-    };
     "events.node-0.4.9" = {
       name = "events.node";
       packageName = "events.node";
@@ -23533,13 +23596,13 @@ let
         sha1 = "a793d3ac0cad4c6ab571e9968fbbab6cb2532929";
       };
     };
-    "expo-pwa-0.0.72" = {
+    "expo-pwa-0.0.74" = {
       name = "expo-pwa";
       packageName = "expo-pwa";
-      version = "0.0.72";
+      version = "0.0.74";
       src = fetchurl {
-        url = "https://registry.npmjs.org/expo-pwa/-/expo-pwa-0.0.72.tgz";
-        sha512 = "Mhyl8aqUwncBDo+zBWpqoXIFe38cfK0A4axKmJaiy8IIZd+ficVqo4zXrYVeuKpBY+P+eqEbXLbhTJlktkMhow==";
+        url = "https://registry.npmjs.org/expo-pwa/-/expo-pwa-0.0.74.tgz";
+        sha512 = "Y3lzJl9Q+0KuYt6003eacwpfoEYzO+w2R3oBDtfwGU16KbQkm2O6zGAYluBGnlPoph+fCUmyi2mT2ucd5KSlDQ==";
       };
     };
     "express-2.5.11" = {
@@ -24658,13 +24721,13 @@ let
         sha512 = "LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==";
       };
     };
-    "filesize-6.2.5" = {
+    "filesize-6.3.0" = {
       name = "filesize";
       packageName = "filesize";
-      version = "6.2.5";
+      version = "6.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/filesize/-/filesize-6.2.5.tgz";
-        sha512 = "JkM1y2+IpnEwp3pbXOUXR+9ytuZE07ZnWb/OR0H/WOSkjWASpmXgC0ZBIs4/SAYq9wHqExeQxcYNoJKf6s0RCg==";
+        url = "https://registry.npmjs.org/filesize/-/filesize-6.3.0.tgz";
+        sha512 = "ytx0ruGpDHKWVoiui6+BY/QMNngtDQ/pJaFwfBpQif0J63+E8DLdFyqS3NkKQn7vIruUEpoGD9JUJSg7Kp+I0g==";
       };
     };
     "filestream-5.0.0" = {
@@ -24838,6 +24901,15 @@ let
         sha512 = "1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==";
       };
     };
+    "find-yarn-workspace-root2-1.2.16" = {
+      name = "find-yarn-workspace-root2";
+      packageName = "find-yarn-workspace-root2";
+      version = "1.2.16";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz";
+        sha512 = "hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==";
+      };
+    };
     "findit-1.2.0" = {
       name = "findit";
       packageName = "findit";
@@ -24892,13 +24964,13 @@ let
         sha512 = "ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==";
       };
     };
-    "firefox-profile-4.1.0" = {
+    "firefox-profile-4.2.0" = {
       name = "firefox-profile";
       packageName = "firefox-profile";
-      version = "4.1.0";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.1.0.tgz";
-        sha512 = "n+0jsWhW57i7cAmdHg67W6u5vVSoIJN9D+d7M3w1MzhFLE5X/QxBfP80ksjNvNQDFXGdJQAnW9YupLkzgCxaFQ==";
+        url = "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.2.0.tgz";
+        sha512 = "Z+/6GQ0JEW2eqgj63EYNbgKSgoIz7w1yXlkOWAIRkCNnj50rkfnQIz8uYwJkobxwYQM8vjFIbYiVtYuQV8US2A==";
       };
     };
     "first-chunk-stream-2.0.0" = {
@@ -25531,13 +25603,13 @@ let
         sha512 = "wJaE62fLaB3jCYvY2ZHjZvmKK2iiLiiehX38rz5QZxtdN8fVPJDeZUiVvJrHStdTc+23LHlyZuSEKgFc0pxi2g==";
       };
     };
-    "fp-ts-2.10.2" = {
+    "fp-ts-2.10.4" = {
       name = "fp-ts";
       packageName = "fp-ts";
-      version = "2.10.2";
+      version = "2.10.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fp-ts/-/fp-ts-2.10.2.tgz";
-        sha512 = "YB/FSwESW8C3kVCbbyFiZSXXoQEJ/SaeHHorL6KCKHoPIPV6v/hyfMiXBPMjW7O7D9jfxlRs6VeCRonfqi1Tcg==";
+        url = "https://registry.npmjs.org/fp-ts/-/fp-ts-2.10.4.tgz";
+        sha512 = "vMTB5zNc9PnE20q145PNbkiL9P9WegwmKVOFloi/NfHnPdAlcob6I3AKqlH/9u3k3/M/GOftZhcJdBrb+NtnDA==";
       };
     };
     "fragment-cache-0.2.1" = {
@@ -26044,13 +26116,13 @@ let
         sha1 = "979e22f9451b4b38f051f7937c919dbacc692958";
       };
     };
-    "fx-runner-1.0.13" = {
+    "fx-runner-1.1.0" = {
       name = "fx-runner";
       packageName = "fx-runner";
-      version = "1.0.13";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fx-runner/-/fx-runner-1.0.13.tgz";
-        sha512 = "Ces2bm+LNuXehkvmN1/Z+oEDkI/jHBp9xdyBtBy7hcgvF18/pv/D8F6A6kQgNkMZsnBgLEv+VvdDxyqkfkYycw==";
+        url = "https://registry.npmjs.org/fx-runner/-/fx-runner-1.1.0.tgz";
+        sha512 = "v/Eo69DDFW30zPdvjCYVXddjVvLy2xGeRbg0S18bPd8kEc0q9VsDoDkjyOxY5lTZsAqcQGy0OWjs3HCfRVBNSg==";
       };
     };
     "galactus-0.2.1" = {
@@ -26485,15 +26557,6 @@ let
         sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
       };
     };
-    "gh-got-5.0.0" = {
-      name = "gh-got";
-      packageName = "gh-got";
-      version = "5.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz";
-        sha1 = "ee95be37106fd8748a96f8d1db4baea89e1bfa8a";
-      };
-    };
     "gh-release-fetch-1.1.0" = {
       name = "gh-release-fetch";
       packageName = "gh-release-fetch";
@@ -26699,15 +26762,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz";
         sha1 = "f985fedcc0a9aa579dc88d7aff068d55cc6251a0";
-      };
-    };
-    "github-username-3.0.0" = {
-      name = "github-username";
-      packageName = "github-username";
-      version = "3.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz";
-        sha1 = "0a772219b3130743429f2456d0bdd3db55dce7b1";
       };
     };
     "gl-matrix-2.8.1" = {
@@ -27566,13 +27620,13 @@ let
         sha512 = "zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==";
       };
     };
-    "graphql-ws-4.2.2" = {
+    "graphql-ws-4.4.2" = {
       name = "graphql-ws";
       packageName = "graphql-ws";
-      version = "4.2.2";
+      version = "4.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.2.2.tgz";
-        sha512 = "b6TLtWLAmKunD72muL9EeItRGpio9+V3Cx4zJsBkRA+3wxzTWXDvQr9/3qSwJ3D/2abz0ys2KHTM6lB1uH7KIQ==";
+        url = "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.4.2.tgz";
+        sha512 = "Cz+t1w+8+tiHIKzcz45tMwrxJpPSQ7KNjQrfN8ADAELECkkBB7aSvAgpShWz0Tne8teH/UxzJsULObLVq5eMvQ==";
       };
     };
     "gray-matter-2.1.1" = {
@@ -27593,13 +27647,13 @@ let
         sha512 = "CgXlq3PGpBRj8RMnLSYs46Hvl5q9Up9kwuMAcYlvS4sNgH5j4Ao7hbY+HI62PaYTeIdffiJidLEIeZVCmZCrFA==";
       };
     };
-    "grouped-queue-1.1.0" = {
+    "grouped-queue-2.0.0" = {
       name = "grouped-queue";
       packageName = "grouped-queue";
-      version = "1.1.0";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/grouped-queue/-/grouped-queue-1.1.0.tgz";
-        sha512 = "rZOFKfCqLhsu5VqjBjEWiwrYqJR07KxIkH4mLZlNlGDfntbb4FbMyGFP14TlvRPrU9S3Hnn/sgxbC5ZeN0no3Q==";
+        url = "https://registry.npmjs.org/grouped-queue/-/grouped-queue-2.0.0.tgz";
+        sha512 = "/PiFUa7WIsl48dUeCvhIHnwNmAAzlI/eHoJl0vu3nsFA366JleY7Ff8EVTplZu5kO0MIdZjKTTnzItL61ahbnw==";
       };
     };
     "growl-1.10.5" = {
@@ -28140,6 +28194,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz";
         sha512 = "WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==";
+      };
+    };
+    "hash-wasm-4.6.0" = {
+      name = "hash-wasm";
+      packageName = "hash-wasm";
+      version = "4.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.6.0.tgz";
+        sha512 = "Wi96tJDftxUQciCUi2Vs/Nw8al3psRATe/FhyezrajJKCXKRHvpiFARTZuUgdlGB7825LiN+FluH7SFoGdiGRA==";
       };
     };
     "hash.js-1.1.7" = {
@@ -29034,13 +29097,13 @@ let
         sha512 = "yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==";
       };
     };
-    "http-proxy-middleware-1.1.2" = {
+    "http-proxy-middleware-1.2.0" = {
       name = "http-proxy-middleware";
       packageName = "http-proxy-middleware";
-      version = "1.1.2";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.1.2.tgz";
-        sha512 = "YRFUeOG3q85FJjAaYVJUoNRW9a73SDlOtAyQOS5PHLr18QeZ/vEhxywNoOPiEO8BxCegz4RXzTHcvyLEGB78UA==";
+        url = "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.2.0.tgz";
+        sha512 = "vNw+AxT0+6VTM1rCJw1bpiIaUQ1Ww/vTyIEOUzdW9kNX4yuhhqV3jLSKDJo/Y/lqEIshaKCDujtvEqWiD9Dn6Q==";
       };
     };
     "http-signature-0.11.0" = {
@@ -29464,6 +29527,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz";
         sha1 = "09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c";
+      };
+    };
+    "image-size-0.9.7" = {
+      name = "image-size";
+      packageName = "image-size";
+      version = "0.9.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/image-size/-/image-size-0.9.7.tgz";
+        sha512 = "KRVgLNZkr00YGN0qn9MlIrmlxbRhsCcEb1Byq3WKGnIV4M48iD185cprRtaoK4t5iC+ym2Q5qlArxZ/V1yzDgA==";
       };
     };
     "image-type-3.1.0" = {
@@ -30310,6 +30382,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/invoices/-/invoices-1.1.7.tgz";
         sha512 = "AMCHpf/7sJOjeRbTgCLLvhH41ZnUv0D809ZFJRhR2dGOfp8GxJHzfnNqtgYGxQiW0+dVK2ooBVyR+dqoEQs6mw==";
+      };
+    };
+    "invoices-1.2.0" = {
+      name = "invoices";
+      packageName = "invoices";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/invoices/-/invoices-1.2.0.tgz";
+        sha512 = "x9jMmN/afPZkeL7qwMj15r+RSV7ztPsfxKgByD3bXR/WhmjrlfU+zwfliohScW/UV1b0FUSq6A7DgTME4tdMSQ==";
       };
     };
     "iota-array-1.0.0" = {
@@ -31545,15 +31626,6 @@ let
         sha512 = "AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==";
       };
     };
-    "is-scoped-1.0.0" = {
-      name = "is-scoped";
-      packageName = "is-scoped";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz";
-        sha1 = "449ca98299e713038256289ecb2b540dc437cb30";
-      };
-    };
     "is-scoped-2.1.0" = {
       name = "is-scoped";
       packageName = "is-scoped";
@@ -32049,13 +32121,13 @@ let
         sha512 = "BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==";
       };
     };
-    "istextorbinary-2.6.0" = {
+    "istextorbinary-5.12.0" = {
       name = "istextorbinary";
       packageName = "istextorbinary";
-      version = "2.6.0";
+      version = "5.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz";
-        sha512 = "+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==";
+        url = "https://registry.npmjs.org/istextorbinary/-/istextorbinary-5.12.0.tgz";
+        sha512 = "wLDRWD7qpNTYubk04+q3en1+XZGS4vYWK0+SxNSXJLaITMMEK+J3o/TlOMyULeH1qozVZ9uUkKcyMA8odyxz8w==";
       };
     };
     "isuri-2.0.3" = {
@@ -32283,13 +32355,13 @@ let
         sha512 = "0soPJif+yjmzmOF+4cF2hyhxUWWpXpQntsm2joJXFFoRcQiPzsG4dbLKYqYPT3Fc6PjZ8MaLtCkDqqckVSfmRw==";
       };
     };
-    "jitdb-3.0.3" = {
+    "jitdb-3.1.2" = {
       name = "jitdb";
       packageName = "jitdb";
-      version = "3.0.3";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jitdb/-/jitdb-3.0.3.tgz";
-        sha512 = "BTXAauBdig83EUkBFdWY9dzdf8wB5DlJ4aa/uCMwmf2eki7DhQBT7rrJFuscR/Mkmqt00G1oxiqa4gnA+oPJ6Q==";
+        url = "https://registry.npmjs.org/jitdb/-/jitdb-3.1.2.tgz";
+        sha512 = "DDmf7oG0MrQ5LJd4yE20b/58kZJ1wTtzDjzn5EWYYYm8yBcR9bWXFDd3Wqc9JS+Ce3fiEo4cqsfm6BxX+Wa8Kw==";
       };
     };
     "jju-1.4.0" = {
@@ -32409,13 +32481,13 @@ let
         sha1 = "bcb4045c8dd0539c134bc1488cdd3e768a7a9e51";
       };
     };
-    "jquery.terminal-2.22.0" = {
+    "jquery.terminal-2.23.2" = {
       name = "jquery.terminal";
       packageName = "jquery.terminal";
-      version = "2.22.0";
+      version = "2.23.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jquery.terminal/-/jquery.terminal-2.22.0.tgz";
-        sha512 = "0VDAqWMrqIcI7Mduqkgw/SM9G8aTMJUx/Lu8rxHVPfn10wkHZmaVywczVQgQWRCSdGa+/hy/qZEdaVPPmLyplw==";
+        url = "https://registry.npmjs.org/jquery.terminal/-/jquery.terminal-2.23.2.tgz";
+        sha512 = "C92ZOquPhjGcB0PAEUHPlnkEycgtQoCoiCYZ3d7FyuK7z/JDSIXuNk5kosaVn3/NwFZ7jlFgy+s3kksHI0aFHg==";
       };
     };
     "js-base64-2.6.4" = {
@@ -32706,49 +32778,49 @@ let
         sha512 = "xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==";
       };
     };
-    "jsii-1.28.0" = {
+    "jsii-1.29.0" = {
       name = "jsii";
       packageName = "jsii";
-      version = "1.28.0";
+      version = "1.29.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii/-/jsii-1.28.0.tgz";
-        sha512 = "B6CbHi60fabeQZJYNea8wSUsrILJzN7ng+yx69GmMJ4C6NtCVt7Oc/CITfhY/cYTwdhN3FAJf01e5/v8qj6bUA==";
+        url = "https://registry.npmjs.org/jsii/-/jsii-1.29.0.tgz";
+        sha512 = "7o1yE/si/nbGsNquSejwxaiPq0iDSTPfDENd7ZyO3xzGIROV8UZSs+VhGyys9t/VF4og8p9s2olkajEN60fzMw==";
       };
     };
-    "jsii-pacmak-1.28.0" = {
+    "jsii-pacmak-1.29.0" = {
       name = "jsii-pacmak";
       packageName = "jsii-pacmak";
-      version = "1.28.0";
+      version = "1.29.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.28.0.tgz";
-        sha512 = "QAW8rq7M9rA/QSXwaJKMVpttkNW/BJgE9GT6i9UahobQMkmp+zsXCJUENeRg2mndLqX0DDyxO1in/fuIeCeR3A==";
+        url = "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.29.0.tgz";
+        sha512 = "wpVDrvh+hClB4Y68v/sYCcRnXlXoDwEUTC0X+uz9o5xUHs/WfuDglS5AAhq6g51INAQc0ed3anrkqmFcDK6QPw==";
       };
     };
-    "jsii-reflect-1.28.0" = {
+    "jsii-reflect-1.29.0" = {
       name = "jsii-reflect";
       packageName = "jsii-reflect";
-      version = "1.28.0";
+      version = "1.29.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.28.0.tgz";
-        sha512 = "jFu9dUy5D0PrxVnaDilb50agbSr0wZRya6StwHyw8Wly3ruzS8uuSB1aWmEwN371m5ewDD4m9nPEQ9zMmKFvMQ==";
+        url = "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.29.0.tgz";
+        sha512 = "r1XpKsnaMTaI0B2XXJ4rF1rbufqFDThASrArE+SyuuGeWTJxWQ4UtIzvXNVFLbZba0A5hX4K0JxiMIfaRFCEEg==";
       };
     };
-    "jsii-rosetta-1.28.0" = {
+    "jsii-rosetta-1.29.0" = {
       name = "jsii-rosetta";
       packageName = "jsii-rosetta";
-      version = "1.28.0";
+      version = "1.29.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.28.0.tgz";
-        sha512 = "lttDhXiBuWaN0DwsWakD5o7GxyVP8yMCRvpmpXOqz1eK+MMlZp654R6o39M7RksXhhxipCNwfbIY3T7Y7N85qQ==";
+        url = "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.29.0.tgz";
+        sha512 = "WhTlFFm/xp2ictShT7XreBoqNpFj/U4MK4VyHyzYV1jS58uvJJMkwifMz/MOqciqRtWIAvGM3Ria4EB3VqmTfA==";
       };
     };
-    "jsii-srcmak-0.1.255" = {
+    "jsii-srcmak-0.1.257" = {
       name = "jsii-srcmak";
       packageName = "jsii-srcmak";
-      version = "0.1.255";
+      version = "0.1.257";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.255.tgz";
-        sha512 = "vWIcR+z9HmqHX4lwJI9TFkGhBsZK2tPlgnvANJ09+SwrrLdBFOBFOJB298U5vMyQ/2mf0VFGlFFoJO9mA/6B4A==";
+        url = "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.257.tgz";
+        sha512 = "Nfym9T84GR8kMjx6Lcah/RhIW8c38BEt/nltagrf9wnBhXWPgQoIP9f6nSsKaGHy2srI6gNSNFFR7sSIS90TyA==";
       };
     };
     "json-bigint-0.2.3" = {
@@ -33003,6 +33075,15 @@ let
         sha1 = "9db7b59496ad3f3cfef30a75142d2d930ad72651";
       };
     };
+    "json-stringify-nice-1.1.3" = {
+      name = "json-stringify-nice";
+      packageName = "json-stringify-nice";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.3.tgz";
+        sha512 = "w8+cZZFgcPtFkZTmkA1UpRH0GXXfpeuc/cClNkQjLt9JoQd8cBFSyB8J1WWjJrthIYViHobwnh3jA4z5X2LdGA==";
+      };
+    };
     "json-stringify-pretty-compact-3.0.0" = {
       name = "json-stringify-pretty-compact";
       packageName = "json-stringify-pretty-compact";
@@ -33039,13 +33120,13 @@ let
         sha512 = "0/4Lv6IenJV0qj2oBdgPIAmFiKKnh8qh7bmLFJ+/ZZHLjSeiL3fKKGX3UryvKPbxFbhV+JcYo9KUC19GJ/Z/4A==";
       };
     };
-    "json2jsii-0.1.188" = {
+    "json2jsii-0.1.218" = {
       name = "json2jsii";
       packageName = "json2jsii";
-      version = "0.1.188";
+      version = "0.1.218";
       src = fetchurl {
-        url = "https://registry.npmjs.org/json2jsii/-/json2jsii-0.1.188.tgz";
-        sha512 = "XeUcBQl0rngTFmiSIx0XNW+g0QgAJcqwsUYzvGcDPPSvPngIGmJ/X6d0UH/nDmSVyEilYyKnVP7iYh3y9by9fA==";
+        url = "https://registry.npmjs.org/json2jsii/-/json2jsii-0.1.218.tgz";
+        sha512 = "QlMkNAY8xxyZVZWzxnD8eRYkX8CwiDaUr5nBSm+Hlv7h+jRPoOVD++PujzZHq2OvQYxjb2QjIuGlbrXYzfjdTQ==";
       };
     };
     "json3-3.2.6" = {
@@ -33397,6 +33478,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/just-detect-adblock/-/just-detect-adblock-1.1.0.tgz";
         sha512 = "xtgnwBBZaLtKspGo6jDX/H0FDsHrn41mQVWhNHge7pZe6Nj2gU2izfC09O0rPU/i97iMcJFVjbecFiTAvmNhLQ==";
+      };
+    };
+    "just-diff-3.1.1" = {
+      name = "just-diff";
+      packageName = "just-diff";
+      version = "3.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/just-diff/-/just-diff-3.1.1.tgz";
+        sha512 = "sdMWKjRq8qWZEjDcVA6llnUT8RDEBIfOiGpYFPYa9u+2c39JCsejktSP7mj5eRid5EIvTzIpQ2kDOCw1Nq9BjQ==";
+      };
+    };
+    "just-diff-apply-3.0.0" = {
+      name = "just-diff-apply";
+      packageName = "just-diff-apply";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-3.0.0.tgz";
+        sha512 = "K2MLc+ZC2DVxX4V61bIKPeMUUfj1YYZ3h0myhchDXOW1cKoPZMnjIoNCqv9bF2n5Oob1PFxuR2gVJxkxz4e58w==";
       };
     };
     "jwa-1.4.1" = {
@@ -33994,15 +34093,6 @@ let
         sha1 = "a1d78fc3a50474cb80845d3b3b6e1da49a446e8e";
       };
     };
-    "lazy-cache-2.0.2" = {
-      name = "lazy-cache";
-      packageName = "lazy-cache";
-      version = "2.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz";
-        sha1 = "b9190a4f913354694840859f8a8f7084d8822264";
-      };
-    };
     "lazyness-1.2.0" = {
       name = "lazyness";
       packageName = "lazyness";
@@ -34309,13 +34399,13 @@ let
         sha512 = "IR5ASkAU4NHTN1JFeP9bYvhARhaBg8VD8yUcmvNIvFWg6L3dsM2yK1A9EM6MpPvWYKH9SEiljB59ZUa5s2pYnA==";
       };
     };
-    "libnpmaccess-4.0.1" = {
+    "libnpmaccess-4.0.2" = {
       name = "libnpmaccess";
       packageName = "libnpmaccess";
-      version = "4.0.1";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-4.0.1.tgz";
-        sha512 = "ZiAgvfUbvmkHoMTzdwmNWCrQRsDkOC+aM5BDfO0C9aOSwF3R1LdFDBD+Rer1KWtsoQYO35nXgmMR7OUHpDRxyA==";
+        url = "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-4.0.2.tgz";
+        sha512 = "avXtJibZuGap0/qADDYqb9zdpgzVu/yG5+tl2sTRa7MCkDNv2ZlGwCYI0r6/+tmqXPj0iB9fKexHz426vB326w==";
       };
     };
     "libnpmconfig-1.2.1" = {
@@ -34327,13 +34417,13 @@ let
         sha512 = "9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==";
       };
     };
-    "libnpmpublish-4.0.0" = {
+    "libnpmpublish-4.0.1" = {
       name = "libnpmpublish";
       packageName = "libnpmpublish";
-      version = "4.0.0";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-4.0.0.tgz";
-        sha512 = "2RwYXRfZAB1x/9udKpZmqEzSqNd7ouBRU52jyG14/xG8EF+O9A62d7/XVR3iABEQHf1iYhkm0Oq9iXjrL3tsXA==";
+        url = "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-4.0.1.tgz";
+        sha512 = "hZCrZ8v4G9YH3DxpIyBdob25ijD5v5LNzRbwsej4pPDopjdcLLj1Widl+BUeFa7D0ble1JYL4F3owjLJqiA8yA==";
       };
     };
     "libsodium-0.7.9" = {
@@ -34667,6 +34757,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/load-plugin/-/load-plugin-3.0.0.tgz";
         sha512 = "od7eKCCZ62ITvFf8nHHrIiYmgOHb4xVNDRDqxBWSaao5FZyyZVX8OmRCbwjDGPrSrgIulwPNyBsWCGnhiDC0oQ==";
+      };
+    };
+    "load-yaml-file-0.2.0" = {
+      name = "load-yaml-file";
+      packageName = "load-yaml-file";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/load-yaml-file/-/load-yaml-file-0.2.0.tgz";
+        sha512 = "OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==";
       };
     };
     "loader-runner-2.4.0" = {
@@ -37657,13 +37756,13 @@ let
         sha512 = "Ci6bIfq/UgcxPTYa8dQQ5FY3BzKkT894bwXWXxC/zqs0XgMO2cT20CGkOqda7gZNkmK5VP4x89IGZ6K7hfbn3Q==";
       };
     };
-    "mem-8.1.0" = {
+    "mem-8.1.1" = {
       name = "mem";
       packageName = "mem";
-      version = "8.1.0";
+      version = "8.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mem/-/mem-8.1.0.tgz";
-        sha512 = "FIkgXo0kTi3XpvaznV5Muk6Y6w8SkdmRXcY7ZLonQesuYezp59UooLxAVBcGuN6PH2tXN84mR3vyzSc6oSMUfA==";
+        url = "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz";
+        sha512 = "qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==";
       };
     };
     "mem-fs-1.2.0" = {
@@ -37675,22 +37774,13 @@ let
         sha512 = "b8g0jWKdl8pM0LqAPdK9i8ERL7nYrzmJfRhxMiWH2uYdfYnb7uXnmwVb0ZGe7xyEl4lj+nLIU3yf4zPUT+XsVQ==";
       };
     };
-    "mem-fs-editor-6.0.0" = {
+    "mem-fs-editor-8.1.2" = {
       name = "mem-fs-editor";
       packageName = "mem-fs-editor";
-      version = "6.0.0";
+      version = "8.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-6.0.0.tgz";
-        sha512 = "e0WfJAMm8Gv1mP5fEq/Blzy6Lt1VbLg7gNnZmZak7nhrBTibs+c6nQ4SKs/ZyJYHS1mFgDJeopsLAv7Ow0FMFg==";
-      };
-    };
-    "mem-fs-editor-7.1.0" = {
-      name = "mem-fs-editor";
-      packageName = "mem-fs-editor";
-      version = "7.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-7.1.0.tgz";
-        sha512 = "BH6QEqCXSqGeX48V7zu+e3cMwHU7x640NB8Zk8VNvVZniz+p4FK60pMx/3yfkzo6miI6G3a8pH6z7FeuIzqrzA==";
+        url = "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-8.1.2.tgz";
+        sha512 = "owE6PKMRegrYb37Lsar3yLSwK9wLGvHkNIOzBO3ycFeoOwshdF8j593EqjU7ucFAf3ZvcFVwfpo8Q8LqgFQg0A==";
       };
     };
     "memfs-3.2.2" = {
@@ -37709,6 +37799,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz";
         sha512 = "HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==";
+      };
+    };
+    "memoize-one-5.2.1" = {
+      name = "memoize-one";
+      packageName = "memoize-one";
+      version = "5.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz";
+        sha512 = "zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==";
       };
     };
     "memoizeasync-1.1.0" = {
@@ -38863,13 +38962,13 @@ let
         sha1 = "ebb3a977e7af1c683ae6fda12b545a6ba6c5853d";
       };
     };
-    "mobx-6.2.0" = {
+    "mobx-6.3.0" = {
       name = "mobx";
       packageName = "mobx";
-      version = "6.2.0";
+      version = "6.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mobx/-/mobx-6.2.0.tgz";
-        sha512 = "j5f16JIq2v4flvYCqaAB9tMtJt/y5efR2OO5Xy+w4/MBMeQ1WeGR0T8BtiNgmxM/OQzPFUKb5DTex9Y8a/yk+g==";
+        url = "https://registry.npmjs.org/mobx/-/mobx-6.3.0.tgz";
+        sha512 = "Aa1+VXsg4WxqJMTQfWoYuJi5UD10VZhiobSmcs5kcmI3BIT0aVtn7DysvCeDADCzl7dnbX+0BTHUj/v7gLlZpQ==";
       };
     };
     "mobx-react-7.1.0" = {
@@ -39403,13 +39502,13 @@ let
         sha1 = "2a8f2ddf70eed564dff2d57f1e1a137d9f05078b";
       };
     };
-    "multiserver-3.7.0" = {
+    "multiserver-3.7.1" = {
       name = "multiserver";
       packageName = "multiserver";
-      version = "3.7.0";
+      version = "3.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/multiserver/-/multiserver-3.7.0.tgz";
-        sha512 = "70SSDMNT+e3VsDG4x7OKFW8+UqyZsBWfKD9rAvsRWCbMe9ySODheJCZ91Xyha5FrA32UtWIHGSY3m5jATfEmVQ==";
+        url = "https://registry.npmjs.org/multiserver/-/multiserver-3.7.1.tgz";
+        sha512 = "wc+s3NNXjYEFT6AmeW8fVVBTZWhfwwbFU0M0KurZH6jAbsnWYQnEsnN90iqFkSmHkAnPW2hvT4O+lAfWsf/lVQ==";
       };
     };
     "multiserver-address-1.0.1" = {
@@ -40124,22 +40223,22 @@ let
         sha512 = "AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==";
       };
     };
-    "netlify-6.1.18" = {
+    "netlify-6.1.20" = {
       name = "netlify";
       packageName = "netlify";
-      version = "6.1.18";
+      version = "6.1.20";
       src = fetchurl {
-        url = "https://registry.npmjs.org/netlify/-/netlify-6.1.18.tgz";
-        sha512 = "hVOf6l67ldiVfJPsMp4Ztunvv81hbGr5RGw2WUlR6b7Hp1bM1oaydEx/MrsLtVVDwy2KEYxkwcMY3m7CiHnh5g==";
+        url = "https://registry.npmjs.org/netlify/-/netlify-6.1.20.tgz";
+        sha512 = "a0WYQIcJIIEmK7MxUWD/4awyBeGTukolaTgl84SILrnT6WC/HQqK8bIEPVJ5IhmbZioJIcl4UZMaDyWuPin6Kw==";
       };
     };
-    "netlify-redirect-parser-3.0.15" = {
+    "netlify-redirect-parser-3.0.16" = {
       name = "netlify-redirect-parser";
       packageName = "netlify-redirect-parser";
-      version = "3.0.15";
+      version = "3.0.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/netlify-redirect-parser/-/netlify-redirect-parser-3.0.15.tgz";
-        sha512 = "AWciaJpE83idl6VRPkZBW0TIOUZIPL30poFfruo/xMUJJuvgHw+wfExBnEpgXQ1sAdIWcZajhfKeLEXl1jWDLw==";
+        url = "https://registry.npmjs.org/netlify-redirect-parser/-/netlify-redirect-parser-3.0.16.tgz";
+        sha512 = "K8/CvBZKRfF0A01MntMw/DlZxrixwN8K9Qysswi0VkcE436WhWqp86Nwci4XdX6d389KImnluIWkY4Mhq1MyZQ==";
       };
     };
     "netlify-redirector-0.2.1" = {
@@ -40349,13 +40448,13 @@ let
         sha512 = "zPpIr24OdcdM6lbg9QbFUGaLx9RueAkg1I4ZueuuB5452ZrxYfdwaBkhLGFCgpy3AaQ1w8HaY/8k2HmeyD9FXw==";
       };
     };
-    "node-abi-2.21.0" = {
+    "node-abi-2.26.0" = {
       name = "node-abi";
       packageName = "node-abi";
-      version = "2.21.0";
+      version = "2.26.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz";
-        sha512 = "smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==";
+        url = "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz";
+        sha512 = "ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==";
       };
     };
     "node-addon-api-1.7.2" = {
@@ -41169,22 +41268,13 @@ let
         sha1 = "df7c3ed5a277c3f9d4b5d819b05311d10a200ae6";
       };
     };
-    "npm-api-1.0.1" = {
-      name = "npm-api";
-      packageName = "npm-api";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/npm-api/-/npm-api-1.0.1.tgz";
-        sha512 = "4sITrrzEbPcr0aNV28QyOmgn6C9yKiF8k92jn4buYAK8wmA5xo1qL3II5/gT1r7wxbXBflSduZ2K3FbtOrtGkA==";
-      };
-    };
-    "npm-bundled-1.1.1" = {
+    "npm-bundled-1.1.2" = {
       name = "npm-bundled";
       packageName = "npm-bundled";
-      version = "1.1.1";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz";
-        sha512 = "gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==";
+        url = "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz";
+        sha512 = "x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==";
       };
     };
     "npm-conf-1.1.3" = {
@@ -41347,6 +41437,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.6.0.tgz";
         sha512 = "Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==";
+      };
+    };
+    "npm-registry-fetch-10.1.1" = {
+      name = "npm-registry-fetch";
+      packageName = "npm-registry-fetch";
+      version = "10.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-10.1.1.tgz";
+        sha512 = "F6a3l+ffCQ7hvvN16YG5bpm1rPZntCg66PLHDQ1apWJPOCUVHoKnL2w5fqEaTVhp42dmossTyXeR7hTGirfXrg==";
       };
     };
     "npm-registry-fetch-9.0.0" = {
@@ -42169,13 +42268,13 @@ let
         sha512 = "kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==";
       };
     };
-    "oo-ascii-tree-1.28.0" = {
+    "oo-ascii-tree-1.29.0" = {
       name = "oo-ascii-tree";
       packageName = "oo-ascii-tree";
-      version = "1.28.0";
+      version = "1.29.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.28.0.tgz";
-        sha512 = "lCeBgtQutG2+K7BOJDurYNfCepvckj7jWtq2VVP1kseLry/VbLzE/oLiXEeK6iWUXJbBE2IzmxwGuUwee293yw==";
+        url = "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.29.0.tgz";
+        sha512 = "DUwUL3Yc3lS2znWBlOi5eEU4pKoGGK2IaB/S7XygSBzmSS2jJE6+waAip17FNeNXfC4aXClr95HxZXamCLtYqQ==";
       };
     };
     "opal-runtime-1.0.11" = {
@@ -43375,13 +43474,13 @@ let
         sha512 = "HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==";
       };
     };
-    "packet-stream-2.0.5" = {
+    "packet-stream-2.0.6" = {
       name = "packet-stream";
       packageName = "packet-stream";
-      version = "2.0.5";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.5.tgz";
-        sha512 = "+4S+qBUdqD57ka5MDd6nAYGBPril5eyLpbga2y0kPyYhrKvjb8CYTP9r40WLbSxgT/qEGmvgWOrvQe+FYtCI7w==";
+        url = "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.6.tgz";
+        sha512 = "kSxHpoTqlgNEetMp77snCTVILwLw4dJX6pB/z1g1PRG5xylH8cf9upIPygt+epBC3l14XrcZH4/kQYSrzp2Ijg==";
       };
     };
     "packet-stream-codec-1.1.3" = {
@@ -43402,13 +43501,13 @@ let
         sha512 = "GfTeVQGJ6WyBQbQD4t3ocHbyOmTQLmWjkCKSZPmKiGFKYKNUaM5U2gbLzUW8WG1XmS9yQFnsTFA0k3o1+q4klQ==";
       };
     };
-    "pacote-11.3.1" = {
+    "pacote-11.3.3" = {
       name = "pacote";
       packageName = "pacote";
-      version = "11.3.1";
+      version = "11.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pacote/-/pacote-11.3.1.tgz";
-        sha512 = "TymtwoAG12cczsJIrwI/euOQKtjrQHlD0k0oyt9QSmZGpqa+KdlxKdWR/YUjYizkixaVyztxt/Wsfo8bL3A6Fg==";
+        url = "https://registry.npmjs.org/pacote/-/pacote-11.3.3.tgz";
+        sha512 = "GQxBX+UcVZrrJRYMK2HoG+gPeSUX/rQhnbPkkGrCYa4n2F/bgClFPaMm0nsdnYrxnmUy85uMHoFXZ0jTD0drew==";
       };
     };
     "pad-0.0.5" = {
@@ -43427,15 +43526,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz";
         sha1 = "ad1f22ce1bf0fdc0d6ddd908af17f351a404b8ac";
-      };
-    };
-    "paged-request-2.0.2" = {
-      name = "paged-request";
-      packageName = "paged-request";
-      version = "2.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/paged-request/-/paged-request-2.0.2.tgz";
-        sha512 = "NWrGqneZImDdcMU/7vMcAOo1bIi5h/pmpJqe7/jdsy85BA/s5MSaU/KlpxwW/IVPmIwBcq2uKPrBWWhEWhtxag==";
       };
     };
     "pako-0.2.9" = {
@@ -43562,6 +43652,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz";
         sha512 = "bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==";
+      };
+    };
+    "parse-conflict-json-1.1.1" = {
+      name = "parse-conflict-json";
+      packageName = "parse-conflict-json";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-1.1.1.tgz";
+        sha512 = "4gySviBiW5TRl7XHvp1agcS7SOe0KZOjC//71dzZVWJrY9hCrgtvl5v3SyIxCZ4fZF47TxD9nfzmxcx76xmbUw==";
       };
     };
     "parse-english-4.2.0" = {
@@ -44680,31 +44779,13 @@ let
         sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
       };
     };
-    "pino-6.11.1" = {
+    "pino-6.11.2" = {
       name = "pino";
       packageName = "pino";
-      version = "6.11.1";
+      version = "6.11.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pino/-/pino-6.11.1.tgz";
-        sha512 = "PoDR/4jCyaP1k2zhuQ4N0NuhaMtei+C9mUHBRRJQujexl/bq3JkeL2OC23ada6Np3zeUMHbO4TGzY2D/rwZX3w==";
-      };
-    };
-    "pino-6.9.0" = {
-      name = "pino";
-      packageName = "pino";
-      version = "6.9.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pino/-/pino-6.9.0.tgz";
-        sha512 = "9RrRJsKOsgj50oGoR/y4EEVyUjMb/eRu8y4hjwPqM6q214xsxSxY/IKB+aEEv0slqNd4U0RVRfivKfy83UxgUQ==";
-      };
-    };
-    "pino-std-serializers-2.5.0" = {
-      name = "pino-std-serializers";
-      packageName = "pino-std-serializers";
-      version = "2.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz";
-        sha512 = "wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==";
+        url = "https://registry.npmjs.org/pino/-/pino-6.11.2.tgz";
+        sha512 = "bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==";
       };
     };
     "pino-std-serializers-3.2.0" = {
@@ -44723,6 +44804,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pipe-functions/-/pipe-functions-1.3.0.tgz";
         sha512 = "6Rtbp7criZRwedlvWbUYxqlqJoAlMvYHo2UcRWq79xZ54vZcaNHpVBOcWkX3ErT2aUA69tv+uiv4zKJbhD/Wgg==";
+      };
+    };
+    "pipeline-pipe-0.1.5" = {
+      name = "pipeline-pipe";
+      packageName = "pipeline-pipe";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pipeline-pipe/-/pipeline-pipe-0.1.5.tgz";
+        sha512 = "HFub9yAfxEWBZZmsA12dWiFpg9+er8Sp7bpVwKP41AsAeO6570PVhU2Ckkt8fMnHBwm1edLLg2wIfpNGCDvI0Q==";
       };
     };
     "pipeworks-1.3.1" = {
@@ -45149,13 +45239,13 @@ let
         sha512 = "3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==";
       };
     };
-    "postcss-8.2.7" = {
+    "postcss-8.2.10" = {
       name = "postcss";
       packageName = "postcss";
-      version = "8.2.7";
+      version = "8.2.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/postcss/-/postcss-8.2.7.tgz";
-        sha512 = "DsVLH3xJzut+VT+rYr0mtvOtpTjSyqDwPf5EZWXcb0uAKfitGpTY9Ec+afi2+TgdN8rWS9Cs88UDYehKo/RvOw==";
+        url = "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz";
+        sha512 = "b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==";
       };
     };
     "postcss-calc-7.0.5" = {
@@ -45653,13 +45743,13 @@ let
         sha512 = "36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==";
       };
     };
-    "postcss-selector-parser-6.0.4" = {
+    "postcss-selector-parser-6.0.5" = {
       name = "postcss-selector-parser";
       packageName = "postcss-selector-parser";
-      version = "6.0.4";
+      version = "6.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz";
-        sha512 = "gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==";
+        url = "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.5.tgz";
+        sha512 = "aFYPoYmXbZ1V6HZaSvat08M97A8HqO6Pjz+PiNpw/DhuRrC72XWAdp3hL6wusDCN31sSmcZyMGa2hZEuX+Xfhg==";
       };
     };
     "postcss-svgo-4.0.3" = {
@@ -45840,6 +45930,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz";
         sha1 = "aa9591bcaa24923f1e0f4849d240f47efc1075ac";
+      };
+    };
+    "preferred-pm-3.0.3" = {
+      name = "preferred-pm";
+      packageName = "preferred-pm";
+      version = "3.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.0.3.tgz";
+        sha512 = "+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==";
       };
     };
     "prelude-ls-1.1.2" = {
@@ -46328,6 +46427,15 @@ let
         sha512 = "W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==";
       };
     };
+    "promise-all-reject-late-1.0.1" = {
+      name = "promise-all-reject-late";
+      packageName = "promise-all-reject-late";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz";
+        sha512 = "vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==";
+      };
+    };
     "promise-breaker-5.0.0" = {
       name = "promise-breaker";
       packageName = "promise-breaker";
@@ -46335,6 +46443,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/promise-breaker/-/promise-breaker-5.0.0.tgz";
         sha512 = "mgsWQuG4kJ1dtO6e/QlNDLFtMkMzzecsC69aI5hlLEjGHFNpHrvGhFi4LiK5jg2SMQj74/diH+wZliL9LpGsyA==";
+      };
+    };
+    "promise-call-limit-1.0.1" = {
+      name = "promise-call-limit";
+      packageName = "promise-call-limit";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-1.0.1.tgz";
+        sha512 = "3+hgaa19jzCGLuSCbieeRsu5C2joKfYn8pY6JAuXFRVfF4IO+L7UPpFWNTeWT9pM7uhskvbPPd/oEOktCn317Q==";
       };
     };
     "promise-deferred-2.0.3" = {
@@ -47651,13 +47768,13 @@ let
         sha1 = "15931d3cd967ade52206f523aa7331aef7d43af7";
       };
     };
-    "pyright-1.1.132" = {
+    "pyright-1.1.134" = {
       name = "pyright";
       packageName = "pyright";
-      version = "1.1.132";
+      version = "1.1.134";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pyright/-/pyright-1.1.132.tgz";
-        sha512 = "quvG9Ip2NwKEShsLJ7eLlkQ/ST5SX84QCgO/k7gGqlCHwuifn9/v7LrzdpdFbkVnQR51egUNWwwLQRoIBT6vUA==";
+        url = "https://registry.npmjs.org/pyright/-/pyright-1.1.134.tgz";
+        sha512 = "wQSdU6X3olAwCZy3tSA0fn8nMQGEwm01rm1dHM+aN2crzXIcUQ9sLOf+wCn5PFlLGsm/CXH7ROYmeMs3jXQ8Rw==";
       };
     };
     "q-0.9.7" = {
@@ -47939,13 +48056,13 @@ let
         sha512 = "NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==";
       };
     };
-    "quick-format-unescaped-4.0.3" = {
+    "quick-format-unescaped-4.0.1" = {
       name = "quick-format-unescaped";
       packageName = "quick-format-unescaped";
-      version = "4.0.3";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz";
-        sha512 = "MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==";
+        url = "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz";
+        sha512 = "RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==";
       };
     };
     "quick-lru-1.1.0" = {
@@ -48407,13 +48524,13 @@ let
         sha512 = "dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==";
       };
     };
-    "react-devtools-core-4.12.2" = {
+    "react-devtools-core-4.12.4" = {
       name = "react-devtools-core";
       packageName = "react-devtools-core";
-      version = "4.12.2";
+      version = "4.12.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.12.2.tgz";
-        sha512 = "cvAiJCSIIan2A22o4j4Twc7PdDrwqiAQVBeZ+osS2T/wv2Ua3a0J8Sgx4pTH5Y7VoWn5WiGCHkAW4S1lYl3kcA==";
+        url = "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.12.4.tgz";
+        sha512 = "hVCT7wRtA5xWclgLb3oA51RNBAlbuTauEYkqFX+qRAkPLVJoX8qdJnO7r+47SSUckD5vkBm3kaAhg6597m7gDA==";
       };
     };
     "react-dom-16.14.0" = {
@@ -48720,15 +48837,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz";
         sha512 = "6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==";
-      };
-    };
-    "read-pkg-up-5.0.0" = {
-      name = "read-pkg-up";
-      packageName = "read-pkg-up";
-      version = "5.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-5.0.0.tgz";
-        sha512 = "XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==";
       };
     };
     "read-pkg-up-7.0.1" = {
@@ -49055,13 +49163,13 @@ let
         sha1 = "8984b5815d99cb220469c99eeeffe38913e6cc0b";
       };
     };
-    "redis-3.1.1" = {
+    "redis-3.1.2" = {
       name = "redis";
       packageName = "redis";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/redis/-/redis-3.1.1.tgz";
-        sha512 = "QhkKhOuzhogR1NDJfBD34TQJz2ZJwDhhIC6ZmvpftlmfYShHHQXjjNspAJ+Z2HH5NwSBVYBVganbiZ8bgFMHjg==";
+        url = "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz";
+        sha512 = "grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==";
       };
     };
     "redis-commands-1.7.0" = {
@@ -50990,13 +51098,13 @@ let
         sha512 = "y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==";
       };
     };
-    "sass-1.32.10" = {
+    "sass-1.32.11" = {
       name = "sass";
       packageName = "sass";
-      version = "1.32.10";
+      version = "1.32.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sass/-/sass-1.32.10.tgz";
-        sha512 = "Nx0pcWoonAkn7CRp0aE/hket1UP97GiR1IFw3kcjV3pnenhWgZEWUf0ZcfPOV2fK52fnOcK3JdC/YYZ9E47DTQ==";
+        url = "https://registry.npmjs.org/sass/-/sass-1.32.11.tgz";
+        sha512 = "O9tRcob/fegUVSIV1ihLLZcftIOh0AF1VpKgusUfLqnb2jQ0GLDwI5ivv1FYWivGv8eZ/AwntTyTzjcHu0c/qw==";
       };
     };
     "sax-0.5.8" = {
@@ -51114,15 +51222,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz";
         sha512 = "6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==";
-      };
-    };
-    "scoped-regex-1.0.0" = {
-      name = "scoped-regex";
-      packageName = "scoped-regex";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz";
-        sha1 = "a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8";
       };
     };
     "scoped-regex-2.1.0" = {
@@ -51663,15 +51762,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz";
         sha1 = "045f9782d011ae9a6803ddd382b24392b3d890f7";
-      };
-    };
-    "set-getter-0.1.0" = {
-      name = "set-getter";
-      packageName = "set-getter";
-      version = "0.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz";
-        sha1 = "d769c182c9d5a51f409145f2fba82e5e86e80376";
       };
     };
     "set-immediate-shim-1.0.1" = {
@@ -52574,13 +52664,13 @@ let
         sha512 = "1jAYPRgMapO2BYL+HWsUq5gsAiDGmI0Pn7omc0lk24tcUOMhUB+1hb0u9WBMNzHvXBjevBkjOctjpnt2hMKN6Q==";
       };
     };
-    "snyk-gradle-plugin-3.14.0" = {
+    "snyk-gradle-plugin-3.14.2" = {
       name = "snyk-gradle-plugin";
       packageName = "snyk-gradle-plugin";
-      version = "3.14.0";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.14.0.tgz";
-        sha512 = "2A8ifM91TyzSx/U2fYvHXbaCRVsEx60hGFQjbSH9Hl9AokxEzMi2qti7wsObs1jUX2m198D1mdXu4k/Y1jWxXg==";
+        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.14.2.tgz";
+        sha512 = "l/nivKDZz7e2wymrwP6g2WQD8qgaYeE22SnbZrfIpwGolif81U28A9FsRedwkxKyB/shrM0vGEoD3c3zI8NLBw==";
       };
     };
     "snyk-module-3.1.0" = {
@@ -52619,13 +52709,13 @@ let
         sha512 = "FdYa/7NibnJPqBfobyw5jgI1/rd0LpMZf2W4WYYLRc2Hz7LZjKAByPjIX6qoA+lB9SC7yk5HYwWj2n4Fbg/DDw==";
       };
     };
-    "snyk-nuget-plugin-1.21.0" = {
+    "snyk-nuget-plugin-1.21.1" = {
       name = "snyk-nuget-plugin";
       packageName = "snyk-nuget-plugin";
-      version = "1.21.0";
+      version = "1.21.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.21.0.tgz";
-        sha512 = "c/JYF3sZzMN/lYz171zrEkVcPqDVcUTVgKIKHiL8nhhuFKxZQ1gzqOgk+lnfN31TLoTNQsZ3DhW/WY+4zEALvw==";
+        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.21.1.tgz";
+        sha512 = "nRtedIvrow5ODqOKkQWolKrxn8ZoNL3iNJGuW0jNhwv+/9K0XE1UORM5F1ENAsd+nzCSO/kiYAXCc5CNK8HWEw==";
       };
     };
     "snyk-paket-parser-1.6.0" = {
@@ -53636,13 +53726,13 @@ let
         sha1 = "475393ff9e91479aea62dcaf0ca3d14983a7fb40";
       };
     };
-    "srcset-3.0.0" = {
+    "srcset-3.0.1" = {
       name = "srcset";
       packageName = "srcset";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/srcset/-/srcset-3.0.0.tgz";
-        sha512 = "D59vF08Qzu/C4GAOXVgMTLfgryt5fyWo93FZyhEWANo0PokFz/iWdDe13mX3O5TRf6l8vMTqckAfR4zPiaH0yQ==";
+        url = "https://registry.npmjs.org/srcset/-/srcset-3.0.1.tgz";
+        sha512 = "MM8wDGg5BQJEj94tDrZDrX9wrC439/Eoeg3sgmVLPMjHgrAFeXAKk3tmFlCbKw5k+yOEhPXRpPlRcisQmqWVSQ==";
       };
     };
     "srt2vtt-1.3.1" = {
@@ -53717,13 +53807,13 @@ let
         sha512 = "pJAFizB6OcuJLX4RJJuU9HWyPwM2CqLi/vs08lhVIR3TGxacxpavvK5LzbxT+Y3iWkBchOTKS5hHCigA5aaung==";
       };
     };
-    "ssb-db2-2.0.2" = {
+    "ssb-db2-2.1.1" = {
       name = "ssb-db2";
       packageName = "ssb-db2";
-      version = "2.0.2";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-db2/-/ssb-db2-2.0.2.tgz";
-        sha512 = "ylN4uqh18gJjDrkaYWsuEEMV4rCLcKuYIkL26hgtAVJm9AfuOTBIdhZZHdfeAMd2ZkcqAmIR62XUeQL3czvOsA==";
+        url = "https://registry.npmjs.org/ssb-db2/-/ssb-db2-2.1.1.tgz";
+        sha512 = "6A2vLmDpz454ttFV3iVEI0qCIPYgsOlBtM3PCKn0arRvBKQ86e3Grr1/gCcx68fz8yT4fTC1o9ikWiZ/uUGIdg==";
       };
     };
     "ssb-ebt-5.6.7" = {
@@ -55661,13 +55751,13 @@ let
         sha512 = "SROWH0rB0DJ+0Ii264cprmNu/NJyZacs5wFD71ya93Cg/oA2lKHgQm4F6j0EWA4ktFMzeuJJm/eX6fka39hEHA==";
       };
     };
-    "svelte2tsx-0.1.186" = {
+    "svelte2tsx-0.1.188" = {
       name = "svelte2tsx";
       packageName = "svelte2tsx";
-      version = "0.1.186";
+      version = "0.1.188";
       src = fetchurl {
-        url = "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.1.186.tgz";
-        sha512 = "E4BmTNmIg6yHEqazhcQ8S60GI7AaV2JKf2y5deOyr3o2zpow4gGyz7yE0uSnFDdqp2iafCD7PImWZ/v1R6uQVw==";
+        url = "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.1.188.tgz";
+        sha512 = "+clvG/h9Z02fhx8sxDruKppheCcAXWhkKNjz9f3R4jdwVJgTHbr66qgewIjN1i2Id3D9tBKnKgaghm8H1W55sA==";
       };
     };
     "sver-compat-1.5.0" = {
@@ -55985,13 +56075,22 @@ let
         sha512 = "F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==";
       };
     };
-    "table-6.1.0" = {
+    "table-6.4.0" = {
       name = "table";
       packageName = "table";
-      version = "6.1.0";
+      version = "6.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/table/-/table-6.1.0.tgz";
-        sha512 = "T4G5KMmqIk6X87gLKWyU5exPpTjLjY5KyrFWaIjv3SvgaIUGXV7UEzGEnZJdTA38/yUS6f9PlKezQ0bYXG3iIQ==";
+        url = "https://registry.npmjs.org/table/-/table-6.4.0.tgz";
+        sha512 = "/Vfr23BDjJT2kfsCmYtnJqEPdD/8Dh/MDIQxfcbe+09lZUel6gluquwdMTrLERBw623Nv34DLGZ11krWn5AAqw==";
+      };
+    };
+    "table-6.5.1" = {
+      name = "table";
+      packageName = "table";
+      version = "6.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/table/-/table-6.5.1.tgz";
+        sha512 = "xGDXWTBJxahkzPQCsn1S9ESHEenU7TbMD5Iv4FeopXv/XwJyWatFjfbor+6ipI10/MNPXBYUamYukOrbPZ9L/w==";
       };
     };
     "table-layout-0.4.5" = {
@@ -56074,24 +56173,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz";
         sha1 = "b4d4f0deed206ae7df775b129ea2ca6de52f26dd";
-      };
-    };
-    "tap-bail-1.0.0" = {
-      name = "tap-bail";
-      packageName = "tap-bail";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tap-bail/-/tap-bail-1.0.0.tgz";
-        sha1 = "c5a8cc71191f037938cd567f97bda3ca9700199a";
-      };
-    };
-    "tap-parser-5.4.0" = {
-      name = "tap-parser";
-      packageName = "tap-parser";
-      version = "5.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz";
-        sha512 = "BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==";
       };
     };
     "tapable-0.2.9" = {
@@ -56580,13 +56661,13 @@ let
         sha1 = "7f5ee823ae805207c00af2df4a84ec3fcfa570b4";
       };
     };
-    "textextensions-2.6.0" = {
+    "textextensions-5.12.0" = {
       name = "textextensions";
       packageName = "textextensions";
-      version = "2.6.0";
+      version = "5.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/textextensions/-/textextensions-2.6.0.tgz";
-        sha512 = "49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==";
+        url = "https://registry.npmjs.org/textextensions/-/textextensions-5.12.0.tgz";
+        sha512 = "IYogUDaP65IXboCiPPC0jTLLBzYlhhw2Y4b0a2trPgbHNGGGEfuHE6tds+yDcCf4mpNDaGISFzwSSezcXt+d6w==";
       };
     };
     "textlint-rule-helper-1.2.0" = {
@@ -57660,6 +57741,15 @@ let
         sha512 = "1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==";
       };
     };
+    "treeverse-1.0.4" = {
+      name = "treeverse";
+      packageName = "treeverse";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/treeverse/-/treeverse-1.0.4.tgz";
+        sha512 = "whw60l7r+8ZU8Tu/Uc2yxtc4ZTZbR/PF3u1IPNKGQ6p8EICLb3Z2lAgoqw9bqYd8IkgnsaOcLzYHFckjqNsf0g==";
+      };
+    };
     "trim-0.0.1" = {
       name = "trim";
       packageName = "trim";
@@ -58371,13 +58461,13 @@ let
         sha512 = "7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==";
       };
     };
-    "typegram-3.2.3" = {
+    "typegram-3.2.4" = {
       name = "typegram";
       packageName = "typegram";
-      version = "3.2.3";
+      version = "3.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/typegram/-/typegram-3.2.3.tgz";
-        sha512 = "zlkY7vNTLcwQhLUyYXAUzRelzH752LBFl8m4u04d5g5P7lM9bGegeIRwzd3mVCHJH6R3s48pKeFTVSdVlN+omg==";
+        url = "https://registry.npmjs.org/typegram/-/typegram-3.2.4.tgz";
+        sha512 = "UkWgXIXZYwXK0q6zyZ4xtlETAmmgAt1Y4EFL5Ia87bIort1HHBw+RAMnO7eC1PYogCAKPSCeCSBAZVIoxQ/Dvw==";
       };
     };
     "typescript-2.9.2" = {
@@ -60748,6 +60838,24 @@ let
         sha1 = "7d13b27b1facc2e2da90405eb5ea6e5bdd252ea5";
       };
     };
+    "version-compare-1.1.0" = {
+      name = "version-compare";
+      packageName = "version-compare";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/version-compare/-/version-compare-1.1.0.tgz";
+        sha512 = "zVKtPOJTC9x23lzS4+4D7J+drq80BXVYAmObnr5zqxxFVH7OffJ1lJlAS7LYsQNV56jx/wtbw0UV7XHLrvd6kQ==";
+      };
+    };
+    "version-range-1.1.0" = {
+      name = "version-range";
+      packageName = "version-range";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/version-range/-/version-range-1.1.0.tgz";
+        sha512 = "R1Ggfg2EXamrnrV3TkZ6yBNgITDbclB3viwSjbZ3+eK0VVNK4ajkYJTnDz5N0bIMYDtK9MUBvXJUnKO5RWWJ6w==";
+      };
+    };
     "vfile-1.4.0" = {
       name = "vfile";
       packageName = "vfile";
@@ -61081,22 +61189,22 @@ let
         sha512 = "DTMa8QbVmujFPvD3NxoC5jjIXCyCG+cvn3hNzwQRhvhsk8LblNymBZBwzfcDdgEtqsi4O/2AB5HnMIRzxhzEzg==";
       };
     };
-    "vscode-debugadapter-testsupport-1.46.0" = {
+    "vscode-debugadapter-testsupport-1.47.0" = {
       name = "vscode-debugadapter-testsupport";
       packageName = "vscode-debugadapter-testsupport";
-      version = "1.46.0";
+      version = "1.47.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-debugadapter-testsupport/-/vscode-debugadapter-testsupport-1.46.0.tgz";
-        sha512 = "6n+uu4+Q5sZvN2FgFLNJkyaE6AECYzFh+Hfv+IeJoVKA7KNiQ1SNd3yTsvSFxkS00LmVU6V00XGaqZRlwM15Jg==";
+        url = "https://registry.npmjs.org/vscode-debugadapter-testsupport/-/vscode-debugadapter-testsupport-1.47.0.tgz";
+        sha512 = "zhEuaMt2RCOcJoTZ5p35k2WhCzk51UN1PlrtwfWJ8fiFhjDvXIG+682Wkq1VyL12EhTf4qOLMLn0X4JlX7eJ6g==";
       };
     };
-    "vscode-debugprotocol-1.46.0" = {
+    "vscode-debugprotocol-1.47.0" = {
       name = "vscode-debugprotocol";
       packageName = "vscode-debugprotocol";
-      version = "1.46.0";
+      version = "1.47.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.46.0.tgz";
-        sha512 = "V10u1L679DJZfOtQXhKylJPMqNbhazav4mRxPrBE8/Jpznow1b1j1EGDDvJ4prQ623CLAnvpFfVkVQ+CX3xdtg==";
+        url = "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.47.0.tgz";
+        sha512 = "ii7oCz3Wfr/SGtFr5AYop5dJm0dUmpg0hq2lTzTBdaht8nSheYMMjPntxULBR+2TUxXLcCKFZkF2UEJQduYsIQ==";
       };
     };
     "vscode-emmet-helper-1.2.17" = {
@@ -61666,6 +61774,15 @@ let
         sha512 = "ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==";
       };
     };
+    "walk-up-path-1.0.0" = {
+      name = "walk-up-path";
+      packageName = "walk-up-path";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz";
+        sha512 = "hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==";
+      };
+    };
     "walker-1.0.7" = {
       name = "walker";
       packageName = "walker";
@@ -62071,13 +62188,13 @@ let
         sha512 = "OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==";
       };
     };
-    "webtorrent-0.117.0" = {
+    "webtorrent-0.118.0" = {
       name = "webtorrent";
       packageName = "webtorrent";
-      version = "0.117.0";
+      version = "0.118.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.117.0.tgz";
-        sha512 = "CeBZP6rr1n0qAq747YjXZcDwMmUIi0d3x38qtEb8zrjjURSDd81vmtT1Y9LPJoYsY55jaYtUHGp4Ht6agQ3vWg==";
+        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.118.0.tgz";
+        sha512 = "xXwwM2P+vtDsMRx9eRPNQqHD+6E7Zz7OTZqWAr2XDXg3TWGCf9HmwpgV53+F9H0oqw+l4j7vR9DRjAjChPQpZA==";
       };
     };
     "well-known-symbols-2.0.0" = {
@@ -62240,6 +62357,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz";
         sha1 = "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a";
+      };
+    };
+    "which-pm-2.0.0" = {
+      name = "which-pm";
+      packageName = "which-pm";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/which-pm/-/which-pm-2.0.0.tgz";
+        sha512 = "Lhs9Pmyph0p5n5Z3mVnN0yWcbQYUAD7rbQUiMsQxOJ3T57k7RFe35SUwWMf7dsbDZks1uOmw4AecB/JMDj3v/w==";
       };
     };
     "which-pm-runs-1.0.0" = {
@@ -63088,13 +63214,13 @@ let
         sha512 = "N1XQngeqMBoj9wM4ZFadVV2MymImeiFfYD+fJrNlcVcOHsJFFQe7n3b+aBoTPwARuq2HQxukfzVpQmAk1gN4sQ==";
       };
     };
-    "xdl-59.0.32" = {
+    "xdl-59.0.34" = {
       name = "xdl";
       packageName = "xdl";
-      version = "59.0.32";
+      version = "59.0.34";
       src = fetchurl {
-        url = "https://registry.npmjs.org/xdl/-/xdl-59.0.32.tgz";
-        sha512 = "BY6tKRFueOlyua1btLEhdO5O7HdR/JfbCkMnRN9/slqHSPt7riL2maCKYYeT/HtvEXiww8Wrj0g6sJ97gqG/7g==";
+        url = "https://registry.npmjs.org/xdl/-/xdl-59.0.34.tgz";
+        sha512 = "gcnWDPydwr/0JAwTv0vbWU8PaYjiRWSSjwzsIcnqlh5aZZdMfEle+TwfXRhPwJm5jut4BgnzOfQqMV8CfXKbXQ==";
       };
     };
     "xenvar-0.5.1" = {
@@ -63989,22 +64115,13 @@ let
         sha512 = "CP0fwGk5Y+jel+A0AQbyqnIFZRRpkKOeYUibiTSmlgV9PcgNFFVwn86VcUIpDLOqVjF+9v+O9FWQMo+IUcV2mA==";
       };
     };
-    "yeoman-environment-2.10.3" = {
+    "yeoman-environment-3.2.0" = {
       name = "yeoman-environment";
       packageName = "yeoman-environment";
-      version = "2.10.3";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.10.3.tgz";
-        sha512 = "pLIhhU9z/G+kjOXmJ2bPFm3nejfbH+f1fjYRSOteEXDBrv1EoJE/e+kuHixSXfCYfTkxjYsvRaDX+1QykLCnpQ==";
-      };
-    };
-    "yeoman-generator-4.13.0" = {
-      name = "yeoman-generator";
-      packageName = "yeoman-generator";
-      version = "4.13.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-4.13.0.tgz";
-        sha512 = "f2/5N5IR3M2Ozm+QocvZQudlQITv2DwI6Mcxfy7R7gTTzaKgvUpgo/pQMJ+WQKm0KN0YMWCFOZpj0xFGxevc1w==";
+        url = "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-3.2.0.tgz";
+        sha512 = "Z2G4qgbjSLQ0BOiPQ4PCbqSYNhOP/HeWItu/hrlBv1gtBK6c3vkHSLioX8SduVYOKrn04X4H7cIG7hXpD3RsOQ==";
       };
     };
     "yn-3.1.1" = {
@@ -64088,13 +64205,13 @@ let
         sha512 = "Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==";
       };
     };
-    "zeromq-5.2.7" = {
+    "zeromq-5.2.8" = {
       name = "zeromq";
       packageName = "zeromq";
-      version = "5.2.7";
+      version = "5.2.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/zeromq/-/zeromq-5.2.7.tgz";
-        sha512 = "z0R3qtmy4SFgYa/oDjxWFAAGjQb0IU1sJ0XVLflp3W72f2ALXHJzKPgcyCdgMQZTnvSULpZP2HbIYdemLtbBiQ==";
+        url = "https://registry.npmjs.org/zeromq/-/zeromq-5.2.8.tgz";
+        sha512 = "bXzsk7KOmgLSv1tC0Ms1VXBy90+Rz27ZYf27cLuldRYbpqYpuWJfxxHFhO710t22zgWBnmdUP0m3SKFpLI0u5g==";
       };
     };
     "zerr-1.0.4" = {
@@ -64175,15 +64292,15 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "11.2.9";
+    version = "11.2.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-11.2.9.tgz";
-      sha512 = "jSX8HFRYSbbamKLhzgPZ2zEsXDtJzspwnzFROJfOpe9fQkMFo8wiOkmY2amyaNzAMyooHXerRcRDWkRTyQj3Jg==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-11.2.10.tgz";
+      sha512 = "x7u36KmX1iiyDZhkeB6yXRrNj1no+mf6arnAvJYXH2JxqsZDqp19hP8b1QcGVMSl9CZUT/vA0KT3XuI4aJ6TfQ==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.1102.9"
-      sources."@angular-devkit/core-11.2.9"
-      sources."@angular-devkit/schematics-11.2.9"
+      sources."@angular-devkit/architect-0.1102.10"
+      sources."@angular-devkit/core-11.2.10"
+      sources."@angular-devkit/schematics-11.2.10"
       sources."@npmcli/ci-detect-1.3.0"
       (sources."@npmcli/git-2.0.8" // {
         dependencies = [
@@ -64198,13 +64315,13 @@ in
       sources."@npmcli/move-file-1.1.2"
       sources."@npmcli/node-gyp-1.0.2"
       sources."@npmcli/promise-spawn-1.3.2"
-      (sources."@npmcli/run-script-1.8.4" // {
+      (sources."@npmcli/run-script-1.8.5" // {
         dependencies = [
           sources."read-package-json-fast-2.0.2"
         ];
       })
-      sources."@schematics/angular-11.2.9"
-      sources."@schematics/update-0.1102.9"
+      sources."@schematics/angular-11.2.10"
+      sources."@schematics/update-0.1102.10"
       sources."@tootallnate/once-1.1.2"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."abbrev-1.1.1"
@@ -64238,7 +64355,7 @@ in
       sources."builtins-1.0.3"
       sources."cacache-15.0.6"
       sources."caseless-0.12.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chardet-0.7.0"
       sources."chownr-2.0.0"
       sources."clean-stack-2.2.0"
@@ -64358,7 +64475,7 @@ in
       sources."mute-stream-0.0.8"
       sources."node-gyp-7.1.2"
       sources."nopt-5.0.0"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-install-checks-4.0.0"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-package-arg-8.1.0"
@@ -65000,7 +65117,7 @@ in
       sources."@angular-devkit/core-11.2.6"
       (sources."@angular-devkit/schematics-11.2.6" // {
         dependencies = [
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."ora-5.3.0"
         ];
       })
@@ -65021,7 +65138,7 @@ in
         dependencies = [
           sources."@angular-devkit/core-11.2.4"
           sources."@angular-devkit/schematics-11.2.4"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."ora-5.3.0"
         ];
       })
@@ -65065,11 +65182,11 @@ in
       sources."bl-4.1.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       sources."buffer-5.7.1"
       sources."buffer-from-1.1.1"
       sources."callsites-3.1.0"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."chalk-3.0.0"
       sources."chardet-0.7.0"
       sources."chokidar-3.5.1"
@@ -65089,10 +65206,10 @@ in
       sources."cross-spawn-7.0.3"
       sources."deepmerge-4.2.2"
       sources."defaults-1.0.3"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
-      (sources."enhanced-resolve-5.7.0" // {
+      (sources."enhanced-resolve-5.8.0" // {
         dependencies = [
           sources."tapable-2.2.0"
         ];
@@ -65117,7 +65234,7 @@ in
       sources."fill-range-7.0.1"
       (sources."fork-ts-checker-webpack-plugin-6.2.0" // {
         dependencies = [
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
         ];
       })
       sources."fs-extra-9.1.0"
@@ -65140,7 +65257,7 @@ in
       sources."inherits-2.0.4"
       (sources."inquirer-7.3.3" // {
         dependencies = [
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."is-fullwidth-code-point-3.0.0"
           sources."string-width-4.2.2"
         ];
@@ -65171,7 +65288,7 @@ in
       sources."lodash.toarray-4.4.0"
       (sources."log-symbols-4.1.0" // {
         dependencies = [
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
         ];
       })
       sources."lru-cache-6.0.0"
@@ -65195,7 +65312,7 @@ in
       sources."onetime-5.1.2"
       (sources."ora-5.4.0" // {
         dependencies = [
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
         ];
       })
       sources."os-name-4.0.0"
@@ -65269,7 +65386,7 @@ in
       sources."tsconfig-paths-3.9.0"
       (sources."tsconfig-paths-webpack-plugin-3.5.1" // {
         dependencies = [
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
         ];
       })
       sources."tslib-1.14.1"
@@ -65319,28 +65436,28 @@ in
     };
     dependencies = [
       sources."@akryum/winattr-3.0.0"
-      (sources."@apollo/protobufjs-1.0.5" // {
+      (sources."@apollo/protobufjs-1.2.0" // {
         dependencies = [
           sources."@types/node-10.17.58"
         ];
       })
-      sources."@apollographql/apollo-tools-0.4.9"
+      sources."@apollographql/apollo-tools-0.4.12"
       sources."@apollographql/graphql-playground-html-1.6.27"
       sources."@apollographql/graphql-upload-8-fork-8.1.3"
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      sources."@babel/core-7.13.15"
-      sources."@babel/generator-7.13.9"
+      sources."@babel/core-7.13.16"
+      sources."@babel/generator-7.13.16"
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.12.13"
-      sources."@babel/helper-compilation-targets-7.13.13"
+      sources."@babel/helper-compilation-targets-7.13.16"
       sources."@babel/helper-create-class-features-plugin-7.13.11"
       sources."@babel/helper-create-regexp-features-plugin-7.12.17"
       sources."@babel/helper-define-polyfill-provider-0.2.0"
       sources."@babel/helper-explode-assignable-expression-7.13.0"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
-      sources."@babel/helper-hoist-variables-7.13.0"
+      sources."@babel/helper-hoist-variables-7.13.16"
       sources."@babel/helper-member-expression-to-functions-7.13.12"
       sources."@babel/helper-module-imports-7.13.12"
       sources."@babel/helper-module-transforms-7.13.14"
@@ -65354,9 +65471,9 @@ in
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
       sources."@babel/helper-wrap-function-7.13.0"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       sources."@babel/highlight-7.13.10"
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12"
       sources."@babel/plugin-proposal-async-generator-functions-7.13.15"
       sources."@babel/plugin-proposal-class-properties-7.13.0"
@@ -65388,10 +65505,10 @@ in
       sources."@babel/plugin-transform-arrow-functions-7.13.0"
       sources."@babel/plugin-transform-async-to-generator-7.13.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.12.13"
-      sources."@babel/plugin-transform-block-scoping-7.12.13"
+      sources."@babel/plugin-transform-block-scoping-7.13.16"
       sources."@babel/plugin-transform-classes-7.13.0"
       sources."@babel/plugin-transform-computed-properties-7.13.0"
-      sources."@babel/plugin-transform-destructuring-7.13.0"
+      sources."@babel/plugin-transform-destructuring-7.13.17"
       sources."@babel/plugin-transform-dotall-regex-7.12.13"
       sources."@babel/plugin-transform-duplicate-keys-7.12.13"
       sources."@babel/plugin-transform-exponentiation-operator-7.12.13"
@@ -65423,17 +65540,17 @@ in
       sources."@babel/preset-flow-7.13.13"
       sources."@babel/preset-modules-0.1.4"
       sources."@babel/preset-typescript-7.13.0"
-      (sources."@babel/register-7.13.14" // {
+      (sources."@babel/register-7.13.16" // {
         dependencies = [
           sources."make-dir-2.1.0"
           sources."pify-4.0.1"
           sources."semver-5.7.1"
         ];
       })
-      sources."@babel/runtime-7.13.10"
+      sources."@babel/runtime-7.13.17"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@hapi/address-2.1.4"
       sources."@hapi/bourne-1.3.2"
       sources."@hapi/hoek-8.5.1"
@@ -65487,7 +65604,7 @@ in
       sources."@types/mime-1.3.2"
       sources."@types/minimatch-3.0.4"
       sources."@types/node-14.14.41"
-      (sources."@types/node-fetch-2.5.7" // {
+      (sources."@types/node-fetch-2.5.8" // {
         dependencies = [
           sources."form-data-3.0.1"
         ];
@@ -65532,8 +65649,14 @@ in
       sources."ansi-styles-3.2.1"
       sources."apollo-cache-control-0.12.0"
       sources."apollo-datasource-0.8.0"
-      sources."apollo-env-0.6.6"
-      sources."apollo-graphql-0.6.1"
+      sources."apollo-env-0.9.0"
+      (sources."apollo-graphql-0.6.1" // {
+        dependencies = [
+          sources."@types/node-fetch-2.5.7"
+          sources."apollo-env-0.6.6"
+          sources."form-data-3.0.1"
+        ];
+      })
       sources."apollo-link-1.2.14"
       sources."apollo-reporting-protobuf-0.6.2"
       (sources."apollo-server-caching-0.6.0" // {
@@ -65616,7 +65739,7 @@ in
       })
       sources."brace-expansion-1.1.11"
       sources."braces-2.3.2"
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       sources."buffer-5.7.1"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
@@ -65636,7 +65759,7 @@ in
       sources."call-bind-1.0.2"
       sources."call-me-maybe-1.0.1"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."caseless-0.12.0"
       sources."caw-2.0.1"
       sources."chalk-2.4.2"
@@ -65666,6 +65789,7 @@ in
       sources."clipboard-2.0.8"
       sources."cliui-7.0.4"
       sources."clone-1.0.4"
+      sources."clone-deep-4.0.1"
       sources."clone-response-1.0.2"
       sources."cmd-shim-3.0.3"
       sources."collection-visit-1.0.0"
@@ -65693,8 +65817,8 @@ in
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-3.10.1"
-      (sources."core-js-compat-3.10.1" // {
+      sources."core-js-3.11.0"
+      (sources."core-js-compat-3.11.0" // {
         dependencies = [
           sources."semver-7.0.0"
         ];
@@ -65765,7 +65889,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."ejs-2.7.4"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       sources."emoji-regex-7.0.3"
       sources."encodeurl-1.0.2"
       sources."end-of-stream-1.4.4"
@@ -65941,7 +66065,7 @@ in
       (sources."inquirer-7.3.3" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."cli-cursor-3.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -66280,6 +66404,7 @@ in
       sources."set-value-2.0.1"
       sources."setprototypeof-1.2.0"
       sources."sha.js-2.4.11"
+      sources."shallow-clone-3.0.1"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shell-quote-1.7.2"
@@ -66664,12 +66789,12 @@ in
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
-      sources."@babel/generator-7.13.9"
+      sources."@babel/generator-7.13.16"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/highlight-7.13.10"
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/template-7.12.13"
-      sources."@babel/types-7.13.14"
+      sources."@babel/types-7.13.17"
       sources."@webassemblyjs/ast-1.11.0"
       sources."@webassemblyjs/floating-point-hex-parser-1.11.0"
       sources."@webassemblyjs/helper-api-error-1.11.0"
@@ -66690,7 +66815,6 @@ in
       sources."has-flag-3.0.0"
       sources."js-tokens-4.0.0"
       sources."jsesc-2.5.2"
-      sources."lodash-4.17.21"
       sources."source-map-0.5.7"
       sources."supports-color-5.5.0"
       sources."to-fast-properties-2.0.0"
@@ -66746,17 +66870,17 @@ in
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      (sources."@babel/core-7.13.15" // {
+      (sources."@babel/core-7.13.16" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
       })
-      (sources."@babel/generator-7.13.9" // {
+      (sources."@babel/generator-7.13.16" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
       })
-      sources."@babel/helper-compilation-targets-7.13.13"
+      sources."@babel/helper-compilation-targets-7.13.16"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
       sources."@babel/helper-member-expression-to-functions-7.13.12"
@@ -66768,20 +66892,20 @@ in
       sources."@babel/helper-split-export-declaration-7.12.13"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       sources."@babel/highlight-7.13.10"
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."JSV-4.0.2"
       sources."ansi-styles-3.2.1"
       sources."array-unique-0.3.2"
       sources."async-3.2.0"
       sources."balanced-match-1.0.2"
       sources."brace-expansion-1.1.11"
-      sources."browserslist-4.16.4"
-      sources."caniuse-lite-1.0.30001209"
+      sources."browserslist-4.16.5"
+      sources."caniuse-lite-1.0.30001214"
       sources."chalk-2.4.2"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -66792,7 +66916,7 @@ in
       sources."convert-source-map-1.7.0"
       sources."debug-4.3.2"
       sources."ejs-3.1.6"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       sources."ensure-posix-path-1.1.1"
       sources."escalade-3.1.1"
       sources."escape-string-regexp-1.0.5"
@@ -66932,7 +67056,7 @@ in
           sources."tslib-2.2.0"
         ];
       })
-      (sources."aws-sdk-2.888.0" // {
+      (sources."aws-sdk-2.892.0" // {
         dependencies = [
           sources."uuid-3.3.2"
         ];
@@ -66952,7 +67076,7 @@ in
       sources."buffer-4.9.2"
       sources."buffer-crc32-0.2.13"
       sources."bytes-3.1.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chardet-0.7.0"
       sources."cheerio-1.0.0-rc.5"
       sources."cheerio-select-tmp-0.1.1"
@@ -67121,10 +67245,10 @@ in
   balanceofsatoshis = nodeEnv.buildNodePackage {
     name = "balanceofsatoshis";
     packageName = "balanceofsatoshis";
-    version = "8.0.6";
+    version = "8.0.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/balanceofsatoshis/-/balanceofsatoshis-8.0.6.tgz";
-      sha512 = "sl/gbf3fqpdnbzeBxlxN8epCQfYbTTMAj0Pix721LC0OGmLq0ePeXJIPvLrObYTU2AB57p0jV6NEWWf9eVKkcQ==";
+      url = "https://registry.npmjs.org/balanceofsatoshis/-/balanceofsatoshis-8.0.8.tgz";
+      sha512 = "v52KtlVv4Sdp0GaqH9vPYSwOCgIvTruMX0yv8ev+GguqY1kV+mCykCIFW3++ysu97pog00LhImvFbxndAU68rA==";
     };
     dependencies = [
       sources."@alexbosworth/html2unicode-1.1.5"
@@ -67255,7 +67379,7 @@ in
         dependencies = [
           sources."ansi-regex-5.0.0"
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."is-fullwidth-code-point-3.0.0"
           sources."string-width-4.2.2"
           sources."strip-ansi-6.0.0"
@@ -67335,7 +67459,7 @@ in
       sources."create-hmac-1.1.7"
       sources."crypto-js-4.0.0"
       sources."crypto-random-string-2.0.0"
-      sources."csv-parse-4.15.3"
+      sources."csv-parse-4.15.4"
       sources."cycle-1.0.3"
       sources."dashdash-1.14.1"
       sources."debug-2.6.9"
@@ -67447,7 +67571,7 @@ in
           sources."ansi-escapes-4.3.2"
           sources."ansi-regex-5.0.0"
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."cli-cursor-3.1.0"
           sources."cli-width-3.0.0"
           sources."external-editor-3.1.0"
@@ -67462,7 +67586,7 @@ in
           sources."tmp-0.0.33"
         ];
       })
-      (sources."invoices-1.1.7" // {
+      (sources."invoices-1.2.0" // {
         dependencies = [
           sources."bech32-2.0.0"
           sources."bn.js-5.2.0"
@@ -67538,8 +67662,10 @@ in
           sources."@grpc/proto-loader-0.6.0"
           sources."@types/node-14.14.37"
           sources."@types/ws-7.4.1"
+          sources."bech32-2.0.0"
           sources."bn.js-5.2.0"
           sources."bolt09-0.1.4"
+          sources."invoices-1.1.7"
           sources."lightning-3.3.4"
         ];
       })
@@ -67550,15 +67676,25 @@ in
       })
       (sources."ln-telegram-3.2.2" // {
         dependencies = [
+          sources."ajv-8.1.0"
+          sources."ansi-regex-5.0.0"
           sources."asyncjs-util-1.2.4"
           sources."bech32-2.0.0"
           sources."bn.js-5.2.0"
           sources."bolt07-1.7.1"
+          sources."bolt09-0.1.4"
+          sources."invoices-1.1.7"
+          sources."is-fullwidth-code-point-3.0.0"
+          sources."json-schema-traverse-1.0.0"
           (sources."ln-service-51.5.0" // {
             dependencies = [
+              sources."bolt09-0.1.3"
               sources."invoices-1.1.6"
             ];
           })
+          sources."string-width-4.2.2"
+          sources."strip-ansi-6.0.0"
+          sources."table-6.0.9"
         ];
       })
       sources."lodash-4.17.21"
@@ -67638,9 +67774,12 @@ in
           sources."asyncjs-util-1.2.4"
           sources."bech32-2.0.0"
           sources."bn.js-5.2.0"
+          sources."bolt09-0.1.4"
+          sources."invoices-1.1.7"
           (sources."ln-service-51.5.0" // {
             dependencies = [
               sources."bolt07-1.7.1"
+              sources."bolt09-0.1.3"
               sources."invoices-1.1.6"
             ];
           })
@@ -67718,7 +67857,7 @@ in
       sources."strip-ansi-4.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-2.0.0"
-      (sources."table-6.0.9" // {
+      (sources."table-6.4.0" // {
         dependencies = [
           sources."ajv-8.1.0"
           sources."ansi-regex-5.0.0"
@@ -67760,13 +67899,13 @@ in
       sources."typedarray-0.0.6"
       sources."typedarray-to-buffer-3.1.5"
       sources."typeforce-1.18.0"
-      sources."typegram-3.2.3"
+      sources."typegram-3.2.4"
       sources."unique-string-2.0.0"
       sources."unpipe-1.0.0"
       (sources."update-notifier-5.1.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."import-lazy-2.1.0"
           sources."semver-7.3.5"
           sources."supports-color-7.2.0"
@@ -68357,17 +68496,17 @@ in
   btc-rpc-explorer = nodeEnv.buildNodePackage {
     name = "btc-rpc-explorer";
     packageName = "btc-rpc-explorer";
-    version = "3.1.0";
+    version = "3.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/btc-rpc-explorer/-/btc-rpc-explorer-3.1.0.tgz";
-      sha512 = "LKY3+CWOAe6A7SaXRYHZSu27TNeBrUl3LkYTOvRZAIatNNwaM1dTCxUjNRBsnsHCp0Tp9/UGLncLaf2wJ1BLcg==";
+      url = "https://registry.npmjs.org/btc-rpc-explorer/-/btc-rpc-explorer-3.1.1.tgz";
+      sha512 = "QHoiW1H2P6Sx7L5IEvbZnnQsfy7eaibY/KS2UAX9VINXNdGS9RxqEdLOe9yTdcy5pzIFpQKIBspOnHcBOjVa8A==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/highlight-7.13.10"
-      sources."@babel/parser-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/parser-7.13.16"
+      sources."@babel/types-7.13.17"
       sources."@kwsites/file-exists-1.1.1"
       sources."@kwsites/promise-deferred-1.1.1"
       sources."@types/minimist-1.2.1"
@@ -68696,7 +68835,7 @@ in
       })
       sources."readable-stream-3.6.0"
       sources."redent-3.0.0"
-      sources."redis-3.1.1"
+      sources."redis-3.1.2"
       sources."redis-commands-1.7.0"
       sources."redis-errors-1.2.0"
       sources."redis-parser-3.0.0"
@@ -69237,7 +69376,7 @@ in
       sha512 = "Oo/tO5aqmjsBORN93dSnidF7+2u77Q9zwUn9VbCQkZqCNfeZZcwIV9AG108hMYwtcXqtKQC7wevX6rmi9l8lng==";
     };
     dependencies = [
-      sources."@jsii/spec-1.28.0"
+      sources."@jsii/spec-1.29.0"
       sources."@types/node-10.17.58"
       sources."ansi-regex-5.0.0"
       sources."ansi-styles-4.3.0"
@@ -69250,7 +69389,7 @@ in
       sources."cdk8s-1.0.0-beta.11"
       sources."cliui-7.0.4"
       sources."clone-2.1.2"
-      (sources."codemaker-1.28.0" // {
+      (sources."codemaker-1.29.0" // {
         dependencies = [
           sources."fs-extra-9.1.0"
         ];
@@ -69308,37 +69447,37 @@ in
       sources."is-weakmap-2.0.1"
       sources."is-weakset-2.0.1"
       sources."isarray-2.0.5"
-      (sources."jsii-1.28.0" // {
+      (sources."jsii-1.29.0" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-pacmak-1.28.0" // {
+      (sources."jsii-pacmak-1.29.0" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-reflect-1.28.0" // {
+      (sources."jsii-reflect-1.29.0" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-rosetta-1.28.0" // {
+      (sources."jsii-rosetta-1.29.0" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-srcmak-0.1.255" // {
+      (sources."jsii-srcmak-0.1.257" // {
         dependencies = [
           sources."fs-extra-9.1.0"
         ];
       })
       sources."json-schema-0.2.5"
-      sources."json2jsii-0.1.188"
+      sources."json2jsii-0.1.218"
       sources."jsonfile-6.1.0"
       sources."jsonschema-1.4.0"
       sources."locate-path-5.0.0"
@@ -69354,7 +69493,7 @@ in
       sources."object-is-1.1.5"
       sources."object-keys-1.1.1"
       sources."object.assign-4.1.2"
-      sources."oo-ascii-tree-1.28.0"
+      sources."oo-ascii-tree-1.29.0"
       sources."p-limit-2.3.0"
       sources."p-locate-4.1.0"
       sources."p-try-2.2.0"
@@ -69424,18 +69563,19 @@ in
   cdktf-cli = nodeEnv.buildNodePackage {
     name = "cdktf-cli";
     packageName = "cdktf-cli";
-    version = "0.2.2";
+    version = "0.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/cdktf-cli/-/cdktf-cli-0.2.2.tgz";
-      sha512 = "tkUGs4+739C+3lklwQQM/wLgp41maVlJUK/2cCzuNxVBgobLXBxn55lHxbmEuh2Ddc8PtNV31uzHzn1f2ZzdfQ==";
+      url = "https://registry.npmjs.org/cdktf-cli/-/cdktf-cli-0.3.0.tgz";
+      sha512 = "8ZICMcjBkKMBzzyVQfa3CGb/kkxBfvr7nxvOLpyEO1ecJt4E1gkrAwsKb8oVX/zfQ371UJqrqJxwBwb+OUT5Wg==";
     };
     dependencies = [
-      sources."@cdktf/hcl2json-0.2.2"
-      sources."@jsii/spec-1.28.0"
+      sources."@cdktf/hcl2json-0.3.0"
+      sources."@jsii/spec-1.29.0"
       sources."@skorfmann/ink-confirm-input-3.0.0"
-      sources."@skorfmann/terraform-cloud-1.9.1"
+      sources."@skorfmann/terraform-cloud-1.10.0"
       sources."@types/node-14.14.41"
       sources."@types/node-fetch-2.5.10"
+      sources."@types/yauzl-2.9.1"
       sources."@types/yoga-layout-1.9.2"
       (sources."ansi-escapes-4.3.2" // {
         dependencies = [
@@ -69468,8 +69608,8 @@ in
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
       sources."case-1.6.3"
-      sources."cdktf-0.2.2"
-      sources."chalk-4.1.0"
+      sources."cdktf-0.3.0"
+      sources."chalk-4.1.1"
       sources."ci-info-2.0.0"
       sources."cli-boxes-2.2.1"
       sources."cli-cursor-3.1.0"
@@ -69490,7 +69630,7 @@ in
       sources."commonmark-0.29.3"
       sources."compress-commons-4.1.0"
       sources."concat-map-0.0.1"
-      sources."constructs-3.3.71"
+      sources."constructs-3.3.74"
       sources."convert-to-spaces-1.0.2"
       sources."core-util-is-1.0.2"
       sources."crc-32-1.2.0"
@@ -69521,6 +69661,8 @@ in
       sources."escalade-3.1.1"
       sources."escape-string-regexp-2.0.0"
       sources."exit-on-epipe-1.0.1"
+      sources."extract-zip-2.0.1"
+      sources."fd-slicer-1.1.0"
       sources."find-up-4.1.0"
       sources."flatted-2.0.2"
       sources."follow-redirects-1.13.3"
@@ -69532,6 +69674,7 @@ in
       sources."function-bind-1.1.1"
       sources."get-caller-file-2.0.5"
       sources."get-intrinsic-1.1.1"
+      sources."get-stream-5.2.0"
       sources."glob-7.1.6"
       sources."graceful-fs-4.2.6"
       sources."has-1.0.3"
@@ -69570,7 +69713,7 @@ in
       sources."is-wsl-2.2.0"
       sources."isarray-1.0.0"
       sources."js-tokens-4.0.0"
-      (sources."jsii-1.28.0" // {
+      (sources."jsii-1.29.0" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
@@ -69578,10 +69721,10 @@ in
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-pacmak-1.28.0" // {
+      (sources."jsii-pacmak-1.29.0" // {
         dependencies = [
           sources."camelcase-6.2.0"
-          sources."codemaker-1.28.0"
+          sources."codemaker-1.29.0"
           sources."decamelize-5.0.0"
           sources."escape-string-regexp-4.0.0"
           sources."fs-extra-9.1.0"
@@ -69590,7 +69733,7 @@ in
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-reflect-1.28.0" // {
+      (sources."jsii-reflect-1.29.0" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
@@ -69598,7 +69741,7 @@ in
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-rosetta-1.28.0" // {
+      (sources."jsii-rosetta-1.29.0" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
@@ -69606,7 +69749,7 @@ in
           sources."yargs-16.2.0"
         ];
       })
-      (sources."jsii-srcmak-0.1.255" // {
+      (sources."jsii-srcmak-0.1.257" // {
         dependencies = [
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
@@ -69648,7 +69791,7 @@ in
       sources."object.assign-4.1.2"
       sources."once-1.4.0"
       sources."onetime-5.1.2"
-      sources."oo-ascii-tree-1.28.0"
+      sources."oo-ascii-tree-1.29.0"
       sources."open-7.4.2"
       sources."p-limit-2.3.0"
       sources."p-locate-4.1.0"
@@ -69656,12 +69799,14 @@ in
       sources."patch-console-1.0.0"
       sources."path-exists-4.0.0"
       sources."path-is-absolute-1.0.1"
+      sources."pend-1.2.0"
       sources."printj-1.1.2"
       sources."process-nextick-args-2.0.1"
       sources."prop-types-15.7.2"
+      sources."pump-3.0.0"
       sources."quick-lru-4.0.1"
       sources."react-16.14.0"
-      sources."react-devtools-core-4.12.2"
+      sources."react-devtools-core-4.12.4"
       sources."react-is-16.13.1"
       sources."react-reconciler-0.24.0"
       sources."readable-stream-3.6.0"
@@ -69739,6 +69884,7 @@ in
         ];
       })
       sources."yargs-parser-20.2.7"
+      sources."yauzl-2.10.0"
       sources."yn-3.1.1"
       sources."yoga-layout-prebuilt-1.10.0"
       sources."zip-stream-4.1.0"
@@ -69928,10 +70074,10 @@ in
   coc-diagnostic = nodeEnv.buildNodePackage {
     name = "coc-diagnostic";
     packageName = "coc-diagnostic";
-    version = "0.18.2";
+    version = "0.18.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-diagnostic/-/coc-diagnostic-0.18.2.tgz";
-      sha512 = "uiWZlGLle3EXfC+1AmYmPrQfYeL2gY1BKpROBr5BWgT2+1W21gAlY1mziopAk0AmCNA8M4wgvfgc+CC3KVYkjQ==";
+      url = "https://registry.npmjs.org/coc-diagnostic/-/coc-diagnostic-0.18.3.tgz";
+      sha512 = "VL6XhOU9roM9wKcDZrJ+MeabNDXI9vb2aUinDHOJx+7e19MIbACfFgMJfVxOkSWNRrTHyOlElnHCcYzS8gk2qQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -70260,10 +70406,10 @@ in
   coc-metals = nodeEnv.buildNodePackage {
     name = "coc-metals";
     packageName = "coc-metals";
-    version = "1.0.3";
+    version = "1.0.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-metals/-/coc-metals-1.0.3.tgz";
-      sha512 = "7mIC/YiAYNS9kzv0tPi6IcKTWRDRAwjKbot4g/RwBxpyGAzTBvsfmpqnWvHiZbk4kd8mKG2qmWR9OEy7CNzNEQ==";
+      url = "https://registry.npmjs.org/coc-metals/-/coc-metals-1.0.4.tgz";
+      sha512 = "nMarefi4Y2ReRiKa/GpyJRKMyF+J+cT3pc1mw6MvmuhpkhrQtf/feMYJ+7/h7l38NqAxjHkBvAiHZqDpWB675Q==";
     };
     dependencies = [
       sources."@chemzqm/neovim-5.2.13"
@@ -70310,7 +70456,7 @@ in
       sources."fb-watchman-2.0.1"
       sources."flatted-2.0.2"
       sources."follow-redirects-1.13.3"
-      sources."fp-ts-2.10.2"
+      sources."fp-ts-2.10.4"
       sources."fs-extra-8.1.0"
       sources."fs-minipass-2.1.0"
       sources."fs.realpath-1.0.0"
@@ -70548,15 +70694,14 @@ in
           sources."isobject-3.0.1"
         ];
       })
-      sources."call-bind-1.0.2"
       sources."call-me-maybe-1.0.1"
       sources."callsites-3.1.0"
       sources."camelcase-2.1.1"
       sources."camelcase-keys-2.1.0"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."capture-stack-trace-1.0.1"
       sources."ccount-1.1.0"
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -70615,7 +70760,7 @@ in
         ];
       })
       sources."copy-descriptor-0.1.1"
-      sources."core-js-3.10.1"
+      sources."core-js-3.11.0"
       sources."cosmiconfig-3.1.0"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-7.0.3"
@@ -70651,14 +70796,14 @@ in
       sources."domutils-1.7.0"
       sources."dot-prop-5.3.0"
       sources."duplexer3-0.1.4"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."enquirer-2.3.6"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
       sources."escape-string-regexp-1.0.5"
-      (sources."eslint-7.24.0" // {
+      (sources."eslint-7.25.0" // {
         dependencies = [
           sources."eslint-visitor-keys-2.0.0"
         ];
@@ -70778,7 +70923,6 @@ in
       sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
       sources."get-caller-file-1.0.3"
-      sources."get-intrinsic-1.1.1"
       sources."get-stdin-5.0.1"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
@@ -70814,7 +70958,6 @@ in
         ];
       })
       sources."has-flag-3.0.0"
-      sources."has-symbols-1.0.2"
       (sources."has-value-1.0.0" // {
         dependencies = [
           sources."isobject-3.0.1"
@@ -70853,7 +70996,6 @@ in
       sources."is-alphanumeric-1.0.0"
       sources."is-alphanumerical-1.0.4"
       sources."is-arrayish-0.2.1"
-      sources."is-boolean-object-1.1.0"
       sources."is-buffer-1.1.6"
       sources."is-ci-1.2.1"
       sources."is-core-module-2.2.0"
@@ -70880,7 +71022,6 @@ in
       sources."is-installed-globally-0.1.0"
       sources."is-npm-1.0.0"
       sources."is-number-2.1.0"
-      sources."is-number-object-1.0.4"
       sources."is-obj-2.0.0"
       sources."is-path-inside-1.0.1"
       sources."is-plain-obj-1.1.0"
@@ -70895,7 +71036,6 @@ in
       sources."is-regexp-1.0.0"
       sources."is-retry-allowed-1.2.0"
       sources."is-stream-1.1.0"
-      sources."is-string-1.0.5"
       sources."is-supported-regexp-flag-1.0.1"
       sources."is-utf8-0.2.1"
       sources."is-whitespace-character-1.0.4"
@@ -71319,7 +71459,7 @@ in
       sources."sugarss-1.0.1"
       sources."supports-color-5.5.0"
       sources."svg-tags-1.0.0"
-      (sources."table-6.1.0" // {
+      (sources."table-6.5.1" // {
         dependencies = [
           sources."ajv-8.1.0"
           sources."json-schema-traverse-1.0.0"
@@ -71451,13 +71591,13 @@ in
   coc-pyright = nodeEnv.buildNodePackage {
     name = "coc-pyright";
     packageName = "coc-pyright";
-    version = "1.1.129";
+    version = "1.1.133";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-pyright/-/coc-pyright-1.1.129.tgz";
-      sha512 = "XlybP7uY9BgkeGKCFhIxnmpos3rYJ8wIB+MW4w0Fyu51Ap2fxamU7FDmOcOIbjmp1tglldSZm2+A+KloHDuUgw==";
+      url = "https://registry.npmjs.org/coc-pyright/-/coc-pyright-1.1.133.tgz";
+      sha512 = "BO/5eaJpFpwkcH9Oo3pst0Xn25TiD41schWqG2837AEQwWJvvv+EJgAfU4OP2G3reCQFo/8IONIwBvSwMYDGIA==";
     };
     dependencies = [
-      sources."pyright-1.1.132"
+      sources."pyright-1.1.134"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -71531,10 +71671,10 @@ in
   coc-rust-analyzer = nodeEnv.buildNodePackage {
     name = "coc-rust-analyzer";
     packageName = "coc-rust-analyzer";
-    version = "0.42.0";
+    version = "0.43.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.42.0.tgz";
-      sha512 = "H6/r68GvhIMWDZWWFtOUsyRNxaVlMRLrS+uMqcipxfkx+Pl1pWfnfsmymjd9okbtrWiKWgG6G63v7T2rVl4+YA==";
+      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.43.1.tgz";
+      sha512 = "NWuXDc9NrqVN1HO7NTUfH68Xr05yJA5bJXfQOSasOxxjsMyijL/aYwmlflSV93DO0zzWmsBPBTmBjBXxAms0cQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -71609,9 +71749,9 @@ in
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      sources."@babel/core-7.13.15"
-      sources."@babel/generator-7.13.9"
-      sources."@babel/helper-compilation-targets-7.13.13"
+      sources."@babel/core-7.13.16"
+      sources."@babel/generator-7.13.16"
+      sources."@babel/helper-compilation-targets-7.13.16"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
       sources."@babel/helper-member-expression-to-functions-7.13.12"
@@ -71623,16 +71763,16 @@ in
       sources."@babel/helper-split-export-declaration-7.12.13"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       (sources."@babel/highlight-7.13.10" // {
         dependencies = [
           sources."chalk-2.4.2"
         ];
       })
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@nodelib/fs.scandir-2.1.4"
       sources."@nodelib/fs.stat-2.0.4"
       sources."@nodelib/fs.walk-1.2.6"
@@ -71654,13 +71794,12 @@ in
       sources."balanced-match-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.16.4"
-      sources."call-bind-1.0.2"
+      sources."browserslist-4.16.5"
       sources."callsites-3.1.0"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."caniuse-lite-1.0.30001209"
-      (sources."chalk-4.1.0" // {
+      sources."caniuse-lite-1.0.30001214"
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -71697,7 +71836,7 @@ in
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       sources."emoji-regex-8.0.0"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
@@ -71718,7 +71857,6 @@ in
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."gensync-1.0.0-beta.2"
-      sources."get-intrinsic-1.1.1"
       sources."get-stdin-8.0.0"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.2"
@@ -71731,7 +71869,6 @@ in
       sources."hard-rejection-2.1.0"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
-      sources."has-symbols-1.0.2"
       sources."hosted-git-info-4.0.2"
       sources."html-tags-3.1.0"
       sources."htmlparser2-3.10.1"
@@ -71744,14 +71881,12 @@ in
       sources."import-lazy-4.0.0"
       sources."imurmurhash-0.1.4"
       sources."indent-string-4.0.0"
-      sources."indexes-of-1.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.8"
       sources."is-alphabetical-1.0.4"
       sources."is-alphanumerical-1.0.4"
       sources."is-arrayish-0.2.1"
-      sources."is-boolean-object-1.1.0"
       sources."is-buffer-2.0.5"
       sources."is-core-module-2.2.0"
       sources."is-decimal-1.0.4"
@@ -71760,10 +71895,8 @@ in
       sources."is-glob-4.0.1"
       sources."is-hexadecimal-1.0.4"
       sources."is-number-7.0.0"
-      sources."is-number-object-1.0.4"
       sources."is-plain-obj-2.1.0"
       sources."is-regexp-2.1.0"
-      sources."is-string-1.0.5"
       sources."is-typedarray-1.0.0"
       sources."is-unicode-supported-0.1.0"
       sources."isexe-2.0.0"
@@ -71841,7 +71974,7 @@ in
       sources."postcss-safe-parser-4.0.2"
       sources."postcss-sass-0.4.4"
       sources."postcss-scss-2.1.1"
-      sources."postcss-selector-parser-6.0.4"
+      sources."postcss-selector-parser-6.0.5"
       sources."postcss-syntax-0.36.2"
       sources."postcss-value-parser-4.1.0"
       sources."punycode-2.1.1"
@@ -71902,7 +72035,7 @@ in
       sources."sugarss-2.0.0"
       sources."supports-color-5.5.0"
       sources."svg-tags-1.0.0"
-      sources."table-6.1.0"
+      sources."table-6.5.1"
       sources."to-fast-properties-2.0.0"
       sources."to-regex-range-5.0.1"
       sources."trim-newlines-3.0.0"
@@ -71910,7 +72043,6 @@ in
       sources."type-fest-0.18.1"
       sources."typedarray-to-buffer-3.1.5"
       sources."unified-9.2.1"
-      sources."uniq-1.0.1"
       sources."unist-util-find-all-after-3.0.2"
       sources."unist-util-is-4.1.0"
       sources."unist-util-stringify-position-2.0.3"
@@ -72129,9 +72261,8 @@ in
       sources."balanced-match-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."builtin-modules-1.1.1"
-      sources."call-bind-1.0.2"
       sources."callsites-3.1.0"
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -72152,7 +72283,7 @@ in
       sources."emoji-regex-8.0.0"
       sources."enquirer-2.3.6"
       sources."escape-string-regexp-1.0.5"
-      sources."eslint-7.24.0"
+      sources."eslint-7.25.0"
       sources."eslint-plugin-vue-7.9.0"
       sources."eslint-scope-5.1.1"
       (sources."eslint-utils-2.1.0" // {
@@ -72188,7 +72319,6 @@ in
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
-      sources."get-intrinsic-1.1.1"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.2"
       (sources."globals-13.8.0" // {
@@ -72198,19 +72328,15 @@ in
       })
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
-      sources."has-symbols-1.0.2"
       sources."ignore-4.0.6"
       sources."import-fresh-3.3.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."is-boolean-object-1.1.0"
       sources."is-core-module-2.2.0"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-3.0.0"
       sources."is-glob-4.0.1"
-      sources."is-number-object-1.0.4"
-      sources."is-string-1.0.5"
       sources."isexe-2.0.0"
       sources."js-tokens-4.0.0"
       sources."js-yaml-3.14.1"
@@ -72257,7 +72383,7 @@ in
       sources."strip-ansi-6.0.0"
       sources."strip-json-comments-3.1.1"
       sources."supports-color-5.5.0"
-      (sources."table-6.1.0" // {
+      (sources."table-6.5.1" // {
         dependencies = [
           sources."ajv-8.1.0"
           sources."json-schema-traverse-1.0.0"
@@ -72569,13 +72695,12 @@ in
       sources."@nodelib/fs.scandir-2.1.4"
       sources."@nodelib/fs.stat-2.0.4"
       sources."@nodelib/fs.walk-1.2.6"
-      sources."@npmcli/ci-detect-1.3.0"
       sources."@npmcli/git-2.0.8"
       sources."@npmcli/installed-package-contents-1.0.7"
       sources."@npmcli/move-file-1.1.2"
       sources."@npmcli/node-gyp-1.0.2"
       sources."@npmcli/promise-spawn-1.3.2"
-      sources."@npmcli/run-script-1.8.4"
+      sources."@npmcli/run-script-1.8.5"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@tootallnate/once-1.1.2"
@@ -72947,13 +73072,13 @@ in
         ];
       })
       sources."normalize-url-4.5.0"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-install-checks-4.0.0"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-package-arg-8.1.2"
       sources."npm-packlist-2.1.5"
       sources."npm-pick-manifest-6.1.1"
-      sources."npm-registry-fetch-9.0.0"
+      sources."npm-registry-fetch-10.1.1"
       sources."npm-run-path-4.0.1"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
@@ -72984,7 +73109,7 @@ in
           sources."semver-6.3.0"
         ];
       })
-      sources."pacote-11.3.1"
+      sources."pacote-11.3.3"
       sources."parent-module-1.0.1"
       sources."parseurl-1.3.3"
       sources."path-exists-3.0.0"
@@ -74653,10 +74778,10 @@ in
   elasticdump = nodeEnv.buildNodePackage {
     name = "elasticdump";
     packageName = "elasticdump";
-    version = "6.68.1";
+    version = "6.69.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.68.1.tgz";
-      sha512 = "OGsAZGrhHIJw4koiMJ1U80eVJIcpKsN6u7Iq+d1Tu3TJvBSvYHShM3SllYbsbFzIdt8kBNj3XWsogajUpeX0+w==";
+      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.69.2.tgz";
+      sha512 = "HvwyYhkQ1Sw/eGCJkgNHEdPHy9W15WNeON35kzYeuQvY46df2W/p/L8Lik13iyWUMW7ky+v1qm9sGBhs40D/OQ==";
     };
     dependencies = [
       sources."@fast-csv/format-4.3.5"
@@ -74847,7 +74972,7 @@ in
         ];
       })
       sources."@malept/cross-spawn-promise-1.1.1"
-      sources."@sindresorhus/is-4.0.0"
+      sources."@sindresorhus/is-4.0.1"
       sources."@szmarczak/http-timer-4.0.5"
       sources."@types/cacheable-request-6.0.1"
       sources."@types/glob-7.1.3"
@@ -74905,7 +75030,7 @@ in
       sources."camelcase-2.1.1"
       sources."camelcase-keys-2.1.0"
       sources."caseless-0.12.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chardet-0.7.0"
       sources."chownr-1.1.4"
       sources."chromium-pickle-js-0.2.0"
@@ -74930,7 +75055,7 @@ in
       sources."concat-map-0.0.1"
       sources."config-chain-1.1.12"
       sources."console-control-strings-1.1.0"
-      sources."core-js-3.10.1"
+      sources."core-js-3.11.0"
       sources."core-util-is-1.0.2"
       sources."cross-spawn-7.0.3"
       sources."currently-unhandled-0.4.1"
@@ -75161,7 +75286,7 @@ in
         ];
       })
       sources."nice-try-1.0.5"
-      (sources."node-abi-2.21.0" // {
+      (sources."node-abi-2.26.0" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
@@ -75187,7 +75312,7 @@ in
         ];
       })
       sources."normalize-url-4.5.0"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       (sources."npm-conf-1.1.3" // {
         dependencies = [
           sources."pify-3.0.0"
@@ -75431,14 +75556,14 @@ in
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      (sources."@babel/core-7.13.15" // {
+      (sources."@babel/core-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
       })
-      sources."@babel/generator-7.13.9"
+      sources."@babel/generator-7.13.16"
       sources."@babel/helper-annotate-as-pure-7.12.13"
-      (sources."@babel/helper-compilation-targets-7.13.13" // {
+      (sources."@babel/helper-compilation-targets-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -75455,19 +75580,19 @@ in
       sources."@babel/helper-split-export-declaration-7.12.13"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       sources."@babel/highlight-7.13.10"
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/plugin-proposal-object-rest-spread-7.13.8"
       sources."@babel/plugin-syntax-jsx-7.12.13"
       sources."@babel/plugin-syntax-object-rest-spread-7.8.3"
-      sources."@babel/plugin-transform-destructuring-7.13.0"
+      sources."@babel/plugin-transform-destructuring-7.13.17"
       sources."@babel/plugin-transform-parameters-7.13.0"
       sources."@babel/plugin-transform-react-jsx-7.13.12"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
-      sources."@sindresorhus/is-4.0.0"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
+      sources."@sindresorhus/is-4.0.1"
       sources."@szmarczak/http-timer-4.0.5"
       sources."@types/cacheable-request-6.0.1"
       sources."@types/http-cache-semantics-4.0.0"
@@ -75492,7 +75617,7 @@ in
       sources."auto-bind-4.0.0"
       sources."balanced-match-1.0.2"
       sources."brace-expansion-1.1.11"
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       sources."cacheable-lookup-5.0.4"
       (sources."cacheable-request-7.0.1" // {
         dependencies = [
@@ -75508,7 +75633,7 @@ in
           sources."quick-lru-4.0.1"
         ];
       })
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."chalk-2.4.2"
       sources."ci-info-2.0.0"
       sources."cli-boxes-2.2.1"
@@ -75545,7 +75670,7 @@ in
       })
       sources."defer-to-connect-2.0.1"
       sources."dot-prop-5.3.0"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       sources."emoji-regex-8.0.0"
       sources."emojilib-2.4.0"
       sources."end-of-stream-1.4.4"
@@ -75578,7 +75703,7 @@ in
       (sources."ink-3.0.8" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -75588,7 +75713,7 @@ in
       (sources."ink-text-input-4.0.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -75679,7 +75804,7 @@ in
       sources."punycode-2.1.1"
       sources."quick-lru-5.1.1"
       sources."react-16.14.0"
-      sources."react-devtools-core-4.12.2"
+      sources."react-devtools-core-4.12.4"
       sources."react-is-16.13.1"
       sources."react-reconciler-0.24.0"
       (sources."read-pkg-5.2.0" // {
@@ -75805,7 +75930,7 @@ in
       })
       sources."@fluentui/date-time-utilities-7.9.1"
       sources."@fluentui/dom-utilities-1.1.2"
-      sources."@fluentui/keyboard-key-0.2.16"
+      sources."@fluentui/keyboard-key-0.2.17"
       sources."@fluentui/react-7.168.0"
       sources."@fluentui/react-focus-7.17.6"
       sources."@fluentui/react-window-provider-1.0.2"
@@ -75820,7 +75945,7 @@ in
           sources."normalize-path-2.1.1"
         ];
       })
-      sources."@microsoft/load-themed-styles-1.10.161"
+      sources."@microsoft/load-themed-styles-1.10.165"
       sources."@nodelib/fs.scandir-2.1.4"
       sources."@nodelib/fs.stat-2.0.4"
       sources."@nodelib/fs.walk-1.2.6"
@@ -76819,7 +76944,7 @@ in
       sources."normalize-path-3.0.0"
       sources."normalize-url-4.5.0"
       sources."now-and-later-2.0.1"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-packlist-1.4.8"
       sources."npmlog-4.1.2"
@@ -77074,7 +77199,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      (sources."sass-1.32.10" // {
+      (sources."sass-1.32.11" // {
         dependencies = [
           sources."anymatch-3.1.2"
           sources."binary-extensions-2.2.0"
@@ -77490,10 +77615,10 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "7.24.0";
+    version = "7.25.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz";
-      sha512 = "k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==";
+      url = "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz";
+      sha512 = "TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.11"
@@ -77518,9 +77643,8 @@ in
       sources."astral-regex-2.0.0"
       sources."balanced-match-1.0.2"
       sources."brace-expansion-1.1.11"
-      sources."call-bind-1.0.2"
       sources."callsites-3.1.0"
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -77571,9 +77695,7 @@ in
       sources."flat-cache-3.0.4"
       sources."flatted-3.1.1"
       sources."fs.realpath-1.0.0"
-      sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
-      sources."get-intrinsic-1.1.1"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.2"
       (sources."globals-13.8.0" // {
@@ -77581,20 +77703,15 @@ in
           sources."type-fest-0.20.2"
         ];
       })
-      sources."has-1.0.3"
       sources."has-flag-3.0.0"
-      sources."has-symbols-1.0.2"
       sources."ignore-4.0.6"
       sources."import-fresh-3.3.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."is-boolean-object-1.1.0"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-3.0.0"
       sources."is-glob-4.0.1"
-      sources."is-number-object-1.0.4"
-      sources."is-string-1.0.5"
       sources."isexe-2.0.0"
       sources."js-tokens-4.0.0"
       sources."js-yaml-3.14.1"
@@ -77636,7 +77753,7 @@ in
       sources."strip-ansi-6.0.0"
       sources."strip-json-comments-3.1.1"
       sources."supports-color-5.5.0"
-      (sources."table-6.1.0" // {
+      (sources."table-6.5.1" // {
         dependencies = [
           sources."ajv-8.1.0"
           sources."json-schema-traverse-1.0.0"
@@ -77695,9 +77812,8 @@ in
       sources."astral-regex-2.0.0"
       sources."balanced-match-1.0.2"
       sources."brace-expansion-1.1.11"
-      sources."call-bind-1.0.2"
       sources."callsites-3.1.0"
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -77716,7 +77832,7 @@ in
       sources."emoji-regex-8.0.0"
       sources."enquirer-2.3.6"
       sources."escape-string-regexp-1.0.5"
-      sources."eslint-7.24.0"
+      sources."eslint-7.25.0"
       sources."eslint-scope-5.1.1"
       (sources."eslint-utils-2.1.0" // {
         dependencies = [
@@ -77749,9 +77865,7 @@ in
       sources."flat-cache-3.0.4"
       sources."flatted-3.1.1"
       sources."fs.realpath-1.0.0"
-      sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
-      sources."get-intrinsic-1.1.1"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.2"
       (sources."globals-13.8.0" // {
@@ -77759,20 +77873,15 @@ in
           sources."type-fest-0.20.2"
         ];
       })
-      sources."has-1.0.3"
       sources."has-flag-4.0.0"
-      sources."has-symbols-1.0.2"
       sources."ignore-4.0.6"
       sources."import-fresh-3.3.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."is-boolean-object-1.1.0"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-3.0.0"
       sources."is-glob-4.0.1"
-      sources."is-number-object-1.0.4"
-      sources."is-string-1.0.5"
       sources."isexe-2.0.0"
       sources."js-tokens-4.0.0"
       sources."js-yaml-3.14.1"
@@ -77815,7 +77924,7 @@ in
       sources."strip-ansi-6.0.0"
       sources."strip-json-comments-3.1.1"
       sources."supports-color-8.1.1"
-      (sources."table-6.1.0" // {
+      (sources."table-6.5.1" // {
         dependencies = [
           sources."ajv-8.1.0"
           sources."json-schema-traverse-1.0.0"
@@ -77861,10 +77970,10 @@ in
   expo-cli = nodeEnv.buildNodePackage {
     name = "expo-cli";
     packageName = "expo-cli";
-    version = "4.4.1";
+    version = "4.4.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/expo-cli/-/expo-cli-4.4.1.tgz";
-      sha512 = "yJS0aHxzkaKmd55hppBxn+s7KCxRXFbqlZF5r2v2eE3vmLlDEnPWI8WQ//algAZO52nYCJtZBOa2EswESdK66g==";
+      url = "https://registry.npmjs.org/expo-cli/-/expo-cli-4.4.3.tgz";
+      sha512 = "wSap0vOOFRgg+SUrB4QPNdJH7FeTZAXgEIdrQIayoliRe+e/466Buh1j9v5g0CE6INhRjX+Ak2u9z5pVJxa4MQ==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
@@ -77874,10 +77983,10 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."@babel/generator-7.13.9"
+      sources."@babel/generator-7.13.16"
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.12.13"
-      (sources."@babel/helper-compilation-targets-7.13.13" // {
+      (sources."@babel/helper-compilation-targets-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -77892,7 +78001,7 @@ in
       sources."@babel/helper-explode-assignable-expression-7.13.0"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
-      sources."@babel/helper-hoist-variables-7.13.0"
+      sources."@babel/helper-hoist-variables-7.13.16"
       sources."@babel/helper-member-expression-to-functions-7.13.12"
       sources."@babel/helper-module-imports-7.13.12"
       sources."@babel/helper-module-transforms-7.13.14"
@@ -77906,13 +78015,13 @@ in
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
       sources."@babel/helper-wrap-function-7.13.0"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       (sources."@babel/highlight-7.13.10" // {
         dependencies = [
           sources."chalk-2.4.2"
         ];
       })
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/plugin-proposal-async-generator-functions-7.13.15"
       sources."@babel/plugin-proposal-class-properties-7.12.13"
       sources."@babel/plugin-proposal-dynamic-import-7.13.8"
@@ -77946,10 +78055,10 @@ in
       sources."@babel/plugin-transform-arrow-functions-7.13.0"
       sources."@babel/plugin-transform-async-to-generator-7.13.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.12.13"
-      sources."@babel/plugin-transform-block-scoping-7.12.13"
+      sources."@babel/plugin-transform-block-scoping-7.13.16"
       sources."@babel/plugin-transform-classes-7.13.0"
       sources."@babel/plugin-transform-computed-properties-7.13.0"
-      sources."@babel/plugin-transform-destructuring-7.13.0"
+      sources."@babel/plugin-transform-destructuring-7.13.17"
       sources."@babel/plugin-transform-dotall-regex-7.12.13"
       sources."@babel/plugin-transform-duplicate-keys-7.12.13"
       sources."@babel/plugin-transform-exponentiation-operator-7.12.13"
@@ -77994,14 +78103,14 @@ in
       })
       sources."@babel/preset-modules-0.1.4"
       sources."@babel/preset-typescript-7.12.17"
-      sources."@babel/runtime-7.13.10"
+      sources."@babel/runtime-7.13.17"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@expo/apple-utils-0.0.0-alpha.17"
       sources."@expo/bunyan-4.0.0"
-      sources."@expo/config-3.3.36"
-      sources."@expo/config-plugins-1.0.26"
+      sources."@expo/config-3.3.38"
+      sources."@expo/config-plugins-1.0.28"
       sources."@expo/config-types-40.0.0-beta.2"
       (sources."@expo/configure-splash-screen-0.3.4" // {
         dependencies = [
@@ -78009,7 +78118,7 @@ in
           sources."pngjs-5.0.0"
         ];
       })
-      (sources."@expo/dev-server-0.1.62" // {
+      (sources."@expo/dev-server-0.1.64" // {
         dependencies = [
           sources."body-parser-1.19.0"
           sources."bytes-3.1.0"
@@ -78024,7 +78133,7 @@ in
           sources."statuses-1.5.0"
         ];
       })
-      sources."@expo/dev-tools-0.13.92"
+      sources."@expo/dev-tools-0.13.94"
       (sources."@expo/devcert-1.0.0" // {
         dependencies = [
           sources."debug-3.2.7"
@@ -78032,20 +78141,20 @@ in
           sources."sudo-prompt-8.2.5"
         ];
       })
-      (sources."@expo/image-utils-0.3.12" // {
+      (sources."@expo/image-utils-0.3.13" // {
         dependencies = [
           sources."tempy-0.3.0"
         ];
       })
-      (sources."@expo/json-file-8.2.28" // {
+      (sources."@expo/json-file-8.2.29" // {
         dependencies = [
           sources."@babel/code-frame-7.10.4"
           sources."json5-1.0.1"
         ];
       })
-      sources."@expo/metro-config-0.1.62"
-      sources."@expo/osascript-2.0.25"
-      (sources."@expo/package-manager-0.0.40" // {
+      sources."@expo/metro-config-0.1.64"
+      sources."@expo/osascript-2.0.26"
+      (sources."@expo/package-manager-0.0.41" // {
         dependencies = [
           sources."npm-package-arg-7.0.0"
           sources."rimraf-3.0.2"
@@ -78058,7 +78167,7 @@ in
         ];
       })
       sources."@expo/results-1.0.0"
-      (sources."@expo/schemer-1.3.27" // {
+      (sources."@expo/schemer-1.3.28" // {
         dependencies = [
           sources."ajv-5.5.2"
           sources."fast-deep-equal-1.1.0"
@@ -78067,7 +78176,7 @@ in
       })
       sources."@expo/simple-spinner-1.0.2"
       sources."@expo/spawn-async-1.5.0"
-      (sources."@expo/webpack-config-0.12.66" // {
+      (sources."@expo/webpack-config-0.12.68" // {
         dependencies = [
           sources."@babel/runtime-7.9.0"
           sources."react-refresh-0.8.3"
@@ -78128,7 +78237,6 @@ in
       sources."@nodelib/fs.scandir-2.1.4"
       sources."@nodelib/fs.stat-2.0.4"
       sources."@nodelib/fs.walk-1.2.6"
-      sources."@npmcli/ci-detect-1.3.0"
       (sources."@npmcli/git-2.0.8" // {
         dependencies = [
           sources."mkdirp-1.0.4"
@@ -78145,7 +78253,7 @@ in
       })
       sources."@npmcli/node-gyp-1.0.2"
       sources."@npmcli/promise-spawn-1.3.2"
-      sources."@npmcli/run-script-1.8.4"
+      sources."@npmcli/run-script-1.8.5"
       sources."@pmmmwh/react-refresh-webpack-plugin-0.3.3"
       sources."@react-native-community/cli-debugger-ui-4.13.1"
       (sources."@react-native-community/cli-server-api-4.9.0" // {
@@ -78169,7 +78277,7 @@ in
         ];
       })
       sources."@segment/loosely-validate-event-2.0.0"
-      sources."@sindresorhus/is-4.0.0"
+      sources."@sindresorhus/is-4.0.1"
       sources."@szmarczak/http-timer-4.0.5"
       sources."@tootallnate/once-1.1.2"
       sources."@types/anymatch-1.3.1"
@@ -78384,7 +78492,7 @@ in
         ];
       })
       sources."browserify-zlib-0.2.0"
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       sources."buffer-5.7.1"
       sources."buffer-equal-0.0.1"
       sources."buffer-from-1.1.1"
@@ -78415,9 +78523,9 @@ in
       })
       sources."camelcase-5.3.1"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."caseless-0.12.0"
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -78548,8 +78656,8 @@ in
           sources."semver-6.3.0"
         ];
       })
-      sources."core-js-3.10.1"
-      (sources."core-js-compat-3.10.1" // {
+      sources."core-js-3.11.0"
+      (sources."core-js-compat-3.11.0" // {
         dependencies = [
           sources."semver-7.0.0"
         ];
@@ -78688,7 +78796,7 @@ in
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       (sources."elliptic-6.5.4" // {
         dependencies = [
           sources."bn.js-4.12.0"
@@ -78770,7 +78878,7 @@ in
           sources."ms-2.0.0"
         ];
       })
-      (sources."expo-pwa-0.0.72" // {
+      (sources."expo-pwa-0.0.74" // {
         dependencies = [
           sources."commander-2.20.0"
         ];
@@ -79307,7 +79415,7 @@ in
       sources."nopt-5.0.0"
       sources."normalize-path-3.0.0"
       sources."normalize-url-4.5.0"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-install-checks-4.0.0"
       sources."npm-normalize-package-bin-1.0.1"
       (sources."npm-package-arg-6.1.0" // {
@@ -79324,7 +79432,7 @@ in
           sources."semver-7.3.5"
         ];
       })
-      (sources."npm-registry-fetch-9.0.0" // {
+      (sources."npm-registry-fetch-10.1.1" // {
         dependencies = [
           sources."hosted-git-info-4.0.2"
           sources."minipass-3.1.3"
@@ -79421,7 +79529,7 @@ in
           sources."semver-6.3.0"
         ];
       })
-      (sources."pacote-11.3.1" // {
+      (sources."pacote-11.3.3" // {
         dependencies = [
           sources."hosted-git-info-4.0.2"
           sources."minipass-3.1.3"
@@ -79617,7 +79725,7 @@ in
         ];
       })
       sources."postcss-safe-parser-4.0.2"
-      sources."postcss-selector-parser-6.0.4"
+      sources."postcss-selector-parser-6.0.5"
       (sources."postcss-svgo-4.0.3" // {
         dependencies = [
           sources."postcss-value-parser-3.3.1"
@@ -80332,7 +80440,7 @@ in
           sources."uuid-7.0.3"
         ];
       })
-      (sources."xdl-59.0.32" // {
+      (sources."xdl-59.0.34" // {
         dependencies = [
           sources."chownr-1.1.4"
           sources."fs-minipass-1.2.7"
@@ -80596,7 +80704,7 @@ in
           sources."@oclif/plugin-help-3.2.2"
           sources."ansi-regex-3.0.0"
           sources."ansi-styles-3.2.1"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."color-convert-1.9.3"
           sources."color-name-1.1.3"
           sources."has-flag-4.0.0"
@@ -81433,7 +81541,7 @@ in
       sources."fecha-4.2.1"
       sources."figures-2.0.0"
       sources."file-uri-to-path-2.0.0"
-      sources."filesize-6.2.5"
+      sources."filesize-6.3.0"
       sources."fill-range-7.0.1"
       (sources."finalhandler-1.1.2" // {
         dependencies = [
@@ -82047,7 +82155,7 @@ in
       sources."astral-regex-2.0.0"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chardet-0.7.0"
       sources."clean-stack-2.2.0"
       sources."cli-cursor-3.1.0"
@@ -82229,7 +82337,7 @@ in
       sources."buffer-to-arraybuffer-0.0.5"
       sources."camelcase-5.3.1"
       sources."caseless-0.12.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chardet-0.7.0"
       sources."cli-cursor-3.1.0"
       sources."cli-width-3.0.0"
@@ -82821,7 +82929,7 @@ in
       sources."@medv/blessed-2.0.1"
       sources."ansi-regex-5.0.0"
       sources."ansi-styles-4.3.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
       sources."emoji-regex-8.0.0"
@@ -82877,19 +82985,19 @@ in
       })
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      (sources."@babel/core-7.13.15" // {
+      (sources."@babel/core-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
           sources."source-map-0.5.7"
         ];
       })
-      (sources."@babel/generator-7.13.9" // {
+      (sources."@babel/generator-7.13.16" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
       })
       sources."@babel/helper-annotate-as-pure-7.12.13"
-      (sources."@babel/helper-compilation-targets-7.13.13" // {
+      (sources."@babel/helper-compilation-targets-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -82907,13 +83015,13 @@ in
       sources."@babel/helper-split-export-declaration-7.12.13"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       (sources."@babel/highlight-7.13.10" // {
         dependencies = [
           sources."chalk-2.4.2"
         ];
       })
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/plugin-proposal-object-rest-spread-7.10.4"
       sources."@babel/plugin-proposal-optional-chaining-7.13.12"
       sources."@babel/plugin-syntax-jsx-7.12.13"
@@ -82921,11 +83029,11 @@ in
       sources."@babel/plugin-syntax-optional-chaining-7.8.3"
       sources."@babel/plugin-transform-parameters-7.13.0"
       sources."@babel/plugin-transform-react-jsx-7.13.12"
-      sources."@babel/runtime-7.13.10"
-      sources."@babel/standalone-7.13.15"
+      sources."@babel/runtime-7.13.17"
+      sources."@babel/standalone-7.13.17"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@graphql-tools/schema-7.1.3"
       (sources."@graphql-tools/utils-7.7.3" // {
         dependencies = [
@@ -83022,7 +83130,7 @@ in
       })
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       sources."bytes-3.1.0"
       (sources."cacheable-request-6.1.0" // {
         dependencies = [
@@ -83034,9 +83142,9 @@ in
       sources."call-bind-1.0.2"
       sources."camel-case-4.1.2"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."ccount-1.1.0"
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -83084,7 +83192,7 @@ in
         ];
       })
       sources."content-type-1.0.4"
-      sources."contentful-management-7.15.1"
+      sources."contentful-management-7.17.1"
       sources."contentful-sdk-core-6.7.0"
       sources."convert-hrtime-3.0.0"
       (sources."convert-source-map-1.7.0" // {
@@ -83134,7 +83242,7 @@ in
       sources."dotenv-8.2.0"
       sources."duplexer3-0.1.4"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       sources."emoji-regex-7.0.3"
       sources."encodeurl-1.0.2"
       sources."end-of-stream-1.4.4"
@@ -83755,7 +83863,7 @@ in
       sources."moo-0.5.1"
       sources."ms-2.1.2"
       sources."multicb-1.2.2"
-      sources."multiserver-3.7.0"
+      sources."multiserver-3.7.1"
       sources."multiserver-address-1.0.1"
       sources."multiserver-scopes-1.0.0"
       sources."muxrpc-6.5.2"
@@ -83765,7 +83873,7 @@ in
       sources."non-private-ip-1.4.4"
       sources."options-0.0.6"
       sources."os-homedir-1.0.2"
-      sources."packet-stream-2.0.5"
+      sources."packet-stream-2.0.6"
       sources."packet-stream-codec-1.1.3"
       sources."pako-1.0.11"
       sources."private-box-0.3.1"
@@ -83908,10 +84016,10 @@ in
   gitmoji-cli = nodeEnv.buildNodePackage {
     name = "gitmoji-cli";
     packageName = "gitmoji-cli";
-    version = "3.3.1";
+    version = "3.4.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-3.3.1.tgz";
-      sha512 = "wsCS8L8QTb9ghnJJpn1qKj+LokhGQ7OlKSM/n6/LhB8E4w/Pn4hiSgqcBthaL5J6CwJiWjpbNSA4t3sE0yqEPw==";
+      url = "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-3.4.0.tgz";
+      sha512 = "a5XeeQlD5D6MGDp+whDE72IdTTC1zCYrksLlUPDigB3yVM5wuHsEtwdOkadJG4wgebLaDVA5S00E/GVb5PgSZw==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
@@ -83963,7 +84071,7 @@ in
       })
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chardet-0.7.0"
       sources."ci-info-2.0.0"
       sources."cli-boxes-2.2.1"
@@ -84282,16 +84390,12 @@ in
           sources."tslib-2.1.0"
         ];
       })
-      (sources."@graphql-tools/url-loader-6.8.2" // {
+      (sources."@graphql-tools/url-loader-6.8.3" // {
         dependencies = [
-          (sources."@graphql-tools/utils-7.7.3" // {
-            dependencies = [
-              sources."tslib-2.2.0"
-            ];
-          })
-          sources."cross-fetch-3.1.1"
+          sources."@graphql-tools/utils-7.7.3"
+          sources."cross-fetch-3.1.4"
           sources."form-data-4.0.0"
-          sources."tslib-2.1.0"
+          sources."tslib-2.2.0"
         ];
       })
       (sources."@graphql-tools/utils-6.2.4" // {
@@ -84473,7 +84577,7 @@ in
       sources."graphql-subscriptions-1.2.1"
       sources."graphql-type-json-0.3.2"
       sources."graphql-upload-11.0.0"
-      sources."graphql-ws-4.2.2"
+      sources."graphql-ws-4.4.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
@@ -84769,7 +84873,7 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."ws-7.4.4"
+      sources."ws-7.4.5"
       sources."y18n-5.0.8"
       sources."yallist-4.0.0"
       sources."yaml-1.10.2"
@@ -85052,7 +85156,7 @@ in
       (sources."marked-terminal-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."supports-color-7.2.0"
         ];
       })
@@ -86304,7 +86408,7 @@ in
       sources."nel-1.2.0"
       sources."node-gyp-build-4.2.3"
       sources."uuid-3.4.0"
-      sources."zeromq-5.2.7"
+      sources."zeromq-5.2.8"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -86660,7 +86764,7 @@ in
       sources."is-wsl-2.2.0"
       sources."isexe-2.0.0"
       sources."jquery-3.6.0"
-      sources."jquery.terminal-2.22.0"
+      sources."jquery.terminal-2.23.2"
       sources."jsonfile-2.4.0"
       sources."keyboardevent-key-polyfill-1.1.0"
       sources."line-reader-0.4.0"
@@ -86820,7 +86924,7 @@ in
         dependencies = [
           sources."ansi-escapes-4.3.2"
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."cli-cursor-3.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -87022,7 +87126,7 @@ in
       (sources."@ot-builder/cli-help-shower-1.0.4" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -87032,7 +87136,7 @@ in
       (sources."@ot-builder/cli-proc-1.0.4" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -87042,7 +87146,7 @@ in
       (sources."@ot-builder/cli-shared-1.0.4" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -87167,7 +87271,7 @@ in
       (sources."otb-ttc-bundle-1.0.4" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -87231,7 +87335,7 @@ in
       (sources."verda-1.2.2" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."cliui-6.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -87451,7 +87555,7 @@ in
       sources."async-mutex-0.1.4"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
-      (sources."aws-sdk-2.888.0" // {
+      (sources."aws-sdk-2.892.0" // {
         dependencies = [
           sources."sax-1.2.1"
           sources."uuid-3.3.2"
@@ -87483,7 +87587,7 @@ in
       sources."camel-case-3.0.0"
       sources."camelcase-4.1.0"
       sources."caseless-0.12.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."charenc-0.0.2"
       sources."chokidar-3.5.1"
       sources."chownr-1.1.4"
@@ -87834,7 +87938,7 @@ in
       sources."needle-2.6.0"
       sources."nextgen-events-1.3.4"
       sources."no-case-2.3.2"
-      (sources."node-abi-2.21.0" // {
+      (sources."node-abi-2.26.0" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
@@ -87865,7 +87969,7 @@ in
       sources."noop-logger-0.1.1"
       sources."nopt-4.0.3"
       sources."normalize-path-3.0.0"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-packlist-1.4.8"
       sources."npmlog-4.1.2"
@@ -88196,7 +88300,7 @@ in
       sha512 = "znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==";
     };
     dependencies = [
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."argparse-1.0.10"
       sources."bluebird-3.7.2"
       sources."catharsis-0.8.11"
@@ -88419,7 +88523,7 @@ in
         ];
       })
       sources."camelcase-6.2.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."ci-info-2.0.0"
       sources."cli-boxes-2.2.1"
       (sources."cliui-7.0.4" // {
@@ -88715,7 +88819,7 @@ in
       sources."braces-3.0.2"
       sources."call-bind-1.0.2"
       sources."cardinal-2.1.1"
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."has-flag-4.0.0"
           sources."supports-color-7.2.0"
@@ -89749,7 +89853,11 @@ in
           sources."pify-5.0.0"
         ];
       })
-      sources."@lerna/npm-dist-tag-4.0.0"
+      (sources."@lerna/npm-dist-tag-4.0.0" // {
+        dependencies = [
+          sources."npm-registry-fetch-9.0.0"
+        ];
+      })
       sources."@lerna/npm-install-4.0.0"
       (sources."@lerna/npm-publish-4.0.0" // {
         dependencies = [
@@ -89768,7 +89876,11 @@ in
       sources."@lerna/profiler-4.0.0"
       sources."@lerna/project-4.0.0"
       sources."@lerna/prompt-4.0.0"
-      sources."@lerna/publish-4.0.0"
+      (sources."@lerna/publish-4.0.0" // {
+        dependencies = [
+          sources."npm-registry-fetch-9.0.0"
+        ];
+      })
       sources."@lerna/pulse-till-done-4.0.0"
       sources."@lerna/query-graph-4.0.0"
       sources."@lerna/resolve-symlink-4.0.0"
@@ -89795,7 +89907,7 @@ in
       sources."@npmcli/move-file-1.1.2"
       sources."@npmcli/node-gyp-1.0.2"
       sources."@npmcli/promise-spawn-1.3.2"
-      sources."@npmcli/run-script-1.8.4"
+      sources."@npmcli/run-script-1.8.5"
       sources."@octokit/auth-token-2.4.5"
       sources."@octokit/core-3.4.0"
       (sources."@octokit/endpoint-6.0.11" // {
@@ -89804,19 +89916,19 @@ in
         ];
       })
       sources."@octokit/graphql-4.6.1"
-      sources."@octokit/openapi-types-6.0.0"
+      sources."@octokit/openapi-types-6.1.1"
       sources."@octokit/plugin-enterprise-rest-6.0.1"
       sources."@octokit/plugin-paginate-rest-2.13.3"
       sources."@octokit/plugin-request-log-1.0.3"
-      sources."@octokit/plugin-rest-endpoint-methods-5.0.0"
+      sources."@octokit/plugin-rest-endpoint-methods-5.0.1"
       (sources."@octokit/request-5.4.15" // {
         dependencies = [
           sources."is-plain-object-5.0.0"
         ];
       })
       sources."@octokit/request-error-2.0.5"
-      sources."@octokit/rest-18.5.2"
-      sources."@octokit/types-6.13.0"
+      sources."@octokit/rest-18.5.3"
+      sources."@octokit/types-6.13.2"
       sources."@tootallnate/once-1.1.2"
       sources."@types/minimatch-3.0.4"
       sources."@types/minimist-1.2.1"
@@ -89871,7 +89983,7 @@ in
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
       sources."caseless-0.12.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chardet-0.7.0"
       sources."chownr-2.0.0"
       sources."ci-info-2.0.0"
@@ -90121,8 +90233,8 @@ in
       sources."jsonparse-1.3.1"
       sources."jsprim-1.4.1"
       sources."kind-of-6.0.3"
-      sources."libnpmaccess-4.0.1"
-      (sources."libnpmpublish-4.0.0" // {
+      sources."libnpmaccess-4.0.2"
+      (sources."libnpmpublish-4.0.1" // {
         dependencies = [
           sources."normalize-package-data-3.0.2"
         ];
@@ -90206,7 +90318,7 @@ in
         ];
       })
       sources."normalize-url-3.3.0"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-install-checks-4.0.0"
       (sources."npm-lifecycle-3.1.5" // {
         dependencies = [
@@ -90229,7 +90341,7 @@ in
       sources."npm-package-arg-8.1.2"
       sources."npm-packlist-2.1.5"
       sources."npm-pick-manifest-6.1.1"
-      sources."npm-registry-fetch-9.0.0"
+      sources."npm-registry-fetch-10.1.1"
       sources."npm-run-path-4.0.1"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
@@ -90255,7 +90367,7 @@ in
       sources."p-timeout-3.2.0"
       sources."p-try-2.2.0"
       sources."p-waterfall-2.1.1"
-      sources."pacote-11.3.1"
+      sources."pacote-11.3.3"
       sources."parent-module-1.0.1"
       sources."parse-github-repo-url-1.4.1"
       sources."parse-json-5.2.0"
@@ -91364,18 +91476,18 @@ in
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      sources."@babel/core-7.13.15"
-      sources."@babel/generator-7.13.9"
+      sources."@babel/core-7.13.16"
+      sources."@babel/generator-7.13.16"
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.12.13"
-      sources."@babel/helper-compilation-targets-7.13.13"
+      sources."@babel/helper-compilation-targets-7.13.16"
       sources."@babel/helper-create-class-features-plugin-7.13.11"
       sources."@babel/helper-create-regexp-features-plugin-7.12.17"
       sources."@babel/helper-define-polyfill-provider-0.2.0"
       sources."@babel/helper-explode-assignable-expression-7.13.0"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
-      sources."@babel/helper-hoist-variables-7.13.0"
+      sources."@babel/helper-hoist-variables-7.13.16"
       sources."@babel/helper-member-expression-to-functions-7.13.12"
       sources."@babel/helper-module-imports-7.13.12"
       sources."@babel/helper-module-transforms-7.13.14"
@@ -91389,13 +91501,13 @@ in
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
       sources."@babel/helper-wrap-function-7.13.0"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       (sources."@babel/highlight-7.13.10" // {
         dependencies = [
           sources."chalk-2.4.2"
         ];
       })
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12"
       sources."@babel/plugin-external-helpers-7.8.3"
       sources."@babel/plugin-proposal-async-generator-functions-7.13.15"
@@ -91428,10 +91540,10 @@ in
       sources."@babel/plugin-transform-arrow-functions-7.13.0"
       sources."@babel/plugin-transform-async-to-generator-7.13.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.12.13"
-      sources."@babel/plugin-transform-block-scoping-7.12.13"
+      sources."@babel/plugin-transform-block-scoping-7.13.16"
       sources."@babel/plugin-transform-classes-7.13.0"
       sources."@babel/plugin-transform-computed-properties-7.13.0"
-      sources."@babel/plugin-transform-destructuring-7.13.0"
+      sources."@babel/plugin-transform-destructuring-7.13.17"
       sources."@babel/plugin-transform-dotall-regex-7.12.13"
       sources."@babel/plugin-transform-duplicate-keys-7.12.13"
       sources."@babel/plugin-transform-exponentiation-operator-7.12.13"
@@ -91461,10 +91573,10 @@ in
       sources."@babel/preset-env-7.13.15"
       sources."@babel/preset-modules-0.1.4"
       sources."@babel/preset-stage-2-7.8.3"
-      sources."@babel/runtime-7.13.10"
+      sources."@babel/runtime-7.13.17"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@cnakazawa/watch-1.0.4"
       sources."@comandeer/babel-plugin-banner-5.0.0"
       sources."@istanbuljs/load-nyc-config-1.1.0"
@@ -91642,7 +91754,7 @@ in
         ];
       })
       sources."browserify-zlib-0.2.0"
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       sources."bser-2.1.1"
       sources."buffer-5.2.1"
       sources."buffer-from-1.1.1"
@@ -91658,7 +91770,7 @@ in
       sources."cached-path-relative-1.0.2"
       sources."call-bind-1.0.2"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."capture-exit-2.0.0"
       sources."caseless-0.12.0"
       (sources."chalk-3.0.0" // {
@@ -91730,7 +91842,7 @@ in
       })
       sources."copy-descriptor-0.1.1"
       sources."core-js-2.6.12"
-      (sources."core-js-compat-3.10.1" // {
+      (sources."core-js-compat-3.11.0" // {
         dependencies = [
           sources."semver-7.0.0"
         ];
@@ -91782,7 +91894,7 @@ in
       sources."duplexer2-0.1.4"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       (sources."elliptic-6.5.4" // {
         dependencies = [
           sources."bn.js-4.12.0"
@@ -92553,7 +92665,7 @@ in
       sources."aws4-1.11.0"
       sources."bcrypt-pbkdf-1.0.2"
       sources."caseless-0.12.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
       sources."combined-stream-1.0.8"
@@ -92916,10 +93028,10 @@ in
   mathjax = nodeEnv.buildNodePackage {
     name = "mathjax";
     packageName = "mathjax";
-    version = "3.1.2";
+    version = "3.1.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/mathjax/-/mathjax-3.1.2.tgz";
-      sha512 = "BojKspBv4nNWzO1wC6VEI+g9gHDOhkaGHGgLxXkasdU4pwjdO5AXD5M/wcLPkXYPjZ/N+6sU8rjQTlyvN2cWiQ==";
+      url = "https://registry.npmjs.org/mathjax/-/mathjax-3.1.4.tgz";
+      sha512 = "Okmc+F3l7vRWNMALbH0HMMoTJWVn1cbeDbybHppCeophIGdFS+xxD/OffYpZirUOHzesZostpzEwsLSst+4W8w==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -92990,7 +93102,7 @@ in
       sources."buffer-crc32-0.2.13"
       sources."buffer-from-1.1.1"
       sources."camel-case-3.0.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chownr-1.1.4"
       sources."clean-css-4.2.3"
       sources."color-convert-2.0.1"
@@ -93135,12 +93247,12 @@ in
     dependencies = [
       sources."@fluentui/date-time-utilities-7.9.1"
       sources."@fluentui/dom-utilities-1.1.2"
-      sources."@fluentui/keyboard-key-0.2.16"
+      sources."@fluentui/keyboard-key-0.2.17"
       sources."@fluentui/react-7.168.0"
       sources."@fluentui/react-focus-7.17.6"
       sources."@fluentui/react-window-provider-1.0.2"
       sources."@fluentui/theme-1.7.4"
-      sources."@microsoft/load-themed-styles-1.10.161"
+      sources."@microsoft/load-themed-styles-1.10.165"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@uifabric/foundation-7.9.26"
@@ -93417,7 +93529,7 @@ in
       sources."braces-3.0.2"
       sources."browser-stdout-1.3.1"
       sources."camelcase-6.2.0"
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."supports-color-7.2.0"
         ];
@@ -93652,23 +93764,23 @@ in
   netlify-cli = nodeEnv.buildNodePackage {
     name = "netlify-cli";
     packageName = "netlify-cli";
-    version = "3.18.3";
+    version = "3.21.9";
     src = fetchurl {
-      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-3.18.3.tgz";
-      sha512 = "VonzQOBohu/+G++NiVIwoyrwDaGo7VV4kzqrJr9pc7KWm95iBT+4FBvlzAk4VYg6vU5/3WYcOIwQTNSOZKcJiA==";
+      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-3.21.9.tgz";
+      sha512 = "GRdQHPz8gVmU1Gy6ZWv/B2t3MjQN2hLHBG4yRY6S7DbRQc8XaY9PLJPrmodycumFdzx6Da+SMmhZrzkKfZ/xSg==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      (sources."@babel/core-7.13.15" // {
+      (sources."@babel/core-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
       })
-      sources."@babel/generator-7.13.9"
+      sources."@babel/generator-7.13.16"
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.12.13"
-      (sources."@babel/helper-compilation-targets-7.13.13" // {
+      (sources."@babel/helper-compilation-targets-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -93683,7 +93795,7 @@ in
       sources."@babel/helper-explode-assignable-expression-7.13.0"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
-      sources."@babel/helper-hoist-variables-7.13.0"
+      sources."@babel/helper-hoist-variables-7.13.16"
       sources."@babel/helper-member-expression-to-functions-7.13.12"
       sources."@babel/helper-module-imports-7.13.12"
       sources."@babel/helper-module-transforms-7.13.14"
@@ -93697,9 +93809,9 @@ in
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
       sources."@babel/helper-wrap-function-7.13.0"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       sources."@babel/highlight-7.13.10"
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12"
       sources."@babel/plugin-proposal-async-generator-functions-7.13.15"
       sources."@babel/plugin-proposal-class-properties-7.13.0"
@@ -93729,10 +93841,10 @@ in
       sources."@babel/plugin-transform-arrow-functions-7.13.0"
       sources."@babel/plugin-transform-async-to-generator-7.13.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.12.13"
-      sources."@babel/plugin-transform-block-scoping-7.12.13"
+      sources."@babel/plugin-transform-block-scoping-7.13.16"
       sources."@babel/plugin-transform-classes-7.13.0"
       sources."@babel/plugin-transform-computed-properties-7.13.0"
-      sources."@babel/plugin-transform-destructuring-7.13.0"
+      sources."@babel/plugin-transform-destructuring-7.13.17"
       sources."@babel/plugin-transform-dotall-regex-7.12.13"
       sources."@babel/plugin-transform-duplicate-keys-7.12.13"
       sources."@babel/plugin-transform-exponentiation-operator-7.12.13"
@@ -93764,10 +93876,10 @@ in
         ];
       })
       sources."@babel/preset-modules-0.1.4"
-      sources."@babel/runtime-7.13.10"
+      sources."@babel/runtime-7.13.17"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@bugsnag/browser-7.9.2"
       sources."@bugsnag/core-7.9.2"
       sources."@bugsnag/cuid-3.0.0"
@@ -93777,11 +93889,12 @@ in
       sources."@dabh/diagnostics-2.0.2"
       sources."@jest/types-24.9.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
-      (sources."@netlify/build-11.1.0" // {
+      (sources."@netlify/build-11.2.5" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."execa-3.4.0"
+          sources."is-plain-obj-2.1.0"
           sources."locate-path-5.0.0"
           sources."resolve-2.0.0-next.3"
           sources."semver-6.3.0"
@@ -93792,20 +93905,22 @@ in
           sources."locate-path-5.0.0"
         ];
       })
-      (sources."@netlify/config-6.0.1" // {
+      (sources."@netlify/config-6.2.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."execa-3.4.0"
+          sources."is-plain-obj-2.1.0"
         ];
       })
       (sources."@netlify/framework-info-3.3.0" // {
         dependencies = [
+          sources."is-plain-obj-2.1.0"
           sources."locate-path-5.0.0"
         ];
       })
-      sources."@netlify/functions-utils-1.3.25"
-      (sources."@netlify/git-utils-1.0.8" // {
+      sources."@netlify/functions-utils-1.3.28"
+      (sources."@netlify/git-utils-1.0.9" // {
         dependencies = [
           sources."braces-3.0.2"
           sources."execa-3.4.0"
@@ -93835,7 +93950,7 @@ in
           sources."to-regex-range-5.0.1"
         ];
       })
-      sources."@netlify/plugins-list-2.6.0"
+      sources."@netlify/plugins-list-2.8.0"
       (sources."@netlify/run-utils-1.0.7" // {
         dependencies = [
           sources."execa-3.4.0"
@@ -93845,7 +93960,7 @@ in
       sources."@netlify/traffic-mesh-agent-darwin-x64-0.27.10"
       sources."@netlify/traffic-mesh-agent-linux-x64-0.27.10"
       sources."@netlify/traffic-mesh-agent-win32-x64-0.27.10"
-      (sources."@netlify/zip-it-and-ship-it-3.4.0" // {
+      (sources."@netlify/zip-it-and-ship-it-3.7.0" // {
         dependencies = [
           sources."locate-path-5.0.0"
           sources."resolve-2.0.0-next.3"
@@ -93882,7 +93997,7 @@ in
           sources."@oclif/plugin-help-3.2.2"
           sources."ansi-regex-3.0.0"
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."color-convert-1.9.3"
           sources."color-name-1.1.3"
           sources."is-fullwidth-code-point-2.0.0"
@@ -93915,10 +94030,8 @@ in
       })
       (sources."@oclif/errors-1.3.4" // {
         dependencies = [
-          sources."ansi-styles-4.3.0"
           sources."clean-stack-3.0.1"
           sources."escape-string-regexp-4.0.0"
-          sources."wrap-ansi-7.0.0"
         ];
       })
       sources."@oclif/linewrap-1.0.0"
@@ -93966,7 +94079,7 @@ in
       (sources."@oclif/plugin-plugins-1.10.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."fs-extra-9.1.0"
           sources."jsonfile-6.1.0"
           sources."tslib-2.2.0"
@@ -93981,7 +94094,7 @@ in
           sources."universal-user-agent-6.0.0"
         ];
       })
-      sources."@octokit/openapi-types-6.0.0"
+      sources."@octokit/openapi-types-6.1.1"
       (sources."@octokit/plugin-paginate-rest-1.1.2" // {
         dependencies = [
           sources."@octokit/types-2.16.2"
@@ -94006,7 +94119,7 @@ in
         ];
       })
       sources."@octokit/rest-16.43.2"
-      sources."@octokit/types-6.13.0"
+      sources."@octokit/types-6.13.2"
       sources."@rollup/plugin-babel-5.3.0"
       (sources."@rollup/plugin-commonjs-17.1.0" // {
         dependencies = [
@@ -94115,7 +94228,7 @@ in
       sources."at-least-node-1.0.0"
       sources."atob-2.1.2"
       sources."atob-lite-2.0.0"
-      (sources."aws-sdk-2.888.0" // {
+      (sources."aws-sdk-2.892.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."ieee754-1.1.13"
@@ -94139,6 +94252,7 @@ in
       })
       sources."base64-js-1.5.1"
       sources."before-after-hook-2.2.1"
+      sources."better-opn-2.1.1"
       sources."binary-extensions-2.2.0"
       sources."bl-4.1.0"
       (sources."body-parser-1.19.0" // {
@@ -94160,7 +94274,7 @@ in
           sources."extend-shallow-2.0.1"
         ];
       })
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       sources."btoa-lite-1.0.0"
       sources."buffer-5.7.1"
       sources."buffer-alloc-1.2.0"
@@ -94189,7 +94303,7 @@ in
       sources."call-bind-1.0.2"
       sources."call-me-maybe-1.0.1"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."cardinal-2.1.1"
       sources."caw-2.0.1"
       (sources."chalk-2.4.2" // {
@@ -94248,7 +94362,7 @@ in
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."argparse-1.0.10"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."clean-stack-3.0.1"
           sources."escape-string-regexp-4.0.0"
           sources."extract-stack-2.0.0"
@@ -94258,7 +94372,12 @@ in
         ];
       })
       sources."cli-width-2.2.1"
-      sources."cliui-6.0.0"
+      (sources."cliui-6.0.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."wrap-ansi-6.2.0"
+        ];
+      })
       sources."clone-1.0.4"
       sources."clone-response-1.0.2"
       sources."code-point-at-1.1.0"
@@ -94316,7 +94435,7 @@ in
           sources."safe-buffer-5.1.2"
         ];
       })
-      (sources."core-js-compat-3.10.1" // {
+      (sources."core-js-compat-3.11.0" // {
         dependencies = [
           sources."semver-7.0.0"
         ];
@@ -94439,7 +94558,7 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       sources."elegant-spinner-1.0.1"
       sources."elf-cam-0.1.1"
       sources."emoji-regex-8.0.0"
@@ -94450,7 +94569,7 @@ in
       sources."envinfo-7.8.1"
       sources."error-ex-1.3.2"
       sources."error-stack-parser-2.0.6"
-      sources."esbuild-0.11.12"
+      sources."esbuild-0.11.13"
       sources."escalade-3.1.1"
       sources."escape-goat-2.1.1"
       sources."escape-html-1.0.3"
@@ -94543,7 +94662,7 @@ in
           sources."ansi-regex-5.0.0"
           sources."ansi-styles-4.3.0"
           sources."cacheable-request-7.0.1"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."decompress-response-5.0.0"
           sources."defer-to-connect-2.0.1"
           sources."got-10.7.0"
@@ -94705,12 +94824,11 @@ in
         ];
       })
       sources."http-proxy-1.18.1"
-      (sources."http-proxy-middleware-1.1.2" // {
+      (sources."http-proxy-middleware-1.2.0" // {
         dependencies = [
           sources."braces-3.0.2"
           sources."fill-range-7.0.1"
           sources."is-number-7.0.0"
-          sources."is-plain-obj-3.0.0"
           sources."micromatch-4.0.4"
           sources."to-regex-range-5.0.1"
         ];
@@ -94749,7 +94867,7 @@ in
       (sources."inquirer-autocomplete-prompt-1.3.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
         ];
       })
       sources."into-stream-3.1.0"
@@ -94786,13 +94904,14 @@ in
       sources."is-observable-1.1.0"
       sources."is-path-cwd-2.2.0"
       sources."is-path-inside-3.0.3"
-      sources."is-plain-obj-2.1.0"
+      sources."is-plain-obj-3.0.0"
       sources."is-plain-object-2.0.4"
       sources."is-promise-2.2.2"
       sources."is-reference-1.2.1"
       sources."is-retry-allowed-1.2.0"
       sources."is-stream-2.0.0"
       sources."is-typedarray-1.0.0"
+      sources."is-unicode-supported-0.1.0"
       sources."is-url-1.2.4"
       sources."is-windows-1.0.2"
       sources."is-wsl-2.2.0"
@@ -94907,7 +95026,12 @@ in
           sources."moize-5.4.7"
         ];
       })
-      sources."log-symbols-3.0.0"
+      (sources."log-symbols-4.1.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."chalk-4.1.1"
+        ];
+      })
       (sources."log-update-2.3.0" // {
         dependencies = [
           sources."ansi-escapes-3.2.0"
@@ -94944,9 +95068,13 @@ in
       sources."md5-hex-2.0.0"
       sources."md5-o-matic-0.1.1"
       sources."media-typer-0.3.0"
-      sources."memoize-one-5.1.1"
+      sources."memoize-one-5.2.1"
       sources."merge-descriptors-1.0.1"
-      sources."merge-options-3.0.4"
+      (sources."merge-options-3.0.4" // {
+        dependencies = [
+          sources."is-plain-obj-2.1.0"
+        ];
+      })
       sources."merge-stream-2.0.0"
       sources."merge2-1.4.1"
       sources."methods-1.1.2"
@@ -94991,12 +95119,12 @@ in
       sources."natural-orderby-2.0.3"
       sources."negotiator-0.6.2"
       sources."nested-error-stacks-2.1.0"
-      (sources."netlify-6.1.18" // {
+      (sources."netlify-6.1.20" // {
         dependencies = [
           sources."qs-6.10.1"
         ];
       })
-      sources."netlify-redirect-parser-3.0.15"
+      sources."netlify-redirect-parser-3.0.16"
       sources."netlify-redirector-0.2.1"
       sources."nice-try-1.0.5"
       sources."node-fetch-2.6.1"
@@ -95086,8 +95214,18 @@ in
           sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."cli-cursor-3.1.0"
+          sources."color-convert-1.9.3"
+          sources."color-name-1.1.3"
+          sources."has-flag-3.0.0"
+          (sources."log-symbols-3.0.0" // {
+            dependencies = [
+              sources."ansi-styles-3.2.1"
+              sources."chalk-2.4.2"
+            ];
+          })
           sources."mute-stream-0.0.8"
           sources."restore-cursor-3.1.0"
+          sources."supports-color-5.5.0"
         ];
       })
       sources."os-name-3.1.0"
@@ -95574,7 +95712,7 @@ in
         ];
       })
       sources."word-wrap-1.2.3"
-      (sources."wrap-ansi-6.2.0" // {
+      (sources."wrap-ansi-7.0.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
         ];
@@ -96096,7 +96234,7 @@ in
       sources."ms-2.1.3"
       sources."needle-2.6.0"
       sources."nopt-4.0.3"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-packlist-1.4.8"
       sources."npmlog-4.1.2"
@@ -96140,16 +96278,16 @@ in
   node-red = nodeEnv.buildNodePackage {
     name = "node-red";
     packageName = "node-red";
-    version = "1.3.2";
+    version = "1.3.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-red/-/node-red-1.3.2.tgz";
-      sha512 = "tOtD5Z8l4WNuGNfUp/LFSC/ou74LfKhIWSgT4i9WTTUxUvSlWCBu8TsPNbjl9yM17Ox2ebe57mEnOHvTjQlEyA==";
+      url = "https://registry.npmjs.org/node-red/-/node-red-1.3.3.tgz";
+      sha512 = "byKE+FxquGqaZ8HOCaZ6iz7CUwhJeBCfNqsuOCpUDxOa/Zqg2vh0OnZBv3W2DburZq/hEy2/LZxpXPg6iYSh4A==";
     };
     dependencies = [
-      sources."@babel/runtime-7.13.10"
-      sources."@node-red/editor-api-1.3.2"
-      sources."@node-red/editor-client-1.3.2"
-      (sources."@node-red/nodes-1.3.2" // {
+      sources."@babel/runtime-7.13.17"
+      sources."@node-red/editor-api-1.3.3"
+      sources."@node-red/editor-client-1.3.3"
+      (sources."@node-red/nodes-1.3.3" // {
         dependencies = [
           sources."cookie-0.4.1"
           sources."http-errors-1.7.3"
@@ -96163,9 +96301,9 @@ in
           })
         ];
       })
-      sources."@node-red/registry-1.3.2"
-      sources."@node-red/runtime-1.3.2"
-      sources."@node-red/util-1.3.2"
+      sources."@node-red/registry-1.3.3"
+      sources."@node-red/runtime-1.3.3"
+      sources."@node-red/util-1.3.3"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       (sources."agent-base-6.0.2" // {
@@ -96473,7 +96611,7 @@ in
       sources."node-red-node-rbe-0.5.0"
       sources."node-red-node-tail-0.3.1"
       sources."nopt-5.0.0"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-packlist-1.4.8"
       sources."npmlog-4.1.2"
@@ -97056,7 +97194,7 @@ in
       sources."callsites-3.1.0"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chardet-0.7.0"
       sources."ci-info-2.0.0"
       sources."clean-stack-2.2.0"
@@ -97338,7 +97476,7 @@ in
       sources."os-tmpdir-1.0.2"
       (sources."ow-0.21.0" // {
         dependencies = [
-          sources."@sindresorhus/is-4.0.0"
+          sources."@sindresorhus/is-4.0.1"
           sources."type-fest-0.20.2"
         ];
       })
@@ -97518,10 +97656,10 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "7.10.0";
+    version = "7.11.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-7.10.0.tgz";
-      sha512 = "DD4eEB71HGVt6pS6n4LmFD4eHsrglJ+QtLhv/kP2UWNKkJalL8TPfsiw9p8LmWKa6ed61LHPw5FE6krS3aGv0A==";
+      url = "https://registry.npmjs.org/npm/-/npm-7.11.1.tgz";
+      sha512 = "F9dUPQQBm5me6t74m63CrrBSzUcLART9BmsxiJU3jZK8SBnxiqzxvsU70/uqY0cjYSoYP7AuZ2w8YfGUwhcf6A==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -97536,22 +97674,21 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "11.4.1";
+    version = "11.5.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-11.4.1.tgz";
-      sha512 = "bWElM5CeJ9gA/wvtqB4ljcKzAZ3BlPM2g/7mVi8mPdCR2N6dhgS4q5GCzQn4ZvpeKSFll3bUGkiR/lgSQOlN8Q==";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-11.5.1.tgz";
+      sha512 = "4b12O2ioGKbS/4a3i/QfHNIMkNEEq7LtngUSFPatJ3FURIjGT13N/glKO/g2tPmuOtuaTXCnTJlyWBLnf+A//g==";
     };
     dependencies = [
       sources."@nodelib/fs.scandir-2.1.4"
       sources."@nodelib/fs.stat-2.0.4"
       sources."@nodelib/fs.walk-1.2.6"
-      sources."@npmcli/ci-detect-1.3.0"
       sources."@npmcli/git-2.0.8"
       sources."@npmcli/installed-package-contents-1.0.7"
       sources."@npmcli/move-file-1.1.2"
       sources."@npmcli/node-gyp-1.0.2"
       sources."@npmcli/promise-spawn-1.3.2"
-      sources."@npmcli/run-script-1.8.4"
+      sources."@npmcli/run-script-1.8.5"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@tootallnate/once-1.1.2"
@@ -97602,7 +97739,7 @@ in
       })
       sources."camelcase-6.2.0"
       sources."caseless-0.12.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chownr-2.0.0"
       sources."ci-info-2.0.0"
       sources."cint-8.2.1"
@@ -97740,7 +97877,7 @@ in
       })
       sources."make-fetch-happen-8.0.14"
       sources."map-age-cleaner-0.1.3"
-      sources."mem-8.1.0"
+      sources."mem-8.1.1"
       sources."merge2-1.4.1"
       sources."micromatch-4.0.4"
       sources."mime-db-1.47.0"
@@ -97762,13 +97899,13 @@ in
       sources."node-gyp-7.1.2"
       sources."nopt-5.0.0"
       sources."normalize-url-4.5.0"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-install-checks-4.0.0"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-package-arg-8.1.2"
       sources."npm-packlist-2.1.5"
       sources."npm-pick-manifest-6.1.1"
-      sources."npm-registry-fetch-9.0.0"
+      sources."npm-registry-fetch-10.1.1"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
       sources."oauth-sign-0.9.0"
@@ -97785,7 +97922,7 @@ in
           sources."semver-6.3.0"
         ];
       })
-      sources."pacote-11.3.1"
+      sources."pacote-11.3.3"
       sources."parse-github-url-1.0.2"
       sources."path-exists-4.0.0"
       sources."path-is-absolute-1.0.1"
@@ -98122,21 +98259,21 @@ in
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      (sources."@babel/core-7.13.15" // {
+      (sources."@babel/core-7.13.16" // {
         dependencies = [
           sources."json5-2.2.0"
           sources."semver-6.3.0"
           sources."source-map-0.5.7"
         ];
       })
-      (sources."@babel/generator-7.13.9" // {
+      (sources."@babel/generator-7.13.16" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
       })
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.12.13"
-      (sources."@babel/helper-compilation-targets-7.13.13" // {
+      (sources."@babel/helper-compilation-targets-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -98151,7 +98288,7 @@ in
       sources."@babel/helper-explode-assignable-expression-7.13.0"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
-      sources."@babel/helper-hoist-variables-7.13.0"
+      sources."@babel/helper-hoist-variables-7.13.16"
       sources."@babel/helper-member-expression-to-functions-7.13.12"
       sources."@babel/helper-module-imports-7.13.12"
       sources."@babel/helper-module-transforms-7.13.14"
@@ -98165,9 +98302,9 @@ in
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
       sources."@babel/helper-wrap-function-7.13.0"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       sources."@babel/highlight-7.13.10"
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12"
       sources."@babel/plugin-proposal-async-generator-functions-7.13.15"
       sources."@babel/plugin-proposal-class-properties-7.13.0"
@@ -98199,10 +98336,10 @@ in
       sources."@babel/plugin-transform-arrow-functions-7.13.0"
       sources."@babel/plugin-transform-async-to-generator-7.13.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.12.13"
-      sources."@babel/plugin-transform-block-scoping-7.12.13"
+      sources."@babel/plugin-transform-block-scoping-7.13.16"
       sources."@babel/plugin-transform-classes-7.13.0"
       sources."@babel/plugin-transform-computed-properties-7.13.0"
-      sources."@babel/plugin-transform-destructuring-7.13.0"
+      sources."@babel/plugin-transform-destructuring-7.13.17"
       sources."@babel/plugin-transform-dotall-regex-7.12.13"
       sources."@babel/plugin-transform-duplicate-keys-7.12.13"
       sources."@babel/plugin-transform-exponentiation-operator-7.12.13"
@@ -98236,10 +98373,10 @@ in
         ];
       })
       sources."@babel/preset-modules-0.1.4"
-      sources."@babel/runtime-7.13.10"
+      sources."@babel/runtime-7.13.17"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@iarna/toml-2.2.5"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
@@ -98344,7 +98481,7 @@ in
           sources."pako-1.0.11"
         ];
       })
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       (sources."buffer-4.9.2" // {
         dependencies = [
           sources."isarray-1.0.0"
@@ -98361,7 +98498,7 @@ in
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chokidar-2.1.8"
@@ -98388,7 +98525,7 @@ in
       sources."convert-source-map-1.7.0"
       sources."copy-descriptor-0.1.1"
       sources."core-js-2.6.12"
-      (sources."core-js-compat-3.10.1" // {
+      (sources."core-js-compat-3.11.0" // {
         dependencies = [
           sources."semver-7.0.0"
         ];
@@ -98500,7 +98637,7 @@ in
       sources."duplexer2-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       (sources."elliptic-6.5.4" // {
         dependencies = [
           sources."bn.js-4.12.0"
@@ -98863,7 +99000,7 @@ in
       sources."postcss-ordered-values-4.1.2"
       sources."postcss-reduce-initial-4.0.3"
       sources."postcss-reduce-transforms-4.0.2"
-      sources."postcss-selector-parser-6.0.4"
+      sources."postcss-selector-parser-6.0.5"
       sources."postcss-svgo-4.0.3"
       sources."postcss-unique-selectors-4.0.1"
       sources."postcss-value-parser-3.3.1"
@@ -98995,7 +99132,7 @@ in
         ];
       })
       sources."sprintf-js-1.0.3"
-      sources."srcset-3.0.0"
+      sources."srcset-3.0.1"
       sources."sshpk-1.16.1"
       sources."stable-0.1.8"
       (sources."static-eval-2.1.0" // {
@@ -100464,7 +100601,7 @@ in
       sources."binary-extensions-2.2.0"
       sources."braces-3.0.2"
       sources."callsites-3.1.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."chokidar-3.5.1"
       sources."cliui-7.0.4"
       sources."color-convert-2.0.1"
@@ -100940,10 +101077,10 @@ in
   pyright = nodeEnv.buildNodePackage {
     name = "pyright";
     packageName = "pyright";
-    version = "1.1.132";
+    version = "1.1.134";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.132.tgz";
-      sha512 = "quvG9Ip2NwKEShsLJ7eLlkQ/ST5SX84QCgO/k7gGqlCHwuifn9/v7LrzdpdFbkVnQR51egUNWwwLQRoIBT6vUA==";
+      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.134.tgz";
+      sha512 = "wQSdU6X3olAwCZy3tSA0fn8nMQGEwm01rm1dHM+aN2crzXIcUQ9sLOf+wCn5PFlLGsm/CXH7ROYmeMs3jXQ8Rw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -101292,18 +101429,18 @@ in
       sha512 = "coA9MuNPfN+8TyFj7aOycw2e5W9t+sSgFOUyK30oDrh2MWWWHLjY0I4V1puyCconC2arggfDE2GYXvqOTCGv9Q==";
     };
     dependencies = [
-      sources."@babel/cli-7.13.14"
+      sources."@babel/cli-7.13.16"
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      (sources."@babel/core-7.13.15" // {
+      (sources."@babel/core-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
       })
-      sources."@babel/generator-7.13.9"
+      sources."@babel/generator-7.13.16"
       sources."@babel/helper-annotate-as-pure-7.12.13"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.12.13"
-      (sources."@babel/helper-compilation-targets-7.13.13" // {
+      (sources."@babel/helper-compilation-targets-7.13.16" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -101318,7 +101455,7 @@ in
       sources."@babel/helper-explode-assignable-expression-7.13.0"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
-      sources."@babel/helper-hoist-variables-7.13.0"
+      sources."@babel/helper-hoist-variables-7.13.16"
       sources."@babel/helper-member-expression-to-functions-7.13.12"
       sources."@babel/helper-module-imports-7.13.12"
       sources."@babel/helper-module-transforms-7.13.14"
@@ -101332,9 +101469,9 @@ in
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
       sources."@babel/helper-wrap-function-7.13.0"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       sources."@babel/highlight-7.13.10"
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12"
       sources."@babel/plugin-proposal-async-generator-functions-7.13.15"
       sources."@babel/plugin-proposal-class-properties-7.13.0"
@@ -101367,10 +101504,10 @@ in
       sources."@babel/plugin-transform-arrow-functions-7.13.0"
       sources."@babel/plugin-transform-async-to-generator-7.13.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.12.13"
-      sources."@babel/plugin-transform-block-scoping-7.12.13"
+      sources."@babel/plugin-transform-block-scoping-7.13.16"
       sources."@babel/plugin-transform-classes-7.13.0"
       sources."@babel/plugin-transform-computed-properties-7.13.0"
-      sources."@babel/plugin-transform-destructuring-7.13.0"
+      sources."@babel/plugin-transform-destructuring-7.13.17"
       sources."@babel/plugin-transform-dotall-regex-7.12.13"
       sources."@babel/plugin-transform-duplicate-keys-7.12.13"
       sources."@babel/plugin-transform-exponentiation-operator-7.12.13"
@@ -101413,11 +101550,11 @@ in
       sources."@babel/preset-modules-0.1.4"
       sources."@babel/preset-react-7.13.13"
       sources."@babel/preset-stage-0-7.8.3"
-      sources."@babel/register-7.13.14"
-      sources."@babel/runtime-7.13.10"
+      sources."@babel/register-7.13.16"
+      sources."@babel/runtime-7.13.17"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@reach/router-1.3.4"
       sources."@sindresorhus/is-0.7.0"
       sources."@types/glob-7.1.3"
@@ -101577,7 +101714,7 @@ in
         ];
       })
       sources."browserify-zlib-0.1.4"
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       sources."buffer-5.7.1"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
@@ -101611,7 +101748,7 @@ in
       sources."camel-case-3.0.0"
       sources."camelcase-5.3.1"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."case-sensitive-paths-webpack-plugin-2.4.0"
       sources."caw-2.0.1"
       (sources."chalk-2.4.2" // {
@@ -101661,6 +101798,7 @@ in
           sources."string-width-3.1.0"
         ];
       })
+      sources."clone-deep-4.0.1"
       sources."clone-response-1.0.2"
       sources."coa-2.0.2"
       sources."collection-visit-1.0.0"
@@ -101695,7 +101833,7 @@ in
       sources."copy-concurrently-1.0.5"
       sources."copy-descriptor-0.1.1"
       sources."core-js-2.6.12"
-      (sources."core-js-compat-3.10.1" // {
+      (sources."core-js-compat-3.11.0" // {
         dependencies = [
           sources."semver-7.0.0"
         ];
@@ -101835,7 +101973,7 @@ in
       sources."duplexify-3.7.1"
       sources."ee-first-1.1.1"
       sources."ejs-2.7.4"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       (sources."elliptic-6.5.4" // {
         dependencies = [
           sources."bn.js-4.12.0"
@@ -102106,7 +102244,7 @@ in
         dependencies = [
           sources."ansi-escapes-4.3.2"
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."figures-3.2.0"
@@ -102493,7 +102631,7 @@ in
           sources."postcss-value-parser-3.3.1"
         ];
       })
-      sources."postcss-selector-parser-6.0.4"
+      sources."postcss-selector-parser-6.0.5"
       (sources."postcss-svgo-4.0.3" // {
         dependencies = [
           sources."postcss-value-parser-3.3.1"
@@ -102652,6 +102790,7 @@ in
       sources."setimmediate-1.0.5"
       sources."setprototypeof-1.1.1"
       sources."sha.js-2.4.11"
+      sources."shallow-clone-3.0.1"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shorthash-0.0.2"
@@ -103232,7 +103371,7 @@ in
     };
     dependencies = [
       sources."@babel/code-frame-7.12.13"
-      (sources."@babel/generator-7.13.9" // {
+      (sources."@babel/generator-7.13.16" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
@@ -103244,11 +103383,11 @@ in
       sources."@babel/helper-split-export-declaration-7.12.13"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/highlight-7.13.10"
-      sources."@babel/parser-7.13.15"
-      sources."@babel/runtime-7.13.10"
+      sources."@babel/parser-7.13.16"
+      sources."@babel/runtime-7.13.17"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@emotion/is-prop-valid-0.8.8"
       sources."@emotion/memoize-0.7.4"
       sources."@emotion/stylis-0.8.5"
@@ -103328,7 +103467,7 @@ in
       sources."concat-map-0.0.1"
       sources."console-browserify-1.2.0"
       sources."constants-browserify-1.0.0"
-      sources."core-js-3.10.1"
+      sources."core-js-3.11.0"
       sources."core-util-is-1.0.2"
       (sources."create-ecdh-4.0.4" // {
         dependencies = [
@@ -103431,7 +103570,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
       sources."mkdirp-1.0.4"
-      sources."mobx-6.2.0"
+      sources."mobx-6.3.0"
       sources."mobx-react-7.1.0"
       sources."mobx-react-lite-3.2.0"
       sources."ms-2.1.2"
@@ -103869,11 +104008,10 @@ in
       sources."buffer-indexof-polyfill-1.0.2"
       sources."buffers-0.1.1"
       sources."builtin-modules-3.2.0"
-      sources."call-bind-1.0.2"
       sources."callsites-3.1.0"
       sources."camelcase-6.2.0"
       sources."chainsaw-0.1.0"
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -103923,7 +104061,7 @@ in
       sources."entities-2.2.0"
       sources."escalade-3.1.1"
       sources."escape-string-regexp-1.0.5"
-      (sources."eslint-7.24.0" // {
+      (sources."eslint-7.25.0" // {
         dependencies = [
           sources."ignore-4.0.6"
         ];
@@ -103977,7 +104115,6 @@ in
       sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
       sources."get-caller-file-2.0.5"
-      sources."get-intrinsic-1.1.1"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.2"
       (sources."globals-13.8.0" // {
@@ -103990,7 +104127,6 @@ in
       sources."growl-1.10.5"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
-      sources."has-symbols-1.0.2"
       sources."he-1.2.0"
       sources."htmlparser2-6.1.0"
       sources."http-proxy-agent-4.0.1"
@@ -104001,17 +104137,14 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."is-binary-path-2.1.0"
-      sources."is-boolean-object-1.1.0"
       sources."is-core-module-2.2.0"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-3.0.0"
       sources."is-glob-4.0.1"
       sources."is-module-1.0.0"
       sources."is-number-7.0.0"
-      sources."is-number-object-1.0.4"
       sources."is-plain-obj-2.1.0"
       sources."is-reference-1.2.1"
-      sources."is-string-1.0.5"
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
       sources."js-tokens-4.0.0"
@@ -104138,7 +104271,7 @@ in
       sources."strip-ansi-6.0.0"
       sources."strip-json-comments-3.1.1"
       sources."supports-color-5.5.0"
-      (sources."table-6.1.0" // {
+      (sources."table-6.5.1" // {
         dependencies = [
           sources."ajv-8.1.0"
           sources."json-schema-traverse-1.0.0"
@@ -104349,10 +104482,10 @@ in
   sass = nodeEnv.buildNodePackage {
     name = "sass";
     packageName = "sass";
-    version = "1.32.10";
+    version = "1.32.11";
     src = fetchurl {
-      url = "https://registry.npmjs.org/sass/-/sass-1.32.10.tgz";
-      sha512 = "Nx0pcWoonAkn7CRp0aE/hket1UP97GiR1IFw3kcjV3pnenhWgZEWUf0ZcfPOV2fK52fnOcK3JdC/YYZ9E47DTQ==";
+      url = "https://registry.npmjs.org/sass/-/sass-1.32.11.tgz";
+      sha512 = "O9tRcob/fegUVSIV1ihLLZcftIOh0AF1VpKgusUfLqnb2jQ0GLDwI5ivv1FYWivGv8eZ/AwntTyTzjcHu0c/qw==";
     };
     dependencies = [
       sources."anymatch-3.1.2"
@@ -104512,10 +104645,10 @@ in
   serverless = nodeEnv.buildNodePackage {
     name = "serverless";
     packageName = "serverless";
-    version = "2.35.0";
+    version = "2.38.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serverless/-/serverless-2.35.0.tgz";
-      sha512 = "qtPKwZ3bSO/PB9sshKlTO0lgSvk8m0B21XQ3myxr27vVgyF5AL/NKnKDYkEOutFMAWXp5eJS/3OUqaO5uXlq+A==";
+      url = "https://registry.npmjs.org/serverless/-/serverless-2.38.0.tgz";
+      sha512 = "M/PAO3e3XoAdWvAd02iq+K4KkWmdxx8hLMCPg4tne0XZaLF5pTOvBWTdACgkuuikQDdo+Px8dl4idsIciEGezQ==";
     };
     dependencies = [
       sources."2-thenable-1.0.0"
@@ -104547,7 +104680,7 @@ in
         ];
       })
       sources."@serverless/component-metrics-1.0.8"
-      (sources."@serverless/components-3.8.3" // {
+      (sources."@serverless/components-3.9.0" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
           sources."js-yaml-3.14.1"
@@ -104576,13 +104709,13 @@ in
         ];
       })
       sources."@serverless/template-1.1.4"
-      (sources."@serverless/utils-4.0.1" // {
+      (sources."@serverless/utils-4.1.0" // {
         dependencies = [
           sources."jwt-decode-3.1.2"
           sources."write-file-atomic-3.0.3"
         ];
       })
-      sources."@serverless/utils-china-1.0.14"
+      sources."@serverless/utils-china-1.0.15"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@tencent-sdk/capi-1.1.8"
@@ -104653,7 +104786,7 @@ in
       sources."async-2.6.3"
       sources."asynckit-0.4.0"
       sources."at-least-node-1.0.0"
-      (sources."aws-sdk-2.888.0" // {
+      (sources."aws-sdk-2.892.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."ieee754-1.1.13"
@@ -104722,7 +104855,7 @@ in
           sources."traverse-0.3.9"
         ];
       })
-      (sources."chalk-4.1.0" // {
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -104888,7 +105021,7 @@ in
       sources."file-uri-to-path-1.0.0"
       sources."filename-reserved-regex-2.0.0"
       sources."filenamify-3.0.0"
-      sources."filesize-6.2.5"
+      sources."filesize-6.3.0"
       sources."fill-range-7.0.1"
       sources."find-requires-1.0.0"
       sources."flat-5.0.2"
@@ -104929,7 +105062,7 @@ in
       sources."globby-11.0.3"
       (sources."got-11.8.2" // {
         dependencies = [
-          sources."@sindresorhus/is-4.0.0"
+          sources."@sindresorhus/is-4.0.1"
           sources."@szmarczak/http-timer-4.0.5"
           sources."cacheable-request-7.0.1"
           sources."decompress-response-6.0.0"
@@ -105102,7 +105235,7 @@ in
       sources."nested-error-stacks-2.1.0"
       sources."next-tick-1.0.0"
       sources."nice-try-1.0.5"
-      (sources."node-abi-2.21.0" // {
+      (sources."node-abi-2.26.0" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
@@ -105128,7 +105261,6 @@ in
       sources."p-event-2.3.1"
       sources."p-finally-1.0.0"
       sources."p-is-promise-1.1.0"
-      sources."p-limit-3.1.0"
       sources."p-timeout-2.0.1"
       (sources."package-json-6.5.0" // {
         dependencies = [
@@ -105382,7 +105514,6 @@ in
       sources."yamljs-0.3.0"
       sources."yauzl-2.10.0"
       sources."yeast-0.1.2"
-      sources."yocto-queue-0.1.0"
       sources."zip-stream-4.1.0"
     ];
     buildInputs = globalBuildInputs;
@@ -106022,10 +106153,10 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.551.0";
+    version = "1.563.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.551.0.tgz";
-      sha512 = "Z2fh6n/EGO/2ILLOeFvJpWAHSZjOtKDACtfK+Xm/ob+SoAOjEPGdGlFt0RmCUV/VGxfP1aRZ8zkxnj573OmPPA==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.563.0.tgz";
+      sha512 = "o0Cb8JR70NzR4OLDKJDx04zj9Cq4gKhFLvQxU1MxZv0Hko7K6FmMDxdgyljd3nU5wl1QyVNdnug1H4XaHfhhvA==";
     };
     dependencies = [
       sources."@arcanis/slice-ansi-1.0.2"
@@ -106052,7 +106183,7 @@ in
       })
       sources."@snyk/docker-registry-v2-client-1.13.9"
       sources."@snyk/fast-glob-3.2.6-patch"
-      (sources."@snyk/fix-1.547.0" // {
+      (sources."@snyk/fix-1.554.0" // {
         dependencies = [
           sources."chalk-4.1.0"
           sources."strip-ansi-6.0.0"
@@ -106064,7 +106195,7 @@ in
       (sources."@snyk/inquirer-7.3.3-patch" // {
         dependencies = [
           sources."ansi-escapes-4.3.2"
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."strip-ansi-6.0.0"
         ];
       })
@@ -106074,7 +106205,7 @@ in
           sources."tmp-0.2.1"
         ];
       })
-      (sources."@snyk/mix-parser-1.3.1" // {
+      (sources."@snyk/mix-parser-1.3.2" // {
         dependencies = [
           sources."tslib-2.2.0"
         ];
@@ -106090,7 +106221,7 @@ in
           sources."tmp-0.1.0"
         ];
       })
-      (sources."@snyk/snyk-hex-plugin-1.1.2" // {
+      (sources."@snyk/snyk-hex-plugin-1.1.4" // {
         dependencies = [
           sources."tslib-2.2.0"
         ];
@@ -106118,7 +106249,7 @@ in
       sources."@types/uuid-8.3.0"
       (sources."@yarnpkg/core-2.4.0" // {
         dependencies = [
-          sources."@sindresorhus/is-4.0.0"
+          sources."@sindresorhus/is-4.0.1"
           sources."chalk-3.0.0"
           sources."cross-spawn-7.0.3"
           sources."got-11.8.2"
@@ -106225,7 +106356,7 @@ in
       sources."color-name-1.1.4"
       sources."concat-map-0.0.1"
       sources."configstore-5.0.1"
-      sources."core-js-3.10.1"
+      sources."core-js-3.11.0"
       sources."core-util-is-1.0.2"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
@@ -106408,7 +106539,7 @@ in
       sources."lodash.values-4.3.0"
       (sources."log-symbols-4.1.0" // {
         dependencies = [
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
         ];
       })
       sources."lowercase-keys-2.0.0"
@@ -106448,7 +106579,7 @@ in
       sources."open-7.4.2"
       (sources."ora-5.3.0" // {
         dependencies = [
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."strip-ansi-6.0.0"
         ];
       })
@@ -106540,7 +106671,7 @@ in
       sources."snyk-config-4.0.0"
       (sources."snyk-cpp-plugin-2.2.1" // {
         dependencies = [
-          sources."chalk-4.1.0"
+          sources."chalk-4.1.1"
           sources."tslib-2.2.0"
         ];
       })
@@ -106561,7 +106692,7 @@ in
           sources."tmp-0.2.1"
         ];
       })
-      (sources."snyk-gradle-plugin-3.14.0" // {
+      (sources."snyk-gradle-plugin-3.14.2" // {
         dependencies = [
           sources."chalk-3.0.0"
           sources."rimraf-3.0.2"
@@ -106592,7 +106723,7 @@ in
           sources."uuid-8.3.2"
         ];
       })
-      (sources."snyk-nuget-plugin-1.21.0" // {
+      (sources."snyk-nuget-plugin-1.21.1" // {
         dependencies = [
           sources."jszip-3.4.0"
           sources."pako-1.0.11"
@@ -106987,7 +107118,6 @@ in
       sources."ansi-styles-2.2.1"
       sources."anymatch-1.3.2"
       sources."append-batch-0.0.2"
-      sources."argparse-1.0.10"
       sources."arr-diff-2.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
@@ -107008,8 +107138,7 @@ in
       sources."async-write-2.1.0"
       sources."atob-2.1.2"
       sources."atomic-file-1.1.5"
-      sources."atomically-1.7.0"
-      sources."atomically-universal-0.1.1"
+      sources."atomic-file-rw-0.2.1"
       sources."attach-ware-1.1.1"
       sources."available-typed-arrays-1.0.2"
       sources."bail-1.0.5"
@@ -107027,7 +107156,7 @@ in
       sources."binary-search-1.3.6"
       sources."binary-search-bounds-2.0.5"
       sources."bindings-1.5.0"
-      sources."bipf-1.5.0"
+      sources."bipf-1.5.1"
       sources."blake2s-1.1.0"
       sources."brace-expansion-1.1.11"
       sources."braces-1.8.5"
@@ -107146,8 +107275,6 @@ in
       })
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
-      sources."esprima-4.0.1"
-      sources."events-to-array-1.1.2"
       (sources."execa-4.1.0" // {
         dependencies = [
           sources."cross-spawn-7.0.3"
@@ -107250,6 +107377,7 @@ in
           sources."kind-of-4.0.0"
         ];
       })
+      sources."hash-wasm-4.6.0"
       sources."hashlru-2.3.0"
       sources."he-0.5.0"
       sources."heap-0.2.6"
@@ -107325,14 +107453,13 @@ in
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
       sources."isobject-2.1.0"
-      (sources."jitdb-3.0.3" // {
+      (sources."jitdb-3.1.2" // {
         dependencies = [
           sources."mkdirp-1.0.4"
           sources."push-stream-11.0.0"
           sources."typedarray-to-buffer-4.0.0"
         ];
       })
-      sources."js-yaml-3.14.1"
       sources."jsesc-3.0.2"
       sources."json-buffer-2.0.11"
       sources."kind-of-3.2.2"
@@ -107401,7 +107528,7 @@ in
           sources."arrify-2.0.1"
         ];
       })
-      sources."multiserver-3.7.0"
+      sources."multiserver-3.7.1"
       sources."multiserver-address-1.0.1"
       sources."multiserver-scopes-1.0.0"
       sources."mutexify-1.3.1"
@@ -107483,7 +107610,7 @@ in
       sources."p-limit-2.3.0"
       sources."p-locate-4.1.0"
       sources."p-try-2.2.0"
-      sources."packet-stream-2.0.5"
+      sources."packet-stream-2.0.6"
       sources."packet-stream-codec-1.1.3"
       sources."parse-entities-1.2.2"
       sources."parse-glob-3.0.4"
@@ -107753,13 +107880,12 @@ in
       sources."source-map-url-0.4.1"
       sources."split-buffer-1.0.0"
       sources."split-string-3.1.0"
-      sources."sprintf-js-1.0.3"
       sources."ssb-blobs-1.2.2"
       sources."ssb-caps-1.1.0"
       sources."ssb-client-4.9.0"
       sources."ssb-config-3.4.5"
       sources."ssb-db-19.2.0"
-      (sources."ssb-db2-2.0.2" // {
+      (sources."ssb-db2-2.1.1" // {
         dependencies = [
           sources."abstract-leveldown-6.2.3"
           (sources."flumecodec-0.0.1" // {
@@ -107856,8 +107982,6 @@ in
       sources."strip-final-newline-2.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-2.0.0"
-      sources."tap-bail-1.0.0"
-      sources."tap-parser-5.4.0"
       (sources."tape-4.13.3" // {
         dependencies = [
           sources."glob-7.1.6"
@@ -108029,7 +108153,7 @@ in
       sources."async-1.5.2"
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      (sources."aws-sdk-2.888.0" // {
+      (sources."aws-sdk-2.892.0" // {
         dependencies = [
           sources."uuid-3.3.2"
         ];
@@ -108807,9 +108931,9 @@ in
     dependencies = [
       sources."@babel/code-frame-7.12.13"
       sources."@babel/compat-data-7.13.15"
-      sources."@babel/core-7.13.15"
-      sources."@babel/generator-7.13.9"
-      sources."@babel/helper-compilation-targets-7.13.13"
+      sources."@babel/core-7.13.16"
+      sources."@babel/generator-7.13.16"
+      sources."@babel/helper-compilation-targets-7.13.16"
       sources."@babel/helper-function-name-7.12.13"
       sources."@babel/helper-get-function-arity-7.12.13"
       sources."@babel/helper-member-expression-to-functions-7.13.12"
@@ -108821,16 +108945,16 @@ in
       sources."@babel/helper-split-export-declaration-7.12.13"
       sources."@babel/helper-validator-identifier-7.12.11"
       sources."@babel/helper-validator-option-7.12.17"
-      sources."@babel/helpers-7.13.10"
+      sources."@babel/helpers-7.13.17"
       (sources."@babel/highlight-7.13.10" // {
         dependencies = [
           sources."chalk-2.4.2"
         ];
       })
-      sources."@babel/parser-7.13.15"
+      sources."@babel/parser-7.13.16"
       sources."@babel/template-7.12.13"
-      sources."@babel/traverse-7.13.15"
-      sources."@babel/types-7.13.14"
+      sources."@babel/traverse-7.13.17"
+      sources."@babel/types-7.13.17"
       sources."@nodelib/fs.scandir-2.1.4"
       sources."@nodelib/fs.stat-2.0.4"
       sources."@nodelib/fs.walk-1.2.6"
@@ -108852,13 +108976,12 @@ in
       sources."balanced-match-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.16.4"
-      sources."call-bind-1.0.2"
+      sources."browserslist-4.16.5"
       sources."callsites-3.1.0"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."caniuse-lite-1.0.30001209"
-      (sources."chalk-4.1.0" // {
+      sources."caniuse-lite-1.0.30001214"
+      (sources."chalk-4.1.1" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
@@ -108895,7 +109018,7 @@ in
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
-      sources."electron-to-chromium-1.3.717"
+      sources."electron-to-chromium-1.3.720"
       sources."emoji-regex-8.0.0"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
@@ -108915,7 +109038,6 @@ in
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."gensync-1.0.0-beta.2"
-      sources."get-intrinsic-1.1.1"
       sources."get-stdin-8.0.0"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.2"
@@ -108928,7 +109050,6 @@ in
       sources."hard-rejection-2.1.0"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
-      sources."has-symbols-1.0.2"
       sources."hosted-git-info-4.0.2"
       sources."html-tags-3.1.0"
       sources."htmlparser2-3.10.1"
@@ -108941,14 +109062,12 @@ in
       sources."import-lazy-4.0.0"
       sources."imurmurhash-0.1.4"
       sources."indent-string-4.0.0"
-      sources."indexes-of-1.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.8"
       sources."is-alphabetical-1.0.4"
       sources."is-alphanumerical-1.0.4"
       sources."is-arrayish-0.2.1"
-      sources."is-boolean-object-1.1.0"
       sources."is-buffer-2.0.5"
       sources."is-core-module-2.2.0"
       sources."is-decimal-1.0.4"
@@ -108957,10 +109076,8 @@ in
       sources."is-glob-4.0.1"
       sources."is-hexadecimal-1.0.4"
       sources."is-number-7.0.0"
-      sources."is-number-object-1.0.4"
       sources."is-plain-obj-2.1.0"
       sources."is-regexp-2.1.0"
-      sources."is-string-1.0.5"
       sources."is-typedarray-1.0.0"
       sources."is-unicode-supported-0.1.0"
       sources."isexe-2.0.0"
@@ -109037,7 +109154,7 @@ in
       sources."postcss-safe-parser-4.0.2"
       sources."postcss-sass-0.4.4"
       sources."postcss-scss-2.1.1"
-      sources."postcss-selector-parser-6.0.4"
+      sources."postcss-selector-parser-6.0.5"
       sources."postcss-syntax-0.36.2"
       sources."postcss-value-parser-4.1.0"
       sources."punycode-2.1.1"
@@ -109097,7 +109214,7 @@ in
       sources."sugarss-2.0.0"
       sources."supports-color-5.5.0"
       sources."svg-tags-1.0.0"
-      sources."table-6.1.0"
+      sources."table-6.5.1"
       sources."to-fast-properties-2.0.0"
       sources."to-regex-range-5.0.1"
       sources."trim-newlines-3.0.0"
@@ -109105,7 +109222,6 @@ in
       sources."type-fest-0.18.1"
       sources."typedarray-to-buffer-3.1.5"
       sources."unified-9.2.1"
-      sources."uniq-1.0.1"
       sources."unist-util-find-all-after-3.0.2"
       sources."unist-util-is-4.1.0"
       sources."unist-util-stringify-position-2.0.3"
@@ -109136,10 +109252,10 @@ in
   svelte-language-server = nodeEnv.buildNodePackage {
     name = "svelte-language-server";
     packageName = "svelte-language-server";
-    version = "0.13.0";
+    version = "0.13.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/svelte-language-server/-/svelte-language-server-0.13.0.tgz";
-      sha512 = "ov9SZmsCdfy3GcyvrlulEkYnkCc1EK/Qoety+xLsIZtVLMBitudp0OmHx5AWHk+FF2+78A0PYL2z8PEBX6UPjA==";
+      url = "https://registry.npmjs.org/svelte-language-server/-/svelte-language-server-0.13.2.tgz";
+      sha512 = "mOcSqZUM9zJORyl1FbODC4TSvlYgOgQmlEKzDj77D1JyuXfYD+XSnqxJufwa0DqI05y8uKMBKj0AWWeTu1OZjw==";
     };
     dependencies = [
       sources."@emmetio/abbreviation-2.2.2"
@@ -109188,7 +109304,7 @@ in
       sources."strip-indent-3.0.0"
       sources."svelte-3.35.0"
       sources."svelte-preprocess-4.6.9"
-      sources."svelte2tsx-0.1.186"
+      sources."svelte2tsx-0.1.188"
       sources."to-regex-range-5.0.1"
       sources."tslib-2.2.0"
       sources."typescript-4.2.4"
@@ -109226,7 +109342,7 @@ in
       sources."@trysound/sax-0.1.1"
       sources."ansi-styles-4.3.0"
       sources."boolbase-1.0.0"
-      sources."chalk-4.1.0"
+      sources."chalk-4.1.1"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
       sources."commander-7.2.0"
@@ -110059,7 +110175,7 @@ in
       sources."minimist-1.2.5"
       sources."mkdirp-classic-0.5.3"
       sources."napi-build-utils-1.0.2"
-      sources."node-abi-2.21.0"
+      sources."node-abi-2.26.0"
       sources."node-addon-api-3.0.2"
       sources."noop-logger-0.1.1"
       sources."npmlog-4.1.2"
@@ -111315,7 +111431,7 @@ in
       sources."content-type-1.0.4"
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
-      sources."core-js-3.10.1"
+      sources."core-js-3.11.0"
       sources."core-util-is-1.0.2"
       sources."css-select-1.2.0"
       sources."css-what-2.1.3"
@@ -111493,7 +111609,7 @@ in
       })
       sources."nopt-4.0.3"
       sources."normalize-url-4.5.0"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-packlist-1.4.8"
       sources."npmlog-4.1.2"
@@ -111673,10 +111789,10 @@ in
   three = nodeEnv.buildNodePackage {
     name = "three";
     packageName = "three";
-    version = "0.127.0";
+    version = "0.128.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/three/-/three-0.127.0.tgz";
-      sha512 = "wtgrn+mhYUbobxT7QN3GPdu3SRpSBQvwY6uOzLChWS7QE//f7paDU/+wlzbg+ngeIvBBqjBHSRuywTh8A99Jng==";
+      url = "https://registry.npmjs.org/three/-/three-0.128.0.tgz";
+      sha512 = "i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -112568,7 +112684,7 @@ in
       sources."node-fetch-2.6.1"
       sources."node-pre-gyp-0.15.0"
       sources."nopt-4.0.3"
-      sources."npm-bundled-1.1.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-packlist-1.4.8"
       sources."npmlog-4.1.2"
@@ -112723,6 +112839,201 @@ in
     meta = {
       description = "vim language server";
       homepage = "https://github.com/iamcco/vim-language-server#readme";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  vls = nodeEnv.buildNodePackage {
+    name = "vls";
+    packageName = "vls";
+    version = "0.7.2";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/vls/-/vls-0.7.2.tgz";
+      sha512 = "9nKgSPtNxQlc32K5GgZV++MdsCpNuac/SfxnEmVI0DCF4E0Uekj+RUo7Zk6NnA4veiNMN+AEjAIlbXYWPHgX6Q==";
+    };
+    dependencies = [
+      sources."@babel/code-frame-7.12.11"
+      sources."@babel/helper-validator-identifier-7.12.11"
+      (sources."@babel/highlight-7.13.10" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+        ];
+      })
+      (sources."@eslint/eslintrc-0.4.0" // {
+        dependencies = [
+          sources."globals-12.4.0"
+        ];
+      })
+      sources."acorn-7.4.1"
+      sources."acorn-jsx-5.3.1"
+      sources."ajv-6.12.6"
+      sources."ansi-colors-4.1.1"
+      sources."ansi-regex-5.0.0"
+      sources."ansi-styles-3.2.1"
+      sources."argparse-1.0.10"
+      sources."astral-regex-2.0.0"
+      sources."balanced-match-1.0.2"
+      sources."brace-expansion-1.1.11"
+      sources."builtin-modules-1.1.1"
+      sources."callsites-3.1.0"
+      (sources."chalk-4.1.1" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+          sources."has-flag-4.0.0"
+          sources."supports-color-7.2.0"
+        ];
+      })
+      sources."color-convert-1.9.3"
+      sources."color-name-1.1.3"
+      sources."commander-2.20.3"
+      sources."concat-map-0.0.1"
+      sources."cross-spawn-7.0.3"
+      sources."debug-4.3.2"
+      sources."deep-is-0.1.3"
+      sources."diff-4.0.2"
+      sources."doctrine-3.0.0"
+      sources."emoji-regex-8.0.0"
+      sources."enquirer-2.3.6"
+      sources."escape-string-regexp-1.0.5"
+      sources."eslint-7.25.0"
+      sources."eslint-plugin-vue-7.9.0"
+      sources."eslint-scope-5.1.1"
+      (sources."eslint-utils-2.1.0" // {
+        dependencies = [
+          sources."eslint-visitor-keys-1.3.0"
+        ];
+      })
+      sources."eslint-visitor-keys-2.0.0"
+      (sources."espree-7.3.1" // {
+        dependencies = [
+          sources."eslint-visitor-keys-1.3.0"
+        ];
+      })
+      sources."esprima-4.0.1"
+      (sources."esquery-1.4.0" // {
+        dependencies = [
+          sources."estraverse-5.2.0"
+        ];
+      })
+      (sources."esrecurse-4.3.0" // {
+        dependencies = [
+          sources."estraverse-5.2.0"
+        ];
+      })
+      sources."estraverse-4.3.0"
+      sources."esutils-2.0.3"
+      sources."fast-deep-equal-3.1.3"
+      sources."fast-json-stable-stringify-2.1.0"
+      sources."fast-levenshtein-2.0.6"
+      sources."file-entry-cache-6.0.1"
+      sources."flat-cache-3.0.4"
+      sources."flatted-3.1.1"
+      sources."fs.realpath-1.0.0"
+      sources."function-bind-1.1.1"
+      sources."functional-red-black-tree-1.0.1"
+      sources."glob-7.1.6"
+      sources."glob-parent-5.1.2"
+      (sources."globals-13.8.0" // {
+        dependencies = [
+          sources."type-fest-0.20.2"
+        ];
+      })
+      sources."has-1.0.3"
+      sources."has-flag-3.0.0"
+      sources."ignore-4.0.6"
+      sources."import-fresh-3.3.0"
+      sources."imurmurhash-0.1.4"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
+      sources."is-core-module-2.2.0"
+      sources."is-extglob-2.1.1"
+      sources."is-fullwidth-code-point-3.0.0"
+      sources."is-glob-4.0.1"
+      sources."isexe-2.0.0"
+      sources."js-tokens-4.0.0"
+      sources."js-yaml-3.14.1"
+      sources."json-schema-traverse-0.4.1"
+      sources."json-stable-stringify-without-jsonify-1.0.1"
+      sources."levn-0.4.1"
+      sources."lodash-4.17.21"
+      sources."lodash.clonedeep-4.5.0"
+      sources."lodash.flatten-4.4.0"
+      sources."lodash.truncate-4.4.2"
+      sources."lru-cache-6.0.0"
+      sources."minimatch-3.0.4"
+      sources."minimist-1.2.5"
+      sources."mkdirp-0.5.5"
+      sources."ms-2.1.2"
+      sources."natural-compare-1.4.0"
+      sources."once-1.4.0"
+      sources."optionator-0.9.1"
+      sources."parent-module-1.0.1"
+      sources."path-is-absolute-1.0.1"
+      sources."path-key-3.1.1"
+      sources."path-parse-1.0.6"
+      sources."prelude-ls-1.2.1"
+      sources."prettier-2.2.1"
+      sources."progress-2.0.3"
+      sources."punycode-2.1.1"
+      sources."regexpp-3.1.0"
+      sources."require-from-string-2.0.2"
+      sources."resolve-1.20.0"
+      sources."resolve-from-4.0.0"
+      sources."rimraf-3.0.2"
+      sources."semver-7.3.5"
+      sources."shebang-command-2.0.0"
+      sources."shebang-regex-3.0.0"
+      (sources."slice-ansi-4.0.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+        ];
+      })
+      sources."sprintf-js-1.0.3"
+      sources."string-width-4.2.2"
+      sources."strip-ansi-6.0.0"
+      sources."strip-json-comments-3.1.1"
+      sources."supports-color-5.5.0"
+      (sources."table-6.5.1" // {
+        dependencies = [
+          sources."ajv-8.1.0"
+          sources."json-schema-traverse-1.0.0"
+        ];
+      })
+      sources."text-table-0.2.0"
+      sources."tslib-1.14.1"
+      (sources."tslint-6.1.3" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+          sources."semver-5.7.1"
+        ];
+      })
+      sources."tsutils-2.29.0"
+      sources."type-check-0.4.0"
+      sources."type-fest-0.8.1"
+      sources."typescript-4.2.4"
+      sources."uri-js-4.4.1"
+      sources."v8-compile-cache-2.3.0"
+      (sources."vue-eslint-parser-7.6.0" // {
+        dependencies = [
+          sources."eslint-visitor-keys-1.3.0"
+          sources."espree-6.2.1"
+        ];
+      })
+      sources."which-2.0.2"
+      sources."word-wrap-1.2.3"
+      sources."wrappy-1.0.2"
+      sources."yallist-4.0.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Vue Language Server";
+      homepage = "https://github.com/vuejs/vetur/tree/master/server";
       license = "MIT";
     };
     production = true;
@@ -113619,8 +113930,8 @@ in
       sources."v8-compile-cache-2.3.0"
       sources."vm-browserify-1.1.2"
       sources."vsce-1.87.1"
-      sources."vscode-debugadapter-testsupport-1.46.0"
-      sources."vscode-debugprotocol-1.46.0"
+      sources."vscode-debugadapter-testsupport-1.47.0"
+      sources."vscode-debugprotocol-1.47.0"
       (sources."watchpack-1.7.5" // {
         dependencies = [
           sources."chokidar-3.5.1"
@@ -114917,10 +115228,10 @@ in
   web-ext = nodeEnv.buildNodePackage {
     name = "web-ext";
     packageName = "web-ext";
-    version = "6.0.0";
+    version = "6.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/web-ext/-/web-ext-6.0.0.tgz";
-      sha512 = "djjTY89kM5ULdKYQo+6TYJSlT+0zNkanW5hQJNybOqGyovUYpH7C3Ns9Pd1cy6ApbmG2VV4Gds9u4yCSuRfHUw==";
+      url = "https://registry.npmjs.org/web-ext/-/web-ext-6.1.0.tgz";
+      sha512 = "f9sBuysFoCJAuS03wRtSBH8dPKQUZvCVT+AoqBW3tBBN6a92P0PyGF2lTwZJ5wrOOvXu7w2DvuAFOU6CnBugFw==";
     };
     dependencies = [
       sources."@babel/code-frame-7.12.11"
@@ -114942,10 +115253,11 @@ in
       (sources."@eslint/eslintrc-0.4.0" // {
         dependencies = [
           sources."debug-4.3.2"
+          sources."globals-12.4.0"
           sources."ms-2.1.2"
         ];
       })
-      sources."@mdn/browser-compat-data-3.1.3"
+      sources."@mdn/browser-compat-data-3.2.4"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@types/minimatch-3.0.4"
@@ -114953,8 +115265,8 @@ in
       sources."@types/yauzl-2.9.1"
       sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
-      sources."addons-linter-2.21.0"
-      sources."addons-scanner-utils-4.2.0"
+      sources."addons-linter-3.2.0"
+      sources."addons-scanner-utils-4.4.0"
       sources."adm-zip-0.5.5"
       sources."ajv-6.12.6"
       sources."ajv-merge-patch-4.1.0"
@@ -114971,17 +115283,6 @@ in
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-4.3.0"
       sources."any-promise-1.3.0"
-      (sources."archiver-5.2.0" // {
-        dependencies = [
-          sources."async-3.2.0"
-        ];
-      })
-      (sources."archiver-utils-2.1.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
       sources."argparse-1.0.10"
       sources."array-differ-3.0.0"
       sources."array-filter-0.0.1"
@@ -114999,9 +115300,7 @@ in
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
       sources."balanced-match-1.0.2"
-      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."bl-4.1.0"
       sources."bluebird-2.9.34"
       sources."boolbase-1.0.0"
       (sources."boxen-5.0.1" // {
@@ -115010,7 +115309,6 @@ in
         ];
       })
       sources."brace-expansion-1.1.11"
-      sources."buffer-5.7.1"
       sources."buffer-crc32-0.2.13"
       sources."buffer-equal-constant-time-1.0.1"
       sources."buffer-from-1.1.1"
@@ -115025,8 +115323,8 @@ in
       sources."camelcase-6.2.0"
       sources."caseless-0.12.0"
       sources."chalk-4.1.0"
-      sources."cheerio-1.0.0-rc.5"
-      sources."cheerio-select-tmp-0.1.1"
+      sources."cheerio-1.0.0-rc.6"
+      sources."cheerio-select-1.4.0"
       (sources."chrome-launcher-0.13.4" // {
         dependencies = [
           sources."mkdirp-0.5.5"
@@ -115049,23 +115347,15 @@ in
       sources."combined-stream-1.0.8"
       sources."commander-2.20.3"
       sources."common-tags-1.8.0"
-      sources."compress-commons-4.1.0"
       sources."concat-map-0.0.1"
-      (sources."concat-stream-1.6.2" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
+      sources."concat-stream-1.6.2"
       sources."configstore-5.0.1"
       sources."core-js-3.8.3"
       sources."core-util-is-1.0.2"
-      sources."crc-32-1.2.0"
-      sources."crc32-stream-4.0.2"
       sources."cross-spawn-7.0.3"
       sources."crypto-random-string-2.0.0"
-      sources."css-select-3.1.2"
-      sources."css-what-4.0.0"
+      sources."css-select-4.1.2"
+      sources."css-what-5.0.0"
       sources."dashdash-1.14.1"
       sources."debounce-1.2.0"
       sources."debug-2.6.9"
@@ -115080,14 +115370,13 @@ in
       sources."defer-to-connect-1.1.3"
       sources."define-properties-1.1.3"
       sources."delayed-stream-1.0.0"
-      (sources."dispensary-0.61.0" // {
+      (sources."dispensary-0.62.0" // {
         dependencies = [
           sources."async-3.2.0"
-          sources."pino-6.9.0"
         ];
       })
       sources."doctrine-3.0.0"
-      sources."dom-serializer-1.2.0"
+      sources."dom-serializer-1.3.1"
       sources."domelementtype-2.2.0"
       sources."domhandler-4.2.0"
       sources."domutils-2.6.0"
@@ -115099,14 +115388,14 @@ in
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."enquirer-2.3.6"
-      sources."entities-2.1.0"
+      sources."entities-2.2.0"
       sources."error-ex-1.3.2"
       sources."es6-error-4.1.1"
       sources."es6-promisify-6.1.1"
       sources."escalade-3.1.1"
       sources."escape-goat-2.1.1"
       sources."escape-string-regexp-1.0.5"
-      (sources."eslint-7.21.0" // {
+      (sources."eslint-7.24.0" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
           sources."debug-4.3.2"
@@ -115142,7 +115431,6 @@ in
       sources."esutils-2.0.3"
       sources."event-to-promise-0.8.0"
       sources."execa-4.1.0"
-      sources."exit-on-epipe-1.0.1"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-3.1.3"
@@ -115157,10 +115445,9 @@ in
       sources."fast-safe-stringify-2.0.7"
       sources."fd-slicer-1.1.0"
       sources."file-entry-cache-6.0.1"
-      (sources."firefox-profile-4.1.0" // {
+      (sources."firefox-profile-4.2.0" // {
         dependencies = [
           sources."fs-extra-9.0.1"
-          sources."uuid-8.3.2"
         ];
       })
       sources."first-chunk-stream-3.0.0"
@@ -115170,17 +115457,15 @@ in
       sources."fluent-syntax-0.13.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
-      sources."fs-constants-1.0.0"
       (sources."fs-extra-9.1.0" // {
         dependencies = [
           sources."universalify-2.0.0"
         ];
       })
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.3.2"
       sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
-      (sources."fx-runner-1.0.13" // {
+      (sources."fx-runner-1.1.0" // {
         dependencies = [
           sources."commander-2.9.0"
           sources."isexe-1.1.2"
@@ -115195,7 +115480,11 @@ in
       sources."glob-parent-5.1.2"
       sources."glob-to-regexp-0.4.1"
       sources."global-dirs-3.0.0"
-      sources."globals-12.4.0"
+      (sources."globals-13.8.0" // {
+        dependencies = [
+          sources."type-fest-0.20.2"
+        ];
+      })
       (sources."got-9.6.0" // {
         dependencies = [
           sources."get-stream-4.1.0"
@@ -115214,9 +115503,8 @@ in
       sources."http-cache-semantics-4.1.0"
       sources."http-signature-1.2.0"
       sources."human-signals-1.1.1"
-      sources."iconv-lite-0.4.24"
-      sources."ieee754-1.2.1"
       sources."ignore-4.0.6"
+      sources."image-size-0.9.7"
       sources."immediate-3.0.6"
       sources."import-fresh-3.3.0"
       sources."import-lazy-2.1.0"
@@ -115228,7 +115516,6 @@ in
       sources."is-absolute-0.1.7"
       sources."is-arguments-1.1.0"
       sources."is-arrayish-0.2.1"
-      sources."is-boolean-object-1.1.0"
       sources."is-ci-2.0.0"
       sources."is-date-object-1.0.2"
       sources."is-docker-2.2.1"
@@ -115238,13 +115525,11 @@ in
       sources."is-installed-globally-0.4.0"
       sources."is-mergeable-object-1.1.1"
       sources."is-npm-5.0.0"
-      sources."is-number-object-1.0.4"
       sources."is-obj-2.0.0"
       sources."is-path-inside-3.0.3"
       sources."is-regex-1.1.2"
       sources."is-relative-0.1.3"
       sources."is-stream-2.0.0"
-      sources."is-string-1.0.5"
       sources."is-typedarray-1.0.0"
       sources."is-utf8-0.2.1"
       sources."is-wsl-2.2.0"
@@ -115276,22 +115561,11 @@ in
         ];
       })
       sources."jsprim-1.4.1"
-      (sources."jszip-3.6.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
+      sources."jszip-3.6.0"
       sources."jwa-1.4.1"
       sources."jws-3.2.2"
       sources."keyv-3.1.0"
       sources."latest-version-5.1.0"
-      (sources."lazystream-1.0.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
       sources."lcid-3.1.1"
       sources."levn-0.4.1"
       sources."lie-3.3.0"
@@ -115299,8 +115573,6 @@ in
       sources."lines-and-columns-1.1.6"
       sources."lodash-4.17.21"
       sources."lodash.clonedeep-4.5.0"
-      sources."lodash.defaults-4.2.0"
-      sources."lodash.difference-4.5.0"
       sources."lodash.flatten-4.4.0"
       sources."lodash.includes-4.3.0"
       sources."lodash.isboolean-3.0.3"
@@ -115310,7 +115582,6 @@ in
       sources."lodash.isstring-4.0.1"
       sources."lodash.once-4.1.1"
       sources."lodash.truncate-4.4.2"
-      sources."lodash.union-4.6.0"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-6.0.0"
       (sources."make-dir-3.1.0" // {
@@ -115345,19 +115616,12 @@ in
       sources."natural-compare-1.4.0"
       sources."natural-compare-lite-1.4.0"
       sources."ncp-2.0.0"
-      (sources."needle-2.6.0" // {
-        dependencies = [
-          sources."debug-3.2.7"
-          sources."ms-2.1.3"
-        ];
-      })
       sources."node-forge-0.10.0"
       (sources."node-notifier-9.0.0" // {
         dependencies = [
           sources."uuid-8.3.2"
         ];
       })
-      sources."normalize-path-3.0.0"
       sources."normalize-url-4.5.0"
       sources."npm-run-path-4.0.1"
       sources."nth-check-2.0.0"
@@ -115388,17 +115652,11 @@ in
       sources."path-key-3.1.1"
       sources."pend-1.2.0"
       sources."performance-now-2.1.0"
-      (sources."pino-6.11.1" // {
-        dependencies = [
-          sources."pino-std-serializers-3.2.0"
-        ];
-      })
-      sources."pino-std-serializers-2.5.0"
-      sources."postcss-8.2.7"
+      sources."pino-6.11.2"
+      sources."pino-std-serializers-3.2.0"
+      sources."postcss-8.2.10"
       sources."prelude-ls-1.2.1"
       sources."prepend-http-2.0.0"
-      sources."printj-1.1.2"
-      sources."probe-image-size-6.0.0"
       sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
       sources."psl-1.8.0"
@@ -115406,15 +115664,19 @@ in
       sources."punycode-2.1.1"
       sources."pupa-2.1.1"
       sources."qs-6.5.2"
-      sources."quick-format-unescaped-4.0.3"
+      sources."queue-6.0.2"
+      sources."quick-format-unescaped-4.0.1"
       (sources."rc-1.2.8" // {
         dependencies = [
           sources."ini-1.3.8"
           sources."strip-json-comments-2.0.1"
         ];
       })
-      sources."readable-stream-3.6.0"
-      sources."readdir-glob-1.1.1"
+      (sources."readable-stream-2.3.7" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
       sources."regenerator-runtime-0.13.8"
       sources."regexp.prototype.flags-1.3.1"
       sources."regexpp-3.1.0"
@@ -115440,7 +115702,7 @@ in
       sources."safe-json-stringify-1.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-7.3.4"
+      sources."semver-7.3.5"
       (sources."semver-diff-3.1.1" // {
         dependencies = [
           sources."semver-6.3.0"
@@ -115462,7 +115724,6 @@ in
       sources."split-0.3.3"
       sources."sprintf-js-1.0.3"
       sources."sshpk-1.16.1"
-      sources."stream-parser-0.3.1"
       sources."stream-to-array-2.3.0"
       sources."stream-to-promise-3.0.0"
       (sources."string-width-4.2.2" // {
@@ -115483,13 +115744,14 @@ in
       sources."strip-final-newline-2.0.0"
       sources."strip-json-comments-3.1.1"
       sources."supports-color-7.2.0"
-      (sources."table-6.1.0" // {
+      (sources."table-6.5.1" // {
         dependencies = [
           sources."ajv-8.1.0"
+          sources."ansi-regex-5.0.0"
           sources."json-schema-traverse-1.0.0"
+          sources."strip-ansi-6.0.0"
         ];
       })
-      sources."tar-stream-2.2.0"
       sources."text-table-0.2.0"
       sources."thenify-3.3.1"
       sources."thenify-all-1.6.0"
@@ -115544,7 +115806,6 @@ in
           sources."async-3.2.0"
         ];
       })
-      sources."zip-stream-4.1.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -115559,15 +115820,15 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "5.33.2";
+    version = "5.35.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-5.33.2.tgz";
-      sha512 = "X4b7F1sYBmJx8mlh2B7mV5szEkE0jYNJ2y3akgAP0ERi0vLCG1VvdsIxt8lFd4st6SUy0lf7W0CCQS566MBpJg==";
+      url = "https://registry.npmjs.org/webpack/-/webpack-5.35.1.tgz";
+      sha512 = "uWKYStqJ23+N6/EnMEwUjPSSKUG1tFmcuKhALEh/QXoUxwN8eb3ATNIZB38A+fO6QZ0xfc7Cu7KNV9LXNhDCsw==";
     };
     dependencies = [
       sources."@types/eslint-7.2.10"
       sources."@types/eslint-scope-3.7.0"
-      sources."@types/estree-0.0.46"
+      sources."@types/estree-0.0.47"
       sources."@types/json-schema-7.0.7"
       sources."@types/node-14.14.41"
       sources."@webassemblyjs/ast-1.11.0"
@@ -115590,14 +115851,14 @@ in
       sources."acorn-8.1.1"
       sources."ajv-6.12.6"
       sources."ajv-keywords-3.5.2"
-      sources."browserslist-4.16.4"
+      sources."browserslist-4.16.5"
       sources."buffer-from-1.1.1"
-      sources."caniuse-lite-1.0.30001209"
+      sources."caniuse-lite-1.0.30001214"
       sources."chrome-trace-event-1.0.3"
       sources."colorette-1.2.2"
       sources."commander-2.20.3"
-      sources."electron-to-chromium-1.3.717"
-      sources."enhanced-resolve-5.7.0"
+      sources."electron-to-chromium-1.3.720"
+      sources."enhanced-resolve-5.8.0"
       sources."es-module-lexer-0.4.1"
       sources."escalade-3.1.1"
       sources."eslint-scope-5.1.1"
@@ -116659,7 +116920,7 @@ in
       sources."utp-native-2.4.0"
       sources."videostream-3.2.2"
       sources."vlc-command-1.2.0"
-      (sources."webtorrent-0.117.0" // {
+      (sources."webtorrent-0.118.0" // {
         dependencies = [
           sources."debug-4.3.2"
           sources."decompress-response-6.0.0"
@@ -116715,8 +116976,8 @@ in
       sha512 = "P1Ct7+DNrOcr2JAxDZ3Q5i5sx2LSveu7iLaoUL0A+YiG0GKf0l5+9j3rwMeyh6JeTL1+HfQV1rnwEvzhNIvpFw==";
     };
     dependencies = [
-      sources."@babel/runtime-7.13.10"
-      sources."@babel/runtime-corejs3-7.13.10"
+      sources."@babel/runtime-7.13.17"
+      sources."@babel/runtime-corejs3-7.13.17"
       sources."@types/json5-0.0.29"
       sources."adverb-where-0.2.2"
       sources."aria-query-4.2.2"
@@ -116732,7 +116993,7 @@ in
       sources."commander-2.20.3"
       sources."concat-map-0.0.1"
       sources."contains-path-0.1.0"
-      sources."core-js-pure-3.10.1"
+      sources."core-js-pure-3.11.0"
       sources."damerau-levenshtein-1.0.6"
       sources."debug-2.6.9"
       sources."define-properties-1.1.3"
@@ -116907,24 +117168,60 @@ in
   yo = nodeEnv.buildNodePackage {
     name = "yo";
     packageName = "yo";
-    version = "3.1.1";
+    version = "4.0.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/yo/-/yo-3.1.1.tgz";
-      sha512 = "GFg4QC1xi3gkbHGGUFme8/8XPg3kDISu/qJfx56X207yuv1FSevGY/eKuym7kh0bniCB4n3rseWW+QZXPH8LIw==";
+      url = "https://registry.npmjs.org/yo/-/yo-4.0.0.tgz";
+      sha512 = "u4nr6946GQ1HXrX0K9YAHK8wJmvVNIAYIsC/NSTIXOSK61N400UCY1HLQr5oo7TJcpZAe7aO3k3jFJXIvRb6Qw==";
     };
     dependencies = [
-      sources."@babel/code-frame-7.12.13"
-      sources."@babel/helper-validator-identifier-7.12.11"
-      sources."@babel/highlight-7.13.10"
-      sources."@babel/runtime-7.13.10"
-      sources."@mrmlnc/readdir-enhanced-2.2.1"
-      sources."@nodelib/fs.stat-1.1.3"
+      sources."@babel/runtime-7.13.17"
+      sources."@nodelib/fs.scandir-2.1.4"
+      sources."@nodelib/fs.stat-2.0.4"
+      sources."@nodelib/fs.walk-1.2.6"
+      (sources."@npmcli/arborist-2.4.0" // {
+        dependencies = [
+          sources."semver-7.3.5"
+        ];
+      })
+      (sources."@npmcli/git-2.0.8" // {
+        dependencies = [
+          sources."mkdirp-1.0.4"
+          sources."semver-7.3.5"
+          sources."which-2.0.2"
+        ];
+      })
+      sources."@npmcli/installed-package-contents-1.0.7"
+      sources."@npmcli/map-workspaces-1.0.3"
+      (sources."@npmcli/metavuln-calculator-1.1.1" // {
+        dependencies = [
+          sources."semver-7.3.5"
+        ];
+      })
+      (sources."@npmcli/move-file-1.1.2" // {
+        dependencies = [
+          sources."mkdirp-1.0.4"
+        ];
+      })
+      sources."@npmcli/name-from-folder-1.0.1"
+      sources."@npmcli/node-gyp-1.0.2"
+      sources."@npmcli/promise-spawn-1.3.2"
+      sources."@npmcli/run-script-1.8.5"
       sources."@sindresorhus/is-0.7.0"
-      sources."@types/glob-7.1.3"
+      sources."@tootallnate/once-1.1.2"
       sources."@types/minimatch-3.0.4"
-      sources."@types/node-14.14.41"
-      sources."@types/normalize-package-data-2.4.0"
-      sources."JSONStream-1.3.5"
+      sources."abbrev-1.1.1"
+      (sources."agent-base-6.0.2" // {
+        dependencies = [
+          sources."debug-4.3.2"
+          sources."ms-2.1.2"
+        ];
+      })
+      (sources."agentkeepalive-4.1.4" // {
+        dependencies = [
+          sources."debug-4.3.2"
+          sources."ms-2.1.2"
+        ];
+      })
       sources."aggregate-error-3.1.0"
       sources."ajv-6.12.6"
       sources."ansi-0.3.1"
@@ -116932,40 +117229,41 @@ in
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
+      sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
-      sources."arr-diff-4.0.0"
-      sources."arr-flatten-1.1.0"
-      sources."arr-union-3.1.0"
+      (sources."argparse-1.0.10" // {
+        dependencies = [
+          sources."sprintf-js-1.0.3"
+        ];
+      })
       sources."array-differ-3.0.0"
       sources."array-find-index-1.0.2"
-      sources."array-union-1.0.2"
+      sources."array-union-2.1.0"
       sources."array-uniq-1.0.3"
-      sources."array-unique-0.3.2"
       sources."arrify-1.0.1"
+      sources."asap-2.0.6"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
-      sources."assign-symbols-1.0.0"
       sources."astral-regex-1.0.0"
       sources."async-2.6.3"
       sources."asynckit-0.4.0"
-      sources."atob-2.1.2"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
-      sources."axios-0.21.1"
       sources."balanced-match-1.0.2"
-      (sources."base-0.11.2" // {
+      sources."bcrypt-pbkdf-1.0.2"
+      (sources."bin-links-2.2.1" // {
         dependencies = [
-          sources."define-property-1.0.0"
+          sources."mkdirp-1.0.4"
+          sources."write-file-atomic-3.0.3"
         ];
       })
-      sources."bcrypt-pbkdf-1.0.2"
       (sources."bin-version-2.0.0" // {
         dependencies = [
           sources."execa-0.1.1"
         ];
       })
       sources."bin-version-check-3.0.0"
-      sources."binaryextensions-2.3.0"
+      sources."binaryextensions-4.15.0"
       sources."boolean-3.0.3"
       (sources."boxen-1.3.0" // {
         dependencies = [
@@ -116973,44 +117271,28 @@ in
         ];
       })
       sources."brace-expansion-1.1.11"
-      (sources."braces-2.3.2" // {
+      sources."braces-3.0.2"
+      sources."buffer-from-1.1.1"
+      sources."builtins-1.0.3"
+      (sources."cacache-15.0.6" // {
         dependencies = [
-          sources."extend-shallow-2.0.1"
+          sources."mkdirp-1.0.4"
         ];
       })
-      sources."buffer-from-1.1.1"
-      sources."cache-base-1.0.1"
       (sources."cacheable-request-2.1.4" // {
         dependencies = [
           sources."get-stream-3.0.0"
           sources."lowercase-keys-1.0.0"
         ];
       })
-      sources."call-me-maybe-1.0.1"
       sources."camelcase-2.1.1"
       sources."camelcase-keys-2.1.0"
       sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
+      sources."chownr-2.0.0"
       sources."ci-info-1.6.0"
-      (sources."class-utils-0.3.6" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
       sources."clean-stack-2.2.0"
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
@@ -117019,26 +117301,26 @@ in
       sources."cli-width-2.2.1"
       sources."clone-2.1.2"
       sources."clone-buffer-1.0.0"
-      sources."clone-deep-4.0.1"
       sources."clone-regexp-1.0.1"
       sources."clone-response-1.0.2"
       sources."clone-stats-1.0.0"
       sources."cloneable-readable-1.1.3"
+      sources."cmd-shim-4.1.0"
       sources."code-point-at-1.1.0"
-      sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."colors-1.0.3"
       sources."combined-stream-1.0.8"
+      sources."commander-7.1.0"
+      sources."common-ancestor-path-1.0.1"
       sources."commondir-1.0.1"
-      sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
       sources."conf-1.4.0"
       sources."config-chain-1.1.12"
       sources."configstore-3.1.5"
-      sources."copy-descriptor-0.1.1"
-      sources."core-js-3.10.1"
+      sources."console-control-strings-1.1.0"
+      sources."core-js-3.11.0"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-6.0.5"
@@ -117050,127 +117332,83 @@ in
       })
       sources."crypto-random-string-1.0.0"
       sources."currently-unhandled-0.4.1"
-      sources."dargs-6.1.0"
+      sources."cyclist-1.0.1"
       sources."dashdash-1.14.1"
-      sources."dateformat-3.0.3"
+      sources."dateformat-4.5.1"
       sources."debug-2.6.9"
+      sources."debuglog-1.0.1"
       sources."decamelize-1.2.0"
       sources."decode-uri-component-0.2.0"
       sources."decompress-response-3.3.0"
       sources."deep-extend-0.6.0"
       sources."default-uid-1.0.0"
       sources."define-properties-1.1.3"
-      sources."define-property-2.0.2"
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
+      sources."depd-1.1.2"
       sources."detect-node-2.0.5"
-      sources."diff-3.5.0"
-      (sources."dir-glob-2.0.0" // {
+      sources."dezalgo-1.0.3"
+      sources."diff-5.0.0"
+      (sources."dir-glob-3.0.1" // {
         dependencies = [
-          sources."path-type-3.0.0"
+          sources."path-type-4.0.0"
         ];
       })
       sources."dot-prop-4.2.1"
       sources."downgrade-root-1.2.2"
-      sources."download-stats-0.3.4"
       sources."duplexer3-0.1.4"
       sources."ecc-jsbn-0.1.2"
-      (sources."editions-2.3.1" // {
-        dependencies = [
-          sources."semver-6.3.0"
-        ];
-      })
-      sources."ejs-2.7.4"
+      sources."editions-6.1.0"
+      sources."ejs-3.1.6"
       sources."emoji-regex-8.0.0"
       sources."encodeurl-1.0.2"
+      (sources."encoding-0.1.13" // {
+        dependencies = [
+          sources."iconv-lite-0.6.2"
+        ];
+      })
       sources."end-of-stream-1.4.4"
       sources."env-paths-1.0.0"
-      sources."errlop-2.2.0"
-      sources."error-7.2.1"
+      sources."err-code-2.0.3"
+      sources."errlop-4.1.0"
+      sources."error-10.4.0"
       sources."error-ex-1.3.2"
       sources."es6-error-4.1.1"
       sources."es6-promise-4.2.8"
       sources."escape-string-regexp-1.0.5"
+      sources."esprima-4.0.1"
       sources."execa-1.0.0"
       sources."execall-1.0.0"
       sources."exit-hook-1.1.1"
-      (sources."expand-brackets-2.1.4" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
       sources."extend-3.0.2"
-      (sources."extend-shallow-3.0.2" // {
-        dependencies = [
-          sources."is-extendable-1.0.1"
-        ];
-      })
       sources."external-editor-3.1.0"
-      (sources."extglob-2.0.4" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-          sources."extend-shallow-2.0.1"
-        ];
-      })
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-3.1.3"
-      sources."fast-glob-2.2.7"
+      sources."fast-glob-3.2.5"
       sources."fast-json-stable-stringify-2.1.0"
+      sources."fastq-1.11.0"
       sources."figures-2.0.0"
       sources."filelist-1.0.2"
-      (sources."fill-range-4.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
+      sources."fill-range-7.0.1"
       sources."filter-obj-2.0.2"
       sources."find-up-2.1.0"
       sources."find-versions-2.0.0"
+      sources."find-yarn-workspace-root2-1.2.16"
       sources."first-chunk-stream-2.0.0"
-      sources."follow-redirects-1.13.3"
-      sources."for-in-1.0.2"
       sources."foreachasync-3.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
-      sources."fragment-cache-0.2.1"
       sources."from2-2.3.0"
+      sources."fs-minipass-2.1.0"
       sources."fs.realpath-1.0.0"
       sources."fullname-4.0.1"
       sources."function-bind-1.1.1"
       sources."gauge-1.2.7"
       sources."get-stdin-4.0.1"
       sources."get-stream-4.1.0"
-      sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      (sources."gh-got-5.0.0" // {
-        dependencies = [
-          sources."get-stream-3.0.0"
-          sources."got-6.7.1"
-          sources."prepend-http-1.0.4"
-          sources."url-parse-lax-1.0.0"
-        ];
-      })
-      sources."github-username-3.0.0"
       sources."glob-7.1.6"
-      (sources."glob-parent-3.1.0" // {
-        dependencies = [
-          sources."is-glob-3.1.0"
-        ];
-      })
-      sources."glob-to-regexp-0.3.0"
+      sources."glob-parent-5.1.2"
       (sources."global-agent-2.2.0" // {
         dependencies = [
           sources."semver-7.3.5"
@@ -117179,7 +117417,7 @@ in
       sources."global-dirs-0.1.1"
       sources."global-tunnel-ng-2.7.1"
       sources."globalthis-1.0.2"
-      sources."globby-8.0.2"
+      sources."globby-11.0.3"
       (sources."got-8.3.2" // {
         dependencies = [
           sources."get-stream-3.0.0"
@@ -117187,7 +117425,7 @@ in
         ];
       })
       sources."graceful-fs-4.2.6"
-      sources."grouped-queue-1.1.0"
+      sources."grouped-queue-2.0.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
@@ -117200,94 +117438,95 @@ in
       sources."has-symbol-support-x-1.4.2"
       sources."has-to-string-tag-x-1.4.1"
       sources."has-unicode-2.0.1"
-      sources."has-value-1.0.0"
-      (sources."has-values-1.0.0" // {
-        dependencies = [
-          sources."kind-of-4.0.0"
-        ];
-      })
       sources."hosted-git-info-2.8.9"
       sources."http-cache-semantics-3.8.1"
+      (sources."http-proxy-agent-4.0.1" // {
+        dependencies = [
+          sources."debug-4.3.2"
+          sources."ms-2.1.2"
+        ];
+      })
       sources."http-signature-1.2.0"
-      sources."human-signals-1.1.1"
+      (sources."https-proxy-agent-5.0.0" // {
+        dependencies = [
+          sources."debug-4.3.2"
+          sources."ms-2.1.2"
+        ];
+      })
+      sources."human-signals-2.1.0"
+      sources."humanize-ms-1.2.1"
       sources."humanize-string-1.0.2"
       sources."iconv-lite-0.4.24"
-      sources."ignore-3.3.10"
+      sources."ignore-5.1.8"
+      sources."ignore-walk-3.0.3"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."indent-string-4.0.0"
+      sources."infer-owner-1.0.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.8"
       sources."inquirer-6.5.2"
       sources."insight-0.10.3"
-      sources."interpret-1.4.0"
       (sources."into-stream-3.1.0" // {
         dependencies = [
           sources."p-is-promise-1.1.0"
         ];
       })
+      sources."ip-1.1.5"
       sources."ip-regex-2.1.0"
-      sources."is-accessor-descriptor-1.0.0"
       sources."is-arrayish-0.2.1"
-      sources."is-buffer-1.1.6"
       sources."is-ci-1.2.1"
       sources."is-core-module-2.2.0"
-      sources."is-data-descriptor-1.0.0"
-      sources."is-descriptor-1.0.2"
       sources."is-docker-1.1.0"
-      sources."is-extendable-0.1.1"
       sources."is-extglob-2.1.1"
       sources."is-finite-1.1.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
       sources."is-installed-globally-0.1.0"
+      sources."is-lambda-1.0.1"
       sources."is-npm-1.0.0"
-      (sources."is-number-3.0.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
+      sources."is-number-7.0.0"
       sources."is-obj-1.0.1"
       sources."is-object-1.0.2"
       sources."is-path-inside-1.0.1"
       sources."is-plain-obj-1.1.0"
-      sources."is-plain-object-2.0.4"
       sources."is-redirect-1.0.0"
       sources."is-regexp-1.0.0"
       sources."is-retry-allowed-1.2.0"
       sources."is-root-1.0.0"
-      sources."is-scoped-1.0.0"
+      sources."is-scoped-2.1.0"
       sources."is-stream-1.1.0"
       sources."is-supported-regexp-flag-1.0.1"
       sources."is-typedarray-1.0.0"
+      sources."is-unicode-supported-0.1.0"
       sources."is-utf8-0.2.1"
-      sources."is-windows-1.0.2"
       sources."is-wsl-1.1.0"
       sources."isarray-1.0.0"
       sources."isbinaryfile-4.0.6"
       sources."isexe-2.0.0"
-      sources."isobject-3.0.1"
       sources."isstream-0.1.2"
-      sources."istextorbinary-2.6.0"
+      sources."istextorbinary-5.12.0"
       sources."isurl-1.0.0"
       (sources."jake-10.8.2" // {
         dependencies = [
           sources."async-0.9.2"
         ];
       })
-      sources."js-tokens-4.0.0"
+      sources."js-yaml-3.14.1"
       sources."jsbn-0.1.1"
       sources."json-buffer-3.0.0"
       sources."json-parse-better-errors-1.0.2"
       sources."json-parse-even-better-errors-2.3.1"
       sources."json-schema-0.2.3"
       sources."json-schema-traverse-0.4.1"
+      sources."json-stringify-nice-1.1.3"
       sources."json-stringify-safe-5.0.1"
       sources."jsonparse-1.3.1"
       sources."jsprim-1.4.1"
+      sources."just-diff-3.1.1"
+      sources."just-diff-apply-3.0.0"
       sources."keyv-3.0.0"
-      sources."kind-of-6.0.3"
       (sources."latest-version-3.1.0" // {
         dependencies = [
           sources."get-stream-3.0.0"
@@ -117297,11 +117536,15 @@ in
           sources."url-parse-lax-1.0.0"
         ];
       })
-      sources."lazy-cache-2.0.2"
-      sources."lines-and-columns-1.1.6"
       (sources."load-json-file-1.1.0" // {
         dependencies = [
           sources."pify-2.3.0"
+        ];
+      })
+      (sources."load-yaml-file-0.2.0" // {
+        dependencies = [
+          sources."pify-4.0.1"
+          sources."strip-bom-3.0.0"
         ];
       })
       sources."locate-path-2.0.0"
@@ -117317,31 +117560,25 @@ in
       sources."lru-cache-6.0.0"
       sources."macos-release-2.4.1"
       sources."make-dir-1.3.0"
+      (sources."make-fetch-happen-8.0.14" // {
+        dependencies = [
+          sources."http-cache-semantics-4.1.0"
+        ];
+      })
       sources."map-age-cleaner-0.1.3"
-      sources."map-cache-0.2.2"
       sources."map-obj-1.0.1"
-      sources."map-visit-1.0.0"
       (sources."matcher-3.0.0" // {
         dependencies = [
           sources."escape-string-regexp-4.0.0"
         ];
       })
       sources."mem-5.1.1"
-      sources."mem-fs-1.2.0"
-      (sources."mem-fs-editor-6.0.0" // {
+      (sources."mem-fs-1.2.0" // {
         dependencies = [
-          sources."dir-glob-2.2.2"
-          sources."globby-9.2.0"
-          sources."ignore-4.0.6"
-          (sources."path-type-3.0.0" // {
-            dependencies = [
-              sources."pify-3.0.0"
-            ];
-          })
-          sources."pify-4.0.1"
-          sources."slash-2.0.0"
+          sources."through2-3.0.2"
         ];
       })
+      sources."mem-fs-editor-8.1.2"
       (sources."meow-3.7.0" // {
         dependencies = [
           sources."find-up-1.1.2"
@@ -117351,35 +117588,59 @@ in
       })
       sources."merge-stream-2.0.0"
       sources."merge2-1.4.1"
-      sources."micromatch-3.1.10"
+      sources."micromatch-4.0.4"
       sources."mime-db-1.47.0"
       sources."mime-types-2.1.30"
       sources."mimic-fn-2.1.0"
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
-      (sources."mixin-deep-1.3.2" // {
+      sources."minipass-3.1.3"
+      sources."minipass-collect-1.0.2"
+      sources."minipass-fetch-1.3.3"
+      sources."minipass-flush-1.0.5"
+      sources."minipass-json-stream-1.0.1"
+      sources."minipass-pipeline-1.2.4"
+      sources."minipass-sized-1.0.3"
+      sources."minizlib-2.1.2"
+      sources."mkdirp-0.5.5"
+      (sources."mkdirp-infer-owner-2.0.0" // {
         dependencies = [
-          sources."is-extendable-1.0.1"
+          sources."mkdirp-1.0.4"
         ];
       })
-      sources."mkdirp-0.5.5"
-      sources."moment-2.29.1"
       sources."ms-2.0.0"
-      (sources."multimatch-4.0.0" // {
+      (sources."multimatch-5.0.0" // {
         dependencies = [
-          sources."array-union-2.1.0"
           sources."arrify-2.0.1"
         ];
       })
       sources."mute-stream-0.0.7"
-      sources."nanomatch-1.2.13"
       sources."nice-try-1.0.5"
-      sources."node-fetch-2.6.1"
+      (sources."node-gyp-7.1.2" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."env-paths-2.2.1"
+          sources."gauge-2.7.4"
+          sources."is-fullwidth-code-point-1.0.0"
+          sources."npmlog-4.1.2"
+          sources."semver-7.3.5"
+          sources."string-width-1.0.2"
+          sources."strip-ansi-3.0.1"
+          sources."which-2.0.2"
+        ];
+      })
+      sources."nopt-5.0.0"
       sources."normalize-package-data-2.5.0"
+      sources."normalize-path-3.0.0"
       sources."normalize-url-2.0.1"
-      sources."npm-api-1.0.1"
+      sources."npm-bundled-1.1.2"
       sources."npm-conf-1.1.3"
+      (sources."npm-install-checks-4.0.0" // {
+        dependencies = [
+          sources."semver-7.3.5"
+        ];
+      })
       (sources."npm-keyword-5.0.0" // {
         dependencies = [
           sources."get-stream-3.0.0"
@@ -117390,27 +117651,26 @@ in
           sources."url-parse-lax-1.0.0"
         ];
       })
+      sources."npm-normalize-package-bin-1.0.1"
+      (sources."npm-package-arg-8.1.2" // {
+        dependencies = [
+          sources."hosted-git-info-4.0.2"
+          sources."semver-7.3.5"
+        ];
+      })
+      sources."npm-packlist-2.1.5"
+      (sources."npm-pick-manifest-6.1.1" // {
+        dependencies = [
+          sources."semver-7.3.5"
+        ];
+      })
+      sources."npm-registry-fetch-10.1.1"
       sources."npm-run-path-2.0.2"
       sources."npmlog-2.0.4"
       sources."number-is-nan-1.0.1"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
-      (sources."object-copy-0.1.0" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."is-accessor-descriptor-0.1.6"
-          sources."is-data-descriptor-0.1.4"
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."kind-of-3.2.2"
-        ];
-      })
       sources."object-keys-1.1.1"
-      sources."object-visit-1.0.1"
-      sources."object.pick-1.3.0"
       sources."once-1.4.0"
       (sources."onetime-2.0.1" // {
         dependencies = [
@@ -117429,17 +117689,21 @@ in
       sources."p-is-promise-2.1.0"
       sources."p-limit-1.3.0"
       sources."p-locate-2.0.0"
+      sources."p-map-4.0.0"
       sources."p-some-4.1.0"
       sources."p-timeout-2.0.1"
       sources."p-try-1.0.0"
       sources."package-json-5.0.0"
+      (sources."pacote-11.3.3" // {
+        dependencies = [
+          sources."mkdirp-1.0.4"
+        ];
+      })
       sources."pad-component-0.0.1"
-      sources."paged-request-2.0.2"
+      sources."parse-conflict-json-1.1.1"
       sources."parse-help-1.0.0"
       sources."parse-json-2.2.0"
-      sources."pascalcase-0.1.1"
       sources."passwd-user-3.0.0"
-      sources."path-dirname-1.0.2"
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
       sources."path-is-inside-1.0.2"
@@ -117451,14 +117715,42 @@ in
         ];
       })
       sources."performance-now-2.1.0"
+      sources."picomatch-2.2.3"
       sources."pify-3.0.0"
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
+      (sources."pipeline-pipe-0.1.5" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
+      (sources."pkg-dir-4.2.0" // {
+        dependencies = [
+          sources."find-up-4.1.0"
+          sources."locate-path-5.0.0"
+          sources."p-limit-2.3.0"
+          sources."p-locate-4.1.0"
+          sources."p-try-2.2.0"
+          sources."path-exists-4.0.0"
+        ];
+      })
       sources."pkg-up-2.0.0"
-      sources."posix-character-classes-0.1.1"
+      (sources."preferred-pm-3.0.3" // {
+        dependencies = [
+          sources."find-up-5.0.0"
+          sources."locate-path-6.0.0"
+          sources."p-limit-3.1.0"
+          sources."p-locate-5.0.0"
+          sources."path-exists-4.0.0"
+        ];
+      })
       sources."prepend-http-2.0.0"
       sources."pretty-bytes-5.6.0"
       sources."process-nextick-args-2.0.1"
+      sources."promise-all-reject-late-1.0.1"
+      sources."promise-call-limit-1.0.1"
+      sources."promise-inflight-1.0.1"
+      sources."promise-retry-2.0.1"
       sources."proto-list-1.2.4"
       sources."pseudomap-1.0.2"
       sources."psl-1.8.0"
@@ -117466,12 +117758,15 @@ in
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."query-string-5.1.1"
+      sources."queue-microtask-1.2.3"
       sources."rc-1.2.8"
       (sources."read-chunk-3.2.0" // {
         dependencies = [
           sources."pify-4.0.1"
         ];
       })
+      sources."read-cmd-shim-2.0.0"
+      sources."read-package-json-fast-2.0.2"
       sources."read-pkg-1.1.0"
       (sources."read-pkg-up-4.0.0" // {
         dependencies = [
@@ -117492,19 +117787,16 @@ in
           sources."safe-buffer-5.1.2"
         ];
       })
-      sources."rechoir-0.6.2"
+      sources."readdir-scoped-modules-1.1.0"
       (sources."redent-1.0.0" // {
         dependencies = [
           sources."indent-string-2.1.0"
         ];
       })
       sources."regenerator-runtime-0.13.8"
-      sources."regex-not-1.0.2"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
       sources."remove-trailing-separator-1.1.0"
-      sources."repeat-element-1.1.4"
-      sources."repeat-string-1.6.1"
       sources."repeating-2.0.1"
       sources."replace-ext-1.0.1"
       (sources."request-2.88.2" // {
@@ -117513,20 +117805,20 @@ in
         ];
       })
       sources."resolve-1.20.0"
-      sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
       sources."restore-cursor-2.0.0"
-      sources."ret-0.1.15"
-      sources."rimraf-2.7.1"
+      sources."retry-0.12.0"
+      sources."reusify-1.0.4"
+      sources."rimraf-3.0.2"
       sources."roarr-2.15.4"
       sources."root-check-1.0.0"
       sources."run-async-2.4.1"
+      sources."run-parallel-1.2.0"
       sources."rx-4.1.0"
       sources."rxjs-6.6.7"
       sources."safe-buffer-5.2.1"
-      sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."scoped-regex-1.0.0"
+      sources."scoped-regex-2.1.0"
       sources."semver-5.7.1"
       sources."semver-compare-1.0.0"
       sources."semver-diff-2.1.0"
@@ -117537,83 +117829,35 @@ in
           sources."type-fest-0.13.1"
         ];
       })
-      sources."set-getter-0.1.0"
-      (sources."set-value-2.0.1" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
-      sources."shallow-clone-3.0.1"
+      sources."set-blocking-2.0.0"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
-      sources."shelljs-0.8.4"
       sources."signal-exit-3.0.3"
-      sources."slash-1.0.0"
-      (sources."snapdragon-0.8.2" // {
+      sources."slash-3.0.0"
+      sources."smart-buffer-4.1.0"
+      sources."socks-2.6.1"
+      (sources."socks-proxy-agent-5.0.0" // {
         dependencies = [
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      (sources."snapdragon-node-2.1.1" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
-      (sources."snapdragon-util-3.0.1" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
+          sources."debug-4.3.2"
+          sources."ms-2.1.2"
         ];
       })
       sources."sort-keys-2.0.0"
       sources."sort-on-3.0.0"
-      sources."source-map-0.5.7"
-      sources."source-map-resolve-0.5.3"
-      sources."source-map-url-0.4.1"
       sources."spawn-sync-1.0.15"
       sources."spdx-correct-3.1.1"
       sources."spdx-exceptions-2.3.0"
       sources."spdx-expression-parse-3.0.1"
       sources."spdx-license-ids-3.0.7"
-      sources."split-string-3.1.0"
       sources."sprintf-js-1.1.2"
       sources."sshpk-1.16.1"
-      (sources."static-extend-0.1.2" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
+      sources."ssri-8.0.1"
       sources."strict-uri-encode-1.1.0"
       (sources."string-length-2.0.0" // {
         dependencies = [
           sources."strip-ansi-4.0.0"
         ];
       })
-      sources."string-template-0.2.1"
       (sources."string-width-2.1.1" // {
         dependencies = [
           sources."strip-ansi-4.0.0"
@@ -117667,6 +117911,11 @@ in
         ];
       })
       sources."taketalk-1.0.0"
+      (sources."tar-6.1.0" // {
+        dependencies = [
+          sources."mkdirp-1.0.4"
+        ];
+      })
       (sources."term-size-1.2.0" // {
         dependencies = [
           sources."cross-spawn-5.1.0"
@@ -117677,20 +117926,19 @@ in
         ];
       })
       sources."text-table-0.2.0"
-      sources."textextensions-2.6.0"
+      sources."textextensions-5.12.0"
       sources."through-2.3.8"
-      sources."through2-3.0.2"
+      (sources."through2-4.0.2" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
       sources."timed-out-4.0.1"
       sources."titleize-1.0.1"
       sources."tmp-0.0.33"
-      (sources."to-object-path-0.3.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."to-regex-3.0.2"
-      sources."to-regex-range-2.1.1"
+      sources."to-regex-range-5.0.1"
       sources."tough-cookie-3.0.1"
+      sources."treeverse-1.0.4"
       sources."trim-newlines-1.0.0"
       sources."tslib-1.14.1"
       sources."tunnel-0.0.6"
@@ -117699,31 +117947,24 @@ in
       sources."twig-1.15.4"
       sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
-      sources."union-value-1.0.1"
+      sources."typedarray-to-buffer-3.1.5"
+      sources."unique-filename-1.1.1"
+      sources."unique-slug-2.0.2"
       sources."unique-string-1.0.0"
-      (sources."unset-value-1.0.0" // {
-        dependencies = [
-          (sources."has-value-0.3.1" // {
-            dependencies = [
-              sources."isobject-2.1.0"
-            ];
-          })
-          sources."has-values-0.1.4"
-        ];
-      })
-      sources."untildify-3.0.3"
+      sources."untildify-4.0.0"
       sources."unzip-response-2.0.1"
       sources."update-notifier-2.5.0"
       sources."uri-js-4.4.1"
-      sources."urix-0.1.0"
       sources."url-parse-lax-3.0.0"
       sources."url-to-options-1.0.1"
-      sources."use-3.1.1"
       sources."user-home-2.0.0"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.4.0"
       sources."validate-npm-package-license-3.0.4"
+      sources."validate-npm-package-name-3.0.0"
       sources."verror-1.10.0"
+      sources."version-compare-1.1.0"
+      sources."version-range-1.1.0"
       sources."vinyl-2.2.1"
       (sources."vinyl-file-3.0.0" // {
         dependencies = [
@@ -117731,7 +117972,14 @@ in
         ];
       })
       sources."walk-2.3.14"
+      sources."walk-up-path-1.0.0"
       sources."which-1.3.1"
+      (sources."which-pm-2.0.0" // {
+        dependencies = [
+          sources."path-exists-4.0.0"
+        ];
+      })
+      sources."wide-align-1.1.3"
       sources."widest-line-2.0.1"
       sources."windows-release-3.3.3"
       (sources."with-open-file-0.1.7" // {
@@ -117759,46 +118007,58 @@ in
         ];
       })
       sources."yeoman-doctor-4.0.0"
-      (sources."yeoman-environment-2.10.3" // {
+      (sources."yeoman-environment-3.2.0" // {
         dependencies = [
           sources."ansi-escapes-4.3.2"
-          sources."ansi-regex-5.0.0"
+          sources."ansi-regex-2.1.1"
           sources."ansi-styles-4.3.0"
+          sources."arrify-2.0.1"
+          sources."chalk-4.1.1"
           sources."cli-cursor-3.1.0"
           sources."cli-width-3.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."cross-spawn-7.0.3"
-          sources."debug-3.2.7"
-          sources."execa-4.1.0"
-          sources."figures-3.2.0"
-          sources."get-stream-5.2.0"
-          sources."has-flag-4.0.0"
-          (sources."inquirer-7.3.3" // {
+          sources."debug-4.3.2"
+          sources."escape-string-regexp-4.0.0"
+          sources."execa-5.0.0"
+          (sources."figures-3.2.0" // {
             dependencies = [
-              sources."chalk-4.1.0"
-              sources."strip-ansi-6.0.0"
+              sources."escape-string-regexp-1.0.5"
             ];
           })
+          sources."find-up-5.0.0"
+          (sources."gauge-2.7.4" // {
+            dependencies = [
+              sources."is-fullwidth-code-point-1.0.0"
+              sources."string-width-1.0.2"
+              sources."strip-ansi-3.0.1"
+            ];
+          })
+          sources."get-stream-6.0.1"
+          sources."has-flag-4.0.0"
+          sources."inquirer-8.0.0"
           sources."is-fullwidth-code-point-3.0.0"
           sources."is-stream-2.0.0"
-          sources."ms-2.1.3"
+          sources."locate-path-6.0.0"
+          sources."log-symbols-4.1.0"
+          sources."ms-2.1.2"
           sources."mute-stream-0.0.8"
           sources."npm-run-path-4.0.1"
+          sources."npmlog-4.1.2"
           sources."onetime-5.1.2"
+          sources."p-limit-3.1.0"
+          sources."p-locate-5.0.0"
+          sources."path-exists-4.0.0"
           sources."path-key-3.1.1"
           sources."restore-cursor-3.1.0"
           sources."semver-7.3.5"
           sources."shebang-command-2.0.0"
           sources."shebang-regex-3.0.0"
-          (sources."string-width-4.2.2" // {
+          sources."string-width-4.2.2"
+          (sources."strip-ansi-6.0.0" // {
             dependencies = [
-              sources."strip-ansi-6.0.0"
-            ];
-          })
-          (sources."strip-ansi-4.0.0" // {
-            dependencies = [
-              sources."ansi-regex-3.0.0"
+              sources."ansi-regex-5.0.0"
             ];
           })
           sources."supports-color-7.2.0"
@@ -117806,45 +118066,7 @@ in
           sources."which-2.0.2"
         ];
       })
-      (sources."yeoman-generator-4.13.0" // {
-        dependencies = [
-          sources."debug-4.3.2"
-          sources."diff-4.0.2"
-          sources."dir-glob-2.2.2"
-          sources."ejs-3.1.6"
-          sources."find-up-3.0.0"
-          sources."globby-9.2.0"
-          sources."ignore-4.0.6"
-          sources."locate-path-3.0.0"
-          (sources."make-dir-3.1.0" // {
-            dependencies = [
-              sources."semver-6.3.0"
-            ];
-          })
-          (sources."mem-fs-editor-7.1.0" // {
-            dependencies = [
-              sources."rimraf-3.0.2"
-            ];
-          })
-          sources."mkdirp-1.0.4"
-          sources."ms-2.1.2"
-          sources."p-limit-2.3.0"
-          sources."p-locate-3.0.0"
-          sources."p-try-2.2.0"
-          sources."parse-json-5.2.0"
-          (sources."path-type-3.0.0" // {
-            dependencies = [
-              sources."pify-3.0.0"
-            ];
-          })
-          sources."pify-4.0.1"
-          sources."read-pkg-5.2.0"
-          sources."read-pkg-up-5.0.0"
-          sources."semver-7.3.5"
-          sources."slash-2.0.0"
-          sources."type-fest-0.6.0"
-        ];
-      })
+      sources."yocto-queue-0.1.0"
       (sources."yosay-2.0.2" // {
         dependencies = [
           sources."ansi-regex-2.1.1"


### PR DESCRIPTION
###### Motivation for this change
Incorporating Nix into my Neovim workflow. I noticed that VLS (which is the new Vue Language Server) wasn't available as a node package.

###### Things done

Followed guide as per https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/node.section.md

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
