### PR TITLE
check_systemd: 2.2.1 -> 2.3.1

### DIFF
--- a/pkgs/servers/monitoring/nagios/plugins/check_systemd.nix
+++ b/pkgs/servers/monitoring/nagios/plugins/check_systemd.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "check_systemd";
-  version = "2.2.1";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "Josef-Friedrich";
     repo = pname;
     rev = "v${version}";
-    sha256 = "04r14dhqzrdndn235dvr6afy4s4g4asynsgvj99cmyq55nah4asn";
+    sha256 = "11sc0gycxzq1vfvin501jnwnky2ky6ns64yjiw8vq9vmkbf8nni6";
   };
 
   propagatedBuildInputs = with python3Packages; [ nagiosplugin ];
@@ -29,6 +29,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "Nagios / Icinga monitoring plugin to check systemd for failed units";
     inherit (src.meta) homepage;
+    changelog = "https://github.com/Josef-Friedrich/check_systemd/releases";
     maintainers = with maintainers; [ symphorien ];
     license = licenses.lgpl2Only;
     platforms = platforms.linux;


### PR DESCRIPTION

### nixpkgs-check report

**version:** `nixpkgs-check v0.1.0` on NixOS 20.09.3732.91b77fe6942, sandbox = "true"
**packages declared changed:** {"check_systemd"}
**manual tests declared performed:**
 * 😢 not built on NixOS
 * 😢 not built on MacOS
 * 😢 not built on Other Linux distributions

**complies with contributing.md:** ✔ yes
**package check_systemd:** ✔ continued building
**closure size for check_systemd:** ✔ increased by 13.5 KB, from 98.4 MB to 98.4 MB
**tests of check_systemd:** 😢 there are no tests
**binaries of check_systemd:**
  * *updated binaries:*
    * ✔ check_systemd continued running successfully


