### PR TITLE
ddcutil: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/tools/misc/ddcutil/default.nix
+++ b/pkgs/tools/misc/ddcutil/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ddcutil";
-  version = "1.0.1";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner  = "rockowitz";
     repo   = "ddcutil";
     rev    = "v${version}";
-    sha256 = "sha256-F/tKW81bAyYtwpxhl5XC8YyMB+6S0XmqqigwJY2WFDU=";
+    sha256 = "0wv8a8zjahzmi4qx0lc24mwyi3jklj1yxqq26fwklmfh5dv1y8yc";
   };
 
   patches = [

--- a/pkgs/tools/misc/ddcutil/nixos-paths.diff
+++ b/pkgs/tools/misc/ddcutil/nixos-paths.diff
@@ -1,32 +1,30 @@
-diff --git a/src/app_sysenv/query_sysenv_modules.c b/src/app_sysenv/query_sysenv_modules.c
-index 59df64f1..fb244dd0 100644
---- a/src/app_sysenv/query_sysenv_modules.c
-+++ b/src/app_sysenv/query_sysenv_modules.c
-@@ -50,7 +50,9 @@ bool is_module_loadable(char * module_name, int depth) {
-    g_snprintf(module_name_ko, 100, "%s.ko", module_name);
- 
-    char dirname[PATH_MAX];
--   g_snprintf(dirname, PATH_MAX, "/lib/modules/%s/kernel/drivers/i2c", utsbuf.release);
-+   g_snprintf(dirname, PATH_MAX,
-+      "/run/booted-system/kernel-modules/lib/modules/%s/kernel/drivers/i2c",
-+      utsbuf.release);
- 
-    struct dirent *dent;
-      DIR           *d;
-diff --git a/src/util/linux_util.c b/src/util/linux_util.c
-index 5eb8491c..3a129ccf 100644
 --- a/src/util/linux_util.c
 +++ b/src/util/linux_util.c
-@@ -29,8 +29,10 @@ bool is_module_builtin(char * module_name)
-    int rc = uname(&utsbuf);
-    assert(rc == 0);
+@@ -125,6 +125,7 @@
+                   "lib64",
+                   "lib32",
+                   "usr/lib",  // needed for arch?
++                  "run/booted-system/kernel-modules/lib",  // NixOS
+                   NULL};
+    int result = -1;
+    int ndx = 0;
+@@ -204,14 +205,15 @@
+    if (debug)
+       printf("(%s) machine: %s", __func__, utsbuf.machine);
  
--   char modules_builtin_fn[100];
--   snprintf(modules_builtin_fn, 100, "/lib/modules/%s/modules.builtin", utsbuf.release);
-+   char modules_builtin_fn[PATH_MAX];
-+   snprintf(modules_builtin_fn, PATH_MAX,
-+      "/run/booted-system/kernel-modules/lib/modules/%s/modules.builtin",
-+      utsbuf.release);
+-   char * libdirs[3];
++   char * libdirs[4];
+    libdirs[0] = "lib";
++   libdirs[1] = "run/booted-system/kernel-modules/lib";
+    if (streq(utsbuf.machine, "amd_64")){
+-      libdirs[1] = "lib64";
+-      libdirs[2] = NULL;
++      libdirs[2] = "lib64";
++      libdirs[3] = NULL;
+    }
+    else
+-      libdirs[1] = NULL;
++      libdirs[2] = NULL;
  
-    char ko_name[40];
-    snprintf(ko_name, 40, "%s.ko", module_name);
+    int libsndx = 0;
+    bool found = false;


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@gebner can you check if the patch works? For some reason I can't reproduce the errors in #118362.