### PR TITLE
zookeeper: 3.6.2 -> 3.6.3

### DIFF
--- a/pkgs/development/libraries/zookeeper_mt/default.nix
+++ b/pkgs/development/libraries/zookeeper_mt/default.nix
@@ -14,19 +14,19 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://apache/zookeeper/${zookeeper.pname}-${version}/apache-${zookeeper.pname}-${version}.tar.gz";
-    sha512 = "16994067d460a1b6af6a71f3458c64ee32629e876a1ff6646d57be62f1a5adab57462af84074ecaded4186dd3fde035ee24cd9d578b8e5044073eb05f4ab9c3e";
+    sha512 = "90643aa0ae1b9bf1f5e137dfbcee7e3c53db15e5038d7e406e4a1c345d6a0531bf7afa2b03f99d419ebd0fe892f127a7abfe582f786034ba823e53a0a9246bfb";
   };
 
   sourceRoot = "apache-${zookeeper.pname}-${version}/zookeeper-client/zookeeper-client-c";
 
   nativeBuildInputs = [
     autoreconfHook
+    pkg-config
     jre
   ];
 
   buildInputs = [
     openssl
-    pkg-config
     zookeeper
   ];
 

--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, fetchurl, jre, makeWrapper, bash, coreutils, runtimeShell }:
+{ lib, stdenv, fetchurl, jre, makeWrapper, bash, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "zookeeper";
-  version = "3.6.2";
+  version = "3.6.3";
 
   src = fetchurl {
     url = "mirror://apache/zookeeper/${pname}-${version}/apache-${pname}-${version}-bin.tar.gz";
-    sha512 = "caff5111bb6876b7124760bc006e6fa2523efa54b99321a3c9cd8192ea0d5596abc7d70a054b1aac9b20a411407dae7611c7aba870c23bff28eb1643ba499199";
+    sha512 = "3f7b1b7d9cf5647d52ad0076c922e108fa956e986b5624667c493cf6d8ff09d3ca88f623c79a799fe49c72e868cb3c9d0f77cb69608de74a183b2cbad10bc827";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
   phases = ["unpackPhase" "installPhase"];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out
     cp -R conf docs lib $out
     # Without this, zkCli.sh tries creating a log file in the Nix store.
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
         --prefix PATH : "${bash}/bin"
     done
     chmod -x $out/bin/zkEnv.sh
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2020-25649, CVE-2021-21295, CVE-2021-28165 and CVE-2021-21409.

https://zookeeper.apache.org/doc/r3.6.3/releasenotes.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>perl530Packages.NetZooKeeper</li>
    <li>perl532Packages.NetZooKeeper</li>
    <li>zkfuse</li>
    <li>zookeeper</li>
    <li>zookeeper_mt</li>
  </ul>
</details>