### PR TITLE
KDE Gear 21.04.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -100,6 +100,18 @@
       Now nginx uses the zlib-ng library by default.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     KDE Gear (formerly KDE Applications) is upgraded to 21.04, see its
+     <link xlink:href="https://kde.org/announcements/gear/21.04/">release
+     notes</link> for details.
+    </para>
+    <para>
+     The <code>kdeApplications</code> package set is now <code>kdeGear</code>,
+     in keeping with the new name. The old name remains for compatibility, but
+     it is deprecated.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -8,7 +8,7 @@ let
   cfg = xcfg.desktopManager.plasma5;
 
   libsForQt5 = pkgs.plasma5Packages;
-  inherit (libsForQt5) kdeApplications kdeFrameworks plasma5;
+  inherit (libsForQt5) kdeGear kdeFrameworks plasma5;
   inherit (pkgs) writeText;
 
   pulseaudio = config.hardware.pulseaudio;
@@ -213,7 +213,7 @@ in
 
       environment.systemPackages =
         with libsForQt5;
-        with plasma5; with kdeApplications; with kdeFrameworks;
+        with plasma5; with kdeGear; with kdeFrameworks;
         [
           frameworkintegration
           kactivities

--- a/pkgs/applications/kde/akonadi-import-wizard.nix
+++ b/pkgs/applications/kde/akonadi-import-wizard.nix
@@ -2,7 +2,8 @@
   mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
   akonadi, karchive, kcontacts, kcrash, kidentitymanagement, kio,
-  kmailtransport, kwallet, mailcommon, mailimporter, messagelib
+  kmailtransport, kwallet, mailcommon, mailimporter, messagelib,
+  qtkeychain, libsecret
 }:
 
 mkDerivation {
@@ -15,6 +16,7 @@ mkDerivation {
   buildInputs = [
     akonadi karchive kcontacts kcrash kidentitymanagement kio
     kmailtransport kwallet mailcommon mailimporter messagelib
+    qtkeychain libsecret
   ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/applications/kde/akonadi/0001-akonadi-paths.patch
+++ b/pkgs/applications/kde/akonadi/0001-akonadi-paths.patch
@@ -19,18 +19,18 @@ index 44ceec5..eb5fa50 100644
              QCoreApplication::instance()->exit(255);
          });
 -        start(QStringLiteral("akonadiserver"), args, RestartOnCrash);
-+        start(QStringLiteral(CMAKE_INSTALL_FULL_BINDIR "/akonadiserver"), args, RestartOnCrash);
++        start(QStringLiteral(NIX_OUT "/bin/akonadiserver"), args, RestartOnCrash);
      }
- 
+
      ~StorageProcessControl() override
 @@ -69,7 +69,7 @@ public:
          connect(this, &Akonadi::ProcessControl::unableToStart, this, []() {
              qCCritical(AKONADICONTROL_LOG) << "Failed to start AgentServer!";
          });
 -        start(QStringLiteral("akonadi_agent_server"), args, RestartOnCrash);
-+        start(QStringLiteral(CMAKE_INSTALL_FULL_BINDIR "/akonadi_agent_server"), args, RestartOnCrash);
++        start(QStringLiteral(NIX_OUT "/bin/akonadi_agent_server"), args, RestartOnCrash);
      }
- 
+
      ~AgentServerProcessControl() override
 diff --git a/src/akonadicontrol/agentprocessinstance.cpp b/src/akonadicontrol/agentprocessinstance.cpp
 index 8e92e08..f98dfd8 100644
@@ -41,7 +41,7 @@ index 8e92e08..f98dfd8 100644
          Q_ASSERT(agentInfo.launchMethod == AgentType::Launcher);
          const QStringList arguments = QStringList() << executable << identifier();
 -        const QString agentLauncherExec = Akonadi::StandardDirs::findExecutable(QStringLiteral("akonadi_agent_launcher"));
-+        const QString agentLauncherExec = QLatin1String(CMAKE_INSTALL_FULL_BINDIR "/akonadi_agent_launcher");
++        const QString agentLauncherExec = QLatin1String(NIX_OUT "/bin/akonadi_agent_launcher");
          mController->start(agentLauncherExec, arguments);
      }
      return true;
@@ -55,11 +55,11 @@ index 1a437ac..3550f9d 100644
      QString defaultOptions;
 -    QString defaultServerPath;
      QString defaultCleanShutdownCommand;
- 
+
  #ifndef Q_OS_WIN
 @@ -80,16 +79,7 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
  #endif
- 
+
      const bool defaultInternalServer = true;
 -#ifdef MYSQLD_EXECUTABLE
 -    if (QFile::exists(QStringLiteral(MYSQLD_EXECUTABLE))) {
@@ -78,15 +78,15 @@ index 1a437ac..3550f9d 100644
 @@ -99,10 +89,10 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
  #endif
      }
- 
+
 -    mMysqlInstallDbPath = findExecutable(QStringLiteral("mysql_install_db"));
 +    mMysqlInstallDbPath = QLatin1String(NIXPKGS_MYSQL_MYSQL_INSTALL_DB);
      qCDebug(AKONADISERVER_LOG) << "Found mysql_install_db: " << mMysqlInstallDbPath;
- 
+
 -    mMysqlCheckPath = findExecutable(QStringLiteral("mysqlcheck"));
 +    mMysqlCheckPath = QLatin1String(NIXPKGS_MYSQL_MYSQLCHECK);
      qCDebug(AKONADISERVER_LOG) << "Found mysqlcheck: " << mMysqlCheckPath;
- 
+
      mInternalServer = settings.value(QStringLiteral("QMYSQL/StartServer"), defaultInternalServer).toBool();
 @@ -119,7 +109,7 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
      mUserName = settings.value(QStringLiteral("User")).toString();
@@ -96,7 +96,7 @@ index 1a437ac..3550f9d 100644
 +    mMysqldPath = QLatin1String(NIXPKGS_MYSQL_MYSQLD);
      mCleanServerShutdownCommand = settings.value(QStringLiteral("CleanServerShutdownCommand"), defaultCleanShutdownCommand).toString();
      settings.endGroup();
- 
+
 @@ -129,9 +119,6 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
          // intentionally not namespaced as we are the only one in this db instance when using internal mode
          mDatabaseName = QStringLiteral("akonadi");
@@ -104,9 +104,9 @@ index 1a437ac..3550f9d 100644
 -    if (mInternalServer && (mMysqldPath.isEmpty() || !QFile::exists(mMysqldPath))) {
 -        mMysqldPath = defaultServerPath;
 -    }
- 
+
      qCDebug(AKONADISERVER_LOG) << "Using mysqld:" << mMysqldPath;
- 
+
 @@ -141,9 +128,6 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
          settings.setValue(QStringLiteral("Name"), mDatabaseName);
          settings.setValue(QStringLiteral("Host"), mHostName);
@@ -119,10 +119,10 @@ index 1a437ac..3550f9d 100644
          settings.sync();
 @@ -215,7 +199,7 @@ bool DbConfigMysql::startInternalServer()
  #endif
- 
+
      // generate config file
 -    const QString globalConfig = StandardDirs::locateResourceFile("config", QStringLiteral("mysql-global.conf"));
-+    const QString globalConfig = QLatin1String(CMAKE_INSTALL_PREFIX "/etc/xdg/akonadi/mysql-global.conf");
++    const QString globalConfig = QLatin1String(NIX_OUT "/etc/xdg/akonadi/mysql-global.conf");
      const QString localConfig = StandardDirs::locateResourceFile("config", QStringLiteral("mysql-local.conf"));
      const QString actualConfig = StandardDirs::saveDir("data") + QLatin1String("/mysql.conf");
      if (globalConfig.isEmpty()) {
@@ -138,10 +138,10 @@ index 4df61da..e3469c4 100644
      QString defaultInitDbPath;
 -    QString defaultPgUpgradePath;
      QString defaultPgData;
- 
+
  #ifndef Q_WS_WIN // We assume that PostgreSQL is running as service on Windows
 @@ -138,12 +136,8 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
- 
+
      mInternalServer = settings.value(QStringLiteral("QPSQL/StartServer"), defaultInternalServer).toBool();
      if (mInternalServer) {
 -        const auto paths = postgresSearchPaths(QStringLiteral("/usr/lib/postgresql"));
@@ -153,7 +153,7 @@ index 4df61da..e3469c4 100644
 -        defaultPgUpgradePath = QStandardPaths::findExecutable(QStringLiteral("pg_upgrade"), paths);
          defaultPgData = StandardDirs::saveDir("data", QStringLiteral("db_data"));
      }
- 
+
 @@ -162,20 +156,14 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
      mUserName = settings.value(QStringLiteral("User")).toString();
      mPassword = settings.value(QStringLiteral("Password")).toString();
@@ -185,6 +185,6 @@ index 4df61da..e3469c4 100644
          settings.setValue(QStringLiteral("InitDbPath"), mInitDbPath);
          settings.setValue(QStringLiteral("StartServer"), mInternalServer);
          settings.endGroup();
--- 
+--
 2.31.1
 

--- a/pkgs/applications/kde/akonadi/0001-akonadi-paths.patch
+++ b/pkgs/applications/kde/akonadi/0001-akonadi-paths.patch
@@ -1,6 +1,6 @@
-From f4d718502ecd8242500078a7783e27caba72871e Mon Sep 17 00:00:00 2001
+From ca8ff6e6d527ee968300cce5e8cd148f6a4d256b Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
-Date: Sun, 31 Jan 2021 11:00:03 -0600
+Date: Sun, 25 Apr 2021 08:00:10 -0500
 Subject: [PATCH 1/3] akonadi paths
 
 ---
@@ -11,45 +11,45 @@ Subject: [PATCH 1/3] akonadi paths
  4 files changed, 11 insertions(+), 40 deletions(-)
 
 diff --git a/src/akonadicontrol/agentmanager.cpp b/src/akonadicontrol/agentmanager.cpp
-index 31e0cf2..6436e87 100644
+index 44ceec5..eb5fa50 100644
 --- a/src/akonadicontrol/agentmanager.cpp
 +++ b/src/akonadicontrol/agentmanager.cpp
-@@ -48,7 +48,7 @@ public:
-                 []() {
-                     QCoreApplication::instance()->exit(255);
-                 });
+@@ -47,7 +47,7 @@ public:
+         connect(this, &Akonadi::ProcessControl::unableToStart, this, []() {
+             QCoreApplication::instance()->exit(255);
+         });
 -        start(QStringLiteral("akonadiserver"), args, RestartOnCrash);
-+        start(QLatin1String(NIX_OUT "/bin/akonadiserver"), args, RestartOnCrash);
++        start(QStringLiteral(CMAKE_INSTALL_FULL_BINDIR "/akonadiserver"), args, RestartOnCrash);
      }
  
      ~StorageProcessControl() override
-@@ -70,7 +70,7 @@ public:
-                 []() {
-                     qCCritical(AKONADICONTROL_LOG) << "Failed to start AgentServer!";
-                 });
+@@ -69,7 +69,7 @@ public:
+         connect(this, &Akonadi::ProcessControl::unableToStart, this, []() {
+             qCCritical(AKONADICONTROL_LOG) << "Failed to start AgentServer!";
+         });
 -        start(QStringLiteral("akonadi_agent_server"), args, RestartOnCrash);
-+        start(QLatin1String(NIX_OUT "/bin/akonadi_agent_server"), args, RestartOnCrash);
++        start(QStringLiteral(CMAKE_INSTALL_FULL_BINDIR "/akonadi_agent_server"), args, RestartOnCrash);
      }
  
      ~AgentServerProcessControl() override
 diff --git a/src/akonadicontrol/agentprocessinstance.cpp b/src/akonadicontrol/agentprocessinstance.cpp
-index c98946c..aa307ca 100644
+index 8e92e08..f98dfd8 100644
 --- a/src/akonadicontrol/agentprocessinstance.cpp
 +++ b/src/akonadicontrol/agentprocessinstance.cpp
-@@ -49,7 +49,7 @@ bool AgentProcessInstance::start(const AgentType &agentInfo)
+@@ -47,7 +47,7 @@ bool AgentProcessInstance::start(const AgentType &agentInfo)
      } else {
          Q_ASSERT(agentInfo.launchMethod == AgentType::Launcher);
          const QStringList arguments = QStringList() << executable << identifier();
 -        const QString agentLauncherExec = Akonadi::StandardDirs::findExecutable(QStringLiteral("akonadi_agent_launcher"));
-+        const QString agentLauncherExec = QLatin1String(NIX_OUT "/bin/akonadi_agent_launcher");
++        const QString agentLauncherExec = QLatin1String(CMAKE_INSTALL_FULL_BINDIR "/akonadi_agent_launcher");
          mController->start(agentLauncherExec, arguments);
      }
      return true;
 diff --git a/src/server/storage/dbconfigmysql.cpp b/src/server/storage/dbconfigmysql.cpp
-index d595a3a..99324f6 100644
+index 1a437ac..3550f9d 100644
 --- a/src/server/storage/dbconfigmysql.cpp
 +++ b/src/server/storage/dbconfigmysql.cpp
-@@ -69,7 +69,6 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
+@@ -72,7 +72,6 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
      // determine default settings depending on the driver
      QString defaultHostName;
      QString defaultOptions;
@@ -57,7 +57,7 @@ index d595a3a..99324f6 100644
      QString defaultCleanShutdownCommand;
  
  #ifndef Q_OS_WIN
-@@ -78,16 +77,7 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
+@@ -80,16 +79,7 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
  #endif
  
      const bool defaultInternalServer = true;
@@ -75,7 +75,7 @@ index d595a3a..99324f6 100644
      if (!mysqladminPath.isEmpty()) {
  #ifndef Q_OS_WIN
          defaultCleanShutdownCommand = QStringLiteral("%1 --defaults-file=%2/mysql.conf --socket=%3/%4 shutdown")
-@@ -97,10 +87,10 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
+@@ -99,10 +89,10 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
  #endif
      }
  
@@ -88,7 +88,7 @@ index d595a3a..99324f6 100644
      qCDebug(AKONADISERVER_LOG) << "Found mysqlcheck: " << mMysqlCheckPath;
  
      mInternalServer = settings.value(QStringLiteral("QMYSQL/StartServer"), defaultInternalServer).toBool();
-@@ -117,7 +107,7 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
+@@ -119,7 +109,7 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
      mUserName = settings.value(QStringLiteral("User")).toString();
      mPassword = settings.value(QStringLiteral("Password")).toString();
      mConnectionOptions = settings.value(QStringLiteral("Options"), defaultOptions).toString();
@@ -97,7 +97,7 @@ index d595a3a..99324f6 100644
      mCleanServerShutdownCommand = settings.value(QStringLiteral("CleanServerShutdownCommand"), defaultCleanShutdownCommand).toString();
      settings.endGroup();
  
-@@ -127,9 +117,6 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
+@@ -129,9 +119,6 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
          // intentionally not namespaced as we are the only one in this db instance when using internal mode
          mDatabaseName = QStringLiteral("akonadi");
      }
@@ -107,7 +107,7 @@ index d595a3a..99324f6 100644
  
      qCDebug(AKONADISERVER_LOG) << "Using mysqld:" << mMysqldPath;
  
-@@ -139,9 +126,6 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
+@@ -141,9 +128,6 @@ bool DbConfigMysql::init(QSettings &settings, bool storeSettings)
          settings.setValue(QStringLiteral("Name"), mDatabaseName);
          settings.setValue(QStringLiteral("Host"), mHostName);
          settings.setValue(QStringLiteral("Options"), mConnectionOptions);
@@ -117,20 +117,20 @@ index d595a3a..99324f6 100644
          settings.setValue(QStringLiteral("StartServer"), mInternalServer);
          settings.endGroup();
          settings.sync();
-@@ -214,7 +198,7 @@ bool DbConfigMysql::startInternalServer()
+@@ -215,7 +199,7 @@ bool DbConfigMysql::startInternalServer()
  #endif
  
      // generate config file
 -    const QString globalConfig = StandardDirs::locateResourceFile("config", QStringLiteral("mysql-global.conf"));
-+    const QString globalConfig = QLatin1String(NIX_OUT "/etc/xdg/akonadi/mysql-global.conf");
-     const QString localConfig  = StandardDirs::locateResourceFile("config", QStringLiteral("mysql-local.conf"));
++    const QString globalConfig = QLatin1String(CMAKE_INSTALL_PREFIX "/etc/xdg/akonadi/mysql-global.conf");
+     const QString localConfig = StandardDirs::locateResourceFile("config", QStringLiteral("mysql-local.conf"));
      const QString actualConfig = StandardDirs::saveDir("data") + QLatin1String("/mysql.conf");
      if (globalConfig.isEmpty()) {
 diff --git a/src/server/storage/dbconfigpostgresql.cpp b/src/server/storage/dbconfigpostgresql.cpp
-index dd273fc..05288d9 100644
+index 4df61da..e3469c4 100644
 --- a/src/server/storage/dbconfigpostgresql.cpp
 +++ b/src/server/storage/dbconfigpostgresql.cpp
-@@ -127,9 +127,7 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
+@@ -125,9 +125,7 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
      // determine default settings depending on the driver
      QString defaultHostName;
      QString defaultOptions;
@@ -140,7 +140,7 @@ index dd273fc..05288d9 100644
      QString defaultPgData;
  
  #ifndef Q_WS_WIN // We assume that PostgreSQL is running as service on Windows
-@@ -140,12 +138,8 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
+@@ -138,12 +136,8 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
  
      mInternalServer = settings.value(QStringLiteral("QPSQL/StartServer"), defaultInternalServer).toBool();
      if (mInternalServer) {
@@ -154,7 +154,7 @@ index dd273fc..05288d9 100644
          defaultPgData = StandardDirs::saveDir("data", QStringLiteral("db_data"));
      }
  
-@@ -164,20 +158,14 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
+@@ -162,20 +156,14 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
      mUserName = settings.value(QStringLiteral("User")).toString();
      mPassword = settings.value(QStringLiteral("Password")).toString();
      mConnectionOptions = settings.value(QStringLiteral("Options"), defaultOptions).toString();
@@ -177,7 +177,7 @@ index dd273fc..05288d9 100644
      qCDebug(AKONADISERVER_LOG) << "Found pg_upgrade:" << mPgUpgradePath;
      mPgData = settings.value(QStringLiteral("PgData"), defaultPgData).toString();
      if (mPgData.isEmpty()) {
-@@ -194,7 +182,6 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
+@@ -192,7 +180,6 @@ bool DbConfigPostgresql::init(QSettings &settings, bool storeSettings)
              settings.setValue(QStringLiteral("Port"), mHostPort);
          }
          settings.setValue(QStringLiteral("Options"), mConnectionOptions);
@@ -186,5 +186,5 @@ index dd273fc..05288d9 100644
          settings.setValue(QStringLiteral("StartServer"), mInternalServer);
          settings.endGroup();
 -- 
-2.29.2
+2.31.1
 

--- a/pkgs/applications/kde/akonadi/0002-akonadi-timestamps.patch
+++ b/pkgs/applications/kde/akonadi/0002-akonadi-timestamps.patch
@@ -1,6 +1,6 @@
-From badd4be311afd37a99126c60490f1ae5daced6c4 Mon Sep 17 00:00:00 2001
+From f6c446cf6fab2edbd2606b4c6100903e9437362a Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
-Date: Sun, 31 Jan 2021 11:00:15 -0600
+Date: Sun, 25 Apr 2021 08:01:02 -0500
 Subject: [PATCH 2/3] akonadi timestamps
 
 ---
@@ -8,19 +8,19 @@ Subject: [PATCH 2/3] akonadi timestamps
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/src/server/storage/dbconfigmysql.cpp b/src/server/storage/dbconfigmysql.cpp
-index 99324f6..3c170a8 100644
+index 3550f9d..e9e8887 100644
 --- a/src/server/storage/dbconfigmysql.cpp
 +++ b/src/server/storage/dbconfigmysql.cpp
-@@ -240,8 +240,7 @@ bool DbConfigMysql::startInternalServer()
+@@ -241,8 +241,7 @@ bool DbConfigMysql::startInternalServer()
      bool confUpdate = false;
      QFile actualFile(actualConfig);
      // update conf only if either global (or local) is newer than actual
--    if ((QFileInfo(globalConfig).lastModified() > QFileInfo(actualFile).lastModified()) ||
--            (QFileInfo(localConfig).lastModified()  > QFileInfo(actualFile).lastModified())) {
+-    if ((QFileInfo(globalConfig).lastModified() > QFileInfo(actualFile).lastModified())
+-        || (QFileInfo(localConfig).lastModified() > QFileInfo(actualFile).lastModified())) {
 +    if (true) {
          QFile globalFile(globalConfig);
          QFile localFile(localConfig);
          if (globalFile.open(QFile::ReadOnly) && actualFile.open(QFile::WriteOnly)) {
 -- 
-2.29.2
+2.31.1
 

--- a/pkgs/applications/kde/akonadi/0003-akonadi-revert-make-relocatable.patch
+++ b/pkgs/applications/kde/akonadi/0003-akonadi-revert-make-relocatable.patch
@@ -1,6 +1,6 @@
-From 82bfa975af60757374ffad787e56a981d6df0f98 Mon Sep 17 00:00:00 2001
+From 4b90a0bd4411a66bbe6ecf85ce89a60a58bee969 Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
-Date: Sun, 31 Jan 2021 11:01:24 -0600
+Date: Sun, 25 Apr 2021 08:01:21 -0500
 Subject: [PATCH 3/3] akonadi revert make relocatable
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 3/3] akonadi revert make relocatable
  2 files changed, 3 insertions(+), 6 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4bb5fec..35720b4 100644
+index 4e8cc81..63161b7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -343,9 +343,6 @@ configure_package_config_file(
+@@ -368,9 +368,6 @@ configure_package_config_file(
      "${CMAKE_CURRENT_SOURCE_DIR}/KF5AkonadiConfig.cmake.in"
      "${CMAKE_CURRENT_BINARY_DIR}/KF5AkonadiConfig.cmake"
      INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR}
@@ -41,5 +41,5 @@ index bcf7320..1574319 100644
  # set the directories
  if(NOT AKONADI_INSTALL_DIR)
 -- 
-2.29.2
+2.31.1
 

--- a/pkgs/applications/kde/akonadi/default.nix
+++ b/pkgs/applications/kde/akonadi/default.nix
@@ -33,5 +33,6 @@ mkDerivation {
     ''-DNIXPKGS_POSTGRES_PG_CTL=\"\"''
     ''-DNIXPKGS_POSTGRES_PG_UPGRADE=\"\"''
     ''-DNIXPKGS_POSTGRES_INITDB=\"\"''
+    ''-DNIX_OUT=\"${placeholder "out"}\"''
   ];
 }

--- a/pkgs/applications/kde/akonadi/default.nix
+++ b/pkgs/applications/kde/akonadi/default.nix
@@ -34,5 +34,6 @@ mkDerivation {
     ''-DNIXPKGS_POSTGRES_PG_UPGRADE=\"\"''
     ''-DNIXPKGS_POSTGRES_INITDB=\"\"''
     ''-DNIX_OUT=\"${placeholder "out"}\"''
+    ''-I${lib.getDev kio}/include/KF5''  # Fixes: kio_version.h: No such file or directory
   ];
 }

--- a/pkgs/applications/kde/akonadi/default.nix
+++ b/pkgs/applications/kde/akonadi/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, kdepimTeam,
+  mkDerivation, lib, kdepimTeam, substituteAll,
   extra-cmake-modules, shared-mime-info, qtbase, accounts-qt,
   boost, kaccounts-integration, kcompletion, kconfigwidgets, kcrash, kdbusaddons,
   kdesignerplugin, ki18n, kiconthemes, kio, kitemmodels, kwindowsystem, mariadb, qttools,
@@ -34,7 +34,4 @@ mkDerivation {
     ''-DNIXPKGS_POSTGRES_PG_UPGRADE=\"\"''
     ''-DNIXPKGS_POSTGRES_INITDB=\"\"''
   ];
-  preConfigure = ''
-    NIX_CFLAGS_COMPILE+=" -DNIX_OUT=\"$out\""
-  '';
 }

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -30,6 +30,9 @@ still shows most of the available features is in `./gwenview.nix`.
 }:
 
 let
+  minQtVersion = "5.15";
+  broken = lib.versionOlder libsForQt5.qtbase.version minQtVersion;
+
   mirror = "mirror://kde";
   srcs = import ./srcs.nix { inherit fetchurl mirror; };
 
@@ -45,10 +48,13 @@ let
 
         outputs = args.outputs or [ "out" ];
 
-        meta = {
-          platforms = lib.platforms.linux;
-          homepage = "http://www.kde.org";
-        } // (args.meta or {});
+        meta =
+          let meta = args.meta or {}; in
+          meta // {
+            homepage = meta.homepage or "http://www.kde.org";
+            platforms = meta.platforms or lib.platforms.linux;
+            broken = meta.broken or broken;
+          };
       });
 
   packages = self: with self;

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/release-service/20.12.3/src -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/release-service/21.04.0/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/kcachegrind.nix
+++ b/pkgs/applications/kde/kcachegrind.nix
@@ -1,8 +1,8 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, kdoctools,
-  karchive, ki18n, kio, perl, python3, php, qttools
-  , kdbusaddons
+  karchive, ki18n, kio, perl, python3, php, qttools,
+  kdbusaddons
 }:
 
 mkDerivation {

--- a/pkgs/applications/kde/kdeconnect-kde.nix
+++ b/pkgs/applications/kde/kdeconnect-kde.nix
@@ -21,6 +21,7 @@
 , qca-qt5
 , qtgraphicaleffects
 , qtmultimedia
+, qtquickcontrols2
 , qtx11extras
 , sshfs
 }:
@@ -46,6 +47,7 @@ mkDerivation {
     qca-qt5
     qtgraphicaleffects
     qtmultimedia
+    qtquickcontrols2
     qtx11extras
   ];
 

--- a/pkgs/applications/kde/kdenlive/default.nix
+++ b/pkgs/applications/kde/kdenlive/default.nix
@@ -26,6 +26,7 @@
 , phonon-backend-gstreamer
 , qtdeclarative
 , qtmultimedia
+, qtnetworkauth
 , qtquickcontrols2
 , qtscript
 , rttr
@@ -61,6 +62,7 @@ mkDerivation {
     phonon-backend-gstreamer
     qtdeclarative
     qtmultimedia
+    qtnetworkauth
     qtquickcontrols2
     qtscript
     shared-mime-info

--- a/pkgs/applications/kde/kdepim-runtime/default.nix
+++ b/pkgs/applications/kde/kdepim-runtime/default.nix
@@ -5,7 +5,8 @@
   akonadi, akonadi-calendar, akonadi-contacts, akonadi-mime, akonadi-notes,
   kalarmcal, kcalutils, kcontacts, kdav, kdelibs4support, kidentitymanagement,
   kimap, kldap, kmailtransport, kmbox, kmime, knotifications, knotifyconfig,
-  pimcommon, qtwebengine, libkgapi, qca-qt5, qtnetworkauth, qtspeech, qtxmlpatterns,
+  pimcommon, libkgapi, libsecret,
+  qca-qt5, qtkeychain, qtnetworkauth, qtspeech, qtwebengine, qtxmlpatterns,
 }:
 
 mkDerivation {
@@ -19,6 +20,7 @@ mkDerivation {
     akonadi akonadi-calendar akonadi-contacts akonadi-mime akonadi-notes
     kalarmcal kcalutils kcontacts kdav kdelibs4support kidentitymanagement kimap
     kldap kmailtransport kmbox kmime knotifications knotifyconfig qtwebengine
-    pimcommon libkgapi qca-qt5 qtnetworkauth qtspeech qtxmlpatterns
+    pimcommon libkgapi libsecret
+    qca-qt5 qtkeychain qtnetworkauth qtspeech qtxmlpatterns
   ];
 }

--- a/pkgs/applications/kde/kldap.nix
+++ b/pkgs/applications/kde/kldap.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
-  cyrus_sasl, ki18n, kio, kmbox, openldap
+  cyrus_sasl, ki18n, kio, kmbox, openldap, qtkeychain
 }:
 
 mkDerivation {
@@ -11,7 +11,7 @@ mkDerivation {
     maintainers = kdepimTeam;
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  buildInputs = [ ki18n kio kmbox ];
+  buildInputs = [ ki18n kio kmbox qtkeychain ];
   propagatedBuildInputs = [ cyrus_sasl openldap ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/applications/kde/kldap.nix
+++ b/pkgs/applications/kde/kldap.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
-  cyrus_sasl, ki18n, kio, kmbox, openldap, qtkeychain
+  cyrus_sasl, ki18n, kio, kmbox, libsecret, openldap, qtkeychain
 }:
 
 mkDerivation {
@@ -11,7 +11,7 @@ mkDerivation {
     maintainers = kdepimTeam;
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  buildInputs = [ ki18n kio kmbox qtkeychain ];
+  buildInputs = [ ki18n kio kmbox libsecret qtkeychain ];
   propagatedBuildInputs = [ cyrus_sasl openldap ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -7,7 +7,8 @@
   kmail-account-wizard, kmailtransport, knotifications, knotifyconfig,
   kontactinterface, kparts, kpty, kservice, ktextwidgets, ktnef, kwallet,
   kwidgetsaddons, kwindowsystem, kxmlgui, libgravatar, libksieve, mailcommon,
-  messagelib, pim-sieve-editor, qtscript, qtwebengine, akonadi, kdepim-addons
+  messagelib, pim-sieve-editor, qtscript, qtwebengine, akonadi, kdepim-addons,
+  qtkeychain, libsecret
 }:
 
 mkDerivation {
@@ -24,7 +25,7 @@ mkDerivation {
     knotifications knotifyconfig kontactinterface kparts kpty kservice
     ktextwidgets ktnef kwidgetsaddons kwindowsystem kxmlgui libgravatar
     libksieve mailcommon messagelib pim-sieve-editor qtscript qtwebengine
-    kdepim-addons
+    kdepim-addons qtkeychain libsecret
   ];
   propagatedUserEnvPkgs = [ kdepim-runtime kwallet akonadi ];
 }

--- a/pkgs/applications/kde/kmailtransport.nix
+++ b/pkgs/applications/kde/kmailtransport.nix
@@ -3,7 +3,7 @@
   extra-cmake-modules, kdoctools,
   akonadi, akonadi-mime, cyrus_sasl, kcmutils,
   ki18n, kio, kmime, kwallet, ksmtp, libkgapi,
-  kcalendarcore, kcontacts
+  kcalendarcore, kcontacts, qtkeychain, libsecret
 }:
 
 mkDerivation {
@@ -13,7 +13,10 @@ mkDerivation {
     maintainers = kdepimTeam;
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  buildInputs = [ akonadi kcmutils ki18n kio ksmtp libkgapi kcalendarcore kcontacts ];
+  buildInputs = [
+    akonadi kcmutils ki18n kio ksmtp libkgapi kcalendarcore kcontacts
+    qtkeychain libsecret
+  ];
   propagatedBuildInputs = [ akonadi-mime cyrus_sasl kmime kwallet ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/applications/kde/pim-sieve-editor.nix
+++ b/pkgs/applications/kde/pim-sieve-editor.nix
@@ -2,7 +2,7 @@
   mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
   kdbusaddons, kcrash, kbookmarks, kiconthemes, kio, kpimtextedit,
-  kmailtransport, pimcommon, libksieve
+  kmailtransport, libksieve, pimcommon, qtkeychain, libsecret
 }:
 
 mkDerivation {
@@ -14,6 +14,6 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     kdbusaddons kcrash kbookmarks kiconthemes kio kpimtextedit kmailtransport
-    pimcommon libksieve
+    libksieve pimcommon qtkeychain libsecret
   ];
 }

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1795 +4,1803 @@
 
 {
   akonadi = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akonadi-20.12.3.tar.xz";
-      sha256 = "0bcjyh1w8aaq7bp0df8zla7zvddig5ziz9avj82c6d453hfsq6dr";
-      name = "akonadi-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akonadi-21.04.0.tar.xz";
+      sha256 = "1ka1cxwqvcdyy9i1p7v7vrcrs9d1kx892wzq1dw3jrq9x57l5drz";
+      name = "akonadi-21.04.0.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akonadi-calendar-20.12.3.tar.xz";
-      sha256 = "057iz29y8dvxa26kf995akgy427c20d27i59gdfnl183wikmw9wk";
-      name = "akonadi-calendar-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akonadi-calendar-21.04.0.tar.xz";
+      sha256 = "1yf92jx7x19cp95c8nbkgmz5q1cg7096gdwy525df56h3pgbm651";
+      name = "akonadi-calendar-21.04.0.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akonadi-calendar-tools-20.12.3.tar.xz";
-      sha256 = "1fdcf6s1ij2l44zg7rha9hhha1k3m4xh0mgkyc836jkqy02jx3j6";
-      name = "akonadi-calendar-tools-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akonadi-calendar-tools-21.04.0.tar.xz";
+      sha256 = "1g0k1c11lysk3mi6k83lw70d64x543pcdgc9af1hyckb6clzh2gm";
+      name = "akonadi-calendar-tools-21.04.0.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akonadiconsole-20.12.3.tar.xz";
-      sha256 = "0skam7yl9m28m51yj0inzcxa5rbz5r4hz104b0ncg9hjjqi7qyfl";
-      name = "akonadiconsole-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akonadiconsole-21.04.0.tar.xz";
+      sha256 = "0l6famxpw64w7gmknx4szsg16hjydp3cr2mp0z0dfzi4m1i64gi7";
+      name = "akonadiconsole-21.04.0.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akonadi-contacts-20.12.3.tar.xz";
-      sha256 = "1ql7rx3fj12iddsvjip17w3gqm4slcmy3id3b892xwlx4izz2dr4";
-      name = "akonadi-contacts-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akonadi-contacts-21.04.0.tar.xz";
+      sha256 = "1130dvx8dpfvqsydhx1qy83bqx4drgb762ycf10cqkjvm6sjg3jh";
+      name = "akonadi-contacts-21.04.0.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akonadi-import-wizard-20.12.3.tar.xz";
-      sha256 = "080dyygqwc4m38vqkd4yvpy1xa4302a20gcbl5vi06as750qswgn";
-      name = "akonadi-import-wizard-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akonadi-import-wizard-21.04.0.tar.xz";
+      sha256 = "1idxpymfags4zrqlagndrkp9yvr24vvd4rzm7gm2zxwilw90smdh";
+      name = "akonadi-import-wizard-21.04.0.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akonadi-mime-20.12.3.tar.xz";
-      sha256 = "1dnxswwvgm3vj5l12xnv5c7jpmrx3180xpdpgj4xp4nmzvfrfpgl";
-      name = "akonadi-mime-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akonadi-mime-21.04.0.tar.xz";
+      sha256 = "037v29sq0q46i675n177ny3n5rvndvdpvydbika89gkiyag6hh1v";
+      name = "akonadi-mime-21.04.0.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akonadi-notes-20.12.3.tar.xz";
-      sha256 = "1fp5mif6w14snrndw2w4y66hsi14x7qyr9p343hdma4lmd65lic7";
-      name = "akonadi-notes-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akonadi-notes-21.04.0.tar.xz";
+      sha256 = "0l0m3qpqj4g6j58kfc2xc48cwhhf0538h5bw5m8z123pcggp3w20";
+      name = "akonadi-notes-21.04.0.tar.xz";
     };
   };
   akonadi-search = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akonadi-search-20.12.3.tar.xz";
-      sha256 = "0bac20n5mbfvl5p5qyiy1dygv1lz0spvm37ah3bp4iz9k4maqp7q";
-      name = "akonadi-search-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akonadi-search-21.04.0.tar.xz";
+      sha256 = "189z9vqn05ph7c6sfr413hywrrqs1yn5sj84563bjf3rdzn4zp67";
+      name = "akonadi-search-21.04.0.tar.xz";
     };
   };
   akregator = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/akregator-20.12.3.tar.xz";
-      sha256 = "10friff769kq83b9nxx2wj16bgzjh9gblc9r20gvm1qw5vm4l58b";
-      name = "akregator-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/akregator-21.04.0.tar.xz";
+      sha256 = "1px3sxsbhh98822i3yxs9sq019f78njfai07rsyf9wbawa6xj2sm";
+      name = "akregator-21.04.0.tar.xz";
     };
   };
   analitza = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/analitza-20.12.3.tar.xz";
-      sha256 = "187mnzdclqmn6d7yxxvy7xhcaasmgjz6mgk43dxn7rpn20lbx800";
-      name = "analitza-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/analitza-21.04.0.tar.xz";
+      sha256 = "1g4sfcdp13xsbfc1c64pgj7ax75z9cpqgy3sri4cm4qk9d2kkj0i";
+      name = "analitza-21.04.0.tar.xz";
     };
   };
   ark = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ark-20.12.3.tar.xz";
-      sha256 = "0fsv808a554cpka4pvhk829kldm2asnk8dyvr1wiidgpjpjxzwp4";
-      name = "ark-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ark-21.04.0.tar.xz";
+      sha256 = "034ywf6favaj7cbfmcgz00yrmvpb8vxsw4yq8a7y6f40b590aphf";
+      name = "ark-21.04.0.tar.xz";
     };
   };
   artikulate = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/artikulate-20.12.3.tar.xz";
-      sha256 = "1gnnfa0mwafh5msfy41n8fib1mfp713hdyfcqsmfpb04p5251grm";
-      name = "artikulate-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/artikulate-21.04.0.tar.xz";
+      sha256 = "0pbsbhl1phfzrgb393qf60n8k20f1qkda7a0mk6rxp1zj00pg7zw";
+      name = "artikulate-21.04.0.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/audiocd-kio-20.12.3.tar.xz";
-      sha256 = "06jg3q73hnr7wswqhffj5mncnpvrlmhh4c4k5302jp0c61i5pbv0";
-      name = "audiocd-kio-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/audiocd-kio-21.04.0.tar.xz";
+      sha256 = "1bbdw5gxjzpvvbq28zhazdr2ir1i3diy7rvz77cmw7jlj98x40m0";
+      name = "audiocd-kio-21.04.0.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/baloo-widgets-20.12.3.tar.xz";
-      sha256 = "0cznzgzn8x9kgn9pjq3fybici88y4al18n0c5vv1h31vz59fqfqi";
-      name = "baloo-widgets-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/baloo-widgets-21.04.0.tar.xz";
+      sha256 = "08y590n7rrha28pyjmf3liishmfjyx422ryd5viwb21g3isdb5ir";
+      name = "baloo-widgets-21.04.0.tar.xz";
     };
   };
   blinken = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/blinken-20.12.3.tar.xz";
-      sha256 = "0vfvlrdan60dx1prd1m4vhakvz5ddi70gzagfjb5c0py9802qqgl";
-      name = "blinken-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/blinken-21.04.0.tar.xz";
+      sha256 = "00fb1a98f6qs2pjcb2hc4rh2zgnqzhg21dal0rc4ddglm0mvgq27";
+      name = "blinken-21.04.0.tar.xz";
     };
   };
   bomber = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/bomber-20.12.3.tar.xz";
-      sha256 = "03d08j8wh989fsxb632fpbjg3zwqyv70jd8msjy4ajxl4039q9sp";
-      name = "bomber-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/bomber-21.04.0.tar.xz";
+      sha256 = "0fkikbyayd5ickhjwgd57kb89698w9ni89218bc47gkqvgm7zdzy";
+      name = "bomber-21.04.0.tar.xz";
     };
   };
   bovo = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/bovo-20.12.3.tar.xz";
-      sha256 = "114rq2a7jr9f9957zfn2fgiylf4ymgx5534i8qw7h78gxnb5915v";
-      name = "bovo-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/bovo-21.04.0.tar.xz";
+      sha256 = "1k6k9hkzrnz2802k4pq0aabdbkwwdvqi8c669cjhxwqxrpxhlan3";
+      name = "bovo-21.04.0.tar.xz";
     };
   };
   calendarsupport = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/calendarsupport-20.12.3.tar.xz";
-      sha256 = "044d9aarq5agh42h88l5bjc6nfsrb5797zlq0wfyx6laxnw8yhdb";
-      name = "calendarsupport-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/calendarsupport-21.04.0.tar.xz";
+      sha256 = "0m3x1pimy5sldgzkggwxyv3r0vn802bysf73nf6azgqachj1rm4g";
+      name = "calendarsupport-21.04.0.tar.xz";
     };
   };
   cantor = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/cantor-20.12.3.tar.xz";
-      sha256 = "0f6ad4mzn54bjc1q9yxana6j5hfdgr2d7gra27x5jfcn079qjijb";
-      name = "cantor-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/cantor-21.04.0.tar.xz";
+      sha256 = "0saz2xapfqmqlh9cmz8vkhsz5ai9fjgzp5y4rg4nc77b6wfwijpp";
+      name = "cantor-21.04.0.tar.xz";
     };
   };
   cervisia = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/cervisia-20.12.3.tar.xz";
-      sha256 = "0802rws42a1ipw2m5r9k7plr7yhyicws8ryx75vivn41v4qanq15";
-      name = "cervisia-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/cervisia-21.04.0.tar.xz";
+      sha256 = "1r76mdrq4v8f850kgx6wamhhpnvj5giclnfp8ck0f86lqx228xhz";
+      name = "cervisia-21.04.0.tar.xz";
     };
   };
   dolphin = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/dolphin-20.12.3.tar.xz";
-      sha256 = "1wx1z2bfcd8irhfbh2j4bhdl72afjwfbrh1ps8xzah14vqjvi54p";
-      name = "dolphin-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/dolphin-21.04.0.tar.xz";
+      sha256 = "1gmxrxs4h9bk1lxs2gn0gv44067wk19p8mq85n6dbpry9sfyb229";
+      name = "dolphin-21.04.0.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/dolphin-plugins-20.12.3.tar.xz";
-      sha256 = "102ykanh4a0pdm0j6wns5jaq76f71y96dgymm2mbgwrfrydcmcpw";
-      name = "dolphin-plugins-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/dolphin-plugins-21.04.0.tar.xz";
+      sha256 = "1ll8yhglncbzdmq6kpzavgd2q9llfbcqjyz8x97nlwibqszrbcwz";
+      name = "dolphin-plugins-21.04.0.tar.xz";
     };
   };
   dragon = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/dragon-20.12.3.tar.xz";
-      sha256 = "0aipkxyks1b7jdbxcb6i7l2kb6gahla07h4mls8fsmal4ha808ga";
-      name = "dragon-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/dragon-21.04.0.tar.xz";
+      sha256 = "00lnrskgvxclf75h89ycgafajkw1ddqg74lv38dv9yc21lh683k9";
+      name = "dragon-21.04.0.tar.xz";
     };
   };
   elisa = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/elisa-20.12.3.tar.xz";
-      sha256 = "0rcqwx68hb8cipbd9nd3sl922i63qaaphf6fnryhg7rinh2x75vs";
-      name = "elisa-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/elisa-21.04.0.tar.xz";
+      sha256 = "152i6748pkgnbpd192wd161w001l13gyinar1gphg46gb0z898sg";
+      name = "elisa-21.04.0.tar.xz";
     };
   };
   eventviews = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/eventviews-20.12.3.tar.xz";
-      sha256 = "0pkfhvrf423irvijqjk7a2px23zi053c57lqkp3cjag9z994wqkv";
-      name = "eventviews-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/eventviews-21.04.0.tar.xz";
+      sha256 = "1zq97jfgl0k7k1nhv6zcnbicl1af86rz6hzski9hm387bh60rn5v";
+      name = "eventviews-21.04.0.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ffmpegthumbs-20.12.3.tar.xz";
-      sha256 = "1cwn3rjqghbd2ivb268g68zibqyvvn1a07hcwa8bfjxw8y5cx890";
-      name = "ffmpegthumbs-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ffmpegthumbs-21.04.0.tar.xz";
+      sha256 = "06ycd5q5b4j6xxvrfvvpfdbmzrk8xysv7k8m64yypxnv9r7h1rsa";
+      name = "ffmpegthumbs-21.04.0.tar.xz";
     };
   };
   filelight = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/filelight-20.12.3.tar.xz";
-      sha256 = "0njapqiv2201bk57wl96ky8n78a31234vf2srcjs0nrdmbcp0si0";
-      name = "filelight-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/filelight-21.04.0.tar.xz";
+      sha256 = "1bfpqc67mkqz1w7wwv3p28q0n55vc78l94nyg805zs9adk00886v";
+      name = "filelight-21.04.0.tar.xz";
     };
   };
   granatier = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/granatier-20.12.3.tar.xz";
-      sha256 = "1x2l9f9xwrqf06r2qcrlf8941k6kfqb69442cy1ss9jfl9axy3vl";
-      name = "granatier-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/granatier-21.04.0.tar.xz";
+      sha256 = "0qcnr7n2401ykgwbz4lcsgp19fkb90lfbblbmrnbcslfc5pz8jz8";
+      name = "granatier-21.04.0.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/grantlee-editor-20.12.3.tar.xz";
-      sha256 = "1n6qi2pvhrhnzpq45757s75rslpzjgl60x7g5fv9cpfjk5knqzkc";
-      name = "grantlee-editor-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/grantlee-editor-21.04.0.tar.xz";
+      sha256 = "0rfcv63flw5izccqxz7mz43hvlim1cilnmrvk2vxc258vl1a226p";
+      name = "grantlee-editor-21.04.0.tar.xz";
     };
   };
   grantleetheme = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/grantleetheme-20.12.3.tar.xz";
-      sha256 = "0z9s5bmy89k3gzczim2prvb5mnylzin93d4h4nz6j7p5sk8aqgg3";
-      name = "grantleetheme-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/grantleetheme-21.04.0.tar.xz";
+      sha256 = "1jxdi7as6c81sy7zs59y6a0gmsjz6xwh6vbcr3r64wx62hj6vyls";
+      name = "grantleetheme-21.04.0.tar.xz";
     };
   };
   gwenview = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/gwenview-20.12.3.tar.xz";
-      sha256 = "18j13db432hhgz3kdrfcs555wy1fyjap8jha0aaw4w08bx8ll8v8";
-      name = "gwenview-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/gwenview-21.04.0.tar.xz";
+      sha256 = "06yyf7f49xbcfzbm10rr0xcmyxmlafh188wq8bjc8mp7p6fq7yd5";
+      name = "gwenview-21.04.0.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/incidenceeditor-20.12.3.tar.xz";
-      sha256 = "04yf0z6wsmb7zibfvv0pgyjzfacqa3drqqbc35d0hnvjzh39q1a4";
-      name = "incidenceeditor-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/incidenceeditor-21.04.0.tar.xz";
+      sha256 = "1fch2d5jgh3raf2zqc4vapgwf3gkdfsd71djvd626q3dsbh82qxz";
+      name = "incidenceeditor-21.04.0.tar.xz";
     };
   };
   itinerary = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/itinerary-20.12.3.tar.xz";
-      sha256 = "0jpk9f11r563inbm7yrx0lwpb937b1ilgshc9i50fhaqqgii39rp";
-      name = "itinerary-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/itinerary-21.04.0.tar.xz";
+      sha256 = "132y5v5qy89hfvp1j3x6rr6bg4wdzhd177isrs110w0aizdrbjcn";
+      name = "itinerary-21.04.0.tar.xz";
     };
   };
   juk = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/juk-20.12.3.tar.xz";
-      sha256 = "01sz8qnp71z34yyvgwhami5rybnlqy3r81ki21r45lvmlbd2i9l7";
-      name = "juk-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/juk-21.04.0.tar.xz";
+      sha256 = "11plw0h56n4fmhi47rmjw8qdki3r5yf3v7zfc0svwkb12lrvcp6z";
+      name = "juk-21.04.0.tar.xz";
     };
   };
   k3b = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/k3b-20.12.3.tar.xz";
-      sha256 = "132v5jcn7dmrbb69sllyv72d2d7vg9bpnpjzfmvirqa80x0x7s48";
-      name = "k3b-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/k3b-21.04.0.tar.xz";
+      sha256 = "1a6gm7bk486fr2haap6212vzx8hhrwkgjplyyq1nb27v61rpir2n";
+      name = "k3b-21.04.0.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kaccounts-integration-20.12.3.tar.xz";
-      sha256 = "0md6jwi0295n2s8mkvc793a4sxfzf6fidwpnjal2dsxkzdr0nfcq";
-      name = "kaccounts-integration-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kaccounts-integration-21.04.0.tar.xz";
+      sha256 = "1znfyslk4w45923xfxflipf0zwxf91k949carnbhzfiplab30gpy";
+      name = "kaccounts-integration-21.04.0.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kaccounts-providers-20.12.3.tar.xz";
-      sha256 = "05q6wzdbr1vm8g8qjssk0hnzrqkpq5qrrjwgqj8nkqgipzgclwdf";
-      name = "kaccounts-providers-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kaccounts-providers-21.04.0.tar.xz";
+      sha256 = "17rnqsagg60zd5nf7hag74kc9s7nj01ps3z411j8zwa1vlbqidg0";
+      name = "kaccounts-providers-21.04.0.tar.xz";
     };
   };
   kaddressbook = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kaddressbook-20.12.3.tar.xz";
-      sha256 = "15fpcxlnf42wc2z942rrgydb21v30ml3633cvsscrbjc3vys9vc3";
-      name = "kaddressbook-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kaddressbook-21.04.0.tar.xz";
+      sha256 = "1p9lcs4jd8n52hd0mpckwiv23zivzflkih2lpdbqcw55s75g03bl";
+      name = "kaddressbook-21.04.0.tar.xz";
     };
   };
   kajongg = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kajongg-20.12.3.tar.xz";
-      sha256 = "0h3kdvrp6y6ydhbmvwc8h1l0zh16jy519k5ragwkd9039cvyryxi";
-      name = "kajongg-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kajongg-21.04.0.tar.xz";
+      sha256 = "11hxc0scc700zmw5736z3vcign09g5rgnfmg98z3j34bms7iff5n";
+      name = "kajongg-21.04.0.tar.xz";
     };
   };
   kalarm = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kalarm-20.12.3.tar.xz";
-      sha256 = "0pkr9vm5hvdwyqb2mpi1qq5cxv0fd8czlq2hq8kb4ghskwd2nm6z";
-      name = "kalarm-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kalarm-21.04.0.tar.xz";
+      sha256 = "1zcyc6nlsdh9ixl10n6xlnfj78z6j218a9aipj1vws0jx7zahl12";
+      name = "kalarm-21.04.0.tar.xz";
     };
   };
   kalarmcal = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kalarmcal-20.12.3.tar.xz";
-      sha256 = "184qdpwwqnwlny0iil2vrw6x1al575mm6fx9iqbpg6hwz131nzhg";
-      name = "kalarmcal-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kalarmcal-21.04.0.tar.xz";
+      sha256 = "0cp5mian3zkyb51l6h2j7dkdhhmhk9vh33yvfa9x5q998sknr1m3";
+      name = "kalarmcal-21.04.0.tar.xz";
     };
   };
   kalgebra = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kalgebra-20.12.3.tar.xz";
-      sha256 = "0bx7v28qgpyjxka3kxjas6n1r5rq88vq064qscgjrn25536bg6p9";
-      name = "kalgebra-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kalgebra-21.04.0.tar.xz";
+      sha256 = "1w9vy3130kxw68fnpvzvq2k40dyain0ncsflf24fmn7dzjl4wpxn";
+      name = "kalgebra-21.04.0.tar.xz";
     };
   };
   kalzium = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kalzium-20.12.3.tar.xz";
-      sha256 = "1r7zvknc8kkx5kcs111ij6k6byj93xbg47bpi8wfh17i2fdrccw2";
-      name = "kalzium-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kalzium-21.04.0.tar.xz";
+      sha256 = "0fnqj1xnlgkb5wfx7j2zzbypyyql44srd555bdb1w0q37w1zxxgm";
+      name = "kalzium-21.04.0.tar.xz";
     };
   };
   kamera = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kamera-20.12.3.tar.xz";
-      sha256 = "0g6i4a975n9sxcjvpihz3wmldivk65i6p175vq2nik46jq6kxnj6";
-      name = "kamera-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kamera-21.04.0.tar.xz";
+      sha256 = "068ic1nf15x4h7h877q7by3hkd5dap9a2kdm7x2jwcqhwriiirw2";
+      name = "kamera-21.04.0.tar.xz";
     };
   };
   kamoso = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kamoso-20.12.3.tar.xz";
-      sha256 = "0zmhfcdihb5gd0gvnx3gmsn85dl4h1a42672592qrv7mv9yfl8x4";
-      name = "kamoso-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kamoso-21.04.0.tar.xz";
+      sha256 = "0npabci0x04g7v56x3pb5ps560d0xdshaznlci05bn3czxdas93h";
+      name = "kamoso-21.04.0.tar.xz";
     };
   };
   kanagram = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kanagram-20.12.3.tar.xz";
-      sha256 = "0yzz8apm76vhfgbx72jjfrc8z090xp9l6lr318wla809bvk92kn5";
-      name = "kanagram-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kanagram-21.04.0.tar.xz";
+      sha256 = "0ccnzrra54hqx7acsaiz8fk5gnax9y4j195hsbix7mghgb5ylz8r";
+      name = "kanagram-21.04.0.tar.xz";
     };
   };
   kapman = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kapman-20.12.3.tar.xz";
-      sha256 = "1734r0i37w8cbsmhmv6553l2prcg6l960j2j387x3lm6ynm8szl5";
-      name = "kapman-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kapman-21.04.0.tar.xz";
+      sha256 = "1i7jr8xlh3v4wz9bbc335q79zx96nfp15hhqnhkgxsqc216zn8qm";
+      name = "kapman-21.04.0.tar.xz";
     };
   };
   kapptemplate = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kapptemplate-20.12.3.tar.xz";
-      sha256 = "0587cwsjh9776zwb9dlqsn75bin5cv80yyixd9hqx86kqkxabw4c";
-      name = "kapptemplate-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kapptemplate-21.04.0.tar.xz";
+      sha256 = "0l2y562s7rk99zr5vbp03gbv0fwbd211j4n51g3yry7vbk433aiw";
+      name = "kapptemplate-21.04.0.tar.xz";
     };
   };
   kate = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kate-20.12.3.tar.xz";
-      sha256 = "1zfl53b3166ijr41bymlv0mvavjxv9sv5cf8xrpihn0rzs52vg41";
-      name = "kate-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kate-21.04.0.tar.xz";
+      sha256 = "1m11fh5c527d6b8a5wmglj9z0d2caak5bqh1g7fql1ygw06wr01p";
+      name = "kate-21.04.0.tar.xz";
     };
   };
   katomic = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/katomic-20.12.3.tar.xz";
-      sha256 = "1qmby2cp1sz31hraxybcb60a6smaf8ksy3m8nzkk7kpr11mzss0q";
-      name = "katomic-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/katomic-21.04.0.tar.xz";
+      sha256 = "0hrlmzqnw03nv334q680zwk700c8pvnaw57gh1ixphzsbx871yrk";
+      name = "katomic-21.04.0.tar.xz";
     };
   };
   kbackup = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kbackup-20.12.3.tar.xz";
-      sha256 = "04qj9645r427ki2jbj5ij243y6svw24ilwz5pz2qp0dp95wndfql";
-      name = "kbackup-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kbackup-21.04.0.tar.xz";
+      sha256 = "1l3bk7dj2grbki41fhxawrwn4vpncf3m2b5bq5ivj4vj4jc6vlyz";
+      name = "kbackup-21.04.0.tar.xz";
     };
   };
   kblackbox = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kblackbox-20.12.3.tar.xz";
-      sha256 = "0z4w3f22d8dmvmv4jmbgk91ga0qbw54xmawkikks5b0xgqkwkls7";
-      name = "kblackbox-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kblackbox-21.04.0.tar.xz";
+      sha256 = "17ba03qmyaiqda064dhxl0kwvncll7fznjvnfvby9lgdpzfjj8j9";
+      name = "kblackbox-21.04.0.tar.xz";
     };
   };
   kblocks = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kblocks-20.12.3.tar.xz";
-      sha256 = "0rsxyyaz6gs4a8qz5gsl865ky8a25hl282m293zsyd66wsc0f3hv";
-      name = "kblocks-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kblocks-21.04.0.tar.xz";
+      sha256 = "01i24fizs8d6yvyldln905vnww8ajy3aswn55xhxinjwhx9dcy7n";
+      name = "kblocks-21.04.0.tar.xz";
     };
   };
   kbounce = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kbounce-20.12.3.tar.xz";
-      sha256 = "0yyzr0zmsvfafrvy23vd4grdzpgc1w5ava0fb90x174mv0k2v55s";
-      name = "kbounce-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kbounce-21.04.0.tar.xz";
+      sha256 = "05wy4my4hil72cmj3p2hf9bshpknyps8xmp0mrbigyrzg505zjj2";
+      name = "kbounce-21.04.0.tar.xz";
     };
   };
   kbreakout = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kbreakout-20.12.3.tar.xz";
-      sha256 = "1djiixrwda25p2d8bvhkwn07v2gib35kwm94i1j5yxn0v68m86q1";
-      name = "kbreakout-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kbreakout-21.04.0.tar.xz";
+      sha256 = "0084id4wwk31m7wjkl5grcpbyqyzqx6cxixhdy48v7djdnn43jfj";
+      name = "kbreakout-21.04.0.tar.xz";
     };
   };
   kbruch = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kbruch-20.12.3.tar.xz";
-      sha256 = "1g2ihgxx6fj98cibfla9rig1mpgivs0l0ipkg5v8ax9wy7cmrx82";
-      name = "kbruch-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kbruch-21.04.0.tar.xz";
+      sha256 = "0qygd4zx039qckv4zzkgvz70wm8hg156bmb70g9g0nv5bzh4y02g";
+      name = "kbruch-21.04.0.tar.xz";
     };
   };
   kcachegrind = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kcachegrind-20.12.3.tar.xz";
-      sha256 = "1sk9bxz6lx3kadfv862d52pm69fcvg160y84y3qj59b9ms2qpqcm";
-      name = "kcachegrind-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kcachegrind-21.04.0.tar.xz";
+      sha256 = "1bdlzp35914nvbzcf4n6qrjmg7c0dc7c13kwq9gr5q6i4lvf275r";
+      name = "kcachegrind-21.04.0.tar.xz";
     };
   };
   kcalc = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kcalc-20.12.3.tar.xz";
-      sha256 = "1plq0xfaq2wwhsqddiq5wssn3k3i9dxrr5p80zanzngqcwbql1jl";
-      name = "kcalc-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kcalc-21.04.0.tar.xz";
+      sha256 = "0x0b19yaif6mjh20lbvl87phna781ya3l9hpwj2941vgvffwwpsh";
+      name = "kcalc-21.04.0.tar.xz";
     };
   };
   kcalutils = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kcalutils-20.12.3.tar.xz";
-      sha256 = "0as3900mcsdngrszd19928dfacm3qa7y1y2v65vf9mn0alz367qx";
-      name = "kcalutils-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kcalutils-21.04.0.tar.xz";
+      sha256 = "0kvl8ghwcamxayvwbsyjzib5b19v3k5hch17lj2pjsj20dgfl4qv";
+      name = "kcalutils-21.04.0.tar.xz";
     };
   };
   kcharselect = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kcharselect-20.12.3.tar.xz";
-      sha256 = "1qz96clyh7wl7sb3hkpkij96a0s9zx9saxhvbwrkqjqdhnqai8c3";
-      name = "kcharselect-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kcharselect-21.04.0.tar.xz";
+      sha256 = "1gp75qkwphgxpjkc1fwqkrbkkmc45l55ck8mqvbpz4aq8bscc0nx";
+      name = "kcharselect-21.04.0.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kcolorchooser-20.12.3.tar.xz";
-      sha256 = "0aamaml734mcbja9j4m9grp0zsxvy8ivzia49l2pmq27ci23ygad";
-      name = "kcolorchooser-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kcolorchooser-21.04.0.tar.xz";
+      sha256 = "0cgzclfmcn7l98ycm313sp8fhmx46fbn88l9cykywi27idymmb9v";
+      name = "kcolorchooser-21.04.0.tar.xz";
     };
   };
   kcron = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kcron-20.12.3.tar.xz";
-      sha256 = "0jn5mymzbifblg1sl4h9micql8baxmbpjclmlxp9r59m3vlpd0pf";
-      name = "kcron-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kcron-21.04.0.tar.xz";
+      sha256 = "144y4cn8xpkmn1gsab8wpvhqrnfidcjrbp2cy9xhx18as5ckpjn3";
+      name = "kcron-21.04.0.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdebugsettings-20.12.3.tar.xz";
-      sha256 = "1nsinb3psnvab0gc88hl374fr8f3iwxzi5ly9fg41f0z5a4hp9qv";
-      name = "kdebugsettings-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdebugsettings-21.04.0.tar.xz";
+      sha256 = "1xpbw9v9ws9i7a6ag5f6z7d15svyyx34p5vibm4p4j70vd7q5rwk";
+      name = "kdebugsettings-21.04.0.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdeconnect-kde-20.12.3.tar.xz";
-      sha256 = "1a08js0nrjzkfs46wydyz2ipivvgyc0hyyz4cxglhs5i97gab601";
-      name = "kdeconnect-kde-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdeconnect-kde-21.04.0.tar.xz";
+      sha256 = "1zbn2hi245934ljxgrzc3s2rpyapwrrkzx5vcjhnf8ri9v6sxhgp";
+      name = "kdeconnect-kde-21.04.0.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kde-dev-scripts-20.12.3.tar.xz";
-      sha256 = "1qng0232gzfzqlx5ri7lkkhri6wj9gci14xc62qqhklkmfdfx3nh";
-      name = "kde-dev-scripts-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kde-dev-scripts-21.04.0.tar.xz";
+      sha256 = "0plg145hp3bpxb2x3j8hja6fjn7yzmvx8j7zw123xnmqbzi25f6s";
+      name = "kde-dev-scripts-21.04.0.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kde-dev-utils-20.12.3.tar.xz";
-      sha256 = "09k9c0dk6gq3372zarmq7kfid7kn2s1vfdcrzal6wg57axfqs8d7";
-      name = "kde-dev-utils-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kde-dev-utils-21.04.0.tar.xz";
+      sha256 = "1cgzkhpb81s1zbx4rsfprmjn3cwqykyaaymg4bm7nqwnq97bbmc5";
+      name = "kde-dev-utils-21.04.0.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdeedu-data-20.12.3.tar.xz";
-      sha256 = "0cg62yvv39zgshqmfwl5p007b4za6x1nimfmn0hk8j9paas4ykkr";
-      name = "kdeedu-data-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdeedu-data-21.04.0.tar.xz";
+      sha256 = "0s4x0n8skwn117iiffi8rp4l5ddizfdqlc9lm49ijlvzkvhz3g3p";
+      name = "kdeedu-data-21.04.0.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdegraphics-mobipocket-20.12.3.tar.xz";
-      sha256 = "1zbizlk84idqxk0mr6zi86f3z4wrcc0k75s2s0xwfavjp5wvjj4l";
-      name = "kdegraphics-mobipocket-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdegraphics-mobipocket-21.04.0.tar.xz";
+      sha256 = "00pxfffc2xb7mszzgq6b3kp1h3m870k81rqarsy2igxxpbr3dr2p";
+      name = "kdegraphics-mobipocket-21.04.0.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdegraphics-thumbnailers-20.12.3.tar.xz";
-      sha256 = "0g3z6jai2v7pin23vk8xh66r9y8bw2768aykqhh5s507q0k8cnfx";
-      name = "kdegraphics-thumbnailers-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdegraphics-thumbnailers-21.04.0.tar.xz";
+      sha256 = "0yga4pa37zpgawq2hhc5w3scw40fwyp7901vbh6zspbdzya9lb50";
+      name = "kdegraphics-thumbnailers-21.04.0.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdenetwork-filesharing-20.12.3.tar.xz";
-      sha256 = "1lg3431wgrswam1mgck1p2kfgrwk0pk02nzh7xxgvh78104npbb2";
-      name = "kdenetwork-filesharing-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdenetwork-filesharing-21.04.0.tar.xz";
+      sha256 = "07a9pflvjf7ffi9jqx43f43wykl7z92z3pr1ca9q36fxw7cdixad";
+      name = "kdenetwork-filesharing-21.04.0.tar.xz";
     };
   };
   kdenlive = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdenlive-20.12.3.tar.xz";
-      sha256 = "11l5m19vbkjgvxcxh64ccwk33ws5sjpxr68d8459piggkdlr97wd";
-      name = "kdenlive-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdenlive-21.04.0.tar.xz";
+      sha256 = "1psb7mvffiqnv5n4b0wwa6s2ykcfkc4dxsvbxh2k67gmvq58zgmh";
+      name = "kdenlive-21.04.0.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdepim-addons-20.12.3.tar.xz";
-      sha256 = "0wd64aby2yrg937m9sfyzby3gxhwp2n1h6ijxxz7h2wi5mw3aqdp";
-      name = "kdepim-addons-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdepim-addons-21.04.0.tar.xz";
+      sha256 = "02xlp9xm15462y02wz05kn5vkg11lkiblz0cx43i8rcyiqnxbldz";
+      name = "kdepim-addons-21.04.0.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdepim-runtime-20.12.3.tar.xz";
-      sha256 = "0lp3cvkbfqd0zn7gh0as1ksknzqwxpz70zbks70wzdf4i59k2sxv";
-      name = "kdepim-runtime-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdepim-runtime-21.04.0.tar.xz";
+      sha256 = "1m1fshyivm1mz4hj9qaq33wdjkqxpjjbr0rkscb2b56a6jg4glza";
+      name = "kdepim-runtime-21.04.0.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdesdk-kioslaves-20.12.3.tar.xz";
-      sha256 = "0x48xzqg85rc639rrd7y43y1bvzyw189vydra13wbg063acx79n8";
-      name = "kdesdk-kioslaves-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdesdk-kioslaves-21.04.0.tar.xz";
+      sha256 = "068hqm1f2wllq3gcpmsib8cky6fhgpmqvmzvymcfc19ccyzwayhf";
+      name = "kdesdk-kioslaves-21.04.0.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdesdk-thumbnailers-20.12.3.tar.xz";
-      sha256 = "1n49psav0528dzg7b8h79pwngzjh1if7n47y7y8f5dj3smnyi6mv";
-      name = "kdesdk-thumbnailers-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdesdk-thumbnailers-21.04.0.tar.xz";
+      sha256 = "0cj6xsazqv94l02bp1pr5kny5id0kr5kqv3xkwv4jvmq317vfi3i";
+      name = "kdesdk-thumbnailers-21.04.0.tar.xz";
     };
   };
   kdf = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdf-20.12.3.tar.xz";
-      sha256 = "1qvjkfnagcyplkpx5v7vwfhs0xjll7g5jc0fvmkxqf38v2m5wb77";
-      name = "kdf-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdf-21.04.0.tar.xz";
+      sha256 = "1vbc75z33gx8pvy0kbmrhcg209qxxnvw7ccw83wk9hhzqg7mj5gf";
+      name = "kdf-21.04.0.tar.xz";
     };
   };
   kdialog = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdialog-20.12.3.tar.xz";
-      sha256 = "1ph26rks7yfjr28gvgyq77d8mnxxj0dxldd83lw94plhwlsnf7r3";
-      name = "kdialog-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdialog-21.04.0.tar.xz";
+      sha256 = "0damdppa2hm18nd99nzx23nac3k5ps0f5kc04cgfip4cr34rpg5s";
+      name = "kdialog-21.04.0.tar.xz";
     };
   };
   kdiamond = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kdiamond-20.12.3.tar.xz";
-      sha256 = "1wljkv0hacahc6n1x40diycvd32qlw363yzf3qm2l3h55g1ynca7";
-      name = "kdiamond-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kdiamond-21.04.0.tar.xz";
+      sha256 = "1lpwghy8v4242rm2vzm3wng43h5ys6r7spzlv53h329kpzd2259v";
+      name = "kdiamond-21.04.0.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/keditbookmarks-20.12.3.tar.xz";
-      sha256 = "0nfpdm672vs5h5ivxj6aaicj1b8nqcp7gw81jvjnq3nqk1k488v8";
-      name = "keditbookmarks-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/keditbookmarks-21.04.0.tar.xz";
+      sha256 = "1adk2g9hg7mls2vrrslmmy0nfvpgri9jlmii4pqfwl9kilcnk7lc";
+      name = "keditbookmarks-21.04.0.tar.xz";
     };
   };
   kfind = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kfind-20.12.3.tar.xz";
-      sha256 = "0rzilsw9y8cd4vmksl3jpddc0qc3y60yz7f6yk11n0hpszy0ixp6";
-      name = "kfind-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kfind-21.04.0.tar.xz";
+      sha256 = "1122h7jmsf49j7388py6pp72gfkqqzv971n7dkzpyqhfirqaigvj";
+      name = "kfind-21.04.0.tar.xz";
     };
   };
   kfloppy = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kfloppy-20.12.3.tar.xz";
-      sha256 = "00ff15fcgp1bgl4qin6md18p93wbpg3p230kgjk76qp8rmnwamg8";
-      name = "kfloppy-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kfloppy-21.04.0.tar.xz";
+      sha256 = "19maj0a469wnyindbrmqby8qikxcz38czagfygpq16y9bnkbvp3s";
+      name = "kfloppy-21.04.0.tar.xz";
     };
   };
   kfourinline = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kfourinline-20.12.3.tar.xz";
-      sha256 = "0rj1b60g7dng8yqw92lv9kk8fbnc7wwc9gbikkkjsrmw20hsl4jj";
-      name = "kfourinline-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kfourinline-21.04.0.tar.xz";
+      sha256 = "0yna3lydp0gii1rasij5593gaf4w9pbv7y5l6hz5qddb5y6r82ds";
+      name = "kfourinline-21.04.0.tar.xz";
     };
   };
   kgeography = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kgeography-20.12.3.tar.xz";
-      sha256 = "0i9sg203rbkcjl5si8fprmz31m90i5gq7ckv6vrsnmf3y0f6324m";
-      name = "kgeography-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kgeography-21.04.0.tar.xz";
+      sha256 = "1hcjp34jzz9qx8jp065gisnr9gn1v1ifnajfnaa3vc6sq1m1bvvi";
+      name = "kgeography-21.04.0.tar.xz";
     };
   };
   kget = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kget-20.12.3.tar.xz";
-      sha256 = "0kh2yv3fq6mdfqfiqiqd01l8rmr36pmcmjdqqaagsb16jprxivnl";
-      name = "kget-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kget-21.04.0.tar.xz";
+      sha256 = "0lws94g3780kdnxw2wf8vl41fq8ffxwaafma3r7p15rs05cyl1rv";
+      name = "kget-21.04.0.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kgoldrunner-20.12.3.tar.xz";
-      sha256 = "01c2ia8hs8i92ayah3jlsrqb62mcfa0phmm8rjbpnv8ybkjba720";
-      name = "kgoldrunner-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kgoldrunner-21.04.0.tar.xz";
+      sha256 = "02gldv7l8igzzmmyrkyixgzncsh0ysmfhx0lfc27pdj0mvfpm3m2";
+      name = "kgoldrunner-21.04.0.tar.xz";
     };
   };
   kgpg = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kgpg-20.12.3.tar.xz";
-      sha256 = "0z4xlgdhdagniabbzsvrpgzm2k3vwmk6li2wp9y719yj1jm23iyz";
-      name = "kgpg-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kgpg-21.04.0.tar.xz";
+      sha256 = "0a5xik5wb0b15p612lxzwqr5b58d4d7v3c7ghxmm8g27k36igqff";
+      name = "kgpg-21.04.0.tar.xz";
     };
   };
   khangman = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/khangman-20.12.3.tar.xz";
-      sha256 = "0alk18a95m5cl3zxf4y69i6vs1v027s5zwkbgrczznnxx2isv82r";
-      name = "khangman-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/khangman-21.04.0.tar.xz";
+      sha256 = "0pkqhbvw375v3cwn7ilfn7x93nadnxl07swcj5dbxn84gs33aj7c";
+      name = "khangman-21.04.0.tar.xz";
     };
   };
   khelpcenter = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/khelpcenter-20.12.3.tar.xz";
-      sha256 = "0mixgxi4a56x1xgan4rz3f6bifm21rwnm193klsd15bkd29yfa8f";
-      name = "khelpcenter-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/khelpcenter-21.04.0.tar.xz";
+      sha256 = "04fvipc3dzjl2fsgbla8w7kmv239ch86da8539gwg7l54bdmb5pv";
+      name = "khelpcenter-21.04.0.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kidentitymanagement-20.12.3.tar.xz";
-      sha256 = "161dj154r43gmw7768llanvmismf5fa141xblji6q40ss5aknsh3";
-      name = "kidentitymanagement-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kidentitymanagement-21.04.0.tar.xz";
+      sha256 = "1y83k7lzyzc5r6f7pqkbzqm1xnjv0z11vg8yazqwmfcv1whbzxda";
+      name = "kidentitymanagement-21.04.0.tar.xz";
     };
   };
   kig = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kig-20.12.3.tar.xz";
-      sha256 = "1ncy071wlyinkzhalnhg23x6n01031m2sx5kzh8gllp023mn2cnf";
-      name = "kig-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kig-21.04.0.tar.xz";
+      sha256 = "0d4p7py3lf05dsfy9x98aq6fwk6fsvf97jwxsdz4z3r49qvcp3hp";
+      name = "kig-21.04.0.tar.xz";
     };
   };
   kigo = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kigo-20.12.3.tar.xz";
-      sha256 = "1s4ykxlr47gk6n44fnv390m619i0jnxbxs4vd3vv7f9hfl65k598";
-      name = "kigo-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kigo-21.04.0.tar.xz";
+      sha256 = "0ans0mj9ql6vdmnc130sw0wkkm8rc1bpiww36a76nw8n28cfcyzi";
+      name = "kigo-21.04.0.tar.xz";
     };
   };
   killbots = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/killbots-20.12.3.tar.xz";
-      sha256 = "056slp4d9gk40i75gk42cvaq300zr228srqly2gap4879vqs04pa";
-      name = "killbots-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/killbots-21.04.0.tar.xz";
+      sha256 = "1qf2lahvi5g9cgvbgp6sj9vw1g8fcvcwaxgaqnc5akl03p51gz2k";
+      name = "killbots-21.04.0.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kimagemapeditor-20.12.3.tar.xz";
-      sha256 = "15z2mygfhk4bq212f76x60zzia1339hw1jg5vf24q2xs26gppprr";
-      name = "kimagemapeditor-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kimagemapeditor-21.04.0.tar.xz";
+      sha256 = "1f3y10bk5541sgi2qfww56mfq245a9wg38vpw2c8ygf4lc5rh67s";
+      name = "kimagemapeditor-21.04.0.tar.xz";
     };
   };
   kimap = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kimap-20.12.3.tar.xz";
-      sha256 = "080k4zyl7rlgzyfz6hsygv4wpw1hf08qnv4sbakpy3j8h6cbn79j";
-      name = "kimap-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kimap-21.04.0.tar.xz";
+      sha256 = "0fbcwsiz1q5s9d70zn7y183p477ykyjpw27i3k2mxb9ggk0h8bnx";
+      name = "kimap-21.04.0.tar.xz";
     };
   };
   kio-extras = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kio-extras-20.12.3.tar.xz";
-      sha256 = "1qj1cxzlpwh47vx7n3lm86556a53i6x3nvj5xc51mkh8pkdr0nxs";
-      name = "kio-extras-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kio-extras-21.04.0.tar.xz";
+      sha256 = "1p5kd5c4p5yc9fmppa6sivgv5kn1l9krzzw5h5y8xmi9g896yjjg";
+      name = "kio-extras-21.04.0.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kio-gdrive-20.12.3.tar.xz";
-      sha256 = "0w3vizdrjrikpgq137l5g0anvk0nb5wkr4m7pn0qma0sd03wqsa5";
-      name = "kio-gdrive-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kio-gdrive-21.04.0.tar.xz";
+      sha256 = "0p1y30syzbj7lg8hpxb5r255ba0v93gc219r1v7gb1ja5p7pjvsh";
+      name = "kio-gdrive-21.04.0.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kipi-plugins-20.12.3.tar.xz";
-      sha256 = "0wf0f6n1kpbcrlrfnmhkvcva4n86nav3lwfka29xwmk0brq35ghn";
-      name = "kipi-plugins-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kipi-plugins-21.04.0.tar.xz";
+      sha256 = "1x26yw1f47pylly2211kdld17m0p42a5miygwc7rnvasvh0dngwf";
+      name = "kipi-plugins-21.04.0.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kirigami-gallery-20.12.3.tar.xz";
-      sha256 = "0925n23wa69v69f0i3fafkaqsvn3sv41ili7c62110zx5n92qd3v";
-      name = "kirigami-gallery-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kirigami-gallery-21.04.0.tar.xz";
+      sha256 = "04hq0hikx692glb83xs8fg97dv53ayzd8lp776zv4p3sd6dpaysf";
+      name = "kirigami-gallery-21.04.0.tar.xz";
     };
   };
   kiriki = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kiriki-20.12.3.tar.xz";
-      sha256 = "0xnwdvnblz8qpgngjmmn218nrjxhy6f6z6ispszirr39mxvqgdhd";
-      name = "kiriki-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kiriki-21.04.0.tar.xz";
+      sha256 = "0dlimwhw6ii9x4m7166hbl3n6zi5pcvbsg303jm8pjc2bj83izis";
+      name = "kiriki-21.04.0.tar.xz";
     };
   };
   kiten = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kiten-20.12.3.tar.xz";
-      sha256 = "0yjfdbrm5kijf5rh45ih8x3hxcj9y9d5bivpi2xqdnl8w6dq0hnq";
-      name = "kiten-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kiten-21.04.0.tar.xz";
+      sha256 = "0vvq75q7j4j2hzzwnsr5zafphqvhwggb0mbs6y1ccb6yfm5vy3a4";
+      name = "kiten-21.04.0.tar.xz";
     };
   };
   kitinerary = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kitinerary-20.12.3.tar.xz";
-      sha256 = "1p8s27clnvn87kmlvv00j9s50n82awb19cvh4kwm7h77f3aai7jm";
-      name = "kitinerary-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kitinerary-21.04.0.tar.xz";
+      sha256 = "0sxzc2c0i1qjn5302a3cg7inx020r3n1pzjif6bhw4phynbzxliy";
+      name = "kitinerary-21.04.0.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kjumpingcube-20.12.3.tar.xz";
-      sha256 = "0rr0972scdr0x5ba3gqdprhg0ipm75577bx79m1jhkbqrcsr9kvg";
-      name = "kjumpingcube-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kjumpingcube-21.04.0.tar.xz";
+      sha256 = "12khypxl87725zs5ykwcp1ag27v5q89n9cvn879d6lp7qqs7mjx8";
+      name = "kjumpingcube-21.04.0.tar.xz";
     };
   };
   kldap = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kldap-20.12.3.tar.xz";
-      sha256 = "0lynv6101wqyi88rm34kwl4a4rdb59q69x918y4ggc4jzvgvq32c";
-      name = "kldap-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kldap-21.04.0.tar.xz";
+      sha256 = "1mqqpzqpz0hlldb0nz3dnm33d1hwpxcwj9hdqik5bzbfnr7ww04g";
+      name = "kldap-21.04.0.tar.xz";
     };
   };
   kleopatra = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kleopatra-20.12.3.tar.xz";
-      sha256 = "187agxw1s441qpskv8s74nvmsqmgh5z3mid85i8lvm5bqsdzjc5z";
-      name = "kleopatra-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kleopatra-21.04.0.tar.xz";
+      sha256 = "0w58nsklvc63ps0m92knf0n2wkmksq432ckx1959klimgqacffy0";
+      name = "kleopatra-21.04.0.tar.xz";
     };
   };
   klettres = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/klettres-20.12.3.tar.xz";
-      sha256 = "1zfbcciki2gz14b0mq7nv7pq90n2kf6dn33nkrwy086rmfm245dw";
-      name = "klettres-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/klettres-21.04.0.tar.xz";
+      sha256 = "1kxyisvmpgf4m5qzi7w6lfmnnpp96f4v72pls5k68q01ygf7mlrg";
+      name = "klettres-21.04.0.tar.xz";
     };
   };
   klickety = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/klickety-20.12.3.tar.xz";
-      sha256 = "155qhsgslx9nw4fzm5x5c09i3vwkqbl5xxa1arcxjpwsashfri2q";
-      name = "klickety-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/klickety-21.04.0.tar.xz";
+      sha256 = "0jiaxfzvdbygmfd6d0bsakzsvzkjvlhhidjz1wmvxq0jla4qna6b";
+      name = "klickety-21.04.0.tar.xz";
     };
   };
   klines = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/klines-20.12.3.tar.xz";
-      sha256 = "06syv5wxf2d9wqh5l7lwwjd0i3q8jqhimgb2ndyv2sp3p6zyx28n";
-      name = "klines-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/klines-21.04.0.tar.xz";
+      sha256 = "1ay26by2hwn7b0i48xgsxdysqpwzkvsz6g974c93103f5ygn8wjl";
+      name = "klines-21.04.0.tar.xz";
     };
   };
   kmag = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmag-20.12.3.tar.xz";
-      sha256 = "1p31i6hnhmmmx97bi1zb6c71zi1428gzf11sx66yhvfpj6vjx4rj";
-      name = "kmag-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmag-21.04.0.tar.xz";
+      sha256 = "06yw7397v5wcdx4jxpyc2mxgbxr744wgnqm7w2xb4771izlwq3qy";
+      name = "kmag-21.04.0.tar.xz";
     };
   };
   kmahjongg = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmahjongg-20.12.3.tar.xz";
-      sha256 = "1kx6l03x68cvr78iqjc7byraw714pbynavzm4vr8spadqr1scmj2";
-      name = "kmahjongg-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmahjongg-21.04.0.tar.xz";
+      sha256 = "0w4fpnafn9vir8c6ha6kl1x8vbmvmjax0p1qzxa7596hf3lvcncq";
+      name = "kmahjongg-21.04.0.tar.xz";
     };
   };
   kmail = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmail-20.12.3.tar.xz";
-      sha256 = "192wqkvq062xaq42bwl9f1rn7bc60slb3c0ika3mn446mr04s7j1";
-      name = "kmail-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmail-21.04.0.tar.xz";
+      sha256 = "11ghi1bqc8ldsb04z7fs5ba9b9fvsmcxxjp8j837iv0qz5rwh0fw";
+      name = "kmail-21.04.0.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmail-account-wizard-20.12.3.tar.xz";
-      sha256 = "1djc4fl5nyvnz26kbpqav5qy6azcrl0vmfaphmh4msx01823w50n";
-      name = "kmail-account-wizard-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmail-account-wizard-21.04.0.tar.xz";
+      sha256 = "0jalwjk5jyih765i7cpa0qidw3di17cz1fygmzgdz1v6kasg3h0c";
+      name = "kmail-account-wizard-21.04.0.tar.xz";
     };
   };
   kmailtransport = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmailtransport-20.12.3.tar.xz";
-      sha256 = "1m2r30rlmfb41m6hqmbrrw6lf7im4xlsxpfqf2h8qiss9avxf66p";
-      name = "kmailtransport-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmailtransport-21.04.0.tar.xz";
+      sha256 = "1jgw93q8jpgkg8ms7pjral1wz1ycs12ikjnsw2fiybd67syd2dns";
+      name = "kmailtransport-21.04.0.tar.xz";
     };
   };
   kmbox = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmbox-20.12.3.tar.xz";
-      sha256 = "0cwhzppckk3lv5p8nwba1vw57hkpbpgk69wnax6ad5x6nkynri8f";
-      name = "kmbox-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmbox-21.04.0.tar.xz";
+      sha256 = "01p1ihr08dnmzsq22ipy06grnz59nxyc2vfqbh6hc949mhl3kwx4";
+      name = "kmbox-21.04.0.tar.xz";
     };
   };
   kmime = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmime-20.12.3.tar.xz";
-      sha256 = "0va7xxr9bk27nalpr1959g7kbsbn4q974qhsnfvyac7qv0wnh7iq";
-      name = "kmime-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmime-21.04.0.tar.xz";
+      sha256 = "096vbbr8qnwcws7c6llxwk0klbfrhh4k83384bkhw5m5xawnqaq4";
+      name = "kmime-21.04.0.tar.xz";
     };
   };
   kmines = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmines-20.12.3.tar.xz";
-      sha256 = "11g98f8q77a1zivpv46bahqzkxna15mxm9abc5nmbhhrfl3n2ljr";
-      name = "kmines-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmines-21.04.0.tar.xz";
+      sha256 = "08dynl219n0jd58i01ccmgphc03z2x143l0a8v11x0m5cfazvzpp";
+      name = "kmines-21.04.0.tar.xz";
     };
   };
   kmix = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmix-20.12.3.tar.xz";
-      sha256 = "05za6km6lgkc79rk6iksbvfbc62110j6dlvsas2ld67cisar5y38";
-      name = "kmix-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmix-21.04.0.tar.xz";
+      sha256 = "1s2cnbmpkchp1wc5217r17ramj7a8xrm4l9hb74lyw4fc78455z2";
+      name = "kmix-21.04.0.tar.xz";
     };
   };
   kmousetool = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmousetool-20.12.3.tar.xz";
-      sha256 = "0xsjwjm517j2pqc04fvam181yrhb6qsi4nyxzc9c7xwwqm1pw03a";
-      name = "kmousetool-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmousetool-21.04.0.tar.xz";
+      sha256 = "0iaqgflnyl62ynxcip8zbxm25hgr82yc9d3z5v36mv0q3lq4bi92";
+      name = "kmousetool-21.04.0.tar.xz";
     };
   };
   kmouth = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmouth-20.12.3.tar.xz";
-      sha256 = "152xgpq8mlwpaq82cff0llwpkw2jylwbpwfbish7glqghryzrgwh";
-      name = "kmouth-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmouth-21.04.0.tar.xz";
+      sha256 = "0sza7arw0nfga6g9fv7rbkgkxmn694awzhkjbklafdvcjyn3dw2v";
+      name = "kmouth-21.04.0.tar.xz";
     };
   };
   kmplot = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kmplot-20.12.3.tar.xz";
-      sha256 = "1b70kfjp83dnslpb9732dsci3yq0iglr6ikbm6lsbf2qbxxshjl3";
-      name = "kmplot-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kmplot-21.04.0.tar.xz";
+      sha256 = "1wpz5kb06ym920ghmrfb0jh6z4nadlb7d9z0l85vkm3y1rz0iisy";
+      name = "kmplot-21.04.0.tar.xz";
     };
   };
   knavalbattle = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/knavalbattle-20.12.3.tar.xz";
-      sha256 = "1a7rja1zb06aa9brjlsd0jx3vxn3gmdq1fg0gzmmfg77mdmb3l6g";
-      name = "knavalbattle-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/knavalbattle-21.04.0.tar.xz";
+      sha256 = "0xn7mkmcr4p6c8kdcdxk7k9ifv12l0fflg2nkgmr1gbjxkpyy435";
+      name = "knavalbattle-21.04.0.tar.xz";
     };
   };
   knetwalk = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/knetwalk-20.12.3.tar.xz";
-      sha256 = "1bnm1lfp0igav57ys5yqim2wky8xpkk52zy50k5l5p32sd7g2x59";
-      name = "knetwalk-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/knetwalk-21.04.0.tar.xz";
+      sha256 = "127s5fgjpcndgbg30wd9sv3jrskq7ib4rnrw5qdfsxv8c77kv74m";
+      name = "knetwalk-21.04.0.tar.xz";
     };
   };
   knights = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/knights-20.12.3.tar.xz";
-      sha256 = "0z85xw91fqgrhz8kl1gshqy6n4ah14b5z1ajr0m0x817xy2ifys9";
-      name = "knights-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/knights-21.04.0.tar.xz";
+      sha256 = "09w3qqvp5k8z3bfwz6zlclagn11j1nar0bp2sgnjmi9cy2rs74n3";
+      name = "knights-21.04.0.tar.xz";
     };
   };
   knotes = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/knotes-20.12.3.tar.xz";
-      sha256 = "1n642jqwlg8nrmlm9xllbcdffwq3gy32pr6fp3k076x28kjg7mh6";
-      name = "knotes-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/knotes-21.04.0.tar.xz";
+      sha256 = "0zy10amznrkbj663h0b5a410ry65kh1sw2k9ra43zx45bpamh62q";
+      name = "knotes-21.04.0.tar.xz";
     };
   };
   kolf = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kolf-20.12.3.tar.xz";
-      sha256 = "1xxmw85gxs96djanx5q0vzz0h5ilckyz644vvxqillng6f54skbp";
-      name = "kolf-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kolf-21.04.0.tar.xz";
+      sha256 = "0220b4mbphb7c7p3szhi976dx8ln0f64ghika7b9x2cmdxcizfcq";
+      name = "kolf-21.04.0.tar.xz";
     };
   };
   kollision = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kollision-20.12.3.tar.xz";
-      sha256 = "16bfbhb7dlfkwbald1vsbfffphpvzc3pglcjdc3wval8kqh9f7i0";
-      name = "kollision-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kollision-21.04.0.tar.xz";
+      sha256 = "0cfn7l4ccl26rqm9i8rqp07yx6jc12xqhm16pgamrf8qv40vch9f";
+      name = "kollision-21.04.0.tar.xz";
     };
   };
   kolourpaint = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kolourpaint-20.12.3.tar.xz";
-      sha256 = "0gp9pnagajhzy2f4cmvimvwr3sfk87w6zjwi264nk0cgd41pi51g";
-      name = "kolourpaint-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kolourpaint-21.04.0.tar.xz";
+      sha256 = "0xp1kas6hk279aqm5g36qlsylpd43p9pv6vdk2dy4cilds4fc3vw";
+      name = "kolourpaint-21.04.0.tar.xz";
     };
   };
   kompare = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kompare-20.12.3.tar.xz";
-      sha256 = "0zzvcxwr2vb48i8dj1r7m9841177zdci762f5ljk5wn8lbgysmvv";
-      name = "kompare-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kompare-21.04.0.tar.xz";
+      sha256 = "17p1i4gfgzbps60zq3svicp6yz6w33wvcp145lq1iqkj80pf5qyf";
+      name = "kompare-21.04.0.tar.xz";
     };
   };
   konqueror = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/konqueror-20.12.3.tar.xz";
-      sha256 = "1y6jpq1v5yxdhanyll3kgg9m5p0ri66cvsbg3vhiay377s992927";
-      name = "konqueror-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/konqueror-21.04.0.tar.xz";
+      sha256 = "04mli5dv05v7fin58zrhm7jmddj8qa2qz7w3qdbjd3a4iz7y7z71";
+      name = "konqueror-21.04.0.tar.xz";
     };
   };
   konquest = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/konquest-20.12.3.tar.xz";
-      sha256 = "11ygcif5z7nn8x599m4dk0a8kdriiqg177f7v05pf0fhd7x72968";
-      name = "konquest-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/konquest-21.04.0.tar.xz";
+      sha256 = "1ryh7d3ndvrw8vjaraxyzyw08sx9w4yny7hdj1ss7319y041a07s";
+      name = "konquest-21.04.0.tar.xz";
     };
   };
   konsole = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/konsole-20.12.3.tar.xz";
-      sha256 = "138kvndy7xjjmac2wy2lsqi5pckba6nwbfgsdd91fbmfqkyl5k94";
-      name = "konsole-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/konsole-21.04.0.tar.xz";
+      sha256 = "1dlr0w77sccibhp37xi49bi6g4679fymgziznqxjvhk5l141f2i6";
+      name = "konsole-21.04.0.tar.xz";
     };
   };
   kontact = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kontact-20.12.3.tar.xz";
-      sha256 = "0vysa621chslz8l0xhnxs8bymkgjwqg24bhp2kw5lllz4f46iidl";
-      name = "kontact-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kontact-21.04.0.tar.xz";
+      sha256 = "08d1837kkcqc8gp9hmd351yymjdl31vg6nk1vcrlb7xsndqcsb79";
+      name = "kontact-21.04.0.tar.xz";
     };
   };
   kontactinterface = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kontactinterface-20.12.3.tar.xz";
-      sha256 = "1nqxk2x0bzndfv35g1l8yhafknyb0s68vrmcwf4kd15g5rf3k7rw";
-      name = "kontactinterface-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kontactinterface-21.04.0.tar.xz";
+      sha256 = "1h4v7jz4d5nl23fyjz946qszmidvdkayhsb1ffzk53bv8wpjh76m";
+      name = "kontactinterface-21.04.0.tar.xz";
     };
   };
   kontrast = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kontrast-20.12.3.tar.xz";
-      sha256 = "12q21d6fj29akvy6yk769pfwwhw24y13bhhbwrpnyv2ih96j9s8d";
-      name = "kontrast-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kontrast-21.04.0.tar.xz";
+      sha256 = "1bjkmhal9prizv1dlz8gdlki096a8d09bwksc0xxq3kml1r5gmfm";
+      name = "kontrast-21.04.0.tar.xz";
     };
   };
   konversation = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/konversation-20.12.3.tar.xz";
-      sha256 = "0cwnlihdidr5pxcbz4l68w1q6a9g3y1997gk7xqqnh4kz2fkc37q";
-      name = "konversation-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/konversation-21.04.0.tar.xz";
+      sha256 = "1fq4w0awg2xj6f7ivvpqrcch68ss01vnh0diwagryhrb0g0a37n7";
+      name = "konversation-21.04.0.tar.xz";
+    };
+  };
+  kopeninghours = {
+    version = "21.04.0";
+    src = fetchurl {
+      url = "${mirror}/stable/release-service/21.04.0/src/kopeninghours-21.04.0.tar.xz";
+      sha256 = "11gkri2sk1dz4hndpid4c84pxkdzc1fdpzw8h2x0141njl62421c";
+      name = "kopeninghours-21.04.0.tar.xz";
     };
   };
   kopete = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kopete-20.12.3.tar.xz";
-      sha256 = "0jl498q59dfwkazf7iqzlvia9jr6hhmkhy0hprbvww4av2si7x6w";
-      name = "kopete-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kopete-21.04.0.tar.xz";
+      sha256 = "14ypdl4xy4izg14nbdczif5i8q5kjly5gnyz032iy0cgnkarhi4q";
+      name = "kopete-21.04.0.tar.xz";
     };
   };
   korganizer = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/korganizer-20.12.3.tar.xz";
-      sha256 = "16mz7rmh65xljlf1jq719nkihr23wh840lf5cxzcx3vpk4gcc87w";
-      name = "korganizer-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/korganizer-21.04.0.tar.xz";
+      sha256 = "0znbwnzn35q4fdlj9n7hdqvq9rz3g8dyan9v1z9rh11cmdn4pc6h";
+      name = "korganizer-21.04.0.tar.xz";
     };
   };
   kosmindoormap = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kosmindoormap-20.12.3.tar.xz";
-      sha256 = "02dgnwand9sbas4v4c12xn8szgc3a7crmh8dd4q7rpcrzm2x1m9k";
-      name = "kosmindoormap-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kosmindoormap-21.04.0.tar.xz";
+      sha256 = "1c31f7b79xq9sxmfqxfs3082yrbqwkmw02brja8dg1h2avn0r3cy";
+      name = "kosmindoormap-21.04.0.tar.xz";
     };
   };
   kpat = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kpat-20.12.3.tar.xz";
-      sha256 = "1v1lzvl0xb5h4vma78ln400a81wilx16m987aijxg4c8gq4h5n11";
-      name = "kpat-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kpat-21.04.0.tar.xz";
+      sha256 = "043apdv55kc8d2dih65vb4fkwmaqybz167z0g5nfrrg0ilnqhifn";
+      name = "kpat-21.04.0.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kpimtextedit-20.12.3.tar.xz";
-      sha256 = "07lkc5zgsgvjz9544ckp17sii5bm06fynb0s046rks6z8fcncxrk";
-      name = "kpimtextedit-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kpimtextedit-21.04.0.tar.xz";
+      sha256 = "1acj6w164xg3v1svzlf4qa10kkzbhlnzrl4cp0brak81gal7bnrp";
+      name = "kpimtextedit-21.04.0.tar.xz";
     };
   };
   kpkpass = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kpkpass-20.12.3.tar.xz";
-      sha256 = "0lcgalcyfd5ggznwifwvvybj6z080gx12y4gx4mdh7jjjx0j4ng9";
-      name = "kpkpass-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kpkpass-21.04.0.tar.xz";
+      sha256 = "0s1f9j3n3ki71kzi8zw95q4v8y3dcgi5cnpq5rk03qb69yqf45xi";
+      name = "kpkpass-21.04.0.tar.xz";
     };
   };
   kpmcore = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kpmcore-20.12.3.tar.xz";
-      sha256 = "02jaz24wvw4jqi0k41067wwwy5yi6z80a1ah36ypxawzah9y94ik";
-      name = "kpmcore-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kpmcore-21.04.0.tar.xz";
+      sha256 = "0cb71d0w2jhbpm0da9rzn484930c022gxn2m4y9bgimaz0cgzcp7";
+      name = "kpmcore-21.04.0.tar.xz";
     };
   };
   kpublictransport = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kpublictransport-20.12.3.tar.xz";
-      sha256 = "15y6h44wdl78rfs40b71ijmvs2qb2ylnq72r8v6rn3fdnfhx2l4r";
-      name = "kpublictransport-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kpublictransport-21.04.0.tar.xz";
+      sha256 = "18zmsq9585d8sx6qvcfw6wb183nzga9l0b6mm06cl89bwpr2bdbb";
+      name = "kpublictransport-21.04.0.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kqtquickcharts-20.12.3.tar.xz";
-      sha256 = "1icc28acp7n8f5hiiq9rvmyv21f1ayghcr8d97lwm29aagsblx5j";
-      name = "kqtquickcharts-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kqtquickcharts-21.04.0.tar.xz";
+      sha256 = "09lw31sx93gw3s6hmwi0xaxyjnfx2nhij8iayam1sg644vx9a7ws";
+      name = "kqtquickcharts-21.04.0.tar.xz";
     };
   };
   krdc = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/krdc-20.12.3.tar.xz";
-      sha256 = "0s7wp11zcgp5z1drywm636wx5lkbalym4xxpmrb28xbdcgy9wgi2";
-      name = "krdc-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/krdc-21.04.0.tar.xz";
+      sha256 = "08iqydss6lyc6823762fq1p5c1hs7hv2crwv609gw97cvxvc8ww1";
+      name = "krdc-21.04.0.tar.xz";
     };
   };
   kreversi = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kreversi-20.12.3.tar.xz";
-      sha256 = "0v6nhrzxd7pwc7wyj1wv7spbc437vb14pwdd731w8s02223kkkzf";
-      name = "kreversi-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kreversi-21.04.0.tar.xz";
+      sha256 = "02zk0bwjmhgpk7fbvzwxap0xda2vxfyfjy38zagm5wgpgd4acsj4";
+      name = "kreversi-21.04.0.tar.xz";
     };
   };
   krfb = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/krfb-20.12.3.tar.xz";
-      sha256 = "0675smz307zwb4sdnhdlcgi7v38pxj0frr4c3cbhcpcmkjnbayc4";
-      name = "krfb-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/krfb-21.04.0.tar.xz";
+      sha256 = "0vjf10fg8nqbc7dr19i1hlqpgi1z2bcm1zrpf2rs85fi4pxrw7lg";
+      name = "krfb-21.04.0.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kross-interpreters-20.12.3.tar.xz";
-      sha256 = "1rq3gl0mndx3qhd0zk532z4m95zb4gwgahx208n6l5xh4rwgn7ck";
-      name = "kross-interpreters-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kross-interpreters-21.04.0.tar.xz";
+      sha256 = "1203gmm6pcv37k2m3yah1qgazja8qxkn18dqxmnw7fj3903mqxjw";
+      name = "kross-interpreters-21.04.0.tar.xz";
     };
   };
   kruler = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kruler-20.12.3.tar.xz";
-      sha256 = "1nvghf3gdn06nkk070zfbjmmh4z1anxxj15mwmdk3xriiwwm4w9z";
-      name = "kruler-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kruler-21.04.0.tar.xz";
+      sha256 = "0yrpkb755g2xy329336dl9yarl6dhcj5cwgv1sy75w1k3gibsz5y";
+      name = "kruler-21.04.0.tar.xz";
     };
   };
   kshisen = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kshisen-20.12.3.tar.xz";
-      sha256 = "19grx2zs26il2jplff4nb5sakvbkgsf9a91269gfjzsxzijf166q";
-      name = "kshisen-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kshisen-21.04.0.tar.xz";
+      sha256 = "087vynb6gr3l2291nvxcdk27ib10063fyhhxa7ibvfw68j612fri";
+      name = "kshisen-21.04.0.tar.xz";
     };
   };
   ksirk = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ksirk-20.12.3.tar.xz";
-      sha256 = "1rq4r5d1mhdkpfxv71s6pyaac8yaf03z4ayfhjh1azf3zvv9i8a5";
-      name = "ksirk-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ksirk-21.04.0.tar.xz";
+      sha256 = "1qrgkzgm7vnjz6mk7gqkxkx6i7p1dfnlw8fhxa6h1ihvgfmxr6kr";
+      name = "ksirk-21.04.0.tar.xz";
     };
   };
   ksmtp = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ksmtp-20.12.3.tar.xz";
-      sha256 = "0qmriih43q1lp4bq68hzlnwzab0vcjyjddyhs44gv9r83icw6rw6";
-      name = "ksmtp-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ksmtp-21.04.0.tar.xz";
+      sha256 = "0mn4ciyg0c8rxbcc3d99slm03jbca7b6gaplh8zz54p2krf86my5";
+      name = "ksmtp-21.04.0.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ksnakeduel-20.12.3.tar.xz";
-      sha256 = "132pdhfi9jy55y0ys785pz5xjw9f6fxx061ppvfy11giz9cbphsc";
-      name = "ksnakeduel-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ksnakeduel-21.04.0.tar.xz";
+      sha256 = "1s3k4k2a27rfp300bgxm1qhsg0dnlz72ip3csdixkidwcig7v017";
+      name = "ksnakeduel-21.04.0.tar.xz";
     };
   };
   kspaceduel = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kspaceduel-20.12.3.tar.xz";
-      sha256 = "0ff1dpj01szzgg6yb774lzpimlf7japkv4ns0xb3a6vp5ghfayxw";
-      name = "kspaceduel-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kspaceduel-21.04.0.tar.xz";
+      sha256 = "0acgmh4blmp2vmzqnxvphixbjmfv12al99hxwv1iavdfyl88yfqz";
+      name = "kspaceduel-21.04.0.tar.xz";
     };
   };
   ksquares = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ksquares-20.12.3.tar.xz";
-      sha256 = "0qp2j4abjjvazcqv9zyclvb425587dcwrsnlfrv7ami64ndr7xkb";
-      name = "ksquares-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ksquares-21.04.0.tar.xz";
+      sha256 = "1y23c86qz1qcmjzfsrj974c4ccai4rrp7ajmwxi7wgzgzwypflir";
+      name = "ksquares-21.04.0.tar.xz";
     };
   };
   ksudoku = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ksudoku-20.12.3.tar.xz";
-      sha256 = "0ykippr4d9s7mkmnqpbb3wa2l9cbhrmhvqaargm0553iqnwh6w4r";
-      name = "ksudoku-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ksudoku-21.04.0.tar.xz";
+      sha256 = "0r6m6jpjpz759gq40bxh5n7lg89gn2kfmiik2i06d1slz9v54iv0";
+      name = "ksudoku-21.04.0.tar.xz";
     };
   };
   ksystemlog = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ksystemlog-20.12.3.tar.xz";
-      sha256 = "1szh1iqriynpsbcrilia46vpsj52ifk8q0paib79byf9wals4gqy";
-      name = "ksystemlog-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ksystemlog-21.04.0.tar.xz";
+      sha256 = "06az8kfsp468hr3xzcfbra81xbfv12w2jzhd4n2cirsi6k8vhx14";
+      name = "ksystemlog-21.04.0.tar.xz";
     };
   };
   kteatime = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kteatime-20.12.3.tar.xz";
-      sha256 = "1y9cc8xjfn3pqmqh34lrnq2slj8y09k3njwkxkxzk20ni676j5ph";
-      name = "kteatime-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kteatime-21.04.0.tar.xz";
+      sha256 = "1zk7gbdsxyw59lfr0r2nnxm08jjls0zcp7wqkm4sq2gyczs73vy5";
+      name = "kteatime-21.04.0.tar.xz";
     };
   };
   ktimer = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktimer-20.12.3.tar.xz";
-      sha256 = "1yypwzrqkl09hbc8d24m51pjz8lzj80xi6f86xb0jazdl7d83flw";
-      name = "ktimer-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktimer-21.04.0.tar.xz";
+      sha256 = "0czwbd0id7a9w8wwpfsv2s06xc9my996bcdj0bn37091yik1wqzr";
+      name = "ktimer-21.04.0.tar.xz";
     };
   };
   ktnef = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktnef-20.12.3.tar.xz";
-      sha256 = "0wvqi09kz49m9lbxnk8070ikp4syhrxb90dgyiz1vax12baz7mvq";
-      name = "ktnef-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktnef-21.04.0.tar.xz";
+      sha256 = "0zs0bfb2g7rxcxc7ngjzszrcnj9qarpnig7b29xcrmnsxppa9z8y";
+      name = "ktnef-21.04.0.tar.xz";
     };
   };
   ktorrent = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktorrent-20.12.3.tar.xz";
-      sha256 = "12gj8bmbgvplc6r8ic104q18hq4dwiajhj0dwm1yjwmnslzdplr8";
-      name = "ktorrent-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktorrent-21.04.0.tar.xz";
+      sha256 = "0f28iyb2mrin2n5f6msxib9lh38qxid1sz5p5dq1g703gyqgr345";
+      name = "ktorrent-21.04.0.tar.xz";
     };
   };
   ktouch = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktouch-20.12.3.tar.xz";
-      sha256 = "1yv81mfavbvvlzc41ydfs1yjynza12n1cj8w36dgbgm6dwcldwfw";
-      name = "ktouch-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktouch-21.04.0.tar.xz";
+      sha256 = "0f46dsjcgqqg1f24sl3za624h5kpynqdi480hnc0fc6yaf3nm2mm";
+      name = "ktouch-21.04.0.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-accounts-kcm-20.12.3.tar.xz";
-      sha256 = "0jj6cspzmbn1fnkq5dfc7vzylbsq8vglcgwx4a2x8j5g7s8vm9y2";
-      name = "ktp-accounts-kcm-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-accounts-kcm-21.04.0.tar.xz";
+      sha256 = "1vvnk9nfq4z3m73yr59y65v0nvqwn4xjx6lrm754dnqr6vldv01p";
+      name = "ktp-accounts-kcm-21.04.0.tar.xz";
     };
   };
   ktp-approver = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-approver-20.12.3.tar.xz";
-      sha256 = "1brzpm50d4nqkva34h9va15xm4l7g0hvq1b610qnn9mvhikrzy43";
-      name = "ktp-approver-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-approver-21.04.0.tar.xz";
+      sha256 = "0j407a3bfmi4gn5v3gfazfidyp1kxn4vbs40xm5pkgxr4ykvzqj5";
+      name = "ktp-approver-21.04.0.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-auth-handler-20.12.3.tar.xz";
-      sha256 = "1i8jcxl828kany2668aid5vmhrla5rv6frb36xy7wdxv6y2q2gcc";
-      name = "ktp-auth-handler-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-auth-handler-21.04.0.tar.xz";
+      sha256 = "1lqjb3mawdvwrx7b2q2f3kr132shbgs9lvlzdn450pn9cn1c4z7i";
+      name = "ktp-auth-handler-21.04.0.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-call-ui-20.12.3.tar.xz";
-      sha256 = "079jlq7zs3zb37bnb48q68rcfjg3b263qplgcpgs1f77k9g449ql";
-      name = "ktp-call-ui-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-call-ui-21.04.0.tar.xz";
+      sha256 = "1f2rzm5jfw12b6v2yfzjs152sq2ak3k7zk3nwipyiy86n0f25yqp";
+      name = "ktp-call-ui-21.04.0.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-common-internals-20.12.3.tar.xz";
-      sha256 = "0c9hcyfsjhd2ydm5ldgxh9j5wbckavn4nj2n8l4zkyxk7knxf5w4";
-      name = "ktp-common-internals-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-common-internals-21.04.0.tar.xz";
+      sha256 = "0j3fnvyln6w7m3z416blpvrk1bpcbd5403h6pyjyq3dsvswzd21x";
+      name = "ktp-common-internals-21.04.0.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-contact-list-20.12.3.tar.xz";
-      sha256 = "03gqm2pjf2i6f0gvifd7bqclkfjbpabnlavadxf71qlnf7fki3rf";
-      name = "ktp-contact-list-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-contact-list-21.04.0.tar.xz";
+      sha256 = "1bym3sf3szmgi3nbczlilcazkjd1jfy7v0p0c3844c33fid6ln4q";
+      name = "ktp-contact-list-21.04.0.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-contact-runner-20.12.3.tar.xz";
-      sha256 = "047bzbb02y17yq973bzxf1h1c41f25njrsxc5qa7igvwwcid7hbc";
-      name = "ktp-contact-runner-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-contact-runner-21.04.0.tar.xz";
+      sha256 = "1afcsc8bfvyqy9y32a73x01xar50g48q9jbvnsggmjb20qbgk6fz";
+      name = "ktp-contact-runner-21.04.0.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-desktop-applets-20.12.3.tar.xz";
-      sha256 = "1m4nizagb7i45ys8k60kw1m5jfflxy1iy3qp1i17d0fy4xk81i6h";
-      name = "ktp-desktop-applets-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-desktop-applets-21.04.0.tar.xz";
+      sha256 = "1achgl8prdl33hw73nfjcm0djxzf9xy76n365kqzfz757fvy025w";
+      name = "ktp-desktop-applets-21.04.0.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-filetransfer-handler-20.12.3.tar.xz";
-      sha256 = "0wq9n5q8xgv70ikxavmmq7jnj24w9m3k7xaxl8qs7aas14jlcg29";
-      name = "ktp-filetransfer-handler-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-filetransfer-handler-21.04.0.tar.xz";
+      sha256 = "0mhvx3x4mf9b1mmn901995107ixz9qd80ydx468k30w13k8hwjpg";
+      name = "ktp-filetransfer-handler-21.04.0.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-kded-module-20.12.3.tar.xz";
-      sha256 = "0j28hdikn5713ngl3hf1gjr7syzba92irffhfrj6ia582gm7j2nz";
-      name = "ktp-kded-module-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-kded-module-21.04.0.tar.xz";
+      sha256 = "1d3rpbqks6x6bv12mzpd6g5x2h35hf4xfx871i23pq7p2n4nna8f";
+      name = "ktp-kded-module-21.04.0.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-send-file-20.12.3.tar.xz";
-      sha256 = "0lmyxvq49ibbvgg69cy1iayfgd4g777xbqdgzx0jgvvmd6ryrrqq";
-      name = "ktp-send-file-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-send-file-21.04.0.tar.xz";
+      sha256 = "1lyshgan77cia7cnirjfyg0hw0wgazjw9z21ig0czs3hr6qqf277";
+      name = "ktp-send-file-21.04.0.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktp-text-ui-20.12.3.tar.xz";
-      sha256 = "0gqgqjv0wamzcfzicvgc8n3jl4xizpzdjsq92bsbg1yk51ihn6iq";
-      name = "ktp-text-ui-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktp-text-ui-21.04.0.tar.xz";
+      sha256 = "04k2m4f873hz783szmkgpc0y6mjpwld5z3xcbdqippfzcdn4hg0v";
+      name = "ktp-text-ui-21.04.0.tar.xz";
     };
   };
   ktuberling = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/ktuberling-20.12.3.tar.xz";
-      sha256 = "0d4z9kk0vdljaf6damyjxnplmg6s1g6caw1ffd1dnyxhkszlka86";
-      name = "ktuberling-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/ktuberling-21.04.0.tar.xz";
+      sha256 = "14yg3pghm4l3qgpi1i5zicjyak62w2ci4b36914kn5b3yfxh132i";
+      name = "ktuberling-21.04.0.tar.xz";
     };
   };
   kturtle = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kturtle-20.12.3.tar.xz";
-      sha256 = "17mqi9kb57bva2rzqnmkiilr114zqqlh5f6sn9c13x7s8npdpgp6";
-      name = "kturtle-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kturtle-21.04.0.tar.xz";
+      sha256 = "1l8drllf7a1d3zra23ysyli8jl6xgl3xciqfkhc1fxhdkncx24cd";
+      name = "kturtle-21.04.0.tar.xz";
     };
   };
   kubrick = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kubrick-20.12.3.tar.xz";
-      sha256 = "0a581gajl9k3864q3y99kcxqfh8adbwpyrc1rakgzwbwd342wgrj";
-      name = "kubrick-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kubrick-21.04.0.tar.xz";
+      sha256 = "0m8ps0yxqijshgx09cypzd3l1n0zlrqcrkjcd725zwxarpm0z0hk";
+      name = "kubrick-21.04.0.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kwalletmanager-20.12.3.tar.xz";
-      sha256 = "16lx0nblxlzmlydblysrbf92dxf0biqxrzwvy7nhsnkk2yh18m4r";
-      name = "kwalletmanager-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kwalletmanager-21.04.0.tar.xz";
+      sha256 = "1rh7xdwn0kdw8j936asxy8llar144144xgvp7sjlpi5y93ayf8vk";
+      name = "kwalletmanager-21.04.0.tar.xz";
     };
   };
   kwave = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kwave-20.12.3.tar.xz";
-      sha256 = "1bd193wszlzra1xg6ahijmswmpkm8ra05pzbk6zvc67j71kzdmzs";
-      name = "kwave-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kwave-21.04.0.tar.xz";
+      sha256 = "1wy6sxmf9pk2677xdsbpgy01p284rzqwiyzm1hr971xbra5h4k6i";
+      name = "kwave-21.04.0.tar.xz";
     };
   };
   kwordquiz = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/kwordquiz-20.12.3.tar.xz";
-      sha256 = "0vqkj7zmp8v0iydll8gn7ybwha19sxpqd608wj6c7clwcr0y39yp";
-      name = "kwordquiz-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/kwordquiz-21.04.0.tar.xz";
+      sha256 = "0wnihn75yvhz2j310vr806vkbfywhr26wny07fpbzcishyjb89vi";
+      name = "kwordquiz-21.04.0.tar.xz";
     };
   };
   libgravatar = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libgravatar-20.12.3.tar.xz";
-      sha256 = "130wk6v40rz0rsc1z8yyl5zf4s6rbhlwgqdjijp1k6xnsp7xm8n4";
-      name = "libgravatar-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libgravatar-21.04.0.tar.xz";
+      sha256 = "0li6p9df000bmkqgmwiix7ab4sah05r1n4gm109jjglh0a41bfvr";
+      name = "libgravatar-21.04.0.tar.xz";
     };
   };
   libkcddb = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkcddb-20.12.3.tar.xz";
-      sha256 = "0m7fj11lp6i7fal0ckbpshyp5rw1pn3vxirnrg8ydp8ggs22jqi0";
-      name = "libkcddb-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkcddb-21.04.0.tar.xz";
+      sha256 = "1fzbhn0rnlmxdglfb48f4f3ddagkgny2665mgv8gdbcq3vg62zwr";
+      name = "libkcddb-21.04.0.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkcompactdisc-20.12.3.tar.xz";
-      sha256 = "192la7rlknjwlqw69yyqxcg2yar7p8fklykah5i3l5r6rcvx2h1w";
-      name = "libkcompactdisc-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkcompactdisc-21.04.0.tar.xz";
+      sha256 = "1skaic0vfspdkv0q574ia4jszq1a5smf4s9ls4flfk5qxmkv6862";
+      name = "libkcompactdisc-21.04.0.tar.xz";
     };
   };
   libkdcraw = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkdcraw-20.12.3.tar.xz";
-      sha256 = "1vwdr04z31aq37mx83vbgimkrpxq67dmlb68sl1wyivmllp084jg";
-      name = "libkdcraw-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkdcraw-21.04.0.tar.xz";
+      sha256 = "1ir6m61yb8f0ic39jxxnzjd9jjkb0ksln3fkls5v0af6g546bgab";
+      name = "libkdcraw-21.04.0.tar.xz";
     };
   };
   libkdegames = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkdegames-20.12.3.tar.xz";
-      sha256 = "1l8nwbjkgsnqxqjc94wqq6phyxdj9n8y075bzv45xagf82b926s0";
-      name = "libkdegames-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkdegames-21.04.0.tar.xz";
+      sha256 = "1q0m4kq32gsllxz8vx0qj9qii5y2lbd6wclwlykhayx1fcncwrj7";
+      name = "libkdegames-21.04.0.tar.xz";
     };
   };
   libkdepim = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkdepim-20.12.3.tar.xz";
-      sha256 = "1armxkai841ki9hgfwb4q53c8rlp55zgz1416dhrr97jrn03ckfa";
-      name = "libkdepim-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkdepim-21.04.0.tar.xz";
+      sha256 = "1ai5l9qcjnpwndvv744sx85b0yyg4wz01r0v9b0b62zwx8i35clb";
+      name = "libkdepim-21.04.0.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkeduvocdocument-20.12.3.tar.xz";
-      sha256 = "1x5w40avw73kjryiss71x10635l012jv5criaqlwyn3jfaf2idg0";
-      name = "libkeduvocdocument-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkeduvocdocument-21.04.0.tar.xz";
+      sha256 = "0264i01w44fjdh14psmw8ynmb8vzkw94lqqff1ia8bw5n0ihr914";
+      name = "libkeduvocdocument-21.04.0.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkexiv2-20.12.3.tar.xz";
-      sha256 = "1r11j2j0ymxg4dbhrznyr34cwdqcgh124lk9fmhdpjgq2q276qmp";
-      name = "libkexiv2-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkexiv2-21.04.0.tar.xz";
+      sha256 = "0grhibpq47yba9mjdhr1p0sbw62vxsrwfydi5ybpa8fjgvbbbprr";
+      name = "libkexiv2-21.04.0.tar.xz";
     };
   };
   libkgapi = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkgapi-20.12.3.tar.xz";
-      sha256 = "0h9rcn03jgw3rxxm3ylh1ap7ryswzm78hpfi6x9gdsfiqc8q8rpx";
-      name = "libkgapi-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkgapi-21.04.0.tar.xz";
+      sha256 = "1x811g0mbgjz8spngdsqdxfhkyic9kqxkhx9nq592zihaqkl3ifz";
+      name = "libkgapi-21.04.0.tar.xz";
     };
   };
   libkipi = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkipi-20.12.3.tar.xz";
-      sha256 = "1a0lpp3qkirsv8r6hpmndkn2f895jad5x7xlnxyf2x1s9qhzyvxv";
-      name = "libkipi-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkipi-21.04.0.tar.xz";
+      sha256 = "0gk8bfhq1z9f82mnjm2xjabgxn0qjrabw53bb67lwvrrgaliliqb";
+      name = "libkipi-21.04.0.tar.xz";
     };
   };
   libkleo = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkleo-20.12.3.tar.xz";
-      sha256 = "034m92af08g5769kr9xs91mgkl3ribcafsmm96isjbngj9acqjcr";
-      name = "libkleo-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkleo-21.04.0.tar.xz";
+      sha256 = "073ghnw1s09fvai22ag37n20mmhkbl4gp4y58nbgw43gfy5gsv6z";
+      name = "libkleo-21.04.0.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkmahjongg-20.12.3.tar.xz";
-      sha256 = "16wb744gbi4rgz9k9zr4dm7ilhjhjyaszawjmm626p4k145rcg4v";
-      name = "libkmahjongg-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkmahjongg-21.04.0.tar.xz";
+      sha256 = "1n2jswdvpvc9jcqsvqf0nniaf893432v123my2q6msk2zvss6pcb";
+      name = "libkmahjongg-21.04.0.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libkomparediff2-20.12.3.tar.xz";
-      sha256 = "0py3k5mn9kf82qcy89r1lkrhn702dgrjbgcd9ddslqfpiw8cb1l3";
-      name = "libkomparediff2-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libkomparediff2-21.04.0.tar.xz";
+      sha256 = "13kpaasyhrhhrgk8a5qg9qv65wdv6qvnz2gjbjv8qgp4k4jmwv7h";
+      name = "libkomparediff2-21.04.0.tar.xz";
     };
   };
   libksane = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libksane-20.12.3.tar.xz";
-      sha256 = "02sbizfw2a819l5f7di3k7x7cc4n19pipv68dfhsrh1hk6c5iia6";
-      name = "libksane-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libksane-21.04.0.tar.xz";
+      sha256 = "17a5i21h99qvv8sig7xh5n149ji8fqch5m0w6fqirrwf0iz66363";
+      name = "libksane-21.04.0.tar.xz";
     };
   };
   libksieve = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libksieve-20.12.3.tar.xz";
-      sha256 = "0j149jszdslnyia09fn6xsbkxa2p0xmxz05pf3byxl9albxq17q0";
-      name = "libksieve-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libksieve-21.04.0.tar.xz";
+      sha256 = "04zyiqmkr78rnilv5zmmbr09k1nycgpc3qw3a9qy4xzh5amkl8wl";
+      name = "libksieve-21.04.0.tar.xz";
     };
   };
   libktorrent = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/libktorrent-20.12.3.tar.xz";
-      sha256 = "1ykyfvr7w3h058gls7pnh9qwc6b4v9lp85s10qdbbsaiyly0h7n3";
-      name = "libktorrent-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/libktorrent-21.04.0.tar.xz";
+      sha256 = "0c8hbsk2vjkmdvnws4kaa9bylzyzmx12fxm354qm65n4j6pdd59v";
+      name = "libktorrent-21.04.0.tar.xz";
     };
   };
   lokalize = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/lokalize-20.12.3.tar.xz";
-      sha256 = "1a1dzg6qwd3dxcvln7nkpc5r6v6agqnzja6s09w9jb0gflrql372";
-      name = "lokalize-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/lokalize-21.04.0.tar.xz";
+      sha256 = "1wb95y89qi4z7hsldyq75w69rgdca3m0ji85khfvsb4h3cgilana";
+      name = "lokalize-21.04.0.tar.xz";
     };
   };
   lskat = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/lskat-20.12.3.tar.xz";
-      sha256 = "1fmyskr5i08gfjaghih2gihj6sgm8v5mn0m4wjmr9plg1vi6flcv";
-      name = "lskat-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/lskat-21.04.0.tar.xz";
+      sha256 = "1acxbsldcjk3d84ip5z15y8x6nngj2vnb40s5p3mv47r6vgbh0qd";
+      name = "lskat-21.04.0.tar.xz";
     };
   };
   mailcommon = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/mailcommon-20.12.3.tar.xz";
-      sha256 = "0z0ppv6yi5n54hi6x5s5nagciqpdbxyl0z5sa3whl7d6ikga0s4m";
-      name = "mailcommon-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/mailcommon-21.04.0.tar.xz";
+      sha256 = "1ljchkfrnknlzgjrrpwszzyv8m066d29xwns1yp8smqzk723g0gx";
+      name = "mailcommon-21.04.0.tar.xz";
     };
   };
   mailimporter = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/mailimporter-20.12.3.tar.xz";
-      sha256 = "1lkkvriq69v0lpmk38my8k0vnw2yq182g6139i5r7krcyvrz4ynn";
-      name = "mailimporter-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/mailimporter-21.04.0.tar.xz";
+      sha256 = "06zvaq3ccrgsd6idnd9m201924bnm72nvcg66v1salcdk93a8sv5";
+      name = "mailimporter-21.04.0.tar.xz";
     };
   };
   marble = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/marble-20.12.3.tar.xz";
-      sha256 = "1hkvp97mjg6gqs0b39j2rpgwwi70vzwhm4szmcjc2083vllv3cap";
-      name = "marble-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/marble-21.04.0.tar.xz";
+      sha256 = "1c63x75fzhkqgvijd1pmpywq4dx7gkyw9x90aj54fzkgjzwzqzhq";
+      name = "marble-21.04.0.tar.xz";
     };
   };
   markdownpart = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/markdownpart-20.12.3.tar.xz";
-      sha256 = "1g3r07fj4azpjbp6p6brcnd5dv7hi34w6z6a8bsg8cckmvhrirbl";
-      name = "markdownpart-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/markdownpart-21.04.0.tar.xz";
+      sha256 = "0xgnj2g0hqwflw550fj6jzq36pc8j9vwb6p9cbvfljd8yv8va9kq";
+      name = "markdownpart-21.04.0.tar.xz";
     };
   };
   mbox-importer = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/mbox-importer-20.12.3.tar.xz";
-      sha256 = "0rjk9blsbgjpd6l6ghrlzj04llaibjs8ngcfddxgixg8dxvsp0k9";
-      name = "mbox-importer-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/mbox-importer-21.04.0.tar.xz";
+      sha256 = "0rxrf1sxb5pzrkr8m2n1f3xgpwsihn6b6d5nilxmmsl5c60ya8j8";
+      name = "mbox-importer-21.04.0.tar.xz";
     };
   };
   messagelib = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/messagelib-20.12.3.tar.xz";
-      sha256 = "08rcw7y69xkrv0pwfz44hrbzkx9li2nabfjpgc9sc6i8klikgbis";
-      name = "messagelib-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/messagelib-21.04.0.tar.xz";
+      sha256 = "1qsvqrkh30vyfrsxkpriqkzizxg9mx6v2xx7j6gyhz7pmrskx8rg";
+      name = "messagelib-21.04.0.tar.xz";
     };
   };
   minuet = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/minuet-20.12.3.tar.xz";
-      sha256 = "0jidbfqsnk3dyd5f459p2jsyxs2jjpx3j356sg6c3hbs4imz5nm6";
-      name = "minuet-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/minuet-21.04.0.tar.xz";
+      sha256 = "0djqp807g47fy163bp0pkrhb7j37ijqdfyafz74871j2frrmnc97";
+      name = "minuet-21.04.0.tar.xz";
     };
   };
   okular = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/okular-20.12.3.tar.xz";
-      sha256 = "1p3kdc0awgpihf10m3fxypq5hqr5vvwbcm8w3h39rk1m5g6hymxf";
-      name = "okular-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/okular-21.04.0.tar.xz";
+      sha256 = "0l0vrglxy9331sqn3lx76hvbh7b0znsafl5ia61srk48kb0w9rqy";
+      name = "okular-21.04.0.tar.xz";
     };
   };
   palapeli = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/palapeli-20.12.3.tar.xz";
-      sha256 = "14hqifg18ngqsafp1k78wi2k7jpxglvcjdw55f0fi0iqjnsrk6xa";
-      name = "palapeli-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/palapeli-21.04.0.tar.xz";
+      sha256 = "0f7ylr46alafp2gz9sf7xgnjm9vgyx5r7nipbqjl4wi8w908rklw";
+      name = "palapeli-21.04.0.tar.xz";
     };
   };
   parley = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/parley-20.12.3.tar.xz";
-      sha256 = "0j4bbqlh0rix0wkfwp0jsf07akbysxnasbr1f2zwj75487mcwajn";
-      name = "parley-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/parley-21.04.0.tar.xz";
+      sha256 = "0a186zqpi815apf2grlj11xp64kw80i43779z99r665jpp6189z3";
+      name = "parley-21.04.0.tar.xz";
     };
   };
   partitionmanager = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/partitionmanager-20.12.3.tar.xz";
-      sha256 = "06kk64gynlxf7njdgaklrx8b4jlbqpk6bbx0nk4lzbyw191dfr0m";
-      name = "partitionmanager-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/partitionmanager-21.04.0.tar.xz";
+      sha256 = "02dgbqx1a6wahds04jcjdjh56pyrm47165hwv98ccarakrvn8yqm";
+      name = "partitionmanager-21.04.0.tar.xz";
     };
   };
   picmi = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/picmi-20.12.3.tar.xz";
-      sha256 = "1xwkdrs6wmhhz6vrs17d7vj6sdlwl60mh8cb7yxx03pw5g6gkdd2";
-      name = "picmi-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/picmi-21.04.0.tar.xz";
+      sha256 = "1pwswzc02blvf49v4i2grw9mlm9y1ydmms6mg50iyi6qrnzbv6r3";
+      name = "picmi-21.04.0.tar.xz";
     };
   };
   pimcommon = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/pimcommon-20.12.3.tar.xz";
-      sha256 = "18gy521g0i806bjjdkszgajac733inrakhkdw1fslhcg2b90m6hb";
-      name = "pimcommon-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/pimcommon-21.04.0.tar.xz";
+      sha256 = "0bprmk20pmngvxxxpygajnlr4yx9acrz7dw6bfnn6d8kig281qdn";
+      name = "pimcommon-21.04.0.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/pim-data-exporter-20.12.3.tar.xz";
-      sha256 = "17zc56420ndqfk8aw1mn1vwf34icgf03bbvvvg4s3m6cibnj0x4q";
-      name = "pim-data-exporter-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/pim-data-exporter-21.04.0.tar.xz";
+      sha256 = "0rbkr1vgl14q4hi4byn20kfhkz3yzmrydhb3f1i2amp08ca4x71n";
+      name = "pim-data-exporter-21.04.0.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/pim-sieve-editor-20.12.3.tar.xz";
-      sha256 = "1d1z4i3g5n6rfs48phb700a68na75yg7cr4f3q2wzlnyyvpd1m51";
-      name = "pim-sieve-editor-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/pim-sieve-editor-21.04.0.tar.xz";
+      sha256 = "1yxc4i0bsgrj9wsn44k7w3z1zkcm4y9qd8zd7shsqpca9lb9n13y";
+      name = "pim-sieve-editor-21.04.0.tar.xz";
     };
   };
   poxml = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/poxml-20.12.3.tar.xz";
-      sha256 = "1z7py6qjrx0j0mya5cmxc0gm1fmjwbkrm0g8916vdlyc4m5vpg9l";
-      name = "poxml-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/poxml-21.04.0.tar.xz";
+      sha256 = "0yhygizd0i6az1pd34lh4ij2x8867svbh2bic9lgcpmqbza9054g";
+      name = "poxml-21.04.0.tar.xz";
     };
   };
   print-manager = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/print-manager-20.12.3.tar.xz";
-      sha256 = "19kwrl95p56zm5g11sws8h4vdc59w694ghhnmrwpyj2qra350dwa";
-      name = "print-manager-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/print-manager-21.04.0.tar.xz";
+      sha256 = "1k5pqh264jy698jdzsk7d6bhadnwvgx1g3rpji06pb0igr1zn820";
+      name = "print-manager-21.04.0.tar.xz";
     };
   };
   rocs = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/rocs-20.12.3.tar.xz";
-      sha256 = "0709qyixnhsrdhkqqkwigmbfnr21rz2yapvmfylmaipdfm0i72wv";
-      name = "rocs-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/rocs-21.04.0.tar.xz";
+      sha256 = "11yzgrmb15zv24pfr3096g9zgsvgdlw43vnbjgbr7s8xvnprlh5l";
+      name = "rocs-21.04.0.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/signon-kwallet-extension-20.12.3.tar.xz";
-      sha256 = "1a7hvkga6sj3sr4qv75n7p9gq44agncs0c7c9k6wni84h3y0icyp";
-      name = "signon-kwallet-extension-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/signon-kwallet-extension-21.04.0.tar.xz";
+      sha256 = "05jaa74j6rd89cj8szfgw5izjlkakbjmz7qiwlswyjd4lafjz65n";
+      name = "signon-kwallet-extension-21.04.0.tar.xz";
     };
   };
   spectacle = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/spectacle-20.12.3.tar.xz";
-      sha256 = "1h29w4ajmgfksdmxanfmb1gdjk4h7hpc2zwiqf0yrq8vm2hhxqjc";
-      name = "spectacle-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/spectacle-21.04.0.tar.xz";
+      sha256 = "0cqf9p7mc5wyl5qy6866m7xhndwmgd3hmw7amkpzngmmz4h9i2p0";
+      name = "spectacle-21.04.0.tar.xz";
     };
   };
   step = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/step-20.12.3.tar.xz";
-      sha256 = "08z2zh8qq46288pddz9p5w10plpd26wgwil92maj6z765dqcxwqn";
-      name = "step-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/step-21.04.0.tar.xz";
+      sha256 = "169ka33nkzrxdk874180v6yzmrngl98gzyql4p5ssmmdh0vrkg25";
+      name = "step-21.04.0.tar.xz";
     };
   };
   svgpart = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/svgpart-20.12.3.tar.xz";
-      sha256 = "1ldkyd7kb8m6zw7siw2rryxzk6v26xc00arwlq1zsy4inbs8idgl";
-      name = "svgpart-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/svgpart-21.04.0.tar.xz";
+      sha256 = "0chfyxl94kp5pif6lzhlm7q8rg9l4lg74x4y04wslrfqcn1gghdj";
+      name = "svgpart-21.04.0.tar.xz";
     };
   };
   sweeper = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/sweeper-20.12.3.tar.xz";
-      sha256 = "12lp9m4sxblwp16dbb6gi1pf0yvav8gh5as1fpfx9kazava3xkhp";
-      name = "sweeper-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/sweeper-21.04.0.tar.xz";
+      sha256 = "1iysxrfdp8bv0vgssv062yllsq4w3jf9vdi66jm9ka8i9w8wqpsv";
+      name = "sweeper-21.04.0.tar.xz";
     };
   };
   umbrello = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/umbrello-20.12.3.tar.xz";
-      sha256 = "0y6kyir86k9cjpmhm4giqfn7g651hfsbl1zq2j2y2nqiisc7vysp";
-      name = "umbrello-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/umbrello-21.04.0.tar.xz";
+      sha256 = "17xwsjc1ph2glscv41x4f5bagw1q5ackqpy1wcg8m9jrg9ipqpqx";
+      name = "umbrello-21.04.0.tar.xz";
     };
   };
   yakuake = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/yakuake-20.12.3.tar.xz";
-      sha256 = "1y151cp5ygkxfd9ar4c38h2c1xwpx8mihh5f2sz6gbykzm3impbx";
-      name = "yakuake-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/yakuake-21.04.0.tar.xz";
+      sha256 = "1jkwcc4pdb06v4q7bnqppdkjf8n8qpfp9mk02l77brnxxf8i9r3b";
+      name = "yakuake-21.04.0.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "20.12.3";
+    version = "21.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.12.3/src/zeroconf-ioslave-20.12.3.tar.xz";
-      sha256 = "1zx7xmj7vj9d39cnnsgb15lbkr8yc81mcqilhq3jfhd3zgp8lrlv";
-      name = "zeroconf-ioslave-20.12.3.tar.xz";
+      url = "${mirror}/stable/release-service/21.04.0/src/zeroconf-ioslave-21.04.0.tar.xz";
+      sha256 = "03cmz3y8f48y26aybyygwssqicp0kz4ry9xm30rvvc5hiv0n6hj7";
+      name = "zeroconf-ioslave-21.04.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/tools/analysis/qcachegrind/default.nix
+++ b/pkgs/development/tools/analysis/qcachegrind/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation {
   postInstall = ''
      mkdir -p $out/bin
      cp -p converters/dprof2calltree $out/bin/dprof2calltree
-     cp -p converters/hotshot2calltree.cmake $out/bin/hotshot2calltree
+     cp -p converters/hotshot2calltree.in $out/bin/hotshot2calltree
      cp -p converters/memprof2calltree $out/bin/memprof2calltree
      cp -p converters/op2calltree $out/bin/op2calltree
      cp -p converters/pprof2calltree $out/bin/pprof2calltree

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -48,7 +48,7 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
   inherit kdeFrameworks plasma5 kdeGear qt5;
 
   # Alias for backwards compatibility. Added 2021-05-07.
-  kdeApplications = lib.warn "kdeApplications was renamed to kdeGear" kdeGear;
+  kdeApplications = kdeGear;
 
   ### LIBRARIES
 

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -47,6 +47,9 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
 
   inherit kdeFrameworks plasma5 kdeGear qt5;
 
+  # Alias for backwards compatibility. Added 2021-05-07.
+  kdeApplications = lib.warn "kdeApplications was renamed to kdeGear" kdeGear;
+
   ### LIBRARIES
 
   accounts-qt = callPackage ../development/libraries/accounts-qt { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -35,17 +35,17 @@ let
     };
   in (lib.makeOverridable mkPlasma5 attrs);
 
-  kdeApplications = let
-    mkApplications = import ../applications/kde;
+  kdeGear = let
+    mkGear = import ../applications/kde;
     attrs = {
       inherit libsForQt5;
       inherit (pkgs) lib fetchurl;
     };
-  in (lib.makeOverridable mkApplications attrs);
+  in (lib.makeOverridable mkGear attrs);
 
-in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeApplications // qt5 // {
+in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
 
-  inherit kdeFrameworks plasma5 kdeApplications qt5;
+  inherit kdeFrameworks plasma5 kdeGear qt5;
 
   ### LIBRARIES
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update KDE Applications 20.12.3 to KDE Gear 21.04.0.
- Change the attribute name from `kdeApplications` to `kdeGear`.

Attn: @NixOS/qt-kde 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
