### PR TITLE
python3Packages.detectron2: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/detectron2/default.nix
+++ b/pkgs/development/python-modules/detectron2/default.nix
@@ -15,7 +15,7 @@
 , pytest
 , torch
 , pyyaml
-, tensorflow-tensorboard
+, tensorboard
 , tqdm
 , which
 }:
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     fvcore
     matplotlib
     pycocotools
-    tensorflow-tensorboard
+    tensorboard
     hydra-core
   ];
 

--- a/pkgs/development/python-modules/detectron2/default.nix
+++ b/pkgs/development/python-modules/detectron2/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, cloudpickle
+, cython
+, fetchFromGitHub
+, fvcore
+, matplotlib
+, pycocotools
+, pydot
+, pytest
+, pytestrunner
+, pytorch
+, pyyaml
+, tensorflow-tensorboard
+, tqdm
+, which
+}:
+
+buildPythonPackage rec {
+  name = "detectron2";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "facebookresearch";
+    repo = "detectron2";
+    rev = "v${version}";
+    sha256 = "0icy7pxgj83bir26z6qfb3wxas45jii4agldwf70my2fngp23qpj";
+  };
+
+  nativeBuildInputs = [
+    which
+  ];
+
+  propagatedBuildInputs = [
+    cython
+    pyyaml
+    pytorch
+    pydot
+    tqdm
+    cloudpickle
+    fvcore
+    matplotlib
+    pycocotools
+    tensorflow-tensorboard
+  ];
+
+  doCheck = false;
+
+  checkInputs = [
+    pytest
+    pytestrunner
+  ];
+
+  meta = with lib; {
+    description = "Facebooks's next-generation platform for object detection, segmentation and other visual recognition tasks";
+    homepage = "https://github.com/facebookresearch/detectron2";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/detectron2/default.nix
+++ b/pkgs/development/python-modules/detectron2/default.nix
@@ -1,14 +1,18 @@
 { lib
 , buildPythonPackage
+, black
 , cloudpickle
 , cython
 , fetchFromGitHub
+, fetchPypi
 , fvcore
+, hydra-core
 , matplotlib
+, omegaconf
+, pybind11
 , pycocotools
 , pydot
 , pytest
-, pytestrunner
 , pytorch
 , pyyaml
 , tensorflow-tensorboard
@@ -18,21 +22,28 @@
 
 buildPythonPackage rec {
   name = "detectron2";
-  version = "0.2.1";
+  version = "0.5";
 
   src = fetchFromGitHub {
     owner = "facebookresearch";
-    repo = "detectron2";
+    repo = name;
     rev = "v${version}";
-    sha256 = "0icy7pxgj83bir26z6qfb3wxas45jii4agldwf70my2fngp23qpj";
+    sha256 = "15fvf38vaxmnf5yhnn0dk9smf9gmkbs3mp1jfpxzxh4s3r05fvgd";
   };
+
+  patchPhase = ''
+    substituteInPlace setup.py --replace "black==21.4b2" "black>=21.4b2"
+  '';
 
   nativeBuildInputs = [
     which
   ];
 
   propagatedBuildInputs = [
+    black
     cython
+    omegaconf
+    pybind11
     pyyaml
     pytorch
     pydot
@@ -42,13 +53,13 @@ buildPythonPackage rec {
     matplotlib
     pycocotools
     tensorflow-tensorboard
+    hydra-core
   ];
 
   doCheck = false;
 
   checkInputs = [
     pytest
-    pytestrunner
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/detectron2/default.nix
+++ b/pkgs/development/python-modules/detectron2/default.nix
@@ -13,7 +13,7 @@
 , pycocotools
 , pydot
 , pytest
-, pytorch
+, torch
 , pyyaml
 , tensorflow-tensorboard
 , tqdm
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     omegaconf
     pybind11
     pyyaml
-    pytorch
+    torch
     pydot
     tqdm
     cloudpickle

--- a/pkgs/development/python-modules/detectron2/default.nix
+++ b/pkgs/development/python-modules/detectron2/default.nix
@@ -22,13 +22,13 @@
 
 buildPythonPackage rec {
   name = "detectron2";
-  version = "0.5";
+  version = "0.6";
 
   src = fetchFromGitHub {
     owner = "facebookresearch";
     repo = name;
     rev = "v${version}";
-    sha256 = "15fvf38vaxmnf5yhnn0dk9smf9gmkbs3mp1jfpxzxh4s3r05fvgd";
+    sha256 = "1w6cgvc8r2lwr72yxicls650jr46nriv1csivp2va9k1km8jx2sf";
   };
 
   patchPhase = ''

--- a/pkgs/development/python-modules/fvcore/default.nix
+++ b/pkgs/development/python-modules/fvcore/default.nix
@@ -14,11 +14,11 @@
 
 buildPythonPackage rec {
   pname = "fvcore";
-  version = "0.1.5.post20210402";
+  version = "0.1.5.post20221221";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0zrb1dhiqdmjs6s36a2wrk4m4hry34zdy27l7rflwzc2q093rmji";
+    hash = "sha256-8vsLuQVyrmUcEceOIEk+0ZsiQFUKfku7LW3oe90DeGA=";
   };
 
   # There's an actual, proper test failure in here. Might blow up later

--- a/pkgs/development/python-modules/fvcore/default.nix
+++ b/pkgs/development/python-modules/fvcore/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchPypi
+, iopath
+, numpy
+, pillow
+, pyyaml
+, tabulate
+, termcolor
+, tqdm
+, yacs
+}:
+
+buildPythonPackage rec {
+  pname = "fvcore";
+  version = "0.1.5.post20210402";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zrb1dhiqdmjs6s36a2wrk4m4hry34zdy27l7rflwzc2q093rmji";
+  };
+
+  # There's an actual, proper test failure in here. Might blow up later
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    numpy
+    yacs
+    pyyaml
+    tqdm
+    termcolor
+    pillow
+    tabulate
+    iopath
+  ];
+
+  meta = with lib; {
+    description = "Collection of common code that's shared among different research projects in FAIR computer vision team";
+    homepage = "https://github.com/facebookresearch/fvcore";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/iopath/default.nix
+++ b/pkgs/development/python-modules/iopath/default.nix
@@ -3,7 +3,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , portalocker
-, pytorch
+, torch
 , tqdm
 }:
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     tqdm
     portalocker
-    pytorch
+    torch
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/iopath/default.nix
+++ b/pkgs/development/python-modules/iopath/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, portalocker
+, pytorch
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "iopath";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "facebookresearch";
+    repo = "iopath";
+    rev = "v${version}";
+    sha256 = "1v79z6rja4q21na31mzs6ff63as8k6gpssi2d0wpikgzk84xva0l";
+  };
+
+  # A few tests do HTTP. One could disable them individually
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    tqdm
+    portalocker
+    pytorch
+  ];
+
+  meta = with lib; {
+    description = "A python library that provides common I/O interface across different storage backends";
+    homepage = "https://github.com/facebookresearch/iopath";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/iopath/default.nix
+++ b/pkgs/development/python-modules/iopath/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "iopath";
-  version = "0.1.8";
+  version = "0.1.9";
 
   src = fetchFromGitHub {
     owner = "facebookresearch";
     repo = "iopath";
     rev = "v${version}";
-    sha256 = "1v79z6rja4q21na31mzs6ff63as8k6gpssi2d0wpikgzk84xva0l";
+    hash = "sha256-Qubf/mWKMgYz9IVoptMZrwy4lQKsNGgdqpJB1j/u5s8=";
   };
 
   # A few tests do HTTP. One could disable them individually

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4919,6 +4919,8 @@ self: super: with self; {
 
   ionhash = callPackage ../development/python-modules/ionhash { };
 
+  iopath = callPackage ../development/python-modules/iopath { };
+
   iotawattpy = callPackage ../development/python-modules/iotawattpy { };
 
   iowait = callPackage ../development/python-modules/iowait { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2464,6 +2464,8 @@ self: super: with self; {
 
   detect-secrets = callPackage ../development/python-modules/detect-secrets { };
 
+  detectron2 = callPackage ../development/python-modules/detectron2 { };
+
   devito = callPackage ../development/python-modules/devito { };
 
   devolo-home-control-api = callPackage ../development/python-modules/devolo-home-control-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3860,6 +3860,8 @@ self: super: with self; {
 
   fuzzywuzzy = callPackage ../development/python-modules/fuzzywuzzy { };
 
+  fvcore = callPackage ../development/python-modules/fvcore { };
+
   fvs = callPackage ../development/python-modules/fvs { };
 
   fx2 = callPackage ../development/python-modules/fx2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4685,9 +4685,9 @@ self: super: with self; {
 
   hy = callPackage ../development/python-modules/hy { };
 
-  hydra-core = callPackage ../development/python-modules/hydra-core { };
-
   hydra-check = callPackage ../development/python-modules/hydra-check { };
+
+  hydra-core = callPackage ../development/python-modules/hydra-core { };
 
   hydrawiser = callPackage ../development/python-modules/hydrawiser { };
 


### PR DESCRIPTION
###### Motivation for this change

**Looking for maintainers!**

I packaged `detectron2` and its dependencies that were not in nixpkgs (`fvcore`, `iopath`, `yacs`) for personal use. I do not want to maintain this though. I open this pull request in the hope that somebody in need will easily find this, and ideally finish what I started.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
