### PR TITLE
treefmt: init at 0.1.1

### DIFF
--- a/pkgs/development/tools/treefmt/default.nix
+++ b/pkgs/development/tools/treefmt/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+rustPlatform.buildRustPackage rec {
+  pname = "treefmt";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "numtide";
+    repo = "treefmt";
+    rev = "v${version}";
+    sha256 = "0a4yikkqppawii1q0kzsxwfp1aid688wa0lixjwfsl279lr69css";
+  };
+
+  cargoSha256 = "08k60gd23yanfraxpbw9hi7jbqgsxz9mv1ci6q9piis5742zlj9s";
+
+  meta = {
+    description = "one CLI to format the code tree";
+    homepage = "https://github.com/numtide/treefmt";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ zimbatm ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/tools/treefmt/default.nix
+++ b/pkgs/development/tools/treefmt/default.nix
@@ -17,6 +17,5 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/numtide/treefmt";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ zimbatm ];
-    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30915,7 +30915,7 @@ in
 
   fac-build = callPackage ../development/tools/build-managers/fac {};
 
-  treefmt = callPackage ../development/tools/treefmt {};
+  treefmt = callPackage ../development/tools/treefmt { };
 
   bottom = callPackage ../tools/system/bottom {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30915,6 +30915,8 @@ in
 
   fac-build = callPackage ../development/tools/build-managers/fac {};
 
+  treefmt = callPackage ../development/tools/treefmt {};
+
   bottom = callPackage ../tools/system/bottom {};
 
   cagebreak = callPackage ../applications/window-managers/cagebreak/default.nix {


### PR DESCRIPTION
###### Motivation for this change

In the long term, format all of nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).