### PR TITLE
gurobi: 8.1.0 -> 9.1.2

### DIFF
--- a/pkgs/applications/science/math/gurobi/default.nix
+++ b/pkgs/applications/science/math/gurobi/default.nix
@@ -17,14 +17,14 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   buildPhase = ''
-    make --directory=src/build
+    make --directory=src/build $makeFlags
   '';
 
   installPhase = ''
     mkdir -p $out/bin
     cp bin/* $out/bin/
     rm $out/bin/gurobi.sh
-    rm $out/bin/python3.7
+    rm $out/bin/python*
 
     cp lib/gurobi.py $out/bin/gurobi.sh
 

--- a/pkgs/applications/science/math/gurobi/default.nix
+++ b/pkgs/applications/science/math/gurobi/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation rec {
   pname = "gurobi";
   version = "9.1.2";
 
-  src = with lib; fetchurl {
-    url = "https://packages.gurobi.com/${versions.majorMinor version}/gurobi${version}_linux64.tar.gz";
+  src = fetchurl {
+    url = "https://packages.gurobi.com/${lib.versions.majorMinor version}/gurobi${version}_linux64.tar.gz";
     sha256 = "7f60bd675f79476bb2b32cd632aa1d470f8246f2b033b7652d8de86f6e7e429b";
   };
 
@@ -17,9 +17,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   buildPhase = ''
-    cd src/build
-    make
-    cd ../..
+    make --directory=src/build
   '';
 
   installPhase = ''

--- a/pkgs/applications/science/math/gurobi/default.nix
+++ b/pkgs/applications/science/math/gurobi/default.nix
@@ -16,9 +16,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  buildPhase = ''
-    make --directory=src/build $makeFlags
-  '';
+  makeFlags = [ "--directory=src/build" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/science/math/gurobi/default.nix
+++ b/pkgs/applications/science/math/gurobi/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     ln -s $out/lib/gurobi-javadoc.jar $out/share/java/
   '';
 
-  passthru.libSuffix = lib.replaceStrings ["."] [""] (lib.versions.majorMinor version);
+  passthru.libSuffix = lib.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor version);
 
   meta = with lib; {
     description = "Optimization solver for mathematical programming";

--- a/pkgs/applications/science/math/gurobi/default.nix
+++ b/pkgs/applications/science/math/gurobi/default.nix
@@ -1,20 +1,20 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook, python2 }:
+{ stdenv, lib, fetchurl, autoPatchelfHook, python3 }:
 
 let
-  majorVersion = "8.1";
+  majorVersion = "9.1";
 in stdenv.mkDerivation rec {
   pname = "gurobi";
-  version = "${majorVersion}.0";
+  version = "${majorVersion}.2";
 
   src = with lib; fetchurl {
     url = "http://packages.gurobi.com/${versions.majorMinor version}/gurobi${version}_linux64.tar.gz";
-    sha256 = "1yjqbzqnq4jjkjm616d36bgd3rmqr0a1ii17n0prpdjzmdlq63dz";
+    sha256 = "7f60bd675f79476bb2b32cd632aa1d470f8246f2b033b7652d8de86f6e7e429b";
   };
 
   sourceRoot = "gurobi${builtins.replaceStrings ["."] [""] version}/linux64";
 
   nativeBuildInputs = [ autoPatchelfHook ];
-  buildInputs = [ (python2.withPackages (ps: [ ps.gurobipy ])) ];
+  buildInputs = [ (python3.withPackages (ps: [ ps.gurobipy ])) ];
 
   strictDeps = true;
 
@@ -27,9 +27,8 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp bin/* $out/bin/
-    rm $out/bin/gurobi.env
     rm $out/bin/gurobi.sh
-    rm $out/bin/python2.7
+    rm $out/bin/python3.7
 
     cp lib/gurobi.py $out/bin/gurobi.sh
 

--- a/pkgs/applications/science/math/gurobi/default.nix
+++ b/pkgs/applications/science/math/gurobi/default.nix
@@ -1,13 +1,11 @@
 { stdenv, lib, fetchurl, autoPatchelfHook, python3 }:
 
-let
-  majorVersion = "9.1";
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "gurobi";
-  version = "${majorVersion}.2";
+  version = "9.1.2";
 
   src = with lib; fetchurl {
-    url = "http://packages.gurobi.com/${versions.majorMinor version}/gurobi${version}_linux64.tar.gz";
+    url = "https://packages.gurobi.com/${versions.majorMinor version}/gurobi${version}_linux64.tar.gz";
     sha256 = "7f60bd675f79476bb2b32cd632aa1d470f8246f2b033b7652d8de86f6e7e429b";
   };
 
@@ -47,7 +45,7 @@ in stdenv.mkDerivation rec {
     ln -s $out/lib/gurobi-javadoc.jar $out/share/java/
   '';
 
-  passthru.libSuffix = lib.replaceStrings ["."] [""] majorVersion;
+  passthru.libSuffix = lib.replaceStrings ["."] [""] (lib.versions.majorMinor version);
 
   meta = with lib; {
     description = "Optimization solver for mathematical programming";

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -1,6 +1,6 @@
-{ python, gurobi }:
+{ buildPythonPackage, python, gurobi }:
 
-python.pkgs.buildPythonPackage {
+buildPythonPackage {
   pname = "gurobipy";
   version = "9.1.2";
   src = gurobi.src;

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -1,5 +1,4 @@
 { lib, fetchurl, python }:
-assert with python.pkgs; isPy27 || isPy36 || isPy37 || isPy38 || isPy39;
 
 python.pkgs.buildPythonPackage rec {
   pname = "gurobipy";

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -1,12 +1,9 @@
-{ lib, fetchurl, python }:
+{ python, gurobi }:
 
-python.pkgs.buildPythonPackage rec {
+python.pkgs.buildPythonPackage {
   pname = "gurobipy";
   version = "9.1.2";
-  src = fetchurl {
-    url = "https://packages.gurobi.com/${lib.versions.majorMinor version}/gurobi${version}_linux64.tar.gz";
-    sha256 = "7f60bd675f79476bb2b32cd632aa1d470f8246f2b033b7652d8de86f6e7e429b";
-  };
+  src = gurobi.src;
   setSourceRoot = "sourceRoot=$(echo gurobi*/*64)";
   patches = [ ./no-clever-setup.patch ];
   postInstall = "mv lib/libgurobi*.so* $out/lib";

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -17,4 +17,11 @@ buildPythonPackage {
       patchelf --set-rpath $out/lib \
         $out/lib/${python.libPrefix}/site-packages/gurobipy/gurobipy.so
     '';
+
+  meta = with lib; {
+    description = "The Gurobi Python interface";
+    homepage = "https://www.gurobi.com";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
 }

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -3,10 +3,15 @@
 buildPythonPackage {
   pname = "gurobipy";
   version = "9.1.2";
+
   src = gurobi.src;
+
   setSourceRoot = "sourceRoot=$(echo gurobi*/*64)";
+
   patches = [ ./no-clever-setup.patch ];
+
   postInstall = "mv lib/libgurobi*.so* $out/lib";
+
   postFixup =
     ''
       patchelf --set-rpath $out/lib \

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, python, gurobi }:
+{ lib, buildPythonPackage, python, gurobi }:
 
 buildPythonPackage {
   pname = "gurobipy";

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -12,11 +12,10 @@ buildPythonPackage {
 
   postInstall = "mv lib/libgurobi*.so* $out/lib";
 
-  postFixup =
-    ''
-      patchelf --set-rpath $out/lib \
-        $out/lib/${python.libPrefix}/site-packages/gurobipy/gurobipy.so
-    '';
+  postFixup = ''
+    patchelf --set-rpath $out/lib \
+      $out/lib/${python.libPrefix}/site-packages/gurobipy/gurobipy.so
+  '';
 
   meta = with lib; {
     description = "The Gurobi Python interface";

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -10,7 +10,9 @@ buildPythonPackage {
 
   patches = [ ./no-clever-setup.patch ];
 
-  postInstall = "mv lib/libgurobi*.so* $out/lib";
+  postInstall = ''
+    mv lib/libgurobi*.so* $out/lib
+  '';
 
   postFixup = ''
     patchelf --set-rpath $out/lib \

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -1,21 +1,19 @@
 { fetchurl, python }:
-assert python.pkgs.isPy27;
+assert with python.pkgs; isPy27 || isPy36 || isPy37 || isPy38 || isPy39;
 
 python.pkgs.buildPythonPackage
   { pname = "gurobipy";
-    version = "7.5.2";
+    version = "9.1.2";
     src = fetchurl
-      { url = "http://packages.gurobi.com/7.5/gurobi7.5.2_linux64.tar.gz";
-        sha256 = "13i1dl22lnmg7z9mb48zl3hy1qnpwdpr0zl2aizda0qnb7my5rnj";
+      { url = "http://packages.gurobi.com/9.1/gurobi9.1.2_linux64.tar.gz";
+        sha256 = "7f60bd675f79476bb2b32cd632aa1d470f8246f2b033b7652d8de86f6e7e429b";
       };
     setSourceRoot = "sourceRoot=$(echo gurobi*/*64)";
     patches = [ ./no-clever-setup.patch ];
-    postInstall = "mv lib/libaes*.so* lib/libgurobi*.so* $out/lib";
+    postInstall = "mv lib/libgurobi*.so* $out/lib";
     postFixup =
       ''
         patchelf --set-rpath $out/lib \
-          $out/lib/python2.7/site-packages/gurobipy/gurobipy.so
-        patchelf --add-needed libaes75.so \
-          $out/lib/python2.7/site-packages/gurobipy/gurobipy.so
+          $out/lib/${python.libPrefix}/site-packages/gurobipy/gurobipy.so
       '';
   }

--- a/pkgs/development/python-modules/gurobipy/linux.nix
+++ b/pkgs/development/python-modules/gurobipy/linux.nix
@@ -1,19 +1,19 @@
-{ fetchurl, python }:
+{ lib, fetchurl, python }:
 assert with python.pkgs; isPy27 || isPy36 || isPy37 || isPy38 || isPy39;
 
-python.pkgs.buildPythonPackage
-  { pname = "gurobipy";
-    version = "9.1.2";
-    src = fetchurl
-      { url = "http://packages.gurobi.com/9.1/gurobi9.1.2_linux64.tar.gz";
-        sha256 = "7f60bd675f79476bb2b32cd632aa1d470f8246f2b033b7652d8de86f6e7e429b";
-      };
-    setSourceRoot = "sourceRoot=$(echo gurobi*/*64)";
-    patches = [ ./no-clever-setup.patch ];
-    postInstall = "mv lib/libgurobi*.so* $out/lib";
-    postFixup =
-      ''
-        patchelf --set-rpath $out/lib \
-          $out/lib/${python.libPrefix}/site-packages/gurobipy/gurobipy.so
-      '';
-  }
+python.pkgs.buildPythonPackage rec {
+  pname = "gurobipy";
+  version = "9.1.2";
+  src = fetchurl {
+    url = "https://packages.gurobi.com/${lib.versions.majorMinor version}/gurobi${version}_linux64.tar.gz";
+    sha256 = "7f60bd675f79476bb2b32cd632aa1d470f8246f2b033b7652d8de86f6e7e429b";
+  };
+  setSourceRoot = "sourceRoot=$(echo gurobi*/*64)";
+  patches = [ ./no-clever-setup.patch ];
+  postInstall = "mv lib/libgurobi*.so* $out/lib";
+  postFixup =
+    ''
+      patchelf --set-rpath $out/lib \
+        $out/lib/${python.libPrefix}/site-packages/gurobipy/gurobipy.so
+    '';
+}

--- a/pkgs/development/python-modules/gurobipy/no-clever-setup.patch
+++ b/pkgs/development/python-modules/gurobipy/no-clever-setup.patch
@@ -1,7 +1,7 @@
 diff -Naur a/setup.py b/setup.py
---- a/setup.py	2017-12-22 10:52:43.730264611 -0500
-+++ b/setup.py	2017-12-22 10:53:27.660104199 -0500
-@@ -15,30 +15,6 @@
+--- a/setup.py	2021-04-24 12:53:18.300255006 -0500
++++ b/setup.py	2021-04-24 12:47:51.619052574 -0500
+@@ -15,29 +15,6 @@
  from distutils.command.install import install
  import os,sys,shutil
  
@@ -13,7 +13,6 @@ diff -Naur a/setup.py b/setup.py
 -    def finalize_options(self):
 -        self.cwd = os.path.dirname(os.path.realpath(__file__))
 -    def run(self):
--        assert os.getcwd() == self.cwd, 'Must be run from setup.py directory: %s' % self.cwd
 -        build_dir = os.path.join(os.getcwd(), "build")
 -        if os.path.exists(build_dir):
 -            print('removing %s' % build_dir)
@@ -32,24 +31,11 @@ diff -Naur a/setup.py b/setup.py
  License = """
      This software is covered by the Gurobi End User License Agreement.
      By completing the Gurobi installation process and using the software,
-@@ -79,20 +55,4 @@
+@@ -78,7 +55,5 @@
        packages = ['gurobipy'],
        package_dir={'gurobipy' : srcpath },
        package_data = {'gurobipy' : [srcfile] },
 -      cmdclass={'install' : GurobiInstall, 
 -                'clean'   : GurobiClean }
        )
--
--if os.name == 'posix' and sys.platform == 'darwin': # update Mac paths
--  verstr = sys.version[:3]
--  default = '/Library/Frameworks/Python.framework/Versions/%s/Python' % verstr
--  default = '/System'+default if verstr == '2.7' else default
--  modified = sys.prefix + '/Python'
--  if default != modified:
--    import subprocess
--    from distutils.sysconfig import get_python_lib
--    sitelib = get_python_lib() + '/gurobipy/gurobipy.so'
--    if not os.path.isfile(modified): # Anaconda
--      libver = verstr if verstr == '2.7' else verstr+'m'
--      modified = sys.prefix + '/lib/libpython%s.dylib' % libver # For Anaconda
--    subprocess.call(('install_name_tool', '-change', default, modified, sitelib))
+ 


### PR DESCRIPTION
###### Motivation for this change
Motivated by the Gurobi.jl Julia package requiring Gurobi version 9.0 or 9.1.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
