### PR TITLE
qhull: 2016.1 -> 2020.2

### DIFF
--- a/pkgs/development/libraries/qhull/default.nix
+++ b/pkgs/development/libraries/qhull/default.nix
@@ -1,13 +1,14 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 
-stdenv.mkDerivation {
-  name = "qhull-2016.1";
+stdenv.mkDerivation rec {
+  pname = "qhull";
+  version = "2020.2";
 
   src = fetchFromGitHub {
     owner = "qhull";
     repo = "qhull";
-    rev = "5bbc75608c817b50383a0c24c3977cc09d0bbfde";
-    sha256 = "0wrgqc2mih7h8fs9v5jcn9dr56afqi9bgh2w9dcvzvzvxizr9kjj";
+    rev = version;
+    sha256 = "sha256-djUO3qzY8ch29AuhY3Bn1ajxWZ4/W70icWVrxWRAxRc=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
useful to fix https://github.com/nix-community/poetry2nix/issues/280.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
