### PR TITLE
python3Packages.homeconnect: init at 0.6.3

### DIFF
--- a/pkgs/development/python-modules/homeconnect/default.nix
+++ b/pkgs/development/python-modules/homeconnect/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, requests_oauthlib
+}:
+
+buildPythonPackage rec {
+  pname = "homeconnect";
+  version = "0.6.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n4h4mi23zw3v6fbkz17fa6kkl5v9bfmj0p57jvfzcfww511y9mn";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    requests_oauthlib
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "homeconnect" ];
+
+  meta = with lib; {
+    description = "Python client for the BSH Home Connect REST API";
+    homepage = "https://github.com/DavidMStraub/homeconnect";
+    changelog = "https://github.com/DavidMStraub/homeconnect/releases/tag/v${version}";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -351,7 +351,7 @@
     "hitron_coda" = ps: with ps; [ ];
     "hive" = ps: with ps; [ ]; # missing inputs: pyhiveapi
     "hlk_sw16" = ps: with ps; [ ]; # missing inputs: hlk-sw16
-    "home_connect" = ps: with ps; [ aiohttp-cors ]; # missing inputs: homeconnect
+    "home_connect" = ps: with ps; [ aiohttp-cors homeconnect ];
     "home_plus_control" = ps: with ps; [ aiohttp-cors homepluscontrol ];
     "homeassistant" = ps: with ps; [ ];
     "homekit" = ps: with ps; [ HAP-python pyqrcode pyturbojpeg aiohttp-cors base36 fnvhash ha-ffmpeg zeroconf ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -267,6 +267,7 @@ in with py.pkgs; buildPythonApplication rec {
     "hddtemp"
     "history"
     "history_stats"
+    "home_connect"
     "home_plus_control"
     "homekit"
     "homekit_controller"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3195,6 +3195,8 @@ in {
 
   homeassistant-pyozw = callPackage ../development/python-modules/homeassistant-pyozw { };
 
+  homeconnect = callPackage ../development/python-modules/homeconnect { };
+
   homematicip = callPackage ../development/python-modules/homematicip { };
 
   homepluscontrol = callPackage ../development/python-modules/homepluscontrol { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/DavidMStraub/homeconnect

This is a Home Assistant dependency.

@ulrikstrid did all the work to get this modules ready. It's a break-out from #119628.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
