### PR TITLE
doc: add instructions for creating package tests

### DIFF
--- a/doc/contributing/coding-conventions.chapter.md
+++ b/doc/contributing/coding-conventions.chapter.md
@@ -512,3 +512,73 @@ If you do need to do create this sort of patch file, one way to do so is with gi
     ```ShellSession
     $ git diff > nixpkgs/pkgs/the/package/0001-changes.patch
     ```
+
+## Package tests {#sec-package-tests}
+
+Tests are important to ensure quality and make reviews and automatic updates easy.
+
+Nix package tests are a lightweight alternative to [NixOS module tests](https://nixos.org/manual/nixos/stable/#sec-nixos-tests). They can be used to create simple integration tests for packages while the module tests are used to test services or programs with a graphical user interface on a NixOS VM. Unittests that are included in the source code of a package should be executed in the `checkPhase`.
+
+### Writing package tests {#ssec-package-tests-writing}
+
+This is an example using the `phoronix-test-suite` package with the current best practices.
+
+Add the tests in `passthru.tests` to the package definition like this:
+
+```nix
+{ stdenv, lib, fetchurl, callPackage }:
+
+stdenv.mkDerivation {
+  …
+
+  passthru.tests = {
+    simple-execution = callPackage ./tests.nix { };
+  };
+
+  meta = { … };
+}
+```
+
+Create `tests.nix` in the package directory:
+
+```nix
+{ runCommand, phoronix-test-suite }:
+
+let
+  inherit (phoronix-test-suite) pname version;
+in
+
+runCommand "${pname}-tests" { meta.timeout = 3; }
+  ''
+    # automatic initial setup to prevent interactive questions
+    ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null
+    # get version of installed program and compare with package version
+    if [[ `${phoronix-test-suite}/bin/phoronix-test-suite version` != *"${version}"*  ]]; then
+      echo "Error: program version does not match package version"
+      exit 1
+    fi
+    # run dummy command
+    ${phoronix-test-suite}/bin/phoronix-test-suite dummy_module.dummy-command >/dev/null
+    # needed for Nix to register the command as successful
+    touch $out
+  ''
+```
+
+### Running package tests {#ssec-package-tests-running}
+
+You can run these tests with:
+
+```ShellSession
+$ cd path/to/nixpkgs
+$ nix-build -A phoronix-test-suite.tests
+```
+
+### Examples of package tests {#ssec-package-tests-examples}
+
+Here are examples of package tests:
+
+- [Jasmin compile test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/jasmin/test-assemble-hello-world/default.nix)
+- [Lobster compile test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/lobster/test-can-run-hello-world.nix)
+- [Spacy annotation test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/spacy/annotation-test/default.nix)
+- [Libtorch test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/science/math/libtorch/test/default.nix)
+- [Multiple tests for nanopb](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/nanopb/default.nix)


### PR DESCRIPTION
###### Motivation for this change

This is a **big milestone** in the effort to add tests to packages that was started by @Profpatsch in 2017 (see [NixCon talk](https://www.youtube.com/watch?v=5Z7IckV6gao&list=PLgknCdxP89ReQzhfKwMYjLdwWsc7us8ns&index=15) ). With documentation, people can actually create tests that can be used to ensure quality and help reviews and automatic updates!

Closes #73076
Closes #27604
Closes #46632

This is not perfect, but better than not having it documented.

I would like to link to better examples, but we don't have them yet. That changes hopefully with this documentation.

This introduces the term "Nix package tests" in addition to "NixOS module tests", or "package tests", "nixos tests", "module tests" for short.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
