### PR TITLE
dovecot_fts_xapian: 1.4.7 -> 1.4.9

### DIFF
--- a/pkgs/servers/mail/dovecot/plugins/fts_xapian/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/fts_xapian/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, autoconf, automake, pkg-config, dovecot, libtool, xapian, icu64 }:
 stdenv.mkDerivation rec {
   pname = "fts-xapian";
-  version = "1.4.7";
+  version = "1.4.9";
 
   src = fetchFromGitHub {
     owner = "grosjo";
     repo = "fts-xapian";
     rev = version;
-    sha256 = "K2d1FFAilIggNuP0e698s+9bN08x2s/0Jryp7pmeixc=";
+    sha256 = "0p4ps9h24vr9bldrcf9cdx6l4rdz5i8zyc58qp10h7cc3jilwddy";
   };
 
   buildInputs = [ dovecot xapian icu64 ];
@@ -28,8 +28,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/grosjo/fts-xapian";
     description = "Dovecot FTS plugin based on Xapian";
-    license = licenses.lgpl21;
-    maintainers = with maintainers; [ julm ];
+    changelog = "https://github.com/grosjo/fts-xapian/releases";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ julm symphorien ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

update

tested with the test suite of simple-nixos-mailserver, also I have been running a close revision for several weeks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
