### PR TITLE
[20.09] libupnp: add patch for CVE-2020-13848

### DIFF
--- a/pkgs/development/libraries/pupnp/CVE-2020-13848.patch
+++ b/pkgs/development/libraries/pupnp/CVE-2020-13848.patch
@@ -1,0 +1,50 @@
+Description: CVE-2020-13848
+ remote attackers to cause a denial of service (crash) via a crafted
+ SSDP message due to a NULL pointer dereference in the functions
+ FindServiceControlURLPath and FindServiceEventURLPath in
+ genlib/service_table/service_table.c
+
+---
+Origin: https://github.com/pupnp/pupnp/commit/c805c1de1141cb22f74c0d94dd5664bda37398e0
+Author: Abhijith PA <abhijith@debian.org>
+Bug: https://github.com/pupnp/pupnp/issues/177
+Bug-Debian: https://bugs.debian.org/962282
+Last-Update: 2020-06-07
+
+--- a/upnp/src/genlib/service_table/service_table.c
++++ b/upnp/src/genlib/service_table/service_table.c
+@@ -299,12 +299,11 @@
+     uri_type parsed_url;
+     uri_type parsed_url_in;
+ 
+-    if( ( table )
+-        &&
+-        ( parse_uri( eventURLPath,
+-                     strlen( eventURLPath ),
+-                     &parsed_url_in ) == HTTP_SUCCESS ) ) {
+-
++    if (!table || !eventURLPath) {
++           return NULL;
++    }
++    if (parse_uri(eventURLPath, strlen(eventURLPath), &parsed_url_in) ==
++        HTTP_SUCCESS) {
+         finger = table->serviceList;
+         while( finger ) {
+             if( finger->eventURL )
+@@ -351,11 +350,11 @@
+     uri_type parsed_url;
+     uri_type parsed_url_in;
+ 
+-    if( ( table )
+-        &&
+-        ( parse_uri
+-          ( controlURLPath, strlen( controlURLPath ),
+-            &parsed_url_in ) == HTTP_SUCCESS ) ) {
++    if (!table || !controlURLPath) {
++           return NULL;
++    }
++    if (parse_uri(controlURLPath, strlen(controlURLPath), &parsed_url_in) ==
++        HTTP_SUCCESS) {
+         finger = table->serviceList;
+         while( finger ) {
+             if( finger->controlURL )

--- a/pkgs/development/libraries/pupnp/default.nix
+++ b/pkgs/development/libraries/pupnp/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
   };
   outputs = [ "dev" "out" ];
 
+  patches = [
+    ./CVE-2020-13848.patch
+  ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   hardeningDisable = [ "fortify" ];


### PR DESCRIPTION
###### Motivation for this change
This is **not** a fix for CVE-2021-29462 as handled for `master` in #120060.

This is a fix for its predecessor https://nvd.nist.gov/vuln/detail/CVE-2020-13848 which allows a network attacker to cause a crash via a null pointer dereference. Patch sourced from debian's `1.6.19+git20160116-1.2+deb9u1` (no, not available via any web link that I can find).

I **haven't** attempted to address CVE-2021-29462 because:

 - Bumping to the fixed 1.14.6 breaks reverse dependencies `amule` and `gmrender-resurrect` as it appears to introduce API changes.
 - Though backporting the patch may be fairly easy, the fix doesn't come with a test and it doesn't appear tremendously easy to test the code in question (it's hard to find downstream packages that actually use its `miniserver` functionality).
 - Being vulnerable to CVE-2021-29462 "merely" means that a upnp server run by pupnp doesn't have a proactive mitigation against being used as the target of a dns rebinding attack on other systems on the network. Arguably for such an attack to be possible there would need to be weaknesses present in other components used on the network.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
