### PR TITLE
python3Packages.smhi-pkg: init at 1.0.14

### DIFF
--- a/pkgs/development/python-modules/smhi-pkg/default.nix
+++ b/pkgs/development/python-modules/smhi-pkg/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "smhi-pkg";
+  version = "1.0.14";
+
+  src = fetchFromGitHub {
+    owner = "joysoftware";
+    repo = "pypi_smhi";
+    rev = version;
+    sha256 = "186xwrg3hvr0hszq2kxvygd241q2sp11gfk6mwj9z4zqywwfcbn3";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Disable tests that needs network access
+    "test_smhi_integration_test"
+    "test_smhi_async_integration_test"
+    "test_smhi_async_integration_test_use_session"
+    "test_smhi_async_get_forecast_integration2"
+    "test_async_error_from_api"
+  ];
+
+  pythonImportsCheck = [ "smhi" ];
+
+  meta = with lib; {
+    description = "Python library for accessing SMHI open forecast data";
+    homepage = "https://github.com/joysoftware/pypi_smhi";
+    changelog = "https://github.com/joysoftware/pypi_smhi/releases/tag/${version}";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -760,7 +760,7 @@
     "smartthings" = ps: with ps; [ aiohttp-cors hass-nabucasa ]; # missing inputs: pysmartapp pysmartthings
     "smarttub" = ps: with ps; [ python-smarttub ];
     "smarty" = ps: with ps; [ ]; # missing inputs: pysmarty
-    "smhi" = ps: with ps; [ ]; # missing inputs: smhi-pkg
+    "smhi" = ps: with ps; [ smhi-pkg ];
     "sms" = ps: with ps; [ python-gammu ];
     "smtp" = ps: with ps; [ ];
     "snapcast" = ps: with ps; [ snapcast ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -356,6 +356,7 @@ in with py.pkgs; buildPythonApplication rec {
     "simulated"
     "sleepiq"
     "sma"
+    "smhi"
     "sensor"
     "slack"
     "smarttub"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7997,6 +7997,8 @@ in {
 
   smdebug-rulesconfig = callPackage ../development/python-modules/smdebug-rulesconfig { };
 
+  smhi-pkg = callPackage ../development/python-modules/smhi-pkg { };
+
   smmap2 = throw "smmap2 has been deprecated, use smmap instead."; # added 2020-03-14
 
   smmap = callPackage ../development/python-modules/smmap { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for accessing SMHI open forecast data

https://github.com/joysoftware/pypi_smhi

This is a Home Assistant dependency.

@ulrikstrid did all the work to get this modules ready. It's a break-out from #119628.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
