### PR TITLE
protoc-gen-go-grpc: init at 1.1.0

### DIFF
--- a/pkgs/development/tools/protoc-gen-go-grpc/default.nix
+++ b/pkgs/development/tools/protoc-gen-go-grpc/default.nix
@@ -1,0 +1,29 @@
+{ buildGoPackage
+, fetchFromGitHub
+, lib
+}:
+
+buildGoPackage rec {
+  pname = "protoc-gen-go-grpc";
+  version = "1.1.0";
+
+  goPackagePath = "google.golang.org/grpc";
+
+  src = fetchFromGitHub {
+    owner = "grpc";
+    repo = "grpc-go";
+    rev = "cmd/protoc-gen-go-grpc/v${version}";
+    sha256 = "14rjb8j6fm07rnns3dpwgkzf3y6rmia6i9n7ns6cldc5mbf7nwi3";
+  };
+
+  subPackages = [ "cmd/protoc-gen-go-grpc" ];
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "The Go language implementation of gRPC. HTTP/2 based RPC";
+    license = licenses.asl20;
+    maintainers = [ maintainers.raboof ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/protoc-gen-go-grpc/deps.nix
+++ b/pkgs/development/tools/protoc-gen-go-grpc/deps.nix
@@ -1,0 +1,333 @@
+# file generated from go.mod using vgo2nix (https://github.com/nix-community/vgo2nix)
+[
+  {
+    goPackagePath = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-cloud-go";
+      rev = "v0.26.0";
+      sha256 = "149v3ci17g6wd2pm18mzcncq5qpl9hwdjnz3rlbn5rfidyn46la1";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/census-instrumentation/opencensus-proto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-instrumentation/opencensus-proto";
+      rev = "v0.2.1";
+      sha256 = "19fcx3sc99i5dsklny6r073z5j20vlwn2xqm6di1q3b1xwchzqfj";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/client9/misspell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/client9/misspell";
+      rev = "v0.3.4";
+      sha256 = "1vwf33wsc4la25zk9nylpbp9px3svlmldkm0bha4hp56jws4q9cs";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/cncf/udpa/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cncf/udpa";
+      rev = "5459f2c99403";
+      sha256 = "0i3al193dsp91j7iywqrm6fr56y2sz51ci4vf19mb3j4n2x44gsi";
+      moduleDir = "go";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.0";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/envoyproxy/go-control-plane";
+    fetch = {
+      type = "git";
+      url = "https://github.com/envoyproxy/go-control-plane";
+      rev = "668b12f5399d";
+      sha256 = "0vmhc8ii081x1k2qw4kji7wjyg6l25zp1y6qxi27wq8m341i4rzb";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/envoyproxy/protoc-gen-validate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/envoyproxy/protoc-gen-validate";
+      rev = "v0.1.0";
+      sha256 = "0kxd3wwh3xwqk0r684hsy281xq4y71cd11d4q2hspcjbnlbwh7cy";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev = "23def4e6c14b";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/mock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/mock";
+      rev = "v1.1.1";
+      sha256 = "0ap8wb6pdl6ccmdb43advjll2ly4sz26wsc3axw0hbrjrybybzgy";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.4.2";
+      sha256 = "0m5z81im4nsyfgarjhppayk4hqnrwswr3nix9mj8pff8x9jvcjqw";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.5.0";
+      sha256 = "04pzp583p6b32y34c6jygfxarff9qjs39rarvfh6467z24sdd9k4";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/uuid";
+      rev = "v1.1.2";
+      sha256 = "1rbpfa0v0ly9sdnixcxhf79swki54ikgm1zkwwkj64p1ws66syqd";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev = "14fe0d1b01d4";
+      sha256 = "0zdmk6rbbx39cvfz0r59v2jg5sg9yd02b4pds5n5llgvivi99550";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.0";
+      sha256 = "19ynspzjdynbi85xw06mh8ad5j0qa1vryvxjgvbnyrr8rbm4vd8w";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.5.1";
+      sha256 = "09r89m1wy4cjv2nps1ykp00qjpi0531r07q3s34hr7m6njk4srkl";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "c2843e01d9a2";
+      sha256 = "01xgxbj5r79nmisdvpq48zfy8pzaaj90bn6ngd4nf33j9ar1dp8r";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/exp";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/exp";
+      rev = "509febef88a4";
+      sha256 = "02isrh39z8znrp5znplzy0dip2gnrl3jm1355raliyvhnhg04j6q";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/lint";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/lint";
+      rev = "d0100b6bd8b3";
+      sha256 = "0b0amr9x4ji66iv9ayfx7zrfx52k1m5g66qfcxkgj80qrb1y2yn7";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "d8887717615a";
+      sha256 = "1wfm6ngxjyj7v5a2dqib6lw8bb2rdnf1kl48diykxjrsddn0s163";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev = "d2e6202438be";
+      sha256 = "0wbn75fd10485nb93bm4kqldqifdim5xqy4v7r5sdvimvf3fyhn7";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "112230192c58";
+      sha256 = "05i2k43j2d0llq768hg5pf3hb2yhfzp9la1w5wp0rsnnzblr0lfn";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "d0b11bdaac8a";
+      sha256 = "18yfsmw622l7gc5sqriv5qmck6903vvhivpzp8i3xfy3z33dybdl";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "2c0ae7006135";
+      sha256 = "1lsi2ssxajclj3bciz2a41v1vjv768ja3v6wnbyhxy8xphwkp4fk";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/xerrors";
+      rev = "9bdfabe68543";
+      sha256 = "1yjfi1bk9xb81lqn85nnm13zz725wazvrx3b50hx19qmwg7a4b0c";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.4.0";
+      sha256 = "06zl7w4sxgdq2pl94wy9ncii6h0z3szl4xpqds0sv3b3wbdlhbnn";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/go-genproto";
+      rev = "cb27e3aa2013";
+      sha256 = "0ml73ghqcwbz7ipfk8fnxb5indcml49b5p7vp1fsyny0abyyrmxf";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/protobuf";
+      rev = "v1.25.0";
+      sha256 = "0apfl42x166dh96zfq5kvv4b4ax9xljik6bq1mnvn2240ir3mc23";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "20d25e280405";
+      sha256 = "0k1m83ji9l1a7ng8a7v40psbymxasmssbrrhpdv2wl4rhs0nc3np";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.2";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "honnef.co/go/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dominikh/go-tools";
+      rev = "ea95bdfd59fc";
+      sha256 = "1763nw7pwpzkvzfnm63dgzcgbq9hwmq5l1nffchnhh77vgkaq4ic";
+      moduleDir = "";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -265,6 +265,8 @@ in
 
   protoc-gen-go = callPackage ../development/tools/protoc-gen-go { };
 
+  protoc-gen-go-grpc = callPackage ../development/tools/protoc-gen-go-grpc { };
+
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };
 
   protoc-gen-twirp_php = callPackage ../development/tools/protoc-gen-twirp_php { };


### PR DESCRIPTION
###### Motivation for this change

Provide the protoc-gen-go-grpc protoc plugin

###### Things done

Using `buildGoModule` did not work for this package, and produced the
error "main module (google.golang.org/grpc) does not contain package
google.golang.org/grpc/cmd/protoc-gen-go-grpc". Since `buildGoModule` and
`buildGoPackage` both seem in common use and both have their advantages
(https://github.com/NixOS/nixpkgs/issues/84826) just using
`buildGoPackage` seems like a reasonable solution here.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).