### PR TITLE
buck: use jdk8

### DIFF
--- a/pkgs/development/tools/build-managers/buck/default.nix
+++ b/pkgs/development/tools/build-managers/buck/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, jdk11, ant, python3, watchman, bash, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, jdk8, ant, python3, watchman, bash, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "buck";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     grep -l -r '/bin/bash' --null | xargs -0 sed -i -e "s!/bin/bash!${bash}/bin/bash!g"
   '';
 
-  nativeBuildInputs = [ makeWrapper python3 jdk11 ant watchman ];
+  nativeBuildInputs = [ makeWrapper python3 jdk8 ant watchman ];
 
   buildPhase = ''
     # Set correct version, see https://github.com/facebook/buck/issues/2607
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D -m755 buck-out/gen/*/programs/buck.pex $out/bin/buck
     wrapProgram $out/bin/buck \
-      --prefix PATH : "${lib.makeBinPath [ jdk11 watchman python3 ]}"
+      --prefix PATH : "${lib.makeBinPath [ jdk8 watchman python3 ]}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
closes #120557

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
