### PR TITLE
subversion: add patch for CVE-2020-17525

### DIFF
--- a/pkgs/applications/version-management/subversion/CVE-2020-17525.patch
+++ b/pkgs/applications/version-management/subversion/CVE-2020-17525.patch
@@ -1,0 +1,15 @@
+Patch included in advisory @ https://subversion.apache.org/security/CVE-2020-17525-advisory.txt
+
+--- a/subversion/libsvn_repos/config_file.c
++++ b/subversion/libsvn_repos/config_file.c
+@@ -237,6 +237,10 @@ get_repos_config(svn_stream_t **stream,
+     {
+       /* Search for a repository in the full path. */
+       repos_root_dirent = svn_repos_find_root_path(dirent, scratch_pool);
++      if (repos_root_dirent == NULL)
++        return svn_error_trace(handle_missing_file(stream, checksum, access,
++                                                   url, must_exist,
++                                                   svn_node_none));
+ 
+       /* Attempt to open a repository at repos_root_dirent. */
+       SVN_ERR(svn_repos_open3(&access->repos, repos_root_dirent, NULL,

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -17,7 +17,7 @@ assert javahlBindings -> jdk != null && perl != null;
 
 let
 
-  common = { version, sha256 }: stdenv.mkDerivation (rec {
+  common = { version, sha256, extraPatches ? [ ] }: stdenv.mkDerivation (rec {
     inherit version;
     pname = "subversion";
 
@@ -35,7 +35,7 @@ let
       ++ lib.optional perlBindings perl
       ++ lib.optional saslSupport sasl;
 
-    patches = [ ./apr-1.patch ];
+    patches = [ ./apr-1.patch ] ++ extraPatches;
 
     # We are hitting the following issue even with APR 1.6.x
     # -> https://issues.apache.org/jira/browse/SVN-4813
@@ -118,5 +118,6 @@ in {
   subversion = common {
     version = "1.12.2";
     sha256 = "0wgpw3kzsiawzqk4y0xgh1z93kllxydgv4lsviim45y5wk4bbl1v";
+    extraPatches = [ ./CVE-2020-17525.patch ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2020-17525
https://subversion.apache.org/security/CVE-2020-17525-advisory.txt

Q: This is master, why not bump?
A: Our "latest" subversion is from the 1.12 series, of which our current version is the last release. To upgrade, we'd have to jump to 1.14, and when we do that I _presume_ we're going to be leaving 1.12 behind anyway as `subversion_1_12` (?).  So we'd still need the patch then. Furthermore, I'd like to leave the 1.14 bump to the maintainer.

Q: What about 1.10?
A: We've already got 1.10.7, which is a fixed version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
