### PR TITLE
python3Packages.pysmartthings: init at 0.7.6, python3Packages.pysmartapp: init at 0.3.3

### DIFF
--- a/pkgs/development/python-modules/pysmartapp/default.nix
+++ b/pkgs/development/python-modules/pysmartapp/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, httpsig
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pysmartapp";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "andrewsayre";
+    repo = pname;
+    rev = version;
+    sha256 = "03wk44siqxl15pa46x5vkg4q0mnga34ir7qn897576z2ivbx7awh";
+  };
+
+  propagatedBuildInputs = [
+    httpsig
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pysmartapp" ];
+
+  meta = with lib; {
+    description = "Python implementation to work with SmartApp lifecycle events";
+    homepage = "https://github.com/andrewsayre/pysmartapp";
+    changelog = "https://github.com/andrewsayre/pysmartapp/releases/tag/${version}";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pysmartthings/default.nix
+++ b/pkgs/development/python-modules/pysmartthings/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pysmartthings";
+  version = "0.7.6";
+
+  src = fetchFromGitHub {
+    owner = "andrewsayre";
+    repo = pname;
+    rev = version;
+    sha256 = "0m91lfzdbmq6qv6bihd278psi9ghldxpa1d0dsbii2zf338188qj";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pysmartthings" ];
+
+  meta = with lib; {
+    description = "Python library for interacting with the SmartThings cloud API";
+    homepage = "https://github.com/andrewsayre/pysmartthings";
+    changelog = "https://github.com/andrewsayre/pysmartthings/releases/tag/${version}";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -757,7 +757,7 @@
     "smappee" = ps: with ps; [ aiohttp-cors pysmappee ];
     "smart_meter_texas" = ps: with ps; [ ]; # missing inputs: smart-meter-texas
     "smarthab" = ps: with ps; [ ]; # missing inputs: smarthab
-    "smartthings" = ps: with ps; [ aiohttp-cors hass-nabucasa ]; # missing inputs: pysmartapp pysmartthings
+    "smartthings" = ps: with ps; [ aiohttp-cors hass-nabucasa pysmartapp pysmartthings ];
     "smarttub" = ps: with ps; [ python-smarttub ];
     "smarty" = ps: with ps; [ ]; # missing inputs: pysmarty
     "smhi" = ps: with ps; [ ]; # missing inputs: smhi-pkg

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -358,6 +358,7 @@ in with py.pkgs; buildPythonApplication rec {
     "sma"
     "sensor"
     "slack"
+    "smartthings"
     "smarttub"
     "smtp"
     "smappee"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6518,6 +6518,8 @@ in {
 
   pysmartapp = callPackage ../development/python-modules/pysmartapp { };
 
+  pysmartthings = callPackage ../development/python-modules/pysmartthings { };
+
   pysmb = callPackage ../development/python-modules/pysmb { };
 
   pysmbc = callPackage ../development/python-modules/pysmbc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6514,9 +6514,11 @@ in {
 
   pysmappee = callPackage ../development/python-modules/pysmappee { };
 
-  pysmb = callPackage ../development/python-modules/pysmb { };
-
   pysmart-smartx = callPackage ../development/python-modules/pysmart-smartx { };
+
+  pysmartapp = callPackage ../development/python-modules/pysmartapp { };
+
+  pysmb = callPackage ../development/python-modules/pysmb { };
 
   pysmbc = callPackage ../development/python-modules/pysmbc { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Python library for interacting with the SmartThings cloud API
- Python implementation to work with SmartApp lifecycle events

Those are a Home Assistant dependency.

@ulrikstrid did all the work to get this modules ready. It's a break-out from #119628.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
