### PR TITLE
stlink: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/development/tools/misc/stlink/default.nix
+++ b/pkgs/development/tools/misc/stlink/default.nix
@@ -9,25 +9,22 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "stlink";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
-    owner = "texane";
+    owner = "stlink-org";
     repo = "stlink";
     rev = "v${version}";
-    sha256 = "1mlkrxjxg538335g59hjb0zc739dx4mhbspb26z5gz3lf7d4xv6x";
+    sha256 = "03xypffpbp4imrczbxmq69vgkr7mbp0ps9dk815br5wwlz6vgygl";
   };
 
   buildInputs = [ libusb1' ];
   nativeBuildInputs = [ cmake ];
-  patchPhase = ''
-    sed -i 's@/etc/udev/rules.d@$ENV{out}/etc/udev/rules.d@' CMakeLists.txt
-    sed -i 's@/etc/modprobe.d@$ENV{out}/etc/modprobe.d@' CMakeLists.txt
-  '';
-  preInstall = ''
-    mkdir -p $out/etc/udev/rules.d
-    mkdir -p $out/etc/modprobe.d
-  '';
+
+  cmakeFlags = [
+    "-DSTLINK_MODPROBED_DIR=${placeholder "out"}/etc/modprobe.d"
+    "-DSTLINK_UDEV_RULES_DIR=${placeholder "out"}/lib/udev/rules.d"
+  ];
 
   meta = with lib; {
     description = "In-circuit debug and programming for ST-Link devices";


### PR DESCRIPTION
###### Motivation for this change
new release supports my stlink v3 mini

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - Result of `nixpkgs-review pr 120570` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
    - <details><summary>1 package built:</summary>
      <ul>
        <li>stlink</li>
      </ul>
    </details>
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/cj0478xkd1d8yashwafhy0vscf714qkp-stlink-1.6.0	   87538528`
  - `/nix/store/hb4a42hf45xjdk9vzxg4llr74dx5a9yk-stlink-1.7.0	   87769408`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
