### PR TITLE
RFC: nixos/borgbackup: run as DynamicUser

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -672,6 +672,25 @@
           <literal>yambar-wayland</literal> if you are on wayland.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>borgbackup</literal> module now runs its backup
+          job with an unprivileged, dynamic user allocation, as opposed
+          to root, if no explicit
+          <link xlink:href="options.html#opt-services.borgbackup.jobs.&lt;name&gt;.user"><literal>services.borgbackup.jobs.&lt;name&gt;.user</literal></link>
+          was set. This is possible by equipping the service with a
+          capability (<literal>CAP_DAC_READ_SEARCH</literal>) that lets
+          it bypass filesystem permission checks. Its pre- and
+          post-hooks now run in <literal>ExecStartPre</literal> and
+          <literal>ExecStopPost</literal> respectively, and are not part
+          of the primary backup script anymore. They are still run as
+          root, so that certain tasks (e.g. creating snapshots) still
+          work. If you relied on the <literal>exitStatus</literal>
+          variable in your post-hook you now need to migrate to the
+          systemd provided <literal>EXIT_CODE</literal> variable
+          instead.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -168,6 +168,9 @@ pt-services.clipcat.enable).
 
 - The `yambar` package has been split into `yambar` and `yambar-wayland`, corresponding to the xorg and wayland backend respectively. Please switch to `yambar-wayland` if you are on wayland.
 
+- The `borgbackup` module now runs its backup job with an unprivileged, dynamic user allocation, as opposed to root, if no explicit [`services.borgbackup.jobs.<name>.user`](options.html#opt-services.borgbackup.jobs.<name>.user) was set. This is possible by equipping the service with a capability (`CAP_DAC_READ_SEARCH`) that lets it bypass filesystem permission checks.
+  Its pre- and post-hooks now run in `ExecStartPre` and `ExecStopPost` respectively, and are not part of the primary backup script anymore. They are still run as root, so that certain tasks (e.g. creating snapshots) still work. If you relied on the `exitStatus` variable in your post-hook you now need to migrate to the systemd provided `EXIT_CODE` variable instead.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 - The setting [`services.openssh.logLevel`](options.html#opt-services.openssh.logLevel) `"VERBOSE"` `"INFO"`. This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There should not be the need to run our favorite backup tool as root.
Why don't we execute it as a DynamicUser and give it permissions to
bypass discrectionary access control.

```
       CAP_DAC_READ_SEARCH
              * Bypass file read permission checks and directory read
                and execute permission checks;
              * invoke open_by_handle_at(2);
              * use the linkat(2) AT_EMPTY_PATH flag to create a link to
                a file referred to by a file descriptor.
```
*capabitilies(7)*

This would still be a reduced surface area, than what we have today.

Instead of embedding the pre and post hook into the backup script we
move them to ExecStartPre and ExecStopPost and grant them full
privileges, so they can still achieve tasks like create and delete
snapshots. They are short running scripts and have less surface area
than the whole of borgbackup.

This doesn't come without breaking changes. The `archiveName` could
previously be passed in the `preHook` option, but that will stop working
as soon as we move the hooks into their own scripts. We could alleviate
this problem by setting up an explicit `archiveName` option, that is
being passed into the main backup script.

There is currently also the issue, that the `local` nixos tests job will
not run, because borgbackup cannot write to the local backup location.
This could be fixed by adding the location to `readWritePaths`, but
first we would have to determine if it was actually a local path, and
not a remote one.

Also some users might already have configured borgbackup to have more
constrained user and group settings, so I could imagine this could
extend the permission of those jobs. But I think this could be a
more secure default for most people.

The whole idea apparently isn't new, it came up over at the borg-
backup upstream issue tracker back in 2017.

https://github.com/borgbackup/borg/issues/2125

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
