### PR TITLE
gptman: init at 0.8.0

### DIFF
--- a/pkgs/tools/system/gptman/default.nix
+++ b/pkgs/tools/system/gptman/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gptman";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "cecton";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "11zyjrw4f8gi5s4sd2kl3sdiz0avq7clr8zqnwl04y61b3fpg7y1";
+  };
+
+  cargoSha256 = "1cp8cyrd7ab8r2j28b69c2p3ysix5b9hpsqk07cmzgqwwml0qj12";
+
+  meta = with lib; {
+    description = "A CLI tool for Linux to copy a partition from one disk to another and more.";
+    homepage = "https://github.com/cecton/gptman";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ akshgpt7 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5151,6 +5151,8 @@ in
 
   gpt2tc = callPackage ../tools/text/gpt2tc { };
 
+  gptman = callPackage ../tools/system/gptman { };
+
   ldmtool = callPackage ../tools/misc/ldmtool { };
 
   gphotos-sync = callPackage ../tools/backup/gphotos-sync { };


### PR DESCRIPTION
###### Motivation for this change
`gptman` is a GPT manager that allows you to copy partitions from one disk to another and more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
