### PR TITLE
ffmpeg: add support for libsrt

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     # Build flags
       "--enable-shared"
       (ifMinVer "0.6" "--enable-pic")
-      (enableFeature (srt != null) "libsrt")
+      (ifMinVer "4.0" (enableFeature (srt != null) "libsrt"))
       (enableFeature runtimeCpuDetectBuild "runtime-cpudetect")
       "--enable-hardcoded-tables"
     ] ++

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -2,6 +2,7 @@
 , alsaLib, bzip2, fontconfig, freetype, gnutls, libiconv, lame, libass, libogg
 , libssh, libtheora, libva, libdrm, libvorbis, libvpx, xz, libpulseaudio, soxr
 , x264, x265, xvidcore, zlib, libopus, speex, nv-codec-headers, dav1d
+, srt ? null
 , openglSupport ? false, libGLU ? null, libGL ? null
 , libmfxSupport ? false, intel-media-sdk ? null
 , libaomSupport ? false, libaom ? null
@@ -94,6 +95,7 @@ stdenv.mkDerivation rec {
     # Build flags
       "--enable-shared"
       (ifMinVer "0.6" "--enable-pic")
+      (enableFeature (srt != null) "libsrt")
       (enableFeature runtimeCpuDetectBuild "runtime-cpudetect")
       "--enable-hardcoded-tables"
     ] ++
@@ -171,7 +173,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     bzip2 fontconfig freetype gnutls libiconv lame libass libogg libssh libtheora
-    libvorbis xz soxr x264 x265 xvidcore zlib libopus speex nv-codec-headers
+    libvorbis xz soxr x264 x265 xvidcore zlib libopus speex srt nv-codec-headers
   ] ++ optionals openglSupport [ libGL libGLU ]
     ++ optional libmfxSupport intel-media-sdk
     ++ optional libaomSupport libaom


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Applications like `mpv` and `obs-studio` require srt support in ffmpeg in order to listen/call on the srt (secure reliable transport) protocol.

Rather than have `obs-studio` and `mpv` pull in `ffmpeg-full` where this is enabled by default via https://github.com/NixOS/nixpkgs/pull/91697/commits/47801afc3d342907fc00ea4467d23af636c4a3c, we should simply enable srt by default in the base ffmpeg. 

There are probably other applications that require srt at runtime that go unmentioned, this will only grow in the future.

Based upon: https://github.com/NixOS/nixpkgs/commit/47801afc3d342907fc00ea4467d23af636c4a3c4
Relates to: https://github.com/NixOS/nixpkgs/pull/116173

## Test my changes 

This will compile mpv, with my ffmpeg changes and succeed when ran.
`nix run github:matthewcroughan/nixpkgs/ffmpeg-srt#mpv-unwrapped -- 'srt://0.0.0.0:9000?mode=listener'`

Whereas, this will use the master branch hash at the time of writing and will fail when ran, as ffmpeg doesn't have srt enabled.
`nix run github:nixos/nixpkgs/1fe6ed37fd9beb92afe90671c0c2a662a03463dd#mpv-unwrapped -- 'srt://0.0.0.0:9000?mode=listener'`

##### Example of failure
```
❯ sudo nix --builders ssh://matthew@swordfish run nixpkgs#mpv-unwrapped -- 'srt://0.0.0.0:9000?mode=listener'
[ffmpeg] Protocol not found. Make sure ffmpeg/Libav is compiled with networking support.
Failed to open srt://0.0.0.0:9000?mode=listener.
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
