### PR TITLE
texlive: Refactors toward working texdoc

### DIFF
--- a/doc/languages-frameworks/texlive.section.md
+++ b/doc/languages-frameworks/texlive.section.md
@@ -8,17 +8,17 @@ Since release 15.09 there is a new TeX Live packaging that lives entirely under 
 - It typically won't work to use separately installed packages together. Instead, you can build a custom set of packages like this:
 
   ```nix
-  texlive.combine {
-    inherit (texlive) scheme-small collection-langkorean algorithms cm-super;
+  texlive.buildTexliveCombinedEnv {
+    inherit (texlive.texlivePackages) scheme-small collection-langkorean algorithms cm-super;
   }
   ```
 
 - There are all the schemes, collections and a few thousand packages, as defined upstream (perhaps with tiny differences).
-- By default you only get executables and files needed during runtime, and a little documentation for the core packages. To change that, you need to add `pkgFilter` function to `combine`.
+- By default you only get executables and files needed during runtime, and a little documentation for the core packages. To change that, you need to add `pkgFilter` function to `buildTexliveCombinedEnv`.
 
   ```nix
-  texlive.combine {
-    # inherit (texlive) whatever-you-want;
+  texlive.buildTexliveCombinedEnv {
+    # inherit (texlive.texlivePackages) whatever-you-want;
     pkgFilter = pkg:
       pkg.tlType == "run" || pkg.tlType == "bin" || pkg.pname == "cm-super";
     # elem tlType [ "run" "bin" "doc" "source" ]
@@ -31,7 +31,7 @@ Since release 15.09 there is a new TeX Live packaging that lives entirely under 
   ```ShellSession
   $ nix repl
   nix-repl> :l <nixpkgs>
-  nix-repl> texlive.collection-[TAB]
+  nix-repl> texlive.texlivePackages.collection-[TAB]
   ```
 
 - Note that the wrapper assumes that the result has a chance to be useful. For example, the core executables should be present, as well as some core data files. The supported way of ensuring this is by including some scheme, for example `scheme-basic`, into the combination.
@@ -103,8 +103,8 @@ let
   };
   foiltex = { pkgs = [ foiltex_run ]; };
 
-  latex_with_foiltex = texlive.combine {
-    inherit (texlive) scheme-small;
+  latex_with_foiltex = texlive.buildTexliveCombinedEnv {
+    inherit (texlive.texlivePackages) scheme-small;
     inherit foiltex;
   };
 in

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -217,8 +217,24 @@ rec {
         };
     in self;
 
-  /* Like the above, but aims to support cross compilation. It's still ugly, but
-     hopefully it helps a little bit. */
+  /* Like `makeScope`, but with a non-deprecated `overrideScope`.
+     A bridge between original `makeScope` and `makeScopeWithSplicing`.
+  */
+  makeScope' = newScope: f:
+    let
+      self = f self // {
+        newScope = scope: newScope (self // scope);
+        callPackage = self.newScope {};
+        overrideScope = g: makeScope'
+          newScope
+          (lib.fixedPoints.extends g f);
+        packages = f;
+      };
+    in self;
+
+  /* Like `makeScope'`, but aims to support cross compilation.
+     It's still ugly, but hopefully it helps a little bit.
+  */
   makeScopeWithSplicing = splicePackages: newScope: otherSplices: keep: f:
     let
       spliced = splicePackages {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -101,7 +101,7 @@ let
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (self.customisation) overrideDerivation makeOverridable
       callPackageWith callPackagesWith extendDerivation hydraJob
-      makeScope makeScopeWithSplicing;
+      makeScope makeScope' makeScopeWithSplicing;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio
       hiPrioSet;

--- a/pkgs/applications/misc/gummi/default.nix
+++ b/pkgs/applications/misc/gummi/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     glib gtksourceview3 gtk3 gtkspell3 poppler
-    texlive.bin.core # needed for synctex
+    texlive.texliveBin.core # needed for synctex
   ];
 
   postInstall = ''

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk girara libintl sqlite glib file librsvg
-    texlive.bin.core
+    texlive.texliveBin.core
   ] ++ optional stdenv.isLinux libseccomp
     ++ optional stdenv.isDarwin gtk-mac-integration;
 

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -40,6 +40,9 @@ lib.makeOverridable
 , nativeBuildInputs ? [] # Handy e.g. if using makeWrapper in `postBuild`.
 , buildInputs ? []
 
+, preferLocalBuild ? true
+, allowSubstitutes ? false
+
 , passthru ? {}
 , meta ? {}
 }:
@@ -55,7 +58,8 @@ runCommand name
   rec {
     inherit manifest ignoreCollisions checkCollisionContents passthru
             meta pathsToLink extraPrefix postBuild
-            nativeBuildInputs buildInputs;
+            nativeBuildInputs buildInputs
+            preferLocalBuild allowSubstitutes;
     pkgs = builtins.toJSON (map (drv: {
       paths =
         # First add the usual output(s): respect if user has chosen explicitly,
@@ -71,8 +75,6 @@ runCommand name
           (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
       priority = drv.meta.priority or 5;
     }) paths);
-    preferLocalBuild = true;
-    allowSubstitutes = false;
     # XXX: The size is somewhat arbitrary
     passAsFile = if builtins.stringLength pkgs >= 128*1024 then [ "pkgs" ] else [ ];
   }

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
     pango
     poppler
     t1lib
-    texlive.bin.core # kpathsea for DVI support
+    texlive.texliveBin.core # kpathsea for DVI support
   ] ++ lib.optional supportXPS libgxps
     ++ lib.optionals supportMultimedia (with gst_all_1; [
       gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav ]);

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     mate.caja
     mate.mate-desktop
     hicolor-icon-theme
-    texlive.bin.core  # for synctex, used by the pdf back-end
+    texlive.texliveBin.core  # for synctex, used by the pdf back-end
   ]
   ++ optionals enableDjvu [ djvulibre ]
   ++ optionals enableEpub [ webkitgtk ]

--- a/pkgs/development/libraries/physics/rivet/default.nix
+++ b/pkgs/development/libraries/physics/rivet/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-N+3ICilozhAxWJ5DumtJKHfKeQG+o4+Lt1NqXIz4EA0=";
   };
 
-  latex = texlive.combine { inherit (texlive)
+  latex = texlive.buildTexliveCombinedEnv { inherit (texlive.texlivePackages)
     scheme-basic
     collection-pstricks
     collection-fontsrecommended

--- a/pkgs/development/python-modules/dot2tex/default.nix
+++ b/pkgs/development/python-modules/dot2tex/default.nix
@@ -28,8 +28,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pyparsing ];
 
   checkInputs = [
-    (texlive.combine {
-      inherit (texlive) scheme-small preview pstricks;
+    (texlive.buildTexliveCombinedEnv {
+      inherit (texlive.texlivePackages) scheme-small preview pstricks;
     })
   ];
 

--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -46,8 +46,8 @@ let
   versionToName = version: "dwarf-fortress_${lib.replaceStrings ["."] ["_"] version}";
 
   dwarf-therapist-original = pkgs.qt5.callPackage ./dwarf-therapist {
-    texlive = pkgs.texlive.combine {
-      inherit (pkgs.texlive) scheme-basic float caption wrapfig adjmulticol sidecap preprint enumitem;
+    texlive = pkgs.texlive.buildTexliveCombinedEnv {
+      inherit (pkgs.texlive.texlivePackages) scheme-basic float caption wrapfig adjmulticol sidecap preprint enumitem;
     };
   };
 

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -2,8 +2,8 @@
 , python3, gettext, flex, perl, bison, pkg-config, autoreconfHook, dblatex
 , fontconfig, freetype, pango, fontforge, help2man, zip, netpbm, groff
 , makeWrapper, t1utils
-, texlive, tex ? texlive.combine {
-    inherit (texlive) scheme-small lh metafont epsf;
+, texlive, tex ? texlive.buildTexliveCombinedEnv {
+    inherit (texlive.texlivePackages) scheme-small lh metafont epsf;
   }
 }:
 

--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -1,9 +1,13 @@
 { runCommandNoCC, fetchurl, file, texlive, writeShellScript }:
 
+let
+  inherit (texlive) buildTexliveCombinedEnv;
+  tl = texlive.texlivePackages;
+in
 {
   chktex = runCommandNoCC "texlive-test-chktex" {
     nativeBuildInputs = [
-      (with texlive; combine { inherit scheme-infraonly chktex; })
+      (buildTexliveCombinedEnv { inherit (tl) scheme-infraonly chktex; })
     ];
     input = builtins.toFile "chktex-sample.tex" ''
       \documentclass{article}
@@ -40,7 +44,7 @@
 
   # test dvipng's limited capability to render postscript specials via GS
   dvipng.ghostscript = runCommandNoCC "texlive-test-ghostscript" {
-    nativeBuildInputs = [ file (with texlive; combine { inherit scheme-small dvipng; }) ];
+    nativeBuildInputs = [ file (buildTexliveCombinedEnv { inherit (tl) scheme-small dvipng; }) ];
     input = builtins.toFile "postscript-sample.tex" ''
       \documentclass{minimal}
       \begin{document}

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -31,7 +31,7 @@ in
 
   buildInputs =
     [ cairo gd libcerf pango readline zlib ]
-    ++ lib.optional withTeXLive (texlive.combine { inherit (texlive) scheme-small; })
+    ++ lib.optional withTeXLive (texlive.combined.scheme-small)
     ++ lib.optional withLua lua
     ++ lib.optionals withX [ libX11 libXpm libXt libXaw ]
     ++ lib.optionals withQt [ qtbase qtsvg ]

--- a/pkgs/tools/typesetting/tex/dblatex/default.nix
+++ b/pkgs/tools/typesetting/tex/dblatex/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchurl, python3, libxslt, texlive
 , enableAllFeatures ? false, imagemagick ? null, transfig ? null, inkscape ? null, fontconfig ? null, ghostscript ? null
 
-, tex ? texlive.combine { # satisfy all packages that ./configure mentions
-    inherit (texlive) scheme-basic epstopdf anysize appendix changebar
+, tex ? texlive.buildTexliveCombinedEnv { # satisfy all packages that ./configure mentions
+    inherit (texlive.texlivePackages) scheme-basic epstopdf anysize appendix changebar
       fancybox fancyvrb float footmisc listings jknapltx/*for mathrsfs.sty*/
       multirow overpic pdfpages pdflscape graphics stmaryrd subfigure titlesec wasysym
       # pkgs below don't seem requested by dblatex, but our manual fails without them

--- a/pkgs/tools/typesetting/tex/mftrace/default.nix
+++ b/pkgs/tools/typesetting/tex/mftrace/default.nix
@@ -42,11 +42,11 @@ let self = stdenv.mkDerivation rec {
     wrapProgram $out/bin/mftrace --prefix PATH : ${lib.makeBinPath buildInputs}
   '';
 
-  # experimental texlive.combine support
+  # experimental texlive.buildTexliveCombinedEnv support
   # (note that only the bin/ folder will be combined into texlive)
   passthru.tlType = "bin";
   passthru.pkgs = [ self ] ++
-    (with texlive; kpathsea.pkgs ++ t1utils.pkgs ++ metafont.pkgs);
+    (let tl = texlive.texlivePackages; in tl.kpathsea.pkgs ++ tl.t1utils.pkgs ++ tl.metafont.pkgs);
 
   meta = with lib; {
     description = "Scalable PostScript Fonts for MetaFont";

--- a/pkgs/tools/typesetting/tex/nix/default.nix
+++ b/pkgs/tools/typesetting/tex/nix/default.nix
@@ -17,9 +17,9 @@ rec {
     assert generatePDF -> !generatePS;
 
     let
-      tex = pkgs.texlive.combine
+      tex = pkgs.texlive.buildTexliveCombinedEnv
         # always include basic stuff you need for LaTeX
-        ({inherit (pkgs.texlive) scheme-basic;} // texPackages);
+        ({inherit (pkgs.texlive.texlivePackages) scheme-basic;} // texPackages);
     in
 
     pkgs.stdenv.mkDerivation {

--- a/pkgs/tools/typesetting/tex/texlive/UPGRADING.md
+++ b/pkgs/tools/typesetting/tex/texlive/UPGRADING.md
@@ -1,8 +1,8 @@
 # Notes on maintaining/upgrading
 
-## Upgrading texlive.bin
+## Upgrading texlive.texliveBin
 
-texlive contains a few binaries, defined in bin.nix and released once a year.
+texlive contains a few binaries, defined in `bin.nix` and released once a year.
 
 In order to reduce closure size for users who just need a few of them, we split it into
 packages such as core, core-big, xvdi, etc. This requires making assumptions
@@ -12,13 +12,13 @@ you upgrade you may have to do some work here.
 
 ## Updating the package set
 
-texlive contains several thousand packages from CTAN, defined in pkgs.nix.
+texlive contains several thousand packages from CTAN, defined in `pkgs.nix`.
 
 The CTAN mirrors are not version-controlled and continuously moving,
 with more than 100 updates per month.
 
-To create a consistent and reproducible package set in nixpkgs, we snapshot CTAN
-and generate nix expressions for all packages in texlive at that point.
+To create a consistent and reproducible package set in Nixpkgs, we snapshot CTAN
+and generate Nix expressions for all packages in texlive at that point.
 
 We mirror CTAN sources of this snapshot on community-operated servers and on IPFS.
 
@@ -35,8 +35,8 @@ See https://tug.org/texlive/acquire-mirror.html for instructions.
 
 
 ```bash
-curl -L http://mirror.ctan.org/tex-archive/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz \
-         | xzcat | uniq -u | sed -rn -f ./tl2nix.sed > ./pkgs.nix
+curl -L "https://mirror.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz" \
+        | xzcat | uniq -u | sed -rn -f ./tl2nix.sed > ./pkgs.nix
 ```
 
 This will download a current snapshot of the CTAN package database `texlive.tlpdb.xz`

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -6,7 +6,7 @@
 , brotli, cairo, pixman, xorg, clisp, biber, woff2, xxHash
 , makeWrapper, shortenPerlShebang
 # texlive
-, combine, texlivePackages
+, buildTexliveCombinedEnv, texlivePackages
 }:
 
 # Useful resource covering build options:
@@ -446,7 +446,7 @@ xindy = stdenv.mkDerivation {
 
   nativeBuildInputs = [
     pkg-config perl
-    (combine { inherit (tl) scheme-basic cyrillic ec; })
+    (buildTexliveCombinedEnv { inherit (tl) scheme-basic cyrillic ec; })
   ];
   buildInputs = [ clisp libiconv ];
 

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -1,17 +1,19 @@
 { lib, stdenv, fetchurl
-, texlive
 , zlib, libiconv, libpng, libX11
 , freetype, gd, libXaw, icu, ghostscript, libXpm, libXmu, libXext
 , perl, perlPackages, python3Packages, pkg-config
 , poppler, libpaper, graphite2, zziplib, harfbuzz, potrace, gmp, mpfr
 , brotli, cairo, pixman, xorg, clisp, biber, woff2, xxHash
 , makeWrapper, shortenPerlShebang
+# texlive
+, combine, texlivePackages
 }:
 
 # Useful resource covering build options:
 # http://tug.org/texlive/doc/tlbuild.html
 
 let
+  tl = texlivePackages;
   withSystemLibs = map (libname: "--with-system-${libname}");
 
   year = "2020";
@@ -291,7 +293,7 @@ latexindent = perlPackages.buildPerlPackage rec {
   pname = "latexindent";
   inherit (src) version;
 
-  src = lib.head (builtins.filter (p: p.tlType == "run") texlive.latexindent.pkgs);
+  src = lib.head (builtins.filter (p: p.tlType == "run") tl.latexindent.pkgs);
 
   outputs = [ "out" ];
 
@@ -322,7 +324,7 @@ pygmentex = python3Packages.buildPythonApplication rec {
   pname = "pygmentex";
   inherit (src) version;
 
-  src = lib.head (builtins.filter (p: p.tlType == "run") texlive.pygmentex.pkgs);
+  src = lib.head (builtins.filter (p: p.tlType == "run") tl.pygmentex.pkgs);
 
   propagatedBuildInputs = with python3Packages; [ pygments chardet ];
 
@@ -358,7 +360,7 @@ pygmentex = python3Packages.buildPythonApplication rec {
 texlinks = stdenv.mkDerivation rec {
   name = "texlinks.sh";
 
-  src = lib.head (builtins.filter (p: p.tlType == "run") texlive.texlive-scripts-extra.pkgs);
+  src = lib.head (builtins.filter (p: p.tlType == "run") tl.texlive-scripts-extra.pkgs);
 
   dontBuild = true;
   doCheck = false;
@@ -444,7 +446,7 @@ xindy = stdenv.mkDerivation {
 
   nativeBuildInputs = [
     pkg-config perl
-    (texlive.combine { inherit (texlive) scheme-basic cyrillic ec; })
+    (combine { inherit (tl) scheme-basic cyrillic ec; })
   ];
   buildInputs = [ clisp libiconv ];
 

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -41,7 +41,7 @@ let
   mkUniqueOutPaths = pkgs: uniqueStrings
     (map (p: p.outPath) (builtins.filter lib.isDerivation pkgs));
 
-in (buildEnv {
+in buildEnv {
   name = "texlive-${extraName}-${texliveBin.texliveYear}${extraVersion}";
 
   extraPrefix = "/share/texmf";
@@ -52,6 +52,8 @@ in (buildEnv {
     "/"
     "/tex/generic/config" # make it a real directory for scheme-infraonly
   ];
+
+  allowSubstitutes = true;
 
   buildInputs = [ makeWrapper ] ++ pkgList.extraInputs;
 
@@ -279,6 +281,6 @@ in (buildEnv {
   ''
     + texliveBin.cleanBrokenLinks
   ;
-}).overrideAttrs (_: { allowSubstitutes = true; })
+}
 # TODO: make TeX fonts visible by fontconfig: it should be enough to install an appropriate file
 #       similarly, deal with xe(la)tex font visibility?

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -1,11 +1,14 @@
-params: with params;
-# combine =
-args@{
-  pkgFilter ? (pkg: pkg.tlType == "run" || pkg.tlType == "bin" || pkg.pname == "core")
+{ lib, stdenv, buildEnv, makeWrapper, writeText
+, python3, ruby, perl, ghostscript
+, combineTexlivePackages
+, bin
+}:
+
+{ pkgFilter ? (pkg: pkg.tlType == "run" || pkg.tlType == "bin" || pkg.pname == "core")
 , extraName ? "combined"
 , extraVersion ? ""
 , ...
-}:
+} @ args:
 let
   pkgSet = removeAttrs args [ "pkgFilter" "extraName" "extraVersion" ] // {
     # include a fake "core" package
@@ -15,7 +18,7 @@ let
     ];
   };
   pkgList = rec {
-    all = lib.filter pkgFilter (combinePkgs pkgSet);
+    all = lib.filter pkgFilter (combineTexlivePackages pkgSet);
     splitBin = builtins.partition (p: p.tlType == "bin") all;
     bin = mkUniqueOutPaths splitBin.right
       ++ lib.optional

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -591,7 +591,7 @@ mapAliases ({
   procps-ng = procps; # added 2018-06-08
   proj_5 = throw "Proj-5 has been removed from nixpkgs, use proj instead."; # added 2021-04-12
   prometheus-cups-exporter = throw "outdated and broken by design; removed by developer."; # added 2021-03-16
-  pygmentex = texlive.bin.pygmentex; # added 2019-12-15
+  pygmentex = texlive.texliveBin.pygmentex; # added 2019-12-15
   pyload = throw "pyload has been removed from nixpkgs, as it was unmaintained."; # added 2021-03-21
   pyo3-pack = maturin;
   pmenu = throw "pmenu has been removed from nixpkgs, as its maintainer is no longer interested in the package."; # added 2019-12-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16975,7 +16975,7 @@ in
   });
 
   poppler_min = poppler.override { # TODO: maybe reduce even more
-    # this is currently only used by texlive.bin.
+    # this is currently only used by texlive.texliveBin.
     minimal = true;
     suffix = "min";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1055,7 +1055,7 @@ in
   astc-encoder = callPackage ../tools/graphics/astc-encoder { };
 
   asymptote = callPackage ../tools/graphics/asymptote {
-    texLive = texlive.combine { inherit (texlive) scheme-small epsf cm-super texinfo; };
+    texLive = texlive.buildTexliveCombinedEnv { inherit (texlive.texlivePackages) scheme-small epsf cm-super texinfo; };
     gsl = gsl_1;
   };
 
@@ -3145,14 +3145,14 @@ in
 
   asciidoc-full = appendToName "full" (asciidoc.override {
     inherit (python3.pkgs) pygments;
-    texlive = texlive.combine { inherit (texlive) scheme-minimal dvipng; };
+    texlive = texlive.buildTexliveCombinedEnv { inherit (texlive.texlivePackages) scheme-minimal dvipng; };
     w3m = w3m-batch;
     enableStandardFeatures = true;
   });
 
   asciidoc-full-with-plugins = appendToName "full-with-plugins" (asciidoc.override {
     inherit (python3.pkgs) pygments;
-    texlive = texlive.combine { inherit (texlive) scheme-minimal dvipng; };
+    texlive = texlive.buildTexliveCombinedEnv { inherit (texlive.texlivePackages) scheme-minimal dvipng; };
     w3m = w3m-batch;
     enableStandardFeatures = true;
     enableExtraPlugins = true;
@@ -11128,13 +11128,13 @@ in
   mint = callPackage ../development/compilers/mint { };
 
   mitscheme = callPackage ../development/compilers/mit-scheme {
-   texLive = texlive.combine { inherit (texlive) scheme-small; };
+   texLive = texlive.combined.scheme-small;
    texinfo = texinfo5;
    xlibsWrapper = null;
   };
 
   mitschemeX11 = mitscheme.override {
-   texLive = texlive.combine { inherit (texlive) scheme-small; };
+   texLive = texlive.combined.scheme-small;
    texinfo = texinfo5;
    enableX11 = true;
   };
@@ -18308,8 +18308,8 @@ in
 
   R = callPackage ../applications/science/math/R {
     # TODO: split docs into a separate output
-    texLive = texlive.combine {
-      inherit (texlive) scheme-small inconsolata helvetic texinfo fancyvrb cm-super;
+    texLive = texlive.buildTexliveCombinedEnv {
+      inherit (texlive.texlivePackages) scheme-small inconsolata helvetic texinfo fancyvrb cm-super;
     };
     withRecommendedPackages = false;
     inherit (darwin.apple_sdk.frameworks) Cocoa Foundation;
@@ -23957,7 +23957,7 @@ in
 
   ipe = libsForQt514.callPackage ../applications/graphics/ipe {
     ghostscript = ghostscriptX;
-    texlive = texlive.combine { inherit (texlive) scheme-small; };
+    texlive = texlive.combined.scheme-small;
     lua5 = lua5_3;
   };
 
@@ -29390,7 +29390,7 @@ in
   ecm = callPackage ../applications/science/math/ecm { };
 
   eukleides = callPackage ../applications/science/math/eukleides {
-    texLive = texlive.combine { inherit (texlive) scheme-small; };
+    texLive = texlive.combined.scheme-small;
     texinfo = texinfo4;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8155,7 +8155,7 @@ in {
   sphinxcontrib-spelling = callPackage ../development/python-modules/sphinxcontrib-spelling { };
 
   sphinxcontrib-tikz = callPackage ../development/python-modules/sphinxcontrib-tikz {
-    texLive = pkgs.texlive.combine { inherit (pkgs.texlive) scheme-small standalone pgfplots; };
+    texLive = pkgs.texlive.buildTexliveCombinedEnv { inherit (pkgs.texlive.texlivePackages) scheme-small standalone pgfplots; };
   };
 
   sphinxcontrib-websupport = if isPy3k then


### PR DESCRIPTION
The main thing to notice is that `texlive` is now a package scope. Inside it, `texlivePackages` contains what was previously lexically-scoped local `tl`, and the previous interface is provided for compatibility. Evaluations are not slower from the minor testing I did, and may be slightly faster. Please review commit-by-commit.

`lib.makeScope'` now appears, with the interface of `lib.makeScopeWithSplicing` but the (non-deprecated) functionality of `lib.makeScope`, so that the `texlive` scope may be forwards-compatible with `lib.makeScopeWithSplicing`.

`buildenv` now passes through `preferLocalBuild` and `allowSubstitutes` so that `buildTexliveCombinedEnv` doesn't invoke `.overrideAttrs` to achieve that effect.

I'm not sure about names, so feedback is really appreciated there. I tried to keep `callPackage` in the child scope unambiguous.

###### Motivation for this change

While investigating solutions for #118757, working with TeX Live in Nixpkgs was a pain. It's now less of a pain, but still needs work in my opinion to have nice separation between TeX Live, CTAN, and the combination machinery. Something simple like overriding `texliveBin` works without gymnastics, and changes to helper functions can be experimented with without copying & pasting whole files, closer to the flexibility Nixpkgs provides for Python.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  (`No diff detected, stopping review...`)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/120578)
<!-- Reviewable:end -->
