### PR TITLE
simple-http-server: init at 0.6.1

### DIFF
--- a/pkgs/servers/simple-http-server/default.nix
+++ b/pkgs/servers/simple-http-server/default.nix
@@ -1,0 +1,29 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "simple-http-server";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "TheWaWaR";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "01a129i1ph3m8k6zkdcqnnkqbhlqpk7qvvdsz2i2kas54csbgsww";
+  };
+
+  cargoSha256 = "050avk6wff8v1dlsfvxwvldmmgfakdxmhglv2bhvc2f3q8cf1d5d";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  # Currently no tests are implemented, so we avoid building the package twice
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Simple HTTP server in Rust";
+    homepage = "https://github.com/TheWaWaR/simple-http-server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mephistophiles ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31003,6 +31003,8 @@ in
 
   simplehttp2server = callPackage ../servers/simplehttp2server { };
 
+  simple-http-server = callPackage ../servers/simple-http-server { };
+
   diceware = with python3Packages; toPythonApplication diceware;
 
   xml2rfc = with python3Packages; toPythonApplication xml2rfc;


### PR DESCRIPTION
Signed-off-by: Maxim Zhukov <mussitantesmortem@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
