### PR TITLE
ethminer: provide a CUDA-free version

### DIFF
--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   clangStdenv,
   fetchFromGitHub,
   opencl-headers,
@@ -16,11 +17,11 @@
   openssl,
   pkg-config,
   cli11
-}:
+}@args:
 
 # Note that this requires clang < 9.0 to build, and currently
 # clangStdenv provides clang 7.1 which satisfies the requirement.
-let stdenv = clangStdenv;
+let stdenv = if cudaSupport then clangStdenv else args.stdenv;
 
 in stdenv.mkDerivation rec {
   pname = "ethminer";

--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -81,5 +81,6 @@ in stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ nand0p atemu ];
     license = licenses.gpl2;
+    broken = cudaSupport;
   };
 }

--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -8,6 +8,7 @@
   boost,
   makeWrapper,
   cudatoolkit,
+  cudaSupport,
   mesa,
   ethash,
   opencl-info,
@@ -41,6 +42,8 @@ in stdenv.mkDerivation rec {
     "-DAPICORE=ON"
     "-DETHDBUS=OFF"
     "-DCMAKE_BUILD_TYPE=Release"
+  ] ++ lib.optionals (!cudaSupport) [
+    "-DETHASHCUDA=OFF" # on by default
   ];
 
   nativeBuildInputs = [
@@ -54,12 +57,13 @@ in stdenv.mkDerivation rec {
     boost
     opencl-headers
     mesa
-    cudatoolkit
     ethash
     opencl-info
     ocl-icd
     openssl
     jsoncpp
+  ] ++ lib.optionals cudaSupport [
+    cudatoolkit
   ];
 
   preConfigure = ''
@@ -71,7 +75,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Ethereum miner with OpenCL, CUDA and stratum support";
+    description = "Ethereum miner with OpenCL${lib.optionalString cudaSupport ", CUDA"} and stratum support";
     homepage = "https://github.com/ethereum-mining/ethminer";
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ nand0p atemu ];

--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -80,7 +80,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://github.com/ethereum-mining/ethminer";
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ nand0p atemu ];
-    license = licenses.gpl2;
+    license = licenses.gpl3Only;
     broken = cudaSupport;
   };
 }

--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -23,14 +23,14 @@ let stdenv = clangStdenv;
 
 in stdenv.mkDerivation rec {
   pname = "ethminer";
-  version = "0.18.0";
+  version = "0.19.0";
 
   src =
     fetchFromGitHub {
       owner = "ethereum-mining";
       repo = "ethminer";
       rev = "v${version}";
-      sha256 = "10b6s35axmx8kyzn2vid6l5nnzcaf4nkk7f5f7lg3cizv6lsj707";
+      sha256 = "1kyff3vx2r4hjpqah9qk99z6dwz7nsnbnhhl6a76mdhjmgp1q646";
       fetchSubmodules = true;
     };
 

--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -74,7 +74,7 @@ in stdenv.mkDerivation rec {
     description = "Ethereum miner with OpenCL, CUDA and stratum support";
     homepage = "https://github.com/ethereum-mining/ethminer";
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ nand0p atemu ];
     license = licenses.gpl2;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3470,7 +3470,9 @@ in
 
   ethash = callPackage ../development/libraries/ethash { };
 
-  ethminer = callPackage ../tools/misc/ethminer { };
+  ethminer = callPackage ../tools/misc/ethminer { cudaSupport = config.cudaSupport or true; };
+  ethminer-cuda = ethminer.override { cudaSupport = true; };
+  ethminer-free = ethminer.override { cudaSupport = false; };
 
   cuetools = callPackage ../tools/cd-dvd/cuetools { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The cuda version is broken and my AMDGPU system doesn't need it to be built with CUDA.

cc @nand0p @noneucat @r-burns @danieldk 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
