### PR TITLE
 soldat-unstable: unstable-2020-11-26 -> unstable-2021-02-09 

### DIFF
--- a/pkgs/games/soldat-unstable/default.nix
+++ b/pkgs/games/soldat-unstable/default.nix
@@ -64,6 +64,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildPhase = ''
+    runHook preBuild
+
     mkdir -p client/build server/build
 
     # build .so from stb headers
@@ -80,9 +82,13 @@ stdenv.mkDerivation rec {
     pushd server
     make mode=release
     popd
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm644 client/libs/stb/libstb.so -t $out/lib
     install -Dm755 client/build/soldat_* $out/bin/soldat
     install -Dm755 server/build/soldatserver_* $out/bin/soldatserver
@@ -100,6 +106,8 @@ stdenv.mkDerivation rec {
         --add-flags "-fs_userpath \"$configDir\"" \
         --add-flags "-fs_basepath \"${base}/share/soldat\""
     done
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/games/soldat-unstable/default.nix
+++ b/pkgs/games/soldat-unstable/default.nix
@@ -38,8 +38,8 @@ let
 in
 
 stdenv.mkDerivation rec {
-  pname = "soldat-unstable";
-  version = "2021-02-09";
+  pname = "soldat";
+  version = "unstable-2021-02-09";
 
   src = fetchFromGitHub {
     name = "soldat";

--- a/pkgs/games/soldat-unstable/default.nix
+++ b/pkgs/games/soldat-unstable/default.nix
@@ -39,14 +39,14 @@ in
 
 stdenv.mkDerivation rec {
   pname = "soldat-unstable";
-  version = "2020-11-26";
+  version = "2021-02-09";
 
   src = fetchFromGitHub {
     name = "soldat";
     owner = "Soldat";
     repo = "soldat";
-    rev = "2280296ac56883f6a9cad4da48025af8ae7782e7";
-    sha256 = "17i3nlhxm4x4zx00i00aivhxmagbnyizxnpwiqzg57bf23hrvdj3";
+    rev = "c304c3912ca7a88461970a859049d217a44c6375";
+    sha256 = "09sl2zybfcmnl2n3qghp0gylmr71y01534l6nq0y9llbdy0bf306";
   };
 
   nativeBuildInputs = [ fpc makeWrapper autoPatchelfHook ];
@@ -62,13 +62,6 @@ stdenv.mkDerivation rec {
       sha256 = "0wsrazb36i7v4idg06jlzfhqwf56q9szzz7jp5cg4wsvcky3wajf";
     })
   ];
-
-  postPatch = ''
-    for f in client/Makefile server/Makefile; do
-      # fix unportable uname invocation
-      substituteInPlace "$f" --replace "uname -p" "uname -m"
-    done
-  '';
 
   buildPhase = ''
     mkdir -p client/build server/build


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
