### PR TITLE
protobuf-go: init at 1.26.0

### DIFF
--- a/pkgs/development/tools/go-protobuf/default.nix
+++ b/pkgs/development/tools/go-protobuf/default.nix
@@ -16,10 +16,18 @@ buildGoModule rec {
   doCheck = false;
 
   meta = with lib; {
-    homepage    = "https://github.com/golang/protobuf";
-    description = " Go bindings for protocol buffer";
-    maintainers = with maintainers; [ lewo ];
-    license     = licenses.bsd3;
-    platforms   = platforms.unix;
+    homepage        = "https://github.com/golang/protobuf";
+    description     = "Go support for Protocol Buffers";
+    longDescription = ''
+      This module (`github.com/golang/protobuf`) contains Go bindings for protocol buffers.
+
+      It has been superseded by the `google.golang.org/protobuf` module,
+      which contains an updated and simplified API, support for protobuf reflection,
+      and many other improvements.
+      We recommend that new code use the `google.golang.org/protobuf` module.
+    '';
+    maintainers     = with maintainers; [ lewo ];
+    license         = licenses.bsd3;
+    platforms       = platforms.unix;
   };
 }

--- a/pkgs/development/tools/protobuf-go/default.nix
+++ b/pkgs/development/tools/protobuf-go/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "protobuf-go";
+  version = "1.26.0";
+
+  src = fetchFromGitHub {
+    owner = "protocolbuffers";
+    repo = "protobuf-go";
+    rev = "v${version}";
+    sha256 = "sha256:0xq6phaps6d0vcv13ga59gzj4306l0ki9kikhmb52h6pq0iwfqlz";
+  };
+
+  vendorSha256 = "sha256:0rhgx3zkxp9gg4q7vck6x0ps5fp67lc0swbrgbpsghhribi2bgy9";
+
+  meta = with lib; {
+    homepage    = "https://developers.google.com/protocol-buffers";
+    description = "Go support for Protocol Buffers";
+    maintainers = with maintainers; [ raboof ];
+    license     = licenses.bsd3;
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17025,6 +17025,8 @@ in
 
   protobufc = callPackage ../development/libraries/protobufc/1.3.nix { };
 
+  protobuf-go = callPackage ../development/tools/protobuf-go { };
+
   protolock = callPackage ../development/libraries/protolock { };
 
   protozero = callPackage ../development/libraries/protozero { };


### PR DESCRIPTION
###### Motivation for this change

This is the designated replacement for go-protobuf

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).