### PR TITLE
monetdb: 11.39.13 -> 11.39.15

### DIFF
--- a/pkgs/servers/sql/monetdb/default.nix
+++ b/pkgs/servers/sql/monetdb/default.nix
@@ -1,20 +1,33 @@
 { lib, stdenv, fetchurl, cmake, python3
 , bison, openssl, readline, bzip2
+, perl
 }:
 
-stdenv.mkDerivation rec {
+let
+  perlWithDBI = perl.withPackages (p: [ p.DBDMonetdb ]);
+
+in stdenv.mkDerivation rec {
   pname = "monetdb";
-  version = "11.39.13";
+  version = "11.39.15";
 
   src = fetchurl {
     url = "https://dev.monetdb.org/downloads/sources/archive/MonetDB-${version}.tar.bz2";
-    sha256 = "sha256-e30Vykwk6U83/0pS3OWPJ2Oq2SAtNc1S6c1ZO42k39c=";
+    sha256 = "0g8xw6mxm9dhd0yjwln0f0rs59yhs8zr34hppv5g91n371ghn693";
   };
 
   postPatch = ''
     substituteInPlace cmake/monetdb-packages.cmake --replace \
       'get_os_release_info(LINUX_DISTRO LINUX_DISTRO_VERSION)' \
       'set(LINUX_DISTRO "nixos")'
+  '';
+
+  postFixup = ''
+    substituteInPlace "$out/bin/malsample.pl" --replace \
+      '#!/usr/bin/env perl' \
+      '#!${perlWithDBI}/bin/perl'
+    substituteInPlace "$out/bin/sqlsample.pl" --replace \
+      '#!/usr/bin/env perl' \
+      '#!${perlWithDBI}/bin/perl'
   '';
 
   nativeBuildInputs = [ cmake python3 ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5662,6 +5662,22 @@ let
     };
   };
 
+  DBDMonetdb = buildPerlPackage {
+    pname = "DBD-Monetdb";
+    version = "0.09";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SG/SGOELDNER/DBD-monetdb-0.09.tar.gz";
+      sha256 = "18dah5nicb24c79bx8vdvkxk9fhcn383valdhh2zqvfzkj687723";
+    };
+    buildInputs = [ MonetdbCLI ];
+    propagatedBuildInputs = [ DBI ];
+    meta = {
+      homepage = "http://monetdb.cwi.nl";
+      description = "MonetDB Driver for DBI";
+      maintainers = [ maintainers.StillerHarpo ];
+    };
+  };
+
   DBDmysql = buildPerlPackage {
     pname = "DBD-mysql";
     version = "4.050";
@@ -13803,6 +13819,37 @@ let
       maintainers = [ maintainers.sgo ];
     };
   };
+
+  MonetdbCLI = buildPerlPackage {
+    pname = "Monetdb-CLI";
+    version = "0.03";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SG/SGOELDNER/MonetDB-CLI-0.03.tar.gz";
+      sha256 = "1yvb644pbwdcv3a16gcrr8i3lkd818w1gsrvxjcvpxnmms7ly12k";
+    };
+    buildInputs = [ MonetdbMapiPP ];
+    meta = {
+      homepage = "http://monetdb.cwi.nl";
+      description = "MonetDB Call Level Interface";
+      maintainers = [ maintainers.StillerHarpo ];
+    };
+  };
+
+  MonetdbMapiPP = buildPerlPackage {
+    pname = "Monetdb-MapiPP";
+    version = "0.03";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SG/SGOELDNER/MonetDB-CLI-MapiPP-0.03.tar.gz";
+      sha256 = "1h82zbz04nc2fb1bv62a22pbpgg7qalwiyg8vbq5frlwlycz5ihl";
+    };
+    buildInputs = [ IOSocketInet6 ];
+    meta = {
+      homepage = "http://monetdb.cwi.nl";
+      description = " MonetDB::CLI implementation, using the Mapi protocol";
+      maintainers = [ maintainers.StillerHarpo ];
+    };
+  };
+
 
   MonitoringPlugin = buildPerlPackage {
     pname = "Monitoring-Plugin";


### PR DESCRIPTION
Some files in `bin/` can't be successfully executed

- perl scripts are missing the monetdb module `DBD/monetdb.pm`

```
> ./result/bin/sqlsample.pl

Start a simple Monet SQL interaction

install_driver(monetdb) failed: Can't locate DBD/monetdb.pm in @INC (you may need to install the DBD::monetdb module) (@INC contains: /nix/store/hcd1yj7dhcp8is9a5vxxplxjmqmm8j2y-perl-5.32.1-env/lib/perl5/site_perl/5.32.1/x86_64-linux-thread-multi /nix/store/hcd1yj7dhcp8is9a5vxxplxjmqmm8j2y-perl-5.32.1-env/lib/perl5/site_perl/5.32.1 /nix/store/hcd1yj7dhcp8is9a5vxxplxjmqmm8j2y-perl-5.32.1-env/lib/perl5/site_perl /nix/store/6mnbpv86l5ff2vf765hinq95k12dhj85-perl-5.32.1/lib/perl5/site_perl/5.32.1/x86_64-linux-thread-multi /nix/store/6mnbpv86l5ff2vf765hinq95k12dhj85-perl-5.32.1/lib/perl5/site_perl/5.32.1 /nix/store/6mnbpv86l5ff2vf765hinq95k12dhj85-perl-5.32.1/lib/perl5/5.32.1/x86_64-linux-thread-multi /nix/store/6mnbpv86l5ff2vf765hinq95k12dhj85-perl-5.32.1/lib/perl5/5.32.1) at (eval 6) line 3.
Perhaps the DBD::monetdb perl module hasn't been fully installed,
or perhaps the capitalisation of 'monetdb' isn't right.
Available drivers: DBM, ExampleP, File, Gofer, Mem, Proxy, Sponge.
 at ./result/bin/sqlsample.pl line 16.
```
- Other scripts still have references to `/build/`

```
> ./result/bin/Mtest.py
Python available, but pymonetdb package not available
Perl available, but MonetDB driver or DBI module not available

Mtest.py:  ERROR:  Illegal TSTSRCBASE: directory '/build/MonetDB-11.39.15' does not exist!
```

* Tests in MonetDB::CLI::MapiPP fail

```
building '/nix/store/318c3a3p8lkwvsk09v8k2x335ffscrls-perl5.32.1-Monetdb-MapiPP-0.03.drv'...
unpacking sources
unpacking source archive /nix/store/2rw4gqfl8vbx39pg9nyxnj0fz8h1qc15-MonetDB-CLI-MapiPP-0.03.tar.gz
source root is MonetDB-CLI-MapiPP-0.03
setting SOURCE_DATE_EPOCH to timestamp 1153731399 of file MonetDB-CLI-MapiPP-0.03/MapiPP.pm
patching sources
configuring
Checking if your kit is complete...
Looks good
Generating a Unix-style Makefile
Writing Makefile for MonetDB::CLI::MapiPP
Writing MYMETA.yml and MYMETA.json
no configure script, doing nothing
building
build flags: SHELL=/nix/store/jdi2v7ir1sr6vp7pc5x0nhb6lpcmg6xg-bash-4.4-p23/bin/bash
cp MapiPP.pm blib/lib/MonetDB/CLI/MapiPP.pm
Manifying 1 pod document
running tests
check flags: SHELL=/nix/store/jdi2v7ir1sr6vp7pc5x0nhb6lpcmg6xg-bash-4.4-p23/bin/bash VERBOSE=y test
PERL_DL_NONLAZY=1 "/nix/store/6mnbpv86l5ff2vf765hinq95k12dhj85-perl-5.32.1/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00use.t .. ok
t/02cxn.t .. 1/18
#   Failed test 'connect'
#   at t/02cxn.t line 37.
Use of uninitialized value $cxn in concatenation (.) or string at t/02cxn.t line 38.

#   Failed test 'Connection object: '
#   at t/02cxn.t line 38.

#   Failed test 'query'
#   at t/02cxn.t line 41.
Use of uninitialized value $req in concatenation (.) or string at t/02cxn.t line 42.

#   Failed test 'Request object: '
#   at t/02cxn.t line 42.
Use of uninitialized value $cnt in concatenation (.) or string at t/02cxn.t line 45.

#   Failed test 'columncount: '
#   at t/02cxn.t line 45.
#          got: undef
#     expected: '2'
Use of uninitialized value $querytype in concatenation (.) or string at t/02cxn.t line 48.

#   Failed test 'querytype: '
#   at t/02cxn.t line 48.
#          got: undef
#     expected: '1'
Use of uninitialized value $v in concatenation (.) or string at t/02cxn.t line 52.

#   Failed test 'id: '
#   at t/02cxn.t line 52.
Use of uninitialized value $v in concatenation (.) or string at t/02cxn.t line 52.

#   Failed test 'rows_affected: '
#   at t/02cxn.t line 52.
Use of uninitialized value $v in concatenation (.) or string at t/02cxn.t line 57.

#   Failed test 'name( 0 ): '
#   at t/02cxn.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/02cxn.t line 57.

#   Failed test 'name( 1 ): '
#   at t/02cxn.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/02cxn.t line 57.

#   Failed test 'type( 0 ): '
#   at t/02cxn.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/02cxn.t line 57.

#   Failed test 'type( 1 ): '
#   at t/02cxn.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/02cxn.t line 57.

#   Failed test 'length( 0 ): '
#   at t/02cxn.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/02cxn.t line 57.

#   Failed test 'length( 1 ): '
#   at t/02cxn.t line 57.
Can't call method "rows_affected" on an undefined value at t/02cxn.t line 67.
# Looks like your test exited with 111 just after 15.
t/02cxn.t .. Dubious, test returned 111 (wstat 28416, 0x6f00)
Failed 17/18 subtests
t/75mil.t .. 1/18
#   Failed test 'connect'
#   at t/75mil.t line 37.
Use of uninitialized value $cxn in concatenation (.) or string at t/75mil.t line 38.

#   Failed test 'Connection object: '
#   at t/75mil.t line 38.

#   Failed test 'query'
#   at t/75mil.t line 41.
Use of uninitialized value $req in concatenation (.) or string at t/75mil.t line 42.

#   Failed test 'Request object: '
#   at t/75mil.t line 42.
Use of uninitialized value $cnt in concatenation (.) or string at t/75mil.t line 45.

#   Failed test 'columncount: '
#   at t/75mil.t line 45.
#          got: undef
#     expected: '2'
Use of uninitialized value $querytype in concatenation (.) or string at t/75mil.t line 48.

#   Failed test 'querytype: '
#   at t/75mil.t line 48.
#          got: undef
#     expected: '-1'
Use of uninitialized value $v in concatenation (.) or string at t/75mil.t line 52.

#   Failed test 'id: '
#   at t/75mil.t line 52.
Use of uninitialized value $v in concatenation (.) or string at t/75mil.t line 52.

#   Failed test 'rows_affected: '
#   at t/75mil.t line 52.
Use of uninitialized value $v in concatenation (.) or string at t/75mil.t line 57.

#   Failed test 'name( 0 ): '
#   at t/75mil.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/75mil.t line 57.

#   Failed test 'name( 1 ): '
#   at t/75mil.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/75mil.t line 57.

#   Failed test 'type( 0 ): '
#   at t/75mil.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/75mil.t line 57.

#   Failed test 'type( 1 ): '
#   at t/75mil.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/75mil.t line 57.

#   Failed test 'length( 0 ): '
#   at t/75mil.t line 57.
Use of uninitialized value $v in concatenation (.) or string at t/75mil.t line 57.

#   Failed test 'length( 1 ): '
#   at t/75mil.t line 57.
Can't call method "rows_affected" on an undefined value at t/75mil.t line 67.
# Looks like your test exited with 111 just after 15.
t/75mil.t .. Dubious, test returned 111 (wstat 28416, 0x6f00)
Failed 17/18 subtests

Test Summary Report
-------------------
t/02cxn.t (Wstat: 28416 Tests: 15 Failed: 14)
  Failed tests:  2-15
  Non-zero exit status: 111
  Parse errors: Bad plan.  You planned 18 tests but ran 15.
t/75mil.t (Wstat: 28416 Tests: 15 Failed: 14)
  Failed tests:  2-15
  Non-zero exit status: 111
  Parse errors: Bad plan.  You planned 18 tests but ran 15.
Files=3, Tests=32,  1 wallclock secs ( 0.02 usr  0.01 sys +  0.18 cusr  0.03 csys =  0.24 CPU)
Result: FAIL
Failed 2/3 test programs. 28/32 subtests failed.
make: *** [Makefile:845: test_dynamic] Error 111
builder for '/nix/store/318c3a3p8lkwvsk09v8k2x335ffscrls-perl5.32.1-Monetdb-MapiPP-0.03.drv' failed with exit code 2
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
