### PR TITLE
restream: init at 1.1

### DIFF
--- a/pkgs/applications/misc/remarkable/restream/default.nix
+++ b/pkgs/applications/misc/remarkable/restream/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, bash
+, stdenv
+, lz4
+, ffmpeg-full
+, fetchFromGitHub
+, openssh
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "restream";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "rien";
+    repo = pname;
+    rev = version;
+    sha256 = "18z17chl7r5dg12xmr3f9gbgv97nslm8nijigd03iysaj6dhymp3";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ${src}/restream.arm.static $out/libexec/restream.arm.static
+    install -D ${src}/reStream.sh $out/bin/restream
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    # `ffmpeg-full` is used here to bring in `ffplay`, which is used to display
+    # the reMarkable framebuffer
+    wrapProgram "$out/bin/restream" --suffix PATH ":" "${lib.makeBinPath [ ffmpeg-full lz4 openssh ]}"
+  '';
+
+  meta = with lib; {
+    description = "reMarkable screen sharing over SSH";
+    homepage = "https://github.com/rien/reStream";
+    license = licenses.mit;
+    maintainers = [ maintainers.cpcloud ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3003,6 +3003,8 @@ in
 
   remarkable-mouse = python3Packages.callPackage ../applications/misc/remarkable/remarkable-mouse { };
 
+  restream = callPackage ../applications/misc/remarkable/restream { };
+
   ryujinx = callPackage ../misc/emulators/ryujinx { };
 
   scour = with python3Packages; toPythonApplication scour;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This introduces the [`reStream`](https://github.com/rien/reStream) application, a way to share the screen
of a remarkable tablet over SSH.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
