### PR TITLE
languagetool: 5.2 -> 5.3

### DIFF
--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "LanguageTool";
-  version = "5.2";
+  version = "5.3";
 
   src = fetchzip {
     url = "https://www.languagetool.org/download/${pname}-${version}.zip";
-    sha256 = "1fz3rxqg5z2jxbalraz8lwkzj0jh69zzfmf3vpwywilvl7xlhdrd";
+    sha256 = "1km20ajqb65vkhkrf94zy5srcss66ix8padp7ng59pa8pj11wmi2";
   };
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jre ];

--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ jre ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share
     mv -- * $out/share/
 
@@ -22,6 +24,8 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${jre}/bin/java $out/bin/languagetool-http-server \
       --add-flags "-cp $out/share/languagetool-server.jar org.languagetool.server.HTTPServer"
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

A new version was released : 
https://github.com/languagetool-org/languagetool/blob/v5.3/languagetool-standalone/CHANGES.md


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date (no changes needed)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
