### PR TITLE
libsForQt5.libopenshot: use ffmpeg instead of ffmpeg_3

### DIFF
--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -2,7 +2,7 @@
 , pkg-config, cmake, doxygen
 , libopenshot-audio, imagemagick, ffmpeg
 , swig, python3, jsoncpp
-, unittest-cpp, cppzmq, zeromq
+, cppzmq, zeromq
 , qtbase, qtmultimedia
 , llvmPackages
 }:
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Fix build with GCC 10.
     (fetchpatch {
       name = "fix-build-with-gcc-10.patch";
       url = "https://github.com/OpenShot/libopenshot/commit/13290364e7bea54164ab83d973951f2898ad9e23.diff";
@@ -33,10 +34,10 @@ stdenv.mkDerivation rec {
     export _REL_PYTHON_MODULE_PATH=$(toPythonPath $out)
   '';
 
-  nativeBuildInputs = [ pkg-config cmake doxygen ];
+  nativeBuildInputs = [ pkg-config cmake doxygen swig ];
 
   buildInputs =
-  [ imagemagick ffmpeg swig python3 jsoncpp
+  [ imagemagick ffmpeg python3 jsoncpp
     cppzmq zeromq qtbase qtmultimedia ]
     ++ optional stdenv.isDarwin llvmPackages.openmp
   ;

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config cmake doxygen ];
 
   buildInputs =
-  [ imagemagick ffmpeg swig python3 unittest-cpp
+  [ imagemagick ffmpeg swig python3
     cppzmq zeromq qtbase qtmultimedia ]
     ++ optional stdenv.isDarwin llvmPackages.openmp
   ;
@@ -44,7 +44,6 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   LIBOPENSHOT_AUDIO_DIR = libopenshot-audio;
-  "UNITTEST++_INCLUDE_DIR" = "${unittest-cpp}/include/UnitTest++";
 
   doCheck = false;
 

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch
 , pkg-config, cmake, doxygen
-, libopenshot-audio, imagemagick, ffmpeg_3
+, libopenshot-audio, imagemagick, ffmpeg
 , swig, python3
 , unittest-cpp, cppzmq, zeromq
 , qtbase, qtmultimedia
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config cmake doxygen ];
 
   buildInputs =
-  [ imagemagick ffmpeg_3 swig python3 unittest-cpp
+  [ imagemagick ffmpeg swig python3 unittest-cpp
     cppzmq zeromq qtbase qtmultimedia ]
     ++ optional stdenv.isDarwin llvmPackages.openmp
   ;

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch
 , pkg-config, cmake, doxygen
 , libopenshot-audio, imagemagick, ffmpeg
-, swig, python3
+, swig, python3, jsoncpp
 , unittest-cpp, cppzmq, zeromq
 , qtbase, qtmultimedia
 , llvmPackages
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config cmake doxygen ];
 
   buildInputs =
-  [ imagemagick ffmpeg swig python3
+  [ imagemagick ffmpeg swig python3 jsoncpp
     cppzmq zeromq qtbase qtmultimedia ]
     ++ optional stdenv.isDarwin llvmPackages.openmp
   ;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/94003 and #120372

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
