### PR TITLE
ocamlPackages.{h2, hpack}: init at 0.8.0

### DIFF
--- a/pkgs/development/ocaml-modules/h2/default.nix
+++ b/pkgs/development/ocaml-modules/h2/default.nix
@@ -1,0 +1,59 @@
+{ buildDunePackage
+, lib
+, fetchFromGitHub
+, ocaml
+, hpack
+, angstrom
+, faraday
+, base64
+, psq
+, httpaf
+, alcotest
+, yojson
+, hex
+}:
+
+let
+  http2-frame-test-case = fetchFromGitHub {
+    owner = "http2jp";
+    repo = "http2-frame-test-case";
+    rev = "5c67db0d4d68e1fb7d3a241d6e01fc04d981f465";
+    sha256 = "16yyb37f8mk9saw7ndjs5is67yq7qa6b6y7k0c75ibxi4n9aw1r3";
+  };
+in
+
+buildDunePackage rec {
+  pname = "h2";
+
+  inherit (hpack)
+    version
+    src
+    useDune2
+    ;
+
+  minimumOCamlVersion = "4.06";
+
+  propagatedBuildInputs = [
+    angstrom
+    faraday
+    base64
+    psq
+    hpack
+    httpaf
+  ];
+
+  # Tests fail with 4.06
+  doCheck = lib.versionAtLeast ocaml.version "4.07";
+  preCheck = ''
+    ln -s "${http2-frame-test-case}" lib_test/http2-frame-test-case
+  '';
+  checkInputs = [
+    alcotest
+    yojson
+    hex
+  ];
+
+  meta = hpack.meta // {
+    description = "A high-performance, memory-efficient, and scalable HTTP/2 library for OCaml";
+  };
+}

--- a/pkgs/development/ocaml-modules/hpack/default.nix
+++ b/pkgs/development/ocaml-modules/hpack/default.nix
@@ -1,0 +1,37 @@
+{ buildDunePackage
+, lib
+, fetchurl
+, angstrom
+, faraday
+}:
+
+buildDunePackage rec {
+  pname = "hpack";
+  version = "0.8.0";
+
+  src = fetchurl {
+    url = "https://github.com/anmonteiro/ocaml-h2/releases/download/${version}/h2-${version}.tbz";
+    sha256 = "0qcn3yvyz0h419fjg9nb20csfmwmh3ihz0zb0jfzdycf5w4mlry6";
+  };
+
+  useDune2 = true;
+  minimumOCamlVersion = "4.04";
+
+  propagatedBuildInputs = [
+    angstrom
+    faraday
+  ];
+
+  # circular dependency
+  doCheck = false;
+
+  meta = {
+    license = lib.licenses.bsd3;
+    description = "An HPACK (Header Compression for HTTP/2) implementation in OCaml";
+    homepage = "https://github.com/anmonteiro/ocaml-h2";
+    maintainers = with lib.maintainers; [
+      sternenseemann
+      anmonteiro
+    ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -401,6 +401,8 @@ let
       inherit (pkgs) gsl;
     };
 
+    h2 = callPackage ../development/ocaml-modules/h2 { };
+
     hacl_x25519 = callPackage ../development/ocaml-modules/hacl_x25519 { };
 
     herelib = callPackage ../development/ocaml-modules/herelib { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -413,6 +413,8 @@ let
 
     hmap = callPackage ../development/ocaml-modules/hmap { };
 
+    hpack = callPackage ../development/ocaml-modules/hpack { };
+
     hxd = callPackage ../development/ocaml-modules/hxd { };
 
     imagelib = callPackage ../development/ocaml-modules/imagelib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Dependencies of `git-paf` 3.4.0.

Mostly based on <https://github.com/anmonteiro/nix-overlays/blob/master/ocaml/h2/default.nix>. I want to add the other h2-* packages as well, but not motivated currently since this also entails packaging all gluten-* packages.

@anmonteiro I'd be happy to add you as maintainer as well if you want to.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
