### PR TITLE
pkgsStatic: don't overwrite openssl version

### DIFF
--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -110,8 +110,11 @@ in {
     if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
   ) super.ocaml-ng;
 
-  openssl = super.openssl_1_1.overrideAttrs (o: {
-    # OpenSSL doesn't like the `--enable-static` / `--disable-shared` flags.
+  # OpenSSL doesn't like the `--enable-static` / `--disable-shared` flags.
+  openssl_1_0_2 = super.openssl_1_0_2.overrideAttrs (o: {
+    configureFlags = (removeUnknownConfigureFlags o.configureFlags);
+  });
+  openssl_1_1 = super.openssl_1_1.overrideAttrs (o: {
     configureFlags = (removeUnknownConfigureFlags o.configureFlags);
   });
 


### PR DESCRIPTION
###### Motivation for this change
Right now pkgsStatic is clobbering the default openssl version, which causes problems when cross-compiling to windows.

This is the expression I'm testing:
```
with import <nixpkgs> {
  inherit system;
  crossSystem = {
    config = "x86_64-w64-mingw32";
    libc = "msvcrt";
  };

  config = {
    allowUnsupportedSystem = true;
    permittedInsecurePackages = [
      "openssl-1.0.2u"
    ];
  };
  crossOverlays = [(self: super: {
    openssl_1_0_2 = super.openssl_1_0_2.override { withPerl = false; };
  })];
};

pkgsStatic.openssl
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
