### PR TITLE
oathToolkit: 2.6.2 -> 2.6.6

### DIFF
--- a/pkgs/tools/security/oath-toolkit/default.nix
+++ b/pkgs/tools/security/oath-toolkit/default.nix
@@ -1,48 +1,25 @@
-{ lib, stdenv, fetchFromGitLab, fetchpatch, pam, xmlsec, autoreconfHook, pkg-config, libxml2, gtk-doc, perl, gengetopt, bison, help2man }:
+{ lib, stdenv, fetchurl, pam, xmlsec }:
 
 let
   securityDependency =
     if stdenv.isDarwin then xmlsec
     else pam;
 
-in stdenv.mkDerivation {
-  name = "oath-toolkit-2.6.2";
+in stdenv.mkDerivation rec {
+  pname = "oath-toolkit";
+  version = "2.6.6";
 
-  src = fetchFromGitLab {
-    owner = "oath-toolkit";
-    repo = "oath-toolkit";
-    rev = "0dffdec9c5af5c89a5af43add29d8275eefe7414";
-    sha256 = "0n2sl444723f1k0sjmc0mzdwslx51yxac39c2cx2bl3ykacgfv74";
+  src = fetchurl {
+    url = "mirror://savannah/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "0v4lrgip08b8xlivsfn3mwql3nv8hmcpzrn6pi3xp88vqwav6s7x";
   };
 
-  patches = [
-    # fix for glibc>=2.28
-    (fetchpatch {
-      name   = "new_glibc_check.patch";
-      url    = "https://sources.debian.org/data/main/o/oath-toolkit/2.6.1-1.3/debian/patches/new-glibc-check.patch";
-      sha256 = "0h75xyy3xsl485v7w27yqkks6z9sgsjmrv6wiswy15fdj5wyciv3";
-    })
-  ];
-
-  buildInputs = [ securityDependency libxml2 perl gengetopt bison ];
-
-  nativeBuildInputs = [ autoreconfHook gtk-doc help2man pkg-config ];
-
-  # man file generation fails when true
-  enableParallelBuilding = false;
-
-  configureFlags = [ "--disable-pskc" ];
-
-  # Replicate the steps from cfg.mk
-  preAutoreconf = ''
-    printf "gdoc_MANS =\ngdoc_TEXINFOS =\n" > liboath/man/Makefile.gdoc
-    printf "gdoc_MANS =\ngdoc_TEXINFOS =\n" > libpskc/man/Makefile.gdoc
-    touch ChangeLog
-  '';
+  buildInputs = [ securityDependency ];
 
   meta = with lib; {
     description = "Components for building one-time password authentication systems";
     homepage = "https://www.nongnu.org/oath-toolkit/";
+    maintainers = with maintainers; [ schnusch ];
     platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

oath-toolkit-2.6.2 is quite out of date, especially [oathtool's syntax to read keys from files](https://www.nongnu.org/oath-toolkit/oathtool.1.html) is missing.

By building the tarball from <https://savannah.nongnu.org/projects/oath-toolkit/> instead of <https://gitlab.com/oath-toolkit/oath-toolkit> all the changes do not seem necessary anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
