### PR TITLE
mpfi: fix download URL

### DIFF
--- a/pkgs/development/libraries/mpfi/default.nix
+++ b/pkgs/development/libraries/mpfi/default.nix
@@ -1,16 +1,24 @@
-{lib, stdenv, fetchurl, mpfr}:
+{lib, stdenv, fetchurl, autoconf, automake, libtool, texinfo, mpfr}:
 stdenv.mkDerivation rec {
   pname = "mpfi";
   version = "1.5.4";
-  file_nr = "37331";
+  file_nr = "38111";
+
   src = fetchurl {
     # NOTE: the file_nr is whats important here. The actual package name (including the version)
     # is ignored. To find out the correct file_nr, go to https://gforge.inria.fr/projects/mpfi/
     # and click on Download in the section "Latest File Releases".
-    url = "https://gforge.inria.fr/frs/download.php/file/${file_nr}/mpfi-${version}.tar.bz2";
-    sha256 = "sha256-I4PUV7IIxs088uZracTOR0d7Kg2zH77AzUseuqJHGS8=";
+    url = "https://gforge.inria.fr/frs/download.php/file/${file_nr}/mpfi-${version}.tgz";
+    sha256 = "sha256-Ozk4WV1yCvF5c96vcnz8DdQcixbCCtwQOpcPSkOuOlY=";
   };
-  buildInputs = [mpfr];
+
+  nativeBuildInputs = [ autoconf automake libtool texinfo ];
+  buildInputs = [ mpfr ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
   meta = {
     inherit version;
     description = "A multiple precision interval arithmetic library based on MPFR";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The `file_nr` value was wrong, so it was downloading version 1.5.3 instead of 1.5.4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
