### PR TITLE
punes: init at unstable-2021-04-25

### DIFF
--- a/pkgs/misc/emulators/punes/default.nix
+++ b/pkgs/misc/emulators/punes/default.nix
@@ -1,0 +1,61 @@
+{ mkDerivation
+, stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, qtbase
+, qtsvg
+, qttools
+, autoreconfHook
+, cmake
+, pkg-config
+, ffmpeg
+, libGLU
+, alsaLib
+, sndio
+}:
+
+mkDerivation rec {
+  pname = "punes";
+  version = "unstable-2021-04-25";
+
+  src = fetchFromGitHub {
+    owner = "punesemu";
+    repo = "puNES";
+    rev = "4b4c3495a56d3989544cb56079ce641da8aa9b35";
+    sha256 = "1wszvdgm38513v26p14k58shbkxn1qhkn8l0hsqi04vviicad59s";
+  };
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace '`$PKG_CONFIG --variable=host_bins Qt5Core`/lrelease' '${qttools.dev}/bin/lrelease'
+  '';
+
+  nativeBuildInputs = [ autoreconfHook cmake pkg-config qttools ];
+
+  buildInputs = [ ffmpeg qtbase qtsvg libGLU ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ alsaLib ]
+    ++ lib.optionals stdenv.hostPlatform.isBSD [ sndio ];
+
+  dontUseCmakeConfigure = true;
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--prefix=${placeholder "out"}"
+    "--without-opengl-nvidia-cg"
+    "--with-ffmpeg"
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/punesemu/puNES.git";
+  };
+
+  meta = with lib; {
+    description = "Qt-based Nintendo Entertaiment System emulator and NSF/NSFe Music Player";
+    homepage = "https://github.com/punesemu/puNES";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = with platforms; linux ++ freebsd ++ openbsd ++ windows;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30209,6 +30209,8 @@ in
 
   protocol = python3Packages.callPackage ../applications/networking/protocol { };
 
+  punes = libsForQt5.callPackage ../misc/emulators/punes { };
+
   pykms = callPackage ../tools/networking/pykms { };
 
   pyupgrade = with python3Packages; toPythonApplication pyupgrade;


### PR DESCRIPTION
###### Motivation for this change
Packaging [puNES](https://github.com/punesemu/puNES), a Qt-based NES emulator & NSF(e) player.

![Bildschirmfoto von 2021-04-25 20-11-13](https://user-images.githubusercontent.com/23431373/116004312-72bbfc80-a602-11eb-8e3a-dd2356701238.png)

Marked broken on Darwin because I haven't bothered to test it and the repo doesn't even mention macOS compilation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
