### PR TITLE
semiphemeral: init at 0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -492,6 +492,12 @@
       fingerprint = "B422 CFB1 C9EF 73F7 E1E2 698D F53E 3233 42F7 A6D3A";
     }];
   };
+  amanjeev = {
+    email = "aj@amanjeev.com";
+    github = "amanjeev";
+    githubId = 160476;
+    name = "Amanjeev Sethi";
+  };
   amar1729 = {
     email = "amar.paul16@gmail.com";
     github = "amar1729";

--- a/pkgs/tools/misc/semiphemeral/default.nix
+++ b/pkgs/tools/misc/semiphemeral/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "semiphemeral";
+  version = "0.6";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "c90d73b14c826f262b1339d1f5926c5abc6431181090ea87177af821c0866fb7";
+  };
+
+  doCheck = false; # upstream has no tests
+
+  pythonImportsCheck = [ "semiphemeral" ];
+
+  propagatedBuildInputs = with python3.pkgs; [ click sqlalchemy flask tweepy colorama ];
+
+  meta = with lib; {
+    description = "Automatically delete your old tweets, except for the ones you want to keep";
+    homepage = "https://github.com/micahflee/semiphemeral";
+    license = licenses.mit;
+    maintainers = with maintainers; [ amanjeev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25795,6 +25795,8 @@ in
 
   secretscanner = callPackage ../tools/security/secretscanner { };
 
+  semiphemeral = callPackage ../tools/misc/semiphemeral { };
+
   sent = callPackage ../applications/misc/sent { };
 
   seq24 = callPackage ../applications/audio/seq24 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds python package [Semiphemeral](https://github.com/micahflee/semiphemeral). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
