### PR TITLE
nixos/nix-containers: bind container units to machined and dbus

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -737,6 +737,12 @@ in
     unit = {
       description = "Container '%i'";
 
+      # since the stop script uses machinectl we need both machined and dbus always available,
+      # otherwise the stop script will fail and cause the entire container to be killed hard
+      # after the stop timeout elapses.
+      after    = [ "systemd-machined.service" "dbus.service" ];
+      requires = [ "systemd-machined.service" "dbus.service" ];
+
       unitConfig.RequiresMountsFor = "/var/lib/containers/%i";
 
       path = [ pkgs.iproute2 ];
@@ -788,7 +794,7 @@ in
             {
               wantedBy = [ "machines.target" ];
               wants = [ "network.target" ];
-              after = [ "network.target" ];
+              after = unit.after ++ [ "network.target" ];
               restartTriggers = [
                 containerConfig.path
                 config.environment.etc."containers/${name}.conf".source

--- a/nixos/tests/containers-shutdown.nix
+++ b/nixos/tests/containers-shutdown.nix
@@ -1,0 +1,36 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "containers-shutdown";
+
+  machine = { pkgs, ... }: {
+    containers.autostart = {
+      autoStart = true;
+      config = {};
+    };
+
+    containers.triggered = {
+      config = {};
+    };
+  };
+
+  testScript = ''
+    assert "autostart" in machine.succeed("nixos-container list")
+    assert "triggered" in machine.succeed("nixos-container list")
+
+    machine.wait_for_unit("machines.target")
+
+    # stopping either machined or dbus must stop all containers.
+
+    machine.succeed("nixos-container start triggered")
+    machine.systemctl("stop systemd-machined.service")
+    machine.wait_until_fails("systemctl is-active systemd-machined.service")
+    machine.fail("systemctl is-active container@active.service")
+    machine.fail("systemctl is-active container@triggered.service")
+
+    machine.systemctl("start container@autostart.service")
+    machine.succeed("nixos-container start triggered")
+    machine.succeed("systemctl stop dbus.service")
+    machine.wait_until_fails("systemctl is-active dbus.service")
+    machine.fail("systemctl is-active container@active.service")
+    machine.fail("systemctl is-active container@triggered.service")
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

fix  #109695 (containers don't stop properly during system shutdown). not sure whether this is the best way to do it, but can't think of something better that doesn't require moving away from machinectl commands again

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
